### PR TITLE
fix: npm mirror (npmmirror.com) + ENV vars для retry

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,13 +1,15 @@
 # Dev stage
 FROM node:20-alpine AS dev
 WORKDIR /app
-# Staging VPS периодически теряет connectivity к registry.npmjs.org. Ставим
-# агрессивный retry (10 попыток, 20s-2m exponential). Перед npm ci прогреваем
-# DNS через explicit lookup чтобы не залипнуть на первом таймауте.
-RUN npm config set fetch-retries 10 && \
-    npm config set fetch-retry-mintimeout 20000 && \
-    npm config set fetch-retry-maxtimeout 120000 && \
-    npm config set fetch-timeout 600000
+# Staging Jino VPS (RU) теряет connectivity к registry.npmjs.org (Cloudflare).
+# Переключаем на npmmirror.com (Китай, доступен из РФ, честное зеркало - integrity
+# hashes из package-lock.json валидны). Retry оставляем агрессивный через ENV,
+# который npm точно подхватывает (в отличие от 'npm config set' в RUN-layer).
+ENV NPM_CONFIG_REGISTRY=https://registry.npmmirror.com \
+    NPM_CONFIG_FETCH_RETRIES=10 \
+    NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=30000 \
+    NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=300000 \
+    NPM_CONFIG_FETCH_TIMEOUT=900000
 COPY package.json package-lock.json ./
 RUN npm ci
 COPY . .
@@ -17,10 +19,11 @@ CMD ["npm", "run", "dev", "--", "--host"]
 # Builder stage
 FROM node:20-alpine AS builder
 WORKDIR /app
-RUN npm config set fetch-retries 10 && \
-    npm config set fetch-retry-mintimeout 20000 && \
-    npm config set fetch-retry-maxtimeout 120000 && \
-    npm config set fetch-timeout 600000
+ENV NPM_CONFIG_REGISTRY=https://registry.npmmirror.com \
+    NPM_CONFIG_FETCH_RETRIES=10 \
+    NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=30000 \
+    NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=300000 \
+    NPM_CONFIG_FETCH_TIMEOUT=900000
 COPY package.json package-lock.json ./
 RUN npm ci
 COPY . .


### PR DESCRIPTION
## Продолжение #145

PR #145 (retry через `npm config set`) **не сработал** — npm упал за 16s вместо min 20s. Конфиг в RUN-layer не применился (скорее HOME mismatch).

## Что меняю

### 1. ENV vars вместо npm config set
`NPM_CONFIG_*` переменные npm **гарантированно** подхватывает. Никаких `~/.npmrc` проблем.

### 2. Зеркало npmmirror.com
registry.npmjs.org на Cloudflare IP (104.16.x.x), которые **возможно режутся RKN из РФ**. Из моего sandbox работает, из Jino VPS — нет.

`registry.npmmirror.com` — китайское **честное зеркало** npmjs, доступное из РФ. Контент тот же, integrity hashes из `package-lock.json` валидны.

## Риск

Если mirror тоже недоступен из-за сетевых проблем VPS — проблема глобально, решается на VPS стороне (VPN, transparent proxy, другой провайдер).

## Test plan

- [ ] После merge — Deploy to Staging успешно пройдёт `npm ci`