### PR TITLE
feat: портировал PasswordRecoveryModal из old_branch (#64)

### DIFF
--- a/frontend/src/components/PasswordRecoveryModal.vue
+++ b/frontend/src/components/PasswordRecoveryModal.vue
@@ -1,36 +1,41 @@
 <template>
-  <BaseModal :show="show" title="Восстановление доступа" @close="$emit('close')">
-    <p class="recovery-text">Для восстановления доступа обратитесь к администратору:</p>
+  <BaseModal
+    :show="show"
+    :closable="false"
+    width="560px"
+    @close="$emit('close')"
+  >
+    <template #header>
+      <h2 class="recovery-title">Восстановление доступа</h2>
+    </template>
 
-    <div class="contact-list">
-      <button class="contact-item" @click="copyToClipboard('buropropuskov@dreamisland.ru')">
-        <span class="contact-icon">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <rect x="2" y="4" width="20" height="16" rx="2" />
-            <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
-          </svg>
-        </span>
-        <span class="contact-value">buropropuskov@dreamisland.ru</span>
-        <span class="contact-hint">Нажмите, чтобы скопировать</span>
+    <p class="recovery-text">
+      Если вы забыли логин или пароль учётной записи, напишите нам или позвоните:
+    </p>
+
+    <div class="recovery-contacts">
+      <button type="button" class="recovery-contact" @click.stop="copyEmail" data-testid="recovery-copy-email">
+        <img src="@/assets/icons/email-blue.png" class="recovery-contact__icon" alt="" />
+        <span class="recovery-contact__text">buropropuskov@dreamisland.ru</span>
       </button>
-
-      <button class="contact-item" @click="copyToClipboard('+7 (910) 083 00-55')">
-        <span class="contact-icon">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z" />
-          </svg>
-        </span>
-        <span class="contact-value">+7 (910) 083 00-55</span>
-        <span class="contact-hint">Нажмите, чтобы скопировать</span>
+      <button type="button" class="recovery-contact" @click.stop="copyPhone" data-testid="recovery-copy-phone">
+        <img src="@/assets/icons/phone-blue.png" class="recovery-contact__icon" alt="" />
+        <span class="recovery-contact__text">+7 (910) 083 00-55</span>
       </button>
     </div>
 
-    <transition name="toast-fade">
-      <div v-if="showCopiedToast" class="copied-toast">Скопировано</div>
-    </transition>
+    <div class="recovery-notifications">
+      <transition name="recovery-notification" mode="out-in">
+        <div v-if="showNotification" :key="notificationText" class="recovery-notification" data-testid="recovery-notification">
+          {{ notificationText }}
+        </div>
+      </transition>
+    </div>
 
     <template #actions>
-      <button class="btn btn--primary" @click="$emit('close')">Понятно</button>
+      <button type="button" class="recovery-button" @click="$emit('close')" data-testid="recovery-close">
+        Понятно
+      </button>
     </template>
   </BaseModal>
 </template>
@@ -53,8 +58,9 @@ export default {
 
   data() {
     return {
-      showCopiedToast: false,
-      toastTimer: null,
+      showNotification: false,
+      notificationText: '',
+      notificationTimeout: null,
     }
   },
 
@@ -72,117 +78,172 @@ export default {
         document.execCommand('copy')
         document.body.removeChild(textarea)
       }
+    },
 
-      clearTimeout(this.toastTimer)
-      this.showCopiedToast = true
-      this.toastTimer = setTimeout(() => {
-        this.showCopiedToast = false
+    showNotificationMessage(text) {
+      if (this.notificationTimeout) {
+        clearTimeout(this.notificationTimeout)
+        this.notificationTimeout = null
+      }
+      this.notificationText = text
+      this.showNotification = true
+      this.notificationTimeout = setTimeout(() => {
+        this.showNotification = false
+        this.notificationTimeout = null
       }, 2000)
+    },
+
+    async copyEmail() {
+      await this.copyToClipboard('buropropuskov@dreamisland.ru')
+      this.showNotificationMessage('E-mail скопирован')
+    },
+
+    async copyPhone() {
+      await this.copyToClipboard('+7 (910) 083 00-55')
+      this.showNotificationMessage('Номер телефона скопирован')
     },
   },
 
   beforeUnmount() {
-    clearTimeout(this.toastTimer)
+    if (this.notificationTimeout) {
+      clearTimeout(this.notificationTimeout)
+    }
   },
 }
 </script>
 
 <style scoped>
-.recovery-text {
-  margin: 0 0 16px;
-  font-size: 14px;
-  line-height: 1.5;
-  color: var(--color-text);
+/* BaseModal header/actions overrides — убираем border между секциями
+   и выравниваем по old_branch-стилю (цельный плоский контент). */
+:deep(.base-modal__header) {
+  border-bottom: none;
+  padding: 24px 32px 16px;
 }
 
-.contact-list {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
+:deep(.base-modal__body) {
+  padding: 8px 32px 16px;
 }
 
-.contact-item {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 14px 16px;
-  background: var(--color-bg-secondary);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  transition: all 0.2s;
+:deep(.base-modal__actions) {
+  justify-content: center;
+  border-top: none;
+  padding: 0 32px 28px;
+}
+
+.recovery-title {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 800;
+  color: #333;
+  padding: 10px 24px;
+  text-align: center;
+  border: 2px solid var(--color-border);
+  border-radius: 40px;
   width: 100%;
-  text-align: left;
 }
 
-.contact-item:hover {
-  background: var(--color-bg);
-  border-color: var(--color-primary);
-}
-
-.contact-icon {
-  flex-shrink: 0;
-  color: var(--color-primary);
-  display: flex;
-  align-items: center;
-}
-
-.contact-value {
-  flex: 1;
-  font-size: 14px;
-  font-weight: 500;
-  color: var(--color-text);
-}
-
-.contact-hint {
-  font-size: 12px;
-  color: var(--color-text-muted);
-  white-space: nowrap;
-}
-
-.copied-toast {
-  margin-top: 12px;
-  padding: 8px 16px;
-  background-color: var(--color-success);
-  color: #fff;
-  font-size: 13px;
-  font-weight: 500;
-  border-radius: var(--radius-sm);
+.recovery-text {
+  margin: 0 0 24px;
+  font-size: 15px;
+  line-height: 1.5;
+  color: #000;
   text-align: center;
 }
 
-.toast-fade-enter-active,
-.toast-fade-leave-active {
-  transition: opacity 0.3s;
+.recovery-contacts {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
 }
 
-.toast-fade-enter-from,
-.toast-fade-leave-to {
-  opacity: 0;
-}
-
-.btn {
-  padding: 10px 24px;
+.recovery-contact {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 6px 10px;
+  background: transparent;
   border: none;
-  border-radius: var(--radius-sm);
-  font-size: 14px;
-  font-weight: 500;
   cursor: pointer;
+  transition: opacity 0.2s ease;
+}
+
+.recovery-contact:hover {
+  opacity: 0.8;
+}
+
+.recovery-contact__icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+}
+
+.recovery-contact__text {
+  font-size: 15px;
+  color: var(--color-primary);
+  font-weight: 500;
+}
+
+.recovery-contact:hover .recovery-contact__text {
+  text-decoration: underline;
+  text-underline-position: under;
+}
+
+.recovery-notifications {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  min-height: 28px;
+  margin-top: 8px;
+}
+
+.recovery-notification {
+  padding: 4px 16px;
+  border-radius: 40px;
+  background-color: #fff;
+  font-size: 13px;
+  color: #000;
+  font-weight: 500;
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.15);
+  min-width: 160px;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.recovery-notification-enter-active,
+.recovery-notification-leave-active {
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.recovery-notification-enter-from,
+.recovery-notification-leave-to {
+  opacity: 0;
+  transform: translateY(-8px);
+}
+
+.recovery-notification-enter-to,
+.recovery-notification-leave-from {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.recovery-button {
+  background: var(--color-primary);
+  color: #fff;
+  border: none;
+  border-radius: 40px;
+  padding: 12px 40px;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  min-width: 200px;
+  margin: 0 auto;
   transition: background-color 0.2s;
 }
 
-.btn--primary {
-  background-color: var(--color-primary);
-  color: #fff;
-}
-
-.btn--primary:hover {
-  background-color: var(--color-primary-hover);
-}
-
-@media (max-width: 480px) {
-  .contact-hint {
-    display: none;
-  }
+.recovery-button:hover {
+  background-color: #3f4bc9;
 }
 </style>


### PR DESCRIPTION
## Summary

Закрыл пункт из #64 "ВООБЩЕ другое модальное окно восстановления. В old_branch есть корректная, нужно взять компонент PasswordRecoveryModal.vue. (Рисунок №5, верное на Рисунке №7)".

Замена визуала на old_branch-версию:
- Заголовок "Восстановление доступа" в рамке вместо плоского
- Центрированный текст "Если вы забыли логин или пароль..."
- Два контакта с иконками email/phone в колонку
- Большая primary-кнопка "Понятно"
- Единое уведомление копирования с out-in transition и \`:key="notificationText"\` - по аналогии с логином в PR #82
- Раздельные сообщения "E-mail скопирован" / "Номер телефона скопирован" вместо общего "Скопировано"

**Что оставил:**
- BaseModal как обёртку - drag-fix из #82 (drag-out текста не закрывает), focus trap, Escape всё сохраняется.
- closable=false - заголовок-крестик не нужен, есть primary-кнопка "Понятно".
- vh-based sizing из old_branch заменил на px/rem - единый с общими токенами.

## Test plan

- [x] \`npm run lint\` - зелёный.
- [x] \`npm run test:run\` - 204 passed.
- [ ] Staging после deploy:
  - [ ] Логин -> "Забыли пароль?" -> модалка с новым визуалом
  - [ ] Клик по email -> уведомление "E-mail скопирован", через 2с исчезает
  - [ ] Клик по phone подряд -> уведомление меняется на "Номер телефона скопирован" (не дублируется)
  - [ ] Drag выделения текста на оверлей -> модалка НЕ закрывается (регрессия #82)
  - [ ] "Понятно" -> модалка закрывается