### PR TITLE
feat: cookie-based staging auth bypass (#46)

### DIFF
--- a/nginx/staging.conf
+++ b/nginx/staging.conf
@@ -10,11 +10,27 @@ upstream pgadmin {
     server pgadmin:80;
 }
 
+# Cookie-based staging auth: после успешного Basic Auth выставляем cookie на 7
+# дней, последующие запросы проходят без повторного prompt-а. Решает проблему
+# Chromium incognito/hard-reload где basic auth cache сбрасывается при каждом
+# F5. $cookie_staging_auth = "ok" -> auth_basic off; иначе требуем Basic Auth.
+map $cookie_staging_auth $staging_realm {
+    default "Staging";
+    "ok"    off;
+}
+
+# Set-Cookie ставим только на не-401 ответах. На 401 (basic auth fail) cookie
+# НЕ ставим - иначе любой с неправильным паролем получил бы cookie и обошёл auth.
+map $status $staging_auth_set_cookie {
+    "401"   "";
+    default "staging_auth=ok; Path=/; Max-Age=604800; HttpOnly; Secure; SameSite=Strict";
+}
+
 server {
     listen 80;
     server_name _;
 
-    auth_basic "Staging";
+    auth_basic $staging_realm;
     auth_basic_user_file /etc/nginx/.htpasswd;
 
     # Health check (без basic auth — CI/CD и мониторинг)
@@ -69,4 +85,8 @@ server {
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'self';" always;
+
+    # Staging auth cookie (см. map выше). "always" - на всех статусах, map сам
+    # фильтрует 401 в пустую строку (nginx игнорирует пустой Set-Cookie).
+    add_header Set-Cookie $staging_auth_set_cookie always;
 }


### PR DESCRIPTION
## Summary

Фикс второй проблемы из security/UX сессии: **Chromium incognito и hard reload (Ctrl+F5) при каждом F5 показывают basic auth prompt**.

Это известное поведение nginx basic auth: credentials кэшируются в browser session, но incognito + DevTools `Disable cache` + hard reload сбрасывают этот кэш. Итог:
- юзер на F5 получает 401 на `/assets/*.js` (даже если страница сама успевает загрузиться)
- SPA bundle грузится частично → tryRestoreSession падает → redirect на login
- UX: "F5 выкидывает из аккаунта"

## Решение

После успешного Basic Auth ставим HttpOnly cookie `staging_auth=ok` на 7 дней, дальше nginx пропускает без prompt-а:

```nginx
map $cookie_staging_auth $staging_realm {
    default "Staging";  # нет cookie - требуем basic auth
    "ok"    off;         # есть cookie - пропускаем
}

map $status $staging_auth_set_cookie {
    "401"   "";          # basic auth failed - НЕ ставим cookie
    default "staging_auth=ok; Path=/; Max-Age=604800; HttpOnly; Secure; SameSite=Strict";
}

server {
    auth_basic $staging_realm;
    ...
    add_header Set-Cookie $staging_auth_set_cookie always;
}
```

## Защита от обхода

Cookie ставится **только** на non-401 ответах. Если юзер ввёл неправильный пароль → 401 от auth_basic → map возвращает пустую строку → `Set-Cookie` не добавляется. Юзер не может "украсть" cookie через failed login.

Cookie флаги: `HttpOnly` (JS не читает), `Secure` (только HTTPS), `SameSite=Strict` (только same-site).

## Scope

Только `nginx/staging.conf`. Production `nginx.conf` без basic auth, менять не нужно.

## Test plan

- [ ] После deploy: в новом incognito окне открыть staging, ввести basic auth
- [ ] F5 - не должен показать prompt снова
- [ ] Ctrl+F5 - тоже не должен (cookie переживёт)
- [ ] `curl -u admin:... https://stagingburo.washka17.site/ -D - -o /dev/null | grep set-cookie` - видим `staging_auth=ok; ...`
- [ ] `curl -u admin:wrong https://... -D - | grep set-cookie` - НЕ видим `staging_auth`