### PR TITLE
fix: session restore в main.js bootstrap + guard синхронный (#46)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -19,7 +19,7 @@
 </template>
 
 <script>
-import { apiRequest, tryRestoreSession } from '@/api/client'
+import { apiRequest } from '@/api/client'
 import { useAuthStore } from '@/stores/auth'
 import { usePermissionsStore } from '@/stores/permissions'
 import NavMenu from './components/NavMenu.vue';
@@ -79,16 +79,13 @@ export default {
       }
     },
   },
-  async created() {
-    // После F5 access_token в памяти потерян. Refresh cookie живёт на
-    // стороне сервера - пытаемся восстановить сессию одним запросом.
+  created() {
+    // tryRestoreSession вызывается в main.js ДО mount - auth уже hydrated.
+    // Здесь остаётся только загрузить permissions если юзер залогинен.
     const authStore = useAuthStore()
-    if (!authStore.token) {
-      const restored = await tryRestoreSession()
-      if (restored) {
-        const permissionsStore = usePermissionsStore()
-        permissionsStore.fetchPermissions()
-      }
+    if (authStore.token) {
+      const permissionsStore = usePermissionsStore()
+      permissionsStore.fetchPermissions()
     }
   },
 };

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -4,6 +4,7 @@ import App from './App.vue'
 import router from './router'
 import { vPermission } from './directives/permission'
 import bus from './eventBus'
+import { tryRestoreSession } from '@/api/client'
 import './assets/tokens.css'
 
 const app = createApp(App)
@@ -11,4 +12,11 @@ app.config.globalProperties.$bus = bus
 app.use(createPinia())
 app.use(router)
 app.directive('permission', vPermission)
+
+// Bootstrap: пробуем восстановить сессию из HttpOnly refresh cookie
+// ДО первой navigation. Без этого router guard срабатывает раньше
+// чем access token попадает в Pinia, и юзер на F5 выкидывается на /.
+// Silent fail OK - если cookie мёртв, guard просто redirect'ит на /.
+await tryRestoreSession()
+await router.isReady()
 app.mount('#app')

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -115,9 +115,21 @@ const router = createRouter({
   routes
 });
 
-router.beforeEach((to, from, next) => {
+router.beforeEach(async (to, from, next) => {
   const authStore = useAuthStore();
-  const isAuthenticated = authStore.isAuthenticated;
+  let isAuthenticated = authStore.isAuthenticated;
+
+  // После F5 access token в памяти потерян, но refresh cookie живёт
+  // на стороне сервера - пробуем восстановить сессию перед navigation.
+  // tryRestoreSession импортируется lazy чтобы избежать цикла.
+  if (to.meta.requiresAuth && !isAuthenticated) {
+    const { tryRestoreSession } = await import('@/api/client');
+    const restored = await tryRestoreSession();
+    if (restored) {
+      isAuthenticated = authStore.isAuthenticated;
+    }
+  }
+
   const isBuroPropuskov = authStore.isAdmin;
 
   if (to.meta.requiresAuth && !isAuthenticated) {

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -115,21 +115,13 @@ const router = createRouter({
   routes
 });
 
-router.beforeEach(async (to, from, next) => {
+// Guard синхронный - tryRestoreSession вызывается в main.js ДО mount,
+// поэтому к моменту первой navigation auth store уже hydrated (token
+// в памяти если refresh cookie жив). На F5 guard сразу видит реальное
+// состояние без async гонок.
+router.beforeEach((to, from, next) => {
   const authStore = useAuthStore();
-  let isAuthenticated = authStore.isAuthenticated;
-
-  // После F5 access token в памяти потерян, но refresh cookie живёт
-  // на стороне сервера - пробуем восстановить сессию перед navigation.
-  // tryRestoreSession импортируется lazy чтобы избежать цикла.
-  if (to.meta.requiresAuth && !isAuthenticated) {
-    const { tryRestoreSession } = await import('@/api/client');
-    const restored = await tryRestoreSession();
-    if (restored) {
-      isAuthenticated = authStore.isAuthenticated;
-    }
-  }
-
+  const isAuthenticated = authStore.isAuthenticated;
   const isBuroPropuskov = authStore.isAdmin;
 
   if (to.meta.requiresAuth && !isAuthenticated) {


### PR DESCRIPTION
## Summary

Фикс регрессии из #113: после F5 access token в памяти потерян, юзер выкидывался на \`/login\`.

### Почему выкидывало

Router guard проверял \`isAuthenticated\` синхронно. На F5 Pinia сбрасывается, token=null → guard не видит auth → redirect на \`/\` до того как что-либо успевает восстановить сессию из HttpOnly cookie.

### Подходы

**#1: async router guard** (мой первый вариант) - guard ждёт \`tryRestoreSession()\` если \`!isAuthenticated\`. Работает, но:
- Guard async, потенциал race conditions
- Pinia/router startup order становится неявным

**#2: Bootstrap в main.js** (итоговый) - \`tryRestoreSession()\` вызывается до \`app.mount()\`. К моменту первой navigation auth store уже hydrated. Канонический паттерн для Vue+Pinia+Router.

### Fix

\`main.js\`:
\`\`\`js
app.use(createPinia())
app.use(router)
await tryRestoreSession()   // cookie -> access in store
await router.isReady()
app.mount('#app')
\`\`\`

\`router.js\` - guard остаётся синхронным, никаких изменений кроме комментария.
\`App.vue.created()\` - \`tryRestoreSession\` убран (дубль), только \`fetchPermissions\` если залогинен.

### Частота HTTP restore

В обоих подходах \`if (!isAuthenticated)\` check делает \`tryRestoreSession\` **ровно 1 раз** после F5. После успеха token в Pinia → следующие навигации пропускают. Не плохо ни там, ни там.

## Test plan

- [x] \`npx vitest run\` - 214 passed
- [x] \`npm run lint\` - clean
- [ ] Staging: login /news, F5 - остаётся на /news (bootstrap restore сработал)
- [ ] Staging: logout → F5 - редирект на /
- [ ] Staging: стандартные навигации после login - без дополнительных refresh-запросов

Refs: #46