### PR TITLE
feat: auth polish - logout-all + DOMPurify (#46)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "dompurify": "^3.4.1",
         "exceljs": "^4.4.0",
         "mitt": "^3.0.1",
         "pinia": "^2.3.0",
@@ -1743,6 +1744,13 @@
         "undici-types": "~7.18.0"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
@@ -2539,6 +2547,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/duplexer2": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "test:run": "vitest run"
   },
   "dependencies": {
+    "dompurify": "^3.4.1",
     "exceljs": "^4.4.0",
     "mitt": "^3.0.1",
     "pinia": "^2.3.0",

--- a/frontend/src/components/TablesComponent.vue
+++ b/frontend/src/components/TablesComponent.vue
@@ -152,6 +152,7 @@
 
 <script>
 import { apiRequest } from '@/api/client'
+import { sanitizeHtml } from '@/utils/sanitize';
 import OrganizationFilter from '@/components/OrganizationFilter.vue';
 import UnloadingPlaceFilter from '@/components/UnloadingPlaceFilter.vue';
 import RefreshButton from './RefreshButton.vue';
@@ -274,26 +275,7 @@ export default {
         },
         
         sanitizeHtml(content) {
-            if (!content) return '';
-            
-            const forbiddenTags = [
-                'script', 'style', 'link', 'meta', 'iframe', 'frame', 'frameset', 
-                'object', 'embed', 'applet', 'form', 'input', 'button', 'select',
-                'textarea', 'label', 'fieldset', 'legend', 'marquee', 'blink'
-            ];
-            
-            let sanitizedContent = content;
-            
-            forbiddenTags.forEach(tag => {
-                const regex = new RegExp(`<${tag}[^>]*>.*?</${tag}>`, 'gis');
-                sanitizedContent = sanitizedContent.replace(regex, '');
-            });
-            
-            sanitizedContent = sanitizedContent.replace(/ on\w+="[^"]*"/gi, '');
-            sanitizedContent = sanitizedContent.replace(/ javascript:/gi, '');
-            sanitizedContent = sanitizedContent.replace(/ expression\(/gi, '');
-            
-            return sanitizedContent;
+            return sanitizeHtml(content);
         },
 
         async fetchTableData() {

--- a/frontend/src/components/TextConstructor.vue
+++ b/frontend/src/components/TextConstructor.vue
@@ -201,6 +201,8 @@
 </template>
 
 <script>
+import { sanitizeHtml } from '@/utils/sanitize';
+
 export default {
   name: 'TextConstructor',
   props: {
@@ -246,27 +248,7 @@ export default {
   },
   computed: {
     sanitizedContent() {
-      // Запрещенные теги для безопасности
-      const forbiddenTags = [
-        'script', 'style', 'link', 'meta', 'iframe', 'frame', 'frameset', 
-        'object', 'embed', 'applet', 'form', 'input', 'button', 'select',
-        'textarea', 'label', 'fieldset', 'legend', 'marquee', 'blink'
-      ];
-      
-      let content = this.modelValue;
-      
-      // Удаляем запрещенные теги
-      forbiddenTags.forEach(tag => {
-        const regex = new RegExp(`<${tag}[^>]*>.*?</${tag}>`, 'gis');
-        content = content.replace(regex, '');
-      });
-      
-      // Удаляем опасные атрибуты
-      content = content.replace(/ on\w+="[^"]*"/gi, '');
-      content = content.replace(/ javascript:/gi, '');
-      content = content.replace(/ expression\(/gi, '');
-      
-      return content;
+      return sanitizeHtml(this.modelValue);
     }
   },
   methods: {

--- a/frontend/src/utils/sanitize.js
+++ b/frontend/src/utils/sanitize.js
@@ -1,0 +1,21 @@
+import DOMPurify from 'dompurify'
+
+/**
+ * Безопасная очистка HTML перед вставкой через v-html.
+ * DOMPurify - whitelist-based санитизер, покрывает обходы которые regex-blacklist
+ * пропускает (CDATA, HTML entities, mixed case, nested tags).
+ *
+ * Используется для admin-editable контента (инструкции в таблицах, текстовый
+ * конструктор) - input не доверенный, хотя authored админом.
+ *
+ * @param {string} dirty - исходный HTML
+ * @returns {string} - безопасный HTML
+ */
+export function sanitizeHtml(dirty) {
+  if (!dirty) return ''
+  return DOMPurify.sanitize(dirty, {
+    USE_PROFILES: { html: true },
+    FORBID_TAGS: ['style', 'script', 'iframe', 'form', 'input', 'button'],
+    FORBID_ATTR: ['onerror', 'onload', 'onclick', 'onmouseover', 'onfocus']
+  })
+}

--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -141,6 +141,25 @@ func (h *AuthHandler) Logout(c echo.Context) error {
 	return RespondMessage(c, "Logged out successfully")
 }
 
+// LogoutAll godoc
+// @Summary      Выйти со всех устройств
+// @Description  Отзывает все активные refresh-токены пользователя
+// @Tags         auth
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200 {object} map[string]int "количество отозванных сессий в поле revoked"
+// @Failure      401 {object} models.HTTPError
+// @Router       /logout-all [post]
+func (h *AuthHandler) LogoutAll(c echo.Context) error {
+	username := c.Get("username").(string)
+	revoked, err := h.service.LogoutAll(c.Request().Context(), username)
+	if err != nil {
+		return err
+	}
+	h.clearRefreshCookie(c)
+	return RespondSuccess(c, map[string]int{"revoked": revoked})
+}
+
 // requestMeta - helper для сбора IP/UA из echo.Context в services.RequestMeta.
 func requestMeta(c echo.Context) *services.RequestMeta {
 	return &services.RequestMeta{

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -34,6 +34,7 @@ func Setup(e *echo.Echo, auth *handlers.AuthHandler, userTypes *handlers.UserTyp
 	protected.Use(mw.JWTAuth(jwtSecret))
 
 	protected.POST("/logout", auth.Logout)
+	protected.POST("/logout-all", auth.LogoutAll)
 	protected.GET("/user-data", auth.GetUserData)
 	protected.GET("/users/me", auth.GetCurrentUser)
 	protected.GET("/users/current", auth.GetCurrentUser)

--- a/internal/services/auth_service.go
+++ b/internal/services/auth_service.go
@@ -37,6 +37,7 @@ type AuthService interface {
 	Login(ctx context.Context, req models.LoginRequest, meta *RequestMeta) (*models.LoginResponse, error)
 	RefreshToken(ctx context.Context, req models.RefreshTokenRequest, meta *RequestMeta) (*models.TokenPairResponse, error)
 	Logout(ctx context.Context, username string, req models.LogoutRequest, meta *RequestMeta) error
+	LogoutAll(ctx context.Context, username string) (int, error)
 	GetUserData(ctx context.Context, username string) (*models.UserDataResponse, error)
 	GetCurrentUser(ctx context.Context, username string) (*models.CurrentUserResponse, error)
 	GetUserTypes(ctx context.Context) ([]models.UserType, error)
@@ -338,6 +339,25 @@ func (s *authService) Logout(ctx context.Context, username string, req models.Lo
 	s.recordAuthEvent(ctx, &user.ID, user.Username, models.AuthEventLogout, true, meta, "")
 
 	return nil
+}
+
+// LogoutAll отзывает ВСЕ активные refresh_tokens пользователя. Использовать
+// когда подозревается компрометация (юзер сам инициировал "выйти везде"),
+// или автоматически при смене пароля. Возвращает количество отозванных токенов.
+func (s *authService) LogoutAll(ctx context.Context, username string) (int, error) {
+	var user models.User
+	if err := s.db.WithContext(ctx).Where("username = ?", username).First(&user).Error; err != nil {
+		return 0, echo.NewHTTPError(http.StatusUnauthorized, "User not found")
+	}
+
+	result := s.db.WithContext(ctx).
+		Model(&models.RefreshToken{}).
+		Where("user_id = ? AND is_revoked = false", user.ID).
+		Update("is_revoked", true)
+	if result.Error != nil {
+		return 0, echo.NewHTTPError(http.StatusInternalServerError, "Failed to revoke sessions")
+	}
+	return int(result.RowsAffected), nil
 }
 
 // GetUserData возвращает профильные данные пользователя по username.

--- a/internal/services/user_service.go
+++ b/internal/services/user_service.go
@@ -154,6 +154,8 @@ func (s *userService) UpdateType(ctx context.Context, callerTypeID int, username
 }
 
 // UpdatePassword хеширует и обновляет пароль пользователя.
+// После смены пароля все refresh_tokens юзера отзываются - иначе старые
+// сессии (возможно скомпрометированные) продолжили бы жить до истечения TTL.
 func (s *userService) UpdatePassword(ctx context.Context, callerTypeID int, username string, req models.UpdatePasswordRequest) error {
 	if err := s.checkAdmin(ctx, callerTypeID); err != nil {
 		return err
@@ -166,6 +168,18 @@ func (s *userService) UpdatePassword(ctx context.Context, callerTypeID int, user
 		Where("username = ?", username).
 		Update("password", hashed).Error; err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "Error updating password")
+	}
+
+	// Revoke all active refresh tokens: чтобы существующие сессии с этой учёткой
+	// (возможно скомпрометированные) не дожили до своего TTL. Юзеру придётся
+	// перелогиниться на всех устройствах. Not-found = пользователь без активных
+	// сессий - это ок.
+	var user models.User
+	if err := s.db.WithContext(ctx).Where("username = ?", username).First(&user).Error; err == nil {
+		s.db.WithContext(ctx).
+			Model(&models.RefreshToken{}).
+			Where("user_id = ? AND is_revoked = false", user.ID).
+			Update("is_revoked", true)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

**P2** из security-ревью JWT. Три небольших hardening-правки.

### 1. POST /logout-all

Новый endpoint: отзывает **все** активные refresh_tokens текущего юзера. Полезно когда юзер подозревает компрометацию ("выйти везде").

```
POST /api/logout-all
Authorization: Bearer <token>
→ 200 { "revoked": 3 }
```

Также чистит текущее HttpOnly cookie.

### 2. Revoke-all при смене пароля

`PUT /users/:username/password` теперь автоматически инвалидирует все существующие refresh_tokens юзера. Без этого после смены пароля скомпрометированные сессии продолжали бы жить до 7-дневного TTL refresh-токена.

### 3. DOMPurify вместо кастомного sanitizeHtml

`frontend/src/components/TablesComponent.vue` и `TextConstructor.vue` использовали regex-based blacklist для `v-html`:
- легко обходится: CDATA, HTML entities, mixed case, nested tags
- неполный список запрещённых тегов/атрибутов

Заменено на `DOMPurify.sanitize()` (whitelist). Общий wrapper в `frontend/src/utils/sanitize.js`.

## Что НЕ входит (отложено)

- **Sliding refresh TTL** — нужна колонка `last_used_at` + миграция + логика extend-if-recent. Не критично, откладывается до отдельного PR с обоснованием.

## Test plan

- [x] `go test -race ./...` — зелёный (5 пакетов)
- [x] `go vet ./...` — чисто
- [x] `go build ./...` — чисто
- [x] Frontend vitest — 214 passed
- [x] ESLint — чисто
- [ ] После merge + deploy - Playwright MCP на staging:
  - POST /logout-all → refresh-token cookie очищен, next request без credentials 401
  - Смена пароля через админку → другие сессии юзера умирают
  - Инструкция таблицы с `<img src=x onerror=alert(1)>` не выполняет скрипт

## Depends on

После #119 (auth-hardening). Rebased на свежий dev.