### PR TITLE
feat: notifications автосоздание при отправке заявки + POST /notifications (#101)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -134,7 +134,7 @@ func main() {
 	notificationService := services.NewNotificationService(db)
 	requestLogsService := services.NewRequestLogsService(db)
 	employeesHistoryService := services.NewEmployeesHistoryService(db)
-	applicationService := services.NewApplicationService(db, permissionService)
+	applicationService := services.NewApplicationService(db, permissionService, notificationService)
 	approverService := services.NewApproverService(db)
 	consentService := services.NewConsentService(db)
 	settingsService := services.NewSettingsService(db, cfg)

--- a/internal/handlers/applications_expiry_test.go
+++ b/internal/handlers/applications_expiry_test.go
@@ -21,7 +21,8 @@ func TestCheckExpiredAttachments(t *testing.T) {
 
 	// Create the service directly for calling CheckExpiredAttachments.
 	permSvc := services.NewPermissionService(db)
-	appSvc := services.NewApplicationService(db, permSvc)
+	notifSvc := services.NewNotificationService(db)
+	appSvc := services.NewApplicationService(db, permSvc, notifSvc)
 
 	tests := []struct {
 		name string

--- a/internal/handlers/notifications.go
+++ b/internal/handlers/notifications.go
@@ -103,3 +103,31 @@ func (h *NotificationHandler) DeleteAll(c echo.Context) error {
 	}
 	return RespondMessage(c, "Все уведомления удалены")
 }
+
+// Create godoc
+// @Summary      Создание уведомления (admin-only)
+// @Tags         notifications
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        request body models.CreateNotificationRequest true "Данные уведомления"
+// @Success      200 {object} models.Notification
+// @Failure      400 {object} models.HTTPError
+// @Failure      401 {object} models.HTTPError
+// @Failure      403 {object} models.HTTPError
+// @Router       /notifications [post]
+func (h *NotificationHandler) Create(c echo.Context) error {
+	typeID := c.Get("type_id").(int)
+	if typeID != 5 && typeID != 6 {
+		return echo.NewHTTPError(403, "Insufficient permissions")
+	}
+	var req models.CreateNotificationRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	n, err := h.service.Create(c.Request().Context(), req)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, n)
+}

--- a/internal/models/notification.go
+++ b/internal/models/notification.go
@@ -18,3 +18,12 @@ type Notification struct {
 type MarkNotificationReadRequest struct {
 	IsRead bool `json:"is_read"`
 }
+
+// CreateNotificationRequest -- тело запроса на создание уведомления (admin-only).
+type CreateNotificationRequest struct {
+	UserID  int     `json:"user_id" validate:"required,min=1"`
+	Type    *string `json:"type"`
+	Title   *string `json:"title" validate:"required,max=255"`
+	Message *string `json:"message"`
+	Data    *string `json:"data"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -267,6 +267,7 @@ func Setup(e *echo.Echo, auth *handlers.AuthHandler, userTypes *handlers.UserTyp
 	// Уведомления
 	notif := protected.Group("/notifications")
 	notif.GET("", notifications.GetNotifications)
+	notif.POST("", notifications.Create)
 	notif.PUT("/:id/read", notifications.MarkRead)
 	notif.DELETE("/:id", notifications.Delete)
 	notif.DELETE("", notifications.DeleteAll)

--- a/internal/services/application_service.go
+++ b/internal/services/application_service.go
@@ -439,13 +439,14 @@ type ItemInfo struct {
 // --- Реализация ---
 
 type applicationService struct {
-	db                *gorm.DB
-	permissionService PermissionService
+	db                  *gorm.DB
+	permissionService   PermissionService
+	notificationService NotificationService
 }
 
 // NewApplicationService создаёт экземпляр сервиса заявок.
-func NewApplicationService(db *gorm.DB, permSvc PermissionService) ApplicationService {
-	return &applicationService{db: db, permissionService: permSvc}
+func NewApplicationService(db *gorm.DB, permSvc PermissionService, notifSvc NotificationService) ApplicationService {
+	return &applicationService{db: db, permissionService: permSvc, notificationService: notifSvc}
 }
 
 // --- Основные методы ---
@@ -1212,6 +1213,37 @@ func (s *applicationService) SubmitCompleteApplication(ctx context.Context, user
 
 	if err := tx.Commit().Error; err != nil {
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Failed to commit transaction")
+	}
+
+	// Уведомление отправителю о создании заявки
+	if s.notificationService != nil {
+		if err := s.notificationService.CreateForUser(
+			ctx, user.ID,
+			"application_created",
+			"Заявка отправлена",
+			fmt.Sprintf("Ваша заявка %s отправлена и ожидает согласования.", applicationNumber),
+			nil,
+		); err != nil {
+			slog.Warn("notification create failed", "err", err, "user_id", user.ID, "app_id", appID)
+		}
+	}
+
+	// Уведомления ответственным (approvers) о новой заявке
+	if s.notificationService != nil {
+		for _, ru := range responsibleUsers {
+			if !ru.RequiredApproval || ru.UserID == user.ID {
+				continue
+			}
+			if err := s.notificationService.CreateForUser(
+				ctx, ru.UserID,
+				"application_approval_required",
+				"Требуется согласование",
+				fmt.Sprintf("Поступила новая заявка %s на согласование.", applicationNumber),
+				nil,
+			); err != nil {
+				slog.Warn("notification create failed", "err", err, "user_id", ru.UserID, "app_id", appID)
+			}
+		}
 	}
 
 	return &CompleteApplicationResponse{

--- a/internal/services/notification_service.go
+++ b/internal/services/notification_service.go
@@ -16,6 +16,8 @@ type NotificationService interface {
 	MarkRead(ctx context.Context, userID int, id int, req models.MarkNotificationReadRequest) (*models.Notification, error)
 	Delete(ctx context.Context, userID int, id int) error
 	DeleteAll(ctx context.Context, userID int) error
+	Create(ctx context.Context, req models.CreateNotificationRequest) (*models.Notification, error)
+	CreateForUser(ctx context.Context, userID int, notifType, title, message string, data *string) error
 }
 
 type notificationService struct {
@@ -82,4 +84,44 @@ func (s *notificationService) DeleteAll(ctx context.Context, userID int) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "Error deleting notifications")
 	}
 	return nil
+}
+
+// Create создаёт уведомление (admin endpoint + внутренние триггеры).
+func (s *notificationService) Create(ctx context.Context, req models.CreateNotificationRequest) (*models.Notification, error) {
+	if req.UserID <= 0 {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "user_id is required")
+	}
+	if req.Title == nil || *req.Title == "" {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "title is required")
+	}
+	n := models.Notification{
+		UserID:  req.UserID,
+		Type:    req.Type,
+		Title:   req.Title,
+		Message: req.Message,
+		Data:    req.Data,
+	}
+	if err := s.db.WithContext(ctx).Create(&n).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error creating notification")
+	}
+	return &n, nil
+}
+
+// CreateForUser -- helper для триггеров из других сервисов.
+// Ошибки логируются но не прерывают основной flow (уведомления не должны блокировать бизнес-операции).
+func (s *notificationService) CreateForUser(ctx context.Context, userID int, notifType, title, message string, data *string) error {
+	if userID <= 0 || title == "" {
+		return nil
+	}
+	t := notifType
+	ti := title
+	m := message
+	n := models.Notification{
+		UserID:  userID,
+		Type:    &t,
+		Title:   &ti,
+		Message: &m,
+		Data:    data,
+	}
+	return s.db.WithContext(ctx).Create(&n).Error
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -103,7 +103,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	notificationService := services.NewNotificationService(db)
 	requestLogsService := services.NewRequestLogsService(db)
 	employeesHistoryService := services.NewEmployeesHistoryService(db)
-	applicationService := services.NewApplicationService(db, permissionService)
+	applicationService := services.NewApplicationService(db, permissionService, notificationService)
 	approverService := services.NewApproverService(db)
 	consentService := services.NewConsentService(db)
 	settingsService := services.NewSettingsService(db, &config.Config{


### PR DESCRIPTION
## Summary

PR8 серии по issue #101. Фундамент автоматических уведомлений.

### Причина

До этого PR на staging: \`POST /api/notifications\` -> 404 (нет endpoint'а). Уведомления появлялись только из seed-demo. В old_branch Rust-бэкенд триггерил их автоматически на события (новая заявка, отзыв и т.д.), но при порте Go эти триггеры не перенеслись.

### Изменения

Backend:
- \`models.CreateNotificationRequest\` DTO
- \`NotificationService.Create\` - admin endpoint для ручного создания
- \`NotificationService.CreateForUser\` - helper для триггеров из других сервисов; ошибки логируются через slog.Warn но не прерывают основной flow - уведомления не должны блокировать бизнес-операции
- \`POST /notifications\` (manager/buropropuskov only)
- \`ApplicationService\` теперь зависит от \`NotificationService\`, при \`SubmitCompleteApplication\` создаёт уведомления:
  - отправителю: \"Ваша заявка N отправлена и ожидает согласования.\"
  - ответственным с \`required_approval=true\`: \"Поступила новая заявка N на согласование.\"

Frontend: изменений нет, polling через \`setInterval(fetchNotifications, 30000)\` уже был в \`UserNotifications.vue\`/\`UserNotificationsInline.vue\`, теперь получит новые записи автоматически при активности.

### Не в скоупе (follow-up)

Другие триггеры (approve/reject/revoke/status change) оставлены для отдельных PR чтобы не раздувать один PR. Текущего коммита достаточно чтобы \"уведомления начали работать\" на базовом сценарии.

## Test plan

- [x] \`go build ./...\` - clean
- [x] \`go vet ./...\` - clean
- [ ] Go Tests в CI должны пройти (новая зависимость добавлена в testutil и expiry test)
- [ ] Staging: новый юзер отправляет заявку -> в шапке badge появляется через <=30s -> клик открывает список с \"Ваша заявка N отправлена...\"
- [ ] Staging: POST /notifications admin'ом - 200 + запись в БД; обычный юзер - 403

Refs: issue #101