### PR TITLE
refactor: унифицировал docker-compose через base + overrides (замена #63)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,8 +52,8 @@ jobs:
             git fetch origin dev
             git reset --hard origin/dev
             test -f .env || bash scripts/init-env.sh staging ${{ secrets.STAGING_DOMAIN }}
-            docker compose -f docker-compose.staging.yml build
-            docker compose -f docker-compose.staging.yml up -d
+            docker compose -f docker-compose.base.yml -f docker-compose.staging.yml build
+            docker compose -f docker-compose.base.yml -f docker-compose.staging.yml up -d
             docker system prune -f --filter 'until=24h' 2>/dev/null || true
             docker builder prune -f --filter 'until=24h' 2>/dev/null || true
             sleep 5
@@ -87,8 +87,8 @@ jobs:
             git fetch origin prod
             git reset --hard origin/prod
             test -f .env || bash scripts/init-env.sh production ${{ secrets.PROD_DOMAIN }}
-            docker compose -f docker-compose.prod.yml build
-            docker compose -f docker-compose.prod.yml up -d
+            docker compose -f docker-compose.base.yml -f docker-compose.prod.yml build
+            docker compose -f docker-compose.base.yml -f docker-compose.prod.yml up -d
             sleep 5
-            docker compose -f docker-compose.prod.yml exec backend wget -qO- http://localhost:8080/health || exit 1
+            docker compose -f docker-compose.base.yml -f docker-compose.prod.yml exec backend wget -qO- http://localhost:8080/health || exit 1
             echo "Production deploy completed at $(date)"

--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,10 @@ seed:
 	docker compose exec go-backend go run ./cmd/seed $(PASS)
 
 staging-seed:
-	docker compose -f docker-compose.staging.yml exec backend ./seed $(PASS)
+	docker compose -f docker-compose.base.yml -f docker-compose.staging.yml exec backend ./seed $(PASS)
 
 deploy-seed:
-	docker compose -f docker-compose.prod.yml exec backend ./seed $(PASS)
+	docker compose -f docker-compose.base.yml -f docker-compose.prod.yml exec backend ./seed $(PASS)
 
 init:
 	git config core.hooksPath .githooks
@@ -55,28 +55,28 @@ init-production:
 	bash scripts/init-env.sh production $(DOMAIN)
 
 staging-build:
-	docker compose -f docker-compose.staging.yml build
+	docker compose -f docker-compose.base.yml -f docker-compose.staging.yml build
 
 staging-up:
-	docker compose -f docker-compose.staging.yml up -d
+	docker compose -f docker-compose.base.yml -f docker-compose.staging.yml up -d
 
 staging-down:
-	docker compose -f docker-compose.staging.yml down
+	docker compose -f docker-compose.base.yml -f docker-compose.staging.yml down
 
 staging-logs:
-	docker compose -f docker-compose.staging.yml logs -f
+	docker compose -f docker-compose.base.yml -f docker-compose.staging.yml logs -f
 
 deploy-build:
-	docker compose -f docker-compose.prod.yml build
+	docker compose -f docker-compose.base.yml -f docker-compose.prod.yml build
 
 deploy-up:
-	docker compose -f docker-compose.prod.yml up -d
+	docker compose -f docker-compose.base.yml -f docker-compose.prod.yml up -d
 
 deploy-down:
-	docker compose -f docker-compose.prod.yml down
+	docker compose -f docker-compose.base.yml -f docker-compose.prod.yml down
 
 deploy-logs:
-	docker compose -f docker-compose.prod.yml logs -f
+	docker compose -f docker-compose.base.yml -f docker-compose.prod.yml logs -f
 
 security:
 	go install golang.org/x/vuln/cmd/govulncheck@latest && govulncheck ./...

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -1,0 +1,51 @@
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: ${DB_NAME}
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    restart: always
+
+  backend:
+    build:
+      context: .
+      target: production
+    environment:
+      DATABASE_URL: postgres://${DB_USER}:${DB_PASSWORD}@db/${DB_NAME}
+      BIND_HOST: "0.0.0.0"
+      BIND_PORT: "8080"
+      JWT_SECRET: ${JWT_SECRET}
+      JWT_REFRESH_SECRET: ${JWT_REFRESH_SECRET}
+      JWT_ACCESS_TTL: ${JWT_ACCESS_TTL:-15m}
+      JWT_REFRESH_TTL: ${JWT_REFRESH_TTL:-168h}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      DATA_ENCRYPTION_KEY: ${DATA_ENCRYPTION_KEY:-}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-}
+      UPLOAD_PATH: /app/uploads
+    volumes:
+      - uploads:/app/uploads
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: always
+
+  frontend:
+    build:
+      context: ./frontend
+      target: production
+    depends_on:
+      - backend
+    restart: always
+
+volumes:
+  pgdata:
+  uploads:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,51 +1,4 @@
 services:
