### PR TITLE
feat: портировал NewsAndReview + AnnouncementModal из old_branch (#64)

### DIFF
--- a/frontend/src/components/AnnouncementModal.vue
+++ b/frontend/src/components/AnnouncementModal.vue
@@ -1,116 +1,249 @@
 <template>
-  <BaseModal :show="show" title="Объявление" @close="$emit('close')">
-    <template v-if="announcement">
-      <span v-if="announcement.is_important" class="announcement-badge">Важно</span>
-
-      <h4 class="announcement-title">{{ announcement.title }}</h4>
-
-      <p class="announcement-description">{{ announcement.description }}</p>
-
-      <p
-        v-if="announcement.full_text && announcement.full_text !== announcement.description"
-        class="announcement-full-text"
-      >
-        {{ announcement.full_text }}
-      </p>
-
-      <time class="announcement-date">
-        {{ formatDate(announcement.created_at) }}
-      </time>
-    </template>
-
-    <template #actions>
-      <button class="btn btn--primary" @click="$emit('close')">Закрыть</button>
-    </template>
-  </BaseModal>
+  <teleport to="body">
+    <transition name="modal-fade">
+      <div v-if="show" class="modal-overlay" @click.self="close">
+        <div class="modal-content announcement-modal">
+        
+          <div class="modal-body">
+            <!-- Заголовок перед описанием -->
+            
+            
+            <div class="modal-info">
+              <time class="modal-date">{{ formatDate(announcement?.created_at) }}</time>
+              <span class="modal-type" :class="{ important: announcement?.is_important }">
+                {{ announcement?.is_important ? 'Важное объявление' : 'Объявление' }}
+              </span>
+            </div>
+            <h3 class="modal-title">{{ announcement?.title }}</h3>
+            <p class="modal-description">{{ announcement?.description }}</p>
+            <div v-if="announcement?.full_text" class="modal-full-text">
+              {{ announcement.full_text }}
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button class="btn close-modal-btn" @click="close">Закрыть</button>
+          </div>
+        </div>
+      </div>
+    </transition>
+  </teleport>
 </template>
 
 <script>
-import BaseModal from '@/components/ui/BaseModal.vue'
-
 export default {
   name: 'AnnouncementModal',
-  components: { BaseModal },
-
   props: {
     show: {
       type: Boolean,
-      default: false,
+      default: false
     },
     announcement: {
       type: Object,
-      default: null,
-    },
+      default: null
+    }
   },
-
-  emits: ['close'],
-
+  emits: ['update:show', 'close'],
   methods: {
-    formatDate(dateStr) {
-      if (!dateStr) return ''
-      return new Date(dateStr).toLocaleDateString('ru-RU')
+    formatDate(dateString) {
+      if (!dateString) return '';
+      const date = new Date(dateString);
+      return date.toLocaleDateString('ru-RU', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit'
+      }).replace(',', '');
     },
-  },
+    close() {
+      this.$emit('update:show', false);
+      this.$emit('close');
+    }
+  }
 }
 </script>
 
 <style scoped>
