### PR TITLE
test: unit-тесты useNumberFormat и permissions store/directive

### DIFF
--- a/frontend/src/composables/__tests__/useNumberFormat.spec.js
+++ b/frontend/src/composables/__tests__/useNumberFormat.spec.js
@@ -1,0 +1,247 @@
+import { describe, it, expect } from 'vitest'
+import {
+  filterCyrillicLetters,
+  filterLatinLetters,
+  filterBothLetters,
+  filterMixedCyrillic,
+  filterMixedLatin,
+  filterMixedBoth,
+  validatePartValue,
+  formatPartValue,
+  initializeNumberParts,
+} from '../useNumberFormat'
+
+describe('filterCyrillicLetters', () => {
+  it.each([
+    ['АВЕКМНОРСТУХ', 'АВЕКМНОРСТУХ'],
+    ['АВЕ123', 'АВЕ'],
+    ['', ''],
+    ['БГДЖ', ''],
+    ['АБВГДЕ', 'АВЕ'],
+    ['АМ999ОР', 'АМОР'],
+  ])('"%s" -> "%s" (default allowed)', (input, expected) => {
+    expect(filterCyrillicLetters(input, null)).toBe(expected)
+  })
+
+  it.each([
+    ['АБВГ', 'АБ', 'АБ'],
+    ['АБВГ', 'ВГ', 'ВГ'],
+    ['АБВГ', 'Д', ''],
+  ])('"%s" with allowedLetters="%s" -> "%s"', (input, allowed, expected) => {
+    expect(filterCyrillicLetters(input, allowed)).toBe(expected)
+  })
+})
+
+describe('filterLatinLetters', () => {
+  it.each([
+    ['ABC123', 'ABC'],
+    ['HELLO', 'HELLO'],
+    ['abc', ''],
+    ['', ''],
+    ['A1B2C3', 'ABC'],
+    ['123', ''],
+  ])('"%s" -> "%s" (default allowed)', (input, expected) => {
+    expect(filterLatinLetters(input, null)).toBe(expected)
+  })
+
+  it.each([
+    ['ABCD', 'AC', 'AC'],
+    ['ABCD', 'BD', 'BD'],
+    ['ABCD', 'XY', ''],
+  ])('"%s" with allowedLetters="%s" -> "%s"', (input, allowed, expected) => {
+    expect(filterLatinLetters(input, allowed)).toBe(expected)
+  })
+})
+
+describe('filterBothLetters', () => {
+  it.each([
+    ['АBC', 'АBC'],
+    ['А1B2', 'АB'],
+    ['123', ''],
+    ['', ''],
+    ['АвВс', 'АВ'],
+    ['АВCDE', 'АВCDE'],
+  ])('"%s" -> "%s" (default allowed)', (input, expected) => {
+    expect(filterBothLetters(input, null)).toBe(expected)
+  })
+
+  it.each([
+    ['АБCD', 'АБ', 'АБ'],
+    ['АBСD', 'АB', 'АB'],
+  ])('"%s" with allowedLetters="%s" -> "%s"', (input, allowed, expected) => {
+    expect(filterBothLetters(input, allowed)).toBe(expected)
+  })
+})
+
+describe('filterMixedCyrillic', () => {
+  it.each([
+    ['А123В', '123АВ'],
+    ['999', '999'],
+    ['АВЕ', 'АВЕ'],
+    ['БГД123', '123'],
+    ['', ''],
+  ])('"%s" -> "%s"', (input, expected) => {
+    expect(filterMixedCyrillic(input, null)).toBe(expected)
+  })
+})
+
+describe('filterMixedLatin', () => {
+  it.each([
+    ['A123B', '123AB'],
+    ['999', '999'],
+    ['ABC', 'ABC'],
+    ['abc123', '123'],
+    ['', ''],
+  ])('"%s" -> "%s"', (input, expected) => {
+    expect(filterMixedLatin(input, null)).toBe(expected)
+  })
+})
+
+describe('filterMixedBoth', () => {
+  it.each([
+    ['А1B2', '12АB'],
+    ['999', '999'],
+    ['АBC', 'АBC'],
+    ['', ''],
+  ])('"%s" -> "%s"', (input, expected) => {
+    expect(filterMixedBoth(input, null)).toBe(expected)
+  })
+})
+
+describe('validatePartValue', () => {
+  describe('cell_type=numbers', () => {
+    const cell = { cell_type: 'numbers', max_length: 3 }
+
+    it.each([
+      ['123', '123'],
+      ['12345', '123'],
+      ['abc', ''],
+      ['1a2b3c', '123'],
+      ['', ''],
+    ])('"%s" -> "%s"', (input, expected) => {
+      expect(validatePartValue(input, cell)).toBe(expected)
+    })
+  })
+
+  describe('cell_type=letters, cyrillic', () => {
+    const cell = { cell_type: 'letters', alphabet_type: 'cyrillic', max_length: 3 }
+
+    it.each([
+      ['аве', 'АВЕ'],
+      ['АВЕК', 'АВЕ'],
+      ['бгд', ''],
+      ['123', ''],
+    ])('"%s" -> "%s"', (input, expected) => {
+      expect(validatePartValue(input, cell)).toBe(expected)
+    })
+  })
+
+  describe('cell_type=letters, latin', () => {
+    const cell = { cell_type: 'letters', alphabet_type: 'latin', max_length: 2 }
+
+    it.each([
+      ['abc', 'AB'],
+      ['XYZ', 'XY'],
+      ['123', ''],
+    ])('"%s" -> "%s"', (input, expected) => {
+      expect(validatePartValue(input, cell)).toBe(expected)
+    })
+  })
+
+  describe('cell_type=letters, both', () => {
+    const cell = { cell_type: 'letters', alphabet_type: 'both', max_length: 3 }
+
+    it.each([
+      ['аBв', 'АBВ'],
+      ['XАY', 'XАY'],
+    ])('"%s" -> "%s"', (input, expected) => {
+      expect(validatePartValue(input, cell)).toBe(expected)
+    })
+  })
+
+  describe('cell_type=mixed, cyrillic', () => {
+    const cell = { cell_type: 'mixed', alphabet_type: 'cyrillic', max_length: 5 }
+
+    it('keeps digits and allowed Cyrillic letters', () => {
+      expect(validatePartValue('а1в2е', cell)).toBe('12АВЕ')
+    })
+  })
+
+  describe('cell_type=mixed, latin', () => {
+    const cell = { cell_type: 'mixed', alphabet_type: 'latin', max_length: 5 }
+
+    it('keeps digits and uppercase Latin letters', () => {
+      expect(validatePartValue('a1b2c', cell)).toBe('12ABC')
+    })
+  })
+
+  describe('cell_type=mixed, both', () => {
+    const cell = { cell_type: 'mixed', alphabet_type: 'both', max_length: 5 }
+
+    it('keeps digits, Latin and Cyrillic uppercase', () => {
+      expect(validatePartValue('а1B2', cell)).toBe('12АB')
+    })
+  })
+
+  it('respects allowed_letters on cell', () => {
+    const cell = { cell_type: 'letters', alphabet_type: 'cyrillic', max_length: 10, allowed_letters: 'АВ' }
+    expect(validatePartValue('АВЕКМ', cell)).toBe('АВ')
+  })
+})
+
+describe('formatPartValue', () => {
+  it('pads left with zeros', () => {
+    const cell = { cell_type: 'numbers', max_length: 3, padding_side: 'left', padding_char: '0' }
+    expect(formatPartValue('1', cell)).toBe('001')
+  })
+
+  it('pads right with zeros', () => {
+    const cell = { cell_type: 'numbers', max_length: 3, padding_side: 'right', padding_char: '0' }
+    expect(formatPartValue('1', cell)).toBe('100')
+  })
+
+  it('defaults padding_char to 0', () => {
+    const cell = { cell_type: 'numbers', max_length: 3, padding_side: 'left' }
+    expect(formatPartValue('5', cell)).toBe('005')
+  })
+
+  it('does not pad when length matches max_length', () => {
+    const cell = { cell_type: 'numbers', max_length: 3, padding_side: 'left', padding_char: '0' }
+    expect(formatPartValue('123', cell)).toBe('123')
+  })
+
+  it('does not pad when length exceeds max_length', () => {
+    const cell = { cell_type: 'numbers', max_length: 3, padding_side: 'left', padding_char: '0' }
+    expect(formatPartValue('1234', cell)).toBe('1234')
+  })
+
+  it('returns value as-is for non-numbers cell_type', () => {
+    const cell = { cell_type: 'letters', max_length: 3, padding_side: 'left', padding_char: '0' }
+    expect(formatPartValue('A', cell)).toBe('A')
+  })
+
+  it('returns empty string for empty value', () => {
+    const cell = { cell_type: 'numbers', max_length: 3, padding_side: 'left', padding_char: '0' }
+    expect(formatPartValue('', cell)).toBe('')
+  })
+})
+
+describe('initializeNumberParts', () => {
+  it('creates array of empty strings matching cells length', () => {
+    const format = { cells: [{}, {}, {}] }
+    expect(initializeNumberParts(format)).toEqual(['', '', ''])
+  })
+
+  it('returns empty array for single cell', () => {
+    const format = { cells: [{}] }
+    expect(initializeNumberParts(format)).toEqual([''])
+  })
+
+  it('returns empty array when format is null', () => {
+    expect(initializeNumberParts(null)).toEqual([])
+  })
+
+  it('returns empty array when format is undefined', () => {
+    expect(initializeNumberParts(undefined)).toEqual([])
+  })
+})

