### PR TITLE
fix: UI quick wins - тексты, цвета, редирект (#101)

### DIFF
--- a/frontend/src/components/AnnouncementModal.vue
+++ b/frontend/src/components/AnnouncementModal.vue
@@ -172,16 +172,16 @@ export default {
   font-weight: 500;
   padding: 2px 8px;
   border-radius: 20px;
-  background: #fff3cd;
-  color: #856404;
+  background: #FFE0B2;
+  color: #9A3412;
   display: inline-flex;
   align-items: center;
   gap: 6px;
 }
 
 .modal-type.important {
-  background: #ffb3b3;
-  color: #c62828;
+  background: #FECACA;
+  color: #B91C1C;
 }
 
 .modal-description {

--- a/frontend/src/components/LoginComponent.vue
+++ b/frontend/src/components/LoginComponent.vue
@@ -345,7 +345,7 @@ export default {
                 refreshToken: data.refreshToken
             });
             
-            this.$router.push('/personal-cabinet');
+            this.$router.push('/news');
         } else {
             // Проверяем статус код для определения типа ошибки
             if (response.status === 429) {

--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -977,36 +977,6 @@ export default {
     border-bottom: 1px solid #ededf5;
 }
 
-.center__tabs :deep(.filter-tabs) {
-    background: #f3f3fb;
-    border-radius: 12px;
-    padding: 4px;
-    gap: 0;
-}
-
-.center__tabs :deep(.filter-tab) {
-    border: none;
-    background: transparent;
-    border-radius: 8px;
-    padding: 0 22px;
-    height: 32px;
-    font-size: 13px;
-    font-weight: 500;
-    color: #555;
-    transition: background 0.2s, color 0.2s, box-shadow 0.2s;
-}
-
-.center__tabs :deep(.filter-tab:hover) {
-    border-color: transparent;
-    color: var(--color-primary);
-}
-
-.center__tabs :deep(.filter-tab--active) {
-    background: #fff;
-    color: var(--color-primary);
-    box-shadow: 0 1px 3px rgba(79, 91, 223, 0.12);
-}
-
 .filters-row {
     display: flex;
     align-items: center;

--- a/frontend/src/views/CarsView.vue
+++ b/frontend/src/views/CarsView.vue
@@ -226,15 +226,35 @@
             
             <div class="carsview__right-side">
                 <div class="carsview__help">
-                    <p class="help__text" v-if="currentFilter === 'all_system'">
-                        Здесь отображаются <strong class="blue">все автомобили</strong>, которые есть в системе. В этой вкладке доступен только просмотр, добавление, редактирование и удаление машин недоступно.
-                    </p>
-                    <p class="help__text" v-else>
-                        Здесь находятся автомобили, привязанные к вашей <strong class="blue">организации</strong>. Вы можете использовать эти автомобили при подаче автозаявок.
-                    </p>
-                    <p class="help__text" v-if="currentFilter !== 'all_system'">
-                        Новые номера машин попадают в этот список <strong class="blue">автоматически</strong>, при подаче заявки.
-                    </p>
+                    <template v-if="currentFilter === 'organization'">
+                        <p class="help__text">
+                            Здесь находятся автомобили, привязанные к вашей <strong class="blue">организации</strong>. Вы можете использовать эти автомобили при подаче автозаявок.
+                        </p>
+                        <p class="help__text">
+                            Новые номера машин попадают в этот список <strong class="blue">автоматически</strong>, при подаче заявки.
+                        </p>
+                    </template>
+                    <template v-else-if="currentFilter === 'company'">
+                        <p class="help__text">
+                            Здесь находятся автомобили, привязанные к вашей <strong class="blue">компании</strong>. Вы можете использовать эти автомобили при подаче автозаявок.
+                        </p>
+                        <p class="help__text">
+                            Новые номера машин попадают в этот список <strong class="blue">автоматически</strong>, при подаче заявки.
+                        </p>
+                    </template>
+                    <template v-else-if="currentFilter === 'user'">
+                        <p class="help__text">
+                            Здесь находятся <strong class="blue">ваши автомобили</strong>, добавленные лично. Вы можете использовать их при подаче автозаявок.
+                        </p>
+                        <p class="help__text">
+                            Новые номера машин попадают в этот список <strong class="blue">автоматически</strong>, при подаче заявки.
+                        </p>
+                    </template>
+                    <template v-else-if="currentFilter === 'all_system'">
+                        <p class="help__text">
+                            Здесь отображаются <strong class="blue">все автомобили</strong>, которые есть в системе. В этой вкладке доступен только просмотр, добавление, редактирование и удаление машин недоступно.
+                        </p>
+                    </template>
                 </div>
             </div>
         </div>

--- a/frontend/src/views/EmployeeView.vue
+++ b/frontend/src/views/EmployeeView.vue
@@ -206,12 +206,35 @@
             
             <div class="employeesview__right-side">
                 <div class="employeesview__help">
-                    <p class="help__text">
-                        Здесь находятся сотрудники, привязанные к вашей <strong class="blue">организации</strong>. Вы можете использовать этих сотрудников при подаче заявок на пропуск.
-                    </p>
-                    <p class="help__text">
-                        Новые сотрудники попадают в этот список <strong class="blue">автоматически</strong>, при подаче заявки.
-                    </p>
+                    <template v-if="currentFilter === 'organization'">
+                        <p class="help__text">
+                            Здесь находятся сотрудники, привязанные к вашей <strong class="blue">организации</strong>. Вы можете использовать этих сотрудников при подаче заявок на пропуск.
+                        </p>
+                        <p class="help__text">
+                            Новые сотрудники попадают в этот список <strong class="blue">автоматически</strong>, при подаче заявки.
+                        </p>
+                    </template>
+                    <template v-else-if="currentFilter === 'company'">
+                        <p class="help__text">
+                            Здесь находятся сотрудники, привязанные к вашей <strong class="blue">компании</strong>. Вы можете использовать этих сотрудников при подаче заявок на пропуск.
+                        </p>
+                        <p class="help__text">
+                            Новые сотрудники попадают в этот список <strong class="blue">автоматически</strong>, при подаче заявки.
+                        </p>
+                    </template>
+                    <template v-else-if="currentFilter === 'user'">
+                        <p class="help__text">
+                            Здесь находятся <strong class="blue">ваши сотрудники</strong>, добавленные лично. Вы можете использовать их при подаче заявок на пропуск.
+                        </p>
+                        <p class="help__text">
+                            Новые сотрудники попадают в этот список <strong class="blue">автоматически</strong>, при подаче заявки.
+                        </p>
+                    </template>
+                    <template v-else-if="currentFilter === 'all_system'">
+                        <p class="help__text">
+                            Здесь отображаются <strong class="blue">все сотрудники</strong>, которые есть в системе. В этой вкладке доступен только просмотр, добавление, редактирование и удаление сотрудников недоступно.
+                        </p>
+                    </template>
                 </div>
             </div>
         </div>

--- a/frontend/src/views/NewsAndReview.vue
+++ b/frontend/src/views/NewsAndReview.vue
@@ -720,13 +720,13 @@ export default {
     font-weight: 500;
     padding: 2px 8px;
     border-radius: 20px;
-    background: #fff3cd;
-    color: #856404;
+    background: #FFE0B2;
+    color: #9A3412;
 }
 
 .card-type.important {
-    background: #ffebee;
-    color: #c62828;
+    background: #FECACA;
+    color: #B91C1C;
 }
 
 .card-date {

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -111,13 +111,22 @@ func AutoMigrate(db *gorm.DB) error {
 
 // Seed inserts initial data if tables are empty.
 func Seed(db *gorm.DB) error {
-	// Миграция: переводим заявки "Непрочитано" → "В обработке"
+	// Миграция: переводим заявки "Непрочитано" -> "В обработке"
 	if result := db.Model(&models.Application{}).
 		Where("status = ?", models.StatusUnread).
 		Update("status", models.StatusProcessing); result.Error != nil {
 		slog.Error("failed to migrate unread status", "error", result.Error)
 	} else if result.RowsAffected > 0 {
 		slog.Info("migrated unread applications to processing", "count", result.RowsAffected)
+	}
+
+	// Миграция: переводим feedback "Нерешено" -> "Не решено" (статус с пробелом)
+	if result := db.Model(&models.Feedback{}).
+		Where("status = ?", "Нерешено").
+		Update("status", models.FeedbackOpen); result.Error != nil {
+		slog.Error("failed to migrate feedback status", "error", result.Error)
+	} else if result.RowsAffected > 0 {
+		slog.Info("migrated feedback status to spaced form", "count", result.RowsAffected)
 	}
 
 	var count int64

--- a/internal/handlers/feedback_test.go
+++ b/internal/handlers/feedback_test.go
@@ -76,7 +76,7 @@ func TestFeedback_GetMy(t *testing.T) {
 	assert.Contains(t, fb, "status")
 	assert.Contains(t, fb, "is_read")
 	assert.Contains(t, fb, "created_at")
-	assert.Equal(t, "Нерешено", fb["status"])
+	assert.Equal(t, "Не решено", fb["status"])
 	assert.Equal(t, false, fb["is_read"])
 }
 
@@ -146,7 +146,7 @@ func TestFeedback_UpdateStatus(t *testing.T) {
 
 	// Regular user cannot update status
 	rec = testutil.PUT(t, e, fmt.Sprintf("/feedback/%d/status", fbID),
-		`{"status":"Нерешено"}`, testutil.AuthHeader(userToken))
+		`{"status":"Не решено"}`, testutil.AuthHeader(userToken))
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 }
 

--- a/internal/models/feedback.go
+++ b/internal/models/feedback.go
@@ -8,7 +8,7 @@ type Feedback struct {
 	UserID            int        `gorm:"index" json:"user_id"`
 	User              User       `gorm:"constraint:OnDelete:CASCADE" json:"-"`
 	Message           string     `gorm:"type:text" json:"message"`
-	Status            string     `gorm:"size:20;default:'Нерешено'" json:"status"`
+	Status            string     `gorm:"size:20;default:'Не решено'" json:"status"`
 	IsRead            bool       `gorm:"default:false" json:"is_read"`
 	CreatedAt         time.Time  `json:"created_at"`
 	UpdatedAt         time.Time  `json:"updated_at"`
@@ -56,7 +56,7 @@ type CreateFeedbackRequest struct {
 
 // UpdateFeedbackStatusRequest -- запрос на обновление статуса обращения.
 type UpdateFeedbackStatusRequest struct {
-	Status string `json:"status" validate:"required,oneof=Нерешено Решено"`
+	Status string `json:"status" validate:"required,oneof='Не решено' 'Решено'"`
 }
 
 // MarkAsReadRequest -- запрос на отметку обращения прочитанным/непрочитанным.

--- a/internal/models/status.go
+++ b/internal/models/status.go
@@ -21,6 +21,6 @@ const (
 
 // Feedback statuses
 const (
-	FeedbackOpen     = "Нерешено"
+	FeedbackOpen     = "Не решено"
 	FeedbackResolved = "Решено"
 )

--- a/internal/services/feedback_service.go
+++ b/internal/services/feedback_service.go
@@ -85,7 +85,7 @@ func (s *feedbackService) Create(ctx context.Context, username string, req model
 	feedback := models.Feedback{
 		UserID:    userID,
 		Message:   trimmed,
-		Status:    "Нерешено",
+		Status:    models.FeedbackOpen,
 		IsRead:    false,
 		CreatedAt: now,
 		UpdatedAt: now,


### PR DESCRIPTION
## Summary

PR1 серии по issue #101 - быстрые UI правки.

- **Feedback статус**: "Нерешено" -> "Не решено" (с пробелом) в backend-модели, константе, валидации, тесте + миграция существующих записей в БД при запуске сервера. Фронтенд уже использует "Не решено".
- **Редирект после входа**: `/personal-cabinet` -> `/news` в `LoginComponent.vue`.
- **Цвета объявлений**: пастельно-красный (`#FECACA`/`#B91C1C`) для важных, пастельно-оранжевый (`#FFE0B2`/`#9A3412`) для обычных. Изменено в `NewsAndReview.vue` и `AnnouncementModal.vue`.
- **Описания right-side**: в `CarsView.vue` и `EmployeeView.vue` добавлены уникальные тексты под каждую вкладку фильтра (organization, company, user, all_system).
- **Кнопки Активные/Архив в центре заявок**: убраны `:deep()` переопределения `.filter-tabs`, теперь используется общий pill-стиль `FilterTabs` как на остальном сайте.

## Test plan

- [x] `npx vitest run` - 215 passed
- [x] `npm run lint` - clean
- [x] `go vet ./...` - clean
- [x] `go build ./...` - clean
- [ ] Staging: логин -> редирект на /news
- [ ] Staging: /admin/feedback - статус "Не решено" отображается без склейки
- [ ] Staging: объявление на /news и в шапке - пастельные цвета
- [ ] Staging: /carsview и /employeesview - описания меняются при переключении вкладок
- [ ] Staging: /center - кнопки "Активные"/"Архив" в pill-стиле

Refs: issue #101