### PR TITLE
refactor: удалил неподключённый /register handler (#64 #8)

### DIFF
--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -17,27 +17,6 @@ func NewAuthHandler(service services.AuthService) *AuthHandler {
 	return &AuthHandler{service: service}
 }
 
-// Register godoc
-// @Summary      Регистрация пользователя
-// @Description  Создаёт нового пользователя с указанными данными
-// @Tags         auth
-// @Accept       json
-// @Produce      json
-// @Param        request body models.RegisterRequest true "Данные регистрации"
-// @Success      200 {string} string "User registered successfully"
-// @Failure      400 {object} models.HTTPError "Username already exists"
-// @Router       /register [post]
-func (h *AuthHandler) Register(c echo.Context) error {
-	var req models.RegisterRequest
-	if err := BindAndValidate(c, &req); err != nil {
-		return err
-	}
-	if err := h.service.Register(c.Request().Context(), req); err != nil {
-		return err
-	}
-	return RespondMessage(c, "User registered successfully")
-}
-
 // Login godoc
 // @Summary      Авторизация
 // @Description  Проверяет credentials и возвращает access + refresh токены

--- a/internal/services/auth_service.go
+++ b/internal/services/auth_service.go
@@ -7,10 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
-	"log/slog"
 	"systemburo/internal/models"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -23,8 +21,9 @@ import (
 )
 
 // AuthService defines the auth business logic interface.
+// Создание пользователей идёт через UserService.Create (POST /users, admin-only).
+// Публичная регистрация (POST /register) не поддерживается - см. удалённый Register handler.
 type AuthService interface {
-	Register(ctx context.Context, req models.RegisterRequest) error
 	Login(ctx context.Context, req models.LoginRequest) (*models.LoginResponse, error)
 	RefreshToken(ctx context.Context, req models.RefreshTokenRequest) (*models.TokenPairResponse, error)
 	Logout(ctx context.Context, username string, req models.LogoutRequest) error
@@ -135,32 +134,6 @@ func hashRefreshToken(token string) string {
 }
 
 // --- Service Methods ---
-
-// Register регистрирует нового пользователя с хешированием пароля.
-func (s *authService) Register(ctx context.Context, req models.RegisterRequest) error {
-	hashed := hashPassword(req.Password)
-	user := models.User{
-		Username:       req.Username,
-		Password:       hashed,
-		OrganizationID: req.OrganizationID,
-		CompanyID:      req.CompanyID,
-		TypeID:         1,
-		LastName:       req.LastName,
-		FirstName:      req.FirstName,
-		MiddleName:     req.MiddleName,
-		Position:       req.Position,
-		Email:          req.Email,
-		Phone:          req.Phone,
-	}
-	if err := s.db.WithContext(ctx).Create(&user).Error; err != nil {
-		if strings.Contains(err.Error(), "unique") || strings.Contains(err.Error(), "duplicate") {
-			return echo.NewHTTPError(http.StatusBadRequest, "Username already exists")
-		}
-		slog.Error("registration failed", "error", err)
-		return echo.NewHTTPError(http.StatusInternalServerError, "Registration failed")
-	}
-	return nil
-}
 
 // Login выполняет аутентификацию пользователя и возвращает пару токенов.
 func (s *authService) Login(ctx context.Context, req models.LoginRequest) (*models.LoginResponse, error) {


### PR DESCRIPTION
## Summary

Закрывает пункт [8] из сводки по #64.

**Контекст**: \`AuthHandler.Register()\` + \`AuthService.Register()\` создавали публичную регистрацию пользователя (type_id=1 хардкод), но **никогда не были подключены в \`internal/router/router.go\`**. В PR #78 фронт переведён на \`POST /users\` (admin-only через \`UserService.Create\`) → \`/register\` стал неиспользуемым мёртвым кодом.

**Удалено**:
- \`internal/handlers/auth.go\`: \`Register()\` handler
- \`internal/services/auth_service.go\`: метод \`Register()\` из интерфейса \`AuthService\` и реализации
- Неиспользуемые imports (\`strings\`, \`log/slog\`)
- Комментарий в \`AuthService\` документирует: создание пользователей через \`UserService.Create\`, публичная регистрация не поддерживается

**Оставлено**:
- \`models.RegisterRequest\` — используется в \`UserService.Create\`, \`UsersHandler\`, фронте \`CreateUserModal.vue\`
- \`docs/docs.go\` \`/register\` definition — swag regenerate при следующем билде затрёт

## Test plan

- [x] \`go build ./...\` — успешно
- [x] \`go vet ./...\` — чисто
- [x] Тесты не используют удалённый \`Register\` (grep подтвердил)
- [ ] CI \`go test\` покажет что регрессий нет
- [ ] После merge: \`gh api swagger\` не возвращает \`/register\` после регенерации