### PR TITLE
fix: bootstrap race на F5 - tryRestoreSession до app.use(router) (#46)

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -10,13 +10,15 @@ import './assets/tokens.css'
 const app = createApp(App)
 app.config.globalProperties.$bus = bus
 app.use(createPinia())
-app.use(router)
 app.directive('permission', vPermission)
 
-// Bootstrap: пробуем восстановить сессию из HttpOnly refresh cookie
-// ДО первой navigation. Без этого router guard срабатывает раньше
-// чем access token попадает в Pinia, и юзер на F5 выкидывается на /.
-// Silent fail OK - если cookie мёртв, guard просто redirect'ит на /.
+// Bootstrap: восстанавливаем сессию из HttpOnly refresh cookie ДО app.use(router).
+// Vue Router 4.x триггерит initial navigation синхронно при install - если router
+// подключить раньше, guard успеет прочитать пустой authStore.token и редиректнуть
+// на /, а наш await tryRestoreSession() применится уже ПОСЛЕ редиректа.
+// Silent fail OK: если cookie мёртв, guard штатно отправит на /.
 await tryRestoreSession()
+
+app.use(router)
 await router.isReady()
 app.mount('#app')


### PR DESCRIPTION
## Root cause

Vue Router 4.x в `router.install()` **синхронно** запускает initial navigation. Guard выполняется в microtask ещё до того как `await tryRestoreSession()` успеет вернуть управление и установить token в Pinia.

Последовательность **до фикса**:
1. `app.use(router)` — router installed, initial navigation **kicked off**, guard runs with `authStore.token = null`
2. Guard: `requiresAuth=true && !isAuthenticated` → `next('/')` — редирект **уже произошёл**
3. `await tryRestoreSession()` — token устанавливается, но поздно
4. `app.mount()` — SPA рендерит login page вместо /news

## Воспроизведение

Playwright на staging: navigate('/news') → landed на '/' с валидным JWT в Pinia. Token установлен, но path '/' — подтверждение что guard отработал РАНЬШЕ restore.

## Fix

Переместить `tryRestoreSession()` до `app.use(router)`. Pinia уже установлена после `app.use(createPinia())`, поэтому `useAuthStore()` внутри restore работает. Router подключается уже с восстановленным token в store.

```diff
 const app = createApp(App)
 app.use(createPinia())
-app.use(router)
 app.directive('permission', vPermission)

+await tryRestoreSession()
+
+app.use(router)
 await router.isReady()
 app.mount('#app')
-await tryRestoreSession()
```

## Test plan

- [x] `npm run lint` — чисто
- [x] `npm run test:run` — 214/214 passed
- [ ] После deploy - Playwright MCP на staging: login → /news → F5 → остался на /news
- [ ] В incognito тоже работает