### PR TITLE
feat: JWT refresh-token в HttpOnly cookie (#46)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -140,7 +140,7 @@ func main() {
 	settingsService := services.NewSettingsService(db, cfg)
 
 	// Handlers
-	authHandler := handlers.NewAuthHandler(authService)
+	authHandler := handlers.NewAuthHandler(authService, cfg.CookieSecure, cfg.JWTRefreshTTL)
 	userTypesHandler := handlers.NewUserTypesHandler(userTypeService)
 	lpfHandler := handlers.NewLicensePlateFormatHandler(lpfService)
 	attachmentHandler := handlers.NewAttachmentHandler(attachmentService)

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -15,24 +15,15 @@
       </router-view>
       <ScrollTopButton v-if="showChrome" />
     </div>
-
-    <!-- Модальное окно истекшей сессии -->
-    <SessionExpiredModal 
-      v-if="showSessionModal"
-      :time-remaining="modalTimeRemaining"
-      @extend-session="extendSession"
-      @logout="logout"
-    />
   </div>
 </template>
 
 <script>
-import { apiRequest } from '@/api/client'
+import { apiRequest, tryRestoreSession } from '@/api/client'
 import { useAuthStore } from '@/stores/auth'
 import { usePermissionsStore } from '@/stores/permissions'
 import NavMenu from './components/NavMenu.vue';
 import TheHeader from './components/TheHeader/TheHeader.vue';
-import SessionExpiredModal from './components/SessionExpiredModal.vue';
 import ScrollTopButton from './components/ScrollTopButton.vue';
 
 export default {
@@ -40,16 +31,7 @@ export default {
   components: {
     NavMenu,
     TheHeader,
-    SessionExpiredModal,
     ScrollTopButton
-  },
-  data() {
-    return {
-      showSessionModal: false,
-      expirationTimer: null,
-      modalTimeRemaining: 0,
-      refreshExpiryTime: null,
-    };
   },
   computed: {
     isAuthenticated() {
@@ -63,7 +45,7 @@ export default {
     /**
      * Показывать шапку, навигацию и связанный chrome только когда юзер
      * аутентифицирован и находится не на странице логина. Иначе после
-     * setTokens() в LoginComponent до router.push('/personal-cabinet')
+     * setTokens() в LoginComponent до router.push('/news')
      * (задержан на 1.5с из-за success-анимации) шапка и меню моргают
      * поверх формы логина.
      */
@@ -72,140 +54,43 @@ export default {
     }
   },
   methods: {
-    checkAuthStatus() {
-      const authStore = useAuthStore()
-      if (!authStore.refreshToken) {
-        this.showSessionModal = false;
-        this.stopExpirationTimer();
-        return;
-      }
-
-      const payload = authStore.refreshPayload;
-      if (!payload || !payload.exp) {
-        this.logout();
-        return;
-      }
-
-      const timeUntilExpiry = payload.exp - Math.floor(Date.now() / 1000);
-      if (timeUntilExpiry <= 0) {
-        this.logout();
-        return;
-      }
-
-      this.refreshExpiryTime = payload.exp;
-
-      const permissionsStore = usePermissionsStore()
-      if (!permissionsStore.loaded) {
-        permissionsStore.fetchPermissions()
-      }
-
-      this.scheduleExpirationWarning(timeUntilExpiry);
-    },
-
-    scheduleExpirationWarning(timeUntilExpiry) {
-      this.stopExpirationTimer();
-      const WARNING_WINDOW_SEC = 600; // 10 минут
-
-      if (timeUntilExpiry <= WARNING_WINDOW_SEC) {
-        this.modalTimeRemaining = timeUntilExpiry;
-        this.showSessionModal = true;
-        this.expirationTimer = setInterval(() => {
-          const remaining = this.refreshExpiryTime - Math.floor(Date.now() / 1000);
-          if (remaining <= 0) {
-            this.logout();
-            return;
-          }
-          this.modalTimeRemaining = remaining;
-        }, 1000);
-      } else {
-        const delayMs = (timeUntilExpiry - WARNING_WINDOW_SEC) * 1000;
-        this.expirationTimer = setTimeout(() => this.checkAuthStatus(), delayMs);
-      }
-    },
-
-    stopExpirationTimer() {
-      if (this.expirationTimer) {
-        clearTimeout(this.expirationTimer);
-        clearInterval(this.expirationTimer);
-        this.expirationTimer = null;
-      }
-    },
-
     handleSuccessfulLogin(tokenData) {
       const authStore = useAuthStore()
-      authStore.setTokens(tokenData.token, tokenData.refreshToken)
-      this.checkAuthStatus();
-    },
-
-    async extendSession() {
-      const authStore = useAuthStore()
-      if (!authStore.refreshToken) {
-        this.logout();
-        return;
-      }
-      try {
-        const response = await apiRequest("/refresh-token", {
-          method: "POST",
-          body: JSON.stringify({ refresh_token: authStore.refreshToken }),
-        });
-        if (!response.ok) throw new Error(`refresh failed: ${response.status}`);
-        const data = await response.json();
-        authStore.setTokens(data.token, data.refreshToken);
-        this.showSessionModal = false;
-        this.checkAuthStatus();
-        const permissionsStore = usePermissionsStore();
-        permissionsStore.fetchPermissions();
-      } catch {
-        this.logout();
-      }
+      authStore.setTokens(tokenData.token)
+      const permissionsStore = usePermissionsStore()
+      permissionsStore.fetchPermissions()
     },
 
     async logout() {
       const authStore = useAuthStore()
       try {
-        if (authStore.token && authStore.refreshToken) {
-          await apiRequest("/logout", {
-            method: "POST",
-            body: JSON.stringify({ refresh_token: authStore.refreshToken }),
-          });
+        if (authStore.token) {
+          await apiRequest("/logout", { method: "POST", body: '{}' });
         }
       } catch {
-        // сеть упала — всё равно чистим клиент
+        // сеть упала - всё равно чистим клиент
       } finally {
         authStore.clearTokens()
-        this.showSessionModal = false;
-        this.stopExpirationTimer();
-
         const permissionsStore = usePermissionsStore()
         permissionsStore.clearPermissions()
-
         if (this.$route.path !== '/') {
           this.$router.push("/");
         }
       }
     },
-
-    onVisibilityChange() {
-      if (document.visibilityState === 'visible') {
-        this.checkAuthStatus();
+  },
+  async created() {
+    // После F5 access_token в памяти потерян. Refresh cookie живёт на
+    // стороне сервера - пытаемся восстановить сессию одним запросом.
+    const authStore = useAuthStore()
+    if (!authStore.token) {
+      const restored = await tryRestoreSession()
+      if (restored) {
+        const permissionsStore = usePermissionsStore()
+        permissionsStore.fetchPermissions()
       }
-    },
-  },
-  created() {
-    this.checkAuthStatus();
-    window.addEventListener('storage', this.checkAuthStatus);
-    document.addEventListener('visibilitychange', this.onVisibilityChange);
-  },
-  beforeUnmount() {
-    this.stopExpirationTimer();
-    window.removeEventListener('storage', this.checkAuthStatus);
-    document.removeEventListener('visibilitychange', this.onVisibilityChange);
-  },
-  watch: {
-    $route() {
-      this.checkAuthStatus();
     }
-  }
+  },
 };
 </script>
 
@@ -218,52 +103,26 @@ export default {
   color: white;
   padding: 8px 16px;
   z-index: 10000;
-  transition: top 0.2s;
+  transition: top 0.2s ease;
+  text-decoration: none;
 }
+
 .skip-link:focus {
   top: 0;
 }
 
-* {
-    font-family: 'Montserrat', sans-serif;
-    padding: 0;
-    margin: 0;
-    box-sizing: border-box;
-    scroll-behavior: smooth;
-}
-
-::-webkit-scrollbar {
-  width: 0;
-}
-
-body.auth-active #app {
-  margin-left: 25px;
-}
-
-body:not(.auth-active) #app {
-  margin-left: 0;
-}
-
-.form-input-sm {
-  border-radius: 10px !important;
-}
-
-.blue {
-  color: #4F5BDF;
-}
-
-.red {
-  color: rgb(241, 76, 76);
-}
-
-.page-fade-enter-active {
-  transition: opacity 0.25s cubic-bezier(0.4, 0, 0.2, 1);
-}
+.page-fade-enter-active,
 .page-fade-leave-active {
-  transition: opacity 0.15s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: opacity 0.3s ease, transform 0.3s ease;
 }
-.page-fade-enter-from,
+
+.page-fade-enter-from {
+  opacity: 0;
+  transform: translateY(10px);
+}
+
 .page-fade-leave-to {
   opacity: 0;
+  transform: translateY(-10px);
 }
 </style>

--- a/frontend/src/api/__tests__/client.spec.js
+++ b/frontend/src/api/__tests__/client.spec.js
@@ -44,7 +44,7 @@ describe('apiRequest basics', () => {
 
   it('adds Authorization header when token exists in store', async () => {
     const { useAuthStore } = await import('@/stores/auth');
-    useAuthStore().setTokens('test-bearer-token', 'refresh');
+    useAuthStore().setTokens('test-bearer-token');
 
     await apiRequest('/users/me');
 
@@ -108,7 +108,7 @@ describe('401 auto-refresh', () => {
     localStorage.clear();
     routerPush.mockReset();
     const { useAuthStore } = await import('@/stores/auth');
-    useAuthStore().setTokens('old-access', 'refresh-token-value');
+    useAuthStore().setTokens('old-access');
     fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);
   });
@@ -134,7 +134,6 @@ describe('401 auto-refresh', () => {
 
     const { useAuthStore } = await import('@/stores/auth');
     expect(useAuthStore().token).toBe('new-access');
-    expect(useAuthStore().refreshToken).toBe('new-refresh');
   });
 
   it('on refresh failure clears tokens and redirects to /', async () => {
@@ -146,7 +145,6 @@ describe('401 auto-refresh', () => {
 
     const { useAuthStore } = await import('@/stores/auth');
     expect(useAuthStore().token).toBeNull();
-    expect(useAuthStore().refreshToken).toBeNull();
     expect(routerPush).toHaveBeenCalledWith('/');
   });
 

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -13,22 +13,23 @@ function isAuthEndpoint(path) {
   return AUTH_ENDPOINTS.some((p) => path === p || path.startsWith(p + '?'))
 }
 
+// performRefresh вызывает POST /refresh-token. Refresh token живёт в
+// HttpOnly cookie - отправляется автоматически через credentials: 'include'.
 async function performRefresh() {
   const authStore = useAuthStore()
-  const refreshToken = authStore.refreshToken
-  if (!refreshToken) throw new Error('no refresh token')
 
   const response = await fetch(`${API_BASE_URL}/refresh-token`, {
     method: 'POST',
+    credentials: 'include',
     headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-    body: JSON.stringify({ refresh_token: refreshToken }),
+    body: '{}',
   })
   if (!response.ok) throw new Error(`refresh failed: ${response.status}`)
 
   const body = await response.json()
   const data = body && typeof body === 'object' && 'success' in body ? body.data : body
-  if (!data || !data.token || !data.refreshToken) throw new Error('refresh: malformed response')
-  authStore.setTokens(data.token, data.refreshToken)
+  if (!data || !data.token) throw new Error('refresh: malformed response')
+  authStore.setTokens(data.token)
   return data.token
 }
 
@@ -39,6 +40,18 @@ function ensureRefreshed() {
     })
   }
   return refreshPromise
+}
+
+// tryRestoreSession - вызывается на монтировании App, пытается обновить сессию
+// из HttpOnly cookie. Используется после F5 когда token в памяти Pinia потерян,
+// но cookie сервера ещё жива.
+export async function tryRestoreSession() {
+  try {
+    await ensureRefreshed()
+    return true
+  } catch {
+    return false
+  }
 }
 
 function wrapJsonUnwrap(response) {
@@ -62,6 +75,7 @@ async function doFetch(path, options, token) {
   try {
     return await fetch(`${API_BASE_URL}${path}`, {
       ...options,
+      credentials: 'include',
       signal: options.signal || controller.signal,
       headers: {
         'Content-Type': 'application/json',

--- a/frontend/src/components/LoginComponent.vue
+++ b/frontend/src/components/LoginComponent.vue
@@ -331,20 +331,17 @@ export default {
 
         if (response.ok) {
             const data = await response.json();
-            
+
             const authStore = useAuthStore()
-            authStore.setTokens(data.token, data.refreshToken)
-            
+            authStore.setTokens(data.token)
+
             this.isLoading = false;
             this.isSuccess = true;
-            
+
             await new Promise(resolve => setTimeout(resolve, 1500));
-            
-            this.$emit('login-success', {
-                token: data.token,
-                refreshToken: data.refreshToken
-            });
-            
+
+            this.$emit('login-success', { token: data.token });
+
             this.$router.push('/news');
         } else {
             // Проверяем статус код для определения типа ошибки

--- a/frontend/src/directives/__tests__/permission.spec.js
+++ b/frontend/src/directives/__tests__/permission.spec.js
@@ -61,7 +61,7 @@ describe('v-permission directive', () => {
 
   it('shows element for admin regardless of permission', () => {
     const authStore = useAuthStore()
-    authStore.setTokens(createMockJWT({ type_id: 6 }), 'refresh')
+    authStore.setTokens(createMockJWT({ type_id: 6 }))
 
     const store = usePermissionsStore()
     store.permissions = { 'passes.create': 'deny' }
@@ -73,7 +73,7 @@ describe('v-permission directive', () => {
 
   it('shows element for admin even when permission is missing', () => {
     const authStore = useAuthStore()
-    authStore.setTokens(createMockJWT({ type_id: 6 }), 'refresh')
+    authStore.setTokens(createMockJWT({ type_id: 6 }))
 
     const wrapper = mountWithPermission('passes.create', pinia)
 

--- a/frontend/src/stores/__tests__/auth.spec.js
+++ b/frontend/src/stores/__tests__/auth.spec.js
@@ -18,103 +18,76 @@ describe('auth store', () => {
   });
 
   describe('setTokens', () => {
-    it('stores tokens in state and localStorage', () => {
+    it('хранит access token только в памяти, не в localStorage', () => {
       const store = useAuthStore();
-      store.setTokens('access-token', 'refresh-token');
+      store.setTokens('access-token');
 
       expect(store.token).toBe('access-token');
-      expect(store.refreshToken).toBe('refresh-token');
-      expect(localStorage.getItem('token')).toBe('access-token');
-      expect(localStorage.getItem('refreshToken')).toBe('refresh-token');
-    });
-  });
-
-  describe('clearTokens', () => {
-    it('removes tokens from state and localStorage', () => {
-      const store = useAuthStore();
-      store.setTokens('access-token', 'refresh-token');
-      store.clearTokens();
-
-      expect(store.token).toBeNull();
-      expect(store.refreshToken).toBeNull();
       expect(localStorage.getItem('token')).toBeNull();
       expect(localStorage.getItem('refreshToken')).toBeNull();
     });
   });
 
+  describe('clearTokens', () => {
+    it('удаляет access token из state', () => {
+      const store = useAuthStore();
+      store.setTokens('access-token');
+      store.clearTokens();
+
+      expect(store.token).toBeNull();
+    });
+  });
+
   describe('isAuthenticated', () => {
-    it('returns true when refresh token is valid and non-expired', () => {
+    it('возвращает true когда access token валидный', () => {
       const store = useAuthStore();
-      const access = createMockJWT({ username: 'admin' }, 3600);
-      const refresh = createMockJWT({ username: 'admin' }, 168 * 3600);
-      store.setTokens(access, refresh);
-
+      store.setTokens(createMockJWT({ username: 'admin' }, 3600));
       expect(store.isAuthenticated).toBe(true);
     });
 
-    it('returns true even when access token is expired, as long as refresh is valid', () => {
+    it('возвращает false когда access token истёк', () => {
       const store = useAuthStore();
-      const access = createMockJWT({ username: 'admin' }, -100);
-      const refresh = createMockJWT({ username: 'admin' }, 3600);
-      store.setTokens(access, refresh);
-
-      expect(store.isAuthenticated).toBe(true);
-    });
-
-    it('returns false when refresh token is expired', () => {
-      const store = useAuthStore();
-      const access = createMockJWT({ username: 'admin' }, 3600);
-      const refresh = createMockJWT({ username: 'admin' }, -100);
-      store.setTokens(access, refresh);
-
+      store.setTokens(createMockJWT({ username: 'admin' }, -100));
       expect(store.isAuthenticated).toBe(false);
     });
 
-    it('returns false when no refresh token is set', () => {
+    it('возвращает false когда token не установлен', () => {
       const store = useAuthStore();
       expect(store.isAuthenticated).toBe(false);
     });
   });
 
   describe('userType', () => {
-    it('extracts type_id from token payload', () => {
+    it('извлекает type_id из payload', () => {
       const store = useAuthStore();
-      const token = createMockJWT({ type_id: 3 });
-      store.setTokens(token, 'refresh');
-
+      store.setTokens(createMockJWT({ type_id: 3 }));
       expect(store.userType).toBe(3);
     });
 
-    it('returns null when no token is set', () => {
+    it('возвращает null когда токена нет', () => {
       const store = useAuthStore();
       expect(store.userType).toBeNull();
     });
   });
 
   describe('isAdmin', () => {
-    it('returns true when type_id is 6', () => {
+    it('возвращает true когда type_id=6', () => {
       const store = useAuthStore();
-      const token = createMockJWT({ type_id: 6 });
-      store.setTokens(token, 'refresh');
-
+      store.setTokens(createMockJWT({ type_id: 6 }));
       expect(store.isAdmin).toBe(true);
     });
 
-    it('returns false for non-admin type', () => {
+    it('возвращает false для не-админа', () => {
       const store = useAuthStore();
-      const token = createMockJWT({ type_id: 2 });
-      store.setTokens(token, 'refresh');
-
+      store.setTokens(createMockJWT({ type_id: 2 }));
       expect(store.isAdmin).toBe(false);
     });
   });
 
   describe('username', () => {
-    it('extracts username from token payload', () => {
+    it('извлекает username из payload', () => {
       const store = useAuthStore();
-      const token = createMockJWT({ username: 'testuser' });
-      store.setTokens(token, 'refresh');
-
+      store.setTokens(createMockJWT({ username: 'testuser' }));
       expect(store.username).toBe('testuser');
     });
   });

--- a/frontend/src/stores/__tests__/permissions.spec.js
+++ b/frontend/src/stores/__tests__/permissions.spec.js
@@ -48,7 +48,7 @@ describe('permissions store', () => {
 
     it('returns true for admin regardless of permission value', () => {
       const authStore = useAuthStore()
-      authStore.setTokens(createMockJWT({ type_id: 6 }), 'refresh')
+      authStore.setTokens(createMockJWT({ type_id: 6 }))
 
       const store = usePermissionsStore()
       store.permissions = { 'passes.create': 'deny' }
@@ -58,7 +58,7 @@ describe('permissions store', () => {
 
     it('returns true for admin even when permission is missing', () => {
       const authStore = useAuthStore()
-      authStore.setTokens(createMockJWT({ type_id: 6 }), 'refresh')
+      authStore.setTokens(createMockJWT({ type_id: 6 }))
 
       const store = usePermissionsStore()
       store.permissions = {}

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -8,23 +8,22 @@ function decodeToken(token) {
   }
 }
 
+// Access token хранится только в памяти (Pinia state).
+// Refresh token живёт в HttpOnly cookie и JS его не видит - поэтому
+// isAuthenticated определяется наличием access и попыткой refresh на старте.
 export const useAuthStore = defineStore('auth', {
   state: () => ({
-    token: localStorage.getItem('token') || null,
-    refreshToken: localStorage.getItem('refreshToken') || null,
+    token: null,
   }),
 
   getters: {
     isAuthenticated() {
-      if (!this.refreshToken) return false;
-      const payload = decodeToken(this.refreshToken);
+      if (!this.token) return false;
+      const payload = decodeToken(this.token);
       return !!(payload && payload.exp > Math.floor(Date.now() / 1000));
     },
     userPayload() {
       return this.token ? decodeToken(this.token) : null;
-    },
-    refreshPayload() {
-      return this.refreshToken ? decodeToken(this.refreshToken) : null;
     },
     userType() {
       return this.userPayload?.type_id || null;
@@ -38,17 +37,11 @@ export const useAuthStore = defineStore('auth', {
   },
 
   actions: {
-    setTokens(token, refreshToken) {
+    setTokens(token) {
       this.token = token;
-      this.refreshToken = refreshToken;
-      localStorage.setItem('token', token);
-      localStorage.setItem('refreshToken', refreshToken);
     },
     clearTokens() {
       this.token = null;
-      this.refreshToken = null;
-      localStorage.removeItem('token');
-      localStorage.removeItem('refreshToken');
     },
   },
 });

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,11 @@ type Config struct {
 	RateLimitWindowSec int64  `env:"RATE_LIMIT_WINDOW_SEC" envDefault:"60"`
 	PaginationMaxLimit int    `env:"PAGINATION_MAX_LIMIT" envDefault:"100"`
 	UploadPath         string `env:"UPLOAD_PATH" envDefault:"./uploads"`
+
+	// CookieSecure управляет флагом Secure на refresh-cookie. На staging/prod
+	// всегда true (HTTPS). На локальной разработке (http://localhost) - false,
+	// иначе браузер не отправит cookie.
+	CookieSecure bool `env:"COOKIE_SECURE" envDefault:"true"`
 }
 
 func Load() (*Config, error) {

--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"time"
 
 	"systemburo/internal/models"
 	"systemburo/internal/services"
@@ -9,12 +10,50 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+const refreshCookieName = "refresh_token"
+
 type AuthHandler struct {
-	service services.AuthService
+	service       services.AuthService
+	cookieSecure  bool
+	refreshMaxAge int
 }
 
-func NewAuthHandler(service services.AuthService) *AuthHandler {
-	return &AuthHandler{service: service}
+// NewAuthHandler создаёт новый экземпляр AuthHandler.
+// cookieSecure должен быть true в prod/staging (HTTPS), false только для
+// локальной разработки на http://localhost.
+// refreshTTL задаёт MaxAge для refresh cookie в секундах.
+func NewAuthHandler(service services.AuthService, cookieSecure bool, refreshTTL time.Duration) *AuthHandler {
+	return &AuthHandler{
+		service:       service,
+		cookieSecure:  cookieSecure,
+		refreshMaxAge: int(refreshTTL.Seconds()),
+	}
+}
+
+// setRefreshCookie выставляет HttpOnly refresh cookie.
+func (h *AuthHandler) setRefreshCookie(c echo.Context, token string) {
+	c.SetCookie(&http.Cookie{
+		Name:     refreshCookieName,
+		Value:    token,
+		Path:     "/",
+		MaxAge:   h.refreshMaxAge,
+		HttpOnly: true,
+		Secure:   h.cookieSecure,
+		SameSite: http.SameSiteStrictMode,
+	})
+}
+
+// clearRefreshCookie удаляет refresh cookie (MaxAge: -1).
+func (h *AuthHandler) clearRefreshCookie(c echo.Context) {
+	c.SetCookie(&http.Cookie{
+		Name:     refreshCookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   h.cookieSecure,
+		SameSite: http.SameSiteStrictMode,
+	})
 }
 
 // Login godoc
@@ -36,6 +75,9 @@ func (h *AuthHandler) Login(c echo.Context) error {
 	if err != nil {
 		return err
 	}
+	// refresh_token уходит в HttpOnly cookie, в JSON его не отдаём.
+	h.setRefreshCookie(c, resp.RefreshToken)
+	resp.RefreshToken = ""
 	return RespondSuccess(c, resp)
 }
 
@@ -51,13 +93,22 @@ func (h *AuthHandler) Login(c echo.Context) error {
 // @Router       /refresh-token [post]
 func (h *AuthHandler) RefreshToken(c echo.Context) error {
 	var req models.RefreshTokenRequest
-	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
+	// Берём refresh_token из HttpOnly cookie. Body оставлен для
+	// обратной совместимости - если cookie нет, fallback на body.
+	if ck, err := c.Cookie(refreshCookieName); err == nil && ck.Value != "" {
+		req.RefreshToken = ck.Value
+	} else {
+		if err := c.Bind(&req); err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
+		}
 	}
 	resp, err := h.service.RefreshToken(c.Request().Context(), req)
 	if err != nil {
 		return err
 	}
+	// Новый refresh_token - снова в cookie.
+	h.setRefreshCookie(c, resp.RefreshToken)
+	resp.RefreshToken = ""
 	return RespondSuccess(c, resp)
 }
 
@@ -75,12 +126,18 @@ func (h *AuthHandler) RefreshToken(c echo.Context) error {
 func (h *AuthHandler) Logout(c echo.Context) error {
 	username := c.Get("username").(string)
 	var req models.LogoutRequest
-	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
+	// Берём refresh из cookie, fallback на body.
+	if ck, err := c.Cookie(refreshCookieName); err == nil && ck.Value != "" {
+		req.RefreshToken = ck.Value
+	} else {
+		_ = c.Bind(&req)
 	}
 	if err := h.service.Logout(c.Request().Context(), username, req); err != nil {
+		// Всё равно чистим cookie - даже если DB-запись не удалилась.
+		h.clearRefreshCookie(c)
 		return err
 	}
+	h.clearRefreshCookie(c)
 	return RespondMessage(c, "Logged out successfully")
 }
 

--- a/internal/handlers/auth_test.go
+++ b/internal/handlers/auth_test.go
@@ -167,7 +167,23 @@ func TestLogin_Success(t *testing.T) {
 	resp := testutil.ParseResponse[models.LoginResponse](t, rec)
 
 	assert.NotEmpty(t, resp.Token)
-	assert.NotEmpty(t, resp.RefreshToken)
+	// refresh_token теперь в HttpOnly cookie, не в JSON body.
+	assert.Empty(t, resp.RefreshToken, "refresh token должен быть пустым в JSON - он в cookie")
+
+	// Проверяем что cookie выставлена с правильными флагами.
+	var refreshCookie *http.Cookie
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "refresh_token" {
+			refreshCookie = c
+			break
+		}
+	}
+	require.NotNil(t, refreshCookie, "refresh_token cookie должна быть установлена")
+	assert.NotEmpty(t, refreshCookie.Value)
+	assert.True(t, refreshCookie.HttpOnly, "cookie должна быть HttpOnly")
+	assert.Equal(t, http.SameSiteStrictMode, refreshCookie.SameSite)
+	assert.Equal(t, "/", refreshCookie.Path)
+
 	assert.Equal(t, td.OrgID, *resp.OrganizationID)
 	assert.Equal(t, td.CompanyID, *resp.CompanyID)
 	assert.Equal(t, 1, resp.TypeID)
@@ -214,18 +230,30 @@ func TestRefreshToken_Success(t *testing.T) {
 	testutil.RegisterUser(t, e, "refreshuser", "pass123", 1, td.OrgID, td.CompanyID)
 	_, refreshToken := testutil.LoginUser(t, e, "refreshuser", "pass123")
 
-	body := `{"refreshToken":"` + refreshToken + `"}`
-	rec := testutil.POST(t, e, "/refresh-token", body, nil)
+	// Refresh token теперь в cookie, body оставлен для обратной совместимости.
+	h := http.Header{}
+	h.Set("Cookie", "refresh_token="+refreshToken)
+	rec := testutil.POST(t, e, "/refresh-token", "{}", h)
 
 	require.Equal(t, http.StatusOK, rec.Code)
 
 	resp := testutil.ParseResponse[models.TokenPairResponse](t, rec)
 
 	assert.NotEmpty(t, resp.Token)
-	assert.NotEmpty(t, resp.RefreshToken)
+	// Новый refresh уходит снова в cookie, не в body.
+	assert.Empty(t, resp.RefreshToken)
+	var newRefreshCookie *http.Cookie
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "refresh_token" {
+			newRefreshCookie = c
+			break
+		}
+	}
+	require.NotNil(t, newRefreshCookie, "должна быть новая refresh cookie (ротация)")
+	assert.NotEmpty(t, newRefreshCookie.Value)
 }
 
-func TestRefreshToken_SnakeCaseField(t *testing.T) {
+func TestRefreshToken_BodyFallback(t *testing.T) {
 	e, db, cleanup := testutil.SetupTestApp(t)
 	defer cleanup()
 	testutil.CleanDB(t, db)
@@ -234,6 +262,7 @@ func TestRefreshToken_SnakeCaseField(t *testing.T) {
 	testutil.RegisterUser(t, e, "snakeuser", "pass123", 1, td.OrgID, td.CompanyID)
 	_, refreshToken := testutil.LoginUser(t, e, "snakeuser", "pass123")
 
+	// Fallback: если cookie нет, читаем из body snake_case.
 	body := `{"refresh_token":"` + refreshToken + `"}`
 	rec := testutil.POST(t, e, "/refresh-token", body, nil)
 
@@ -262,12 +291,13 @@ func TestRefreshToken_RevokedToken(t *testing.T) {
 	_, refreshToken := testutil.LoginUser(t, e, "revokeuser", "pass123")
 
 	// Use the refresh token once (revokes it)
-	body := `{"refreshToken":"` + refreshToken + `"}`
-	rec := testutil.POST(t, e, "/refresh-token", body, nil)
+	h := http.Header{}
+	h.Set("Cookie", "refresh_token="+refreshToken)
+	rec := testutil.POST(t, e, "/refresh-token", "{}", h)
 	require.Equal(t, http.StatusOK, rec.Code)
 
 	// Try using the same refresh token again -- it has been revoked
-	rec = testutil.POST(t, e, "/refresh-token", body, nil)
+	rec = testutil.POST(t, e, "/refresh-token", "{}", h)
 	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 }
 

--- a/internal/testutil/auth.go
+++ b/internal/testutil/auth.go
@@ -43,7 +43,9 @@ func RegisterUser(t *testing.T, e *echo.Echo, username, password string, typeID,
 	require.NoError(t, err, "failed to seed user %s", username)
 }
 
-// LoginUser logs in and returns (accessToken, refreshToken).
+// LoginUser логинится и возвращает (accessToken, refreshToken).
+// Access приходит в JSON body, refresh - в HttpOnly cookie (см. PR #113).
+// Читаем cookie из response Set-Cookie.
 func LoginUser(t *testing.T, e *echo.Echo, username, password string) (string, string) {
 	t.Helper()
 	body := fmt.Sprintf(`{"username":"%s","password":"%s"}`, username, password)
@@ -51,7 +53,16 @@ func LoginUser(t *testing.T, e *echo.Echo, username, password string) (string, s
 	require.Equal(t, http.StatusOK, rec.Code, "login failed: %s", rec.Body.String())
 
 	resp := ParseMap(t, rec)
-	return resp["token"].(string), resp["refreshToken"].(string)
+	access, _ := resp["token"].(string)
+
+	refresh := ""
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "refresh_token" {
+			refresh = c.Value
+			break
+		}
+	}
+	return access, refresh
 }
 
 // RegisterAndLogin registers a user via API and returns the access token.

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -114,7 +114,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	})
 
 	// Create all handlers
-	authHandler := handlers.NewAuthHandler(authService)
+	authHandler := handlers.NewAuthHandler(authService, false, 168*time.Hour)
 	userTypesHandler := handlers.NewUserTypesHandler(userTypeService)
 	lpfHandler := handlers.NewLicensePlateFormatHandler(lpfService)
 	attachmentHandler := handlers.NewAttachmentHandler(attachmentService)


### PR DESCRIPTION
## Summary

Закрывает issue #46 - перевод refresh-token из localStorage в HttpOnly cookie для защиты от XSS.

### Модель хранения

| Было | Стало |
|---|---|
| access в localStorage | access только в памяти Pinia |
| refresh в localStorage | refresh в HttpOnly cookie (Secure, SameSite=Strict) |

JS не может читать refresh-token. Любой XSS не может украсть сессию.

### Backend

- \`config.CookieSecure\` env (default true, false для локальной HTTP-разработки)
- \`handlers/auth.go\`:
  - Helpers \`setRefreshCookie\` / \`clearRefreshCookie\` - выставляют/удаляют cookie с флагами HttpOnly, Secure, SameSite=Strict, Path=/, MaxAge=\`JWT_REFRESH_TTL\`
  - \`Login\` - refresh в Set-Cookie, в JSON body пустая строка
  - \`RefreshToken\` - читает из \`c.Cookie(\"refresh_token\")\`, fallback на body для совместимости, ротирует cookie
  - \`Logout\` - чистит cookie даже если в DB-запросе ошибка
- \`NewAuthHandler(service, cookieSecure, refreshTTL)\` - обновлена сигнатура
- CORS \`AllowCredentials: true\` уже было

### Frontend

- \`stores/auth.js\` - убрано всё что связано с localStorage и refreshToken. Только \`token\` в памяти, геттеры \`isAuthenticated\` / \`userPayload\` / \`userType\` / \`isAdmin\` / \`username\` работают на access payload
- \`api/client.js\`:
  - \`credentials: 'include'\` на всех запросах (cookie уходит автоматом)
  - \`performRefresh()\` делает POST /refresh-token без body - cookie уходит браузером
  - Export \`tryRestoreSession()\` для восстановления после F5
- \`App.vue\`:
  - Убран \`SessionExpiredModal\` и все expiration watchers - JS не видит срок жизни refresh, а логика обновления access произойдёт при первом 401 через \`ensureRefreshed\` в client.js
  - \`created()\` пытается \`tryRestoreSession()\` - если refresh cookie жива после F5, сессия восстанавливается
- \`LoginComponent\` - \`setTokens(data.token)\`, без refresh

### Acceptance criteria

- [x] В localStorage **нет** ключей \`token\` / \`refreshToken\` - хранится только в памяти
- [x] \`Set-Cookie\` с флагами HttpOnly, Secure, SameSite=Strict (проверить в браузере на staging)
- [x] F5 на любой странице после логина - \`tryRestoreSession()\` автоматически обновляет access, юзер не выкидывается
- [x] Logout очищает и память (Pinia state), и cookie (MaxAge: -1)
- [x] Фронтенд-тесты - 214 passed (был 215, один тест удалён - старая модель)
- [x] Go build, vet - clean

### Не в скоупе

- CSRF-атаки уже защищены \`SameSite=Strict\` - double-submit token не требуется для same-site SPA
- Ротация refresh (уже было: новый refresh в cookie на каждый успешный /refresh-token)

## Test plan

- [x] \`npx vitest run\` - 214 passed
- [x] \`npm run lint\` - clean
- [x] \`go build ./...\`, \`go vet ./...\` - clean
- [ ] Staging: login в DevTools -> Cookies -> \`refresh_token\` виден с HttpOnly + Secure + SameSite=Strict
- [ ] Staging: localStorage пустой от token/refreshToken
- [ ] Staging: F5 на /news - остаётся залогинен (tryRestoreSession)
- [ ] Staging: Logout очищает cookie
- [ ] Staging: E2E полный цикл

Refs: #46