### PR TITLE
fix: BlankSelector получает attachments prop и сохраняет в draft (#64)

### DIFF
--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -11,8 +11,9 @@
             <h4>{{ currentFormTitle }}</h4>
         </div>
         <div class="create__container">
-            <BlankSelector 
+            <BlankSelector
                 ref="blankSelector"
+                :attachments="attachments"
                 :current-application-data="currentApplicationData"
                 @attachment-selected="handleAttachmentSelected"
                 @attachment-added="handleAttachmentAdded"
@@ -1666,10 +1667,8 @@ export default {
 
         saveToLocalStorage() {
             try {
-                const hasAttachments = Object.keys(this.vehiclesByAttachment).length > 0 || 
-                                      Object.keys(this.employeesByAttachment).length > 0 || 
-                                      Object.keys(this.itemsByAttachment).length > 0;
-                
+                const hasAttachments = this.attachments.length > 0;
+
                 const savedData = {
                     message: this.message,
                     organization: this.organization,
@@ -1678,20 +1677,25 @@ export default {
                     phoneNumber: this.phoneNumber,
                     rawPhoneNumber: this.rawPhoneNumber,
                     consentGiven: this.consentGiven,
-                    
+
+                    // attachments - источник истины для UI. Без них vehiclesByAttachment
+                    // остаётся сиротским (ключи без самих attachment-записей) - BlankSelector
+                    // не может отрендерить вложения.
+                    attachments: this.attachments,
+
                     vehiclesByAttachment: hasAttachments ? this.vehiclesByAttachment : {},
                     employeesByAttachment: hasAttachments ? this.employeesByAttachment : {},
                     itemsByAttachment: hasAttachments ? this.itemsByAttachment : {},
-                    
+
                     attachmentDatesByAttachment: hasAttachments ? this.attachmentDatesByAttachment : {},
-                    
+
                     vehicleIdCounter: this.vehicleIdCounter,
                     employeeIdCounter: this.employeeIdCounter,
                     itemIdCounter: this.itemIdCounter,
-                    
+
                     savedAt: new Date().toISOString()
                 };
-                
+
                 localStorage.setItem('draftApplicationState', JSON.stringify(savedData));
             } catch (error) {
                 console.error('Ошибка сохранения состояния в localStorage:', error);
@@ -1711,20 +1715,20 @@ export default {
                     this.phoneNumber = parsedData.phoneNumber || '';
                     this.rawPhoneNumber = parsedData.rawPhoneNumber || '';
                     this.consentGiven = parsedData.consentGiven || false;
-                    
+
+                    this.attachments = parsedData.attachments || [];
+
                     this.vehiclesByAttachment = parsedData.vehiclesByAttachment || {};
                     this.employeesByAttachment = parsedData.employeesByAttachment || {};
                     this.itemsByAttachment = parsedData.itemsByAttachment || {};
-                    
+
                     this.attachmentDatesByAttachment = parsedData.attachmentDatesByAttachment || {};
-                    
+
                     this.vehicleIdCounter = parsedData.vehicleIdCounter || 1;
                     this.employeeIdCounter = parsedData.employeeIdCounter || 1;
                     this.itemIdCounter = parsedData.itemIdCounter || 1;
-                    
-                    const hasAttachments = Object.keys(this.vehiclesByAttachment).length > 0 || 
-                                          Object.keys(this.employeesByAttachment).length > 0 || 
-                                          Object.keys(this.itemsByAttachment).length > 0;
+
+                    const hasAttachments = this.attachments.length > 0;
                     
                     if (!hasAttachments) {
                         this.message = '';


### PR DESCRIPTION
## Summary

**Корневой баг** всех 5 runtime-пунктов CreateApplication из #64 (скрины 10.1, 10.2):

1. \`<BlankSelector>\` **не получал** \`:attachments\` prop. Компонент рендерит карточки вложений из \`props.attachments\` (default \`[]\`). \`CreateApplication.handleAttachmentAdded\` push-ил в локальный \`this.attachments\`, но BlankSelector этого не видел — добавленное вложение не отображалось в списке слева, **его нельзя было выбрать/удалить**.

2. \`saveToLocalStorage\` **не сохранял** \`this.attachments\` в draft — только \`vehiclesByAttachment\`/\`employeesByAttachment\`/\`itemsByAttachment\` maps. После F5: \`attachments=[]\` из \`data()\`, а \`vehiclesByAttachment\` с сиротскими ключами.

## Fix

- Template: \`:attachments="attachments"\` (как в \`old_branch\`)
- \`saveToLocalStorage\`: добавил \`attachments\` в savedData
- \`restoreFromLocalStorage\`: \`this.attachments = parsedData.attachments || []\`
- \`hasAttachments\` считается через \`this.attachments.length\` вместо \`Object.keys(*ByAttachment)\`

## Reproduction

На staging после \`make staging-seed-demo\`:
1. Зайти на \`/new-application\`
2. Добавить вложение через любую кнопку "Добавить" в BlankSelector
3. Наблюдать: правая часть показывает "Автомобили (демо) №1", но в BlankSelector слева счётчики \`0/10\`
4. \`localStorage.draftApplicationState\` содержит \`vehiclesByAttachment: {"1": [], "2": []}\` но \`attachments: undefined\`

После фикса: слева счётчик обновляется, карточка вложения отображается, её можно выбрать кликом, удалить кнопкой "Удалить выбранные".

## Test plan

- [x] \`npm run lint\` — зелёный
- [x] \`npm run test:run\` — 215 passed
- [ ] Staging после deploy: добавить вложение через BlankSelector — видно в списке слева, можно удалить. После F5 сохраняется.