### PR TITLE
refactor: унифицировал docker-compose через base + overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,10 @@ seed:
 	docker compose exec go-backend go run ./cmd/seed $(PASS)
 
 staging-seed:
-	docker compose -f docker-compose.staging.yml exec backend ./seed $(PASS)
+	docker compose -f docker-compose.base.yml -f docker-compose.staging.yml exec backend ./seed $(PASS)
 
 deploy-seed:
-	docker compose -f docker-compose.prod.yml exec backend ./seed $(PASS)
+	docker compose -f docker-compose.base.yml -f docker-compose.prod.yml exec backend ./seed $(PASS)
 
 init:
 	git config core.hooksPath .githooks
@@ -55,28 +55,28 @@ init-production:
 	bash scripts/init-env.sh production $(DOMAIN)
 
 staging-build:
-	docker compose -f docker-compose.staging.yml build
+	docker compose -f docker-compose.base.yml -f docker-compose.staging.yml build
 
 staging-up:
-	docker compose -f docker-compose.staging.yml up -d
+	docker compose -f docker-compose.base.yml -f docker-compose.staging.yml up -d
 
 staging-down:
-	docker compose -f docker-compose.staging.yml down
+	docker compose -f docker-compose.base.yml -f docker-compose.staging.yml down
 
 staging-logs:
-	docker compose -f docker-compose.staging.yml logs -f
+	docker compose -f docker-compose.base.yml -f docker-compose.staging.yml logs -f
 
 deploy-build:
-	docker compose -f docker-compose.prod.yml build
+	docker compose -f docker-compose.base.yml -f docker-compose.prod.yml build
 
 deploy-up:
-	docker compose -f docker-compose.prod.yml up -d
+	docker compose -f docker-compose.base.yml -f docker-compose.prod.yml up -d
 
 deploy-down:
-	docker compose -f docker-compose.prod.yml down
+	docker compose -f docker-compose.base.yml -f docker-compose.prod.yml down
 
 deploy-logs:
-	docker compose -f docker-compose.prod.yml logs -f
+	docker compose -f docker-compose.base.yml -f docker-compose.prod.yml logs -f
 
 security:
 	go install golang.org/x/vuln/cmd/govulncheck@latest && govulncheck ./...

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -1,0 +1,49 @@
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: ${DB_NAME}
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    restart: always
+
+  backend:
+    build:
+      context: .
+      target: production
+    environment:
+      DATABASE_URL: postgres://${DB_USER}:${DB_PASSWORD}@db/${DB_NAME}
+      BIND_HOST: "0.0.0.0"
+      BIND_PORT: "8080"
+      JWT_SECRET: ${JWT_SECRET}
+      JWT_REFRESH_SECRET: ${JWT_REFRESH_SECRET}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      DATA_ENCRYPTION_KEY: ${DATA_ENCRYPTION_KEY:-}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-}
+      UPLOAD_PATH: /app/uploads
+    volumes:
+      - uploads:/app/uploads
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: always
+
+  frontend:
+    build:
+      context: ./frontend
+      target: production
+    depends_on:
+      - backend
+    restart: always
+
+volumes:
+  pgdata:
+  uploads:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,49 +1,4 @@
 services:
-  db:
-    image: postgres:16-alpine
-    environment:
-      POSTGRES_DB: ${DB_NAME}
-      POSTGRES_USER: ${DB_USER}
-      POSTGRES_PASSWORD: ${DB_PASSWORD}
-    volumes:
-      - pgdata:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${DB_USER}"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 10s
-    restart: always
-
-  backend:
-    build:
-      context: .
-      target: production
-    environment:
-      DATABASE_URL: postgres://${DB_USER}:${DB_PASSWORD}@db/${DB_NAME}
-      BIND_HOST: "0.0.0.0"
-      BIND_PORT: "8080"
-      JWT_SECRET: ${JWT_SECRET}
-      JWT_REFRESH_SECRET: ${JWT_REFRESH_SECRET}
-      LOG_LEVEL: ${LOG_LEVEL:-info}
-      DATA_ENCRYPTION_KEY: ${DATA_ENCRYPTION_KEY:-}
-      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-}
-      UPLOAD_PATH: /app/uploads
-    volumes:
-      - uploads:/app/uploads
-    depends_on:
-      db:
-        condition: service_healthy
-    restart: always
-
-  frontend:
-    build:
-      context: ./frontend
-      target: production
-    depends_on:
-      - backend
-    restart: always
-
   nginx:
     image: nginx:1.25-alpine
     ports:
@@ -55,7 +10,3 @@ services:
       - backend
       - frontend
     restart: always
-
-volumes:
-  pgdata:
-  uploads:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,48 +1,7 @@
 services:
-  db:
-    image: postgres:16-alpine
-    environment:
-      POSTGRES_DB: ${DB_NAME}
-      POSTGRES_USER: ${DB_USER}
-      POSTGRES_PASSWORD: ${DB_PASSWORD}
-    volumes:
-      - pgdata:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${DB_USER}"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 10s
-    restart: always
-
   backend:
-    build:
-      context: .
-      target: production
     environment:
-      DATABASE_URL: postgres://${DB_USER}:${DB_PASSWORD}@db/${DB_NAME}
-      BIND_HOST: "0.0.0.0"
-      BIND_PORT: "8080"
-      JWT_SECRET: ${JWT_SECRET}
-      JWT_REFRESH_SECRET: ${JWT_REFRESH_SECRET}
       LOG_LEVEL: ${LOG_LEVEL:-debug}
-      DATA_ENCRYPTION_KEY: ${DATA_ENCRYPTION_KEY:-}
-      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-}
-      UPLOAD_PATH: /app/uploads
-    volumes:
-      - uploads:/app/uploads
-    depends_on:
-      db:
-        condition: service_healthy
-    restart: always
-
-  frontend:
-    build:
-      context: ./frontend
-      target: production
-    depends_on:
-      - backend
-    restart: always
 
   nginx:
     build:
@@ -77,6 +36,4 @@ services:
     restart: always
 
 volumes:
-  pgdata:
-  uploads:
   pgadmin_data:


### PR DESCRIPTION
## Summary

Извлёк общие сервисы (db, backend, frontend) в `docker-compose.base.yml`. Staging и prod — тонкие override-файлы.

### Было:
- `docker-compose.staging.yml` — 82 строки, полная копия всех сервисов
- `docker-compose.prod.yml` — 62 строки, полная копия

### Стало:
- `docker-compose.base.yml` — 42 строки (db + backend + frontend)
- `docker-compose.staging.yml` — 32 строки (nginx с basic auth + pgadmin)
- `docker-compose.prod.yml` — 12 строк (nginx)

### Запуск:
```bash
make staging-up    # docker compose -f base.yml -f staging.yml up -d
make deploy-up     # docker compose -f base.yml -f prod.yml up -d
```

Dev compose (`docker-compose.yml`) не тронут — он слишком отличается (dev target, mounted volumes, go-backend vs backend).

Closes #50

## Test plan

- [ ] `make staging-up` — поднимается корректно
- [ ] `make deploy-up` — поднимается корректно
- [ ] Dev `make up` — не сломан (docker-compose.yml не менялся)