### PR TITLE
feat: refresh token family invalidation (#46)

### DIFF
--- a/internal/handlers/auth_test.go
+++ b/internal/handlers/auth_test.go
@@ -560,3 +560,103 @@ func TestLogin_ExpiredLockAllowsLogin(t *testing.T) {
 	assert.Equal(t, 0, user.FailedLoginCount)
 	assert.Nil(t, user.LockedUntil)
 }
+
+// --- Refresh token family invalidation (P0.1) ---
+
+func TestRefresh_ReuseDetection_InvalidatesFamily(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	testutil.RegisterUser(t, e, "replayuser", "pass123", 1, td.OrgID, td.CompanyID)
+	_, refresh1 := testutil.LoginUser(t, e, "replayuser", "pass123")
+
+	// Легитимная ротация: refresh1 -> refresh2.
+	h1 := http.Header{}
+	h1.Set("Cookie", "refresh_token="+refresh1)
+	rec := testutil.POST(t, e, "/refresh-token", "{}", h1)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Достаём refresh2 из cookie в ответе.
+	var refresh2 string
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "refresh_token" {
+			refresh2 = c.Value
+			break
+		}
+	}
+	require.NotEmpty(t, refresh2)
+
+	// Attacker пробует заюзать revoked refresh1 - должно триггернуть reuse detection.
+	rec = testutil.POST(t, e, "/refresh-token", "{}", h1)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Contains(t, rec.Body.String(), "reuse detected")
+
+	// refresh2 (активный до reuse) теперь тоже revoked - вся family мертва.
+	h2 := http.Header{}
+	h2.Set("Cookie", "refresh_token="+refresh2)
+	rec = testutil.POST(t, e, "/refresh-token", "{}", h2)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code,
+		"family invalidation: текущий активный токен тоже отозван")
+
+	// В БД все токены family должны быть is_revoked=true.
+	var activeCount int64
+	db.Model(&models.RefreshToken{}).
+		Where("user_id = (SELECT id FROM users WHERE username = ?) AND is_revoked = false", "replayuser").
+		Count(&activeCount)
+	assert.Equal(t, int64(0), activeCount, "все токены family должны быть отозваны")
+}
+
+func TestRefresh_NormalRotation_PreservesFamily(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	testutil.RegisterUser(t, e, "rotateuser", "pass123", 1, td.OrgID, td.CompanyID)
+	_, refresh1 := testutil.LoginUser(t, e, "rotateuser", "pass123")
+
+	// Делаем 3 последовательных легитимных ротации.
+	current := refresh1
+	var familyIDs []string
+	for i := 0; i < 3; i++ {
+		h := http.Header{}
+		h.Set("Cookie", "refresh_token="+current)
+		rec := testutil.POST(t, e, "/refresh-token", "{}", h)
+		require.Equal(t, http.StatusOK, rec.Code, "итерация %d", i)
+
+		for _, c := range rec.Result().Cookies() {
+			if c.Name == "refresh_token" {
+				current = c.Value
+				break
+			}
+		}
+	}
+
+	// Все 4 записи (login + 3 refresh) должны иметь один family_id.
+	db.Model(&models.RefreshToken{}).
+		Where("user_id = (SELECT id FROM users WHERE username = ?)", "rotateuser").
+		Distinct().Pluck("family_id", &familyIDs)
+	assert.Len(t, familyIDs, 1, "все токены одной сессии должны быть в одной family")
+	assert.NotEmpty(t, familyIDs[0])
+}
+
+func TestLogin_GeneratesNewFamily(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	testutil.RegisterUser(t, e, "multi", "pass123", 1, td.OrgID, td.CompanyID)
+
+	// Два независимых login - каждый со своей family.
+	testutil.LoginUser(t, e, "multi", "pass123")
+	testutil.LoginUser(t, e, "multi", "pass123")
+
+	var familyIDs []string
+	db.Model(&models.RefreshToken{}).
+		Where("user_id = (SELECT id FROM users WHERE username = ?)", "multi").
+		Distinct().Pluck("family_id", &familyIDs)
+	assert.Len(t, familyIDs, 2, "разные login-ы -> разные family")
+}

