### PR TITLE
test: E2E тесты admin-only access control

### DIFF
--- a/frontend/e2e/tests/admin-access.spec.js
+++ b/frontend/e2e/tests/admin-access.spec.js
@@ -1,0 +1,27 @@
+const { test, expect } = require('@playwright/test');
+const { registerUser, loginAsAdmin, loginAsUser } = require('../helpers/auth');
+
+test.describe('Admin-only Access Control', () => {
+  test('non-admin redirected from /admin/users', async ({ page }) => {
+    const username = `e2e_noadmin_users_${Date.now()}`;
+    await loginAsUser(page, username);
+
+    await page.goto('/admin/users');
+    await expect(page).not.toHaveURL(/admin\/users/);
+  });
+
+  test('non-admin redirected from /admin/settings', async ({ page }) => {
+    const username = `e2e_noadmin_settings_${Date.now()}`;
+    await loginAsUser(page, username);
+
+    await page.goto('/admin/settings');
+    await expect(page).not.toHaveURL(/admin\/settings/);
+  });
+
+  test('admin can access /admin/users', async ({ page }) => {
+    await loginAsAdmin(page);
+
+    await page.goto('/admin/users');
+    await expect(page).toHaveURL(/admin\/users/);
+  });
+});


### PR DESCRIPTION
## Summary

3 E2E теста проверки доступа к admin-страницам:
1. non-admin редиректится с /admin/users
2. non-admin редиректится с /admin/settings
3. admin может открыть /admin/users

Closes #42

## Test plan

- [ ] `npx playwright test admin-access` — все 3 теста проходят