### PR TITLE
fix: unified car history возвращал 0 при отсутствии organization_id (#64)

### DIFF
--- a/internal/services/car_history_service.go
+++ b/internal/services/car_history_service.go
@@ -174,6 +174,10 @@ func (s *carService) GetUnifiedCarHistory(ctx context.Context, req UnifiedCarHis
 		ID int
 	}
 	var carIDs []carIDRow
+	// Фильтры по organization_id/company_id работают так:
+	// - nil: не фильтруем (любая организация/компания) — агрегируем историю по ВСЕМ заявкам
+	//   с такой же парой car_number+car_brand. Клиент часто не знает org/comp машины.
+	// - не nil: точное совпадение.
 	err := s.db.WithContext(ctx).Raw(`
 		SELECT c.id
 		FROM cars c
@@ -181,14 +185,8 @@ func (s *carService) GetUnifiedCarHistory(ctx context.Context, req UnifiedCarHis
 		JOIN applications app ON a.application_id = app.id
 		WHERE LOWER(TRIM(c.car_number)) = LOWER(TRIM(?))
 		AND LOWER(TRIM(c.car_brand)) = LOWER(TRIM(?))
-		AND (
-			(?::integer IS NULL AND app.organization_id IS NULL)
-			OR app.organization_id = ?
-		)
-		AND (
-			(?::integer IS NULL AND app.company_id IS NULL)
-			OR app.company_id = ?
-		)
+		AND (?::integer IS NULL OR app.organization_id = ?)
+		AND (?::integer IS NULL OR app.company_id = ?)
 		ORDER BY c.id
 	`, req.CarNumber, req.CarBrand,
 		req.OrganizationID, req.OrganizationID,


### PR DESCRIPTION
## Summary

Финальный regression-fix для пункта [2] сводки по #64 — "История автомобиля в VehicleDetailsModal".

**Что обнаружилось после seed + #97** (PR #97 починил URL-object, PR #91+#95 дали seed с 3 записями \`cars_history\`):

API вернул пустой список:
\`\`\`
GET /api/cars/history/unified?car_number=А123БВ777&car_brand=Toyota Camry
-> { data: [] }
\`\`\`
хотя \`GET /api/cars/3/history\` возвращает 3 записи.

**Причина** — SQL в \`GetUnifiedCarHistory\`:
\`\`\`sql
(?::integer IS NULL AND app.organization_id IS NULL)
OR app.organization_id = ?
\`\`\`
Семантика: "не передан → ищи только заявки с NULL \`organization_id\`". Но:
1. \`VehicleDetailsModal\` не знает \`organization_id\` машины — передаёт \`null\`
2. Типичные заявки (включая DEMO/001) имеют \`organization_id = 1\`
3. SQL возвращает \`false\` → 0 записей

**Fix**: \`(?::integer IS NULL OR app.organization_id = ?)\` — при \`nil\` фильтре игнорируем колонку (семантика "любая"). То же для \`company_id\`.

## Test plan

- [x] \`go build ./... && go vet ./...\` — чисто
- [ ] Staging после deploy: DEMO/001 → "Автомобили (демо)" → А123БВ777 → "Полная история" → 3 записи (create, entry, exit)
- [ ] CI \`go test ./...\` не ломается (тесты unified history где передан org/comp остаются работать — только new branch в OR)