### PR TITLE
fix: nginx конфликт /news SPA vs API (#64)

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -62,6 +62,10 @@ async function doFetch(path, options, token) {
       signal: options.signal || controller.signal,
       headers: {
         'Content-Type': 'application/json',
+        // Accept: application/json нужен чтобы nginx с Accept-based роутингом
+        // (см. nginx/staging.conf для /news и /announcements) отличал API-запрос
+        // от браузерного перехода по тому же пути и отдавал JSON, а не SPA HTML.
+        'Accept': 'application/json',
         ...(token && { Authorization: `Bearer ${token}` }),
         ...options.headers,
       },

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -10,8 +10,24 @@ server {
     listen 80;
     server_name _;
 
+    # SPA-пути, конфликтующие с API: /news — это И маршрут в Vue router, И префикс API.
+    # Если Accept содержит text/html (браузерная навигация) — отдаём frontend (SPA),
+    # иначе (fetch с Accept: application/json) — на backend.
+    location ~ ^/(news|announcements)(/|$) {
+        if ($http_accept ~* "text/html") {
+            proxy_pass http://frontend;
+            break;
+        }
+        proxy_pass http://backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        client_max_body_size 50M;
+    }
+
     # API — проксируем напрямую на backend (минуя frontend nginx)
-    location ~ ^/(login|refresh-token|logout|user-data|users|user-types|user-types-management|applications|cars|employees|unique-cars|unique-employees|unload-places|organizations|companies|license-plate-formats|application-approvers|citizenships|system-tables|attachments|feedback|get-organization|permissions|consents|settings|news|announcements|notifications|request-logs|health|swagger|uploads)(/|$) {
+    location ~ ^/(login|refresh-token|logout|user-data|users|user-types|user-types-management|applications|cars|employees|unique-cars|unique-employees|unload-places|organizations|companies|license-plate-formats|application-approvers|citizenships|system-tables|attachments|feedback|get-organization|permissions|consents|settings|notifications|request-logs|health|swagger|uploads)(/|$) {
         proxy_pass http://backend;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/nginx/staging.conf
+++ b/nginx/staging.conf
@@ -23,8 +23,26 @@ server {
         proxy_pass http://backend;
     }
 
+    # SPA-пути, конфликтующие с API: /news — это И маршрут в Vue router, И префикс API.
+    # Если Accept содержит text/html (браузерная навигация) — отдаём frontend (SPA),
+    # иначе (fetch с Accept: application/json) — на backend. Без этого переход по
+    # адресной строке на /news возвращал JSON "Missing or invalid authorization header".
+    location ~ ^/(news|announcements)(/|$) {
+        auth_basic off;
+        if ($http_accept ~* "text/html") {
+            proxy_pass http://frontend;
+            break;
+        }
+        proxy_pass http://backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        client_max_body_size 50M;
+    }
+
     # API — без basic auth (защищены JWT), напрямую на backend
-    location ~ ^/(login|refresh-token|logout|user-data|users|user-types|user-types-management|applications|cars|employees|unique-cars|unique-employees|unload-places|organizations|companies|license-plate-formats|application-approvers|citizenships|system-tables|attachments|feedback|get-organization|permissions|consents|settings|news|announcements|notifications|request-logs|swagger|uploads)(/|$) {
+    location ~ ^/(login|refresh-token|logout|user-data|users|user-types|user-types-management|applications|cars|employees|unique-cars|unique-employees|unload-places|organizations|companies|license-plate-formats|application-approvers|citizenships|system-tables|attachments|feedback|get-organization|permissions|consents|settings|notifications|request-logs|swagger|uploads)(/|$) {
         auth_basic off;
         proxy_pass http://backend;
         proxy_set_header Host $host;


### PR DESCRIPTION
## Summary

После merge #88 (двухколоночная страница NewsAndReview из old_branch) переход в браузере на \`/news\` вернул JSON:
\`\`\`
{"success":false,"error":"Missing or invalid authorization header"}
\`\`\`
вместо SPA-страницы.

**Причина**: в \`nginx/nginx.conf\` и \`nginx/staging.conf\` \`/news\` и \`/announcements\` попадали в общий API-whitelist \`location ~ ^/(...|news|announcements|...)(/|$)\` → всегда проксировались на backend. Браузерная навигация на \`/news\` не имеет JWT → backend отвечает 401.

Суть проблемы: \`/news\` и \`/announcements\` — **одновременно** Vue-router routes (SPA) и префиксы API.

## Fix

Выделен отдельный location с \`if ($http_accept ~* "text/html")\`:
- Браузерная навигация (\`Accept: text/html,...\`) → frontend (SPA)
- \`fetch('/news')\` из JS (\`Accept: application/json\`) → backend (API)

\`apiRequest\` в \`frontend/src/api/client.js\` теперь явно шлёт \`Accept: application/json\`, чтобы не зависеть от дефолтного \`*/*\` браузера.

## Files

- \`nginx/nginx.conf\` — dev-конфиг (prod)
- \`nginx/staging.conf\` — staging-конфиг с basic auth
- \`frontend/src/api/client.js\` — Accept header

## Test plan

- [x] \`npm run test:run\` — 211 passed.
- [ ] Staging после deploy:
  - [ ] \`https://stagingburo.washka17.site/news\` → SPA двухколоночная страница
  - [ ] \`fetch('/news')\` → список новостей (JSON)
  - [ ] \`/center\`, \`/personal-cabinet\` — не сломались (SPA fallback \`/\`)