### PR TITLE
fix: разрешил Google Fonts в CSP (#67)

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -34,5 +34,5 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; frame-ancestors 'self';" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'self';" always;
 }

--- a/nginx/staging.conf
+++ b/nginx/staging.conf
@@ -57,5 +57,5 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; frame-ancestors 'self';" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'self';" always;
 }


### PR DESCRIPTION
## Summary
CSP `style-src 'self' 'unsafe-inline'` блокировал подключение шрифтов Montserrat / PT Sans из fonts.googleapis.com в SPA (frontend/index.html). UI откатывался на системный sans-serif.

Правка в `nginx/nginx.conf` и `nginx/staging.conf`:
- `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com`
- `font-src 'self' https://fonts.gstatic.com`

## Test plan
- [ ] CI зелёный
- [ ] После деплоя на staging в консоли нет CSP-ошибок про fonts.googleapis.com
- [ ] DevTools → Network показывает два 200 от googleapis.com / gstatic.com
- [ ] Тексты на экране отрисованы Montserrat, не системным шрифтом

Closes #67