### PR TITLE
fix: шапка и навигация больше не мигают на странице логина (#64)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -2,18 +2,18 @@
   <div id="app">
     <a href="#main-content" class="skip-link">Перейти к основному содержанию</a>
     <NavMenu
-      v-if="isAuthenticated"
+      v-if="showChrome"
       :is-buropropuskov="isBuropropuskov"
       @logout="logout"
     />
     <div class="content" id="main-content">
-      <TheHeader class="theheader" v-if="isAuthenticated"/>
+      <TheHeader class="theheader" v-if="showChrome"/>
       <router-view v-slot="{ Component }" class="content__container">
         <transition name="page-fade" mode="out-in">
           <component :is="Component" @login-success="handleSuccessfulLogin" :key="$route.path" />
         </transition>
       </router-view>
-      <ScrollTopButton v-if="isAuthenticated" />
+      <ScrollTopButton v-if="showChrome" />
     </div>
 
     <!-- Модальное окно истекшей сессии -->
@@ -59,6 +59,16 @@ export default {
     isBuropropuskov() {
       const authStore = useAuthStore()
       return authStore.isAdmin
+    },
+    /**
+     * Показывать шапку, навигацию и связанный chrome только когда юзер
+     * аутентифицирован и находится не на странице логина. Иначе после
+     * setTokens() в LoginComponent до router.push('/personal-cabinet')
+     * (задержан на 1.5с из-за success-анимации) шапка и меню моргают
+     * поверх формы логина.
+     */
+    showChrome() {
+      return this.isAuthenticated && this.$route.path !== '/';
     }
   },
   methods: {


### PR DESCRIPTION
Закрывает пункт #64:
> При успешной авторизации, шапка и навигация отображаются раньше, чем само приложение.

Причина — race между setTokens (isAuthenticated=true сразу) и router.push на /personal-cabinet (задержан 1.5s из-за анимации success-кнопки). В этом окне NavMenu и TheHeader уже отрендерены поверх LoginComponent.

Фикс — один computed showChrome = isAuthenticated && route.path !== '/'. Если юзер на логине — шапка и меню не рендерятся.