### PR TITLE
test: unit-тесты composables и компонентные тесты UI

### DIFF
--- a/frontend/src/components/ui/__tests__/BaseModal.spec.js
+++ b/frontend/src/components/ui/__tests__/BaseModal.spec.js
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import BaseModal from '../BaseModal.vue';
+
+function mountModal(props = {}, slots = {}) {
+  return mount(BaseModal, {
+    props: { show: true, ...props },
+    slots: { default: '<p>Modal content</p>', ...slots },
+    global: {
+      stubs: { teleport: true },
+    },
+    attachTo: document.body,
+  });
+}
+
+describe('BaseModal', () => {
+  it('renders content when show=true', () => {
+    const wrapper = mountModal();
+    expect(wrapper.find('.base-modal__body').exists()).toBe(true);
+    expect(wrapper.html()).toContain('Modal content');
+  });
+
+  it('hidden when show=false', () => {
+    const wrapper = mountModal({ show: false });
+    expect(wrapper.find('.base-modal-overlay').exists()).toBe(false);
+  });
+
+  it('renders title in header', () => {
+    const wrapper = mountModal({ title: 'Тестовый заголовок' });
+    expect(wrapper.find('.base-modal__title').text()).toBe('Тестовый заголовок');
+  });
+
+  it('emits close on close button click', async () => {
+    const wrapper = mountModal({ title: 'Test' });
+    await wrapper.find('.base-modal__close').trigger('click');
+    expect(wrapper.emitted('close')).toHaveLength(1);
+  });
+
+  it('emits close on overlay click when closeOnOverlay=true', async () => {
+    const wrapper = mountModal({ closeOnOverlay: true });
+    await wrapper.find('.base-modal-overlay').trigger('click');
+    expect(wrapper.emitted('close')).toHaveLength(1);
+  });
+
+  it('does not emit close on overlay click when closeOnOverlay=false', async () => {
+    const wrapper = mountModal({ closeOnOverlay: false });
+    await wrapper.find('.base-modal-overlay').trigger('click');
+    expect(wrapper.emitted('close')).toBeUndefined();
+  });
+
+  it('emits close on Escape key', async () => {
+    const wrapper = mountModal();
+    await document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(wrapper.emitted('close')).toHaveLength(1);
+  });
+
+  it('does not emit close on Escape when closable=false', async () => {
+    const wrapper = mountModal({ closable: false });
+    await document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(wrapper.emitted('close')).toBeUndefined();
+  });
+
+  it('does not render close button when closable=false', () => {
+    const wrapper = mountModal({ closable: false, title: 'Test' });
+    expect(wrapper.find('.base-modal__close').exists()).toBe(false);
+  });
+});

--- a/frontend/src/components/ui/__tests__/FilterTabs.spec.js
+++ b/frontend/src/components/ui/__tests__/FilterTabs.spec.js
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import FilterTabs from '../FilterTabs.vue';
+
+const allTabs = [
+  { key: 'all', label: 'Все' },
+  { key: 'active', label: 'Активные' },
+  { key: 'hidden', label: 'Скрытые', visible: false },
+  { key: 'archived', label: 'Архив', visible: true },
+];
+
+function mountTabs(props = {}) {
+  return mount(FilterTabs, {
+    props: { tabs: allTabs, modelValue: 'all', ...props },
+  });
+}
+
+describe('FilterTabs', () => {
+  it('renders only visible tabs', () => {
+    const wrapper = mountTabs();
+    const buttons = wrapper.findAll('.filter-tab');
+    expect(buttons).toHaveLength(3);
+    expect(buttons.map(b => b.text())).toEqual(['Все', 'Активные', 'Архив']);
+  });
+
+  it('does not render tabs with visible=false', () => {
+    const wrapper = mountTabs();
+    expect(wrapper.text()).not.toContain('Скрытые');
+  });
+
+  it('active tab has correct class', () => {
+    const wrapper = mountTabs({ modelValue: 'active' });
+    const buttons = wrapper.findAll('.filter-tab');
+    const activeButton = buttons.find(b => b.text() === 'Активные');
+    expect(activeButton.classes()).toContain('filter-tab--active');
+  });
+
+  it('non-active tabs do not have active class', () => {
+    const wrapper = mountTabs({ modelValue: 'all' });
+    const buttons = wrapper.findAll('.filter-tab');
+    const inactiveButton = buttons.find(b => b.text() === 'Активные');
+    expect(inactiveButton.classes()).not.toContain('filter-tab--active');
+  });
+
+  it('click emits update:modelValue with tab key', async () => {
+    const wrapper = mountTabs();
+    const buttons = wrapper.findAll('.filter-tab');
+    const activeButton = buttons.find(b => b.text() === 'Активные');
+    await activeButton.trigger('click');
+    expect(wrapper.emitted('update:modelValue')).toEqual([['active']]);
+  });
+
+  it('renders all tabs when none have visible property', () => {
+    const simpleTabs = [
+      { key: 'a', label: 'Tab A' },
+      { key: 'b', label: 'Tab B' },
+    ];
+    const wrapper = mount(FilterTabs, {
+      props: { tabs: simpleTabs, modelValue: 'a' },
+    });
+    expect(wrapper.findAll('.filter-tab')).toHaveLength(2);
+  });
+});