-  db:
-    image: postgres:16-alpine
-    environment:
-      POSTGRES_DB: ${DB_NAME}
-      POSTGRES_USER: ${DB_USER}
-      POSTGRES_PASSWORD: ${DB_PASSWORD}
-    volumes:
-      - pgdata:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${DB_USER}"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 10s
-    restart: always
-
-  backend:
-    build:
-      context: .
-      target: production
-    environment:
-      DATABASE_URL: postgres://${DB_USER}:${DB_PASSWORD}@db/${DB_NAME}
-      BIND_HOST: "0.0.0.0"
-      BIND_PORT: "8080"
-      JWT_SECRET: ${JWT_SECRET}
-      JWT_REFRESH_SECRET: ${JWT_REFRESH_SECRET}
-      JWT_ACCESS_TTL: ${JWT_ACCESS_TTL:-15m}
-      JWT_REFRESH_TTL: ${JWT_REFRESH_TTL:-168h}
-      LOG_LEVEL: ${LOG_LEVEL:-info}
-      DATA_ENCRYPTION_KEY: ${DATA_ENCRYPTION_KEY:-}
-      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-}
-      UPLOAD_PATH: /app/uploads
-    volumes:
-      - uploads:/app/uploads
-    depends_on:
-      db:
-        condition: service_healthy
-    restart: always
-
-  frontend:
-    build:
-      context: ./frontend
-      target: production
-    depends_on:
-      - backend
-    restart: always
-
   nginx:
     image: nginx:1.25-alpine
     ports:
@@ -57,7 +10,3 @@ services:
       - backend
       - frontend
     restart: always
-
-volumes:
-  pgdata:
-  uploads:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,50 +1,7 @@
 services:
-  db:
-    image: postgres:16-alpine
-    environment:
-      POSTGRES_DB: ${DB_NAME}
-      POSTGRES_USER: ${DB_USER}
-      POSTGRES_PASSWORD: ${DB_PASSWORD}
-    volumes:
-      - pgdata:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${DB_USER}"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 10s
-    restart: always
-
   backend:
-    build:
-      context: .
-      target: production
     environment:
-      DATABASE_URL: postgres://${DB_USER}:${DB_PASSWORD}@db/${DB_NAME}
-      BIND_HOST: "0.0.0.0"
-      BIND_PORT: "8080"
-      JWT_SECRET: ${JWT_SECRET}
-      JWT_REFRESH_SECRET: ${JWT_REFRESH_SECRET}
-      JWT_ACCESS_TTL: ${JWT_ACCESS_TTL:-15m}
-      JWT_REFRESH_TTL: ${JWT_REFRESH_TTL:-168h}
       LOG_LEVEL: ${LOG_LEVEL:-debug}
-      DATA_ENCRYPTION_KEY: ${DATA_ENCRYPTION_KEY:-}
-      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-}
-      UPLOAD_PATH: /app/uploads
-    volumes:
-      - uploads:/app/uploads
-    depends_on:
-      db:
-        condition: service_healthy
-    restart: always
-
-  frontend:
-    build:
-      context: ./frontend
-      target: production
-    depends_on:
-      - backend
-    restart: always
 
   nginx:
     build:
@@ -79,6 +36,4 @@ services:
     restart: always
 
 volumes:
-  pgdata:
-  uploads:
   pgadmin_data:


### PR DESCRIPTION
## Summary
Тот же рефакторинг compose что и в #63 (`docker-compose.base.yml` + тонкие `staging.yml`/`prod.yml` как overrides + обновлённый `Makefile`), но поверх свежего dev и с учётом двух ранее смерженных PR:

1. **#66 (JWT TTL в env)** — добавил `JWT_ACCESS_TTL`/`JWT_REFRESH_TTL` с дефолтами `15m`/`168h` в `docker-compose.base.yml`.
2. **Обновил `.github/workflows/deploy.yml`** — команды `docker compose` на staging и prod теперь используют `-f docker-compose.base.yml -f docker-compose.{staging,prod}.yml`. Без этого после мержа #63 деплой сломал бы backend (не поднял бы сервисы db/backend/frontend).

PR #63 был открыт до #66 и стал CONFLICTING. Force-push в его ветку заблокирован политикой, открываю replacement.

## Test plan
- [x] `docker compose -f docker-compose.base.yml -f docker-compose.staging.yml config` — рендерится корректно, JWT_ACCESS_TTL/JWT_REFRESH_TTL прокидываются
- [x] `docker compose -f docker-compose.base.yml -f docker-compose.prod.yml config` — аналогично
- [ ] CI зелёный
- [ ] После деплоя на staging: `make staging-up` поднимает всё стандартно; `/health`, `/login` работают; в контейнере backend `env | grep JWT` показывает `15m`/`168h`

Closes #50. Replaces #63.