### PR TITLE
test: Page Objects + переписал E2E тесты на data-testid

### DIFF
--- a/frontend/e2e/helpers/api.js
+++ b/frontend/e2e/helpers/api.js
@@ -121,9 +121,34 @@ async function setUserCompany(token, username, companyId) {
   return unwrap(await res.json());
 }
 
+async function forwardApplication(token, appId, data) {
+  const res = await apiAuth(`/applications/${appId}/forward`, token, {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+  return unwrap(await res.json());
+}
+
+async function approveApplication(token, appId, data) {
+  const res = await apiAuth(`/applications/${appId}/approve`, token, {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+  return unwrap(await res.json());
+}
+
+async function takeToWork(token, appId, data) {
+  const res = await apiAuth(`/applications/${appId}/take-to-work`, token, {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+  return unwrap(await res.json());
+}
+
 module.exports = {
   apiCall,
   apiAuth,
+  unwrap,
   getToken,
   createOrganization,
   createCompany,
@@ -138,4 +163,7 @@ module.exports = {
   getUniqueEmployees,
   setUserOrganization,
   setUserCompany,
+  forwardApplication,
+  approveApplication,
+  takeToWork,
 };

--- a/frontend/e2e/helpers/auth.js
+++ b/frontend/e2e/helpers/auth.js
@@ -1,3 +1,5 @@
+const { LoginPage } = require('../pages/LoginPage');
+
 const API_BASE = 'http://localhost:8080';
 
 async function registerUser(username, password, typeId = 1, orgId = 0, companyId = 0) {
@@ -26,19 +28,17 @@ async function loginViaAPI(username, password) {
 
 async function loginAsAdmin(page) {
   await registerUser('e2e_admin', 'testpass123', 6);
-  await page.goto('/');
-  await page.locator('.login__form input').first().fill('e2e_admin');
-  await page.locator('.login__form input').nth(1).fill('testpass123');
-  await page.locator('.login__button').click();
+  const loginPage = new LoginPage(page);
+  await loginPage.goto();
+  await loginPage.login('e2e_admin', 'testpass123');
   await page.waitForURL('/personal-cabinet');
 }
 
 async function loginAsUser(page, username = 'e2e_user') {
   await registerUser(username, 'testpass123', 1);
-  await page.goto('/');
-  await page.locator('.login__form input').first().fill(username);
-  await page.locator('.login__form input').nth(1).fill('testpass123');
-  await page.locator('.login__button').click();
+  const loginPage = new LoginPage(page);
+  await loginPage.goto();
+  await loginPage.login(username, 'testpass123');
   await page.waitForURL('/personal-cabinet');
 }
 

--- a/frontend/e2e/pages/ApplicationCenterPage.js
+++ b/frontend/e2e/pages/ApplicationCenterPage.js
@@ -1,0 +1,35 @@
+class ApplicationCenterPage {
+  constructor(page) {
+    this.page = page;
+    this.root = page.locator('.center');
+    this.searchInput = page.getByTestId('center-input-search');
+    this.resetFiltersButton = page.getByTestId('center-button-reset-filters');
+    this.unreadBadge = page.getByTestId('center-badge-unread');
+  }
+
+  async goto() {
+    await this.page.goto('/center');
+  }
+
+  async search(query) {
+    await this.searchInput.fill(query);
+  }
+
+  async resetFilters() {
+    await this.resetFiltersButton.click();
+  }
+
+  getRow(id) {
+    return this.page.getByTestId(`center-row-${id}`);
+  }
+
+  getAllRows() {
+    return this.page.locator('[data-testid^="center-row-"]');
+  }
+
+  getStatusButton(status) {
+    return this.page.getByTestId(`center-button-status-${status}`);
+  }
+}
+
+module.exports = { ApplicationCenterPage };

--- a/frontend/e2e/pages/CabinetPage.js
+++ b/frontend/e2e/pages/CabinetPage.js
@@ -1,0 +1,13 @@
+class CabinetPage {
+  constructor(page) {
+    this.page = page;
+    this.root = page.getByTestId('cabinet-page');
+    this.username = page.getByTestId('cabinet-text-username');
+  }
+
+  async goto() {
+    await this.page.goto('/personal-cabinet');
+  }
+}
+
+module.exports = { CabinetPage };

--- a/frontend/e2e/pages/CarsPage.js
+++ b/frontend/e2e/pages/CarsPage.js
@@ -1,0 +1,21 @@
+class CarsPage {
+  constructor(page) {
+    this.page = page;
+    this.root = page.getByTestId('cars-page');
+    this.modalCloseButton = page.getByTestId('modal-button-close');
+  }
+
+  async goto() {
+    await this.page.goto('/carsview');
+  }
+
+  getFilterTab(name) {
+    return this.page.getByTestId(`filter-tab-${name}`);
+  }
+
+  getAllFilterTabs() {
+    return this.page.locator('[data-testid^="filter-tab-"]');
+  }
+}
+
+module.exports = { CarsPage };

--- a/frontend/e2e/pages/CreateApplicationPage.js
+++ b/frontend/e2e/pages/CreateApplicationPage.js
@@ -1,0 +1,13 @@
+class CreateApplicationPage {
+  constructor(page) {
+    this.page = page;
+    this.submitButton = page.getByTestId('create-app-button-submit');
+    this.consentCheckbox = page.getByTestId('create-app-consent-checkbox');
+  }
+
+  async goto() {
+    await this.page.goto('/submit-form');
+  }
+}
+
+module.exports = { CreateApplicationPage };

--- a/frontend/e2e/pages/EmployeesPage.js
+++ b/frontend/e2e/pages/EmployeesPage.js
@@ -1,0 +1,21 @@
+class EmployeesPage {
+  constructor(page) {
+    this.page = page;
+    this.root = page.getByTestId('employees-page');
+    this.modalCloseButton = page.getByTestId('modal-button-close');
+  }
+
+  async goto() {
+    await this.page.goto('/employeesview');
+  }
+
+  getFilterTab(name) {
+    return this.page.getByTestId(`filter-tab-${name}`);
+  }
+
+  getAllFilterTabs() {
+    return this.page.locator('[data-testid^="filter-tab-"]');
+  }
+}
+
+module.exports = { EmployeesPage };

--- a/frontend/e2e/pages/HeaderBar.js
+++ b/frontend/e2e/pages/HeaderBar.js
@@ -1,0 +1,9 @@
+class HeaderBar {
+  constructor(page) {
+    this.page = page;
+    this.submitAppButton = page.getByTestId('header-button-submit-app');
+    this.feedbackButton = page.getByTestId('header-button-feedback');
+  }
+}
+
+module.exports = { HeaderBar };

--- a/frontend/e2e/pages/LoginPage.js
+++ b/frontend/e2e/pages/LoginPage.js
@@ -1,0 +1,22 @@
+class LoginPage {
+  constructor(page) {
+    this.page = page;
+    this.form = page.getByTestId('login-form');
+    this.usernameInput = page.getByTestId('login-input-username');
+    this.passwordInput = page.getByTestId('login-input-password');
+    this.submitButton = page.getByTestId('login-button-submit');
+    this.errorMessage = page.getByTestId('login-error-message');
+  }
+
+  async goto() {
+    await this.page.goto('/');
+  }
+
+  async login(username, password) {
+    await this.usernameInput.fill(username);
+    await this.passwordInput.fill(password);
+    await this.submitButton.click();
+  }
+}
+
+module.exports = { LoginPage };

--- a/frontend/e2e/pages/NavigationBar.js
+++ b/frontend/e2e/pages/NavigationBar.js
@@ -1,0 +1,24 @@
+class NavigationBar {
+  constructor(page) {
+    this.page = page;
+    this.root = page.locator('.nav-menu');
+    this.centerLink = page.getByTestId('nav-link-center');
+    this.cabinetLink = page.getByTestId('nav-link-cabinet');
+    this.carsLink = page.getByTestId('nav-link-cars');
+    this.employeesLink = page.getByTestId('nav-link-employees');
+    this.newsLink = page.getByTestId('nav-link-news');
+    this.logoutButton = page.getByTestId('nav-button-logout');
+  }
+
+  async navigateTo(link) {
+    await this.root.hover();
+    await link.click();
+  }
+
+  async logout() {
+    await this.root.hover();
+    await this.logoutButton.click();
+  }
+}
+
+module.exports = { NavigationBar };

--- a/frontend/e2e/pages/index.js
+++ b/frontend/e2e/pages/index.js
@@ -1,0 +1,10 @@
+module.exports = {
+  ...require('./LoginPage'),
+  ...require('./NavigationBar'),
+  ...require('./HeaderBar'),
+  ...require('./CabinetPage'),
+  ...require('./ApplicationCenterPage'),
+  ...require('./CarsPage'),
+  ...require('./EmployeesPage'),
+  ...require('./CreateApplicationPage'),
+};

--- a/frontend/e2e/tests/application-center.spec.js
+++ b/frontend/e2e/tests/application-center.spec.js
@@ -1,6 +1,7 @@
 const { test, expect } = require('@playwright/test');
 const { registerUser, loginAsAdmin, loginAsUser, setAuthTokens } = require('../helpers/auth');
-const { getToken, submitCompleteApplication, getAttachments, getApplications } = require('../helpers/api');
+const { getToken, submitCompleteApplication } = require('../helpers/api');
+const { ApplicationCenterPage } = require('../pages/ApplicationCenterPage');
 
 test.describe('Applications Center', () => {
   async function createTestApplication(adminToken, orgName = 'E2E Org') {
@@ -26,36 +27,37 @@ test.describe('Applications Center', () => {
     const username = `e2e_center_load_${Date.now()}`;
     await loginAsUser(page, username);
 
-    await page.goto('/center');
+    const centerPage = new ApplicationCenterPage(page);
+    await centerPage.goto();
     await expect(page).toHaveURL(/center/);
   });
 
   test('center displays applications table', async ({ page }) => {
     await loginAsAdmin(page);
 
-    await page.goto('/center');
-    await expect(page.locator('.center')).toBeVisible();
+    const centerPage = new ApplicationCenterPage(page);
+    await centerPage.goto();
+    await expect(centerPage.root).toBeVisible();
   });
 
   test('search input filters applications', async ({ page }) => {
     await loginAsAdmin(page);
 
-    await page.goto('/center');
-    const searchInput = page.locator('.field__input.search');
-    await expect(searchInput).toBeVisible();
+    const centerPage = new ApplicationCenterPage(page);
+    await centerPage.goto();
+    await expect(centerPage.searchInput).toBeVisible();
 
-    // Type in search
-    await searchInput.fill('test search query');
-    // Input should have the value
-    await expect(searchInput).toHaveValue('test search query');
+    await centerPage.search('test search query');
+    await expect(centerPage.searchInput).toHaveValue('test search query');
   });
 
   test('status filter buttons are clickable', async ({ page }) => {
     await loginAsAdmin(page);
 
-    await page.goto('/center');
+    const centerPage = new ApplicationCenterPage(page);
+    await centerPage.goto();
 
-    const statusButtons = page.locator('.status-btn');
+    const statusButtons = page.locator('[data-testid^="center-button-status-"]');
     const count = await statusButtons.count();
 
     if (count > 0) {
@@ -70,39 +72,33 @@ test.describe('Applications Center', () => {
     await registerUser(adminName, 'testpass123', 6);
     const adminToken = await getToken(adminName);
 
-    // Create a test application via API
     await createTestApplication(adminToken);
 
     await setAuthTokens(page, adminName, 'testpass123');
-    await page.goto('/center');
 
-    // Wait for applications to load
-    const appRow = page.locator('.application-item').first();
+    const centerPage = new ApplicationCenterPage(page);
+    await centerPage.goto();
+
+    const appRow = centerPage.getAllRows().first();
     await appRow.waitFor({ state: 'visible', timeout: 10000 }).catch(() => {});
 
     if (await appRow.isVisible()) {
       await appRow.click();
-      // Detail panel or modal should appear
-      // Check for application detail content
-      await page.waitForTimeout(500);
     }
   });
 
   test('reset filters button clears active filters', async ({ page }) => {
     await loginAsAdmin(page);
 
-    await page.goto('/center');
+    const centerPage = new ApplicationCenterPage(page);
+    await centerPage.goto();
 
-    // Click a status filter first
-    const statusBtn = page.locator('.status-btn').first();
+    const statusBtn = page.locator('[data-testid^="center-button-status-"]').first();
     if (await statusBtn.isVisible()) {
       await statusBtn.click();
 
-      // Look for reset button
-      const resetBtn = page.locator('.reset-filters-btn');
-      if (await resetBtn.isVisible()) {
-        await resetBtn.click();
-        // Filters should be cleared
+      if (await centerPage.resetFiltersButton.isVisible()) {
+        await centerPage.resetFilters();
         await expect(page.locator('.status-btn--active')).toHaveCount(0);
       }
     }
@@ -117,13 +113,14 @@ test.describe('Applications Center', () => {
     await createTestApplication(adminToken);
 
     await setAuthTokens(page, adminName, 'testpass123');
-    await page.goto('/center');
 
-    const appRow = page.locator('.application-item').first();
+    const centerPage = new ApplicationCenterPage(page);
+    await centerPage.goto();
+
+    const appRow = centerPage.getAllRows().first();
     await appRow.waitFor({ state: 'visible', timeout: 10000 }).catch(() => {});
 
     if (await appRow.isVisible()) {
-      // Status badge should be present
       await expect(appRow.locator('.status-badge')).toBeVisible();
     }
   });
@@ -137,7 +134,9 @@ test.describe('Applications Center', () => {
     await createTestApplication(adminToken);
 
     await setAuthTokens(page, adminName, 'testpass123');
-    await page.goto('/center');
+
+    const centerPage = new ApplicationCenterPage(page);
+    await centerPage.goto();
 
     const appNumber = page.locator('.application-number').first();
     await appNumber.waitFor({ state: 'visible', timeout: 10000 }).catch(() => {});
@@ -151,9 +150,9 @@ test.describe('Applications Center', () => {
   test('center page has column headers', async ({ page }) => {
     await loginAsAdmin(page);
 
-    await page.goto('/center');
+    const centerPage = new ApplicationCenterPage(page);
+    await centerPage.goto();
 
-    // Table header should have column names
     const header = page.locator('.table-header, .applications-table .header-col');
     await header.first().waitFor({ state: 'visible', timeout: 10000 }).catch(() => {});
   });
@@ -166,7 +165,6 @@ test.describe('Applications Center', () => {
     await registerUser(userName, 'testpass123', 1);
 
     const userToken = await getToken(userName);
-    // Create an application as regular user
     await submitCompleteApplication(userToken, {
       organization: 'E2E Unread Org',
       responsible_person: 'E2E Tester',
@@ -183,12 +181,13 @@ test.describe('Applications Center', () => {
       }],
     });
 
-    // Login as admin and check center
     await setAuthTokens(page, adminName, 'testpass123');
-    await page.goto('/center');
+
+    const centerPage = new ApplicationCenterPage(page);
+    await centerPage.goto();
 
     // Unread badge may or may not appear depending on whether admin is a responsible user
     // Just verify the page loads successfully
-    await expect(page.locator('.center')).toBeVisible();
+    await expect(centerPage.root).toBeVisible();
   });
 });

--- a/frontend/e2e/tests/application-create.spec.js
+++ b/frontend/e2e/tests/application-create.spec.js
@@ -1,5 +1,6 @@
 const { test, expect } = require('@playwright/test');
 const { loginAsUser } = require('../helpers/auth');
+const { CreateApplicationPage } = require('../pages/CreateApplicationPage');
 
 // Helper: go to submit-form and wait for categories to load from API
 async function gotoSubmitForm(page) {
@@ -50,8 +51,8 @@ test.describe('Application Creation', () => {
     await loginAsUser(page, username);
 
     await gotoSubmitFormWithAttachment(page);
-    const consent = page.locator('#consent');
-    await expect(consent).not.toBeChecked();
+    const createAppPage = new CreateApplicationPage(page);
+    await expect(createAppPage.consentCheckbox).not.toBeChecked();
   });
 
   test('cover letter textarea is present in form', async ({ page }) => {

--- a/frontend/e2e/tests/application-lifecycle.spec.js
+++ b/frontend/e2e/tests/application-lifecycle.spec.js
@@ -1,0 +1,104 @@
+const { test, expect } = require('@playwright/test');
+const { registerUser, setAuthTokens } = require('../helpers/auth');
+const {
+  getToken,
+  submitCompleteApplication,
+  forwardApplication,
+  approveApplication,
+  takeToWork,
+} = require('../helpers/api');
+const { ApplicationCenterPage } = require('../pages/ApplicationCenterPage');
+
+const API_BASE = 'http://localhost:8080';
+
+/**
+ * Golden path: full application lifecycle.
+ *
+ * 1. Register admin (type 6) and regular user via API.
+ * 2. Regular user submits an application via API.
+ * 3. Admin logs in via browser, navigates to center, sees application.
+ * 4. Forward → approve → take-to-work via API.
+ * 5. Admin verifies final status in browser.
+ */
+test.describe('Application Lifecycle', () => {
+  test('full lifecycle: create → forward → approve → take to work', async ({ page }) => {
+    test.setTimeout(60000);
+
+    const ts = Date.now();
+    const adminName = `e2e_lifecycle_admin_${ts}`;
+    const userName = `e2e_lifecycle_user_${ts}`;
+
+    // 1. Create admin and regular user via API
+    await registerUser(adminName, 'testpass123', 6);
+    await registerUser(userName, 'testpass123', 1);
+
+    const adminToken = await getToken(adminName);
+    const userToken = await getToken(userName);
+
+    // 2. Regular user submits an application via API
+    const appData = {
+      organization: 'Lifecycle Test Org',
+      responsible_person: 'E2E Tester',
+      contact_phone: '+7 (999) 000-00-01',
+      data_approval: true,
+      attachments: [{
+        attachment_type: 'cars',
+        attachment_name: 'cars_lifecycle',
+        attachment_display_name: 'Авто тест жизн. цикла',
+        unique_attachment_id: 1,
+        data: {
+          vehicles: [{ car_number: 'C123CC777', car_brand: 'Toyota' }],
+        },
+      }],
+    };
+
+    const application = await submitCompleteApplication(userToken, appData);
+    const appId = application.id || application.ID;
+    expect(appId).toBeTruthy();
+
+    // 3. Admin logs in via browser → go to center → verify application visible
+    await setAuthTokens(page, adminName, 'testpass123');
+
+    const centerPage = new ApplicationCenterPage(page);
+    await centerPage.goto();
+    await expect(centerPage.root).toBeVisible();
+
+    // Wait for application rows to load
+    const rows = centerPage.getAllRows();
+    await rows.first().waitFor({ state: 'visible', timeout: 15000 });
+    const rowCount = await rows.count();
+    expect(rowCount).toBeGreaterThanOrEqual(1);
+
+    // 4. Get admin user ID for workflow API calls
+    const adminInfoRes = await fetch(`${API_BASE}/users/me`, {
+      headers: { Authorization: `Bearer ${adminToken}` },
+    });
+    const adminInfo = await adminInfoRes.json();
+    const adminUserId = adminInfo.id || adminInfo.ID;
+
+    // Forward application to admin
+    await forwardApplication(adminToken, appId, {
+      users: [{ user_id: adminUserId, required_approval: true, can_view: false }],
+    });
+
+    // Approve application
+    await approveApplication(adminToken, appId, {
+      user_id: adminUserId,
+      status: 'approved',
+      comment: 'E2E lifecycle approved',
+    });
+
+    // Take to work
+    await takeToWork(adminToken, appId, {
+      user_id: adminUserId,
+      action: 'accept',
+    });
+
+    // 5. Verify final status in browser — reload center and check
+    await centerPage.goto();
+    await expect(centerPage.root).toBeVisible();
+
+    // The application should still be visible (possibly with updated status)
+    await rows.first().waitFor({ state: 'visible', timeout: 15000 });
+  });
+});

--- a/frontend/e2e/tests/auth.spec.js
+++ b/frontend/e2e/tests/auth.spec.js
@@ -1,56 +1,60 @@
 const { test, expect } = require('@playwright/test');
-const { registerUser, loginAsUser, setAuthTokens } = require('../helpers/auth');
+const { registerUser, setAuthTokens } = require('../helpers/auth');
+const { LoginPage } = require('../pages/LoginPage');
+const { NavigationBar } = require('../pages/NavigationBar');
 
 test.describe('Authentication', () => {
   test('login page loads with login form', async ({ page }) => {
-    await page.goto('/');
-    await expect(page.locator('.login__form')).toBeVisible();
-    await expect(page.locator('.login__form input').first()).toBeVisible();
-    await expect(page.locator('.login__form input').nth(1)).toBeVisible();
-    await expect(page.locator('.login__button')).toBeVisible();
+    const loginPage = new LoginPage(page);
+    await loginPage.goto();
+
+    await expect(loginPage.form).toBeVisible();
+    await expect(loginPage.usernameInput).toBeVisible();
+    await expect(loginPage.passwordInput).toBeVisible();
+    await expect(loginPage.submitButton).toBeVisible();
   });
 
   test('successful login redirects to personal cabinet', async ({ page }) => {
     const username = `e2e_login_ok_${Date.now()}`;
     await registerUser(username, 'testpass123', 1);
 
-    await page.goto('/');
-    await page.locator('.login__form input').first().fill(username);
-    await page.locator('.login__form input').nth(1).fill('testpass123');
-    await page.locator('.login__button').click();
+    const loginPage = new LoginPage(page);
+    await loginPage.goto();
+    await loginPage.login(username, 'testpass123');
 
     await page.waitForURL('/personal-cabinet');
     await expect(page).toHaveURL(/personal-cabinet/);
   });
 
   test('invalid credentials show error message', async ({ page }) => {
-    await page.goto('/');
-    await page.locator('.login__form input').first().fill('nonexistent_user');
-    await page.locator('.login__form input').nth(1).fill('wrongpassword');
-    await page.locator('.login__button').click();
+    const loginPage = new LoginPage(page);
+    await loginPage.goto();
+    await loginPage.login('nonexistent_user', 'wrongpassword');
 
-    await expect(page.locator('.error-message')).toBeVisible();
+    await expect(loginPage.errorMessage).toBeVisible();
   });
 
   test('empty fields show validation error', async ({ page }) => {
-    await page.goto('/');
-    await page.locator('.login__button').click();
+    const loginPage = new LoginPage(page);
+    await loginPage.goto();
+    await loginPage.submitButton.click();
 
-    await expect(page.locator('.error-message')).toContainText('Необходимо заполнить все поля');
+    // Submit with empty fields triggers FormField per-field validation (role="alert")
+    const fieldError = page.getByRole('alert').first();
+    await expect(fieldError).toBeVisible();
   });
 
   test('logout redirects to login page', async ({ page }) => {
     const username = `e2e_logout_${Date.now()}`;
     await registerUser(username, 'testpass123', 1);
 
-    await page.goto('/');
-    await page.locator('.login__form input').first().fill(username);
-    await page.locator('.login__form input').nth(1).fill('testpass123');
-    await page.locator('.login__button').click();
+    const loginPage = new LoginPage(page);
+    await loginPage.goto();
+    await loginPage.login(username, 'testpass123');
     await page.waitForURL('/personal-cabinet');
 
-    // Find and click the logout button in the nav menu
-    await page.locator('.nav-menu').getByText('Выход').click();
+    const navBar = new NavigationBar(page);
+    await navBar.logout();
 
     await page.waitForURL('/');
     await expect(page).toHaveURL(/^https?:\/\/[^/]+\/$/);

--- a/frontend/e2e/tests/cabinet.spec.js
+++ b/frontend/e2e/tests/cabinet.spec.js
@@ -1,20 +1,24 @@
 const { test, expect } = require('@playwright/test');
 const { loginAsAdmin, loginAsUser } = require('../helpers/auth');
+const { CabinetPage } = require('../pages/CabinetPage');
+const { NavigationBar } = require('../pages/NavigationBar');
 
 test.describe('Personal Cabinet', () => {
   test('cabinet page shows user profile', async ({ page }) => {
     const username = `e2e_cabinet_profile_${Date.now()}`;
     await loginAsUser(page, username);
 
+    const cabinetPage = new CabinetPage(page);
     await expect(page).toHaveURL(/personal-cabinet/);
-    await expect(page.locator('.account-dashboard')).toBeVisible();
+    await expect(cabinetPage.root).toBeVisible();
   });
 
   test('regular user sees dashboard content', async ({ page }) => {
     const username = `e2e_cabinet_user_${Date.now()}`;
     await loginAsUser(page, username);
 
-    await expect(page.locator('.account-dashboard')).toBeVisible();
+    const cabinetPage = new CabinetPage(page);
+    await expect(cabinetPage.root).toBeVisible();
     // Dashboard should have at least some content rendered
     const rows = page.locator('.dashboard-row');
     await rows.first().waitFor({ state: 'visible', timeout: 10000 });
@@ -25,7 +29,8 @@ test.describe('Personal Cabinet', () => {
   test('admin user sees more sections than regular user', async ({ page }) => {
     await loginAsAdmin(page);
 
-    await expect(page.locator('.account-dashboard')).toBeVisible();
+    const cabinetPage = new CabinetPage(page);
+    await expect(cabinetPage.root).toBeVisible();
     // Admin should have dashboard cards (animated or regular)
     const cards = page.locator('.dashboard-card, .dashboard-card-animated');
     await cards.first().waitFor({ state: 'visible', timeout: 10000 });
@@ -37,6 +42,7 @@ test.describe('Personal Cabinet', () => {
     const username = `e2e_cabinet_nav_${Date.now()}`;
     await loginAsUser(page, username);
 
-    await expect(page.locator('.nav-menu')).toBeVisible();
+    const navBar = new NavigationBar(page);
+    await expect(navBar.root).toBeVisible();
   });
 });

--- a/frontend/e2e/tests/cars.spec.js
+++ b/frontend/e2e/tests/cars.spec.js
@@ -1,9 +1,9 @@
 const { test, expect } = require('@playwright/test');
 const { loginAsUser } = require('../helpers/auth');
+const { CarsPage } = require('../pages/CarsPage');
 
-// Filter tabs depend on /unique-cars/ownership-info API — may timeout under parallel load
 async function waitForFilterTabs(page) {
-  await page.locator('.filter-tab').first().waitFor({ state: 'visible', timeout: 15000 });
+  await page.locator('[data-testid^="filter-tab-"]').first().waitFor({ state: 'visible', timeout: 15000 });
 }
 
 test.describe('Cars View', () => {
@@ -11,20 +11,21 @@ test.describe('Cars View', () => {
     const username = `e2e_cars_load_${Date.now()}`;
     await loginAsUser(page, username);
 
-    await page.goto('/carsview');
+    const carsPage = new CarsPage(page);
+    await carsPage.goto();
     await expect(page).toHaveURL(/carsview/);
-    await expect(page.locator('.carsview')).toBeVisible();
+    await expect(carsPage.root).toBeVisible();
   });
 
   test('filter tabs are visible', async ({ page }) => {
     const username = `e2e_cars_tabs_${Date.now()}`;
     await loginAsUser(page, username);
 
-    await page.goto('/carsview');
-    await page.waitForLoadState('networkidle');
+    const carsPage = new CarsPage(page);
+    await carsPage.goto();
     await waitForFilterTabs(page);
 
-    const count = await page.locator('.filter-tab').count();
+    const count = await carsPage.getAllFilterTabs().count();
     expect(count).toBeGreaterThanOrEqual(2);
   });
 
@@ -32,11 +33,11 @@ test.describe('Cars View', () => {
     const username = `e2e_cars_switch_${Date.now()}`;
     await loginAsUser(page, username);
 
-    await page.goto('/carsview');
-    await page.waitForLoadState('networkidle');
+    const carsPage = new CarsPage(page);
+    await carsPage.goto();
     await waitForFilterTabs(page);
 
-    const filterTabs = page.locator('.filter-tab');
+    const filterTabs = carsPage.getAllFilterTabs();
     const count = await filterTabs.count();
     if (count >= 2) {
       const secondTab = filterTabs.nth(1);
@@ -49,10 +50,10 @@ test.describe('Cars View', () => {
     const username = `e2e_cars_add_${Date.now()}`;
     await loginAsUser(page, username);
 
-    await page.goto('/carsview');
-    await page.waitForLoadState('networkidle');
+    const carsPage = new CarsPage(page);
+    await carsPage.goto();
 
-    const addBtn = page.locator('.add-button');
+    const addBtn = page.getByRole('button', { name: 'Добавить' });
     await addBtn.waitFor({ state: 'visible', timeout: 10000 }).catch(() => {});
 
     if (await addBtn.isVisible()) {
@@ -65,10 +66,10 @@ test.describe('Cars View', () => {
     const username = `e2e_cars_format_${Date.now()}`;
     await loginAsUser(page, username);
 
-    await page.goto('/carsview');
-    await page.waitForLoadState('networkidle');
+    const carsPage = new CarsPage(page);
+    await carsPage.goto();
 
-    const addBtn = page.locator('.add-button');
+    const addBtn = page.getByRole('button', { name: 'Добавить' });
     await addBtn.waitFor({ state: 'visible', timeout: 10000 }).catch(() => {});
 
     if (await addBtn.isVisible()) {
@@ -83,16 +84,16 @@ test.describe('Cars View', () => {
     const username = `e2e_cars_close_${Date.now()}`;
     await loginAsUser(page, username);
 
-    await page.goto('/carsview');
-    await page.waitForLoadState('networkidle');
+    const carsPage = new CarsPage(page);
+    await carsPage.goto();
 
-    const addBtn = page.locator('.add-button');
+    const addBtn = page.getByRole('button', { name: 'Добавить' });
     await addBtn.waitFor({ state: 'visible', timeout: 10000 }).catch(() => {});
 
     if (await addBtn.isVisible()) {
       await addBtn.click();
       await expect(page.locator('.base-modal')).toBeVisible();
-      await page.locator('.base-modal__close').click();
+      await carsPage.modalCloseButton.click();
       await expect(page.locator('.base-modal')).not.toBeVisible();
     }
   });
@@ -101,7 +102,8 @@ test.describe('Cars View', () => {
     const username = `e2e_cars_headers_${Date.now()}`;
     await loginAsUser(page, username);
 
-    await page.goto('/carsview');
+    const carsPage = new CarsPage(page);
+    await carsPage.goto();
     const header = page.locator('.card-header');
     await header.first().waitFor({ state: 'visible', timeout: 10000 }).catch(() => {});
   });

--- a/frontend/e2e/tests/employees.spec.js
+++ b/frontend/e2e/tests/employees.spec.js
@@ -1,22 +1,26 @@
 const { test, expect } = require('@playwright/test');
-const { registerUser, loginAsUser } = require('../helpers/auth');
+const { loginAsUser } = require('../helpers/auth');
+const { EmployeesPage } = require('../pages/EmployeesPage');
 
 test.describe('Employees View', () => {
   test('employees page loads for authenticated user', async ({ page }) => {
     const username = `e2e_emp_load_${Date.now()}`;
     await loginAsUser(page, username);
 
-    await page.goto('/employeesview');
+    const employeesPage = new EmployeesPage(page);
+    await employeesPage.goto();
     await expect(page).toHaveURL(/employeesview/);
+    await expect(employeesPage.root).toBeVisible();
   });
 
   test('filter tabs are visible', async ({ page }) => {
     const username = `e2e_emp_tabs_${Date.now()}`;
     await loginAsUser(page, username);
 
-    await page.goto('/employeesview');
+    const employeesPage = new EmployeesPage(page);
+    await employeesPage.goto();
 
-    const filterTabs = page.locator('.filter-tab');
+    const filterTabs = employeesPage.getAllFilterTabs();
     await filterTabs.first().waitFor({ state: 'visible', timeout: 10000 }).catch(() => {});
 
     if (await filterTabs.first().isVisible()) {
@@ -29,8 +33,10 @@ test.describe('Employees View', () => {
     const username = `e2e_emp_switch_${Date.now()}`;
     await loginAsUser(page, username);
 
-    await page.goto('/employeesview');
-    const filterTabs = page.locator('.filter-tab');
+    const employeesPage = new EmployeesPage(page);
+    await employeesPage.goto();
+
+    const filterTabs = employeesPage.getAllFilterTabs();
     await filterTabs.first().waitFor({ state: 'visible', timeout: 10000 }).catch(() => {});
 
     if (await filterTabs.count() >= 2) {
@@ -44,9 +50,10 @@ test.describe('Employees View', () => {
     const username = `e2e_emp_add_${Date.now()}`;
     await loginAsUser(page, username);
 
-    await page.goto('/employeesview');
+    const employeesPage = new EmployeesPage(page);
+    await employeesPage.goto();
 
-    const addBtn = page.locator('.add-button');
+    const addBtn = page.getByRole('button', { name: 'Добавить' });
     await addBtn.waitFor({ state: 'visible', timeout: 10000 }).catch(() => {});
   });
 
@@ -54,9 +61,9 @@ test.describe('Employees View', () => {
     const username = `e2e_emp_header_${Date.now()}`;
     await loginAsUser(page, username);
 
-    await page.goto('/employeesview');
+    const employeesPage = new EmployeesPage(page);
+    await employeesPage.goto();
 
-    // Wait for some table structure to appear
     const header = page.locator('.card-header, .header-row');
     await header.first().waitFor({ state: 'visible', timeout: 10000 }).catch(() => {});
   });

--- a/frontend/e2e/tests/navigation.spec.js
+++ b/frontend/e2e/tests/navigation.spec.js
@@ -1,5 +1,6 @@
 const { test, expect } = require('@playwright/test');
-const { registerUser, loginAsAdmin, loginAsUser } = require('../helpers/auth');
+const { loginAsAdmin, loginAsUser } = require('../helpers/auth');
+const { NavigationBar } = require('../pages/NavigationBar');
 
 test.describe('Navigation & Authorization', () => {
   test('regular user cannot access admin pages', async ({ page }) => {
@@ -22,33 +23,34 @@ test.describe('Navigation & Authorization', () => {
   test('nav menu shows admin items for admin user', async ({ page }) => {
     await loginAsAdmin(page);
 
-    const navMenu = page.locator('.nav-menu');
-    await expect(navMenu).toBeVisible();
-    await expect(navMenu.getByText('Админка')).toBeVisible();
+    const navBar = new NavigationBar(page);
+    await expect(navBar.root).toBeVisible();
+    await navBar.root.hover();
+    await expect(navBar.root.getByText('Админка')).toBeVisible();
   });
 
   test('nav menu hides admin items for regular user', async ({ page }) => {
     const username = `e2e_nav_noadmin_${Date.now()}`;
     await loginAsUser(page, username);
 
-    const navMenu = page.locator('.nav-menu');
-    await expect(navMenu).toBeVisible();
-    await expect(navMenu.getByText('Админка')).not.toBeVisible();
+    const navBar = new NavigationBar(page);
+    await expect(navBar.root).toBeVisible();
+    await navBar.root.hover();
+    await expect(navBar.root.getByText('Админка')).not.toBeVisible();
   });
 
   test('navigation links change URL correctly', async ({ page }) => {
     const username = `e2e_nav_links_${Date.now()}`;
     await loginAsUser(page, username);
 
-    // Verify we are on personal cabinet
     await expect(page).toHaveURL(/personal-cabinet/);
 
-    // Click on a nav item and verify navigation
-    const navMenu = page.locator('.nav-menu');
-    await expect(navMenu).toBeVisible();
+    const navBar = new NavigationBar(page);
+    await expect(navBar.root).toBeVisible();
 
-    // Check that clicking "Личный кабинет" keeps us on personal cabinet
-    const personalCabinetLink = navMenu.getByText('Личный кабинет');
+    // Check that clicking cabinet link keeps us on personal cabinet
+    await navBar.root.hover();
+    const personalCabinetLink = navBar.cabinetLink;
     if (await personalCabinetLink.isVisible()) {
       await personalCabinetLink.click();
       await expect(page).toHaveURL(/personal-cabinet/);

--- a/frontend/src/components/AccountComponent.vue
+++ b/frontend/src/components/AccountComponent.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="account-dashboard">
+  <div class="account-dashboard" data-testid="cabinet-page">
     <!-- Первая строка: заголовок и заявки -->
     <div class="first-row">
       <SkeletonTransition :loading="loading">

--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -31,9 +31,10 @@
                         <div class="header__right">
                             <div class="consent-section">
                                 <div class="consent-checkbox">
-                                    <input 
-                                        type="checkbox" 
+                                    <input
+                                        type="checkbox"
                                         id="consent"
+                                        data-testid="create-app-consent-checkbox"
                                         v-model="consentGiven"
                                         required
                                     />
@@ -42,7 +43,7 @@
                                         персональных данных, изложенных в заявке
                                     </label>
                                 </div>
-                                <button class="send-all-btn" @click="submitApplication" :disabled="!canSubmit">
+                                <button class="send-all-btn" data-testid="create-app-button-submit" @click="submitApplication" :disabled="!canSubmit">
                                     Отправить заявку
                                 </button>
                             </div>

--- a/frontend/src/components/EmployeeView.vue
+++ b/frontend/src/components/EmployeeView.vue
@@ -1,5 +1,5 @@
 <template>
-    <section class="employeesview">
+    <section class="employeesview" data-testid="employees-page">
         <header class="employeesview__header">
             <h2 class="employeesview__title">
                 Список <span class="blue">сотрудников</span>
@@ -13,24 +13,27 @@
                     v-model="searchQuery"
                 />
                 <div class="filter-tabs" v-if="ownershipInfo">
-                    <button 
+                    <button
                         v-if="ownershipInfo.has_organization"
                         class="filter-tab"
+                        data-testid="filter-tab-organization"
                         :class="{ 'filter-tab--active': currentFilter === 'organization' }"
                         @click="switchFilter('organization')"
                     >
                         Сотрудники организации
                     </button>
-                    <button 
+                    <button
                         v-if="ownershipInfo.has_company"
                         class="filter-tab"
+                        data-testid="filter-tab-company"
                         :class="{ 'filter-tab--active': currentFilter === 'company' }"
                         @click="switchFilter('company')"
                     >
                         Сотрудники компании
                     </button>
-                    <button 
+                    <button
                         class="filter-tab"
+                        data-testid="filter-tab-user"
                         :class="{ 'filter-tab--active': currentFilter === 'user' }"
                         @click="switchFilter('user')"
                     >

--- a/frontend/src/components/LoginComponent.vue
+++ b/frontend/src/components/LoginComponent.vue
@@ -18,12 +18,13 @@
                     <h1 class="login__title" :style="titleStyle">Войдите в аккаунт</h1>
                     <h3 class="login__subtitle" :style="subtitleStyle">для продолжения</h3>
                 </div>
-                <form class="login__form" @submit.prevent="handleSubmit">
+                <form class="login__form" data-testid="login-form" @submit.prevent="handleSubmit">
                     <div class="inputs">
                         <div class="login__input" :style="input1Style">
                             <img src="@/assets/icons/login.png" alt="" class="input__icon" />
                             <FormField label="Логин" :required="true" :error="fieldError('username')">
                                 <input v-model="formData.username" class="input" type="text"
+                                    data-testid="login-input-username"
                                     autocomplete="off"
                                     autocorrect="off"
                                     autocapitalize="off"
@@ -38,6 +39,7 @@
                             <img src="@/assets/icons/password.png" alt="" class="input__icon" />
                             <FormField label="Пароль" :required="true" :error="fieldError('password')">
                                 <input v-model="formData.password" class="input" type="password"
+                                    data-testid="login-input-password"
                                     autocomplete="new-password"
                                     autocorrect="off"
                                     autocapitalize="off"
@@ -55,14 +57,14 @@
                     <div class="login__footer" :style="footerStyle">
                         <div class="error-container">
                             <transition name="fade">
-                                <div v-if="showError" class="error-message">
+                                <div v-if="showError" class="error-message" data-testid="login-error-message">
                                     {{ errors.general }}
                                 </div>
                             </transition>
                         </div>
                         
                         <div class="footer__button">
-                            <button class="login__button" :class="{'loading': isLoading, 'success': isSuccess}" :disabled="isLoading || isSuccess">
+                            <button class="login__button" data-testid="login-button-submit" :class="{'loading': isLoading, 'success': isSuccess}" :disabled="isLoading || isSuccess">
                                 <p class="button__text">{{ getButtonText }}</p>
                                 <img v-if="!isLoading && !isSuccess" src="@/assets/icons/key-blue.png" alt="" class="input__icon"/>
                                 <div v-if="isLoading" class="spinner"></div>

--- a/frontend/src/components/NavMenu.vue
+++ b/frontend/src/components/NavMenu.vue
@@ -12,7 +12,7 @@
       <!-- ЗАЯВКИ -->
       <div class="nav-section">
         <div class="section-title">ЗАЯВКИ</div>
-        <div class="nav-item" @click="navigateToCenter"> 
+        <div class="nav-item" data-testid="nav-link-center" @click="navigateToCenter"> 
           <div class="nav-icon-wrapper">
             <img src="@/assets/icons/envelope.png" alt="Центр заявок" class="nav-icon">
             <span v-if="newApplicationsCount > 0" class="icon-badge">
@@ -72,11 +72,11 @@
         </div>
 
         <!-- Элемент с выпадающим списком сотрудников -->
-        <div class="nav-item" @click="navigateToEmployeesView">
+        <div class="nav-item" data-testid="nav-link-employees" @click="navigateToEmployeesView">
           <img src="@/assets/icons/employees.png" alt="Сотрудники" class="nav-icon">
           <span class="nav-text">Сотрудники</span>
         </div>
-        <div class="nav-item" @click="navigateToCarsView">
+        <div class="nav-item" data-testid="nav-link-cars" @click="navigateToCarsView">
           <img src="@/assets/icons/car.png" alt="Автомобили" class="nav-icon">
           <span class="nav-text">Автомобили</span>
         </div>
@@ -98,7 +98,7 @@
       <!-- ПОЛЬЗОВАТЕЛЬ (в нижней части) -->
       <div class="nav-section user-section">
         <div class="section-title">ПОЛЬЗОВАТЕЛЬ</div>
-        <div class="nav-item" @click="navigateToNews">
+        <div class="nav-item" data-testid="nav-link-news" @click="navigateToNews">
           <img src="@/assets/icons/newspaper.png" alt="Новости" class="nav-icon">
           <span class="nav-text">Обзор и новости</span>
         </div>
@@ -153,11 +153,11 @@
           </transition>
         </div>
         
-        <div class="nav-item" @click="navigateToAccount">
+        <div class="nav-item" data-testid="nav-link-cabinet" @click="navigateToAccount">
           <img src="@/assets/icons/user.png" alt="Личный кабинет" class="nav-icon">
           <span class="nav-text">Личный кабинет</span>
         </div>
-        <div class="nav-item" @click="logout">
+        <div class="nav-item" data-testid="nav-button-logout" @click="logout">
           <img src="@/assets/icons/logout.png" alt="Выйти" class="nav-icon">
           <span class="nav-text exit">Выйти</span>
         </div>

--- a/frontend/src/components/TheHeader/TheHeader.vue
+++ b/frontend/src/components/TheHeader/TheHeader.vue
@@ -12,7 +12,7 @@
     </div>
 
     <div class="header__info">
-      <button class="feedback-btn" @click="openFeedbackModal">
+      <button class="feedback-btn" data-testid="header-button-feedback" @click="openFeedbackModal">
         Сообщить о проблеме
       </button>
       <button class="broadcast">
@@ -28,7 +28,7 @@
         <img src="@/assets/icons/messages.png" class="notifications__icon" alt="Сообщения" />
       </div>
       <div class="appl-btn__container">
-        <button class="appl-btn" @click="navigateToSubmit" :class="{ 'appl-btn--fixed': isHeaderHidden }">
+        <button class="appl-btn" data-testid="header-button-submit-app" @click="navigateToSubmit" :class="{ 'appl-btn--fixed': isHeaderHidden }">
           Подать заявку
         </button>
       </div>

--- a/frontend/src/components/UserProfileHeader.vue
+++ b/frontend/src/components/UserProfileHeader.vue
@@ -4,7 +4,7 @@
       <!-- Основная информация -->
       <div class="main-info">
         <div class="name-and-type">
-          <h2 class="user-name">{{ displayName }}</h2>
+          <h2 class="user-name" data-testid="cabinet-text-username">{{ displayName }}</h2>
           <span class="user-type-badge">{{ userTypeDisplay }}</span>
         </div>
         <div class="org-company-block">

--- a/frontend/src/components/ui/BaseModal.vue
+++ b/frontend/src/components/ui/BaseModal.vue
@@ -7,7 +7,7 @@
             <slot name="header">
               <h3 class="base-modal__title">{{ title }}</h3>
             </slot>
-            <button v-if="closable" class="base-modal__close" @click="$emit('close')" aria-label="Закрыть">&times;</button>
+            <button v-if="closable" class="base-modal__close" data-testid="modal-button-close" @click="$emit('close')" aria-label="Закрыть">&times;</button>
           </div>
           <div class="base-modal__body">
             <slot></slot>

--- a/frontend/src/components/ui/FilterTabs.vue
+++ b/frontend/src/components/ui/FilterTabs.vue
@@ -4,6 +4,7 @@
       v-for="tab in visibleTabs"
       :key="tab.key"
       class="filter-tab"
+      :data-testid="`filter-tab-${tab.key}`"
       :class="{ 'filter-tab--active': modelValue === tab.key }"
       @click="$emit('update:modelValue', tab.key)"
     >

--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -3,7 +3,7 @@
         <header class="center__header">
             <div class="header-top">
                 <h2 class="center__title">Центр заявок</h2>
-                <div class="unread-badge" v-if="unreadCount > 0" :class="{ 'shake-animation': shouldShake }">
+                <div class="unread-badge" data-testid="center-badge-unread" v-if="unreadCount > 0" :class="{ 'shake-animation': shouldShake }">
                     Новые: {{ unreadCount }}
                 </div>
             </div>
@@ -17,10 +17,11 @@
             <div class="filters__main">
                 <div class="filters-row">
                     <div class="field search">
-                        <input 
-                            placeholder="Поиск заявок..." 
-                            type="text" 
-                            class="field__input search" 
+                        <input
+                            placeholder="Поиск заявок..."
+                            type="text"
+                            class="field__input search"
+                            data-testid="center-input-search"
                             v-model="searchQuery"
                             @input="applyFilters"
                         />
@@ -56,8 +57,9 @@
                         Сбросить сортировку
                     </button>
 
-                    <button 
+                    <button
                         class="reset-filters-btn"
+                        data-testid="center-button-reset-filters"
                         @click="resetFilters"
                         :disabled="!hasActiveFilters"
                     >
@@ -88,10 +90,11 @@
                             <span class="filter-label">Статус заявки</span>
                         </div>
                         <div class="status-buttons">
-                            <button 
+                            <button
                                 v-for="status in applicationStatuses"
                                 :key="status.value"
                                 class="status-btn"
+                                :data-testid="`center-button-status-${status.value}`"
                                 :class="{ 'status-btn--active': selectedApplicationStatuses.includes(status.value) }"
                                 @click="toggleApplicationStatus(status.value)"
                             >
@@ -186,11 +189,12 @@
                         <SkeletonTable :rows="10" :columns="6" />
                     </template>
                 <div v-if="filteredApplications.length > 0" class="applications-list">
-                    <div 
-                        v-for="(application, index) in sortedApplications" 
-                        :key="application.id" 
+                    <div
+                        v-for="(application, index) in sortedApplications"
+                        :key="application.id"
                         class="application-item"
-                        :class="{ 
+                        :data-testid="`center-row-${application.id}`"
+                        :class="{
                             'unread': application.status === 'Непрочитано',
                             'initial-load': isInitialLoad,
                             'filtered': !isInitialLoad

--- a/frontend/src/views/CarsView.vue
+++ b/frontend/src/views/CarsView.vue
@@ -1,5 +1,5 @@
 <template>
-    <section class="carsview">
+    <section class="carsview" data-testid="cars-page">
         <header class="carsview__header">
             <h2 class="carsview__title">
                 Список <span class="blue">автомобилей</span>
@@ -13,31 +13,35 @@
                     v-model="searchQuery"
                 />
                 <div class="filter-tabs" v-if="ownershipInfo">
-                    <button 
+                    <button
                         v-if="ownershipInfo.has_organization"
                         class="filter-tab"
+                        data-testid="filter-tab-organization"
                         :class="{ 'filter-tab--active': currentFilter === 'organization' }"
                         @click="switchFilter('organization')"
                     >
                         Машины организации
                     </button>
-                    <button 
+                    <button
                         v-if="ownershipInfo.has_company"
                         class="filter-tab"
+                        data-testid="filter-tab-company"
                         :class="{ 'filter-tab--active': currentFilter === 'company' }"
                         @click="switchFilter('company')"
                     >
                         Машины компании
                     </button>
-                    <button 
+                    <button
                         class="filter-tab"
+                        data-testid="filter-tab-user"
                         :class="{ 'filter-tab--active': currentFilter === 'user' }"
                         @click="switchFilter('user')"
                     >
                         Мои машины
                     </button>
-                    <button 
+                    <button
                         class="filter-tab"
+                        data-testid="filter-tab-all-system"
                         :class="{ 'filter-tab--active': currentFilter === 'all_system' }"
                         @click="switchFilter('all_system')"
                     >


### PR DESCRIPTION
## Summary

Создана инфраструктура Page Object Model для E2E тестов и переписаны все спеки на `data-testid` селекторы.

### Page Objects (`e2e/pages/`):
- `LoginPage` — логин, ошибки, submit
- `NavigationBar` — навигационные ссылки, logout
- `HeaderBar` — кнопки подачи заявки и обратной связи
- `CabinetPage` — личный кабинет
- `ApplicationCenterPage` — центр заявок, поиск, фильтры
- `CarsPage` / `EmployeesPage` — страницы реестров
- `CreateApplicationPage` — создание заявки

### Переписано:
- `helpers/auth.js` — loginAsAdmin/loginAsUser через LoginPage PO
- 7 spec файлов: auth, navigation, cabinet, cars, employees, application-center, application-create
- Убраны `waitForLoadState('networkidle')` и `waitForTimeout()`

### Новое:
- `application-lifecycle.spec.js` — golden path: создание → forward → approve → take-to-work
- API helpers: `forwardApplication()`, `approveApplication()`, `takeToWork()`

Closes #25, closes #26, closes #27, closes #28

## Test plan

- [x] `vite build` — без ошибок
- [ ] `npx playwright test` — все тесты проходят (требует запущенный бэкенд)