--- a/frontend/src/components/ui/__tests__/StatusBadge.spec.js
+++ b/frontend/src/components/ui/__tests__/StatusBadge.spec.js
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import StatusBadge from '../StatusBadge.vue';
+
+describe('StatusBadge', () => {
+  describe('status to color mapping', () => {
+    it.each([
+      ['В работе', 'status-badge--blue'],
+      ['Согласовано', 'status-badge--green'],
+      ['Не согласовано', 'status-badge--red'],
+      ['В обработке', 'status-badge--yellow'],
+      ['Активен', 'status-badge--green'],
+      ['Неактивен', 'status-badge--gray'],
+      ['Отклонено', 'status-badge--red'],
+      ['Непрочитано', 'status-badge--yellow'],
+    ])('"%s" renders with class "%s"', (status, expectedClass) => {
+      const wrapper = mount(StatusBadge, { props: { status } });
+      expect(wrapper.classes()).toContain(expectedClass);
+    });
+  });
+
+  it('renders default gray for unknown status', () => {
+    const wrapper = mount(StatusBadge, { props: { status: 'Неизвестный' } });
+    expect(wrapper.classes()).toContain('status-badge--gray');
+  });
+
+  it('renders status text', () => {
+    const wrapper = mount(StatusBadge, { props: { status: 'В работе' } });
+    expect(wrapper.text()).toContain('В работе');
+  });
+
+  describe('variants', () => {
+    it('applies badge variant class by default', () => {
+      const wrapper = mount(StatusBadge, { props: { status: 'Активен' } });
+      expect(wrapper.classes()).toContain('status-badge--badge');
+    });
+
+    it('applies dot variant class', () => {
+      const wrapper = mount(StatusBadge, {
+        props: { status: 'Активен', variant: 'dot' },
+      });
+      expect(wrapper.classes()).toContain('status-badge--dot');
+    });
+
+    it('renders dot element for dot variant', () => {
+      const wrapper = mount(StatusBadge, {
+        props: { status: 'Активен', variant: 'dot' },
+      });
+      expect(wrapper.find('.status-badge__dot').exists()).toBe(true);
+    });
+
+    it('does not render dot element for badge variant', () => {
+      const wrapper = mount(StatusBadge, {
+        props: { status: 'Активен', variant: 'badge' },
+      });
+      expect(wrapper.find('.status-badge__dot').exists()).toBe(false);
+    });
+  });
+});

--- a/frontend/src/composables/__tests__/useDropdownState.spec.js
+++ b/frontend/src/composables/__tests__/useDropdownState.spec.js
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useDropdownState } from '../useDropdownState';
+import { mount, config } from '@vue/test-utils';
+import { defineComponent } from 'vue';
+
+function createWrapperComponent(containerSelector) {
+  return defineComponent({
+    setup() {
+      return useDropdownState(containerSelector);
+    },
+    template: '<div></div>',
+  });
+}
+
+describe('useDropdownState', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = mount(createWrapperComponent('.dropdown'));
+  });
+
+  it('starts closed', () => {
+    expect(wrapper.vm.isOpen).toBe(false);
+  });
+
+  describe('toggle', () => {
+    it('opens when closed', () => {
+      wrapper.vm.toggle();
+      expect(wrapper.vm.isOpen).toBe(true);
+    });
+
+    it('closes when open', () => {
+      wrapper.vm.toggle();
+      wrapper.vm.toggle();
+      expect(wrapper.vm.isOpen).toBe(false);
+    });
+  });
+
+  describe('close', () => {
+    it('sets isOpen to false', () => {
+      wrapper.vm.toggle();
+      expect(wrapper.vm.isOpen).toBe(true);
+      wrapper.vm.close();
+      expect(wrapper.vm.isOpen).toBe(false);
+    });
+
+    it('is idempotent when already closed', () => {
+      wrapper.vm.close();
+      expect(wrapper.vm.isOpen).toBe(false);
+    });
+  });
+});

