### PR TITLE
revert: Node 24 upgrade (staging VPS не может достучаться до npm registry)

### DIFF
--- a/.github/actions/setup-frontend/action.yml
+++ b/.github/actions/setup-frontend/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - uses: actions/setup-node@v4
       with:
-        node-version: '24'
+        node-version: '20'
         cache: npm
         cache-dependency-path: frontend/package-lock.json
     - name: Install dependencies

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Dev stage
-FROM node:24-alpine AS dev
+FROM node:20-alpine AS dev
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci
@@ -8,7 +8,7 @@ EXPOSE 8081
 CMD ["npm", "run", "dev", "--", "--host"]
 
 # Builder stage
-FROM node:24-alpine AS builder
+FROM node:20-alpine AS builder
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci


### PR DESCRIPTION
Откат #142. npm ci на Node 24 (npm 11) падает с ETIMEDOUT на staging VPS при обращении к registry.npmjs.org. На Node 20 (npm 10) работает.

Вероятная причина — npm 11 изменил сетевое поведение (HTTP/2? agent?), и Jino VPS не может установить connection. На локальном build через Playwright тест прошёл — проблема специфична для VPS.

План:
- Revert, staging снова работает
- Попробовать Node 22 LTS (npm 10.9) отдельным PR
- Либо исследовать npm config на VPS (registry, proxy, HTTP/1.1 force)