-.announcement-badge {
-  display: inline-block;
-  padding: 4px 12px;
-  background-color: var(--color-danger);
-  color: #fff;
-  font-size: 12px;
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+}
+
+.modal-fade-enter-active,
+.modal-fade-leave-active {
+  transition: all 0.4s ease;
+}
+
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+  opacity: 0;
+}
+
+.modal-fade-enter-from .modal-content,
+.modal-fade-leave-to .modal-content {
+  opacity: 0;
+  transform: scale(0.9) translateY(-20px);
+}
+
+.modal-content {
+  background: #fff;
+  border-radius: 50px;
+  width: 600px;
+  max-width: 90vw;
+  max-height: 80vh;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.announcement-modal .modal-content {
+  width: 540px;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 30px 0;
+  flex-shrink: 0;
+}
+
+.modal-title {
+  margin: 0;
+  font-size: 20px;
   font-weight: 600;
-  border-radius: var(--radius-sm);
-  margin-bottom: 12px;
+  color: #1a1a1a;
+  flex: 1;
+  padding-bottom: 15px;
 }
 
 .announcement-title {
-  margin: 0 0 12px;
+  margin: 0 0 10px 0;
   font-size: 18px;
   font-weight: 600;
-  color: var(--color-text);
+  color: #4F5BDF;
 }
 
-.announcement-description {
-  margin: 0 0 12px;
+.modal-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 6px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s ease;
+}
+
+.modal-close:hover {
+  background-color: #f5f5f5;
+}
+
+.modal-body {
+  padding: 20px 40px;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.modal-info {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 15px 0;
+}
+
+.modal-date {
+  font-size: 12px;
+  color: #a2a2a2;
+}
+
+.modal-type {
+  font-size: 11px;
+  font-weight: 500;
+  padding: 2px 8px;
+  border-radius: 20px;
+  background: #fff3cd;
+  color: #856404;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.modal-type.important {
+  background: #ffb3b3;
+  color: #c62828;
+}
+
+.modal-description {
+  font-size: 14px;
+  line-height: 1.5;
+  color: #333;
+  margin: 0 0 20px 0;
+}
+
+.modal-full-text {
   font-size: 14px;
   line-height: 1.6;
-  color: var(--color-text);
+  color: #666;
+  padding-top: 16px;
+  border-top: 1px solid #f0f0f0;
+  margin-top: 8px;
 }
 
-.announcement-full-text {
-  margin: 0 0 16px;
-  font-size: 14px;
-  line-height: 1.6;
-  color: var(--color-text);
-  padding-top: 12px;
-  border-top: 1px solid var(--color-border);
-}
-
-.announcement-date {
-  display: block;
-  font-size: 13px;
-  color: var(--color-text-muted);
+.modal-footer {
+  padding: 16px 30px 24px;
+  border-top: 1px solid #f0f0f0;
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  flex-shrink: 0;
 }
 
 .btn {
-  padding: 10px 24px;
-  border: none;
-  border-radius: var(--radius-sm);
-  font-size: 14px;
+  padding: 8px 24px;
+  font-size: 13px;
   font-weight: 500;
+  border-radius: 30px;
   cursor: pointer;
-  transition: background-color 0.2s;
+  border: 1px solid;
+  transition: all 0.2s ease;
 }
 
-.btn--primary {
-  background-color: var(--color-primary);
-  color: #fff;
+.close-modal-btn {
+  background: #4F5BDF;
+  color: white;
+  border-color: #4F5BDF;
 }
 
-.btn--primary:hover {
-  background-color: var(--color-primary-hover);
+.close-modal-btn:hover {
+  background: #3a45c0;
+}
+
+@media (max-width: 768px) {
+  .modal-content {
+    width: 95vw;
+  }
+  
+  .modal-header {
+    padding: 16px 20px 0;
+  }
+  
+  .modal-body {
+    padding: 16px 20px;
+  }
+  
+  .modal-footer {
+    padding: 12px 20px 20px;
+  }
 }
 </style>

--- a/frontend/src/views/NewsAndReview.vue
+++ b/frontend/src/views/NewsAndReview.vue
@@ -1,1013 +1,1275 @@
 <template>
-  <section class="news-page">
-    <!-- Табы -->
-    <nav class="tabs" role="tablist">
-      <button
-        class="tab"
-        :class="{ 'tab--active': activeTab === 'news' }"
-        role="tab"
-        :aria-selected="activeTab === 'news'"
-        @click="activeTab = 'news'"
-      >
-        Новости
-      </button>
-      <button
-        v-if="isAdmin"
-        class="tab"
-        :class="{ 'tab--active': activeTab === 'announcements' }"
-        role="tab"
-        :aria-selected="activeTab === 'announcements'"
-        @click="activeTab = 'announcements'"
-      >
-        Объявления
-      </button>
-    </nav>
-
-    <!-- Новости -->
-    <div v-if="activeTab === 'news'" class="tab-content" role="tabpanel">
-      <div class="section-header">
-        <h2 class="section-title">Последние новости и обновления</h2>
-        <button
-          v-if="isAdmin && !showNewsForm"
-          class="btn btn--primary"
-          @click="openNewsForm()"
-        >
-          Добавить новость
-        </button>
-      </div>
-
-      <!-- Inline-форма новости -->
-      <div v-if="showNewsForm" class="inline-form">
-        <h3 class="inline-form__title">
-          {{ editingNews ? 'Редактирование новости' : 'Новая новость' }}
-        </h3>
-        <div class="form-group">
-          <label class="form-label" for="news-title">Заголовок</label>
-          <input
-            id="news-title"
-            type="text"
-            class="form-input"
-            v-model="newsForm.title"
-            placeholder="Заголовок новости"
-            maxlength="255"
-          >
-        </div>
-        <div class="form-group">
-          <label class="form-label" for="news-description">Краткое описание</label>
-          <textarea
-            id="news-description"
-            class="form-textarea"
-            v-model="newsForm.description"
-            placeholder="Краткое описание"
-            rows="3"
-          ></textarea>
-        </div>
-        <div class="form-group">
-          <label class="form-label" for="news-fulltext">Полный текст</label>
-          <textarea
-            id="news-fulltext"
-            class="form-textarea"
-            v-model="newsForm.full_text"
-            placeholder="Полный текст новости"
-            rows="6"
-          ></textarea>
-        </div>
-        <div class="inline-form__actions">
-          <button class="btn btn--secondary" @click="showNewsForm = false">Отмена</button>
-          <button
-            class="btn btn--primary"
-            :disabled="!newsForm.title || newsSaving"
-            @click="saveNews"
-          >
-            {{ newsSaving ? 'Сохранение...' : 'Сохранить' }}
-          </button>
-        </div>
-      </div>
-
-      <div v-if="newsLoading" class="loading-state">
-        <div class="spinner"></div>
-      </div>
-
-      <div v-else-if="newsError" class="error-state">
-        <p class="error-message">{{ newsError }}</p>
-        <button class="btn btn--primary" @click="fetchNews">Повторить</button>
-      </div>
-
-      <div v-else-if="newsList.length === 0" class="empty-state">
-        <p class="empty-message">Новостей пока нет</p>
-      </div>
-
-      <div v-else class="cards-list">
-        <article
-          v-for="item in newsList"
-          :key="item.id"
-          class="card"
-        >
-          <div class="card__header">
-            <time class="card__date">{{ formatDate(item.created_at) }}</time>
-            <span
-              v-if="isAdmin"
-              class="status-badge"
-              :class="item.is_active ? 'status-badge--active' : 'status-badge--inactive'"
-            >
-              {{ item.is_active ? 'Активна' : 'Неактивна' }}
-            </span>
-          </div>
-          <h3 class="card__title">{{ item.title }}</h3>
-          <p v-if="item.description" class="card__description">{{ item.description }}</p>
-
-          <div v-if="expandedNewsId === item.id && item.full_text" class="card__full-text">
-            {{ item.full_text }}
-          </div>
-
-          <div class="card__actions">
-            <button
-              v-if="item.full_text"
-              class="btn btn--link"
-              @click="toggleExpand(item.id)"
-            >
-              {{ expandedNewsId === item.id ? 'Свернуть' : 'Подробнее' }}
-            </button>
-
-            <template v-if="isAdmin">
-              <button class="btn btn--text" @click="openNewsForm(item)">Редактировать</button>
-              <button class="btn btn--text btn--danger" @click="confirmDeleteNews(item)">Удалить</button>
-              <button
-                class="btn btn--text"
-                @click="toggleNewsActive(item)"
-              >
-                {{ item.is_active ? 'Деактивировать' : 'Активировать' }}
-              </button>
-            </template>
-          </div>
-        </article>
-      </div>
-    </div>
-
-    <!-- Объявления (только админ) -->
-    <div v-if="activeTab === 'announcements' && isAdmin" class="tab-content" role="tabpanel">
-      <div class="section-header">
-        <h2 class="section-title">Объявления</h2>
-        <button
-          v-if="!showAnnouncementForm"
-          class="btn btn--primary"
-          @click="openAnnouncementForm()"
-        >
-          Добавить объявление
-        </button>
-      </div>
-
-      <!-- Inline-форма объявления -->
-      <div v-if="showAnnouncementForm" class="inline-form">
-        <h3 class="inline-form__title">
-          {{ editingAnnouncement ? 'Редактирование объявления' : 'Новое объявление' }}
-        </h3>
-        <div class="form-group">
-          <label class="form-label" for="ann-title">Заголовок</label>
-          <input
-            id="ann-title"
-            type="text"
-            class="form-input"
-            v-model="announcementForm.title"
-            placeholder="Заголовок объявления"
-            maxlength="255"
-          >
-        </div>
-        <div class="form-group">
-          <label class="form-label" for="ann-description">Краткое описание</label>
-          <textarea
-            id="ann-description"
-            class="form-textarea"
-            v-model="announcementForm.description"
-            placeholder="Краткое описание"
-            rows="3"
-          ></textarea>
-        </div>
-        <div class="form-group">
-          <label class="form-label" for="ann-fulltext">Полный текст</label>
-          <textarea
-            id="ann-fulltext"
-            class="form-textarea"
-            v-model="announcementForm.full_text"
-            placeholder="Полный текст объявления"
-            rows="6"
-          ></textarea>
-        </div>
-        <div class="form-group">
-          <label class="checkbox-label">
-            <input type="checkbox" v-model="announcementForm.is_important">
-            <span class="checkbox-text">Важное объявление</span>
-          </label>
-        </div>
-        <div class="inline-form__actions">
-          <button class="btn btn--secondary" @click="showAnnouncementForm = false">Отмена</button>
-          <button
-            class="btn btn--primary"
-            :disabled="!announcementForm.title || announcementSaving"
-            @click="saveAnnouncement"
-          >
-            {{ announcementSaving ? 'Сохранение...' : 'Сохранить' }}
-          </button>
-        </div>
-      </div>
-
-      <div v-if="announcementsLoading" class="loading-state">
-        <div class="spinner"></div>
-      </div>
-
-      <div v-else-if="announcementsError" class="error-state">
-        <p class="error-message">{{ announcementsError }}</p>
-        <button class="btn btn--primary" @click="fetchAnnouncements">Повторить</button>
-      </div>
-
-      <div v-else-if="announcementsList.length === 0" class="empty-state">
-        <p class="empty-message">Объявлений пока нет</p>
-      </div>
-
-      <div v-else class="cards-list">
-        <article
-          v-for="item in announcementsList"
-          :key="item.id"
-          class="card"
-          :class="{ 'card--highlighted': item.is_active }"
-        >
-          <div class="card__header">
-            <time class="card__date">{{ formatDate(item.created_at) }}</time>
-            <div class="card__badges">
-              <span v-if="item.is_important" class="status-badge status-badge--important">Важное</span>
-              <span
-                class="status-badge"
-                :class="item.is_active ? 'status-badge--active' : 'status-badge--inactive'"
-              >
-                {{ item.is_active ? 'Активное' : 'Неактивное' }}
-              </span>
+  <section class="news">
+    <div class="content-wrapper">
+      <!-- Левая колонка - Новости -->
+      <div class="left-column">
+        <div class="news-container">
+          <div class="news-header">
+            <h2 class="news-title">Последние новости</h2>
+            <div class="header-actions">
+              <button class="manage-btn" @click="openManageModal">Управление</button>
+              <RefreshButton @refresh="fetchAllData" />
             </div>
           </div>
-          <h3 class="card__title">{{ item.title }}</h3>
-          <p v-if="item.description" class="card__description">{{ item.description }}</p>
-
-          <div v-if="expandedAnnouncementId === item.id && item.full_text" class="card__full-text">
-            {{ item.full_text }}
+          <div class="divider"></div>
+          <div class="news-list">
+            <!-- Лоадер -->
+            <div v-if="loadingNews" class="loading-message">
+              <div class="loader"></div>
+              <p>Загрузка новостей...</p>
+            </div>
+            <!-- Новости -->
+            <div v-else-if="newsItems.length > 0" class="news-items">
+              <article
+                v-for="(item, index) in newsItems"
+                :key="item.id"
+                class="news-item"
+                :style="{ animationDelay: `${index * 0.1}s` }"
+              >
+                <div class="item-header">
+                  <time class="news-date">{{ formatDate(item.created_at) }}</time>
+                  <span class="item-type">Новость</span>
+                </div>
+                <h3 class="news-item-title">{{ item.title }}</h3>
+                <p class="news-item-description">{{ item.description }}</p>
+                <button class="news-details-button" @click="openNewsModal(item)">Читать далее</button>
+              </article>
+            </div>
+            <div v-else class="empty-state"><p>Нет новостей</p></div>
           </div>
+        </div>
+      </div>
 
-          <div class="card__actions">
-            <button
-              v-if="item.full_text"
-              class="btn btn--link"
-              @click="expandedAnnouncementId = expandedAnnouncementId === item.id ? null : item.id"
-            >
-              {{ expandedAnnouncementId === item.id ? 'Свернуть' : 'Подробнее' }}
-            </button>
-            <button
-              v-if="!item.is_active"
-              class="btn btn--text"
-              @click="setActiveAnnouncement(item.id)"
-            >
-              Сделать активным
-            </button>
-            <button class="btn btn--text" @click="openAnnouncementForm(item)">Редактировать</button>
-            <button class="btn btn--text btn--danger" @click="confirmDeleteAnnouncement(item)">Удалить</button>
+      <!-- Правая колонка -->
+      <div class="right-column">
+        <div class="guide-card" :style="{ animationDelay: '0.2s' }" @click="openGuide">
+          <div class="guide-content">
+            <div class="guide-text">
+              <h3 class="guide-title">
+                <div class="guide-icon">
+                  <svg width="35" height="35" viewBox="0 0 35 35" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <rect width="35" height="35" fill="url(#pattern0)" />
+                    <defs>
+                      <pattern id="pattern0" patternContentUnits="objectBoundingBox" width="1" height="1">
+                        <use xlink:href="#image0" transform="scale(0.015625)" />
+                      </pattern>
+                      <image id="image0" width="64" height="64" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAACXBIWXMAAAHYAAAB2AH6XKZyAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAwxJREFUeJzt209oHkUcxvGPMQlqBAk9WCoBJZdoDuLJQyMtlBZSKv4Be6m3QpRcKmoN9RQPpVCCUA+e9FRPCqWlHixeVGwPUpFCrNhi0ItQJH+MQpU2TQ+7L+8SeHl3N7OZTbJfWN7Z3fnNPPMw876zs/PSsL15oGRcP17AM3gknJyg/IwvQxfajynMY3UTHM+HbPwgvqtBo4ocr3drVG/OxvfiC0m3bzGHS1jOWcZaxrA7TV/G94FiDmG0pKaOvKHt6grexYPrLHM6U+Z0wJizKugBxzPpDzCTM6729OTI8zSG0/QiTlcnZ+PJY8BwJn0F/1WkJQp5DHgsk16qSkgs8hiQnSytViUkFnkM2NI0BsQWEJvGgNgCOjCDf2zAhKuOBkzhHTyafr5XZWV1M+AgTq65dgovV1VhnQx4Dp9rP2TdTT978Fl6Pzh1MWAnLmAgPf8dz+K39HxAsrrzROiK62LABIbS9DJexHVJ12+tN+zC0dAV18WA1nR7RfIMP5uez+Kw9nAou4bZkboY0OJtXFxz7ZJkAaYS6mTAp/iow70z+LiKSmMakH20/hpvdsl/LM3XYjGEiLxLYlXwCZ5EH97XHueduIvXJPOC/9P4dRPTgH/xVsGYvzEZUkSdvgOi0BgQW0BsGgNiC4hNY0BsAbFpDIgtIDaNAbEFxKYxILaA2DQGxBYQm8aA2AJis+0NKLskNoZXJRsSd4STE4SnimQuasAQvsGegnGxWOmWoagBm6XhJMvuV7plKjsE/pK8qLiMhZJlVM2cHO8OyhjwE8Zxq0Rs7Sj6K3Abr9gijad4DziHP9L0wziBkaCKwnAPV/Fhml4XR7S3n2f360yq5k8OIY8D3RqXZwhkX2I+lEn/mSM2JityDNU8Gw5G8Eua/hZ7M/d2S3Zu1JEbuBaqsJva3Wo8VKGbiQltA5bwUlw54ci756YXX2Ff5tqPkn+RLeBOYF0h+BXnQxY4KHkOiP3NXuQY69aoIhOhReyX/BTOF4irNWW3nfVJ3B3F4+l5nbiHHwQeAg1bkfsR5B+/y7yHCAAAAABJRU5ErkJggg=="/>
+                    </defs>
+                  </svg>
+                </div>
+                <div class="guide-title-text">
+                  Руководство пользования системой <span class="guide-title-blue">подачи заявок</span>
+                </div>
+              </h3>
+              <p class="guide-description">
+                Узнайте, как пользоваться системой, легко и быстро подать заявку:
+                <strong>пошаговая инструкция</strong>
+              </p>
+            </div>
           </div>
-        </article>
+        </div>
+        <div
+          v-if="activeAnnouncement"
+          class="news-card announcement-card"
+          :class="{ 'important-announcement': activeAnnouncement.is_important }"
+          :style="{ animationDelay: '0.1s' }"
+          @click="openAnnouncementModal(activeAnnouncement)"
+        >
+          <div class="card-header">
+            <span class="card-type" :class="{ important: activeAnnouncement.is_important }">
+              {{ activeAnnouncement.is_important ? 'Важное объявление' : 'Объявление' }}
+            </span>
+            <time class="card-date">{{ formatDate(activeAnnouncement.created_at) }}</time>
+          </div>
+          <h3 class="card-title">{{ activeAnnouncement.title }}</h3>
+          <p class="card-description">{{ activeAnnouncement.description }}</p>
+          <button class="card-button">Читать далее</button>
+        </div>
       </div>
     </div>
 
-    <!-- Подтверждение удаления -->
-    <ConfirmationModal
-      :show="showDeleteConfirm"
-      title="Подтверждение удаления"
-      :message="deleteConfirmMessage"
-      confirm-text="Удалить"
-      :confirm-button-style="{ background: '#dc3545', borderColor: '#dc3545' }"
-      @confirm="executeDelete"
-      @cancel="showDeleteConfirm = false"
-    />
+    <!-- Модальное окно управления -->
+    <transition name="modal-fade">
+      <div v-if="showManageModal" class="modal-overlay" @click.self="closeManageModal">
+        <div class="modal-content manage-modal">
+          <div class="modal-header">
+            <h3 class="modal-title">Управление контентом</h3>
+            <button class="modal-close" @click="closeManageModal">
+              <svg width="10" height="10" viewBox="0 0 14 14" fill="none"><path d="M13 1L1 13M1 1L13 13" stroke="#666" stroke-width="2" stroke-linecap="round"/></svg>
+            </button>
+          </div>
 
-    <!-- Toast -->
-    <transition name="toast-fade">
-      <div v-if="toast.visible" class="toast" :class="'toast--' + toast.type">
-        {{ toast.message }}
+          <div class="modal-body">
+            <div class="manage-tabs">
+              <button class="tab-btn" :class="{ active: activeTab === 'news' }" @click="activeTab = 'news'">Новости</button>
+              <button class="tab-btn" :class="{ active: activeTab === 'announcements' }" @click="activeTab = 'announcements'">Объявления</button>
+            </div>
+
+            <!-- Новости -->
+            <div v-if="activeTab === 'news'" class="manage-section">
+              <div class="section-header">
+                <div class="section-title">Список новостей</div>
+                <button class="add-btn" @click="openCreateNewsModal">+ Добавить новость</button>
+              </div>
+              <div class="items-list">
+                <div v-for="item in allNewsItems" :key="item.id" class="manage-item">
+                  <div class="item-main">
+                    <div class="item-title">{{ item.title }}</div>
+                    <div class="item-meta">
+                      <span>{{ formatDate(item.created_at) }}</span>
+                      <span>{{ item.created_by_name || 'Система' }}</span>
+                      <span class="status-text">{{ item.is_active ? 'Активна' : 'Скрыта' }}</span>
+                    </div>
+                  </div>
+                  <div class="item-actions">
+                    <button class="action-btn edit-btn" @click="editNewsItem(item)">Редактировать</button>
+                    <button class="action-btn toggle-btn" @click="toggleNewsActive(item)">{{ item.is_active ? 'Скрыть' : 'Показать' }}</button>
+                    <button class="action-btn delete-btn" @click="deleteNewsItem(item.id)">Удалить</button>
+                  </div>
+                </div>
+                <div v-if="allNewsItems.length === 0" class="empty-manage">Нет новостей</div>
+              </div>
+            </div>
+
+            <!-- Объявления -->
+            <div v-if="activeTab === 'announcements'" class="manage-section">
+              <div class="section-header">
+                <div class="section-title">Список объявлений</div>
+                <button class="add-btn" @click="openCreateAnnouncementModal">+ Добавить объявление</button>
+              </div>
+              <div class="info-message">
+                <span>Активно может быть только одно объявление</span>
+              </div>
+              <div class="items-list">
+                <div v-for="item in allAnnouncements" :key="item.id" class="manage-item">
+                  <div class="item-main">
+                    <div class="item-title">
+                      {{ item.title }}
+                      <span v-if="item.is_important" class="important-badge">Важное</span>
+                      <span v-if="item.is_active" class="active-badge">Активно</span>
+                    </div>
+                    <div class="item-meta">
+                      <span>{{ formatDate(item.created_at) }}</span>
+                      <span>Создал: {{ item.created_by_name || 'Система' }}</span>
+                      <span v-if="item.activated_by_name">Активировал: {{ item.activated_by_name }}</span>
+                    </div>
+                  </div>
+                  <div class="item-actions">
+                    <button class="action-btn edit-btn" @click="editAnnouncement(item)">Редактировать</button>
+                    <button v-if="!item.is_active" class="action-btn activate-btn" @click="setActiveAnnouncement(item.id)">Активировать</button>
+                    <button v-if="item.is_active" class="action-btn deactivate-btn" @click="deactivateAnnouncement(item.id)">Деактивировать</button>
+                    <button class="action-btn delete-btn" @click="deleteAnnouncement(item.id)">Удалить</button>
+                  </div>
+                </div>
+                <div v-if="allAnnouncements.length === 0" class="empty-manage">Нет объявлений</div>
+              </div>
+            </div>
+          </div>
+
+          <div class="modal-footer">
+            <button class="btn close-btn" @click="closeManageModal">Закрыть</button>
+          </div>
+        </div>
       </div>
     </transition>
+
+    <!-- Модальное окно создания/редактирования новости -->
+    <transition name="modal-fade">
+      <div v-if="showNewsModal" class="modal-overlay" @click.self="closeNewsModal">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h3 class="modal-title">{{ editingNews ? 'Редактировать новость' : 'Создать новость' }}</h3>
+            <button class="modal-close" @click="closeNewsModal"><svg width="10" height="10" viewBox="0 0 14 14" fill="none"><path d="M13 1L1 13M1 1L13 13" stroke="#666" stroke-width="2" stroke-linecap="round"/></svg></button>
+          </div>
+          <div class="modal-body">
+            <div class="form-group"><label class="form-label">Заголовок</label><input type="text" class="form-input" v-model="newsForm.title" placeholder="Введите заголовок" /></div>
+            <div class="form-group"><label class="form-label">Краткое описание</label><textarea class="form-textarea" v-model="newsForm.description" placeholder="Введите краткое описание" rows="3"></textarea></div>
+            <div class="form-group"><label class="form-label">Полный текст</label><textarea class="form-textarea" v-model="newsForm.fullText" placeholder="Введите полный текст" rows="5"></textarea></div>
+          </div>
+          <div class="modal-footer">
+            <button class="btn cancel-btn" @click="closeNewsModal">Отмена</button>
+            <button class="btn save-btn" @click="submitNews">Сохранить</button>
+          </div>
+        </div>
+      </div>
+    </transition>
+
+    <!-- Модальное окно создания/редактирования объявления -->
+    <transition name="modal-fade">
+      <div v-if="showAnnouncementModal" class="modal-overlay" @click.self="closeAnnouncementModal">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h3 class="modal-title">{{ editingAnnouncement ? 'Редактировать объявление' : 'Создать объявление' }}</h3>
+            <button class="modal-close" @click="closeAnnouncementModal"><svg width="10" height="10" viewBox="0 0 14 14" fill="none"><path d="M13 1L1 13M1 1L13 13" stroke="#666" stroke-width="2" stroke-linecap="round"/></svg></button>
+          </div>
+          <div class="modal-body">
+            <div class="form-group"><label class="form-label">Заголовок</label><input type="text" class="form-input" v-model="announcementForm.title" placeholder="Введите заголовок" /></div>
+            <div class="form-group"><label class="form-label">Краткое описание</label><textarea class="form-textarea" v-model="announcementForm.description" placeholder="Введите краткое описание" rows="3"></textarea></div>
+            <div class="form-group"><label class="form-label">Полный текст</label><textarea class="form-textarea" v-model="announcementForm.fullText" placeholder="Введите полный текст" rows="5"></textarea></div>
+            <div class="form-group"><label class="checkbox-label"><input type="checkbox" v-model="announcementForm.isImportant" /><span>Важное объявление</span></label></div>
+          </div>
+          <div class="modal-footer">
+            <button class="btn cancel-btn" @click="closeAnnouncementModal">Отмена</button>
+            <button class="btn save-btn" @click="submitAnnouncement">Сохранить</button>
+          </div>
+        </div>
+      </div>
+    </transition>
+
+    <!-- Модальное окно просмотра новости -->
+    <transition name="modal-fade">
+      <div v-if="showNewsDetailsModal" class="modal-overlay" @click.self="closeNewsDetailsModal">
+        <div class="modal-content">
+          <div class="modal-body">
+            <div class="modal-info"><time class="modal-date">{{ formatDate(selectedNews?.created_at) }}</time><span class="modal-type">Новость</span></div>
+            <h3 class="modal-title">{{ selectedNews?.title }}</h3>
+            <p class="modal-description">{{ selectedNews?.description }}</p>
+            <div v-if="selectedNews?.full_text" class="modal-full-text">{{ selectedNews.full_text }}</div>
+          </div>
+          <div class="modal-footer"><button class="btn close-btn" @click="closeNewsDetailsModal">Закрыть</button></div>
+        </div>
+      </div>
+    </transition>
+
+    <!-- Модальное окно просмотра объявления - используем AnnouncementModal -->
+    <AnnouncementModal 
+      :show="showViewAnnouncementModal"
+      :announcement="viewingAnnouncement"
+      @close="closeViewAnnouncementModal"
+    />
   </section>
 </template>
 
 <script>
 import { apiRequest } from '@/api/client'
-import { useAuthStore } from '@/stores/auth'
-import ConfirmationModal from '@/components/ConfirmationModal.vue'
+import RefreshButton from '../components/RefreshButton.vue'
+import AnnouncementModal from '../components/AnnouncementModal.vue'
 
 export default {
-  name: 'NewsAndReview',
-  components: {
-    ConfirmationModal,
+  name: 'LatestNews',
+  components: { 
+    RefreshButton,
+    AnnouncementModal
   },
   data() {
     return {
+      loadingNews: false,
+      showManageModal: false,
+      showNewsDetailsModal: false,
+      showNewsModal: false,
+      showAnnouncementModal: false,
+      showViewAnnouncementModal: false,
       activeTab: 'news',
-
-      // News
-      newsList: [],
-      newsLoading: false,
-      newsError: null,
-      showNewsForm: false,
+      selectedNews: null,
+      viewingAnnouncement: null,
       editingNews: null,
-      newsForm: { title: '', description: '', full_text: '' },
-      newsSaving: false,
-      expandedNewsId: null,
-
-      // Announcements
-      announcementsList: [],
-      announcementsLoading: false,
-      announcementsError: null,
-      showAnnouncementForm: false,
       editingAnnouncement: null,
-      announcementForm: { title: '', description: '', full_text: '', is_important: false },
-      announcementSaving: false,
-      expandedAnnouncementId: null,
-
-      // Delete confirmation
-      showDeleteConfirm: false,
-      deleteConfirmMessage: '',
-      pendingDelete: null,
-
-      // Toast
-      toast: { visible: false, message: '', type: 'success', timer: null },
+      newsForm: { title: '', description: '', fullText: '' },
+      announcementForm: { title: '', description: '', fullText: '', isImportant: false },
+      newsItems: [],
+      allNewsItems: [],
+      activeAnnouncement: null,
+      allAnnouncements: []
     }
   },
-  computed: {
-    isAdmin() {
-      const authStore = useAuthStore()
-      const t = authStore.userType
-      return t === 5 || t === 6
-    },
-  },
-  watch: {
-    activeTab(tab) {
-      if (tab === 'announcements' && this.announcementsList.length === 0) {
-        this.fetchAnnouncements()
-      }
-    },
-  },
   methods: {
-    async fetchNews() {
-      this.newsLoading = true
-      this.newsError = null
-      try {
-        const endpoint = this.isAdmin ? '/news/all' : '/news'
-        const response = await apiRequest(endpoint)
-        if (response.ok) {
-          this.newsList = await response.json() || []
-        } else {
-          const err = await response.json()
-          this.newsError = err.message || 'Не удалось загрузить новости'
-        }
-      } catch {
-        this.newsError = 'Ошибка сети при загрузке новостей'
-      } finally {
-        this.newsLoading = false
-      }
+    formatDate(dateString) {
+      if (!dateString) return ''
+      const date = new Date(dateString)
+      // Добавляем 3 часа для UTC+3 (Москва)
+      const mskDate = new Date(date.getTime() + 3 * 60 * 60 * 1000)
+      return mskDate.toLocaleDateString('ru-RU', { 
+        day: '2-digit', 
+        month: '2-digit', 
+        year: 'numeric', 
+        hour: '2-digit', 
+        minute: '2-digit' 
+      }).replace(',', '')
     },
 
-    async fetchAnnouncements() {
-      this.announcementsLoading = true
-      this.announcementsError = null
+    async fetchNews() {
+      this.loadingNews = true
+      try {
+        const response = await apiRequest('/news')
+        if (response.ok) this.newsItems = await response.json()
+      } catch (error) { console.error('Ошибка загрузки новостей:', error) }
+      finally { this.loadingNews = false }
+    },
+    async fetchAllNews() {
+      try {
+        const response = await apiRequest('/news/all')
+        if (response.ok) this.allNewsItems = await response.json()
+      } catch (error) { console.error('Ошибка загрузки всех новостей:', error) }
+    },
+    async fetchActiveAnnouncement() {
+      try {
+        const response = await apiRequest('/announcements/active')
+        if (response.ok) {
+          this.activeAnnouncement = await response.json()
+        } else {
+          this.activeAnnouncement = null
+        }
+      } catch (error) { console.error('Ошибка загрузки активного объявления:', error) }
+    },
+    async fetchAllAnnouncements() {
       try {
         const response = await apiRequest('/announcements/all')
-        if (response.ok) {
-          this.announcementsList = await response.json() || []
-        } else {
-          const err = await response.json()
-          this.announcementsError = err.message || 'Не удалось загрузить объявления'
-        }
-      } catch {
-        this.announcementsError = 'Ошибка сети при загрузке объявлений'
-      } finally {
-        this.announcementsLoading = false
-      }
+        if (response.ok) this.allAnnouncements = await response.json()
+      } catch (error) { console.error('Ошибка загрузки всех объявлений:', error) }
+    },
+    async fetchAllData() {
+      await Promise.all([this.fetchNews(), this.fetchActiveAnnouncement()])
     },
 
-    openNewsForm(item = null) {
-      this.editingNews = item
-      this.newsForm = item
-        ? { title: item.title, description: item.description || '', full_text: item.full_text || '' }
-        : { title: '', description: '', full_text: '' }
-      this.showNewsForm = true
-    },
-
-    async saveNews() {
-      this.newsSaving = true
+    async createNews() {
       try {
-        const body = {
-          title: this.newsForm.title,
-          description: this.newsForm.description || null,
-          full_text: this.newsForm.full_text || null,
-        }
-
-        let response
-        if (this.editingNews) {
-          response = await apiRequest(`/news/${this.editingNews.id}`, {
-            method: 'PUT',
-            body: JSON.stringify(body),
-          })
-        } else {
-          response = await apiRequest('/news', {
-            method: 'POST',
-            body: JSON.stringify(body),
-          })
-        }
-
+        const response = await apiRequest('/news', {
+          method: 'POST',
+          body: JSON.stringify(this.newsForm)
+        })
         if (response.ok) {
-          this.showNewsForm = false
-          this.showToast(this.editingNews ? 'Новость обновлена' : 'Новость создана', 'success')
+          await this.fetchAllNews()
           await this.fetchNews()
-        } else {
-          const err = await response.json()
-          this.showToast(err.message || 'Ошибка сохранения', 'error')
-        }
-      } catch {
-        this.showToast('Ошибка сети', 'error')
-      } finally {
-        this.newsSaving = false
-      }
+          this.closeNewsModal()
+        } else alert('Ошибка создания новости')
+      } catch (error) { console.error('Ошибка создания новости:', error) }
     },
-
+    async updateNews() {
+      try {
+        const response = await apiRequest(`/news/${this.editingNews.id}`, {
+          method: 'PUT',
+          body: JSON.stringify(this.newsForm)
+        })
+        if (response.ok) {
+          await this.fetchAllNews()
+          await this.fetchNews()
+          this.closeNewsModal()
+        } else alert('Ошибка обновления новости')
+      } catch (error) { console.error('Ошибка обновления новости:', error) }
+    },
     async toggleNewsActive(item) {
       try {
         const response = await apiRequest(`/news/${item.id}`, {
           method: 'PUT',
-          body: JSON.stringify({ is_active: !item.is_active }),
+          body: JSON.stringify({ is_active: !item.is_active })
         })
         if (response.ok) {
-          this.showToast(item.is_active ? 'Новость деактивирована' : 'Новость активирована', 'success')
+          await this.fetchAllNews()
           await this.fetchNews()
-        } else {
-          const err = await response.json()
-          this.showToast(err.message || 'Ошибка обновления', 'error')
-        }
-      } catch {
-        this.showToast('Ошибка сети', 'error')
-      }
+        } else alert('Ошибка изменения статуса')
+      } catch (error) { console.error('Ошибка изменения статуса:', error) }
     },
-
-    confirmDeleteNews(item) {
-      this.pendingDelete = { type: 'news', id: item.id }
-      this.deleteConfirmMessage = `Удалить новость "${item.title}"?`
-      this.showDeleteConfirm = true
-    },
-
-    openAnnouncementForm(item = null) {
-      this.editingAnnouncement = item
-      this.announcementForm = item
-        ? {
-            title: item.title,
-            description: item.description || '',
-            full_text: item.full_text || '',
-            is_important: item.is_important || false,
-          }
-        : { title: '', description: '', full_text: '', is_important: false }
-      this.showAnnouncementForm = true
-    },
-
-    async saveAnnouncement() {
-      this.announcementSaving = true
+    async deleteNewsItem(id) {
+      if (!confirm('Удалить новость?')) return
       try {
-        const body = {
-          title: this.announcementForm.title,
-          description: this.announcementForm.description || null,
-          full_text: this.announcementForm.full_text || null,
-          is_important: this.announcementForm.is_important,
-        }
-
-        let response
-        if (this.editingAnnouncement) {
-          response = await apiRequest(`/announcements/${this.editingAnnouncement.id}`, {
-            method: 'PUT',
-            body: JSON.stringify(body),
-          })
-        } else {
-          response = await apiRequest('/announcements', {
-            method: 'POST',
-            body: JSON.stringify(body),
-          })
-        }
-
+        const response = await apiRequest(`/news/${id}`, { method: 'DELETE' })
         if (response.ok) {
-          this.showAnnouncementForm = false
-          this.showToast(
-            this.editingAnnouncement ? 'Объявление обновлено' : 'Объявление создано',
-            'success',
-          )
-          await this.fetchAnnouncements()
-        } else {
-          const err = await response.json()
-          this.showToast(err.message || 'Ошибка сохранения', 'error')
-        }
-      } catch {
-        this.showToast('Ошибка сети', 'error')
-      } finally {
-        this.announcementSaving = false
-      }
+          await this.fetchAllNews()
+          await this.fetchNews()
+        } else alert('Ошибка удаления новости')
+      } catch (error) { console.error('Ошибка удаления новости:', error) }
     },
 
+    async createAnnouncement() {
+      try {
+        const response = await apiRequest('/announcements', {
+          method: 'POST',
+          body: JSON.stringify(this.announcementForm)
+        })
+        if (response.ok) {
+          await this.fetchAllAnnouncements()
+          await this.fetchActiveAnnouncement()
+          this.closeAnnouncementModal()
+        } else alert('Ошибка создания объявления')
+      } catch (error) { console.error('Ошибка создания объявления:', error) }
+    },
+    async updateAnnouncement() {
+      try {
+        const response = await apiRequest(`/announcements/${this.editingAnnouncement.id}`, {
+          method: 'PUT',
+          body: JSON.stringify(this.announcementForm)
+        })
+        if (response.ok) {
+          await this.fetchAllAnnouncements()
+          await this.fetchActiveAnnouncement()
+          this.closeAnnouncementModal()
+        } else alert('Ошибка обновления объявления')
+      } catch (error) { console.error('Ошибка обновления объявления:', error) }
+    },
     async setActiveAnnouncement(id) {
+      if (!confirm('Активировать это объявление?')) return
       try {
         const response = await apiRequest('/announcements/set-active', {
           method: 'POST',
-          body: JSON.stringify({ announcement_id: id }),
+          body: JSON.stringify({ announcement_id: id })
         })
         if (response.ok) {
-          this.showToast('Активное объявление обновлено', 'success')
-          await this.fetchAnnouncements()
-        } else {
-          const err = await response.json()
-          this.showToast(err.message || 'Ошибка обновления', 'error')
-        }
-      } catch {
-        this.showToast('Ошибка сети', 'error')
-      }
+          await this.fetchAllAnnouncements()
+          await this.fetchActiveAnnouncement()
+        } else alert('Ошибка активации объявления')
+      } catch (error) { console.error('Ошибка активации объявления:', error) }
     },
-
-    confirmDeleteAnnouncement(item) {
-      this.pendingDelete = { type: 'announcement', id: item.id }
-      this.deleteConfirmMessage = `Удалить объявление "${item.title}"?`
-      this.showDeleteConfirm = true
-    },
-
-    async executeDelete() {
-      this.showDeleteConfirm = false
-      if (!this.pendingDelete) return
-
-      const { type, id } = this.pendingDelete
-      this.pendingDelete = null
-
+    async deactivateAnnouncement(id) {
+      if (!confirm('Деактивировать объявление?')) return
       try {
-        const endpoint = type === 'news' ? `/news/${id}` : `/announcements/${id}`
-        const response = await apiRequest(endpoint, { method: 'DELETE' })
+        const response = await apiRequest(`/announcements/${id}`, {
+          method: 'PUT',
+          body: JSON.stringify({ is_active: false })
+        })
         if (response.ok) {
-          this.showToast(type === 'news' ? 'Новость удалена' : 'Объявление удалено', 'success')
-          if (type === 'news') {
-            await this.fetchNews()
-          } else {
-            await this.fetchAnnouncements()
-          }
-        } else {
-          const err = await response.json()
-          this.showToast(err.message || 'Ошибка удаления', 'error')
-        }
-      } catch {
-        this.showToast('Ошибка сети', 'error')
-      }
+          await this.fetchAllAnnouncements()
+          await this.fetchActiveAnnouncement()
+        } else alert('Ошибка деактивации объявления')
+      } catch (error) { console.error('Ошибка деактивации объявления:', error) }
+    },
+    async deleteAnnouncement(id) {
+      if (!confirm('Удалить объявление?')) return
+      try {
+        const response = await apiRequest(`/announcements/${id}`, { method: 'DELETE' })
+        if (response.ok) {
+          await this.fetchAllAnnouncements()
+          await this.fetchActiveAnnouncement()
+        } else alert('Ошибка удаления объявления')
+      } catch (error) { console.error('Ошибка удаления объявления:', error) }
     },
 
-    toggleExpand(id) {
-      this.expandedNewsId = this.expandedNewsId === id ? null : id
+    openManageModal() { this.fetchAllNews(); this.fetchAllAnnouncements(); this.showManageModal = true },
+    closeManageModal() { this.showManageModal = false },
+    openNewsModal(item) { this.selectedNews = item; this.showNewsDetailsModal = true },
+    closeNewsDetailsModal() { this.showNewsDetailsModal = false; this.selectedNews = null },
+    openAnnouncementModal(announcement) { 
+      this.viewingAnnouncement = announcement; 
+      this.showViewAnnouncementModal = true; 
     },
-
-    formatDate(dateString) {
-      if (!dateString) return ''
-      return new Date(dateString).toLocaleDateString('ru-RU', {
-        day: '2-digit',
-        month: '2-digit',
-        year: 'numeric',
-        hour: '2-digit',
-        minute: '2-digit',
-      }).replace(',', '')
+    closeViewAnnouncementModal() { 
+      this.showViewAnnouncementModal = false; 
+      this.viewingAnnouncement = null; 
     },
-
-    showToast(message, type) {
-      if (this.toast.timer) clearTimeout(this.toast.timer)
-      this.toast.message = message
-      this.toast.type = type
-      this.toast.visible = true
-      this.toast.timer = setTimeout(() => {
-        this.toast.visible = false
-      }, 3000)
-    },
+    openCreateNewsModal() { this.editingNews = null; this.newsForm = { title: '', description: '', fullText: '' }; this.showNewsModal = true },
+    editNewsItem(item) { this.editingNews = item; this.newsForm = { title: item.title, description: item.description, fullText: item.full_text || '' }; this.showNewsModal = true },
+    closeNewsModal() { this.showNewsModal = false; this.editingNews = null },
+    submitNews() { if (!this.newsForm.title || !this.newsForm.description) { alert('Заполните заголовок и описание'); return } this.editingNews ? this.updateNews() : this.createNews() },
+    openCreateAnnouncementModal() { this.editingAnnouncement = null; this.announcementForm = { title: '', description: '', fullText: '', isImportant: false }; this.showAnnouncementModal = true },
+    editAnnouncement(item) { this.editingAnnouncement = item; this.announcementForm = { title: item.title, description: item.description, fullText: item.full_text || '', isImportant: item.is_important }; this.showAnnouncementModal = true },
+    closeAnnouncementModal() { this.showAnnouncementModal = false; this.editingAnnouncement = null },
+    submitAnnouncement() { if (!this.announcementForm.title || !this.announcementForm.description) { alert('Заполните заголовок и описание'); return } this.editingAnnouncement ? this.updateAnnouncement() : this.createAnnouncement() },
+    openGuide() { console.log('Открыть инструкцию') }
   },
   mounted() {
-    this.fetchNews()
-    if (this.isAdmin) {
-      this.fetchAnnouncements()
-    }
-  },
-  beforeUnmount() {
-    if (this.toast.timer) clearTimeout(this.toast.timer)
-  },
+    this.fetchAllData()
+  }
 }
 </script>
 
 <style scoped>
-.news-page {
-  padding: 12px;
-}
+/* ... все существующие стили ... */
 
-/* Табы */
-.tabs {
-  display: flex;
-  gap: 4px;
-  margin-bottom: 16px;
-}
-
-.tab {
-  padding: 8px 20px;
-  border: 1px solid var(--color-border);
-  border-radius: 50px;
-  background: #fff;
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--color-text);
-  cursor: pointer;
-  transition: all 0.2s;
-  font-family: 'Montserrat', sans-serif;
-}
-
-.tab:hover {
-  background: #f5f5f5;
-}
-
-.tab--active {
-  background: var(--color-primary);
-  color: #fff;
-  border-color: var(--color-primary);
-}
-
-.tab--active:hover {
-  background: var(--color-primary-hover);
-}
-
-/* Секция */
-.section-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 16px;
-}
-
-.section-title {
-  font-size: 16px;
-  font-weight: 600;
-  color: #000;
+/* Добавляем стили для лоадера */
+.loading-message {
+  text-align: center;
+  color: #a2a2a2;
+  padding: 40px 20px;
   margin: 0;
-}
-
-/* Inline-форма */
-.inline-form {
-  background: #fff;
-  border: 1px solid var(--color-border);
-  border-radius: 20px;
-  padding: 20px;
-  margin-bottom: 16px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
-}
-
-.inline-form__title {
-  margin: 0 0 16px;
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--color-primary);
-}
-
-.inline-form__actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
-  margin-top: 4px;
-}
-
-/* Карточки */
-.cards-list {
+  font-size: 14px;
+  flex-grow: 1;
   display: flex;
   flex-direction: column;
+  align-items: center;
+  justify-content: center;
   gap: 12px;
 }
 
