### PR TITLE
test: добавил data-testid во все компоненты (замена #54 с ребейзом)

### DIFF
--- a/frontend/src/components/AccountComponent.vue
+++ b/frontend/src/components/AccountComponent.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="account-dashboard">
+  <div class="account-dashboard" data-testid="cabinet-page">
     <!-- Первая строка: заголовок и заявки -->
     <div class="first-row">
       <SkeletonTransition :loading="loading">

--- a/frontend/src/components/ApplicationDetail/ApplicationActionBar.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationActionBar.vue
@@ -10,6 +10,7 @@
                     <template v-if="application.confirmation !== 'Не согласовано' && application.status !== 'Завершено'">
                         <button
                             class="accept-btn"
+                            data-testid="app-detail-button-approve"
                             @click="handleCombinedAction('accept')"
                             :disabled="processing"
                         >
@@ -18,6 +19,7 @@
                         </button>
                         <button
                             class="reject-btn"
+                            data-testid="app-detail-button-reject"
                             @click="handleCombinedAction('reject')"
                             :disabled="processing"
                         >
@@ -75,6 +77,7 @@
                     <template v-else-if="application.confirmation === 'Согласовано'">
                         <button
                             class="accept-btn"
+                            data-testid="app-detail-button-take-to-work"
                             @click="handleApplicationAction('accept')"
                             :disabled="processing"
                         >
@@ -83,6 +86,7 @@
                         </button>
                         <button
                             class="reject-btn"
+                            data-testid="app-detail-button-reject"
                             @click="handleApplicationAction('reject')"
                             :disabled="processing"
                         >
@@ -137,6 +141,7 @@
                 <template v-else-if="application.confirmation === 'Согласовано'">
                     <button
                         class="accept-btn"
+                        data-testid="app-detail-button-take-to-work"
                         @click="handleApplicationAction('accept')"
                         :disabled="processing"
                     >
@@ -145,6 +150,7 @@
                     </button>
                     <button
                         class="reject-btn"
+                        data-testid="app-detail-button-reject"
                         @click="handleApplicationAction('reject')"
                         :disabled="processing"
                     >
@@ -166,6 +172,7 @@
                     <template v-if="application.confirmation !== 'Не согласовано' && application.status !== 'Завершено'">
                         <button
                             class="confirm-btn"
+                            data-testid="app-detail-button-approve"
                             @click="updateConfirmation('Согласовано')"
                             :disabled="updatingConfirmation || processing"
                         >
@@ -174,6 +181,7 @@
                         </button>
                         <button
                             class="reject-btn"
+                            data-testid="app-detail-button-reject"
                             @click="updateConfirmation('Не согласовано')"
                             :disabled="updatingConfirmation || processing"
                         >

--- a/frontend/src/components/ApplicationDetail/ApplicationDetail.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationDetail.vue
@@ -29,9 +29,10 @@
                             <span class="weekday">{{ getWeekday(applicationData.sending_datetime) }}</span>
                         </div>
                         <!-- Кнопка пересылки (рядом с датой) -->
-                        <button 
+                        <button
                             v-if="mode === 'center'"
-                            class="forward-btn" 
+                            class="forward-btn"
+                            data-testid="app-detail-button-forward"
                             @click="forwardApplication"
                             :disabled="updatingConfirmation || processingApplication"
                         >

--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="selected-table-card">
+  <div class="selected-table-card" data-testid="cars-table">
     <transition name="slide-down">
       <div v-if="notification.message" class="notification">
         <span>{{ notification.message }}</span>

--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -31,9 +31,10 @@
                         <div class="header__right">
                             <div class="consent-section">
                                 <div class="consent-checkbox">
-                                    <input 
-                                        type="checkbox" 
+                                    <input
+                                        type="checkbox"
                                         id="consent"
+                                        data-testid="create-app-consent-checkbox"
                                         v-model="consentGiven"
                                         required
                                     />
@@ -42,7 +43,7 @@
                                         персональных данных, изложенных в заявке
                                     </label>
                                 </div>
-                                <button class="send-all-btn" @click="submitApplication" :disabled="!canSubmit">
+                                <button class="send-all-btn" data-testid="create-app-button-submit" @click="submitApplication" :disabled="!canSubmit">
                                     Отправить заявку
                                 </button>
                             </div>

--- a/frontend/src/components/FactTable.vue
+++ b/frontend/src/components/FactTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fact-table-card">
+  <div class="fact-table-card" data-testid="fact-table">
     <div class="card-header">
       <div class="card-header__title">
         <h3 class="card-title">{{ tableType === 'cars' ? 'Автомобили' : 'Люди' }} <span class="highlight-text">по факту</span></h3>

--- a/frontend/src/components/LoginComponent.vue
+++ b/frontend/src/components/LoginComponent.vue
@@ -24,6 +24,7 @@
                             <img src="@/assets/icons/login.png" alt="" class="input__icon" />
                             <FormField label="Логин" :required="true" :error="fieldError('username')">
                                 <input v-model="formData.username" class="input" type="text"
+                                    data-testid="login-input-username"
                                     autocomplete="off"
                                     autocorrect="off"
                                     autocapitalize="off"
@@ -38,6 +39,7 @@
                             <img src="@/assets/icons/password.png" alt="" class="input__icon" />
                             <FormField label="Пароль" :required="true" :error="fieldError('password')">
                                 <input v-model="formData.password" class="input" type="password"
+                                    data-testid="login-input-password"
                                     autocomplete="new-password"
                                     autocorrect="off"
                                     autocapitalize="off"
@@ -55,14 +57,14 @@
                     <div class="login__footer" :style="footerStyle">
                         <div class="error-container">
                             <transition name="fade">
-                                <div v-if="showError" class="error-message">
+                                <div v-if="showError" class="error-message" data-testid="login-error-message">
                                     {{ errors.general }}
                                 </div>
                             </transition>
                         </div>
                         
                         <div class="footer__button">
-                            <button class="login__button" :class="{'loading': isLoading, 'success': isSuccess}" :disabled="isLoading || isSuccess">
+                            <button class="login__button" data-testid="login-button-submit" :class="{'loading': isLoading, 'success': isSuccess}" :disabled="isLoading || isSuccess">
                                 <p class="button__text">{{ getButtonText }}</p>
                                 <img v-if="!isLoading && !isSuccess" src="@/assets/icons/key-blue.png" alt="" class="input__icon"/>
                                 <div v-if="isLoading" class="spinner"></div>

--- a/frontend/src/components/NavMenu.vue
+++ b/frontend/src/components/NavMenu.vue
@@ -12,7 +12,7 @@
       <!-- ЗАЯВКИ -->
       <div class="nav-section">
         <div class="section-title">ЗАЯВКИ</div>
-        <div class="nav-item" @click="navigateToCenter"> 
+        <div class="nav-item" data-testid="nav-link-center" @click="navigateToCenter">
           <div class="nav-icon-wrapper">
             <img src="@/assets/icons/envelope.png" alt="Центр заявок" class="nav-icon">
             <span v-if="newApplicationsCount > 0" class="icon-badge">
@@ -72,11 +72,11 @@
         </div>
 
         <!-- Элемент с выпадающим списком сотрудников -->
-        <div class="nav-item" @click="navigateToEmployeesView">
+        <div class="nav-item" data-testid="nav-link-employees" @click="navigateToEmployeesView">
           <img src="@/assets/icons/employees.png" alt="Сотрудники" class="nav-icon">
           <span class="nav-text">Сотрудники</span>
         </div>
-        <div class="nav-item" @click="navigateToCarsView">
+        <div class="nav-item" data-testid="nav-link-cars" @click="navigateToCarsView">
           <img src="@/assets/icons/car.png" alt="Автомобили" class="nav-icon">
           <span class="nav-text">Автомобили</span>
         </div>
@@ -98,7 +98,7 @@
       <!-- ПОЛЬЗОВАТЕЛЬ (в нижней части) -->
       <div class="nav-section user-section">
         <div class="section-title">ПОЛЬЗОВАТЕЛЬ</div>
-        <div class="nav-item" @click="navigateToNews">
+        <div class="nav-item" data-testid="nav-link-news" @click="navigateToNews">
           <img src="@/assets/icons/newspaper.png" alt="Новости" class="nav-icon">
           <span class="nav-text">Обзор и новости</span>
         </div>
@@ -153,11 +153,11 @@
           </transition>
         </div>
         
-        <div class="nav-item" @click="navigateToAccount">
+        <div class="nav-item" data-testid="nav-link-cabinet" @click="navigateToAccount">
           <img src="@/assets/icons/user.png" alt="Личный кабинет" class="nav-icon">
           <span class="nav-text">Личный кабинет</span>
         </div>
-        <div class="nav-item" @click="logout">
+        <div class="nav-item" data-testid="nav-button-logout" @click="logout">
           <img src="@/assets/icons/logout.png" alt="Выйти" class="nav-icon">
           <span class="nav-text exit">Выйти</span>
         </div>

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="selected-table-card">
+  <div class="selected-table-card" data-testid="people-table">
     <transition name="slide-down">
       <div v-if="notification.message" class="notification">
         <span>{{ notification.message }}</span>

--- a/frontend/src/components/TheHeader/TheHeader.vue
+++ b/frontend/src/components/TheHeader/TheHeader.vue
@@ -12,7 +12,7 @@
     </div>
 
     <div class="header__info">
-      <button class="feedback-btn" @click="openFeedbackModal">
+      <button class="feedback-btn" data-testid="header-button-feedback" @click="openFeedbackModal">
         Сообщить о проблеме
       </button>
       <button v-if="activeAnnouncement" class="broadcast" @click="showAnnouncement = true">
@@ -33,7 +33,7 @@
         @update:unread-count="unreadCount = $event"
       />
       <div class="appl-btn__container">
-        <button class="appl-btn" @click="navigateToSubmit" :class="{ 'appl-btn--fixed': isHeaderHidden }">
+        <button class="appl-btn" data-testid="header-button-submit-app" @click="navigateToSubmit" :class="{ 'appl-btn--fixed': isHeaderHidden }">
           Подать заявку
         </button>
       </div>

--- a/frontend/src/components/UserProfileHeader.vue
+++ b/frontend/src/components/UserProfileHeader.vue
@@ -4,7 +4,7 @@
       <!-- Основная информация -->
       <div class="main-info">
         <div class="name-and-type">
-          <h2 class="user-name">{{ displayName }}</h2>
+          <h2 class="user-name" data-testid="cabinet-text-username">{{ displayName }}</h2>
           <span class="user-type-badge">{{ userTypeDisplay }}</span>
         </div>
         <div class="org-company-block">

--- a/frontend/src/components/ui/BaseModal.vue
+++ b/frontend/src/components/ui/BaseModal.vue
@@ -7,7 +7,7 @@
             <slot name="header">
               <h3 class="base-modal__title">{{ title }}</h3>
             </slot>
-            <button v-if="closable" class="base-modal__close" @click="$emit('close')" aria-label="Закрыть">&times;</button>
+            <button v-if="closable" class="base-modal__close" data-testid="modal-button-close" @click="$emit('close')" aria-label="Закрыть">&times;</button>
           </div>
           <div class="base-modal__body">
             <slot></slot>

--- a/frontend/src/components/ui/FilterTabs.vue
+++ b/frontend/src/components/ui/FilterTabs.vue
@@ -5,6 +5,7 @@
       :key="tab.key"
       class="filter-tab"
       :class="{ 'filter-tab--active': modelValue === tab.key }"
+      :data-testid="`filter-tab-${tab.key}`"
       @click="$emit('update:modelValue', tab.key)"
     >
       {{ tab.label }}

--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -3,7 +3,7 @@
         <header class="center__header">
             <div class="header-top">
                 <h2 class="center__title">Центр заявок</h2>
-                <div class="unread-badge" v-if="unreadCount > 0" :class="{ 'shake-animation': shouldShake }">
+                <div class="unread-badge" data-testid="center-badge-unread" v-if="unreadCount > 0" :class="{ 'shake-animation': shouldShake }">
                     Новые: {{ unreadCount }}
                 </div>
             </div>
@@ -17,10 +17,11 @@
             <div class="filters__main">
                 <div class="filters-row">
                     <div class="field search">
-                        <input 
-                            placeholder="Поиск заявок..." 
-                            type="text" 
-                            class="field__input search" 
+                        <input
+                            placeholder="Поиск заявок..."
+                            type="text"
+                            class="field__input search"
+                            data-testid="center-input-search"
                             v-model="searchQuery"
                             @input="applyFilters"
                         />
@@ -56,8 +57,9 @@
                         Сбросить сортировку
                     </button>
 
-                    <button 
+                    <button
                         class="reset-filters-btn"
+                        data-testid="center-button-reset-filters"
                         @click="resetFilters"
                         :disabled="!hasActiveFilters"
                     >
@@ -71,11 +73,12 @@
                             <span class="filter-label">Подтверждение</span>
                         </div>
                         <div class="status-buttons">
-                            <button 
+                            <button
                                 v-for="confirmation in confirmations"
                                 :key="confirmation.value"
                                 class="status-btn"
                                 :class="{ 'status-btn--active': selectedConfirmations.includes(confirmation.value) }"
+                                :data-testid="`center-button-confirmation-${confirmation.value}`"
                                 @click="toggleConfirmation(confirmation.value)"
                             >
                                 {{ confirmation.label }}
@@ -88,11 +91,12 @@
                             <span class="filter-label">Статус заявки</span>
                         </div>
                         <div class="status-buttons">
-                            <button 
+                            <button
                                 v-for="status in applicationStatuses"
                                 :key="status.value"
                                 class="status-btn"
                                 :class="{ 'status-btn--active': selectedApplicationStatuses.includes(status.value) }"
+                                :data-testid="`center-button-status-${status.value}`"
                                 @click="toggleApplicationStatus(status.value)"
                             >
                                 {{ status.label }}
@@ -186,15 +190,16 @@
                         <SkeletonTable :rows="10" :columns="6" />
                     </template>
                 <div v-if="filteredApplications.length > 0" class="applications-list">
-                    <div 
-                        v-for="(application, index) in sortedApplications" 
-                        :key="application.id" 
+                    <div
+                        v-for="(application, index) in sortedApplications"
+                        :key="application.id"
                         class="application-item"
-                        :class="{ 
+                        :class="{
                             'unread': application.status === 'Непрочитано',
                             'initial-load': isInitialLoad,
                             'filtered': !isInitialLoad
                         }"
