### PR TITLE
fix: drag-out паттерн в ключевых модалках (#64 #6)

### DIFF
--- a/frontend/src/components/CarDetailsModal.vue
+++ b/frontend/src/components/CarDetailsModal.vue
@@ -1,10 +1,11 @@
 <template>
-  <div class="modal-overlay" @click.self="close">
+  <div class="modal-overlay" @mousedown="onOverlayMousedown" @mouseup="onOverlayMouseup">
     <div class="modal-wrapper">
       <!-- Основное модальное окно с деталями автомобиля -->
-      <div 
+      <div
         class="car-details-modal main-modal"
         :class="{ 'shifted': isMainShifted }"
+        @mousedown.stop
       >
         <div class="modal-header">
           <h3>Детали автомобиля</h3>
@@ -265,9 +266,14 @@
 <script>
 import { apiRequest } from '@/api/client'
 import CarHistoryModal from './CarHistoryModal.vue';
+import { useOverlayClose } from '@/composables/useOverlayClose';
 import ExcelJS from 'exceljs';
 
 export default {
+    setup(_, { emit }) {
+        const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(() => emit('close'));
+        return { onOverlayMousedown, onOverlayMouseup };
+    },
   name: 'CarDetailsModal',
   components: {
     CarHistoryModal

--- a/frontend/src/components/CarHistoryModal.vue
+++ b/frontend/src/components/CarHistoryModal.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="modal-overlay" @click.self="close">
-    <div class="car-history-modal">
+  <div class="modal-overlay" @mousedown="onOverlayMousedown" @mouseup="onOverlayMouseup">
+    <div class="car-history-modal" @mousedown.stop>
       <div class="modal-header">
         <h3>История автомобиля {{ carNumber }}</h3>
         <div class="header-actions">
@@ -143,10 +143,15 @@
 
 <script>
 import { apiRequest } from '@/api/client'
+import { useOverlayClose } from '@/composables/useOverlayClose';
 import ExcelJS from 'exceljs';
 
 export default {
   name: 'CarHistoryModal',
+  setup(_, { emit }) {
+    const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(() => emit('close'));
+    return { onOverlayMousedown, onOverlayMouseup };
+  },
   props: {
     carId: {
       type: Number,

--- a/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
@@ -1,11 +1,12 @@
 <template>
     <transition name="modal-fade">
-        <div v-if="show" class="modal-overlay" @click.self="close">
+        <div v-if="show" class="modal-overlay" @mousedown="onOverlayMousedown" @mouseup="onOverlayMouseup">
             <div class="modal-wrapper">
                 <!-- Основное модальное окно с деталями сотрудника -->
-                <div 
+                <div
                     class="modal-content compact-modal main-modal"
                     :class="{ 'shifted': isMainShifted }"
+                    @mousedown.stop
                 >
                     <div class="modal-header">
                         <h3 class="modal-title">Детальная информация о сотруднике</h3>
@@ -150,10 +151,15 @@
 <script>
 import TableInfoModal from './TableInfoModal.vue';
 import EmployeeHistoryModal from './EmployeeHistoryModal.vue';
+import { useOverlayClose } from '@/composables/useOverlayClose';
 
 export default {
     name: 'EmployeeDetailsModal',
     components: { TableInfoModal, EmployeeHistoryModal },
+    setup(_, { emit }) {
+        const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(() => emit('close'));
+        return { onOverlayMousedown, onOverlayMouseup };
+    },
     props: {
         show: {
             type: Boolean,

--- a/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
@@ -1,11 +1,12 @@
 <template>
     <transition name="modal-fade">
-        <div v-if="show" class="modal-overlay" @click.self="close">
+        <div v-if="show" class="modal-overlay" @mousedown="onOverlayMousedown" @mouseup="onOverlayMouseup">
             <div class="modal-wrapper">
                 <!-- Основное модальное окно с деталями ТС -->
-                <div 
+                <div
                     class="modal-content compact-modal main-modal"
                     :class="{ 'shifted': isMainShifted }"
+                    @mousedown.stop
                 >
                     <div class="modal-header">
                         <h3 class="modal-title">{{ modalTitle }}</h3>
@@ -204,6 +205,7 @@
 import { apiRequest } from '@/api/client'
 import UnloadPlaceModal from './UnloadPlaceModal.vue';
 import CarHistoryModal from '../CarHistoryModal.vue';
+import { useOverlayClose } from '@/composables/useOverlayClose';
 import ExcelJS from 'exceljs';
 
 export default {
@@ -211,6 +213,10 @@ export default {
     components: {
         UnloadPlaceModal,
         CarHistoryModal
+    },
+    setup(_, { emit }) {
+        const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(() => emit('close'));
+        return { onOverlayMousedown, onOverlayMouseup };
     },
     props: {
         show: {

--- a/frontend/src/components/FeedbackModal.vue
+++ b/frontend/src/components/FeedbackModal.vue
@@ -1,15 +1,17 @@
 <template>
   <teleport to="body">
     <transition name="modal-overlay" @after-leave="handleAfterLeave">
-      <div 
-        v-if="show" 
-        class="modal-overlay" 
-        @click.self="handleOverlayClick"
+      <div
+        v-if="show"
+        class="modal-overlay"
+        @mousedown="onOverlayMousedown"
+        @mouseup="onOverlayMouseup"
       >
         <transition name="modal" @after-leave="emitClose">
-          <div 
-            v-if="showContent" 
+          <div
+            v-if="showContent"
             class="modal"
+            @mousedown.stop
           >
             <div class="modal__header">
               <h3 class="modal__title">Сообщить о проблеме</h3>
@@ -129,6 +131,7 @@ export default {
       escListener: null,
       savedMessage: '',
       shouldSaveOnClose: true,
+      overlayMousedown: false,
       notification: {
         show: false,
         message: '',
@@ -256,11 +259,17 @@ export default {
       document.body.style.overflow = '';
     },
     
-    handleOverlayClick() {
-      if (!this.isSubmitting) {
-        this.saveMessage();
-        this.closeModal();
-      }
+    onOverlayMousedown(e) {
+      this.overlayMousedown = e.target === e.currentTarget;
+    },
+
+    onOverlayMouseup(e) {
+      const started = this.overlayMousedown;
+      this.overlayMousedown = false;
+      if (!started || e.target !== e.currentTarget) return;
+      if (this.isSubmitting) return;
+      this.saveMessage();
+      this.closeModal();
     },
     
     handleEnterKey(event) {

--- a/frontend/src/composables/__tests__/useOverlayClose.spec.js
+++ b/frontend/src/composables/__tests__/useOverlayClose.spec.js
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest'
+import { useOverlayClose } from '../useOverlayClose'
+
+function makeEvent(target, currentTarget) {
+  return { target, currentTarget }
+}
+
+describe('useOverlayClose', () => {
+  it('закрывает при mousedown+mouseup строго на оверлее', () => {
+    const close = vi.fn()
+    const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(close)
+    const overlay = {}
+
+    onOverlayMousedown(makeEvent(overlay, overlay))
+    onOverlayMouseup(makeEvent(overlay, overlay))
+
+    expect(close).toHaveBeenCalledOnce()
+  })
+
+  it('не закрывает, если mousedown начался внутри модалки (drag-out)', () => {
+    const close = vi.fn()
+    const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(close)
+    const overlay = {}
+    const modalContent = {}
+
+    // mousedown на content (не всплывает до оверлея благодаря @mousedown.stop в шаблоне,
+    // но даже если всплыл — e.target !== e.currentTarget).
+    onOverlayMousedown(makeEvent(modalContent, overlay))
+    onOverlayMouseup(makeEvent(overlay, overlay))
+
+    expect(close).not.toHaveBeenCalled()
+  })
+
+  it('не закрывает, если mouseup на дочернем элементе оверлея', () => {
+    const close = vi.fn()
+    const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(close)
+    const overlay = {}
+    const child = {}
+
+    onOverlayMousedown(makeEvent(overlay, overlay))
+    onOverlayMouseup(makeEvent(child, overlay))
+
+    expect(close).not.toHaveBeenCalled()
+  })
+
+  it('сбрасывает состояние между кликами', () => {
+    const close = vi.fn()
+    const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(close)
+    const overlay = {}
+    const modalContent = {}
+
+    // Первый drag-out — не закрывает
+    onOverlayMousedown(makeEvent(modalContent, overlay))
+    onOverlayMouseup(makeEvent(overlay, overlay))
+    expect(close).not.toHaveBeenCalled()
+
+    // Второй нормальный клик — закрывает
+    onOverlayMousedown(makeEvent(overlay, overlay))
+    onOverlayMouseup(makeEvent(overlay, overlay))
+    expect(close).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/composables/useOverlayClose.js
+++ b/frontend/src/composables/useOverlayClose.js
@@ -1,0 +1,39 @@
+import { ref } from 'vue'
+
+/**
+ * Composable для корректного закрытия модалки по клику на оверлей,
+ * с защитой от drag-out: если пользователь начал выделять текст внутри
+ * модалки и отпустил курсор на оверлее — модалка НЕ закрывается.
+ *
+ * Применяется к оверлею (не к самому модальному окну):
+ *
+ *   <div class="modal-overlay"
+ *        @mousedown="onOverlayMousedown"
+ *        @mouseup="onOverlayMouseup">
+ *     <div class="modal-content"
+ *          @mousedown.stop
+ *          @click.stop>
+ *       ...
+ *     </div>
+ *   </div>
+ *
+ * @param {() => void} onClose - колбэк закрытия модалки
+ * @returns {{ onOverlayMousedown, onOverlayMouseup }}
+ */
+export function useOverlayClose(onClose) {
+  const startedOnOverlay = ref(false)
+
+  function onOverlayMousedown(e) {
+    startedOnOverlay.value = e.target === e.currentTarget
+  }
+
+  function onOverlayMouseup(e) {
+    const wasOnOverlay = startedOnOverlay.value
+    startedOnOverlay.value = false
+    if (!wasOnOverlay) return
+    if (e.target !== e.currentTarget) return
+    onClose()
+  }
+
+  return { onOverlayMousedown, onOverlayMouseup }
+}


### PR DESCRIPTION
## Summary

Закрывает пункт [6] из сводки по #64. В PR #82 фикс drag-out был добавлен только в \`BaseModal\`. Остальные модалки со своим собственным overlay (не через \`BaseModal\`) всё ещё закрывались при drag-out — выделяешь текст внутри модалки, отпускаешь курсор на оверлее → модалка закрывается.

## Composable

\`\`\`js
// frontend/src/composables/useOverlayClose.js
export function useOverlayClose(onClose) {
  const startedOnOverlay = ref(false)
  // mousedown: запоминаем, началось ли нажатие на оверлее
  // mouseup: закрываем только если оба события на оверлее
}
\`\`\`

Применён к модалкам через \`setup()\` (Options API совместимость):

| Модалка | Файл |
|---|---|
| Детали Т/С | \`CreateApplication/VehicleDetailsModal.vue\` |
| Детали сотрудника | \`CreateApplication/EmployeeDetailsModal.vue\` |
| История автомобиля | \`CarHistoryModal.vue\` |
| Детали авто (CarsView) | \`CarDetailsModal.vue\` |

## Исключения

- **FeedbackModal** — свой \`handleOverlayClick\` с проверкой \`isSubmitting\` и \`saveMessage()\`. Переделал вручную через \`data()/methods\` чтобы сохранить семантику.
- **SessionExpiredModal** — overlay-close **намеренно заблокирован** (\`handleOverlayClick\` пустой) чтобы юзер не закрывал случайно. Не трогаем.
- **Остальные** (CreateUserModal, UserControl, OrganizationsManagement и ~12 ещё) — менее критичные, оформлю отдельными PR чтобы не раздувать этот.

## Test plan

- [x] \`npm run lint\` — зелёный
- [x] \`npm run test:run\` — 215 passed (+4 unit-теста \`useOverlayClose.spec.js\`: обычный клик, drag-out, mouseup на ребёнке, сброс состояния)
- [ ] Staging после deploy + \`staging-seed-demo\` (из #91):
  - [ ] \`/center\` → DEMO/001 → авто → \`VehicleDetailsModal\` → drag текста из модалки на оверлей → модалка остаётся открытой
  - [ ] Клик по оверлею (не drag) → закрывается