### PR TITLE
refactor: LoaderSpinner миграция часть 2 + unskip 4 E2E

### DIFF
--- a/frontend/e2e/helpers/auth.js
+++ b/frontend/e2e/helpers/auth.js
@@ -1,6 +1,9 @@
 const { LoginPage } = require('../pages/LoginPage');
 
-const API_BASE = 'http://localhost:8080';
+// /api префикс для backend (router.Setup использует api := e.Group("/api")).
+// Для e2e хелпера зовём через абсолютный URL на localhost:8080 (docker compose dev);
+// в CI и staging тесты идут через playwright baseURL + /api относительно.
+const API_BASE = 'http://localhost:8080/api';
 
 // Сеид-пользователи создаются cmd/seed (с SEED_E2E_USERS=true в CI).
 const SEED_ADMIN = { username: 'e2e_admin', password: 'testpass123' };

--- a/frontend/e2e/pages/CarsPage.js
+++ b/frontend/e2e/pages/CarsPage.js
@@ -2,7 +2,10 @@ class CarsPage {
   constructor(page) {
     this.page = page;
     this.root = page.getByTestId('cars-page');
-    this.modalCloseButton = page.getByTestId('modal-button-close');
+    this.addButton = page.getByTestId('cars-view-add-button');
+    this.modal = page.getByTestId('cars-view-modal');
+    this.modalCloseButton = page.getByTestId('cars-view-modal-close');
+    this.formatDropdown = page.getByTestId('cars-view-format-dropdown');
   }
 
   async goto() {

--- a/frontend/e2e/tests/cars.spec.js
+++ b/frontend/e2e/tests/cars.spec.js
@@ -46,57 +46,51 @@ test.describe('Cars View', () => {
     }
   });
 
-  // TODO: селектор .base-modal устарел, модалка открывается с другим классом.
-  // Возвращаем после аудита Vue-компонентов CarsView/BaseModal.
-  test.skip('add car button opens modal', async ({ page }) => {
+  test('add car button opens modal', async ({ page }) => {
     const username = `e2e_cars_add_${Date.now()}`;
     await loginAsUser(page, username);
 
     const carsPage = new CarsPage(page);
     await carsPage.goto();
 
-    const addBtn = page.getByRole('button', { name: 'Добавить' });
-    await addBtn.waitFor({ state: 'visible', timeout: 10000 }).catch(() => {});
+    await carsPage.addButton.waitFor({ state: 'visible', timeout: 10000 }).catch(() => {});
 
-    if (await addBtn.isVisible()) {
-      await addBtn.click();
-      await expect(page.locator('.base-modal')).toBeVisible();
+    if (await carsPage.addButton.isVisible()) {
+      await carsPage.addButton.click();
+      await expect(carsPage.modal).toBeVisible();
     }
   });
 
-  test.skip('car modal has format dropdown', async ({ page }) => {
+  test('car modal has format dropdown', async ({ page }) => {
     const username = `e2e_cars_format_${Date.now()}`;
     await loginAsUser(page, username);
 
     const carsPage = new CarsPage(page);
     await carsPage.goto();
 
-    const addBtn = page.getByRole('button', { name: 'Добавить' });
-    await addBtn.waitFor({ state: 'visible', timeout: 10000 }).catch(() => {});
+    await carsPage.addButton.waitFor({ state: 'visible', timeout: 10000 }).catch(() => {});
 
-    if (await addBtn.isVisible()) {
-      await addBtn.click();
-      await expect(page.locator('.base-modal')).toBeVisible();
-      const formatDropdown = page.locator('.format__dropdown .dropdown__button');
-      await expect(formatDropdown).toBeVisible();
+    if (await carsPage.addButton.isVisible()) {
+      await carsPage.addButton.click();
+      await expect(carsPage.modal).toBeVisible();
+      await expect(carsPage.formatDropdown).toBeVisible();
     }
   });
 
-  test.skip('car modal close button works', async ({ page }) => {
+  test('car modal close button works', async ({ page }) => {
     const username = `e2e_cars_close_${Date.now()}`;
     await loginAsUser(page, username);
 
     const carsPage = new CarsPage(page);
     await carsPage.goto();
 
-    const addBtn = page.getByRole('button', { name: 'Добавить' });
-    await addBtn.waitFor({ state: 'visible', timeout: 10000 }).catch(() => {});
+    await carsPage.addButton.waitFor({ state: 'visible', timeout: 10000 }).catch(() => {});
 
-    if (await addBtn.isVisible()) {
-      await addBtn.click();
-      await expect(page.locator('.base-modal')).toBeVisible();
+    if (await carsPage.addButton.isVisible()) {
+      await carsPage.addButton.click();
+      await expect(carsPage.modal).toBeVisible();
       await carsPage.modalCloseButton.click();
-      await expect(page.locator('.base-modal')).not.toBeVisible();
+      await expect(carsPage.modal).not.toBeVisible();
     }
   });
 

--- a/frontend/e2e/tests/navigation.spec.js
+++ b/frontend/e2e/tests/navigation.spec.js
@@ -29,10 +29,7 @@ test.describe('Navigation & Authorization', () => {
     await expect(navBar.root.getByText('Админка')).toBeVisible();
   });
 
-  // TODO: зависит от корректного type_id у e2e_user — проверить что cmd/seed
-  // выбирает реально non-admin тип, возможно type_id попал на роль которая
-  // тоже видит "Админка".
-  test.skip('nav menu hides admin items for regular user', async ({ page }) => {
+  test('nav menu hides admin items for regular user', async ({ page }) => {
     const username = `e2e_nav_noadmin_${Date.now()}`;
     await loginAsUser(page, username);
 

--- a/frontend/src/components/ApplicationDetail/ApplicationConfirmation.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationConfirmation.vue
@@ -3,7 +3,7 @@
         <div class="confirmation-header">
             <h4>Согласование заявки</h4>
             <div v-if="updatingConfirmation" class="confirmation-loading">
-                <div class="loader"></div>
+                <LoaderSpinner size="small" :label="''" />
             </div>
         </div>
         
@@ -62,8 +62,11 @@
 </template>
 
 <script>
+import LoaderSpinner from '@/components/ui/LoaderSpinner.vue'
+
 export default {
     name: 'ApplicationConfirmation',
+    components: { LoaderSpinner },
     props: {
         application: {
             type: Object,

--- a/frontend/src/components/ApplicationDetail/ApplicationHistory.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationHistory.vue
@@ -68,7 +68,7 @@
 
                 <div class="modal-content" ref="scrollContainer">
                     <div v-if="loading" class="history-loading">
-                        <div class="loader"></div>
+                        <LoaderSpinner label="Загрузка истории…" />
                     </div>
                     
                     <div v-else-if="filteredHistory.length === 0" class="history-empty">
@@ -133,10 +133,12 @@
 
 <script>
 import { apiRequest } from '@/api/client'
+import LoaderSpinner from '@/components/ui/LoaderSpinner.vue';
 import ExcelJS from 'exceljs';
 
 export default {
     name: 'ApplicationHistory',
+    components: { LoaderSpinner },
     props: {
         applicationId: {
             type: Number,

--- a/frontend/src/components/CarDetailsModal.vue
+++ b/frontend/src/components/CarDetailsModal.vue
@@ -86,8 +86,7 @@
             </div>
             
             <div v-if="loadingHistory" class="loading-container">
-              <div class="loader"></div>
-              <span>Загрузка истории...</span>
+              <LoaderSpinner label="Загрузка истории…" />
             </div>
             
             <div v-else-if="history.length === 0" class="no-history">
@@ -266,10 +265,12 @@
 <script>
 import { apiRequest } from '@/api/client'
 import CarHistoryModal from './CarHistoryModal.vue';
+import LoaderSpinner from '@/components/ui/LoaderSpinner.vue';
 import { useOverlayClose } from '@/composables/useOverlayClose';
 import ExcelJS from 'exceljs';
 
 export default {
+    components: { LoaderSpinner },
     setup(_, { emit }) {
         const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(() => emit('close'));
         return { onOverlayMousedown, onOverlayMouseup };

--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -68,8 +68,7 @@
       
       <div class="items-container">
         <div v-if="isLoading" class="loading-message">
-          <div class="loader"></div>
-          <p>Загрузка машин...</p>
+          <LoaderSpinner label="Загрузка машин…" />
         </div>
         
         <div v-else-if="displayItems.length > 0" class="items-body">
@@ -160,13 +159,15 @@ import { apiRequest } from '@/api/client'
 import RefreshButton from './RefreshButton.vue';
 import VehicleDetailsModal from './CreateApplication/VehicleDetailsModal.vue';
 import CarsTableHistoryModal from './CarsTableHistoryModal.vue';
+import LoaderSpinner from '@/components/ui/LoaderSpinner.vue';
 
 export default {
   name: 'CarsTable',
   components: {
     RefreshButton,
     VehicleDetailsModal,
-    CarsTableHistoryModal
+    CarsTableHistoryModal,
+    LoaderSpinner
   },
   props: {
     tableName: { type: String, default: '' },

--- a/frontend/src/components/CarsTableHistoryModal.vue
+++ b/frontend/src/components/CarsTableHistoryModal.vue
@@ -122,7 +122,7 @@
 
       <div class="modal-content" ref="scrollContainer">
         <div v-if="loading" class="history-loading">
-          <div class="loader"></div>
+          <LoaderSpinner label="Загрузка истории…" />
         </div>
         
         <div v-else-if="filteredHistory.length === 0" class="history-empty">
@@ -168,10 +168,12 @@
 
 <script>
 import { apiRequest } from '@/api/client'
+import LoaderSpinner from '@/components/ui/LoaderSpinner.vue';
 import ExcelJS from 'exceljs';
 
 export default {
   name: 'CarsTableHistoryModal',
+  components: { LoaderSpinner },
   props: {
     cars: {
       type: Array,

--- a/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
@@ -128,8 +128,7 @@
                                 </div>
                                 <div class="section-body">
                                     <div v-if="loadingHistory" class="loading-container">
-                                        <div class="loader"></div>
-                                        <span>Загрузка истории...</span>
+                                        <LoaderSpinner label="Загрузка истории…" />
                                     </div>
                                     
                                     <div v-else-if="entryExitHistory.length === 0" class="no-history">
@@ -205,6 +204,7 @@
 import { apiRequest } from '@/api/client'
 import UnloadPlaceModal from './UnloadPlaceModal.vue';
 import CarHistoryModal from '../CarHistoryModal.vue';
+import LoaderSpinner from '@/components/ui/LoaderSpinner.vue';
 import { useOverlayClose } from '@/composables/useOverlayClose';
 import ExcelJS from 'exceljs';
 
@@ -212,7 +212,8 @@ export default {
     name: 'VehicleDetailsModal',
     components: {
         UnloadPlaceModal,
-        CarHistoryModal
+        CarHistoryModal,
+        LoaderSpinner
     },
     setup(_, { emit }) {
         const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(() => emit('close'));

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -61,8 +61,7 @@
       
       <div class="items-container">
         <div v-if="isLoading" class="loading-message">
-          <div class="loader"></div>
-          <p>Загрузка сотрудников...</p>
+          <LoaderSpinner label="Загрузка сотрудников…" />
         </div>
         
         <div v-else-if="displayItems.length > 0" class="items-body">
@@ -120,12 +119,14 @@
 import { apiRequest } from '@/api/client'
 import RefreshButton from './RefreshButton.vue';
 import EmployeesTableHistoryModal from './CreateApplication/EmployeesTableHistoryModal.vue';
+import LoaderSpinner from '@/components/ui/LoaderSpinner.vue';
 
 export default {
   name: 'PeopleTable',
   components: {
     RefreshButton,
-    EmployeesTableHistoryModal
+    EmployeesTableHistoryModal,
+    LoaderSpinner
   },
   props: {
     tableName: {

--- a/frontend/src/views/CarsView.vue
+++ b/frontend/src/views/CarsView.vue
@@ -71,8 +71,9 @@
                         </h3>
                     </div>
                     <div class="card-header__settings">
-                        <button 
-                            class="add-button" 
+                        <button
+                            class="add-button"
+                            data-testid="cars-view-add-button"
                             @click="showAddCarModal"
                             v-if="currentFilter !== 'all_system'"
                         >
@@ -239,7 +240,7 @@
         </div>
 
         <!-- Модальное окно добавления машины -->
-        <div v-if="showModal && currentFilter !== 'all_system'" class="modal-overlay" @click="closeModal">
+        <div v-if="showModal && currentFilter !== 'all_system'" class="modal-overlay" data-testid="cars-view-modal" @click="closeModal">
             <div class="modal-content" @click.stop>
                 <div class="modal-header">
                     <div class="modal-header__top">
@@ -248,7 +249,7 @@
                             {{ notification.message }}
                         </div>
                     </div>
-                    <button class="modal-close" @click="closeModal">×</button>
+                    <button class="modal-close" data-testid="cars-view-modal-close" @click="closeModal">×</button>
                 </div>
                 <div class="modal-body">
                     <div class="data__completion">
@@ -260,7 +261,7 @@
                                 </button>
                             </div>
                             <div class="format__dropdown">
-                                <button class="dropdown__button" @click="toggleFormatDropdown">
+                                <button class="dropdown__button" data-testid="cars-view-format-dropdown" @click="toggleFormatDropdown">
                                     <div class="button__content">
                                         <span class="button__text">{{ selectedFormatText }}</span>
                                         <img src="@/assets/icons/arrow.png" class="button__arrow" :class="{ 'button__arrow--open': isFormatDropdownOpen }" />

--- a/frontend/src/views/NewsAndReview.vue
+++ b/frontend/src/views/NewsAndReview.vue
@@ -15,8 +15,7 @@
           <div class="news-list">
             <!-- Лоадер -->
             <div v-if="loadingNews" class="loading-message">
-              <div class="loader"></div>
-              <p>Загрузка новостей...</p>
+              <LoaderSpinner label="Загрузка новостей…" />
             </div>
             <!-- Новости -->
             <div v-else-if="newsItems.length > 0" class="news-items">
@@ -244,12 +243,14 @@
 import { apiRequest } from '@/api/client'
 import RefreshButton from '../components/RefreshButton.vue'
 import AnnouncementModal from '../components/AnnouncementModal.vue'
+import LoaderSpinner from '@/components/ui/LoaderSpinner.vue'
 
 export default {
   name: 'LatestNews',
-  components: { 
+  components: {
     RefreshButton,
-    AnnouncementModal
+    AnnouncementModal,
+    LoaderSpinner
   },
   data() {
     return {

--- a/frontend/src/views/RequestsView.vue
+++ b/frontend/src/views/RequestsView.vue
@@ -333,7 +333,7 @@
     </div>
 
     <div v-if="isLoading" class="loading-overlay">
-      <div class="spinner"></div>
+      <LoaderSpinner size="large" :label="''" />
     </div>
   </div>
 </template>
@@ -342,12 +342,14 @@
 import { apiRequest, apiRequestRaw } from '@/api/client'
 import SearchComponent from '@/components/SearchComponent.vue'
 import RealTimeChart from '@/components/RealTimeChart.vue'
+import LoaderSpinner from '@/components/ui/LoaderSpinner.vue'
 
 export default {
   name: 'RequestsView',
   components: {
     SearchComponent,
-    RealTimeChart
+    RealTimeChart,
+    LoaderSpinner
   },
   data() {
     return {


### PR DESCRIPTION
## Summary

### [4] LoaderSpinner миграция часть 2 (9 файлов)

Продолжение из PR #94. Заменяет последние \`<div class="loader">\`/\`<div class="spinner">\` на общий \`ui/LoaderSpinner\`.

**Файлы:**
- \`VehicleDetailsModal\` — история въездов/выездов
- \`CarDetailsModal\` — история автомобиля
- \`NewsAndReview\` — лента новостей
- \`PeopleTable\` — таблица сотрудников
- \`CarsTable\` — таблица авто
- \`RequestsView\` — overlay-загрузка (size=large без текста)
- \`CarsTableHistoryModal\` — история машин
- \`ApplicationHistory\` — история заявки
- \`ApplicationConfirmation\` — inline-спиннер в хедере

Не тронуты: \`LoginComponent\` (кастомный lock-замочек), \`.export-loader\` (inline на кнопках экспорта).

### [5] Unskip 4 E2E тестов

- **3 тест в \`cars.spec.js\`**: ждали устаревший \`.base-modal\`, в \`CarsView\` модалка inline. Добавил \`data-testid\` на add-button, modal, close, format-dropdown. CarsPage POM обновлён.
- **\`nav menu hides admin items for regular user\`** (navigation.spec.js): unskip после #91 SEED_DEMO (e2e_user теперь есть).
- **\`e2e/helpers/auth.js\`**: \`API_BASE\` обновлён на \`http://localhost:8080/api\` (после #96).

## Test plan

- [x] \`npm run lint\` — зелёный
- [x] \`npm run test:run\` — 215 passed
- [ ] \`npx playwright test\` (в CI, через workflow_dispatch) — 4 unskipped теста проходят
- [ ] Staging: визуально все спиннеры одного стиля