+                        :data-testid="`center-row-${application.id}`"
                         @click="openApplication(application)"
                         :style="isInitialLoad ? { 'animation-delay': `${index * 0.05}s` } : {}"
                     >

--- a/frontend/src/views/CarsView.vue
+++ b/frontend/src/views/CarsView.vue
@@ -1,5 +1,5 @@
 <template>
-    <section class="carsview">
+    <section class="carsview" data-testid="cars-page">
         <header class="carsview__header">
             <h2 class="carsview__title">
                 Список <span class="blue">автомобилей</span>

--- a/frontend/src/views/EmployeeView.vue
+++ b/frontend/src/views/EmployeeView.vue
@@ -1,5 +1,5 @@
 <template>
-    <section class="employeesview">
+    <section class="employeesview" data-testid="employees-page">
         <header class="employeesview__header">
             <h2 class="employeesview__title">
                 Список <span class="blue">сотрудников</span>


### PR DESCRIPTION
## Summary
Тот же набор data-testid во всех Vue-компонентах что и в #54, но поверх свежего dev (ребейзнут).

PR #54 стал CONFLICTING из-за изменений в Vue-компонентах на dev через #51 (feat: миграция фич из old_branch). Force-push в чужую ветку заблокирован по политике — открываю отдельный PR.

После мержа этого — закрыть #54 как outdated и разблокировать #55 (Page Objects + E2E data-testid) и #61 (Playwright в CI, которому нужны data-testid).

## Test plan
- [x] `npx vitest run` → 203 passed (13 файлов)
- [x] `npx eslint src/` → 0 warnings
- [ ] CI зелёный

Closes #20, #21, #22, #23, #24. Replaces #54.