### PR TITLE
fix(ci): deploy-staging always() - не skip транзитивно на frontend-only PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,14 @@ jobs:
     name: Deploy to Staging
     runs-on: ubuntu-latest
     needs: docker-build
-    if: github.ref == 'refs/heads/dev' && github.event_name == 'push'
+    # always() нужен чтобы deploy не skipped транзитивно когда какие-то
+    # upstream jobs (backend-test/frontend-test) skip из-за paths filter.
+    # Docker Build сам использует always() по той же причине.
+    if: |
+      always() &&
+      github.ref == 'refs/heads/dev' &&
+      github.event_name == 'push' &&
+      needs.docker-build.result == 'success'
     environment: staging
     permissions:
       contents: write


### PR DESCRIPTION
## Root cause

Deploy to Staging **не запускается** на frontend-only PR.

**Почему skipped:**
- Paths filter определяет `backend: false` при PR изменяющих только frontend
- `backend-test` skipped
- `docker-build` needs=[paths, backend-test, frontend-test] — имеет `if: always() && !failure`, поэтому запускается и success
- `deploy-staging` needs=docker-build БЕЗ `always()` → GitHub Actions наследует skip от транзитивных upstream (backend-test) → deploy skipped

Это объясняет:
- PR #141 (eslint, frontend-only) — deploy skipped, staging не обновился
- PR #145 (Dockerfile retry, frontend-only) — deploy skipped

## Fix

```yaml
deploy-staging:
  if: |
    always() &&
    github.ref == 'refs/heads/dev' &&
    github.event_name == 'push' &&
    needs.docker-build.result == 'success'
```

`always()` игнорирует транзитивный skip, `needs.docker-build.result == 'success'` — sanity check что сборка действительно прошла.

## Test plan

- [ ] После merge: Deploy to Staging **запустится** (даже если backend-test skipped)
- [ ] Если npm registry доступен — deploy пройдёт с retry из #145
- [ ] Если нет — deploy упадёт на npm timeout, тут уже отдельная проблема сети VPS