### PR TITLE
fix: URL object в apiRequest ломается после /api префикса (#64)

### DIFF
--- a/frontend/src/components/CarHistoryModal.vue
+++ b/frontend/src/components/CarHistoryModal.vue
@@ -320,21 +320,14 @@ export default {
     async loadHistory() {
       this.loading = true;
       try {
-        const url = new URL('/cars/history/unified', window.location.origin);
-        url.searchParams.append('car_number', this.carNumber);
-        url.searchParams.append('car_brand', this.carBrand || '');
-        
-        if (this.organizationId) {
-          url.searchParams.append('organization_id', this.organizationId);
-        }
-        
-        if (this.companyId) {
-          url.searchParams.append('company_id', this.companyId);
-        }
+        // apiRequest ожидает строку-путь, не URL object — собираем query руками.
+        const params = new URLSearchParams();
+        params.append('car_number', this.carNumber);
+        params.append('car_brand', this.carBrand || '');
+        if (this.organizationId) params.append('organization_id', this.organizationId);
+        if (this.companyId) params.append('company_id', this.companyId);
 
-        console.log('Запрос истории по URL:', url.toString());
-
-        const response = await apiRequest(url, {});
+        const response = await apiRequest(`/cars/history/unified?${params.toString()}`, {});
 
         if (response.ok) {
           this.history = await response.json();

--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -527,19 +527,13 @@ export default {
     
     for (const vehicle of vehicles) {
       try {
-        const url = new URL('/cars/check-active', window.location.origin);
-        url.searchParams.append('car_number', vehicle.plateNumber);
-        url.searchParams.append('car_brand', vehicle.mark);
-        
-        if (this.organizationId) {
-          url.searchParams.append('organization_id', this.organizationId);
-        }
-        
-        if (this.companyId) {
-          url.searchParams.append('company_id', this.companyId);
-        }
+        const params = new URLSearchParams();
+        params.append('car_number', vehicle.plateNumber);
+        params.append('car_brand', vehicle.mark);
+        if (this.organizationId) params.append('organization_id', this.organizationId);
+        if (this.companyId) params.append('company_id', this.companyId);
 
-        const response = await apiRequest(url, {});
+        const response = await apiRequest(`/cars/check-active?${params.toString()}`, {});
 
         if (response.ok) {
           const data = await response.json();

--- a/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
@@ -445,18 +445,20 @@ export default {
             
             this.loadingHistory = true;
             try {
-                // Используем unified endpoint, как в CarHistoryModal
-                const url = new URL('/cars/history/unified', window.location.origin);
-                url.searchParams.append('car_number', this.vehicle.plateNumber || this.vehicle.car_number || '');
-                url.searchParams.append('car_brand', this.vehicle.mark || this.vehicle.car_brand || '');
+                // Используем unified endpoint, как в CarHistoryModal.
+                // Собираем query-строку руками — apiRequest ожидает строку-путь,
+                // а не URL object (после /api префикса URL object ломается при конкатенации).
+                const params = new URLSearchParams();
+                params.append('car_number', this.vehicle.plateNumber || this.vehicle.car_number || '');
+                params.append('car_brand', this.vehicle.mark || this.vehicle.car_brand || '');
                 if (this.vehicle.organizationId) {
-                    url.searchParams.append('organization_id', this.vehicle.organizationId);
+                    params.append('organization_id', this.vehicle.organizationId);
                 }
                 if (this.vehicle.companyId) {
-                    url.searchParams.append('company_id', this.vehicle.companyId);
+                    params.append('company_id', this.vehicle.companyId);
                 }
 
-                const response = await apiRequest(url, {});
+                const response = await apiRequest(`/cars/history/unified?${params.toString()}`, {});
                 
                 if (response.ok) {
                     const allHistory = await response.json();

--- a/frontend/src/components/CreateApplication/VehicleForm.vue
+++ b/frontend/src/components/CreateApplication/VehicleForm.vue
@@ -387,19 +387,13 @@ export default {
             // Ждем небольшую паузу, чтобы не дёргать сервер на каждый символ
             this.checkingTimeout = setTimeout(async () => {
                 try {
-                    const url = new URL('/cars/check-active', window.location.origin);
-                    url.searchParams.append('car_number', plateNumber);
-                    url.searchParams.append('car_brand', this.selectedMark || '');
-                    
-                    if (this.userOrganizationId) {
-                        url.searchParams.append('organization_id', this.userOrganizationId);
-                    }
-                    
-                    if (this.userCompanyId) {
-                        url.searchParams.append('company_id', this.userCompanyId);
-                    }
+                    const params = new URLSearchParams();
+                    params.append('car_number', plateNumber);
+                    params.append('car_brand', this.selectedMark || '');
+                    if (this.userOrganizationId) params.append('organization_id', this.userOrganizationId);
+                    if (this.userCompanyId) params.append('company_id', this.userCompanyId);
 
-                    const response = await apiRequest(url, {});
+                    const response = await apiRequest(`/cars/check-active?${params.toString()}`, {});
 
                     if (response.ok) {
                         const data = await response.json();


### PR DESCRIPTION
## Summary

Регрессия после merge #96 (API_BASE_URL = '/api').

В 4 местах фронт использует \`new URL('/cars/history/unified', window.location.origin)\` и передаёт URL object в \`apiRequest(url, {})\`. Внутри \`doFetch\` делается \`fetch(\`\${API_BASE_URL}\${path}\`)\` — строковая конкатенация с URL object даёт его \`.toString()\` (absolute URL). Раньше \`API_BASE_URL = ''\` и всё работало через absolute URL. После префикса получается \`/apihttps://stagingburo.washka17.site/cars/...\` — невалидно.

Обнаружено при проверке истории автомобиля (issue #64) на staging после \`make staging-seed-demo\`: \`GET /api/cars/3/history\` возвращал 3 записи, но модалка \`VehicleDetailsModal\` показывала "История въездов и выездов отсутствует".

## Fix

Заменил \`new URL()\` + \`url.searchParams\` на \`URLSearchParams\` + строка-путь. \`apiRequest\` получает относительный путь — \`API_BASE_URL\` добавляется корректно.

**Затронуто:**
- \`VehicleDetailsModal.loadCarHistory()\` — unified history
- \`CarHistoryModal.loadHistory()\` — то же
- \`CreateApplication.checkActiveCars()\` — \`/cars/check-active\`
- \`VehicleForm\` active-check — то же

## Test plan

- [x] \`npm run lint\` — зелёный
- [x] \`npm run test:run\` — 215 passed
- [ ] Staging после deploy: открыть DEMO/001 → "Автомобили (демо)" → А123БВ777 → "Полная история" → видны 3 записи (create, entry, exit)