### PR TITLE
feat: HSTS header в nginx configs (#46)

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -41,6 +41,10 @@ server {
     }
 
     # Security headers
+    # HSTS: TLS terminates на внешнем уровне (VPS/Caddy), внутренний nginx работает
+    # по HTTP - echo не может активировать HSTS сам. Ставим на уровне nginx. 2 года -
+    # рекомендация OWASP для production. includeSubDomains + preload для max protection.
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;

--- a/nginx/staging.conf
+++ b/nginx/staging.conf
@@ -60,6 +60,10 @@ server {
     }
 
     # Security headers
+    # HSTS: TLS terminates на внешнем уровне (VPS/Caddy), внутренний nginx работает
+    # по HTTP - echo не может активировать HSTS сам. Ставим на уровне nginx. 2 года -
+    # рекомендация OWASP для production. includeSubDomains + preload для max protection.
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;


### PR DESCRIPTION
## Summary

Завершает **P1** из security-ревью JWT (#119).

Echo `SecureWithConfig` не ставил `Strict-Transport-Security` потому что внутренний nginx → backend работает по HTTP (TLS terminates на внешнем уровне). Echo проверяет `c.IsTLS() || X-Forwarded-Proto=https` — ни то ни другое не срабатывает в нашей конфигурации.

Ставим HSTS на уровне nginx. Применяется и для staging, и для production.

## Что добавлено

```nginx
add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
```

- `max-age=63072000` — 2 года, OWASP recommendation для production
- `includeSubDomains` — защита всех поддоменов
- `preload` — готовность включить в [HSTS preload list](https://hstspreload.org)

## Test plan

- [x] Файлы обновлены: `nginx/nginx.conf` (prod) + `nginx/staging.conf`
- [ ] После auto-deploy на staging: `curl -I -u admin:... https://stagingburo.washka17.site/` должен показать `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload`
- [ ] securityheaders.com grade ≥A

## Risk

HSTS с `includeSubDomains` означает что все поддомены должны быть на HTTPS. Если есть внутренние http-поддомены — они сломаются. На staging нет subdomains, на prod нужно сверить.