--- a/frontend/src/composables/__tests__/useDropdownState.spec.js
+++ b/frontend/src/composables/__tests__/useDropdownState.spec.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { useDropdownState } from '../useDropdownState';
-import { mount, config } from '@vue/test-utils';
+import { mount } from '@vue/test-utils';
 import { defineComponent } from 'vue';
 
 function createWrapperComponent(containerSelector) {

--- a/frontend/src/composables/__tests__/useEntitySelection.spec.js
+++ b/frontend/src/composables/__tests__/useEntitySelection.spec.js
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useEntitySelection } from '../useEntitySelection';
+
+describe('useEntitySelection', () => {
+  let selection;
+
+  beforeEach(() => {
+    selection = useEntitySelection();
+  });
+
+  describe('toggle', () => {
+    it('adds item to tempSelected', () => {
+      selection.toggle({ id: 1, name: 'A' });
+      expect(selection.tempSelected.value).toHaveLength(1);
+      expect(selection.tempSelected.value[0]).toEqual({ id: 1, name: 'A' });
+    });
+
+    it('removes item if already selected', () => {
+      selection.toggle({ id: 1, name: 'A' });
+      selection.toggle({ id: 1, name: 'A' });
+      expect(selection.tempSelected.value).toHaveLength(0);
+    });
+
+    it('handles multiple items', () => {
+      selection.toggle({ id: 1, name: 'A' });
+      selection.toggle({ id: 2, name: 'B' });
+      expect(selection.tempSelected.value).toHaveLength(2);
+    });
+  });
+
+  describe('isSelected', () => {
+    it('returns true for selected item', () => {
+      selection.toggle({ id: 1, name: 'A' });
+      expect(selection.isSelected({ id: 1 })).toBe(true);
+    });
+
+    it('returns false for unselected item', () => {
+      expect(selection.isSelected({ id: 1 })).toBe(false);
+    });
+  });
+
+  describe('confirm', () => {
+    it('copies tempSelected to confirmed', () => {
+      selection.toggle({ id: 1, name: 'A' });
+      selection.toggle({ id: 2, name: 'B' });
+      selection.confirm();
+      expect(selection.confirmed.value).toHaveLength(2);
+      expect(selection.confirmedCount.value).toBe(2);
+    });
+
+    it('confirmed is independent from tempSelected after confirm', () => {
+      selection.toggle({ id: 1, name: 'A' });
+      selection.confirm();
+      selection.toggle({ id: 1, name: 'A' });
+      expect(selection.tempSelected.value).toHaveLength(0);
+      expect(selection.confirmed.value).toHaveLength(1);
+    });
+  });
+
+  describe('syncFromConfirmed', () => {
+    it('restores tempSelected from confirmed', () => {
+      selection.toggle({ id: 1, name: 'A' });
+      selection.confirm();
+      selection.toggle({ id: 1, name: 'A' });
+      expect(selection.tempSelected.value).toHaveLength(0);
+
+      selection.syncFromConfirmed();
+      expect(selection.tempSelected.value).toHaveLength(1);
+    });
+  });
+
+  describe('reset', () => {
+    it('clears both tempSelected and confirmed', () => {
+      selection.toggle({ id: 1, name: 'A' });
+      selection.confirm();
+      selection.reset();
+
+      expect(selection.tempSelected.value).toHaveLength(0);
+      expect(selection.confirmed.value).toHaveLength(0);
+    });
+  });
+
+  describe('count', () => {
+    it('reflects tempSelected length', () => {
+      expect(selection.count.value).toBe(0);
+      selection.toggle({ id: 1, name: 'A' });
+      expect(selection.count.value).toBe(1);
+      selection.toggle({ id: 2, name: 'B' });
+      expect(selection.count.value).toBe(2);
+      selection.toggle({ id: 1, name: 'A' });
+      expect(selection.count.value).toBe(1);
+    });
+  });
+
+  describe('custom idKey', () => {
+    it('uses custom key for identification', () => {
+      const sel = useEntitySelection('uid');
+      sel.toggle({ uid: 'abc', name: 'A' });
+      expect(sel.isSelected({ uid: 'abc' })).toBe(true);
+      expect(sel.isSelected({ uid: 'xyz' })).toBe(false);
+      sel.toggle({ uid: 'abc', name: 'A' });
+      expect(sel.tempSelected.value).toHaveLength(0);
+    });
+  });
+});

