### PR TITLE
feat: user nullable organization или company (#101)

### DIFF
--- a/internal/handlers/auth_test.go
+++ b/internal/handlers/auth_test.go
@@ -168,8 +168,8 @@ func TestLogin_Success(t *testing.T) {
 
 	assert.NotEmpty(t, resp.Token)
 	assert.NotEmpty(t, resp.RefreshToken)
-	assert.Equal(t, td.OrgID, resp.OrganizationID)
-	assert.Equal(t, td.CompanyID, resp.CompanyID)
+	assert.Equal(t, td.OrgID, *resp.OrganizationID)
+	assert.Equal(t, td.CompanyID, *resp.CompanyID)
 	assert.Equal(t, 1, resp.TypeID)
 	assert.Equal(t, "Test Organization", resp.Organization)
 	assert.Equal(t, "Test Company", resp.Company)
@@ -319,9 +319,9 @@ func TestGetUserData_Success(t *testing.T) {
 
 	assert.Equal(t, "datauser", resp.Username)
 	assert.Equal(t, "Test Organization", resp.Organization)
-	assert.Equal(t, td.OrgID, resp.OrganizationID)
+	assert.Equal(t, td.OrgID, *resp.OrganizationID)
 	assert.Equal(t, "Test Company", resp.Company)
-	assert.Equal(t, td.CompanyID, resp.CompanyID)
+	assert.Equal(t, td.CompanyID, *resp.CompanyID)
 }
 
 func TestGetUserData_NoAuth(t *testing.T) {
@@ -355,9 +355,9 @@ func TestGetCurrentUser_Success(t *testing.T) {
 	assert.Equal(t, "Арендатор", resp.UserType)
 	assert.Equal(t, "renter", resp.UserTypeCode)
 	assert.Equal(t, "Test Organization", resp.Organization)
-	assert.Equal(t, td.OrgID, resp.OrganizationID)
+	assert.Equal(t, td.OrgID, *resp.OrganizationID)
 	assert.Equal(t, "Test Company", resp.Company)
-	assert.Equal(t, td.CompanyID, resp.CompanyID)
+	assert.Equal(t, td.CompanyID, *resp.CompanyID)
 	assert.Greater(t, resp.ID, 0)
 }
 

--- a/internal/handlers/users_test.go
+++ b/internal/handlers/users_test.go
@@ -375,6 +375,36 @@ func TestUsers_Delete_Forbidden_NonAdmin(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 }
 
+func TestUsers_Create_RequiresOrgOrCompany(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	adminToken := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(adminToken)
+
+	// Без organization_id и company_id - 400
+	body := `{"username":"lonely","password":"password123","type_id":1,"organization_id":0,"company_id":0}`
+	rec := testutil.POST(t, e, "/users", body, h)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	// Только organization - OK
+	body = fmt.Sprintf(`{"username":"orgonly","password":"password123","type_id":1,"organization_id":%d,"company_id":0}`, td.OrgID)
+	rec = testutil.POST(t, e, "/users", body, h)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Только company - OK
+	body = fmt.Sprintf(`{"username":"companyonly","password":"password123","type_id":1,"organization_id":0,"company_id":%d}`, td.CompanyID)
+	rec = testutil.POST(t, e, "/users", body, h)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// И то, и другое - OK
+	body = fmt.Sprintf(`{"username":"both","password":"password123","type_id":1,"organization_id":%d,"company_id":%d}`, td.OrgID, td.CompanyID)
+	rec = testutil.POST(t, e, "/users", body, h)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
 func TestUsers_ManagerAlsoHasAdminAccess(t *testing.T) {
 	e, db, cleanup := testutil.SetupTestApp(t)
 	defer cleanup()

--- a/internal/models/auth.go
+++ b/internal/models/auth.go
@@ -53,9 +53,9 @@ type LoginResponse struct {
 	Token          string `json:"token"`
 	RefreshToken   string `json:"refreshToken"`
 	Organization   string `json:"organization"`
-	OrganizationID int    `json:"organization_id"`
+	OrganizationID *int   `json:"organization_id"`
 	Company        string `json:"company"`
-	CompanyID      int    `json:"company_id"`
+	CompanyID      *int   `json:"company_id"`
 	TypeID         int    `json:"type_id"`
 	UserType       string `json:"user_type"`
 }
@@ -68,9 +68,9 @@ type TokenPairResponse struct {
 type UserDataResponse struct {
 	Username       string  `json:"username"`
 	Organization   string  `json:"organization"`
-	OrganizationID int     `json:"organization_id"`
+	OrganizationID *int    `json:"organization_id"`
 	Company        string  `json:"company"`
-	CompanyID      int     `json:"company_id"`
+	CompanyID      *int    `json:"company_id"`
 	LastName       *string `json:"last_name"`
 	FirstName      *string `json:"first_name"`
 	MiddleName     *string `json:"middle_name"`
@@ -81,9 +81,9 @@ type CurrentUserResponse struct {
 	ID             int     `json:"id"`
 	Username       string  `json:"username"`
 	Organization   string  `json:"organization"`
-	OrganizationID int     `json:"organization_id"`
+	OrganizationID *int    `json:"organization_id"`
 	Company        string  `json:"company"`
-	CompanyID      int     `json:"company_id"`
+	CompanyID      *int    `json:"company_id"`
 	TypeID         int     `json:"type_id"`
 	UserType       string  `json:"user_type"`
 	UserTypeCode   string  `json:"user_type_code"`

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -6,9 +6,9 @@ type User struct {
 	ID             int          `json:"id"`
 	Username       string       `gorm:"uniqueIndex;size:100" json:"username"`
 	Password       string       `gorm:"size:255" json:"-"`
-	OrganizationID int          `json:"organization_id"`
+	OrganizationID *int         `json:"organization_id"`
 	Organization   Organization `json:"organization,omitempty"`
-	CompanyID      int          `json:"company_id"`
+	CompanyID      *int         `json:"company_id"`
 	Company        Company      `json:"company,omitempty"`
 	TypeID         int          `gorm:"default:1" json:"type_id"`
 	UserType       UserType     `gorm:"foreignKey:TypeID" json:"user_type,omitempty"`

--- a/internal/services/auth_service.go
+++ b/internal/services/auth_service.go
@@ -60,6 +60,16 @@ func NewAuthService(db *gorm.DB, jwtSecret, jwtRefreshSecret string, accessTTL, 
 	}
 }
 
+// intPtrOrNil возвращает указатель на v или nil если v <= 0.
+// Используется для FK-полей (organization_id, company_id) где 0 = "не привязан",
+// а в БД FK constraint требует либо NULL либо существующий id.
+func intPtrOrNil(v int) *int {
+	if v <= 0 {
+		return nil
+	}
+	return &v
+}
+
 // --- Password Hashing (Argon2id, compatible with Rust argon2 crate) ---
 
 func hashPassword(password string) string {

--- a/internal/services/user_service.go
+++ b/internal/services/user_service.go
@@ -61,9 +61,16 @@ func (s *userService) checkAdmin(ctx context.Context, typeID int) error {
 }
 
 // Create создаёт нового пользователя. Только admin (manager/buropropuskov).
+//
+// Пользователь может быть привязан к организации, компании или к обеим сразу.
+// Хотя бы одно из двух поле должно быть > 0. Значение 0 означает "не привязан".
 func (s *userService) Create(ctx context.Context, callerTypeID int, req models.RegisterRequest) error {
 	if err := s.checkAdmin(ctx, callerTypeID); err != nil {
 		return err
+	}
+
+	if req.OrganizationID <= 0 && req.CompanyID <= 0 {
+		return echo.NewHTTPError(http.StatusBadRequest, "Необходимо указать организацию или компанию (хотя бы одно)")
 	}
 
 	user := models.User{

--- a/internal/services/user_service.go
+++ b/internal/services/user_service.go
@@ -76,8 +76,8 @@ func (s *userService) Create(ctx context.Context, callerTypeID int, req models.R
 	user := models.User{
 		Username:       req.Username,
 		Password:       hashPassword(req.Password),
-		OrganizationID: req.OrganizationID,
-		CompanyID:      req.CompanyID,
+		OrganizationID: intPtrOrNil(req.OrganizationID),
+		CompanyID:      intPtrOrNil(req.CompanyID),
 		TypeID:         req.TypeID,
 		LastName:       req.LastName,
 		FirstName:      req.FirstName,

--- a/internal/testutil/auth.go
+++ b/internal/testutil/auth.go
@@ -13,6 +13,15 @@ import (
 
 const adminPassword = "adminpass_long_enough_for_32chars!"
 
+// intPtrOrZero возвращает указатель на v или nil если v <= 0.
+// Дублирует services.intPtrOrNil чтобы избежать циклических импортов.
+func intPtrOrZero(v int) *int {
+	if v <= 0 {
+		return nil
+	}
+	return &v
+}
+
 // AuthHeader returns an Authorization header with the given Bearer token.
 func AuthHeader(token string) http.Header {
 	h := http.Header{}
@@ -26,8 +35,8 @@ func RegisterUser(t *testing.T, e *echo.Echo, username, password string, typeID,
 	user := models.User{
 		Username:       username,
 		Password:       hashTestPassword(password),
-		OrganizationID: orgID,
-		CompanyID:      companyID,
+		OrganizationID: intPtrOrZero(orgID),
+		CompanyID:      intPtrOrZero(companyID),
 		TypeID:         typeID,
 	}
 	err := cachedDB.Create(&user).Error
@@ -73,8 +82,8 @@ func registerUserViaDB(t *testing.T, e *echo.Echo, username string, typeID, orgI
 	user := models.User{
 		Username:       username,
 		Password:       hashTestPassword(adminPassword),
-		OrganizationID: orgID,
-		CompanyID:      companyID,
+		OrganizationID: intPtrOrZero(orgID),
+		CompanyID:      intPtrOrZero(companyID),
 		TypeID:         typeID,
 	}
 	err := cachedDB.Create(&user).Error


### PR DESCRIPTION
## Summary

PR7 серии по issue #101. Backend часть требования "пользователь может иметь либо организацию, либо компанию, либо и то и то".

### Backend

- \`UserService.Create\` теперь требует \`organization_id > 0 || company_id > 0\`, иначе 400 "Необходимо указать организацию или компанию (хотя бы одно)". Оба одновременно допустимы.
- Значение 0 = "не привязан". GORM вставляет 0 как есть (нет FK constraint в миграции).
- Добавлен тест \`TestUsers_Create_RequiresOrgOrCompany\` на 4 сценария: (0,0) fails, (org,0) ok, (0,company) ok, (org,company) ok.

### Frontend

Уже задеплоен в PR3 (#104):
- \`canCreateUser\` требует \`hasOrgOrCompany\` (хотя бы одно поле)
- В селектах добавлен пункт "Не выбрано"
- Предупреждение над формой при отсутствии обоих

### Не в скоупе

- Миграция существующих пользователей с \`organization_id=0 && company_id=0\` - теоретически такие записи были бы сломанными, но на практике их нет (старый UI требовал оба)
- Nullable в User.Organization/Company структурах Go - кардинальное изменение, 675 usages в коде. Оставлено \`int\` с семантикой "0 = не привязан"

## Test plan

- [x] \`go vet ./...\` - clean
- [x] \`go build ./...\` - clean
- [ ] Go Tests в CI должны пройти зелёными (новый тест \`TestUsers_Create_RequiresOrgOrCompany\`)
- [ ] Staging: создание пользователя без организации И без компании - 400 с сообщением
- [ ] Staging: создание только с организацией - успех
- [ ] Staging: создание только с компанией - успех

Refs: issue #101