--- a/frontend/src/directives/__tests__/permission.spec.js
+++ b/frontend/src/directives/__tests__/permission.spec.js
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { vPermission } from '../permission'
+import { usePermissionsStore } from '@/stores/permissions'
+import { useAuthStore } from '@/stores/auth'
+
+function createMockJWT(payload, expiresInSeconds = 3600) {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
+  const body = btoa(JSON.stringify({
+    ...payload,
+    exp: Math.floor(Date.now() / 1000) + expiresInSeconds,
+  }))
+  return `${header}.${body}.fake-signature`
+}
+
+function mountWithPermission(permissionKey, pinia) {
+  return mount({
+    template: `<div v-permission="'${permissionKey}'">Content</div>`,
+    directives: { permission: vPermission },
+  }, {
+    global: { plugins: [pinia] },
+  })
+}
+
+describe('v-permission directive', () => {
+  let pinia
+
+  beforeEach(() => {
+    pinia = createPinia()
+    setActivePinia(pinia)
+    localStorage.clear()
+  })
+
+  it('hides element when permission is denied', () => {
+    const store = usePermissionsStore()
+    store.permissions = { 'passes.create': 'deny' }
+
+    const wrapper = mountWithPermission('passes.create', pinia)
+
+    expect(wrapper.find('div').element.style.display).toBe('none')
+  })
+
+  it('hides element when permission is missing', () => {
+    const store = usePermissionsStore()
+    store.permissions = {}
+
+    const wrapper = mountWithPermission('passes.create', pinia)
+
+    expect(wrapper.find('div').element.style.display).toBe('none')
+  })
+
+  it('shows element when permission is allowed', () => {
+    const store = usePermissionsStore()
+    store.permissions = { 'passes.create': 'allow' }
+
+    const wrapper = mountWithPermission('passes.create', pinia)
+
+    expect(wrapper.find('div').element.style.display).not.toBe('none')
+  })
+
+  it('shows element for admin regardless of permission', () => {
+    const authStore = useAuthStore()
+    authStore.setTokens(createMockJWT({ type_id: 6 }), 'refresh')
+
+    const store = usePermissionsStore()
+    store.permissions = { 'passes.create': 'deny' }
+
+    const wrapper = mountWithPermission('passes.create', pinia)
+
+    expect(wrapper.find('div').element.style.display).not.toBe('none')
+  })
+
+  it('shows element for admin even when permission is missing', () => {
+    const authStore = useAuthStore()
+    authStore.setTokens(createMockJWT({ type_id: 6 }), 'refresh')
+
+    const wrapper = mountWithPermission('passes.create', pinia)
+
+    expect(wrapper.find('div').element.style.display).not.toBe('none')
+  })
+})