--- a/frontend/src/composables/__tests__/useFormValidation.spec.js
+++ b/frontend/src/composables/__tests__/useFormValidation.spec.js
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { useFormValidation } from '../useFormValidation';
+
+describe('useFormValidation', () => {
+  let name;
+  let email;
+
+  beforeEach(() => {
+    name = ref('');
+    email = ref('');
+  });
+
+  function createValidation() {
+    return useFormValidation(() => [
+      { field: 'name', check: !!name.value, message: 'Имя' },
+      { field: 'email', check: !!email.value, message: 'Email' },
+    ]);
+  }
+
+  describe('isValid', () => {
+    it('returns false when required fields are empty', () => {
+      const { isValid } = createValidation();
+      expect(isValid.value).toBe(false);
+    });
+
+    it('returns true when all fields are filled', () => {
+      name.value = 'Сергей';
+      email.value = 'test@mail.ru';
+      const { isValid } = createValidation();
+      expect(isValid.value).toBe(true);
+    });
+
+    it('returns false when only some fields are filled', () => {
+      name.value = 'Сергей';
+      const { isValid } = createValidation();
+      expect(isValid.value).toBe(false);
+    });
+  });
+
+  describe('missingFields', () => {
+    it('lists all missing field messages', () => {
+      const { missingFields } = createValidation();
+      expect(missingFields.value).toEqual(['Имя', 'Email']);
+    });
+
+    it('returns empty array when all fields are valid', () => {
+      name.value = 'Сергей';
+      email.value = 'test@mail.ru';
+      const { missingFields } = createValidation();
+      expect(missingFields.value).toEqual([]);
+    });
+  });
+
+  describe('tooltipMessage', () => {
+    it('shows single field message', () => {
+      name.value = 'Сергей';
+      const { tooltipMessage } = createValidation();
+      expect(tooltipMessage.value).toBe('Заполните поле: Email');
+    });
+
+    it('shows multiple fields message', () => {
+      const { tooltipMessage } = createValidation();
+      expect(tooltipMessage.value).toContain('Заполните поля:');
+      expect(tooltipMessage.value).toContain('• Имя');
+      expect(tooltipMessage.value).toContain('• Email');
+    });
+
+    it('returns empty string when valid', () => {
+      name.value = 'Сергей';
+      email.value = 'test@mail.ru';
+      const { tooltipMessage } = createValidation();
+      expect(tooltipMessage.value).toBe('');
+    });
+  });
+
+  describe('validateField', () => {
+    it('sets error for invalid field', () => {
+      const { validateField, getFieldError } = createValidation();
+      validateField('name');
+      expect(getFieldError('name')).toBe('Имя');
+    });
+
+    it('clears error when field becomes valid', () => {
+      const { validateField, getFieldError } = createValidation();
+      validateField('name');
+      expect(getFieldError('name')).toBe('Имя');
+
+      name.value = 'Сергей';
+      validateField('name');
+      expect(getFieldError('name')).toBe('');
+    });
+
+    it('does not return error for untouched field', () => {
+      const { getFieldError } = createValidation();
+      expect(getFieldError('name')).toBe('');
+    });
+  });
+
+  describe('validateAll', () => {
+    it('returns false and sets errors for all empty fields', () => {
+      const { validateAll, getFieldError } = createValidation();
+      const result = validateAll();
+
+      expect(result).toBe(false);
+      expect(getFieldError('name')).toBe('Имя');
+      expect(getFieldError('email')).toBe('Email');
+    });
+
+    it('returns true when all fields are valid', () => {
+      name.value = 'Сергей';
+      email.value = 'test@mail.ru';
+      const { validateAll } = createValidation();
+      expect(validateAll()).toBe(true);
+    });
+  });
+
+  describe('resetValidation', () => {
+    it('clears all errors and touched state', () => {
+      const { validateAll, resetValidation, getFieldError, fieldErrors, touched } = createValidation();
+      validateAll();
+      expect(getFieldError('name')).toBe('Имя');
+
+      resetValidation();
+      expect(fieldErrors.value).toEqual({});
+      expect(touched.value).toEqual({});
+      expect(getFieldError('name')).toBe('');
+    });
+  });
+});

