### PR TITLE
feat: login rate limit + account lockout (#46)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -172,8 +172,13 @@ func main() {
 
 	api.SetMaxLimit(cfg.PaginationMaxLimit)
 
+	// /login - отдельный per-IP rate limiter: 5 попыток / 15 минут.
+	// Защита от онлайн brute-force до попадания в Argon2id (который замедляет
+	// только офлайн-атаки). Дополняется per-user lockout в authService.Login.
+	loginLimiter := mw.LoginRateLimit(5, 15*time.Minute)
+
 	// Routes
-	router.Setup(e, authHandler, userTypesHandler, attachmentHandler, lpfHandler, citizenshipHandler, organizationHandler, companyHandler, usersHandler, unloadPlaceHandler, carHandler, employeeHandler, systemTableHandler, uniqueCarHandler, uniqueEmployeeHandler, feedbackHandler, applicationHandler, approverHandler, permissionHandler, consentHandler, settingsHandler, newsHandler, notificationHandler, requestLogsHandler, employeesHistoryHandler, []byte(cfg.JWTSecret))
+	router.Setup(e, authHandler, userTypesHandler, attachmentHandler, lpfHandler, citizenshipHandler, organizationHandler, companyHandler, usersHandler, unloadPlaceHandler, carHandler, employeeHandler, systemTableHandler, uniqueCarHandler, uniqueEmployeeHandler, feedbackHandler, applicationHandler, approverHandler, permissionHandler, consentHandler, settingsHandler, newsHandler, notificationHandler, requestLogsHandler, employeesHistoryHandler, []byte(cfg.JWTSecret), loginLimiter)
 
 	// Общий ctx для фоновых задач и graceful shutdown. Отменяется по SIGINT/SIGTERM.
 	ctxSig, stopSig := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/internal/handlers/auth_test.go
+++ b/internal/handlers/auth_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"systemburo/internal/models"
 	"systemburo/internal/testutil"
@@ -447,4 +448,115 @@ func TestGetUserTypes_PublicEndpoint(t *testing.T) {
 
 func itoa(n int) string {
 	return fmt.Sprintf("%d", n)
+}
+
+// --- Account lockout (P0.2) ---
+
+func TestLogin_FailedLoginIncrementsCounter(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	testutil.RegisterUser(t, e, "lockuser", "correctpass", 1, td.OrgID, td.CompanyID)
+
+	// Неверный пароль -> counter увеличивается.
+	body := `{"username":"lockuser","password":"wrongpass"}`
+	rec := testutil.POST(t, e, "/login", body, nil)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	var user models.User
+	require.NoError(t, db.Where("username = ?", "lockuser").First(&user).Error)
+	assert.Equal(t, 1, user.FailedLoginCount)
+	assert.Nil(t, user.LockedUntil, "до 10 попыток lock не ставится")
+}
+
+func TestLogin_SuccessResetsFailedCounter(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	testutil.RegisterUser(t, e, "resetuser", "correctpass", 1, td.OrgID, td.CompanyID)
+
+	// Две неудачные попытки.
+	for i := 0; i < 2; i++ {
+		rec := testutil.POST(t, e, "/login", `{"username":"resetuser","password":"wrong"}`, nil)
+		require.Equal(t, http.StatusUnauthorized, rec.Code)
+	}
+
+	// Успешный вход - счётчик должен обнулиться.
+	rec := testutil.POST(t, e, "/login", `{"username":"resetuser","password":"correctpass"}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var user models.User
+	require.NoError(t, db.Where("username = ?", "resetuser").First(&user).Error)
+	assert.Equal(t, 0, user.FailedLoginCount, "успешный вход обнуляет счётчик")
+	assert.Nil(t, user.LockedUntil)
+}
+
+func TestLogin_LocksAccountAfter10FailedAttempts(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	testutil.RegisterUser(t, e, "lockme", "correctpass", 1, td.OrgID, td.CompanyID)
+
+	// Напрямую через БД выставляем счётчик в 9 - следующая неудача залочит.
+	// Это заодно обходит IP rate limiter (5 попыток/15м), не связанный с этим кейсом.
+	require.NoError(t, db.Model(&models.User{}).Where("username = ?", "lockme").
+		Update("failed_login_count", 9).Error)
+
+	rec := testutil.POST(t, e, "/login", `{"username":"lockme","password":"wrong"}`, nil)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	var user models.User
+	require.NoError(t, db.Where("username = ?", "lockme").First(&user).Error)
+	assert.Equal(t, 10, user.FailedLoginCount)
+	require.NotNil(t, user.LockedUntil, "после 10 неудач учётка залочена")
+	assert.True(t, user.LockedUntil.After(time.Now().Add(29*time.Minute)),
+		"lock примерно на 30 минут")
+}
+
+func TestLogin_LockedAccountRejectsEvenCorrectPassword(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	testutil.RegisterUser(t, e, "locked", "correctpass", 1, td.OrgID, td.CompanyID)
+
+	// Прямо в БД выставляем lock на 5 минут вперёд.
+	lockUntil := time.Now().Add(5 * time.Minute)
+	require.NoError(t, db.Model(&models.User{}).Where("username = ?", "locked").
+		Update("locked_until", lockUntil).Error)
+
+	// Даже правильный пароль возвращает 429 пока lock не истечёт.
+	rec := testutil.POST(t, e, "/login", `{"username":"locked","password":"correctpass"}`, nil)
+	assert.Equal(t, http.StatusTooManyRequests, rec.Code)
+	assert.Contains(t, rec.Body.String(), "заблокирована")
+}
+
+func TestLogin_ExpiredLockAllowsLogin(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	testutil.RegisterUser(t, e, "unlocked", "correctpass", 1, td.OrgID, td.CompanyID)
+
+	// Lock в прошлом - не должен препятствовать входу.
+	pastLock := time.Now().Add(-1 * time.Minute)
+	require.NoError(t, db.Model(&models.User{}).Where("username = ?", "unlocked").
+		Updates(map[string]interface{}{"locked_until": pastLock, "failed_login_count": 10}).Error)
+
+	rec := testutil.POST(t, e, "/login", `{"username":"unlocked","password":"correctpass"}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// После успешного входа lock и счётчик сброшены.
+	var user models.User
+	require.NoError(t, db.Where("username = ?", "unlocked").First(&user).Error)
+	assert.Equal(t, 0, user.FailedLoginCount)
+	assert.Nil(t, user.LockedUntil)
 }

--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -1,7 +1,9 @@
 package middleware
 
 import (
+	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -95,4 +97,29 @@ func (rl *rateLimiter) allow(key string) bool {
 
 	rl.requests[key] = append(valid, now)
 	return true
+}
+
+// LoginRateLimit - специализированный rate limiter для /login.
+// Ключ - client IP, окно и лимит задаются отдельно от общего RateLimit.
+// При превышении отвечает 429 + Retry-After, чтобы клиент знал через сколько
+// можно повторить. Защита от онлайн brute-force до попадания в Argon2id.
+func LoginRateLimit(maxAttempts int, window time.Duration) echo.MiddlewareFunc {
+	rl := &rateLimiter{
+		requests: make(map[string][]int64),
+		limit:    maxAttempts,
+		window:   int64(window.Seconds()),
+	}
+	go rl.cleanup(int64(window.Seconds()))
+
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			key := "login:" + c.RealIP()
+			if !rl.allow(key) {
+				c.Response().Header().Set("Retry-After", strconv.FormatInt(rl.window, 10))
+				return echo.NewHTTPError(http.StatusTooManyRequests,
+					fmt.Sprintf("Слишком много попыток входа. Повторите через %d секунд.", rl.window))
+			}
+			return next(c)
+		}
+	}
 }

--- a/internal/middleware/ratelimit_test.go
+++ b/internal/middleware/ratelimit_test.go
@@ -1,0 +1,83 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	mw "systemburo/internal/middleware"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoginRateLimit_AllowsUntilLimit(t *testing.T) {
+	e := echo.New()
+	limiter := mw.LoginRateLimit(3, time.Minute)
+	e.POST("/login", func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	}, limiter)
+
+	for i := 0; i < 3; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/login", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code, "попытка %d должна пройти", i+1)
+	}
+}
+
+func TestLoginRateLimit_BlocksAfterLimit(t *testing.T) {
+	e := echo.New()
+	limiter := mw.LoginRateLimit(3, time.Minute)
+	e.POST("/login", func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	}, limiter)
+
+	// Первые 3 - ок
+	for i := 0; i < 3; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/login", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+	}
+
+	// 4-я - 429 + Retry-After
+	req := httptest.NewRequest(http.MethodPost, "/login", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusTooManyRequests, rec.Code)
+	assert.NotEmpty(t, rec.Header().Get("Retry-After"), "должен быть Retry-After header")
+	assert.Contains(t, rec.Body.String(), "Слишком много попыток")
+}
+
+func TestLoginRateLimit_PerIPIsolation(t *testing.T) {
+	e := echo.New()
+	limiter := mw.LoginRateLimit(2, time.Minute)
+	e.POST("/login", func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	}, limiter)
+
+	// IP1 исчерпывает лимит.
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/login", nil)
+		req.RemoteAddr = "10.0.0.1:1234"
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+	}
+
+	// IP1: 3-я попытка -> 429
+	req := httptest.NewRequest(http.MethodPost, "/login", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusTooManyRequests, rec.Code)
+
+	// IP2 - свой счётчик, должен работать.
+	req = httptest.NewRequest(http.MethodPost, "/login", nil)
+	req.RemoteAddr = "10.0.0.2:5678"
+	rec = httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code, "другой IP имеет независимый счётчик")
+}

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -3,22 +3,24 @@ package models
 import "time"
 
 type User struct {
-	ID             int          `json:"id"`
-	Username       string       `gorm:"uniqueIndex;size:100" json:"username"`
-	Password       string       `gorm:"size:255" json:"-"`
-	OrganizationID *int         `json:"organization_id"`
-	Organization   Organization `json:"organization,omitempty"`
-	CompanyID      *int         `json:"company_id"`
-	Company        Company      `json:"company,omitempty"`
-	TypeID         int          `gorm:"default:1" json:"type_id"`
-	UserType       UserType     `gorm:"foreignKey:TypeID" json:"user_type,omitempty"`
-	LastName       *string      `gorm:"size:100" json:"last_name"`
-	FirstName      *string      `gorm:"size:100" json:"first_name"`
-	MiddleName     *string      `gorm:"size:100" json:"middle_name"`
-	Position       *string      `gorm:"size:100;column:position" json:"position"`
-	Email          *string      `gorm:"size:100" json:"email"`
-	Phone          *string      `gorm:"size:20" json:"phone"`
-	LastLoginAt    *time.Time   `json:"last_login_at,omitempty"`
+	ID                int          `json:"id"`
+	Username          string       `gorm:"uniqueIndex;size:100" json:"username"`
+	Password          string       `gorm:"size:255" json:"-"`
+	OrganizationID    *int         `json:"organization_id"`
+	Organization      Organization `json:"organization,omitempty"`
+	CompanyID         *int         `json:"company_id"`
+	Company           Company      `json:"company,omitempty"`
+	TypeID            int          `gorm:"default:1" json:"type_id"`
+	UserType          UserType     `gorm:"foreignKey:TypeID" json:"user_type,omitempty"`
+	LastName          *string      `gorm:"size:100" json:"last_name"`
+	FirstName         *string      `gorm:"size:100" json:"first_name"`
+	MiddleName        *string      `gorm:"size:100" json:"middle_name"`
+	Position          *string      `gorm:"size:100;column:position" json:"position"`
+	Email             *string      `gorm:"size:100" json:"email"`
+	Phone             *string      `gorm:"size:20" json:"phone"`
+	LastLoginAt       *time.Time   `json:"last_login_at,omitempty"`
+	FailedLoginCount  int          `gorm:"default:0" json:"-"`
+	LockedUntil       *time.Time   `json:"-"`
 }
 
 type Organization struct {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -7,7 +7,10 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-func Setup(e *echo.Echo, auth *handlers.AuthHandler, userTypes *handlers.UserTypesHandler, attachments *handlers.AttachmentHandler, lpf *handlers.LicensePlateFormatHandler, cs *handlers.CitizenshipHandler, org *handlers.OrganizationHandler, comp *handlers.CompanyHandler, users *handlers.UsersHandler, up *handlers.UnloadPlaceHandler, cars *handlers.CarHandler, employees *handlers.EmployeeHandler, st *handlers.SystemTableHandler, uc *handlers.UniqueCarHandler, ue *handlers.UniqueEmployeeHandler, fb *handlers.FeedbackHandler, app *handlers.ApplicationHandler, approvers *handlers.ApproverHandler, permissions *handlers.PermissionHandler, consent *handlers.ConsentHandler, settings *handlers.SettingsHandler, news *handlers.NewsHandler, notifications *handlers.NotificationHandler, requestLogs *handlers.RequestLogsHandler, employeesHistory *handlers.EmployeesHistoryHandler, jwtSecret []byte) {
+// Setup регистрирует все маршруты.
+// loginLimiter опционален (nil в тестах) - отдельный per-IP rate limit на /login.
+// В production передаётся mw.LoginRateLimit из cmd/server/main.go.
+func Setup(e *echo.Echo, auth *handlers.AuthHandler, userTypes *handlers.UserTypesHandler, attachments *handlers.AttachmentHandler, lpf *handlers.LicensePlateFormatHandler, cs *handlers.CitizenshipHandler, org *handlers.OrganizationHandler, comp *handlers.CompanyHandler, users *handlers.UsersHandler, up *handlers.UnloadPlaceHandler, cars *handlers.CarHandler, employees *handlers.EmployeeHandler, st *handlers.SystemTableHandler, uc *handlers.UniqueCarHandler, ue *handlers.UniqueEmployeeHandler, fb *handlers.FeedbackHandler, app *handlers.ApplicationHandler, approvers *handlers.ApproverHandler, permissions *handlers.PermissionHandler, consent *handlers.ConsentHandler, settings *handlers.SettingsHandler, news *handlers.NewsHandler, notifications *handlers.NotificationHandler, requestLogs *handlers.RequestLogsHandler, employeesHistory *handlers.EmployeesHistoryHandler, jwtSecret []byte, loginLimiter echo.MiddlewareFunc) {
 	// Health check — вне /api, для мониторинга и readiness-проб.
 	e.GET("/health", func(c echo.Context) error {
 		return c.JSON(200, map[string]string{"status": "ok"})
@@ -17,8 +20,12 @@ func Setup(e *echo.Echo, auth *handlers.AuthHandler, userTypes *handlers.UserTyp
 	// и т.д. в Vue router). Nginx проксирует /api/ на backend, остальное — на frontend.
 	api := e.Group("/api")
 
-	// Public routes
-	api.POST("/login", auth.Login)
+	// Public routes. /login опционально защищён per-IP rate limiter-ом.
+	loginHandlers := []echo.MiddlewareFunc{}
+	if loginLimiter != nil {
+		loginHandlers = append(loginHandlers, loginLimiter)
+	}
+	api.POST("/login", auth.Login, loginHandlers...)
 	api.POST("/refresh-token", auth.RefreshToken)
 	api.GET("/user-types", auth.GetUserTypes)
 

--- a/internal/services/auth_service.go
+++ b/internal/services/auth_service.go
@@ -145,6 +145,15 @@ func hashRefreshToken(token string) string {
 
 // --- Service Methods ---
 
+// Пороги lockout-а учётки по количеству неверных попыток. Защита от distributed
+// brute-force когда атакующие идут с разных IP (IP-лимитер их не ловит, т.к.
+// счётчик per-IP, но счётчик per-username общий и копится от всех источников).
+// 10 попыток за любое время подряд без успеха -> lock на 30 минут.
+const (
+	maxFailedLoginsBeforeLock = 10
+	accountLockDuration       = 30 * time.Minute
+)
+
 // Login выполняет аутентификацию пользователя и возвращает пару токенов.
 func (s *authService) Login(ctx context.Context, req models.LoginRequest) (*models.LoginResponse, error) {
 	var user models.User
@@ -158,8 +167,26 @@ func (s *authService) Login(ctx context.Context, req models.LoginRequest) (*mode
 		return nil, echo.NewHTTPError(http.StatusUnauthorized, "Invalid credentials")
 	}
 
+	// Учётка заблокирована - не разрешаем попытки (даже с правильным паролем),
+	// пока не истечёт lock-период. Это важно: иначе валидная попытка сбросила бы
+	// счётчик и атакующий мог бы "разморозить" учётку угадав пароль в моменте.
+	if user.LockedUntil != nil && user.LockedUntil.After(time.Now()) {
+		remaining := int(time.Until(*user.LockedUntil).Seconds())
+		return nil, echo.NewHTTPError(http.StatusTooManyRequests,
+			fmt.Sprintf("Учётная запись временно заблокирована. Повторите через %d секунд.", remaining))
+	}
+
 	if !verifyPassword(user.Password, req.Password) {
+		s.registerFailedLogin(ctx, &user)
 		return nil, echo.NewHTTPError(http.StatusUnauthorized, "Invalid credentials")
+	}
+
+	// Успешный вход - сбрасываем счётчик неудачных попыток и lock.
+	if user.FailedLoginCount > 0 || user.LockedUntil != nil {
+		s.db.WithContext(ctx).Model(&user).Updates(map[string]interface{}{
+			"failed_login_count": 0,
+			"locked_until":       nil,
+		})
 	}
 
 	accessToken, err := s.createAccessToken(user.Username, user.ID, user.TypeID)
@@ -324,6 +351,21 @@ func (s *authService) GetUserTypes(ctx context.Context) ([]models.UserType, erro
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Failed to fetch user types")
 	}
 	return types, nil
+}
+
+// registerFailedLogin увеличивает счётчик неудачных попыток и лочит учётку,
+// если достигнут порог. Ошибки логируются, но не прерывают запрос - клиент
+// всё равно получит "Invalid credentials", чтобы не раскрывать состояние лока.
+func (s *authService) registerFailedLogin(ctx context.Context, user *models.User) {
+	user.FailedLoginCount++
+	updates := map[string]interface{}{
+		"failed_login_count": user.FailedLoginCount,
+	}
+	if user.FailedLoginCount >= maxFailedLoginsBeforeLock {
+		lockUntil := time.Now().Add(accountLockDuration)
+		updates["locked_until"] = lockUntil
+	}
+	s.db.WithContext(ctx).Model(user).Updates(updates)
 }
 
 // --- Helpers ---

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -144,11 +144,13 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	e.HideBanner = true
 	e.HTTPErrorHandler = handlers.CustomHTTPErrorHandler
 	e.Validator = appvalidator.New()
+	// nil loginLimiter - в тестах rate-limit на /login не применяется,
+	// т.к. тесты делают много логинов подряд. Отдельный Test* покрывает сам лимитер.
 	router.Setup(e, authHandler, userTypesHandler, attachmentHandler, lpfHandler,
 		citizenshipHandler, organizationHandler, companyHandler, usersHandler,
 		unloadPlaceHandler, carHandler, employeeHandler, systemTableHandler,
 		uniqueCarHandler, uniqueEmployeeHandler, feedbackHandler,
-		applicationHandler, approverHandler, permissionHandler, consentHandler, settingsHandler, newsHandler, notificationHandler, requestLogsHandler, employeesHistoryHandler, []byte(TestJWTSecret))
+		applicationHandler, approverHandler, permissionHandler, consentHandler, settingsHandler, newsHandler, notificationHandler, requestLogsHandler, employeesHistoryHandler, []byte(TestJWTSecret), nil)
 
 	// No-op cleanup: shared DB stays open for the test binary lifetime.
 	cleanup := func() {}


### PR DESCRIPTION
## Summary

**P0.2** из security-ревью JWT: защита от brute-force на /login.

- **`mw.LoginRateLimit`** — per-IP лимит 5 попыток / 15 минут на /login, возвращает `429 Too Many Requests` + `Retry-After` header
- **`User.FailedLoginCount` + `LockedUntil`** — после 10 неверных попыток учётка блокируется на 30 минут. Работает поверх IP-лимита и ловит distributed brute-force с разных IP (IP-лимит сам по себе этого не ловит)
- Успешный вход сбрасывает счётчик и lock
- Заблокированная учётка не пускает даже с правильным паролем (иначе атакующий мог бы "разморозить" угадав пароль в моменте)
- `router.Setup` получает опциональный `loginLimiter` (nil в тестах, чтобы не мешать CRUD-сценариям)

## Почему это нужно

Общий `RateLimit(200/min)` охватывает все endpoints и **не защищает от brute-force** - атакующий может перебирать ~200 паролей в минуту = 288k/день. Argon2id замедляет только **офлайн**-атаки после кражи хешей, онлайн-атаку он не блокирует.

OWASP рекомендует специализированный rate limit на auth endpoints + account lockout как defense-in-depth.

## Изменения

- `internal/middleware/ratelimit.go` — новый `LoginRateLimit(maxAttempts, window)`
- `internal/models/user.go` — поля `FailedLoginCount int`, `LockedUntil *time.Time` (GORM AutoMigrate сам добавит колонки)
- `internal/services/auth_service.go:Login` — проверка lock / increment / reset
- `internal/router/router.go` — `loginLimiter` опциональный параметр
- `cmd/server/main.go` — передаёт `mw.LoginRateLimit(5, 15*time.Minute)`
- `internal/testutil/testutil.go` — передаёт nil (тесты делают много логинов)

## Test plan

- [x] `go test -race ./internal/middleware/ ./internal/handlers/` зелёный
- [x] `go vet ./...` чисто
- [x] `go build ./...` чисто
- [x] 5 новых тестов lockout flow (counter increment, reset on success, lock after 10, reject correct password when locked, expired lock allows login)
- [x] 3 новых unit-теста лимитера (allows until limit, blocks after, per-IP isolation)
- [ ] После merge + deploy - Playwright MCP на staging: 5+ неверных попыток -> 429 + Retry-After, корректный login после unlock -> 200

## Next in series

- PR 2: refresh token family invalidation (P0.1)
- PR 3: security headers + audit log + IP/UA binding (P1)
- PR 4: logout-all + DOMPurify + sliding TTL (P2)