### PR TITLE
fix: nginx cache headers для SPA (no-cache index.html, immutable /assets)

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -4,6 +4,22 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Ассеты с fingerprint в имени (index-<hash>.js, main-<hash>.css и т.п.)
+    # кешируются агрессивно — при изменении контента имя меняется.
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+        try_files $uri =404;
+    }
+
+    # index.html не кешируется — иначе после deploy браузер продолжит
+    # грузить старую версию, ссылающуюся на удалённый бандл.
+    location = /index.html {
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+        expires 0;
+    }
+
     # SPA fallback — все маршруты отдают index.html
     location / {
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
После deploy #78 приходилось делать hard-refresh — браузер держал в кеше index.html с ссылкой на удалённый бандл. Фикс в frontend/nginx.conf:
- /assets/* — Cache-Control immutable + max-age=1y (имя с fingerprint-хешем, содержимое неизменно)
- index.html — Cache-Control: no-cache, must-revalidate (всегда пройдёт проверку у сервера)

После этого PR каждый следующий deploy будет доставлять новую версию без ручного Ctrl+Shift+R.