### PR TITLE
fix: first-row на personal-cabinet - блоки side-by-side (#101)

### DIFF
--- a/frontend/src/components/AccountComponent.vue
+++ b/frontend/src/components/AccountComponent.vue
@@ -259,6 +259,17 @@ export default {
   margin-bottom: 15px;
 }
 
+/* SkeletonTransition оборачивает детей в div — раскладываем его в flex row
+   чтобы UserProfileHeader и UserNotificationsInline были side-by-side */
+.first-row > div {
+  display: flex;
+  flex-direction: row;
+  gap: 30px;
+  flex: 1;
+  min-width: 0;
+  width: 100%;
+}
+
 .dashboard-row {
  padding: 15px 0;
 }
@@ -315,7 +326,11 @@ export default {
   .first-row {
     flex-direction: column;
   }
-  
+
+  .first-row > div {
+    flex-direction: column;
+  }
+
   .settings {
     width: 100%;
   }


### PR DESCRIPTION
## Summary

Хотфикс для скриншота пользователя: блок \"Уведомления\" оказался под блоком \"Бюро пропусков\" вместо справа от него.

### Root cause

\`SkeletonTransition\` оборачивает оба компонента (\`UserProfileHeader\` + \`UserNotificationsInline\`) в один DIV (default slot из двух внуков). Этот DIV был единственным ребёнком \`.first-row\` и имел \`flex: 0 1 auto\` -> сжимался до естественной ширины (697px из 1840px). Дочерние компоненты внутри него оставались block-level, один под другим.

### Fix

\`.first-row > div\` targetит SkeletonTransition wrapper, делает его \`display: flex; flex-direction: row; gap: 30px; flex: 1; width: 100%\`. Теперь \`UserProfileHeader.account-header\` и \`UserNotificationsInline.notifications\` (оба уже имеют \`flex: 1\`) поровну делят ширину side-by-side.

Мobile breakpoint \`max-width: 1200px\` обновлён: flex-direction меняется на column у обоих контейнеров.

## Test plan

- [x] \`npx vitest run\` - 215 passed
- [x] \`npm run lint\` - clean
- [ ] Staging: /personal-cabinet - \"Бюро пропусков\" слева, \"Уведомления\" справа, gap 30px

Refs: issue #101 (скриншот от 2026-04-23)