### PR TITLE
fix: вернул CSP header в nginx конфиги

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -35,4 +35,5 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; frame-ancestors 'self';" always;
 }

--- a/nginx/staging.conf
+++ b/nginx/staging.conf
@@ -57,4 +57,6 @@ server {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; frame-ancestors 'self';" always;
 }


### PR DESCRIPTION
## Summary

- Вернул `Content-Security-Policy` header, случайно удалённый в коммите a7ca1e2
- Добавил `Permissions-Policy` в staging.conf (был только в prod)

### Изменения:
- `nginx/nginx.conf` — добавлен CSP header
- `nginx/staging.conf` — добавлены CSP + Permissions-Policy headers

### CSP политика:
- `default-src 'self'` — по умолчанию только свой домен
- `script-src 'self' 'unsafe-inline'` — JS + inline (Vue)
- `style-src 'self' 'unsafe-inline'` — CSS + inline
- `img-src 'self' data: blob:` — картинки + base64 + blob (превью)
- `connect-src 'self'` — fetch/XHR только на свой домен (защита от exfiltration)
- `frame-ancestors 'self'` — защита от clickjacking

Closes #48

## Test plan

- [ ] DevTools → Network → Response Headers содержит `Content-Security-Policy`
- [ ] DevTools → Console — нет CSP violation ошибок
- [ ] Smoke: login, навигация, загрузка файла, превью картинки