### PR TITLE
feat: динамическое обновление NavMenu и Центра заявок (#101)

### DIFF
--- a/frontend/src/components/NavMenu.vue
+++ b/frontend/src/components/NavMenu.vue
@@ -179,7 +179,8 @@ export default {
       dropdownLeaveTimeout: null,
       systemTables: [],
       newApplicationsCount: 0,
-      applicationsPollingInterval: null
+      applicationsPollingInterval: null,
+      tablesPollingInterval: null
     };
   },
   methods: {
@@ -331,11 +332,21 @@ export default {
         this.fetchNewApplicationsCount();
       }, 30000);
     },
-    
+
+    startTablesPolling() {
+      this.tablesPollingInterval = setInterval(() => {
+        this.fetchSystemTables();
+      }, 60000);
+    },
+
     stopApplicationsPolling() {
       if (this.applicationsPollingInterval) {
         clearInterval(this.applicationsPollingInterval);
         this.applicationsPollingInterval = null;
+      }
+      if (this.tablesPollingInterval) {
+        clearInterval(this.tablesPollingInterval);
+        this.tablesPollingInterval = null;
       }
     },
     
@@ -348,6 +359,7 @@ export default {
     document.body.classList.add('auth-active');
     await this.fetchSystemTables();
     this.startApplicationsPolling();
+    this.startTablesPolling();
   },
   beforeUnmount() {
     document.body.classList.remove('auth-active');

--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -312,6 +312,7 @@ export default {
             sortDirection: 'desc',
             shouldShake: false,
             shakeInterval: null,
+            applicationsPollInterval: null,
             isInitialLoad: true,
             
             // Дата - теперь поддерживаем и одиночную дату, и диапазон
@@ -908,7 +909,16 @@ export default {
         this.fetchOrganizations();
         this.fetchApplications();
         this.getCurrentUser();
-        
+
+        // Динамическое обновление списка заявок - статусы/confirmations
+        // могут меняться из других сессий (согласование, взятие в работу, завершение).
+        // Polling 30s достаточен для UX без overkill.
+        this.applicationsPollInterval = setInterval(() => {
+            if (!this.isInitialLoad) {
+                this.fetchApplications();
+            }
+        }, 30000);
+
         setTimeout(() => {
             this.isInitialLoad = false;
         }, 1000);
@@ -916,6 +926,9 @@ export default {
     beforeUnmount() {
         if (this.shakeInterval) {
             clearInterval(this.shakeInterval);
+        }
+        if (this.applicationsPollInterval) {
+            clearInterval(this.applicationsPollInterval);
         }
     }
 }


### PR DESCRIPTION
## Summary

PR9 серии по issue #101.

### NavMenu

- Новый \`tablesPollingInterval\` (60s) обновляет список системных таблиц. Если админ создал/активировал/удалил таблицу - другие юзеры увидят изменения в меню без перезагрузки
- \`unread-count\` polling 30s уже был
- \`stopApplicationsPolling\` теперь чистит и \`tablesPollingInterval\`
- lifecycle: \`tablesPollingInterval: null\` в data, \`startTablesPolling\` в mounted, cleanup в beforeUnmount через stopApplicationsPolling

### ApplicationsCenter

- Новый \`applicationsPollInterval\` (30s) - полный \`fetchApplications()\` в фоне. При смене статуса (согласование, взятие в работу, завершение) из другой сессии таблица обновляется автоматически
- Polling не срабатывает в первые 1000ms (пока \`isInitialLoad=true\`), чтобы не конкурировать с первичным fetchApplications

### Закрывает в issue #101

- [x] В NavMenu.vue должны динамически добавляться и обновляться вкладки, уведомления, новые заявки, таблицы
- [x] При изменении статуса заявки, она должна динамично обновляться в таблице всех заявок

## Test plan

- [x] \`npx vitest run\` - 215 passed
- [x] \`npm run lint\` - clean
- [ ] Staging: открыть /center в двух вкладках, поменять статус в одной - через ≤30s обновится в другой
- [ ] Staging: админ создаёт новую системную таблицу - через ≤60s у юзеров появляется в меню "Таблицы"
- [ ] Staging: в NavMenu badge новых заявок обновляется каждые 30s

Refs: issue #101