### PR TITLE
fix: порт UniversalBindingModal и ApplicationSuccessModal из old_branch (#101)

### DIFF
--- a/frontend/src/components/CreateApplication/ApplicationSuccessModal.vue
+++ b/frontend/src/components/CreateApplication/ApplicationSuccessModal.vue
@@ -1,258 +1,641 @@
 <template>
-  <BaseModal :show="show" title="Заявка успешно оформлена!" width="600px" @close="$emit('close')">
-    <div class="success-content">
-      <div class="application-number">
-        <span class="application-number__label">Номер заявки</span>
-        <span class="application-number__value">{{ applicationNumber }}</span>
-      </div>
+    <transition name="modal-fade">
+        <div v-if="show" class="modal-overlay" @click.self="handleClose">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button class="modal-close" @click="handleClose">
+                        <svg width="10" height="10" viewBox="0 0 14 14" fill="none">
+                            <path d="M13 1L1 13M1 1L13 13" stroke="#666" stroke-width="2" stroke-linecap="round"/>
+                        </svg>
+                    </button>
+                </div>
 
-      <div class="progress-bar">
-        <div
-          v-for="(stage, index) in stages"
-          :key="index"
-          class="progress-stage"
-          :class="{ 'progress-stage--active': index <= currentStep }"
-        >
-          <div class="progress-stage__circle">{{ index + 1 }}</div>
-          <span class="progress-stage__label">{{ stage }}</span>
-          <div v-if="index < stages.length - 1" class="progress-stage__line" />
+                <div class="modal-body">
+                    <h2 class="modal-title">Заявка успешно оформлена!</h2>
+
+                    <div class="application-number">
+                        <span class="label">Номер заявки:</span>
+                        <strong class="number">{{ applicationNumber }}</strong>
+                    </div>
+
+                    <div class="info-message">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+                            <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z" fill="#4F5BDF"/>
+                        </svg>
+                        <span>Скоро мы начнём её обрабатывать</span>
+                    </div>
+
+                    <div class="progress-container">
+                        <div class="progress-steps">
+                            <div
+                                v-for="(step, index) in steps"
+                                :key="index"
+                                class="progress-step"
+                                :class="{
+                                    completed: index < currentStep,
+                                    active: index === currentStep
+                                }"
+                            >
+                                <div class="step-icon">
+                                    <div class="step-circle">
+                                        <span v-if="index < currentStep" class="check-icon">+</span>
+                                        <span v-else class="step-number">{{ index + 1 }}</span>
+                                    </div>
+                                    <div class="step-glow"></div>
+                                </div>
+                                <div class="step-label">{{ step }}</div>
+                            </div>
+                        </div>
+                        <div class="progress-track">
+                            <div class="progress-fill" :style="{ width: progressWidth + '%' }">
+                                <div class="progress-sparkle"></div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="attachments-section">
+                        <div class="section-header">
+                            <h3 class="section-title">Вложения в заявке</h3>
+                            <span class="attachments-count">{{ attachmentsData.length }}</span>
+                        </div>
+
+                        <div v-if="attachmentsData.length === 0" class="no-attachments">
+                            <p>Нет вложений</p>
+                        </div>
+
+                        <div v-else class="attachments-list">
+                            <div
+                                v-for="(att, idx) in attachmentsData"
+                                :key="idx"
+                                class="attachment-item"
+                            >
+                                <div class="attachment-content">
+                                    <div class="attachment-name">{{ att.display_name }}</div>
+                                    <div class="attachment-details">
+                                        <span v-if="att.period" class="attachment-period">
+                                            <svg width="12" height="12" viewBox="0 0 24 24" fill="none">
+                                                <path d="M19 3h-1V1h-2v2H8V1H6v2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V9h14v10z" fill="#a2a2a2"/>
+                                            </svg>
+                                            {{ att.period }}
+                                        </span>
+                                        <span v-if="att.time" class="attachment-time">
+                                            <svg width="12" height="12" viewBox="0 0 24 24" fill="none">
+                                                <path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z" fill="#a2a2a2"/>
+                                            </svg>
+                                            {{ att.time }}
+                                        </span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="modal-footer">
+                    <button class="btn close-btn" @click="handleClose">Закрыть</button>
+                </div>
+            </div>
         </div>
-      </div>
-
-      <div class="attachments-section">
-        <h4 class="attachments-title">Вложения</h4>
-        <ul v-if="attachmentsData.length" class="attachments-list">
-          <li v-for="(item, i) in attachmentsData" :key="i" class="attachment-item">
-            <span class="attachment-name">{{ item.display_name }}</span>
-            <span class="attachment-meta">{{ item.period }}<template v-if="item.time">, {{ item.time }}</template></span>
-          </li>
-        </ul>
-        <p v-else class="attachments-empty">Вложения отсутствуют</p>
-      </div>
-    </div>
-
-    <template #actions>
-      <button class="btn btn--primary" @click="$emit('close')">Закрыть</button>
-    </template>
-  </BaseModal>
+    </transition>
 </template>
 
 <script>