--- a/internal/models/refresh_token.go
+++ b/internal/models/refresh_token.go
@@ -2,9 +2,15 @@ package models
 
 import "time"
 
+// RefreshToken хранит хеш refresh-JWT с family_id для reuse detection.
+// FamilyID - uuid, общий для всех токенов-потомков одной сессии (login -> N refresh).
+// При попытке использовать уже revoked токен все токены family_id отзываются
+// (Auth0/OWASP паттерн): если и легитимный юзер, и attacker гоняют одну семью,
+// первый же conflict ломает всю сессию и заставляет перелогиниться.
 type RefreshToken struct {
 	ID        int       `json:"id"`
-	UserID    int       `json:"user_id"`
+	UserID    int       `gorm:"index" json:"user_id"`
+	FamilyID  string    `gorm:"size:36;index" json:"family_id"`
 	TokenHash string    `gorm:"uniqueIndex" json:"token_hash"`
 	ExpiresAt time.Time `json:"expires_at"`
 	CreatedAt time.Time `json:"created_at"`

--- a/internal/services/auth_service.go
+++ b/internal/services/auth_service.go
@@ -6,12 +6,14 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"time"
 
 	"systemburo/internal/models"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"golang.org/x/crypto/argon2"
 	"gorm.io/gorm"
@@ -109,10 +111,14 @@ func (s *authService) createAccessToken(username string, userID int, typeID int)
 }
 
 func (s *authService) createRefreshJWT(username string) (string, error) {
+	// JTI (JWT ID) делает каждый refresh-JWT уникальным, даже если выдан
+	// в ту же секунду. Без него refresh-токены с одинаковым subject+exp
+	// генерируют идентичные JWT -> идентичный hash -> конфликт в uniqueIndex.
 	claims := Claims{
 		TypeID: 0,
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject:   username,
+			ID:        uuid.NewString(),
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(s.refreshTTL)),
 		},
 	}
@@ -199,9 +205,12 @@ func (s *authService) Login(ctx context.Context, req models.LoginRequest) (*mode
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Failed to create refresh token")
 	}
 
-	// Store hashed refresh token in DB
+	// Store hashed refresh token in DB. FamilyID генерируется при login,
+	// наследуется всеми refresh-токенами одной сессии. См. RefreshToken.
+	familyID := uuid.NewString()
 	rt := models.RefreshToken{
 		UserID:    user.ID,
+		FamilyID:  familyID,
 		TokenHash: hashRefreshToken(refreshJWT),
 		ExpiresAt: time.Now().Add(s.refreshTTL),
 	}
@@ -220,6 +229,10 @@ func (s *authService) Login(ctx context.Context, req models.LoginRequest) (*mode
 }
 
 // RefreshToken обновляет пару access/refresh токенов с ротацией.
