### PR TITLE
refactor: миграция на общий LoaderSpinner (часть 1) (#64 #4)

### DIFF
--- a/frontend/src/components/CarHistoryModal.vue
+++ b/frontend/src/components/CarHistoryModal.vue
@@ -88,7 +88,7 @@
 
       <div class="modal-content" ref="scrollContainer">
         <div v-if="loading" class="history-loading">
-          <div class="loader"></div>
+          <LoaderSpinner label="Загрузка истории…" />
         </div>
         
         <div v-else-if="filteredHistory.length === 0" class="history-empty">
@@ -144,10 +144,12 @@
 <script>
 import { apiRequest } from '@/api/client'
 import { useOverlayClose } from '@/composables/useOverlayClose';
+import LoaderSpinner from './ui/LoaderSpinner.vue';
 import ExcelJS from 'exceljs';
 
 export default {
   name: 'CarHistoryModal',
+  components: { LoaderSpinner },
   setup(_, { emit }) {
     const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(() => emit('close'));
     return { onOverlayMousedown, onOverlayMouseup };

--- a/frontend/src/components/CreateApplication/ExistingCarsModal.vue
+++ b/frontend/src/components/CreateApplication/ExistingCarsModal.vue
@@ -103,8 +103,7 @@
 
                         <!-- Состояния загрузки/пусто -->
                         <div v-if="loadingCars" class="loading-state">
-                            <div class="spinner"></div>
-                            <span>Загрузка машин...</span>
+                            <LoaderSpinner label="Загрузка машин…" />
                         </div>
                         <div v-else-if="displayedCars.length === 0" class="empty-state">
                             {{ searchQuery ? 'Ничего не найдено' : 'Нет доступных автомобилей' }}
@@ -133,11 +132,13 @@
 <script>
 import { apiRequest } from '@/api/client'
 import SearchComponent from '@/components/SearchComponent.vue'
+import LoaderSpinner from '@/components/ui/LoaderSpinner.vue'
 
 export default {
     name: 'ExistingCarsModal',
     components: {
-        SearchComponent
+        SearchComponent,
+        LoaderSpinner
     },
     props: {
         visible: {

--- a/frontend/src/components/CreateApplication/ExistingEmployeesModal.vue
+++ b/frontend/src/components/CreateApplication/ExistingEmployeesModal.vue
@@ -91,8 +91,7 @@
                         </div>
 
                         <div v-if="loadingEmployees" class="loading-state">
-                            <div class="spinner"></div>
-                            <span>Загрузка сотрудников...</span>
+                            <LoaderSpinner label="Загрузка сотрудников…" />
                         </div>
                         <div v-else-if="displayedEmployees.length === 0" class="empty-state">
                             {{ searchQuery ? 'Ничего не найдено' : 'Нет доступных сотрудников' }}
@@ -120,11 +119,13 @@
 <script>
 import { apiRequest } from '@/api/client'
 import SearchComponent from '@/components/SearchComponent.vue'
+import LoaderSpinner from '@/components/ui/LoaderSpinner.vue'
 
 export default {
     name: 'ExistingEmployeesModal',
     components: {
-        SearchComponent
+        SearchComponent,
+        LoaderSpinner
     },
     props: {
         visible: {

--- a/frontend/src/components/UserApplications.vue
+++ b/frontend/src/components/UserApplications.vue
@@ -101,8 +101,7 @@
           <!-- Тело таблицы -->
           <div class="applications-body">
             <div v-if="isLoading" class="loading-message">
-              <div class="loader"></div>
-              <p>Загрузка заявок...</p>
+              <LoaderSpinner label="Загрузка заявок…" />
             </div>
             
             <template v-else>
@@ -178,12 +177,14 @@ import { useAuthStore } from '@/stores/auth'
 import RefreshButton from './RefreshButton.vue';
 import SearchComponent from './SearchComponent.vue';
 import ApplicationDetail from './ApplicationDetail/ApplicationDetail.vue';
+import LoaderSpinner from './ui/LoaderSpinner.vue';
 
 export default {
   components: {
     RefreshButton,
     SearchComponent,
-    ApplicationDetail
+    ApplicationDetail,
+    LoaderSpinner
   },
   props: {
     userOrganizationId: {


### PR DESCRIPTION
## Summary

Пункт [4] из сводки по #64 — миграция локальных спиннеров на общий \`ui/LoaderSpinner\` (создан в PR #87). Из ~46 файлов с собственными \`.loader\`/\`.spinner\` — закрыл 4 самых видимых.

| Файл | До | После |
|---|---|---|
| \`UserApplications.vue\` | \`.loader + <p>Загрузка заявок...\` | \`LoaderSpinner label="Загрузка заявок…"\` |
| \`CarHistoryModal.vue\` | \`.loader\` | \`LoaderSpinner label="Загрузка истории…"\` |
| \`ExistingCarsModal.vue\` | \`.spinner + <span>Загрузка машин...\` | \`LoaderSpinner label="Загрузка машин…"\` |
| \`ExistingEmployeesModal.vue\` | \`.spinner + <span>Загрузка сотрудников...\` | \`LoaderSpinner label="Загрузка сотрудников…"\` |

Остальные 42 компонента — отдельными PR, чтобы не раздувать ревью и не тащить все spinners одним махом.

## Test plan

- [x] \`npm run lint\` — зелёный
- [x] \`npm run test:run\` — 215 passed
- [ ] Staging после merge: визуально спиннеры выглядят одинаково (цвет primary, размер medium, текст "Загрузка…"), \`prefers-reduced-motion\` уважают.