-import BaseModal from '@/components/ui/BaseModal.vue'
-
 export default {
-  name: 'ApplicationSuccessModal',
-  components: { BaseModal },
-
-  props: {
-    show: {
-      type: Boolean,
-      default: false,
+    name: 'ApplicationSuccessModal',
+    props: {
+        show: { type: Boolean, default: false },
+        applicationNumber: { type: String, default: '' },
+        attachmentsData: { type: Array, default: () => [] }
     },
-    applicationNumber: {
-      type: String,
-      default: '',
+    emits: ['close'],
+    data() {
+        return {
+            steps: ['Оформлена', 'В обработке', 'Согласование', 'В работе', 'Завершена'],
+            currentStep: 0
+        }
     },
-    attachmentsData: {
-      type: Array,
-      default: () => [],
+    computed: {
+        progressWidth() {
+            return ((this.currentStep + 1) / this.steps.length) * 100
+        }
     },
-  },
-
-  emits: ['close'],
-
-  data() {
-    return {
-      currentStep: 0,
-      stages: ['Оформлена', 'В обработке', 'Согласование', 'В работе', 'Завершена'],
+    methods: {
+        handleClose() {
+            this.$emit('close')
+        }
     }
-  },
 }
 </script>
 
 <style scoped>
-.success-content {
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
+.modal-fade-enter-active,
+.modal-fade-leave-active {
+    transition: all 0.4s ease;
+}
+
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+    opacity: 0;
+}
+
+.modal-fade-enter-from .modal-content,
+.modal-fade-leave-to .modal-content {
+    opacity: 0;
+    transform: scale(0.9) translateY(-20px);
+}
+
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    backdrop-filter: blur(1px);
+}
+
+.modal-content {
+    background: #fff;
+    border-radius: 50px;
+    width: 540px;
+    max-width: 90vw;
+    max-height: 80vh;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.modal-header {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    padding: 20px 30px 0;
+    flex-shrink: 0;
+}
+
+.modal-close {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 6px;
+    border-radius: 6px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background-color 0.2s ease;
+}
+
+.modal-close:hover {
+    background-color: #f5f5f5;
+}
+
+.modal-body {
+    padding: 0 30px 20px;
+    overflow-y: auto;
+    flex: 1;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+}
+
+.modal-body::-webkit-scrollbar {
+    display: none;
+}
+
+.modal-title {
+    font-size: 24px;
+    font-weight: 700;
+    color: #1a1a1a;
+    text-align: center;
+    margin: 0 0 20px 0;
 }
 
 .application-number {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 6px;
-  padding: 16px;
-  background: var(--color-bg);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
+    background: #f8f9fa;
+    border-radius: 20px;
+    padding: 12px 20px;
+    text-align: center;
+    margin-bottom: 20px;
+    border: 1px solid #e6e6e6;
 }
 
-.application-number__label {
-  font-size: 13px;
-  color: var(--color-text-muted);
+.application-number .label {
+    font-size: 13px;
+    color: #666;
+    margin-right: 8px;
 }
 
-.application-number__value {
-  font-size: 22px;
-  font-weight: 700;
-  color: var(--color-primary);
-  letter-spacing: 0.5px;
+.application-number .number {
+    font-size: 18px;
+    font-weight: 700;
+    color: #4F5BDF;
+    letter-spacing: 0.5px;
 }
 
-/* Progress bar */
-.progress-bar {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
+.info-message {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    background: #f0f4ff;
+    border-radius: 20px;
+    padding: 10px 16px;
+    margin-bottom: 28px;
+    color: #4F5BDF;
+    font-size: 13px;
 }
 
-.progress-stage {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  flex: 1;
-  position: relative;
+.info-message svg {
+    flex-shrink: 0;
 }
 
-.progress-stage__circle {
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 13px;
-  font-weight: 600;
-  background: var(--color-border);
-  color: var(--color-text-muted);
-  position: relative;
-  z-index: 1;
-  transition: all 0.3s;
+.progress-container {
+    position: relative;
+    margin-bottom: 28px;
 }
 
-.progress-stage--active .progress-stage__circle {
-  background: var(--color-primary);
-  color: #fff;
+.progress-steps {
+    display: flex;
+    justify-content: space-between;
+    position: relative;
+    z-index: 2;
+    margin-bottom: 20px;
 }
 
-.progress-stage__label {
-  margin-top: 8px;
-  font-size: 11px;
-  color: var(--color-text-muted);
-  text-align: center;
-  line-height: 1.3;
+.progress-step {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    position: relative;
 }
 
-.progress-stage--active .progress-stage__label {
-  color: var(--color-primary);
-  font-weight: 600;
+.step-icon {
+    position: relative;
+    width: 40px;
+    height: 40px;
 }
 
-.progress-stage__line {
-  position: absolute;
-  top: 16px;
-  left: calc(50% + 16px);
-  width: calc(100% - 32px);
-  height: 2px;
-  background: var(--color-border);
+.step-circle {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 14px;
+    font-weight: 600;
+    position: relative;
+    z-index: 2;
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.progress-stage--active .progress-stage__line {
-  background: var(--color-primary);
+.step-number {
+    background: white;
+    border: 2px solid #e6e6e6;
+    color: #a2a2a2;
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.3s ease;
 }
 
-/* Attachments */
-.attachments-title {
-  margin: 0 0 10px;
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--color-text);
+.check-icon {
+    background: #4F5BDF;
+    color: white;
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    animation: checkPop 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+    font-size: 18px;
+    font-weight: bold;
+    position: relative;
+    z-index: 2;
+}
+
+.step-glow {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    background: radial-gradient(circle, rgba(79, 91, 223, 0.3) 0%, rgba(79, 91, 223, 0) 70%);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    pointer-events: none;
+}
+
+.progress-step.active .step-glow {
+    opacity: 1;
+    animation: glowPulse 1.5s ease-in-out infinite;
+}
+
+@keyframes glowPulse {
+    0%, 100% {
+        transform: scale(1);
+        opacity: 0.3;
+    }
+    50% {
+        transform: scale(1.3);
+        opacity: 0.6;
+    }
+}
+
+@keyframes checkPop {
+    0% {
+        transform: scale(0.8);
+        opacity: 0;
+    }
+    100% {
+        transform: scale(1);
+        opacity: 1;
+    }
+}
+
+.progress-step.completed .step-number {
+    border-color: #4F5BDF;
+    background: #4F5BDF;
+    color: white;
+    transform: scale(1.05);
+}
+
+.progress-step.active .step-number {
+    border-color: #4F5BDF;
+    color: #4F5BDF;
+    background: white;
+    animation: pulseBorder 1.5s ease-in-out infinite;
+    box-shadow: 0 0 0 3px rgba(79, 91, 223, 0.2);
+}
+
+@keyframes pulseBorder {
+    0%, 100% {
+        box-shadow: 0 0 0 3px rgba(79, 91, 223, 0.2);
+        transform: scale(1);
+    }
+    50% {
+        box-shadow: 0 0 0 6px rgba(79, 91, 223, 0.1);
+        transform: scale(1.02);
+    }
+}
+
+.step-label {
+    font-size: 11px;
+    font-weight: 500;
+    color: #a2a2a2;
+    text-align: center;
+    transition: all 0.3s ease;
+    white-space: nowrap;
+}
+
+.progress-step.completed .step-label {
+    color: #4F5BDF;
+    font-weight: 600;
+}
+
+.progress-step.active .step-label {
+    color: #4F5BDF;
+    font-weight: 600;
+}
+
+.progress-track {
+    position: absolute;
+    top: 20px;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: #e6e6e6;
+    border-radius: 2px;
+    z-index: 1;
+}
+
+.progress-fill {
+    position: absolute;
+    left: 0;
+    top: 0;
+    height: 100%;
+    background: linear-gradient(90deg, #4F5BDF, #8B9AFF);
+    border-radius: 2px;
+    transition: width 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+    overflow: hidden;
+}
+
+.progress-sparkle {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 20px;
+    height: 100%;
+    background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.8), transparent);
+    animation: sparkleMove 1s ease-in-out infinite;
+}
+
+@keyframes sparkleMove {
+    0% {
+        transform: translateX(-100%);
+        opacity: 0;
+    }
+    50% {
+        opacity: 0.5;
+    }
+    100% {
+        transform: translateX(200%);
+        opacity: 0;
+    }
+}
+
+.attachments-section {
+    margin-top: 8px;
+}
+
+.section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 16px;
+    padding: 0 4px;
+}
+
+.section-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: #333;
+    margin: 0;
+}
+
+.attachments-count {
+    background: #e6e6e6;
+    padding: 2px 8px;
+    border-radius: 20px;
+    font-size: 12px;
+    color: #666;
 }
 
 .attachments-list {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    max-height: 240px;
+    overflow-y: auto;
+    padding-right: 4px;
 }
 
 .attachment-item {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 10px 14px;
-  background: var(--color-bg-secondary);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
+    padding: 12px 16px;
+    background: #fafafa;
+    border: 1px solid #e6e6e6;
+    border-radius: 20px;
+    transition: all 0.2s ease;
+}
+
+.attachment-content {
+    flex: 1;
 }
 
 .attachment-name {
-  font-size: 14px;
-  font-weight: 500;
-  color: var(--color-text);
+    font-weight: 600;
+    font-size: 14px;
+    color: #333;
+    margin-bottom: 6px;
 }
 
-.attachment-meta {
-  font-size: 13px;
-  color: var(--color-text-muted);
-  white-space: nowrap;
-  margin-left: 12px;
+.attachment-details {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
 }
 
-.attachments-empty {
-  margin: 0;
-  font-size: 14px;
-  color: var(--color-text-muted);
-  font-style: italic;
+.attachment-period,
+.attachment-time {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 11px;
+    color: #a2a2a2;
+}
+
+.attachment-period svg,
+.attachment-time svg {
+    flex-shrink: 0;
+}
+
+.no-attachments {
+    text-align: center;
+    padding: 40px 20px;
+    background: #fafafa;
+    border-radius: 20px;
+    border: 1px solid #e6e6e6;
+}
+
+.no-attachments p {
+    margin: 0;
+    font-size: 13px;
+    color: #a2a2a2;
+}
+
+.modal-footer {
+    padding: 16px 30px 24px;
+    border-top: 1px solid #f0f0f0;
+    display: flex;
+    justify-content: center;
+    flex-shrink: 0;
 }
 
 .btn {
-  padding: 10px 24px;
-  border: none;
-  border-radius: var(--radius-sm);
-  font-size: 14px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: background-color 0.2s;
+    padding: 10px 32px;
+    font-size: 14px;
+    font-weight: 500;
+    border-radius: 30px;
+    cursor: pointer;
+    border: 1px solid;
+    transition: background-color 0.2s ease;
 }
 
-.btn--primary {
-  background-color: var(--color-primary);
-  color: #fff;
+.close-btn {
+    background: #4F5BDF;
+    color: white;
+    border-color: #4F5BDF;
+    min-width: 140px;
 }
 
-.btn--primary:hover {
-  background-color: var(--color-primary-hover);
+.close-btn:hover {
+    background: #3a45c0;
+    border-color: #3a45c0;
 }
 
-@media (max-width: 480px) {
-  .progress-stage__circle {
-    width: 26px;
-    height: 26px;
-    font-size: 11px;
-  }
+@media (max-width: 768px) {
+    .modal-content {
+        width: 95vw;
+        margin: 16px;
+        max-height: 85vh;
+        border-radius: 30px;
+    }
 
-  .progress-stage__label {
-    font-size: 10px;
-  }
+    .modal-header {
+        padding: 16px 20px 0;
+    }
 
-  .progress-stage__line {
-    top: 13px;
-    left: calc(50% + 13px);
-    width: calc(100% - 26px);
-  }
+    .modal-body {
+        padding: 0 20px 16px;
+    }
 
-  .attachment-item {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 4px;
-  }
+    .modal-footer {
+        padding: 16px 20px 20px;
+    }
 
-  .attachment-meta {
-    margin-left: 0;
-  }
+    .modal-title {
+        font-size: 18px;
+        margin-bottom: 16px;
+    }
+
+    .step-icon {
+        width: 32px;
+        height: 32px;
+    }
+
+    .step-circle {
+        width: 32px;
+        height: 32px;
+        font-size: 12px;
+    }
+
+    .check-icon {
+        font-size: 14px;
+    }
+
+    .step-label {
+        font-size: 9px;
+        white-space: normal;
+        word-break: break-word;
+        line-height: 1.2;
+    }
+
+    .progress-track {
+        top: 16px;
+    }
+
+    .attachment-item {
+        padding: 10px 12px;
+    }
+
+    .attachment-name {
+        font-size: 13px;
+    }
+
+    .btn {
+        width: 100%;
+        min-width: auto;
+    }
 }
 </style>

--- a/frontend/src/components/CreateApplication/UniversalBindingModal.vue
+++ b/frontend/src/components/CreateApplication/UniversalBindingModal.vue
@@ -1,29 +1,32 @@
 <template>
-    <div class="modal-overlay" @click="$emit('close')">
-        <div class="modal-content" @click.stop>
+    <div class="modal-overlay" @click.self="closeModal">
+        <div class="modal-content">
             <div class="modal-header">
-                <h3>Привязка новых данных</h3>
-                <button class="modal-close" @click="$emit('close')">×</button>
+                <h3 class="modal-title">Привязка новых данных</h3>
+                <button class="modal-close" @click="closeModal">
+                    <svg width="10" height="10" viewBox="0 0 14 14" fill="none">
+                        <path d="M13 1L1 13M1 1L13 13" stroke="#666" stroke-width="2" stroke-linecap="round"/>
+                    </svg>
+                </button>
             </div>
-            
+
             <div class="modal-body">
-                <div class="binding-info">
-                    <p class="binding-description">
-                        Все добавленные данные будут <strong>автоматически привязаны</strong> к вашему аккаунту.
-                        Вы можете дополнительно привязать их к организации и/или компании для использования <strong>другими сотрудниками</strong>:
-                    </p>
-                    
-                    <!-- Секция для новых автомобилей -->
-                    <div v-if="newVehiclesToBind.length > 0" class="data-section vehicles-section">
-                        <div class="section-header">
-                            <h4>Новые автомобили ({{ newVehiclesToBind.length }})</h4>
-                        </div>
-                        
+                <div class="binding-description">
+                    Все добавленные данные будут <strong>автоматически привязаны</strong> к вашему аккаунту.
+                    Вы можете дополнительно привязать их к организации и/или компании для использования <strong>другими сотрудниками</strong>:
+                </div>
+
+                <div v-if="newVehiclesToBind.length > 0" class="data-section">
+                    <div class="section-header">
+                        <h4 class="section-title">Новые автомобили</h4>
+                        <span class="count-badge">{{ newVehiclesToBind.length }}</span>
+                    </div>
+                    <div class="section-body">
                         <div class="items-list">
-                            <div 
-                                v-for="vehicle in newVehiclesToBind" 
+                            <div
+                                v-for="vehicle in newVehiclesToBind"
                                 :key="vehicle.id"
-                                class="item vehicle-item"
+                                class="item"
                                 :class="{ 'item-fact': isVehicleByFact(vehicle) }"
                             >
                                 <div class="item-info">
@@ -34,21 +37,15 @@
                             </div>
                         </div>
 
-                        <div v-if="hasVehiclesForBinding" class="binding-options-section">
+                        <div v-if="hasVehiclesForBinding" class="binding-options">
                             <p class="options-title">Привязать автомобили к:</p>
-                            <div class="binding-options">
-                                <label class="binding-option" v-if="hasOrganization">
-                                    <input 
-                                        type="checkbox" 
-                                        v-model="vehiclesBindToOrganization"
-                                    />
+                            <div class="options-group">
+                                <label v-if="hasOrganization" class="binding-option">
+                                    <input type="checkbox" v-model="vehiclesBindToOrganization" />
                                     <span>Организации "{{ organization }}"</span>
                                 </label>
-                                <label class="binding-option" v-if="hasCompany">
-                                    <input 
-                                        type="checkbox" 
-                                        v-model="vehiclesBindToCompany"
-                                    />
+                                <label v-if="hasCompany" class="binding-option">
+                                    <input type="checkbox" v-model="vehiclesBindToCompany" />
                                     <span>Компании "{{ company }}"</span>
                                 </label>
                             </div>
@@ -57,18 +54,19 @@
                             Автомобили "По факту" не требуют привязки к организации/компании
                         </div>
                     </div>
-                    
-                    <!-- Секция для новых сотрудников -->
-                    <div v-if="newEmployeesToBind.length > 0" class="data-section employees-section">
-                        <div class="section-header">
-                            <h4>Новые сотрудники ({{ newEmployeesToBind.length }})</h4>
-                        </div>
-                        
+                </div>
+
+                <div v-if="newEmployeesToBind.length > 0" class="data-section">
+                    <div class="section-header">
+                        <h4 class="section-title">Новые сотрудники</h4>
+                        <span class="count-badge">{{ newEmployeesToBind.length }}</span>
+                    </div>
+                    <div class="section-body">
                         <div class="items-list">
-                            <div 
-                                v-for="employee in newEmployeesToBind" 
+                            <div
+                                v-for="employee in newEmployeesToBind"
                                 :key="employee.id"
-                                class="item employee-item"
+                                class="item"
                                 :class="{ 'item-fact': isEmployeeByFact(employee) }"
                             >
                                 <div class="item-info">
@@ -79,21 +77,15 @@
                             </div>
                         </div>
 
-                        <div v-if="hasEmployeesForBinding" class="binding-options-section">
+                        <div v-if="hasEmployeesForBinding" class="binding-options">
                             <p class="options-title">Привязать сотрудников к:</p>
-                            <div class="binding-options">
-                                <label class="binding-option" v-if="hasOrganization">
-                                    <input 
-                                        type="checkbox" 
-                                        v-model="employeesBindToOrganization"
-                                    />
+                            <div class="options-group">
+                                <label v-if="hasOrganization" class="binding-option">
+                                    <input type="checkbox" v-model="employeesBindToOrganization" />
                                     <span>Организации "{{ organization }}"</span>
                                 </label>
-                                <label class="binding-option" v-if="hasCompany">
-                                    <input 
-                                        type="checkbox" 
-                                        v-model="employeesBindToCompany"
-                                    />
+                                <label v-if="hasCompany" class="binding-option">
+                                    <input type="checkbox" v-model="employeesBindToCompany" />
                                     <span>Компании "{{ company }}"</span>
                                 </label>
                             </div>
@@ -102,18 +94,21 @@
                             Сотрудники "По факту" не требуют привязки к организации/компании
                         </div>
                     </div>
-
-                    <div class="warning-section">
-                        <p class="warning-text">
-                            <strong class="warning-strong">Внимание!</strong> При привязке данных к организации или компании, они будут доступны для отображения и использования для <strong>всех</strong> сотрудников, которые в них числятся.
-                        </p>
-                    </div>
                 </div>
-                
+
+                <div class="warning-section">
+                    <p class="warning-text">
+                        <strong class="warning-strong">Внимание!</strong> При привязке данных к организации или компании,
+                        они будут доступны для отображения и использования <strong>всем</strong> сотрудникам, которые в них числятся.
+                    </p>
+                </div>
+
                 <div class="modal-actions">
                     <button class="btn skip-btn" @click="handleSkip">Отправить без привязки</button>
                     <button class="btn confirm-btn" @click="handleConfirm">
-                        {{ buttonText }}
+                        <transition name="fade" mode="out-in">
+                            <span :key="buttonText" class="button-text">{{ buttonText }}</span>
+                        </transition>
                     </button>
                 </div>
             </div>
@@ -161,20 +156,13 @@ export default {
     },
     computed: {
         buttonText() {
-            const hasAnyBinding = this.vehiclesBindToOrganization || this.vehiclesBindToCompany || 
+            const hasAnyBinding = this.vehiclesBindToOrganization || this.vehiclesBindToCompany ||
                                  this.employeesBindToOrganization || this.employeesBindToCompany;
-            
-            if (hasAnyBinding) {
-                return 'Привязать и отправить';
-            } else {
-                return 'Отправить заявку';
-            }
+            return hasAnyBinding ? 'Привязать и отправить' : 'Отправить заявку';
         },
-        
         hasVehiclesForBinding() {
             return this.newVehiclesToBind.some(vehicle => !this.isVehicleByFact(vehicle));
         },
-        
         hasEmployeesForBinding() {
             return this.newEmployeesToBind.some(employee => !this.isEmployeeByFact(employee));
         }
@@ -187,16 +175,16 @@ export default {
             if (employee.middleName) parts.push(employee.middleName);
             return parts.join(' ') || 'Не указано';
         },
-        
         isVehicleByFact(vehicle) {
             return vehicle.plateNumber === 'По факту' || vehicle.mark === 'По факту';
         },
-        
         isEmployeeByFact(employee) {
-            return employee.passportSeriesNumber === 'По факту' || 
+            return employee.passportSeriesNumber === 'По факту' ||
                    employee.position === 'По факту';
         },
-        
+        closeModal() {
+            this.$emit('close');
+        },
         handleConfirm() {
             this.$emit('confirm-binding', {
                 vehicles: {
@@ -211,9 +199,7 @@ export default {
                 }
             });
         },
-        
         handleSkip() {
-            // Кнопка "Отправить без привязки" - отправляет данные без привязки к организации/компании
             this.$emit('skip-binding');
         }
     }
@@ -221,6 +207,23 @@ export default {
 </script>
 
 <style scoped>
+.fade-enter-active,
+.fade-leave-active {
+    transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+    opacity: 0;
+    transform: scale(0.95);
+}
+
+.fade-enter-to,
+.fade-leave-from {
+    opacity: 1;
+    transform: scale(1);
+}
+
 .modal-overlay {
     position: fixed;
     top: 0;
@@ -232,30 +235,57 @@ export default {
     align-items: center;
     justify-content: center;
     z-index: 1000;
+    backdrop-filter: blur(1px);
+    animation: overlayAppear 0.4s ease-out;
+}
+
+@keyframes overlayAppear {
+    from {
+        background: rgba(0, 0, 0, 0);
+        backdrop-filter: blur(0px);
+    }
+    to {
+        background: rgba(0, 0, 0, 0.5);
+        backdrop-filter: blur(1px);
+    }
 }
 
 .modal-content {
-    background: white;
-    border-radius: 20px;
-    padding: 0;
+    background: #fff;
+    border-radius: 50px;
     width: 540px;
     max-width: 90vw;
     max-height: 80vh;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+    display: flex;
+    flex-direction: column;
     overflow: hidden;
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+    animation: contentAppear 0.4s cubic-bezier(0.25, 0.1, 0.15, 1);
+}
+
+@keyframes contentAppear {
+    from {
+        opacity: 0;
+        transform: scale(0.9) translateY(-20px);
+    }
+    to {
+        opacity: 1;
+        transform: scale(1) translateY(0);
+    }
 }
 
 .modal-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 16px 24px;
-    border-bottom: 1px solid #e8e8e8;
+    padding: 20px 30px 16px;
+    border-bottom: 1px solid #f0f0f0;
+    flex-shrink: 0;
 }
 
-.modal-header h3 {
+.modal-title {
     margin: 0;
-    font-size: 18px;
+    font-size: 16px;
     font-weight: 600;
     color: #1a1a1a;
 }
@@ -263,30 +293,29 @@ export default {
 .modal-close {
     background: none;
     border: none;
-    font-size: 24px;
-    line-height: 1;
     cursor: pointer;
-    color: #666;
-    padding: 0;
-    width: 24px;
-    height: 24px;
+    padding: 6px;
+    border-radius: 6px;
     display: flex;
     align-items: center;
     justify-content: center;
+    transition: all 0.2s ease;
 }
 
 .modal-close:hover {
-    color: #333;
+    background-color: #f5f5f5;
 }
 
 .modal-body {
-    padding: 20px;
-    max-height: calc(80vh - 60px);
+    padding: 20px 30px;
     overflow-y: auto;
+    flex: 1;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
 }
 
-.binding-info {
-    margin-bottom: 20px;
+.modal-body::-webkit-scrollbar {
+    display: none;
 }
 
 .binding-description {
@@ -304,63 +333,57 @@ export default {
 }
 
 .data-section {
+    border: 1px solid #e6e6e6;
+    border-radius: 20px;
+    background: #fafafa;
     margin-bottom: 20px;
-    padding-bottom: 16px;
-    border-bottom: 1px solid #f0f0f0;
+    overflow: hidden;
 }
 
 .data-section:last-of-type {
-    border-bottom: none;
     margin-bottom: 16px;
-    padding-bottom: 0;
 }
 
 .section-header {
-    margin-bottom: 12px;
+    padding: 12px 20px;
+    border-bottom: 1px solid #e6e6e6;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 }
 
-.section-header h4 {
-    font-size: 16px;
-    font-weight: 600;
-    color: #1a1a1a;
+.section-title {
     margin: 0;
+    font-size: 14px;
+    font-weight: 600;
+    color: #333;
 }
 
-.vehicles-section .section-header h4 {
-    color: #4F5BDF;
-    border-left: 4px solid #4F5BDF;
-    padding-left: 10px;
+.count-badge {
+    background: #e6e6e6;
+    padding: 2px 8px;
+    border-radius: 20px;
+    font-size: 12px;
+    color: #666;
 }
 
-.employees-section .section-header h4 {
-    color: #2e7d32;
-    border-left: 4px solid #2e7d32;
-    padding-left: 10px;
+.section-body {
+    padding: 16px 20px;
 }
 
 .items-list {
     display: flex;
     flex-direction: column;
-    gap: 6px;
-    max-height: 120px;
-    overflow-y: auto;
+    gap: 8px;
     margin-bottom: 16px;
-    padding-right: 4px;
 }
 
 .item {
     padding: 10px 14px;
-    border: 1px solid #e8e8e8;
-    border-radius: 8px;
-    background: #fafafa;
-}
-
-.vehicle-item {
-    border-left: 3px solid #4F5BDF;
-}
-
-.employee-item {
-    border-left: 3px solid #2e7d32;
+    background: white;
+    border: 1px solid #e6e6e6;
+    border-radius: 20px;
+    transition: all 0.2s ease;
 }
 
 .item-fact {
@@ -372,22 +395,22 @@ export default {
     display: flex;
     align-items: center;
     gap: 12px;
-    font-size: 14px;
+    font-size: 13px;
+    flex-wrap: wrap;
 }
 
 .item-number,
 .item-name {
-    font-weight: 600;
-    color: #1a1a1a;
-    min-width: 120px;
+    font-weight: 500;
+    color: #333;
 }
 
 .item-detail {
-    color: #595959;
+    color: #666;
     background: #f0f0f0;
-    padding: 3px 8px;
-    border-radius: 6px;
-    font-size: 13px;
+    padding: 2px 8px;
+    border-radius: 20px;
+    font-size: 12px;
 }
 
 .fact-badge {
@@ -395,28 +418,28 @@ export default {
     color: white;
     font-size: 11px;
     font-weight: 500;
-    padding: 3px 8px;
-    border-radius: 10px;
+    padding: 2px 8px;
+    border-radius: 20px;
     margin-left: auto;
 }
 
-.binding-options-section {
+.binding-options {
     margin-top: 12px;
     padding-top: 12px;
-    border-top: 1px solid #f0f0f0;
+    border-top: 1px solid #e6e6e6;
 }
 
 .options-title {
-    font-size: 14px;
-    font-weight: 600;
-    color: #1a1a1a;
-    margin-bottom: 10px;
+    font-size: 13px;
+    font-weight: 500;
+    color: #333;
+    margin-bottom: 8px;
 }
 
-.binding-options {
+.options-group {
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 6px;
 }
 
 .binding-option {
@@ -424,16 +447,17 @@ export default {
     align-items: center;
     gap: 8px;
     cursor: pointer;
-    font-size: 14px;
-    padding: 6px;
-    border-radius: 6px;
+    font-size: 13px;
+    padding: 4px;
+    border-radius: 20px;
+    transition: background 0.2s;
 }
 
 .binding-option:hover {
-    background-color: #f8f9fa;
+    background: #f0f0f0;
 }
 
-.binding-option input[type="checkbox"] {
+.binding-option input {
     width: 16px;
     height: 16px;
     cursor: pointer;
@@ -441,74 +465,76 @@ export default {
 }
 
 .binding-option span {
-    color: #1a1a1a;
+    color: #333;
 }
 
 .no-binding-message {
     font-size: 12px;
     color: #666;
     font-style: italic;
-    margin-top: 10px;
-    padding: 8px;
+    padding: 8px 12px;
     background: #f8f9fa;
-    border-radius: 6px;
+    border-radius: 20px;
     border-left: 3px solid #ff9800;
+    margin-top: 8px;
 }
 
 .warning-section {
-    margin-top: 16px;
-    padding: 12px;
-    background: #fff5f5;
-    border-radius: 8px;
-    border: 1px solid #ffcdd2;
+    background: #fff3cd;
+    border: 1px solid #ffeeba;
+    border-radius: 20px;
+    padding: 12px 20px;
+    margin: 8px 0 20px;
 }
 
 .warning-text {
+    margin: 0;
     font-size: 12px;
     line-height: 1.5;
-    color: #666;
-    margin: 0;
+    color: #856404;
 }
 
 .warning-strong {
-    color: #d32f2f;
+    font-weight: 600;
 }
 
 .modal-actions {
     display: flex;
     justify-content: flex-end;
-    gap: 10px;
-    padding-top: 16px;
-    border-top: 1px solid #f0f0f0;
+    gap: 12px;
+    margin-top: 16px;
 }
 
 .btn {
-    padding: 10px 20px;
-    font-size: 14px;
+    padding: 8px 20px;
+    font-size: 13px;
     font-weight: 500;
-    border-radius: 8px;
+    border-radius: 30px;
     cursor: pointer;
     border: 1px solid;
-    transition: all 0.2s;
-    min-width: 140px;
+    transition: all 0.2s ease;
 }
 
 .skip-btn {
     background: white;
-    color: #595959;
-    border-color: #d9d9d9;
+    color: #666;
+    border-color: #e6e6e6;
 }
 
 .skip-btn:hover {
-    background: #fafafa;
-    border-color: #bfbfbf;
-    color: #1a1a1a;
+    background: #f5f5f5;
+    border-color: #ccc;
+    color: #333;
 }
 
 .confirm-btn {
     background: #4F5BDF;
     color: white;
     border-color: #4F5BDF;
+    width: 205px;
+    min-width: 200px;
+    position: relative;
+    overflow: hidden;
 }
 
 .confirm-btn:hover {
@@ -516,41 +542,58 @@ export default {
     border-color: #3a45c0;
 }
 
+.button-text {
+    display: inline-block;
+}
+
 @media (max-width: 768px) {
     .modal-content {
         width: 95vw;
         margin: 16px;
         max-height: 85vh;
+        border-radius: 30px;
     }
-    
+
+    .modal-header {
+        padding: 16px 20px;
+    }
+
     .modal-body {
-        max-height: calc(85vh - 60px);
-        padding: 16px;
+        padding: 16px 20px;
     }
-    
-    .modal-actions {
-        flex-direction: column;
+
+    .section-header {
+        padding: 10px 16px;
     }
-    
-    .btn {
-        width: 100%;
-        min-width: auto;
+
+    .section-body {
+        padding: 14px 16px;
     }
-    
+
     .item-info {
         flex-direction: column;
         align-items: flex-start;
         gap: 6px;
     }
-    
-    .item-number,
-    .item-name {
-        min-width: auto;
-    }
-    
+
     .fact-badge {
         margin-left: 0;
         align-self: flex-start;
+    }
+
+    .modal-actions {
+        flex-direction: column;
+        gap: 8px;
+    }
+
+    .btn {
+        width: 100%;
+        min-width: auto;
+    }
+
+    .confirm-btn {
+        width: 100%;
+        min-width: auto;
     }
 }
 </style>


### PR DESCRIPTION
## Summary

PR5 серии по issue #101.

Два компонента переписаны по версии из `origin/old_branch`:

### UniversalBindingModal

- SVG-крестик закрытия вместо `×`
- `count-badge` под заголовком секции
- `section-body` обёртка вокруг списка + options-group
- `options-group` с вертикальным списком чекбоксов
- Fade-transition анимация для текста кнопки (меняется "Отправить заявку"/"Привязать и отправить")
- Transitions при появлении модалки (overlayAppear + contentAppear)
- border-radius 50px у контента, 20px у секций
- backdrop-filter: blur(1px) на overlay

### ApplicationSuccessModal

- Полный перенос из old_branch: больше не использует BaseModal, собственная разметка
- Богатый анимированный прогресс-бар с 5 этапами (Оформлена -> В обработке -> Согласование -> В работе -> Завершена):
  - step-circle с эффектом glow для активного
  - check-icon с анимацией pop для завершённых
  - progress-fill с градиентом и sparkle-анимацией
  - pulseBorder анимация для active step
- Карточка с номером заявки, info-message со SVG
- Список вложений с иконками календаря и времени рядом с периодом и временем
- modal-fade transition

### API совместимость

Пропы и emits (`confirm-binding`, `skip-binding`, `close`) оставлены без изменений. Parent (`CreateApplication.vue`) использует `v-if="showBindingModal"` для видимости, внутри модалки логика не ломается.

## Test plan

- [x] \`npx vitest run\` - 215 passed
- [x] \`npm run lint\` - clean
- [ ] Staging: отправка заявки с новыми авто/сотрудниками - модалка привязки показывается с новым видом
- [ ] Staging: успешная отправка - модалка успеха с анимированным прогресс-баром, номером заявки, списком вложений
- [ ] Staging: клик вне модалки или на крестик - модалка закрывается

Refs: issue #101