### PR TITLE
refactor: API-префикс /api/* (#64 #7)

### DIFF
--- a/frontend/src/api/__tests__/client.spec.js
+++ b/frontend/src/api/__tests__/client.spec.js
@@ -36,10 +36,10 @@ describe('apiRequest basics', () => {
     vi.restoreAllMocks();
   });
 
-  it('calls fetch with the correct URL', async () => {
+  it('calls fetch with the correct URL (with /api prefix)', async () => {
     await apiRequest('/health');
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock.mock.calls[0][0]).toBe('/health');
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/health');
   });
 
   it('adds Authorization header when token exists in store', async () => {
@@ -126,9 +126,9 @@ describe('401 auto-refresh', () => {
     const resp = await apiRequest('/users/me');
 
     expect(fetchMock).toHaveBeenCalledTimes(3);
-    expect(fetchMock.mock.calls[0][0]).toBe('/users/me');
-    expect(fetchMock.mock.calls[1][0]).toBe('/refresh-token');
-    expect(fetchMock.mock.calls[2][0]).toBe('/users/me');
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/users/me');
+    expect(fetchMock.mock.calls[1][0]).toBe('/api/refresh-token');
+    expect(fetchMock.mock.calls[2][0]).toBe('/api/users/me');
     expect(fetchMock.mock.calls[2][1].headers.Authorization).toBe('Bearer new-access');
     expect(await resp.json()).toEqual({ id: 42 });
 
@@ -177,7 +177,7 @@ describe('401 auto-refresh', () => {
 
     let refreshCalls = 0;
     fetchMock.mockImplementation(async (url) => {
-      if (url === '/refresh-token') {
+      if (url === '/api/refresh-token') {
         refreshCalls++;
         await new Promise((r) => setTimeout(r, 10));
         return ok({ token: 'new-access', refreshToken: 'new-refresh' });

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,7 +1,10 @@
 import { useAuthStore } from '@/stores/auth'
 import router from '@/router'
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || ''
+// API_BASE_URL оставляем настраиваемым для локальной разработки с отдельным backend-портом,
+// но на staging/prod он пуст и префикс /api обеспечивает маршрутизацию через nginx:
+// location /api/ -> backend:8080.
+const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || '') + '/api'
 const AUTH_ENDPOINTS = ['/login', '/refresh-token', '/logout']
 
 let refreshPromise = null
@@ -17,7 +20,7 @@ async function performRefresh() {
 
   const response = await fetch(`${API_BASE_URL}/refresh-token`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
     body: JSON.stringify({ refresh_token: refreshToken }),
   })
   if (!response.ok) throw new Error(`refresh failed: ${response.status}`)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -8,18 +8,22 @@ import (
 )
 
 func Setup(e *echo.Echo, auth *handlers.AuthHandler, userTypes *handlers.UserTypesHandler, attachments *handlers.AttachmentHandler, lpf *handlers.LicensePlateFormatHandler, cs *handlers.CitizenshipHandler, org *handlers.OrganizationHandler, comp *handlers.CompanyHandler, users *handlers.UsersHandler, up *handlers.UnloadPlaceHandler, cars *handlers.CarHandler, employees *handlers.EmployeeHandler, st *handlers.SystemTableHandler, uc *handlers.UniqueCarHandler, ue *handlers.UniqueEmployeeHandler, fb *handlers.FeedbackHandler, app *handlers.ApplicationHandler, approvers *handlers.ApproverHandler, permissions *handlers.PermissionHandler, consent *handlers.ConsentHandler, settings *handlers.SettingsHandler, news *handlers.NewsHandler, notifications *handlers.NotificationHandler, requestLogs *handlers.RequestLogsHandler, employeesHistory *handlers.EmployeesHistoryHandler, jwtSecret []byte) {
-	// Health check
+	// Health check — вне /api, для мониторинга и readiness-проб.
 	e.GET("/health", func(c echo.Context) error {
 		return c.JSON(200, map[string]string{"status": "ok"})
 	})
 
+	// Все API-роуты под префиксом /api — разделяет API и SPA-роуты (/news, /center
+	// и т.д. в Vue router). Nginx проксирует /api/ на backend, остальное — на frontend.
+	api := e.Group("/api")
+
 	// Public routes
-	e.POST("/login", auth.Login)
-	e.POST("/refresh-token", auth.RefreshToken)
-	e.GET("/user-types", auth.GetUserTypes)
+	api.POST("/login", auth.Login)
+	api.POST("/refresh-token", auth.RefreshToken)
+	api.GET("/user-types", auth.GetUserTypes)
 
 	// Protected routes
-	protected := e.Group("")
+	protected := api.Group("")
 	protected.Use(mw.JWTAuth(jwtSecret))
 
 	protected.POST("/logout", auth.Logout)

--- a/internal/testutil/http.go
+++ b/internal/testutil/http.go
@@ -39,8 +39,26 @@ func DELETEWithBody(t *testing.T, e *echo.Echo, path, body string, headers http.
 	return doRequest(t, e, http.MethodDelete, path, body, headers)
 }
 
+// applyAPIPrefix добавляет /api к роуту если это не /health (который вне /api).
+// Тесты используют путь без префикса — обратная совместимость после миграции router
+// на api := e.Group("/api").
+func applyAPIPrefix(path string) string {
+	if strings.HasPrefix(path, "/api/") || path == "/api" {
+		return path
+	}
+	if path == "/health" || strings.HasPrefix(path, "/health?") {
+		return path
+	}
+	return "/api" + path
+}
+
 func doRequest(t *testing.T, e *echo.Echo, method, path, body string, headers http.Header) *httptest.ResponseRecorder {
 	t.Helper()
+
+	// Автопрефикс /api — все роуты кроме /health теперь под /api (см. router.Setup).
+	// Тесты написаны с «голыми» путями типа "/login", "/applications" — чтобы не
+	// переписывать 541 вызов, добавляем префикс здесь.
+	path = applyAPIPrefix(path)
 
 	var req *http.Request
 	if body != "" {

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -10,14 +10,13 @@ server {
     listen 80;
     server_name _;
 
-    # SPA-пути, конфликтующие с API: /news — это И маршрут в Vue router, И префикс API.
-    # Если Accept содержит text/html (браузерная навигация) — отдаём frontend (SPA),
-    # иначе (fetch с Accept: application/json) — на backend.
-    location ~ ^/(news|announcements)(/|$) {
-        if ($http_accept ~* "text/html") {
-            proxy_pass http://frontend;
-            break;
-        }
+    # Health check (мониторинг и readiness probe)
+    location = /health {
+        proxy_pass http://backend;
+    }
+
+    # API — всё под /api/ проксируется на backend (router.Setup использует api := e.Group("/api")).
+    location /api/ {
         proxy_pass http://backend;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -26,17 +25,13 @@ server {
         client_max_body_size 50M;
     }
 
-    # API — проксируем напрямую на backend (минуя frontend nginx)
-    location ~ ^/(login|refresh-token|logout|user-data|users|user-types|user-types-management|applications|cars|employees|unique-cars|unique-employees|unload-places|organizations|companies|license-plate-formats|application-approvers|citizenships|system-tables|attachments|feedback|get-organization|permissions|consents|settings|notifications|request-logs|health|swagger|uploads)(/|$) {
+    # Swagger UI — на backend под /swagger/* (не мигрирован в /api)
+    location /swagger/ {
         proxy_pass http://backend;
         proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        client_max_body_size 50M;
     }
 
-    # Всё остальное → frontend (только статика + SPA fallback)
+    # Всё остальное → frontend (статика и SPA fallback, включая /news, /center, /new-application).
     location / {
         proxy_pass http://frontend;
         proxy_set_header Host $host;

--- a/nginx/staging.conf
+++ b/nginx/staging.conf
@@ -17,22 +17,15 @@ server {
     auth_basic "Staging";
     auth_basic_user_file /etc/nginx/.htpasswd;
 
-    # Health check — без авторизации (для CI/CD и мониторинга)
-    location /health {
+    # Health check (без basic auth — CI/CD и мониторинг)
+    location = /health {
         auth_basic off;
         proxy_pass http://backend;
     }
 
-    # SPA-пути, конфликтующие с API: /news — это И маршрут в Vue router, И префикс API.
-    # Если Accept содержит text/html (браузерная навигация) — отдаём frontend (SPA),
-    # иначе (fetch с Accept: application/json) — на backend. Без этого переход по
-    # адресной строке на /news возвращал JSON "Missing or invalid authorization header".
-    location ~ ^/(news|announcements)(/|$) {
+    # API — всё под /api/ без basic auth (JWT). router.Setup использует api := e.Group("/api").
+    location /api/ {
         auth_basic off;
-        if ($http_accept ~* "text/html") {
-            proxy_pass http://frontend;
-            break;
-        }
         proxy_pass http://backend;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -41,15 +34,11 @@ server {
         client_max_body_size 50M;
     }
 
-    # API — без basic auth (защищены JWT), напрямую на backend
-    location ~ ^/(login|refresh-token|logout|user-data|users|user-types|user-types-management|applications|cars|employees|unique-cars|unique-employees|unload-places|organizations|companies|license-plate-formats|application-approvers|citizenships|system-tables|attachments|feedback|get-organization|permissions|consents|settings|notifications|request-logs|swagger|uploads)(/|$) {
+    # Swagger UI
+    location /swagger/ {
         auth_basic off;
         proxy_pass http://backend;
         proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        client_max_body_size 50M;
     }
 
     # pgAdmin
@@ -61,7 +50,7 @@ server {
         proxy_redirect off;
     }
 
-    # Всё остальное → frontend (только статика + SPA fallback)
+    # SPA (включая /news, /center, /new-application и т.д. — теперь не конфликтуют с API)
     location / {
         proxy_pass http://frontend;
         proxy_set_header Host $host;


### PR DESCRIPTION
## Summary

Закрывает пункт [7] из сводки по #64. Чистый рефакторинг — API под префиксом \`/api/*\`, убирает Accept-based nginx hack из PR #90.

## Проблема до

\`/news\` и \`/announcements\` — **одновременно** Vue-router routes (SPA) и API префиксы на backend. Чтобы различать, nginx использовал \`if (\$http_accept ~ "text/html")\` для разделения — хрупко и узкоспециализированно.

## Изменения

### Backend
- \`internal/router/router.go\`: \`api := e.Group("/api")\`, все роуты переведены. \`/health\` остался на корне.
- \`internal/testutil/http.go\`: автопрефикс \`/api\` в тестовых хелперах. 541 вызов \`testutil.GET/POST/PUT/DELETE\` в 26 файлах переписывать не надо — префикс добавляется автоматически в \`doRequest\`.
- \`/health\` и \`/swagger/*\` не трогаются.

### Frontend
- \`frontend/src/api/client.js\`: \`API_BASE_URL = (VITE_API_BASE_URL || '') + '/api'\`.
- Все существующие \`apiRequest('/path')\` автоматически становятся \`/api/path\`.
- Обновил 3 unit-теста в \`client.spec.js\` (\`/health\` → \`/api/health\` и т.д.).

### Nginx
- \`nginx/nginx.conf\` и \`nginx/staging.conf\`: 30+ путей в whitelist → один \`location /api/\`
- Убран Accept-based \`if\` для \`/news\`/\`/announcements\`
- SPA fallback \`/\` теперь покрывает все фронт-роуты (\`/center\`, \`/personal-cabinet\`, \`/news\`, \`/new-application\`)

## Blast radius

- **Совместимость**: старые URLs без \`/api\` (например \`curl stagingburo.washka17.site/applications\`) сломаются. Но извне никто так не ходит — и VK-mini-приложение, и фронт зовут через \`apiRequest\`.
- **E2E тесты**: \`frontend/e2e/*\` используют базовый URL \`stagingburo.washka17.site\` — API запросы внутри фронта автоматически получат \`/api\` префикс.
- **Swagger**: остался на \`/swagger/\` (не мигрирован) — посещение открывает UI для \`/api/*\` endpoints.

## Test plan

- [x] \`go build ./...\` и \`go vet ./...\` — чисто
- [x] \`npm run lint\` — зелёный
- [x] \`npm run test:run\` — 215 passed (обновлены 3 теста client.spec.js)
- [ ] CI \`go test -race ./...\` — критично: 541 вызов testutil.GET/POST должны работать
- [ ] Staging после deploy:
  - [ ] \`/news\`, \`/center\`, \`/personal-cabinet\` — SPA открываются
  - [ ] Логин работает (POST \`/api/login\`)
  - [ ] \`fetch('/applications')\` в фронте → \`GET /api/applications\` → backend
  - [ ] \`/api/health\` возвращает 200 (через \`/api/\`)
  - [ ] \`/health\` без префикса тоже работает (мониторинг)