### PR TITLE
chore: Node 20 -> 24 upgrade

### DIFF
--- a/.github/actions/setup-frontend/action.yml
+++ b/.github/actions/setup-frontend/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '24'
         cache: npm
         cache-dependency-path: frontend/package-lock.json
     - name: Install dependencies

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Dev stage
-FROM node:20-alpine AS dev
+FROM node:24-alpine AS dev
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci
@@ -8,7 +8,7 @@ EXPOSE 8081
 CMD ["npm", "run", "dev", "--", "--host"]
 
 # Builder stage
-FROM node:20-alpine AS builder
+FROM node:24-alpine AS builder
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci


### PR DESCRIPTION
## Summary

Обновление Node с 20 на 24 — frontend build image + CI action.

**Почему:**
- GitHub Actions показывает deprecation warnings: Node 20 будет forced на Node 24 c 2 июня 2026, удалён 16 сентября 2026
- Node 24 stable, V8 значительно быстрее
- Vite 8, Vue 3.5, ESLint 10, vitest 4 официально поддерживают Node 24

## Изменения

- `frontend/Dockerfile`: `node:20-alpine` → `node:24-alpine` в dev + builder stages
- `.github/actions/setup-frontend/action.yml`: `node-version: '20'` → `'24'`

## Test plan

- [x] package.json не имеет `engines` field — никаких ограничений на версию
- [ ] CI: Frontend Lint, Frontend Unit Tests, Docker Build, Deploy to Staging — все должны пройти на Node 24

## Не трогаем

- Production frontend stage (`nginx:1.25-alpine`) — уже не Node
- Go backend — не связан