+// Reuse detection: если пришёл валидный по подписи, но уже отозванный токен -
+// это признак кражи (либо attacker, либо legitimate user использовал старую копию
+// после ротации). Реакция: инвалидировать всю семью (family_id) и заставить
+// перелогиниться. См. Auth0 refresh token rotation pattern.
 func (s *authService) RefreshToken(ctx context.Context, req models.RefreshTokenRequest) (*models.TokenPairResponse, error) {
 	refreshToken := req.GetRefreshToken()
 	claims, err := s.decodeRefreshToken(refreshToken)
@@ -234,20 +247,33 @@ func (s *authService) RefreshToken(ctx context.Context, req models.RefreshTokenR
 		return nil, echo.NewHTTPError(http.StatusUnauthorized, "User not found")
 	}
 
-	// Find and validate stored token
+	// Ищем запись без фильтра is_revoked - чтобы отличить "не существует" от
+	// "существует, но отозван" (второе - признак replay-атаки).
 	tokenHash := hashRefreshToken(refreshToken)
 	var storedToken models.RefreshToken
 	err = s.db.WithContext(ctx).
-		Where("user_id = ? AND token_hash = ? AND is_revoked = false", user.ID, tokenHash).
+		Where("user_id = ? AND token_hash = ?", user.ID, tokenHash).
 		First(&storedToken).Error
 	if err != nil {
 		return nil, echo.NewHTTPError(http.StatusUnauthorized, "Invalid refresh token")
 	}
 
-	// Revoke old token (one-time use)
+	if storedToken.IsRevoked {
+		// Reuse detection: токен валиден по подписи, но уже отозван.
+		// Инвалидируем всю семью - включая текущий активный refresh attacker-а
+		// или legitimate user-а. Оба будут вынуждены перелогиниться.
+		s.db.WithContext(ctx).
+			Model(&models.RefreshToken{}).
+			Where("family_id = ? AND is_revoked = false", storedToken.FamilyID).
+			Update("is_revoked", true)
+		slog.Warn("refresh token reuse detected - family invalidated",
+			"user_id", user.ID, "family_id", storedToken.FamilyID)
+		return nil, echo.NewHTTPError(http.StatusUnauthorized, "Refresh token reuse detected, please log in again")
+	}
+
+	// Ротация: помечаем старый revoked, выдаём новую пару в той же family.
 	s.db.WithContext(ctx).Model(&storedToken).Update("is_revoked", true)
 
-	// Create new pair
 	newAccess, err := s.createAccessToken(username, user.ID, user.TypeID)
 	if err != nil {
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Failed to create token")
@@ -258,9 +284,9 @@ func (s *authService) RefreshToken(ctx context.Context, req models.RefreshTokenR
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Failed to create refresh token")
 	}
 
-	// Store new refresh token
 	rt := models.RefreshToken{
 		UserID:    user.ID,
+		FamilyID:  storedToken.FamilyID,
 		TokenHash: hashRefreshToken(newRefresh),
 		ExpiresAt: time.Now().Add(s.refreshTTL),
 	}


### PR DESCRIPTION
## Summary

**P0.1** из security-ревью JWT: reuse detection с family invalidation. Auth0 / OWASP OAuth2 pattern.

- `RefreshToken.FamilyID` (uuid) — общий для всех токенов одной сессии (login -> N refresh). При login генерируется новый FamilyID, все refresh-потомки наследуют его.
- При попытке использовать уже `is_revoked=true` токен → reuse detection: инвалидируется **вся family**, включая текущий активный refresh. Клиент вынужден перелогиниться.
- Дополнительно: `createRefreshJWT` получил JTI (uuid в `jwt.ID`) — чинит latent bug: два refresh в одну секунду генерировали идентичный JWT → коллизия по `token_hash` uniqueIndex → INSERT молча проваливался.

## Почему это нужно

Без family invalidation: если кто-то украл refresh (MITM, компрометация устройства), legitimate user и attacker гоняют refresh параллельно, каждый неделю. Текущая ротация только revoke-ит конкретный использованный токен, а activenym выданный attacker-у — нет.

С family invalidation: первый же конфликт ломает всю сессию. Это compensating control на случай когда ты ещё не знаешь о компрометации.

## Изменения

- `internal/models/refresh_token.go` — `FamilyID string`, индекс
- `internal/services/auth_service.go`:
  - `createRefreshJWT` — добавлен JTI
  - `Login` — генерирует FamilyID
  - `RefreshToken` — на reuse invalidate всю family, логирует warn
- `internal/handlers/auth_test.go` — 3 новых теста (reuse detection, normal rotation preserves family, new login new family)

GORM AutoMigrate сам добавит колонку family_id при старте - existing refresh_tokens получат family_id='' и перестанут работать при следующем refresh (что эквивалентно force-logout). Для prod это допустимо - пользователи просто перелогинятся. Для нулевого downtime можно было бы заранее забэкфиллить, но плата не стоит усилий.

## Test plan

- [x] `go test -race ./...` зелёный (все 5 пакетов)
- [x] `go vet ./...` чисто
- [x] `go build ./...` чисто
- [x] Новые тесты: replay-attack, normal rotation, new login = new family
- [ ] После merge + deploy - Playwright MCP на staging: login -> refresh -> manual replay старого cookie через DevTools -> 401 + в БД все токены юзера revoked

## Depends on

После #117 (login rate limit). Ветка rebased на свежий dev.