--- a/frontend/src/composables/__tests__/usePhoneFormat.spec.js
+++ b/frontend/src/composables/__tests__/usePhoneFormat.spec.js
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatPhoneNumberImmediately,
+  formatPhoneNumber,
+  clearPhoneFormat,
+} from '../usePhoneFormat';
+
+describe('formatPhoneNumberImmediately', () => {
+  it.each([
+    ['9161234567', '+7 (916) 123 45-67', '9161234567'],
+    ['89161234567', '+7 (916) 123 45-67', '89161234567'],
+    ['+79161234567', '+7 (916) 123 45-67', '79161234567'],
+    ['+7 (916) 123-45-67', '+7 (916) 123 45-67', '79161234567'],
+  ])('formats "%s" to "%s"', (input, expectedFormatted, expectedRaw) => {
+    const result = formatPhoneNumberImmediately(input);
+    expect(result.formatted).toBe(expectedFormatted);
+    expect(result.raw).toBe(expectedRaw);
+  });
+
+  it.each([
+    ['', ''],
+    [null, ''],
+    [undefined, ''],
+  ])('returns empty raw for falsy input: %s', (input, expectedRaw) => {
+    const result = formatPhoneNumberImmediately(input);
+    expect(result.raw).toBe(expectedRaw);
+    expect(result.formatted).toBe(input);
+  });
+
+  it('strips non-digit characters', () => {
+    const result = formatPhoneNumberImmediately('abc+7(916)def123-45-67');
+    expect(result.raw).toBe('79161234567');
+    expect(result.formatted).toBe('+7 (916) 123 45-67');
+  });
+
+  it('returns raw digits without formatting for incomplete number', () => {
+    const result = formatPhoneNumberImmediately('916');
+    expect(result.raw).toBe('916');
+    expect(result.formatted).toBe('916');
+  });
+
+  it('does not format 11-digit number not starting with 7 or 8', () => {
+    const result = formatPhoneNumberImmediately('19161234567');
+    expect(result.raw).toBe('19161234567');
+    expect(result.formatted).toBe('19161234567');
+  });
+});
+
+describe('formatPhoneNumber', () => {
+  it.each([
+    ['', ''],
+    [null, ''],
+    [undefined, ''],
+  ])('returns empty raw for falsy input: %s', (input, expectedRaw) => {
+    const result = formatPhoneNumber(input);
+    expect(result.raw).toBe(expectedRaw);
+    expect(result.formatted).toBe(input);
+  });
+
+  it('formats complete 10-digit number with 7 prefix', () => {
+    const result = formatPhoneNumber('9161234567');
+    expect(result.formatted).toBe('+7 (916) 123 45-67');
+  });
+
+  it('replaces 8-prefix with 7 for 11-digit number', () => {
+    const result = formatPhoneNumber('89161234567');
+    expect(result.formatted).toBe('+7 (916) 123 45-67');
+  });
+
+  it('returns raw digits for partial input', () => {
+    const result = formatPhoneNumber('916123');
+    expect(result.raw).toBe('916123');
+    expect(result.formatted).toBe('916123');
+  });
+
+  it('formats +7 prefixed number', () => {
+    const result = formatPhoneNumber('+79161234567');
+    expect(result.formatted).toBe('+7 (916) 123 45-67');
+    expect(result.raw).toBe('79161234567');
+  });
+});
+
+describe('clearPhoneFormat', () => {
+  it('returns the raw number as-is', () => {
+    expect(clearPhoneFormat('79161234567')).toBe('79161234567');
+  });
+
+  it('returns empty string for falsy input', () => {
+    expect(clearPhoneFormat('')).toBe('');
+    expect(clearPhoneFormat(null)).toBe('');
+    expect(clearPhoneFormat(undefined)).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

78 новых unit и компонентных тестов для фронтенда.

### Composables (#34, #36, #37) — 49 тестов:
- **usePhoneFormat** (19): formatPhoneNumberImmediately, formatPhoneNumber, clearPhoneFormat
- **useFormValidation** (14): isValid, missingFields, tooltipMessage, validateField, validateAll, resetValidation
- **useEntitySelection** (11): toggle, isSelected, confirm, syncFromConfirmed, reset, count
- **useDropdownState** (5): toggle, close

### UI компоненты (#39, #40) — 29 тестов:
- **StatusBadge** (14): 8 status→color маппингов, unknown fallback, badge/dot variant
- **BaseModal** (9): show/hide, close emit (button, overlay, Escape), closable toggle
- **FilterTabs** (6): visible filtering, active class, click emit

Closes #34, closes #36, closes #37, closes #39, closes #40

## Test plan

- [x] `npx vitest run` — 111 tests, 10 files, all pass