-.card {
-  background: #fff;
-  border: 1px solid var(--color-border);
-  border-radius: 20px;
-  padding: 16px 20px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
-  transition: box-shadow 0.2s;
-}
-
-.card:hover {
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
-}
-
-.card--highlighted {
-  border-color: var(--color-primary);
-  background: #f8f8ff;
-}
-
-.card__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 8px;
-}
-
-.card__date {
-  font-size: 12px;
-  font-weight: 500;
-  color: #a2a2a2;
-}
-
-.card__badges {
-  display: flex;
-  gap: 6px;
-}
-
-.card__title {
-  margin: 0 0 8px;
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--color-primary);
-}
-
-.card__description {
-  margin: 0 0 8px;
-  font-size: 13px;
-  line-height: 1.5;
-  color: var(--color-text);
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-}
-
-.card__full-text {
-  margin: 8px 0 12px;
-  padding-top: 8px;
-  border-top: 1px solid var(--color-border);
-  font-size: 13px;
-  line-height: 1.6;
-  color: var(--color-text);
-  white-space: pre-wrap;
-}
-
-.card__actions {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-  margin-top: 8px;
-}
-
-/* Бейджи статуса */
-.status-badge {
-  display: inline-block;
-  padding: 2px 10px;
-  border-radius: 50px;
-  font-size: 11px;
-  font-weight: 600;
-}
-
-.status-badge--active {
-  background: #e6f9ed;
-  color: #1a7a3a;
-}
-
-.status-badge--inactive {
-  background: #f2f2f2;
-  color: #888;
-}
-
-.status-badge--important {
-  background: #fde8e8;
-  color: var(--color-danger);
-}
-
-/* Кнопки */
-.btn {
-  padding: 6px 16px;
-  border: none;
-  border-radius: 50px;
-  cursor: pointer;
-  font-size: 12px;
-  font-weight: 500;
-  font-family: 'Montserrat', sans-serif;
-  transition: all 0.2s;
-  display: inline-flex;
-  align-items: center;
-}
-
-.btn--primary {
-  background: var(--color-primary);
-  color: #fff;
-  height: 32px;
-  padding: 0 20px;
-}
-
-.btn--primary:hover:not(:disabled) {
-  background: var(--color-primary-hover);
-}
-
-.btn--primary:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.btn--secondary {
-  background: #fff;
-  color: var(--color-text);
-  border: 1px solid var(--color-border);
-  height: 32px;
-  padding: 0 20px;
-}
-
-.btn--secondary:hover {
-  background: #f5f5f5;
-}
-
-.btn--link {
-  background: var(--color-primary);
-  color: #fff;
-  padding: 4px 14px;
-  font-size: 12px;
-  border-radius: 50px;
-}
-
-.btn--link:hover {
-  background: var(--color-primary-hover);
-}
-
-.btn--text {
-  background: none;
-  color: var(--color-primary);
-  padding: 4px 8px;
-  font-size: 12px;
-}
-
-.btn--text:hover {
-  text-decoration: underline;
-}
-
-.btn--danger {
-  color: var(--color-danger);
-}
-
-/* Форма */
-.form-group {
-  margin-bottom: 14px;
-}
-
-.form-label {
-  display: block;
-  font-size: 12px;
-  font-weight: 500;
-  color: var(--color-text);
-  margin-bottom: 6px;
-  font-family: 'Montserrat', sans-serif;
-}
-
-.form-input {
-  width: 100%;
-  padding: 8px 12px;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  font-size: 13px;
-  font-family: 'Montserrat', sans-serif;
-  color: var(--color-text);
-  transition: border-color 0.2s;
-  outline: none;
-}
-
-.form-input:focus {
-  border-color: var(--color-primary);
-}
-
-.form-textarea {
-  width: 100%;
-  padding: 8px 12px;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  font-size: 13px;
-  font-family: 'Montserrat', sans-serif;
-  color: var(--color-text);
-  transition: border-color 0.2s;
-  outline: none;
-  resize: vertical;
-  min-height: 60px;
-}
-
-.form-textarea:focus {
-  border-color: var(--color-primary);
-}
-
-.checkbox-label {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  cursor: pointer;
-  font-size: 13px;
-}
-
-.checkbox-label input[type="checkbox"] {
-  accent-color: var(--color-primary);
-  cursor: pointer;
-}
-
-.checkbox-text {
-  font-family: 'Montserrat', sans-serif;
-  font-size: 13px;
-  color: var(--color-text);
-}
-
-/* Состояния */
-.loading-state {
-  display: flex;
-  justify-content: center;
-  padding: 40px;
-}
-
-.spinner {
-  width: 24px;
-  height: 24px;
-  border: 2px solid var(--color-border);
-  border-top-color: var(--color-primary);
+.loader {
+  width: 30px;
+  height: 30px;
+  border: 3px solid #f3f3f3;
+  border-top: 3px solid #4F5BDF;
   border-radius: 50%;
-  animation: spinner-rotate 1s linear infinite;
+  animation: spin 1s linear infinite;
 }
 
-@keyframes spinner-rotate {
-  to { transform: rotate(360deg); }
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
 }
 
-.error-state {
-  text-align: center;
-  padding: 40px 20px;
+.news {
+    padding: 20px;
+    font-family: 'Montserrat', sans-serif;
+    background: linear-gradient(135deg, #f8f9ff 0%, #ffffff 100%);
 }
 
-.error-message {
-  color: var(--color-danger);
-  font-size: 13px;
-  margin: 0 0 12px;
+.content-wrapper {
+    display: flex;
+    gap: 20px;
+    align-items: flex-start;
+}
+
+.left-column {
+    flex: 1;
+}
+
+.news-container {
+    background: #FFFFFF;
+    border: 1px solid #E6E6E6;
+    box-shadow: 0px 3px 10px rgba(0, 0, 0, 0.05);
+    border-radius: 30px;
+    overflow: hidden;
+    min-height: 84vh;
+}
+
+.news-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0 20px;
+    height: 35px;
+}
+
+.news-title {
+    margin: 0;
+    font-weight: 700;
+    font-size: 18px;
+    line-height: 22px;
+    color: #1a1a1a;
+}
+
+.header-actions {
+    display: flex;
+    gap: 8px;
+}
+
+.manage-btn {
+    width: 115px;
+    height: 25px;
+    background: white;
+    border: 1px solid #e6e6e6;
+    border-radius: 30px;
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 500;
+    font-size: 13px;
+    color: #000000;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.manage-btn:hover {
+    background: #f5f5f5;
+    border-color: #4F5BDF;
+}
+
+.divider {
+    height: 1px;
+    background: #E6E6E6;
+    margin: 0;
+}
+
+.news-list {
+    max-height: 600px;
+    overflow-y: scroll;
+    padding: 0;
+}
+
+.news-item {
+    padding: 20px 20px;
+    position: relative;
+    opacity: 0;
+    transform: translateY(20px);
+    animation: slideInUp 0.5s ease forwards;
+    border-bottom: 1px solid #e6e6e6;
+}
+
+@keyframes slideInUp {
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.news-list::-webkit-scrollbar {
+    width: 4px;
+}
+
+.news-list::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.news-list::-webkit-scrollbar-thumb {
+    background: #D9E2FF;
+    border-radius: 4px;
+}
+
+.news-list::-webkit-scrollbar-thumb:hover {
+    background: #4F5BDF;
+}
+
+.news-list {
+    scrollbar-width: thin;
+    scrollbar-color: #D9E2FF transparent;
+}
+
+.item-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 6px;
+}
+
+.news-date {
+    font-weight: 500;
+    font-size: 12px;
+    line-height: 15px;
+    color: #A2A2A2;
+}
+
+.item-type {
+    font-size: 11px;
+    font-weight: 500;
+    padding: 2px 8px;
+    border-radius: 20px;
+    background: #f0f4ff;
+    color: #4F5BDF;
+}
+
+.news-item-title {
+    margin: 0 0 8px 0;
+    font-weight: 700;
+    font-size: 16px;
+    line-height: 20px;
+    color: #1a1a1a;
+}
+
+.news-item-description {
+    margin: 0 0 12px 0;
+    font-weight: 400;
+    font-size: 14px;
+    line-height: 17px;
+    color: #666;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.news-details-button {
+    height: 25px;
+    background: #4F5BDF;
+    border: none;
+    border-radius: 30px;
+    cursor: pointer;
+    padding: 0 16px;
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 500;
+    font-size: 12px;
+    line-height: 25px;
+    color: #FFFFFF;
+    transition: background-color 0.2s ease;
+}
+
+.news-details-button:hover {
+    background: #3a45c5;
 }
 
 .empty-state {
-  text-align: center;
-  padding: 40px;
+    text-align: center;
+    padding: 48px 20px;
+    color: #a2a2a2;
 }
 
-.empty-message {
-  color: #a2a2a2;
-  font-size: 14px;
+.empty-state p {
+    margin: 0;
+    font-size: 14px;
 }
 
-/* Toast */
-.toast {
-  position: fixed;
-  bottom: 24px;
-  right: 24px;
-  padding: 10px 20px;
-  border-radius: 12px;
-  font-size: 13px;
-  font-weight: 500;
-  font-family: 'Montserrat', sans-serif;
-  color: #fff;
-  z-index: 9999;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-}
-
-.toast--success {
-  background: var(--color-success);
-}
-
-.toast--error {
-  background: var(--color-danger);
-}
-
-.toast-fade-enter-active,
-.toast-fade-leave-active {
-  transition: all 0.3s ease;
-}
-
-.toast-fade-enter-from,
-.toast-fade-leave-to {
-  opacity: 0;
-  transform: translateY(10px);
-}
-
-/* Адаптивность */
-@media (max-width: 768px) {
-  .section-header {
+.right-column {
+    width: 450px;
+    flex-shrink: 0;
+    display: flex;
     flex-direction: column;
-    align-items: flex-start;
     gap: 10px;
-  }
+}
 
-  .card {
-    padding: 12px 14px;
-    border-radius: 16px;
-  }
+.news-card {
+    background: white;
+    border: 1px solid #e6e6e6;
+    border-radius: 24px;
+    padding: 20px;
+    cursor: pointer;
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    opacity: 0;
+    transform: translateY(20px);
+    animation: slideInUp 0.5s ease forwards;
+}
 
-  .card__actions {
-    gap: 4px;
-  }
+.news-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+    border-color: #4F5BDF;
+}
 
-  .inline-form {
+.card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 12px;
+}
+
+.card-type {
+    font-size: 11px;
+    font-weight: 500;
+    padding: 2px 8px;
+    border-radius: 20px;
+    background: #fff3cd;
+    color: #856404;
+}
+
+.card-type.important {
+    background: #ffebee;
+    color: #c62828;
+}
+
+.card-date {
+    font-size: 11px;
+    color: #a2a2a2;
+}
+
+.card-title {
+    margin: 0 0 8px 0;
+    font-weight: 700;
+    font-size: 16px;
+    line-height: 20px;
+    color: #1a1a1a;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.card-description {
+    margin: 0 0 16px 0;
+    font-size: 13px;
+    line-height: 1.4;
+    color: #666;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.card-button {
+    background: none;
+    border: none;
+    padding: 0;
+    font-family: 'Montserrat', sans-serif;
+    font-size: 12px;
+    font-weight: 500;
+    color: #4F5BDF;
+    cursor: pointer;
+    transition: transform 0.2s ease;
+}
+
+.card-button:hover {
+    transform: translateX(4px);
+}
+
+.guide-card {
+    background: white;
+    border: 1px solid #e6e6e6;
+    border-radius: 24px;
+    padding: 20px;
+    width: 450px;
+    height: 130px;
+    box-sizing: border-box;
+    transition: all 0.3s ease;
+    cursor: pointer;
+    opacity: 0;
+    transform: translateY(20px);
+    animation: slideInUp 0.5s ease forwards;
+}
+
+.guide-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+    border: 1px solid #4F5BDF;
+}
+
+.guide-content {
+    display: flex;
+    gap: 16px;
+    align-items: flex-start;
+}
+
+.guide-icon {
+    flex-shrink: 0;
+}
+
+.guide-text {
+    flex: 1;
+}
+
+.guide-title {
+    margin: 0 0 12px 0;
+    font-weight: 700;
+    font-size: 20px;
+    line-height: 1.2;
+    color: #1a1a1a;
+    display: flex;
+    gap: 10px;
+    align-items: center;
+}
+
+.guide-title-blue {
+    color: #4F5BDF;
+}
+
+.guide-description {
+    margin: 0;
+    font-size: 12px;
+    line-height: 1.4;
+    color: #a2a2a2;
+    width: 320px;
+}
+
+.guide-description strong {
+    font-weight: 700;
+    color: #a2a2a2;
+}
+
+.manage-modal .modal-content {
+    width: 680px;
+}
+
+.manage-tabs {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 24px;
+    border-bottom: 1px solid #e6e6e6;
+    padding-bottom: 12px;
+}
+
+.tab-btn {
+    background: none;
+    border: none;
+    padding: 8px 20px;
+    font-family: 'Montserrat', sans-serif;
+    font-size: 14px;
+    font-weight: 500;
+    color: #a2a2a2;
+    cursor: pointer;
+    border-radius: 20px;
+    transition: all 0.2s ease;
+}
+
+.tab-btn:hover {
+    color: #4F5BDF;
+    background: #f8f9ff;
+}
+
+.tab-btn.active {
+    color: #4F5BDF;
+    background: #f0f4ff;
+}
+
+.manage-section {
+    margin-top: 8px;
+}
+
+.section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 16px;
+}
+
+.section-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: #333;
+}
+
+.add-btn {
+    background: #4F5BDF;
+    border: none;
+    border-radius: 20px;
+    padding: 6px 16px;
+    font-family: 'Montserrat', sans-serif;
+    font-size: 12px;
+    font-weight: 500;
+    color: white;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.add-btn:hover {
+    background: #3a45c0;
+}
+
+.info-message {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: #f0f4ff;
+    padding: 10px 14px;
+    border-radius: 12px;
+    margin-bottom: 16px;
+    font-size: 12px;
+    color: #4F5BDF;
+}
+
+.items-list {
+    max-height: 420px;
+    overflow-y: auto;
+}
+
+.manage-item {
+    display: flex;
+    justify-content: space-between;
+    flex-direction: column;
+
     padding: 14px;
-    border-radius: 16px;
-  }
+    border-bottom: 1px solid #f0f0f0;
+    transition: background 0.2s ease;
+    border: 1px solid #e6e6e6;
+    border-radius: 20px;
+    margin-bottom: 10px;
+}
+
+.manage-item:hover {
+    background: #fafafa;
+}
+
+.item-main {
+    flex: 1;
+}
+
+.item-title {
+    font-weight: 500;
+    font-size: 14px;
+    color: #333;
+    margin-bottom: 6px;
+}
+
+.item-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    font-size: 11px;
+    color: #a2a2a2;
+}
+
+.status-text {
+    color: #666;
+}
+
+.active-badge {
+    margin-left: 8px;
+    padding: 2px 8px;
+    background: #4F5BDF;
+    color: white;
+    border-radius: 12px;
+    font-size: 10px;
+    font-weight: 500;
+}
+
+.important-badge {
+    margin-left: 8px;
+    padding: 2px 8px;
+    background: #ff9800;
+    color: white;
+    border-radius: 12px;
+    font-size: 10px;
+    font-weight: 500;
+}
+
+.item-actions {
+    display: flex;
+    gap: 8px;
+    padding-top: 10px;
+}
+
+.action-btn {
+    background: none;
+    border: none;
+    padding: 3px 12px;
+    border-radius: 20px;
+    font-family: 'Montserrat', sans-serif;
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    color: #666;
+    border: 1px solid #e6e6e6;
+}
+
+.action-btn:hover {
+    background: #f0f0f0;
+}
+
+.edit-btn:hover {
+    color: #4F5BDF;
+    background: #f0f4ff;
+}
+
+.delete-btn:hover {
+    color: #dc2626;
+    background: #ffebee;
+}
+
+.toggle-btn:hover {
+    color: #4F5BDF;
+    background: #f0f4ff;
+}
+
+.activate-btn:hover {
+    color: #4F5BDF;
+    background: #f0f4ff;
+}
+
+.deactivate-btn:hover {
+    color: #dc2626;
+    background: #ffebee;
+}
+
+.empty-manage {
+    text-align: center;
+    padding: 48px;
+    color: #a2a2a2;
+    font-size: 13px;
+}
+
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    backdrop-filter: blur(1px);
+}
+
+.modal-fade-enter-active,
+.modal-fade-leave-active {
+    transition: all 0.4s ease;
+}
+
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+    opacity: 0;
+}
+
+.modal-fade-enter-from .modal-content,
+.modal-fade-leave-to .modal-content {
+    opacity: 0;
+    transform: scale(0.9) translateY(-20px);
+}
+
+.modal-content {
+    background: #fff;
+    border-radius: 50px;
+    width: 540px;
+    max-width: 90vw;
+    max-height: 80vh;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 20px 30px 0;
+    flex-shrink: 0;
+}
+
+.modal-title {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 600;
+    color: #1a1a1a;
+}
+
+.modal-close {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 6px;
+    border-radius: 6px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background-color 0.2s ease;
+}
+
+.modal-close:hover {
+    background-color: #f5f5f5;
+}
+
+.modal-body {
+    padding: 20px 30px;
+    overflow-y: auto;
+    flex: 1;
+}
+
+.modal-info {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 16px;
+}
+
+.modal-date {
+    font-size: 12px;
+    color: #a2a2a2;
+}
+
+.modal-type {
+    font-size: 11px;
+    font-weight: 500;
+    padding: 2px 8px;
+    border-radius: 20px;
+    background: #f0f4ff;
+    color: #4F5BDF;
+}
+
+.modal-type.announcement {
+    background: #fff3cd;
+    color: #856404;
+}
+
+.modal-description {
+    font-size: 14px;
+    line-height: 1.5;
+    color: #333;
+    margin: 0 0 20px 0;
+}
+
+.modal-full-text {
+    font-size: 14px;
+    line-height: 1.6;
+    color: #666;
+    padding-top: 16px;
+    border-top: 1px solid #f0f0f0;
+    margin-top: 8px;
+}
+
+.modal-footer {
+    padding: 16px 30px 24px;
+    border-top: 1px solid #f0f0f0;
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+    flex-shrink: 0;
+}
+
+.btn {
+    padding: 8px 24px;
+    font-size: 13px;
+    font-weight: 500;
+    border-radius: 30px;
+    cursor: pointer;
+    border: 1px solid;
+    transition: all 0.2s ease;
+}
+
+.close-btn {
+    background: #4F5BDF;
+    color: white;
+    border-color: #4F5BDF;
+}
+
+.close-btn:hover {
+    background: #3a45c0;
+}
+
+.cancel-btn {
+    background: white;
+    color: #666;
+    border-color: #e6e6e6;
+}
+
+.cancel-btn:hover {
+    background: #f5f5f5;
+}
+
+.save-btn {
+    background: #4F5BDF;
+    color: white;
+    border-color: #4F5BDF;
+}
+
+.save-btn:hover {
+    background: #3a45c0;
+}
+
+.form-group {
+    margin-bottom: 20px;
+}
+
+.form-label {
+    display: block;
+    font-size: 13px;
+    font-weight: 500;
+    color: #333;
+    margin-bottom: 8px;
+}
+
+.form-input,
+.form-textarea {
+    width: 100%;
+    padding: 10px 14px;
+    border: 1px solid #e6e6e6;
+    border-radius: 20px;
+    font-family: 'Montserrat', sans-serif;
+    font-size: 13px;
+    transition: all 0.2s ease;
+    resize: vertical;
+}
+
+.form-input:focus,
+.form-textarea:focus {
+    outline: none;
+    border-color: #4F5BDF;
+}
+
+.checkbox-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    font-size: 13px;
+    color: #333;
+}
+
+.checkbox-label input {
+    width: 16px;
+    height: 16px;
+    cursor: pointer;
+    accent-color: #4F5BDF;
+}
+
+@media (max-width: 820px) {
+    .content-wrapper {
+        flex-direction: column;
+    }
+    
+    .left-column,
+    .right-column {
+        width: 100%;
+    }
+    
+    .guide-card {
+        width: 100%;
+    }
+    
+    .modal-content,
+    .manage-modal .modal-content {
+        width: 95vw;
+    }
 }
 </style>


