### PR TITLE
fix: backend gaps из issue #64 (scheduler expired + /users)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -175,11 +175,18 @@ func main() {
 	// Routes
 	router.Setup(e, authHandler, userTypesHandler, attachmentHandler, lpfHandler, citizenshipHandler, organizationHandler, companyHandler, usersHandler, unloadPlaceHandler, carHandler, employeeHandler, systemTableHandler, uniqueCarHandler, uniqueEmployeeHandler, feedbackHandler, applicationHandler, approverHandler, permissionHandler, consentHandler, settingsHandler, newsHandler, notificationHandler, requestLogsHandler, employeesHistoryHandler, []byte(cfg.JWTSecret))
 
+	// Общий ctx для фоновых задач и graceful shutdown. Отменяется по SIGINT/SIGTERM.
+	ctxSig, stopSig := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stopSig()
+
+	// Периодическая проверка истёкших вложений заявок: деактивирует вложения
+	// с прошедшим entry_date_to/entry_time_to, завершает заявку когда все
+	// вложения неактивны. См. ApplicationWorkflowService.CheckExpiredAttachments.
+	go startExpiryScheduler(ctxSig, applicationService, 15*time.Minute)
+
 	// Graceful shutdown
 	go func() {
-		quit := make(chan os.Signal, 1)
-		signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
-		<-quit
+		<-ctxSig.Done()
 		slog.Info("shutting down server...")
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
@@ -196,4 +203,25 @@ func main() {
 		os.Exit(1)
 	}
 	slog.Info("server stopped")
+}
+
+// startExpiryScheduler запускает периодическую проверку истёкших вложений заявок.
+// Первая проверка — сразу при старте; далее — каждый interval, пока ctx не отменён.
+func startExpiryScheduler(ctx context.Context, svc services.ApplicationService, interval time.Duration) {
+	if err := svc.CheckExpiredAttachments(ctx); err != nil {
+		slog.Error("initial expiry check failed", "error", err)
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Info("expiry scheduler stopped")
+			return
+		case <-ticker.C:
+			if err := svc.CheckExpiredAttachments(ctx); err != nil {
+				slog.Error("expiry check failed", "error", err)
+			}
+		}
+	}
 }

--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -8,14 +8,6 @@ export async function login(username, password) {
   return res.json();
 }
 
-export async function register(data) {
-  const res = await apiRequest('/register', {
-    method: 'POST',
-    body: JSON.stringify(data),
-  });
-  return res.json();
-}
-
 export async function refreshToken(token) {
   const res = await apiRequest('/refresh-token', {
     method: 'POST',

--- a/frontend/src/api/users.js
+++ b/frontend/src/api/users.js
@@ -5,6 +5,17 @@ export async function getUsers() {
   return res.json();
 }
 
+// Админ создаёт пользователя. /register не экспонируется, потому что
+// публичная регистрация не предусмотрена — юзеров заводит только админ
+// через защищённый POST /users.
+export async function createUser(data) {
+  const res = await apiRequest('/users', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+  return res.json();
+}
+
 export async function updateUserType(username, typeId) {
   const res = await apiRequest(`/users/${username}/type`, {
     method: 'PUT',

--- a/frontend/src/components/CreateUserModal.vue
+++ b/frontend/src/components/CreateUserModal.vue
@@ -259,7 +259,9 @@ export default {
           phone: this.newUser.phone || null
         };
 
-        const response = await apiRequest("/register", {
+        // Админская регистрация через POST /users (JWT-защищённый).
+        // Публичный /register намеренно не экспонируется.
+        const response = await apiRequest("/users", {
           method: "POST",
           body: JSON.stringify(userData)
         });

--- a/frontend/src/components/UserControl.vue
+++ b/frontend/src/components/UserControl.vue
@@ -974,9 +974,11 @@ export default {
     
     async createUser() {
       if (!this.canCreateUser) return;
-      
+
       try {
-        const response = await apiRequest("/register", {
+        // Админская регистрация через POST /users (JWT-защищённый).
+        // Публичный /register намеренно не экспонируется.
+        const response = await apiRequest("/users", {
           method: "POST",
           body: JSON.stringify({
             username: this.newUser.username,


### PR DESCRIPTION
Закрывает из #64:

- 'Когда истекает срок действия заявки ... она не становится завершённой' — добавил периодический тикер 15m в cmd/server/main.go, вызывает ApplicationWorkflowService.CheckExpiredAttachments. Graceful stop через signal.NotifyContext.
- 'Невозможно создать новых пользователей ... 401 на /register' — фронт (CreateUserModal, UserControl) переключён на защищённый POST /users. /register остаётся неподключённым (намеренно, архитектурно админ создаёт юзеров).