### PR TITLE
feat: фильтр "Заявки на сегодня" в центре заявок (#64)

### DIFF
--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -60,6 +60,15 @@
                     </button>
 
                     <button
+                        class="today-filter-btn"
+                        :class="{ 'today-filter-btn--active': activeToday }"
+                        data-testid="center-button-today"
+                        @click="toggleActiveToday"
+                    >
+                        Заявки на сегодня
+                    </button>
+
+                    <button
                         class="reset-filters-btn"
                         data-testid="center-button-reset-filters"
                         @click="resetFilters"
@@ -330,6 +339,8 @@ export default {
                 { key: 'archive', label: 'Архив' },
             ],
 
+            activeToday: false,
+
             loading: true,
 
             // Данные заявок
@@ -468,12 +479,13 @@ export default {
         },
         
         hasActiveFilters() {
-            return !!this.searchQuery.trim() || 
-                   !!this.selectedOrganizationId || 
-                   this.selectedConfirmations.length > 0 || 
+            return !!this.searchQuery.trim() ||
+                   !!this.selectedOrganizationId ||
+                   this.selectedConfirmations.length > 0 ||
                    this.selectedApplicationStatuses.length > 0 ||
                    !!this.selectedDate ||
-                   (this.dateRangeStart && this.dateRangeEnd);
+                   (this.dateRangeStart && this.dateRangeEnd) ||
+                   this.activeToday;
         },
 
         unreadCount() {
@@ -550,6 +562,12 @@ export default {
             this.applyFilters();
         },
         
+        toggleActiveToday() {
+            this.activeToday = !this.activeToday;
+            this.isInitialLoad = false;
+            this.fetchApplications();
+        },
+
         toggleApplicationStatus(status) {
             const index = this.selectedApplicationStatuses.indexOf(status);
             if (index > -1) {
@@ -569,6 +587,7 @@ export default {
             this.selectedDate = null;
             this.dateRangeStart = null;
             this.dateRangeEnd = null;
+            this.activeToday = false;
 
             this.resetSort();
 
@@ -704,6 +723,10 @@ export default {
                 
                 // Добавляем параметр архива
                 params.append('archive', this.archiveMode === 'archive' ? 'true' : 'false');
+
+                if (this.activeToday) {
+                    params.append('active_today', 'true');
+                }
 
                 // Добавляем параметры даты в запрос к API
                 if (this.selectedDate) {
@@ -1146,6 +1169,34 @@ export default {
 
 .reset-filters-btn:hover:not(:disabled) {
     background: #fed7d7;
+}
+
+.today-filter-btn {
+    padding: 6px 12px;
+    border: 1px solid var(--color-border);
+    background: white;
+    border-radius: 15px;
+    cursor: pointer;
+    font-size: 12px;
+    transition: all 0.2s;
+    height: 30px;
+    color: #333;
+    white-space: nowrap;
+}
+
+.today-filter-btn:hover {
+    background: #f5f5f5;
+}
+
+.today-filter-btn--active {
+    background: var(--color-primary);
+    color: white;
+    border-color: var(--color-primary);
+}
+
+.today-filter-btn--active:hover {
+    background: #3a45c0;
+    border-color: #3a45c0;
 }
 
 .applications-table {

--- a/internal/handlers/application_reads_test.go
+++ b/internal/handlers/application_reads_test.go
@@ -204,6 +204,42 @@ func TestGetApplications_ArchiveTrue_ShowsOnlyArchived(t *testing.T) {
 	assert.Equal(t, float64(appID), apps[0]["id"])
 }
 
+// --- Part 3: Active today ---
+
+func TestGetApplications_ActiveToday_FiltersByAttachmentPeriod(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	makeApprover(t, db, "testadmin")
+
+	// Заявка, активная сегодня: период действия вложения охватывает текущую дату.
+	uaID := seedUniqueAttachment(t, db, "cars", "cars_today", "CarsToday")
+	todayAppID := submitCompleteApplication(t, e, token, "Test Organization", uaID)
+	db.Model(&models.Attachment{}).Where("application_id = ?", todayAppID).Updates(map[string]interface{}{
+		"entry_date_from": "2025-01-01",
+		"entry_date_to":   "2099-12-31",
+	})
+
+	// Заявка с прошедшим периодом — попадает в общий список, но не в active_today.
+	uaID2 := seedUniqueAttachment(t, db, "cars", "cars_past", "CarsPast")
+	pastAppID := submitCompleteApplication(t, e, token, "Test Organization", uaID2)
+	db.Model(&models.Attachment{}).Where("application_id = ?", pastAppID).Updates(map[string]interface{}{
+		"entry_date_from": "2025-01-01",
+		"entry_date_to":   "2025-01-02",
+	})
+
+	rec := testutil.GET(t, e, "/applications?active_today=true", testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	apps := testutil.ParseSlice(t, rec)
+
+	assert.Len(t, apps, 1)
+	assert.Equal(t, float64(todayAppID), apps[0]["id"])
+}
+
 func TestForwardApplication_ArchivedReturns403(t *testing.T) {
 	e, db, cleanup := testutil.SetupTestApp(t)
 	defer cleanup()

--- a/internal/handlers/applications.go
+++ b/internal/handlers/applications.go
@@ -50,6 +50,10 @@ func (h *ApplicationHandler) GetApplications(c echo.Context) error {
 		archive := archiveStr == "true"
 		filter.Archive = &archive
 	}
+	if activeTodayStr := c.QueryParam("active_today"); activeTodayStr != "" {
+		activeToday := activeTodayStr == "true"
+		filter.ActiveToday = &activeToday
+	}
 
 	// Legacy mode: if per_page not specified, return all (backward compat)
 	if c.QueryParam("per_page") == "" {

--- a/internal/services/application_helpers.go
+++ b/internal/services/application_helpers.go
@@ -241,6 +241,20 @@ func applyApplicationFilters(query *gorm.DB, filter ApplicationFilter, includeUs
 		query = query.Where("NOT "+archiveCondition, models.StatusCompleted, models.StatusRejected)
 	}
 
+	// Active today: заявка активна сегодня, если период действия хотя бы одного
+	// вложения (entry_date_from..entry_date_to) включает текущую дату.
+	if filter.ActiveToday != nil && *filter.ActiveToday {
+		query = query.Where(`
+			EXISTS(
+				SELECT 1 FROM attachments att
+				WHERE att.application_id = a.id
+				AND att.entry_date_from IS NOT NULL
+				AND att.entry_date_to IS NOT NULL
+				AND CURRENT_DATE BETWEEN CAST(att.entry_date_from AS DATE) AND CAST(att.entry_date_to AS DATE)
+			)
+		`)
+	}
+
 	return query
 }
 

--- a/internal/services/application_service.go
+++ b/internal/services/application_service.go
@@ -123,13 +123,14 @@ type ApplicationService interface {
 // ApplicationFilter параметры фильтрации списка заявок.
 type ApplicationFilter struct {
 	SearchQuery    *string `query:"search_query"`
-	OrganizationID *int   `query:"organization_id"`
-	CompanyID      *int   `query:"company_id"`
+	OrganizationID *int    `query:"organization_id"`
+	CompanyID      *int    `query:"company_id"`
 	Confirmation   *string `query:"confirmation"`
 	Status         *string `query:"status"`
 	DateFrom       *string `query:"date_from"`
 	DateTo         *string `query:"date_to"`
 	Archive        *bool   `query:"archive"`
+	ActiveToday    *bool   `query:"active_today"`
 }
 
 // ApplicationCreateRequest тело запроса на создание простой заявки.


### PR DESCRIPTION
## Summary

Закрыл ещё один пункт из #64 — фильтр "Заявки на сегодня" в Центре заявок. Заявка считается активной сегодня, если у её вложений период действия (entry_date_from..entry_date_to) включает текущую дату.

- **Бэк**: query-параметр \`active_today\` в \`GET /applications\` (aналогично \`archive\`). SQL EXISTS вложение с entry_date_from IS NOT NULL, entry_date_to IS NOT NULL, CURRENT_DATE BETWEEN from AND to.
- **Фронт**: чипс "Заявки на сегодня" в \`ApplicationsCenter.vue\` рядом со "Сбросить фильтры". Интегрирован в \`hasActiveFilters\` и \`resetFilters\`, активное состояние в primary-цвете.
- **Тест**: \`TestGetApplications_ActiveToday_FiltersByAttachmentPeriod\` — создаёт заявку с периодом 2025-01-01 → 2099-12-31 (активна) и с 2025-01-01 → 2025-01-02 (не активна), проверяет что \`?active_today=true\` возвращает только первую.

Пункт #45 "История автомобиля в VehicleDetailsModal" отложен — на staging нет seeded-заявок с вложениями cars для воспроизведения бага.

## Test plan

- [x] \`go vet ./...\` — зелёный.
- [x] \`npm run lint\` — зелёный.
- [x] \`npm run test:run\` — 204 passed.
- [ ] CI: бэк-тесты проверят новый тест.
- [ ] Ручная проверка на staging: чипс "Заявки на сегодня" отображается, по клику активируется primary-стилем, после активации список заявок фильтруется.