### PR DESCRIPTION
## Summary

Закрыл пункт из #64 "Вкладка 'Обзор и новости' вообще другая полностью (Рисунок №9). Готовая нормальная страница (фронт) находится в old_branch views/NewsAndReviews.vue. (Рисунок №8) Доп. компонент: AnnouncementModal.vue."

**Что было в dev (неправильно, скрин №9):**
- Таб-панель "Новости"/"Объявления" с inline CRUD — это скорее админка, а не публичная страница

**Что стало после порта из old_branch (скрин №8):**
- Двухколоночный layout публичной страницы:
  - Левая колонка: карточки новостей с "Читать далее"
  - Правая колонка: гайд-карточка + карточка активного объявления (кликабельна, открывает \`AnnouncementModal\`)
- Модал "Управление" для админа со внутренними табами "Новости"/"Объявления" и полным CRUD
- \`RefreshButton\` в header для перезагрузки
- Уведомление "Активно может быть только одно объявление" внутри модала управления

**AnnouncementModal** — полный модал с датой, типом ("Важное"/"Обычное"), заголовком, описанием, full_text. Совместим с существующим использованием в \`TheHeader\` (\`:show\`, \`:announcement\`, \`@close\`).

## Адаптации при портировании

Из \`old_branch\` были хардкоды, которые заменил на наши абстракции:
- \`fetch('http://localhost:8080/...')\` → \`apiRequest('/...')\`
- Убраны \`localStorage.getItem('token')\` + \`Authorization: Bearer\` — \`apiRequest\` сам добавляет JWT и делает refresh на 401
- Убраны \`this.\$bus.emit('announcement-updated', ...)\` — их слушал сам же компонент, заменил на прямое обновление \`this.activeAnnouncement\` через \`fetchActiveAnnouncement()\`

Endpoints не изменены, уже все в бэке:
- \`GET /news\`, \`/news/all\`
- \`GET /announcements/active\`, \`/announcements/all\`
- \`POST /news\`, \`/announcements\`, \`/announcements/set-active\`
- \`PUT /news/:id\`, \`/announcements/:id\`
- \`DELETE /news/:id\`, \`/announcements/:id\`

## Test plan

- [x] \`npm run lint\` — зелёный.
- [x] \`npm run test:run\` — 204 passed.
- [ ] Staging после deploy:
  - [ ] \`/news\` — двухколоночный layout с левой колонкой новостей и правой с гайдом + активным объявлением
  - [ ] Клик по карточке объявления открывает \`AnnouncementModal\` с полной информацией
  - [ ] Кнопка "Управление" (суперадмин) открывает модал с табами CRUD
  - [ ] Создание/редактирование/удаление новости работает
  - [ ] Создание/активация/деактивация/удаление объявления работает
  - [ ] \`TheHeader\` "Важное объявление" продолжает открывать \`AnnouncementModal\`