--- a/frontend/src/stores/__tests__/permissions.spec.js
+++ b/frontend/src/stores/__tests__/permissions.spec.js
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { usePermissionsStore } from '../permissions'
+import { useAuthStore } from '../auth'
+
+vi.mock('@/api/permissions', () => ({
+  getMyPermissions: vi.fn(),
+}))
+import { getMyPermissions } from '@/api/permissions'
+
+function createMockJWT(payload, expiresInSeconds = 3600) {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
+  const body = btoa(JSON.stringify({
+    ...payload,
+    exp: Math.floor(Date.now() / 1000) + expiresInSeconds,
+  }))
+  return `${header}.${body}.fake-signature`
+}
+
+describe('permissions store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  describe('hasPermission', () => {
+    it('returns true when permission value is allow', () => {
+      const store = usePermissionsStore()
+      store.permissions = { 'passes.create': 'allow' }
+
+      expect(store.hasPermission('passes.create')).toBe(true)
+    })
+
+    it('returns false when permission value is deny', () => {
+      const store = usePermissionsStore()
+      store.permissions = { 'passes.create': 'deny' }
+
+      expect(store.hasPermission('passes.create')).toBe(false)
+    })
+
+    it('returns false when permission key is missing', () => {
+      const store = usePermissionsStore()
+      store.permissions = {}
+
+      expect(store.hasPermission('passes.create')).toBe(false)
+    })
+
+    it('returns true for admin regardless of permission value', () => {
+      const authStore = useAuthStore()
+      authStore.setTokens(createMockJWT({ type_id: 6 }), 'refresh')
+
+      const store = usePermissionsStore()
+      store.permissions = { 'passes.create': 'deny' }
+
+      expect(store.hasPermission('passes.create')).toBe(true)
+    })
+
+    it('returns true for admin even when permission is missing', () => {
+      const authStore = useAuthStore()
+      authStore.setTokens(createMockJWT({ type_id: 6 }), 'refresh')
+
+      const store = usePermissionsStore()
+      store.permissions = {}
+
+      expect(store.hasPermission('passes.create')).toBe(true)
+    })
+  })
+
+  describe('clearPermissions', () => {
+    it('resets permissions to empty object and loaded to false', () => {
+      const store = usePermissionsStore()
+      store.permissions = { 'passes.create': 'allow' }
+      store.loaded = true
+
+      store.clearPermissions()
+
+      expect(store.permissions).toEqual({})
+      expect(store.loaded).toBe(false)
+    })
+  })
+
+  describe('fetchPermissions', () => {
+    it('populates permissions from API response', async () => {
+      getMyPermissions.mockResolvedValue([
+        { key: 'passes.create', value: 'allow' },
+        { key: 'passes.delete', value: 'deny' },
+      ])
+
+      const store = usePermissionsStore()
+      await store.fetchPermissions()
+
+      expect(store.permissions).toEqual({
+        'passes.create': 'allow',
+        'passes.delete': 'deny',
+      })
+      expect(store.loaded).toBe(true)
+    })
+
+    it('sets loaded to true even with empty response', async () => {
+      getMyPermissions.mockResolvedValue([])
+
+      const store = usePermissionsStore()
+      await store.fetchPermissions()
+
+      expect(store.permissions).toEqual({})
+      expect(store.loaded).toBe(true)
+    })
+
+    it('keeps permissions empty on API error', async () => {
+      getMyPermissions.mockRejectedValue(new Error('Network error'))
+
+      const store = usePermissionsStore()
+      store.permissions = { 'old.key': 'allow' }
+      await store.fetchPermissions()
+
+      expect(store.permissions).toEqual({ 'old.key': 'allow' })
+      expect(store.loaded).toBe(false)
+    })
+
+    it('overwrites previous permissions on re-fetch', async () => {
+      const store = usePermissionsStore()
+      store.permissions = { 'old.key': 'allow' }
+
+      getMyPermissions.mockResolvedValue([
+        { key: 'new.key', value: 'allow' },
+      ])
+
+      await store.fetchPermissions()
+
+      expect(store.permissions).toEqual({ 'new.key': 'allow' })
+      expect(store.permissions).not.toHaveProperty('old.key')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Добавлены unit-тесты для критичных модулей фронтенда: валидация номерных знаков и система разрешений.

### useNumberFormat (#35) — 69 тестов:
- `filterCyrillicLetters` — допустимые/недопустимые буквы, custom allowedLetters, пустые строки
- `filterLatinLetters` — A-Z фильтрация, lowercase отсечение
- `filterBothLetters` — смешанные Cyrillic+Latin
- `filterMixed*` — числа + буквы
- `validatePartValue` — cell_type='numbers'/'letters'/'mixed', max_length, uppercase
- `formatPartValue` — left/right padding
- `initializeNumberParts` — с форматом / без

### Permissions (#38) — 15 тестов:
- **Store (10):** hasPermission allow/deny/missing, admin bypass, clearPermissions, fetchPermissions (mock API)
- **v-permission directive (5):** скрытие при deny, показ при allow, admin bypass

117/117 тестов проходят.

Closes #35, closes #38

## Test plan

- [x] `npx vitest run` — 117 tests, 6 files, all pass