### PR TITLE
test: тесты approval workflow, expired attachments, consent 152-ФЗ

### DIFF
--- a/internal/handlers/applications_approval_test.go
+++ b/internal/handlers/applications_approval_test.go
@@ -1,0 +1,277 @@
+package handlers_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"systemburo/internal/services"
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApprovalWorkflow(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+
+	tests := []struct {
+		name string
+		run  func(t *testing.T)
+	}{
+		{
+			name: "two_required_both_approve_confirmed",
+			run: func(t *testing.T) {
+				testutil.CleanDB(t, db)
+				td := testutil.SeedTestData(t, db)
+
+				senderToken := testutil.RegisterAndLogin(t, e, "ar_sender1", "pass123", 1, td.OrgID, td.CompanyID)
+				appID := createSimpleApplication(t, e, senderToken, td.OrgID)
+
+				// Two required responsible users
+				testutil.RegisterUser(t, e, "ar_resp1a", "pass123", 1, td.OrgID, td.CompanyID)
+				resp1ID := getUserID(t, db, "ar_resp1a")
+				testutil.RegisterUser(t, e, "ar_resp1b", "pass123", 1, td.OrgID, td.CompanyID)
+				resp2ID := getUserID(t, db, "ar_resp1b")
+
+				// Forward with required_approval=true
+				body := fmt.Sprintf(`{"users":[
+					{"user_id":%d,"required_approval":true,"can_view":false},
+					{"user_id":%d,"required_approval":true,"can_view":false}
+				]}`, resp1ID, resp2ID)
+				rec := testutil.POST(t, e, fmt.Sprintf("/applications/%d/forward", appID), body, testutil.AuthHeader(senderToken))
+				require.Equal(t, http.StatusOK, rec.Code, "forward: %s", rec.Body.String())
+
+				// After forward, confirmation should be "Согласование" (pending)
+				rec = testutil.GET(t, e, fmt.Sprintf("/applications/%d/check-approval-status", appID), testutil.AuthHeader(senderToken))
+				require.Equal(t, http.StatusOK, rec.Code)
+				status := testutil.ParseResponse[services.ApprovalStatusResponse](t, rec)
+				require.NotNil(t, status.Confirmation)
+				assert.Equal(t, "Согласование", *status.Confirmation)
+
+				// First user approves
+				resp1Token, _ := testutil.LoginUser(t, e, "ar_resp1a", "pass123")
+				approveBody := fmt.Sprintf(`{"user_id":%d,"status":"approved","comment":"ok"}`, resp1ID)
+				rec = testutil.POST(t, e, fmt.Sprintf("/applications/%d/approve", appID), approveBody, testutil.AuthHeader(resp1Token))
+				require.Equal(t, http.StatusOK, rec.Code, "approve1: %s", rec.Body.String())
+
+				// Still pending — second hasn't voted
+				rec = testutil.GET(t, e, fmt.Sprintf("/applications/%d/check-approval-status", appID), testutil.AuthHeader(senderToken))
+				require.Equal(t, http.StatusOK, rec.Code)
+				status = testutil.ParseResponse[services.ApprovalStatusResponse](t, rec)
+				require.NotNil(t, status.Confirmation)
+				assert.Equal(t, "Согласование", *status.Confirmation)
+
+				// Second user approves
+				resp2Token, _ := testutil.LoginUser(t, e, "ar_resp1b", "pass123")
+				approveBody = fmt.Sprintf(`{"user_id":%d,"status":"approved","comment":"ok too"}`, resp2ID)
+				rec = testutil.POST(t, e, fmt.Sprintf("/applications/%d/approve", appID), approveBody, testutil.AuthHeader(resp2Token))
+				require.Equal(t, http.StatusOK, rec.Code, "approve2: %s", rec.Body.String())
+
+				// Now confirmation = "Согласовано"
+				rec = testutil.GET(t, e, fmt.Sprintf("/applications/%d/check-approval-status", appID), testutil.AuthHeader(senderToken))
+				require.Equal(t, http.StatusOK, rec.Code)
+				status = testutil.ParseResponse[services.ApprovalStatusResponse](t, rec)
+				require.NotNil(t, status.Confirmation)
+				assert.Equal(t, "Согласовано", *status.Confirmation)
+			},
+		},
+		{
+			name: "two_required_one_rejects_not_confirmed",
+			run: func(t *testing.T) {
+				testutil.CleanDB(t, db)
+				td := testutil.SeedTestData(t, db)
+
+				senderToken := testutil.RegisterAndLogin(t, e, "ar_sender2", "pass123", 1, td.OrgID, td.CompanyID)
+				appID := createSimpleApplication(t, e, senderToken, td.OrgID)
+
+				testutil.RegisterUser(t, e, "ar_resp2a", "pass123", 1, td.OrgID, td.CompanyID)
+				resp1ID := getUserID(t, db, "ar_resp2a")
+				testutil.RegisterUser(t, e, "ar_resp2b", "pass123", 1, td.OrgID, td.CompanyID)
+				resp2ID := getUserID(t, db, "ar_resp2b")
+
+				body := fmt.Sprintf(`{"users":[
+					{"user_id":%d,"required_approval":true,"can_view":false},
+					{"user_id":%d,"required_approval":true,"can_view":false}
+				]}`, resp1ID, resp2ID)
+				rec := testutil.POST(t, e, fmt.Sprintf("/applications/%d/forward", appID), body, testutil.AuthHeader(senderToken))
+				require.Equal(t, http.StatusOK, rec.Code)
+
+				// First approves
+				resp1Token, _ := testutil.LoginUser(t, e, "ar_resp2a", "pass123")
+				rec = testutil.POST(t, e, fmt.Sprintf("/applications/%d/approve", appID),
+					fmt.Sprintf(`{"user_id":%d,"status":"approved"}`, resp1ID), testutil.AuthHeader(resp1Token))
+				require.Equal(t, http.StatusOK, rec.Code)
+
+				// Second rejects
+				resp2Token, _ := testutil.LoginUser(t, e, "ar_resp2b", "pass123")
+				rec = testutil.POST(t, e, fmt.Sprintf("/applications/%d/approve", appID),
+					fmt.Sprintf(`{"user_id":%d,"status":"rejected","comment":"no"}`, resp2ID), testutil.AuthHeader(resp2Token))
+				require.Equal(t, http.StatusOK, rec.Code)
+
+				// Confirmation = "Не согласовано"
+				rec = testutil.GET(t, e, fmt.Sprintf("/applications/%d/check-approval-status", appID), testutil.AuthHeader(senderToken))
+				require.Equal(t, http.StatusOK, rec.Code)
+				status := testutil.ParseResponse[services.ApprovalStatusResponse](t, rec)
+				require.NotNil(t, status.Confirmation)
+				assert.Equal(t, "Не согласовано", *status.Confirmation)
+			},
+		},
+		{
+			name: "only_optional_one_approves_confirmed",
+			run: func(t *testing.T) {
+				testutil.CleanDB(t, db)
+				td := testutil.SeedTestData(t, db)
+
+				senderToken := testutil.RegisterAndLogin(t, e, "ar_sender3", "pass123", 1, td.OrgID, td.CompanyID)
+				appID := createSimpleApplication(t, e, senderToken, td.OrgID)
+
+				testutil.RegisterUser(t, e, "ar_resp3a", "pass123", 1, td.OrgID, td.CompanyID)
+				respID := getUserID(t, db, "ar_resp3a")
+
+				// Forward with required_approval=false (optional)
+				body := fmt.Sprintf(`{"users":[{"user_id":%d,"required_approval":false,"can_view":false}]}`, respID)
+				rec := testutil.POST(t, e, fmt.Sprintf("/applications/%d/forward", appID), body, testutil.AuthHeader(senderToken))
+				require.Equal(t, http.StatusOK, rec.Code)
+
+				// Optional user approves
+				respToken, _ := testutil.LoginUser(t, e, "ar_resp3a", "pass123")
+				rec = testutil.POST(t, e, fmt.Sprintf("/applications/%d/approve", appID),
+					fmt.Sprintf(`{"user_id":%d,"status":"approved"}`, respID), testutil.AuthHeader(respToken))
+				require.Equal(t, http.StatusOK, rec.Code)
+
+				// Confirmation = "Согласовано"
+				rec = testutil.GET(t, e, fmt.Sprintf("/applications/%d/check-approval-status", appID), testutil.AuthHeader(senderToken))
+				require.Equal(t, http.StatusOK, rec.Code)
+				status := testutil.ParseResponse[services.ApprovalStatusResponse](t, rec)
+				require.NotNil(t, status.Confirmation)
+				assert.Equal(t, "Согласовано", *status.Confirmation)
+			},
+		},
+		{
+			name: "only_optional_one_rejects_not_confirmed",
+			run: func(t *testing.T) {
+				testutil.CleanDB(t, db)
+				td := testutil.SeedTestData(t, db)
+
+				senderToken := testutil.RegisterAndLogin(t, e, "ar_sender4", "pass123", 1, td.OrgID, td.CompanyID)
+				appID := createSimpleApplication(t, e, senderToken, td.OrgID)
+
+				testutil.RegisterUser(t, e, "ar_resp4a", "pass123", 1, td.OrgID, td.CompanyID)
+				respID := getUserID(t, db, "ar_resp4a")
+
+				body := fmt.Sprintf(`{"users":[{"user_id":%d,"required_approval":false,"can_view":false}]}`, respID)
+				rec := testutil.POST(t, e, fmt.Sprintf("/applications/%d/forward", appID), body, testutil.AuthHeader(senderToken))
+				require.Equal(t, http.StatusOK, rec.Code)
+
+				// Optional user rejects
+				respToken, _ := testutil.LoginUser(t, e, "ar_resp4a", "pass123")
+				rec = testutil.POST(t, e, fmt.Sprintf("/applications/%d/approve", appID),
+					fmt.Sprintf(`{"user_id":%d,"status":"rejected","comment":"nope"}`, respID), testutil.AuthHeader(respToken))
+				require.Equal(t, http.StatusOK, rec.Code)
+
+				// Confirmation = "Не согласовано"
+				rec = testutil.GET(t, e, fmt.Sprintf("/applications/%d/check-approval-status", appID), testutil.AuthHeader(senderToken))
+				require.Equal(t, http.StatusOK, rec.Code)
+				status := testutil.ParseResponse[services.ApprovalStatusResponse](t, rec)
+				require.NotNil(t, status.Confirmation)
+				assert.Equal(t, "Не согласовано", *status.Confirmation)
+			},
+		},
+		{
+			name: "revoke_approval_returns_to_pending",
+			run: func(t *testing.T) {
+				testutil.CleanDB(t, db)
+				td := testutil.SeedTestData(t, db)
+
+				senderToken := testutil.RegisterAndLogin(t, e, "ar_sender5", "pass123", 1, td.OrgID, td.CompanyID)
+				appID := createSimpleApplication(t, e, senderToken, td.OrgID)
+
+				testutil.RegisterUser(t, e, "ar_resp5a", "pass123", 1, td.OrgID, td.CompanyID)
+				respID := getUserID(t, db, "ar_resp5a")
+
+				// Forward optional responsible
+				body := fmt.Sprintf(`{"users":[{"user_id":%d,"required_approval":false,"can_view":false}]}`, respID)
+				rec := testutil.POST(t, e, fmt.Sprintf("/applications/%d/forward", appID), body, testutil.AuthHeader(senderToken))
+				require.Equal(t, http.StatusOK, rec.Code)
+
+				// Approve
+				respToken, _ := testutil.LoginUser(t, e, "ar_resp5a", "pass123")
+				rec = testutil.POST(t, e, fmt.Sprintf("/applications/%d/approve", appID),
+					fmt.Sprintf(`{"user_id":%d,"status":"approved"}`, respID), testutil.AuthHeader(respToken))
+				require.Equal(t, http.StatusOK, rec.Code)
+
+				// Verify approved
+				rec = testutil.GET(t, e, fmt.Sprintf("/applications/%d/check-approval-status", appID), testutil.AuthHeader(senderToken))
+				require.Equal(t, http.StatusOK, rec.Code)
+				status := testutil.ParseResponse[services.ApprovalStatusResponse](t, rec)
+				require.NotNil(t, status.Confirmation)
+				assert.Equal(t, "Согласовано", *status.Confirmation)
+
+				// Revoke
+				rec = testutil.POST(t, e, fmt.Sprintf("/applications/%d/revoke-approval", appID),
+					`{"comment":"changed mind"}`, testutil.AuthHeader(respToken))
+				require.Equal(t, http.StatusOK, rec.Code)
+
+				// Confirmation back to "Согласование"
+				rec = testutil.GET(t, e, fmt.Sprintf("/applications/%d/check-approval-status", appID), testutil.AuthHeader(senderToken))
+				require.Equal(t, http.StatusOK, rec.Code)
+				status = testutil.ParseResponse[services.ApprovalStatusResponse](t, rec)
+				require.NotNil(t, status.Confirmation)
+				assert.Equal(t, "Согласование", *status.Confirmation)
+			},
+		},
+		{
+			name: "mix_required_and_optional_required_takes_priority",
+			run: func(t *testing.T) {
+				testutil.CleanDB(t, db)
+				td := testutil.SeedTestData(t, db)
+
+				senderToken := testutil.RegisterAndLogin(t, e, "ar_sender6", "pass123", 1, td.OrgID, td.CompanyID)
+				appID := createSimpleApplication(t, e, senderToken, td.OrgID)
+
+				testutil.RegisterUser(t, e, "ar_req6", "pass123", 1, td.OrgID, td.CompanyID)
+				reqID := getUserID(t, db, "ar_req6")
+				testutil.RegisterUser(t, e, "ar_opt6", "pass123", 1, td.OrgID, td.CompanyID)
+				optID := getUserID(t, db, "ar_opt6")
+
+				// Forward: one required, one optional
+				body := fmt.Sprintf(`{"users":[
+					{"user_id":%d,"required_approval":true,"can_view":false},
+					{"user_id":%d,"required_approval":false,"can_view":false}
+				]}`, reqID, optID)
+				rec := testutil.POST(t, e, fmt.Sprintf("/applications/%d/forward", appID), body, testutil.AuthHeader(senderToken))
+				require.Equal(t, http.StatusOK, rec.Code)
+
+				// Optional approves — confirmation stays pending because required hasn't voted
+				optToken, _ := testutil.LoginUser(t, e, "ar_opt6", "pass123")
+				rec = testutil.POST(t, e, fmt.Sprintf("/applications/%d/approve", appID),
+					fmt.Sprintf(`{"user_id":%d,"status":"approved"}`, optID), testutil.AuthHeader(optToken))
+				require.Equal(t, http.StatusOK, rec.Code)
+
+				rec = testutil.GET(t, e, fmt.Sprintf("/applications/%d/check-approval-status", appID), testutil.AuthHeader(senderToken))
+				require.Equal(t, http.StatusOK, rec.Code)
+				status := testutil.ParseResponse[services.ApprovalStatusResponse](t, rec)
+				require.NotNil(t, status.Confirmation)
+				assert.Equal(t, "Согласование", *status.Confirmation, "should be pending while required hasn't voted")
+
+				// Required approves — now confirmed
+				reqToken, _ := testutil.LoginUser(t, e, "ar_req6", "pass123")
+				rec = testutil.POST(t, e, fmt.Sprintf("/applications/%d/approve", appID),
+					fmt.Sprintf(`{"user_id":%d,"status":"approved"}`, reqID), testutil.AuthHeader(reqToken))
+				require.Equal(t, http.StatusOK, rec.Code)
+
+				rec = testutil.GET(t, e, fmt.Sprintf("/applications/%d/check-approval-status", appID), testutil.AuthHeader(senderToken))
+				require.Equal(t, http.StatusOK, rec.Code)
+				status = testutil.ParseResponse[services.ApprovalStatusResponse](t, rec)
+				require.NotNil(t, status.Confirmation)
+				assert.Equal(t, "Согласовано", *status.Confirmation, "required approved, so confirmed regardless of optional")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, tt.run)
+	}
+}

--- a/internal/handlers/applications_expiry_test.go
+++ b/internal/handlers/applications_expiry_test.go
@@ -1,0 +1,249 @@
+package handlers_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckExpiredAttachments(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+
+	// Create the service directly for calling CheckExpiredAttachments.
+	permSvc := services.NewPermissionService(db)
+	appSvc := services.NewApplicationService(db, permSvc)
+
+	tests := []struct {
+		name string
+		run  func(t *testing.T)
+	}{
+		{
+			name: "expired_attachment_deactivated_with_car_history",
+			run: func(t *testing.T) {
+				testutil.CleanDB(t, db)
+				td := testutil.SeedTestData(t, db)
+
+				uaID := seedUniqueAttachment(t, db, "cars", "exp_cars1", "Exp Cars 1")
+				token := testutil.RegisterAndLogin(t, e, "exp_sender1", "pass123", 1, td.OrgID, td.CompanyID)
+				appID := submitCompleteApplication(t, e, token, "Test Organization", uaID)
+
+				// Get attachment ID
+				rec := testutil.GET(t, e, fmt.Sprintf("/applications/%d/attachments", appID), testutil.AuthHeader(token))
+				require.Equal(t, http.StatusOK, rec.Code)
+				attachments := testutil.ParseSlice(t, rec)
+				require.NotEmpty(t, attachments)
+				attID := int(attachments[0]["id"].(float64))
+
+				// Activate items so status=1 (CheckExpiredAttachments checks status=1)
+				rec = testutil.POST(t, e, fmt.Sprintf("/applications/%d/update-items-status", appID), "", testutil.AuthHeader(token))
+				require.Equal(t, http.StatusOK, rec.Code)
+
+				// Set entry_date_to to yesterday via raw SQL to avoid GORM type coercion issues
+				yesterday := time.Now().Add(-24 * time.Hour).Format("2006-01-02")
+				result := db.Exec("UPDATE attachments SET entry_date_to = ? WHERE id = ?", yesterday, attID)
+				require.NoError(t, result.Error)
+				require.Equal(t, int64(1), result.RowsAffected, "should update exactly 1 attachment")
+
+				// Run expiry check
+				err := appSvc.CheckExpiredAttachments(context.Background())
+				require.NoError(t, err)
+
+				// Verify attachment deactivated
+				var att models.Attachment
+				err = db.First(&att, attID).Error
+				require.NoError(t, err)
+				require.NotNil(t, att.Status)
+				assert.Equal(t, 0, *att.Status, "attachment should be deactivated")
+
+				// Verify car deactivated
+				var car models.Car
+				err = db.Where("attachment_id = ?", attID).First(&car).Error
+				require.NoError(t, err)
+				require.NotNil(t, car.Status)
+				assert.Equal(t, 0, *car.Status, "car should be deactivated")
+
+				// Verify car history entry created
+				var historyCount int64
+				db.Model(&models.CarHistory{}).
+					Where("car_id = ? AND action_type = 'deactivate'", car.ID).
+					Count(&historyCount)
+				assert.Equal(t, int64(1), historyCount, "car deactivation history should be created")
+			},
+		},
+		{
+			name: "all_attachments_expired_application_completed",
+			run: func(t *testing.T) {
+				testutil.CleanDB(t, db)
+				td := testutil.SeedTestData(t, db)
+
+				uaID := seedUniqueAttachment(t, db, "cars", "exp_cars2", "Exp Cars 2")
+				token := testutil.RegisterAndLogin(t, e, "exp_sender2", "pass123", 1, td.OrgID, td.CompanyID)
+				appID := submitCompleteApplication(t, e, token, "Test Organization", uaID)
+
+				// Activate items
+				rec := testutil.POST(t, e, fmt.Sprintf("/applications/%d/update-items-status", appID), "", testutil.AuthHeader(token))
+				require.Equal(t, http.StatusOK, rec.Code)
+
+				// Set all attachments to expired
+				yesterday := time.Now().Add(-24 * time.Hour).Format("2006-01-02")
+				result := db.Exec("UPDATE attachments SET entry_date_to = ? WHERE application_id = ?", yesterday, appID)
+				require.NoError(t, result.Error)
+				require.GreaterOrEqual(t, result.RowsAffected, int64(1), "should update at least 1 attachment")
+
+				// Run expiry check
+				err := appSvc.CheckExpiredAttachments(context.Background())
+				require.NoError(t, err)
+
+				// Verify application status = "Завершено"
+				var app models.Application
+				err = db.First(&app, appID).Error
+				require.NoError(t, err)
+				require.NotNil(t, app.Status)
+				assert.Equal(t, models.StatusCompleted, *app.Status, "application should be completed when all attachments expired")
+			},
+		},
+		{
+			name: "some_attachments_expired_application_stays_active",
+			run: func(t *testing.T) {
+				testutil.CleanDB(t, db)
+				td := testutil.SeedTestData(t, db)
+
+				uaID1 := seedUniqueAttachment(t, db, "cars", "exp_cars3a", "Exp Cars 3A")
+				uaID2 := seedUniqueAttachment(t, db, "cars", "exp_cars3b", "Exp Cars 3B")
+				token := testutil.RegisterAndLogin(t, e, "exp_sender3", "pass123", 1, td.OrgID, td.CompanyID)
+
+				// Create application with 2 attachments
+				body := fmt.Sprintf(`{
+					"message": "multi attachment test",
+					"organization": "Test Organization",
+					"responsible_person": "Test Person",
+					"contact_phone": "+79001234567",
+					"data_approval": true,
+					"attachments": [
+						{
+							"attachment_type": "cars",
+							"attachment_name": "cars_a",
+							"attachment_display_name": "Cars A",
+							"unique_attachment_id": %d,
+							"entry_date_from": "2026-04-01",
+							"entry_date_to": "2026-12-31",
+							"entry_time_from": "08:00",
+							"entry_time_to": "18:00",
+							"data": {"vehicles": [{"car_number": "B001BB777", "car_brand": "Honda"}]}
+						},
+						{
+							"attachment_type": "cars",
+							"attachment_name": "cars_b",
+							"attachment_display_name": "Cars B",
+							"unique_attachment_id": %d,
+							"entry_date_from": "2026-04-01",
+							"entry_date_to": "2026-12-31",
+							"entry_time_from": "08:00",
+							"entry_time_to": "18:00",
+							"data": {"vehicles": [{"car_number": "C001CC777", "car_brand": "Mazda"}]}
+						}
+					]
+				}`, uaID1, uaID2)
+				rec := testutil.POST(t, e, "/applications/submit-complete-application", body, testutil.AuthHeader(token))
+				require.Equal(t, http.StatusOK, rec.Code, "create: %s", rec.Body.String())
+				resp := testutil.ParseResponse[services.CompleteApplicationResponse](t, rec)
+				appID := resp.ApplicationID
+
+				// Activate all items
+				rec = testutil.POST(t, e, fmt.Sprintf("/applications/%d/update-items-status", appID), "", testutil.AuthHeader(token))
+				require.Equal(t, http.StatusOK, rec.Code)
+
+				// Get both attachments
+				rec = testutil.GET(t, e, fmt.Sprintf("/applications/%d/attachments", appID), testutil.AuthHeader(token))
+				require.Equal(t, http.StatusOK, rec.Code)
+				attachments := testutil.ParseSlice(t, rec)
+				require.Len(t, attachments, 2)
+
+				firstAttID := int(attachments[0]["id"].(float64))
+
+				// Expire only the first attachment
+				yesterday := time.Now().Add(-24 * time.Hour).Format("2006-01-02")
+				result := db.Exec("UPDATE attachments SET entry_date_to = ? WHERE id = ?", yesterday, firstAttID)
+				require.NoError(t, result.Error)
+				require.Equal(t, int64(1), result.RowsAffected)
+
+				// Remember original status
+				var appBefore models.Application
+				err := db.First(&appBefore, appID).Error
+				require.NoError(t, err)
+
+				// Run expiry check
+				err = appSvc.CheckExpiredAttachments(context.Background())
+				require.NoError(t, err)
+
+				// First attachment should be deactivated
+				var att models.Attachment
+				err = db.First(&att, firstAttID).Error
+				require.NoError(t, err)
+				require.NotNil(t, att.Status)
+				assert.Equal(t, 0, *att.Status, "expired attachment should be deactivated")
+
+				// Application should NOT be completed
+				var appAfter models.Application
+				err = db.First(&appAfter, appID).Error
+				require.NoError(t, err)
+				require.NotNil(t, appAfter.Status)
+				assert.NotEqual(t, models.StatusCompleted, *appAfter.Status, "application should stay active when some attachments are still valid")
+			},
+		},
+		{
+			name: "no_expired_attachments_nothing_changes",
+			run: func(t *testing.T) {
+				testutil.CleanDB(t, db)
+				td := testutil.SeedTestData(t, db)
+
+				uaID := seedUniqueAttachment(t, db, "cars", "exp_cars4", "Exp Cars 4")
+				token := testutil.RegisterAndLogin(t, e, "exp_sender4", "pass123", 1, td.OrgID, td.CompanyID)
+				appID := submitCompleteApplication(t, e, token, "Test Organization", uaID)
+
+				// Activate items
+				rec := testutil.POST(t, e, fmt.Sprintf("/applications/%d/update-items-status", appID), "", testutil.AuthHeader(token))
+				require.Equal(t, http.StatusOK, rec.Code)
+
+				// Get attachment to verify its state before
+				rec = testutil.GET(t, e, fmt.Sprintf("/applications/%d/attachments", appID), testutil.AuthHeader(token))
+				require.Equal(t, http.StatusOK, rec.Code)
+				attachments := testutil.ParseSlice(t, rec)
+				require.NotEmpty(t, attachments)
+				attID := int(attachments[0]["id"].(float64))
+
+				// entry_date_to is 2026-04-30, which is in the future — nothing should change.
+				err := appSvc.CheckExpiredAttachments(context.Background())
+				require.NoError(t, err)
+
+				// Attachment still active
+				var att models.Attachment
+				err = db.First(&att, attID).Error
+				require.NoError(t, err)
+				require.NotNil(t, att.Status)
+				assert.Equal(t, 1, *att.Status, "attachment should stay active")
+
+				// Application status unchanged
+				var app models.Application
+				err = db.First(&app, appID).Error
+				require.NoError(t, err)
+				require.NotNil(t, app.Status)
+				assert.NotEqual(t, models.StatusCompleted, *app.Status, "application should not be completed")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, tt.run)
+	}
+}

--- a/internal/handlers/consent_test.go
+++ b/internal/handlers/consent_test.go
@@ -78,3 +78,132 @@ func TestListConsents_Success(t *testing.T) {
 	rec := testutil.GET(t, e, "/consents", testutil.AuthHeader(token))
 	require.Equal(t, http.StatusOK, rec.Code)
 }
+
+func TestDoubleGrant_CreatesTwoConsents(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "double_grant_user", "password123456789012345678901234", 1, td.OrgID, td.CompanyID)
+
+	rec1 := testutil.POST(t, e, "/consents", `{"consent_type":"pd_processing"}`, testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec1.Code)
+
+	rec2 := testutil.POST(t, e, "/consents", `{"consent_type":"pd_processing"}`, testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec2.Code)
+
+	recList := testutil.GET(t, e, "/consents", testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, recList.Code)
+	items := testutil.ParseSlice(t, recList)
+	assert.Len(t, items, 2)
+
+	recCheck := testutil.GET(t, e, "/consents/check/pd_processing", testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, recCheck.Code)
+	checkResp := testutil.ParseMap(t, recCheck)
+	assert.Equal(t, true, checkResp["active"])
+}
+
+func TestHasActive_FalseAfterRevoke(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "revoke_check_user", "password123456789012345678901234", 1, td.OrgID, td.CompanyID)
+
+	rec := testutil.POST(t, e, "/consents", `{"consent_type":"pd_processing"}`, testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	recCheckBefore := testutil.GET(t, e, "/consents/check/pd_processing", testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, recCheckBefore.Code)
+	assert.Equal(t, true, testutil.ParseMap(t, recCheckBefore)["active"])
+
+	recRevoke := testutil.DELETE(t, e, "/consents/pd_processing", testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, recRevoke.Code)
+
+	recCheckAfter := testutil.GET(t, e, "/consents/check/pd_processing", testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, recCheckAfter.Code)
+	assert.Equal(t, false, testutil.ParseMap(t, recCheckAfter)["active"])
+
+	recList := testutil.GET(t, e, "/consents", testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, recList.Code)
+	items := testutil.ParseSlice(t, recList)
+	assert.Len(t, items, 1, "revoked consent should still be in the list")
+	assert.Equal(t, false, items[0]["granted"])
+}
+
+func TestRevokeNonExistent_Returns404(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "no_consent_user", "password123456789012345678901234", 1, td.OrgID, td.CompanyID)
+
+	rec := testutil.DELETE(t, e, "/consents/pd_processing", testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestGrantConsent_InvalidType(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "invalid_type_user", "password123456789012345678901234", 1, td.OrgID, td.CompanyID)
+
+	rec := testutil.POST(t, e, "/consents", `{"consent_type":"invalid_type"}`, testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestListConsents_EmptyForNewUser(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "empty_list_user", "password123456789012345678901234", 1, td.OrgID, td.CompanyID)
+
+	rec := testutil.GET(t, e, "/consents", testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+	items := testutil.ParseSlice(t, rec)
+	assert.Empty(t, items)
+}
+
+func TestGrantRevokeRegrant_Lifecycle(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "lifecycle_user", "password123456789012345678901234", 1, td.OrgID, td.CompanyID)
+
+	// Grant
+	rec := testutil.POST(t, e, "/consents", `{"consent_type":"pd_processing"}`, testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Revoke
+	rec = testutil.DELETE(t, e, "/consents/pd_processing", testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Check → false
+	rec = testutil.GET(t, e, "/consents/check/pd_processing", testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, false, testutil.ParseMap(t, rec)["active"])
+
+	// Re-grant
+	rec = testutil.POST(t, e, "/consents", `{"consent_type":"pd_processing"}`, testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Check → true
+	rec = testutil.GET(t, e, "/consents/check/pd_processing", testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, true, testutil.ParseMap(t, rec)["active"])
+
+	// List → 3 records (grant, revoke updates first, re-grant creates second + original)
+	rec = testutil.GET(t, e, "/consents", testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+	items := testutil.ParseSlice(t, rec)
+	assert.Len(t, items, 2, "should have 2 consent records: original (revoked) + re-granted")
+}

--- a/internal/services/application_workflow_service.go
+++ b/internal/services/application_workflow_service.go
@@ -257,9 +257,9 @@ func (s *applicationService) CheckExpiredAttachments(ctx context.Context) error 
 	tx.Raw(`
 		SELECT id, application_id FROM attachments
 		WHERE status = 1 AND (
-			(entry_date_to IS NOT NULL AND entry_date_to < CURRENT_DATE)
+			(entry_date_to IS NOT NULL AND CAST(entry_date_to AS DATE) < CURRENT_DATE)
 			OR (entry_date_to IS NOT NULL AND entry_time_to IS NOT NULL
-			    AND ((entry_date_to + entry_time_to) AT TIME ZONE 'Europe/Moscow') < CURRENT_TIMESTAMP)
+			    AND (CAST(entry_date_to AS DATE) + CAST(entry_time_to AS TIME)) AT TIME ZONE 'Europe/Moscow' < CURRENT_TIMESTAMP)
 		)
 	`).Scan(&expired)
 


### PR DESCRIPTION
## Summary

Добавлены интеграционные тесты для трёх критичных модулей бизнес-логики.

### Approval Workflow (#29) — 6 сценариев:
1. Два обязательных, оба одобрили → "Согласовано"
2. Два обязательных, один отклонил → "Не согласовано"
3. Только опциональный, одобрил → "Согласовано"
4. Только опциональный, отклонил → "Не согласовано"
5. Отзыв одобрения → возврат к "Согласование"
6. Микс обязательный + опциональный → приоритет обязательного

### Expired Attachments (#30) — 4 сценария:
1. Истёкшее вложение → деактивация attachment + cars + history
2. Все вложения истекли → заявка "Завершено"
3. Часть вложений → заявка активна
4. Нет истёкших → без изменений

### Consent 152-ФЗ (#32) — 6 edge cases:
1. Двойной grant → 2 записи
2. HasActive=false после revoke
3. Revoke несуществующего → 404
4. Невалидный consent_type → 400
5. Пустой list для нового пользователя
6. Grant → revoke → re-grant lifecycle

### Баг-фикс:
`CheckExpiredAttachments` — добавлены `CAST(entry_date_to AS DATE)` и `CAST(entry_time_to AS TIME)` в SQL. Без них PostgreSQL не сравнивал varchar с date, и истёкшие вложения никогда не обрабатывались.

Closes #29, closes #30, closes #32

## Test plan

- [x] `go build ./...` — компиляция без ошибок
- [ ] `go test ./internal/handlers/... -run TestApproval` — 6/6 pass
- [ ] `go test ./internal/handlers/... -run TestExpir` — 4/4 pass
- [ ] `go test ./internal/handlers/... -run TestConsent` — 6/6 pass