### PR TITLE
chore: eslint-plugin-vue flat/recommended (auto-fix чистка)

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -12,7 +12,7 @@ export default [
     ignores: ['dist/', 'node_modules/', 'coverage/', 'playwright-report/', 'test-results/', 'e2e/.auth/']
   },
   js.configs.recommended,
-  ...vue.configs['flat/essential'],
+  ...vue.configs['flat/recommended'],
   {
     languageOptions: {
       ecmaVersion: 'latest',

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,16 +1,35 @@
 <template>
   <div id="app">
-    <a href="#main-content" class="skip-link">Перейти к основному содержанию</a>
+    <a
+      href="#main-content"
+      class="skip-link"
+    >Перейти к основному содержанию</a>
     <NavMenu
       v-if="showChrome"
       :is-buropropuskov="isBuropropuskov"
       @logout="logout"
     />
-    <div class="content" id="main-content">
-      <TheHeader class="theheader" v-if="showChrome"/>
-      <router-view v-slot="{ Component }" class="content__container">
-        <transition name="page-fade" mode="out-in">
-          <component :is="Component" @login-success="handleSuccessfulLogin" :key="$route.path" />
+    <div
+      id="main-content"
+      class="content"
+    >
+      <TheHeader
+        v-if="showChrome"
+        class="theheader"
+      />
+      <router-view
+        v-slot="{ Component }"
+        class="content__container"
+      >
+        <transition
+          name="page-fade"
+          mode="out-in"
+        >
+          <component
+            :is="Component"
+            :key="$route.path"
+            @login-success="handleSuccessfulLogin"
+          />
         </transition>
       </router-view>
       <ScrollTopButton v-if="showChrome" />
@@ -53,6 +72,15 @@ export default {
       return this.isAuthenticated && this.$route.path !== '/';
     }
   },
+  created() {
+    // tryRestoreSession вызывается в main.js ДО mount - auth уже hydrated.
+    // Здесь остаётся только загрузить permissions если юзер залогинен.
+    const authStore = useAuthStore()
+    if (authStore.token) {
+      const permissionsStore = usePermissionsStore()
+      permissionsStore.fetchPermissions()
+    }
+  },
   methods: {
     handleSuccessfulLogin(tokenData) {
       const authStore = useAuthStore()
@@ -78,15 +106,6 @@ export default {
         }
       }
     },
-  },
-  created() {
-    // tryRestoreSession вызывается в main.js ДО mount - auth уже hydrated.
-    // Здесь остаётся только загрузить permissions если юзер залогинен.
-    const authStore = useAuthStore()
-    if (authStore.token) {
-      const permissionsStore = usePermissionsStore()
-      permissionsStore.fetchPermissions()
-    }
   },
 };
 </script>

--- a/frontend/src/components/AccountComponent.vue
+++ b/frontend/src/components/AccountComponent.vue
@@ -1,12 +1,21 @@
 <template>
-  <div class="account-dashboard" data-testid="cabinet-page">
+  <div
+    class="account-dashboard"
+    data-testid="cabinet-page"
+  >
     <!-- Первая строка: заголовок и заявки -->
     <div class="first-row">
       <SkeletonTransition :loading="loading">
         <template #skeleton>
           <div style="display: flex; gap: 20px; width: 100%;">
-            <SkeletonBlock height="200px" style="flex: 1;" />
-            <SkeletonBlock height="200px" style="flex: 1;" />
+            <SkeletonBlock
+              height="200px"
+              style="flex: 1;"
+            />
+            <SkeletonBlock
+              height="200px"
+              style="flex: 1;"
+            />
           </div>
         </template>
 
@@ -49,45 +58,82 @@
     </div>
 
     <!-- Вторая строка: управление пользователями (если доступно) -->
-    <div class="dashboard-row" id="users" v-if="isBuroPropuskov">
+    <div
+      v-if="isBuroPropuskov"
+      id="users"
+      class="dashboard-row"
+    >
       <UserControl 
-        :allUsers="allUsers"
+        :all-users="allUsers"
+        class="dashboard-card dashboard-card-animated"
         @fetch-users="fetchAllUsers"
         @user-updated="handleUserUpdated"
-        class="dashboard-card dashboard-card-animated"
       />
     </div>
 
     <!-- Третья строка: управление организациями (если доступно) -->
-    <div class="dashboard-row" id="organizations" v-if="isBuroPropuskov">
-      <OrganizationsManagement class="dashboard-card dashboard-card-animated"/>
+    <div
+      v-if="isBuroPropuskov"
+      id="organizations"
+      class="dashboard-row"
+    >
+      <OrganizationsManagement class="dashboard-card dashboard-card-animated" />
     </div>
-    <div class="dashboard-row" id="companies" v-if="isBuroPropuskov">
-      <CompaniesManagement class="dashboard-card dashboard-card-animated"/>
+    <div
+      v-if="isBuroPropuskov"
+      id="companies"
+      class="dashboard-row"
+    >
+      <CompaniesManagement class="dashboard-card dashboard-card-animated" />
     </div>
-    <div class="dashboard-row" id="unload_place" v-if="isBuroPropuskov">
-      <UnloadPlacesContainer class="dashboard-card dashboard-card-animated"/>
+    <div
+      v-if="isBuroPropuskov"
+      id="unload_place"
+      class="dashboard-row"
+    >
+      <UnloadPlacesContainer class="dashboard-card dashboard-card-animated" />
     </div>
-    <div class="dashboard-row" id="number" v-if="isBuroPropuskov">
-      <NumberFormat class="dashboard-card dashboard-card-animated"/>
+    <div
+      v-if="isBuroPropuskov"
+      id="number"
+      class="dashboard-row"
+    >
+      <NumberFormat class="dashboard-card dashboard-card-animated" />
     </div>
-    <div class="dashboard-row" v-if="isBuroPropuskov">
+    <div
+      v-if="isBuroPropuskov"
+      class="dashboard-row"
+    >
       <CitizenshipManagement class="dashboard-card dashboard-card-animated" />
     </div>
-    <div class="dashboard-row" id="tables" v-if="isBuroPropuskov">
+    <div
+      v-if="isBuroPropuskov"
+      id="tables"
+      class="dashboard-row"
+    >
       <TableConstructor class="dashboard-card dashboard-card-animated" />
     </div>
-     <div class="dashboard-row" id="user_types" v-if="isBuroPropuskov">
+    <div
+      v-if="isBuroPropuskov"
+      id="user_types"
+      class="dashboard-row"
+    >
       <UserTypes class="dashboard-card dashboard-card-animated" />
     </div>
-    <div class="dashboard-row" id="attachments" v-if="isBuroPropuskov">
+    <div
+      v-if="isBuroPropuskov"
+      id="attachments"
+      class="dashboard-row"
+    >
       <AttachmentsManagement class="dashboard-card dashboard-card-animated" />
     </div>
-    <div class="dashboard-row" id="approvers" v-if="isBuroPropuskov">
+    <div
+      v-if="isBuroPropuskov"
+      id="approvers"
+      class="dashboard-row"
+    >
       <ApplicationApprovers class="dashboard-card dashboard-card-animated" />
     </div>
-
-    
   </div>
 </template>
 
@@ -154,6 +200,12 @@ export default {
   computed: {
     isBuroPropuskov() {
       return this.type_id === 6 || this.user_type === 'buropropuskov';
+    }
+  },
+  mounted() {
+    this.fetchUserData();
+    if (this.isBuroPropuskov) {
+      this.fetchAllUsers();
     }
   },
   methods: {
@@ -233,12 +285,6 @@ export default {
           ...updatedUser
         };
       }
-    }
-  },
-  mounted() {
-    this.fetchUserData();
-    if (this.isBuroPropuskov) {
-      this.fetchAllUsers();
     }
   }
 };

--- a/frontend/src/components/AccountSettings.vue
+++ b/frontend/src/components/AccountSettings.vue
@@ -1,42 +1,80 @@
 <template>
   <div class="account__settings">
     <div class="settings__container">
-      <img src="@/assets/icons/settings.png" class="settings__icon" />
-      <h2 class="settings__title">Управление и настройка системы</h2>
+      <img
+        src="@/assets/icons/settings.png"
+        class="settings__icon"
+      >
+      <h2 class="settings__title">
+        Управление и настройка системы
+      </h2>
     </div>
     <ul class="settings__navigation">
       <li class="navigation__link">
-        <a href="#users" class="link">Пользователи</a>
+        <a
+          href="#users"
+          class="link"
+        >Пользователи</a>
       </li>
       <li class="navigation__link">
-        <a href="#organizations" class="link">Организации</a>
+        <a
+          href="#organizations"
+          class="link"
+        >Организации</a>
       </li>
       <li class="navigation__link">
-        <a href="#companies" class="link">Компании</a>
+        <a
+          href="#companies"
+          class="link"
+        >Компании</a>
       </li>
       <li class="navigation__link">
-        <a href="#" class="link disabled">Доступ</a>
+        <a
+          href="#"
+          class="link disabled"
+        >Доступ</a>
       </li>
       <li class="navigation__link">
-        <a href="#tables" class="link">Таблицы</a>
+        <a
+          href="#tables"
+          class="link"
+        >Таблицы</a>
       </li>
       <li class="navigation__link">
-        <a href="#number" class="link">Авто-номера</a>
+        <a
+          href="#number"
+          class="link"
+        >Авто-номера</a>
       </li>
       <li class="navigation__link">
-        <a href="#unload_place" class="link">Разгрузка</a>
+        <a
+          href="#unload_place"
+          class="link"
+        >Разгрузка</a>
       </li>
       <li class="navigation__link">
-        <a href="#" class="link disabled">Уведомления</a>
+        <a
+          href="#"
+          class="link disabled"
+        >Уведомления</a>
       </li>
       <li class="navigation__link">
-        <a href="#attachments" class="link">Бланки</a>
-      </li>
-       <li class="navigation__link">
-        <a href="#" class="link disabled">Карта</a>
+        <a
+          href="#attachments"
+          class="link"
+        >Бланки</a>
       </li>
       <li class="navigation__link">
-        <a href="#user_types" class="link">Типы аккаунта</a>
+        <a
+          href="#"
+          class="link disabled"
+        >Карта</a>
+      </li>
+      <li class="navigation__link">
+        <a
+          href="#user_types"
+          class="link"
+        >Типы аккаунта</a>
       </li>
     </ul>
   </div>

--- a/frontend/src/components/AnnouncementModal.vue
+++ b/frontend/src/components/AnnouncementModal.vue
@@ -1,27 +1,45 @@
 <template>
   <teleport to="body">
     <transition name="modal-fade">
-      <div v-if="show" class="modal-overlay" @click.self="close">
+      <div
+        v-if="show"
+        class="modal-overlay"
+        @click.self="close"
+      >
         <div class="modal-content announcement-modal">
-        
           <div class="modal-body">
             <!-- Заголовок перед описанием -->
             
             
             <div class="modal-info">
               <time class="modal-date">{{ formatDate(announcement?.created_at) }}</time>
-              <span class="modal-type" :class="{ important: announcement?.is_important }">
+              <span
+                class="modal-type"
+                :class="{ important: announcement?.is_important }"
+              >
                 {{ announcement?.is_important ? 'Важное объявление' : 'Объявление' }}
               </span>
             </div>
-            <h3 class="modal-title">{{ announcement?.title }}</h3>
-            <p class="modal-description">{{ announcement?.description }}</p>
-            <div v-if="announcement?.full_text" class="modal-full-text">
+            <h3 class="modal-title">
+              {{ announcement?.title }}
+            </h3>
+            <p class="modal-description">
+              {{ announcement?.description }}
+            </p>
+            <div
+              v-if="announcement?.full_text"
+              class="modal-full-text"
+            >
               {{ announcement.full_text }}
             </div>
           </div>
           <div class="modal-footer">
-            <button class="btn close-modal-btn" @click="close">Закрыть</button>
+            <button
+              class="btn close-modal-btn"
+              @click="close"
+            >
+              Закрыть
+            </button>
           </div>
         </div>
       </div>

--- a/frontend/src/components/ApplicationApprovers.vue
+++ b/frontend/src/components/ApplicationApprovers.vue
@@ -1,14 +1,19 @@
 <template>
   <div class="approvers-management-container dashboard-card">
     <div class="management-header">
-      <h3 class="management-title">Принимающие заявки</h3>
+      <h3 class="management-title">
+        Принимающие заявки
+      </h3>
       <div class="header-controls">
         <SearchComponent
-          :title="'Поиск принимающих...'"
           v-model="searchQuery"
+          :title="'Поиск принимающих...'"
         />
         
-        <button @click="showAddModal = true" class="add-header-button">
+        <button
+          class="add-header-button"
+          @click="showAddModal = true"
+        >
           Добавить принимающего
         </button>
         <RefreshButton @refresh="refreshData" />
@@ -17,11 +22,19 @@
 
     <div class="content-container">
       <!-- Левая часть - список принимающих (50%) -->
-      <div class="table-section" :class="{'with-details': selectedApprover}">
+      <div
+        class="table-section"
+        :class="{'with-details': selectedApprover}"
+      >
         <div class="table-container">
           <div class="table-header">
-            <div class="header-col id-col" @click="sortBy('id')">
-              <p :class="{ 'active-sort': sortField === 'id' }">ID</p>
+            <div
+              class="header-col id-col"
+              @click="sortBy('id')"
+            >
+              <p :class="{ 'active-sort': sortField === 'id' }">
+                ID
+              </p>
               <img 
                 src="@/assets/icons/sort.png" 
                 class="sort-icon" 
@@ -29,10 +42,15 @@
                   'sorted': sortField === 'id',
                   'desc': sortField === 'id' && sortDirection === 'desc'
                 }" 
-              />
+              >
             </div>
-            <div class="header-col name-col" @click="sortBy('full_name')">
-              <p :class="{ 'active-sort': sortField === 'full_name' }">ФИО</p>
+            <div
+              class="header-col name-col"
+              @click="sortBy('full_name')"
+            >
+              <p :class="{ 'active-sort': sortField === 'full_name' }">
+                ФИО
+              </p>
               <img 
                 src="@/assets/icons/sort.png" 
                 class="sort-icon" 
@@ -40,10 +58,15 @@
                   'sorted': sortField === 'full_name',
                   'desc': sortField === 'full_name' && sortDirection === 'desc'
                 }" 
-              />
+              >
             </div>
-            <div class="header-col date-col" @click="sortBy('created_at')">
-              <p :class="{ 'active-sort': sortField === 'created_at' }">Добавлен</p>
+            <div
+              class="header-col date-col"
+              @click="sortBy('created_at')"
+            >
+              <p :class="{ 'active-sort': sortField === 'created_at' }">
+                Добавлен
+              </p>
               <img 
                 src="@/assets/icons/sort.png" 
                 class="sort-icon" 
@@ -51,7 +74,7 @@
                   'sorted': sortField === 'created_at',
                   'desc': sortField === 'created_at' && sortDirection === 'desc'
                 }" 
-              />
+              >
             </div>
           </div>
 
@@ -67,7 +90,10 @@
                 <span class="cell-content id-value">{{ approver.id }}</span>
               </div>
               <div class="table-col name-col">
-                <span class="truncate-text" :title="getFullName(approver)">
+                <span
+                  class="truncate-text"
+                  :title="getFullName(approver)"
+                >
                   {{ getFullName(approver) }}
                 </span>
               </div>
@@ -86,16 +112,24 @@
       </div>
 
       <!-- Правая часть - детали принимающего (50%) -->
-      <div v-if="selectedApprover" class="details-section">
+      <div
+        v-if="selectedApprover"
+        class="details-section"
+      >
         <div class="details-content">
           <div class="details-header">
-            <h3 class="details-title">{{ getFullName(selectedApprover) }}</h3>
+            <h3 class="details-title">
+              {{ getFullName(selectedApprover) }}
+            </h3>
             <button 
-              @click="confirmDeleteApprover(selectedApprover)"
               class="delete-btn"
               title="Удалить"
+              @click="confirmDeleteApprover(selectedApprover)"
             >
-              <img src="@/assets/icons/delete.png" class="delete-icon" />
+              <img
+                src="@/assets/icons/delete.png"
+                class="delete-icon"
+              >
             </button>
           </div>
           
@@ -120,37 +154,55 @@
         </div>
       </div>
       
-      <div v-else class="no-selection-message">
+      <div
+        v-else
+        class="no-selection-message"
+      >
         <p>Выберите принимающего</p>
       </div>
     </div>
 
-    <div v-if="filteredApprovers.length === 0 && !searchQuery" class="no-results">
+    <div
+      v-if="filteredApprovers.length === 0 && !searchQuery"
+      class="no-results"
+    >
       <p>Нет принимающих</p>
     </div>
 
     <!-- Модальное окно добавления принимающего -->
-    <div v-if="showAddModal" class="modal-overlay" @click.self="closeAddModal">
+    <div
+      v-if="showAddModal"
+      class="modal-overlay"
+      @click.self="closeAddModal"
+    >
       <div class="modal modal-compact">
         <div class="modal-header">
           <h3>Добавить принимающего</h3>
-          <button class="modal-close" @click="closeAddModal">×</button>
+          <button
+            class="modal-close"
+            @click="closeAddModal"
+          >
+            ×
+          </button>
         </div>
         
         <div class="modal-content">
           <div class="user-search-section">
             <input
+              ref="searchInput"
               v-model="userSearchQuery"
-              @input="searchUsers"
-              @focus="showUserDropdown = true"
-              @blur="onSearchBlur"
               class="search-input"
               placeholder="Поиск пользователей..."
               type="text"
-              ref="searchInput"
               autocomplete="off"
-            />
-            <div v-if="showUserDropdown && filteredAvailableUsers.length > 0" class="user-dropdown">
+              @input="searchUsers"
+              @focus="showUserDropdown = true"
+              @blur="onSearchBlur"
+            >
+            <div
+              v-if="showUserDropdown && filteredAvailableUsers.length > 0"
+              class="user-dropdown"
+            >
               <div class="user-dropdown-content">
                 <div 
                   v-for="user in filteredAvailableUsers" 
@@ -159,16 +211,24 @@
                   @mousedown.prevent="addUser(user)"
                 >
                   <div class="user-info">
-                    <div class="user-name">{{ getFullName(user) }}</div>
+                    <div class="user-name">
+                      {{ getFullName(user) }}
+                    </div>
                     <div class="user-details">
                       <span class="user-username">@{{ user.username }}</span>
-                      <span v-if="user.position" class="user-position">{{ user.position }}</span>
+                      <span
+                        v-if="user.position"
+                        class="user-position"
+                      >{{ user.position }}</span>
                     </div>
                   </div>
                 </div>
               </div>
             </div>
-            <div v-else-if="showUserDropdown && filteredAvailableUsers.length === 0" class="user-dropdown no-results-dropdown">
+            <div
+              v-else-if="showUserDropdown && filteredAvailableUsers.length === 0"
+              class="user-dropdown no-results-dropdown"
+            >
               <div class="user-dropdown-content">
                 <div class="no-results-message">
                   Нет доступных пользователей
@@ -193,12 +253,15 @@
                   <div class="selected-user-info">
                     <span class="selected-user-name">{{ getFullName(user) }}</span>
                     <span class="selected-user-username">@{{ user.username }}</span>
-                    <span v-if="user.position" class="selected-user-position">{{ user.position }}</span>
+                    <span
+                      v-if="user.position"
+                      class="selected-user-position"
+                    >{{ user.position }}</span>
                   </div>
                   <button 
-                    @click="removeUser(user)"
                     class="remove-user-btn"
                     title="Удалить из списка"
+                    @click="removeUser(user)"
                   >
                     ×
                   </button>
@@ -209,13 +272,16 @@
         </div>
         
         <div class="modal-footer">
-          <button class="modal-cancel-btn" @click="closeAddModal">
+          <button
+            class="modal-cancel-btn"
+            @click="closeAddModal"
+          >
             Отмена
           </button>
           <button 
             class="modal-add-btn"
-            @click="addApprovers"
             :disabled="selectedUsers.length === 0 || loading"
+            @click="addApprovers"
           >
             {{ loading ? 'Добавление...' : `Добавить (${selectedUsers.length})` }}
           </button>
@@ -224,7 +290,11 @@
     </div>
 
     <!-- Уведомления -->
-    <div v-if="notification.show" class="notification" :class="notification.type">
+    <div
+      v-if="notification.show"
+      class="notification"
+      :class="notification.type"
+    >
       {{ notification.message }}
     </div>
   </div>
@@ -339,6 +409,9 @@ export default {
                position.includes(query);
       }).slice(0, 10);
     }
+  },
+  mounted() {
+    this.refreshData();
   },
   methods: {
     getFullName(user) {
@@ -503,9 +576,6 @@ export default {
         this.notification.show = false;
       }, 3000);
     }
-  },
-  mounted() {
-    this.refreshData();
   }
 };
 </script>

--- a/frontend/src/components/ApplicationDetail/ApplicationActionBar.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationActionBar.vue
@@ -1,260 +1,345 @@
 <template>
-    <div class="action-buttons-wrapper">
-        <!-- Режим центра заявок -->
-        <div v-if="mode === 'center'" class="action-buttons">
-            <!-- Для пользователей, которые одновременно являются принимающими и ответственными -->
-            <template v-if="isApproverUser && isResponsibleUser">
-                <!-- Если пользователь еще не голосовал -->
-                <template v-if="!hasUserVoted">
-                    <!-- Показываем кнопки согласования, если заявка не отклонена окончательно и не завершена -->
-                    <template v-if="application.confirmation !== 'Не согласовано' && application.status !== 'Завершено'">
-                        <button
-                            class="accept-btn"
-                            data-testid="app-detail-button-approve"
-                            @click="handleCombinedAction('accept')"
-                            :disabled="processing"
-                        >
-                            <span v-if="processing" class="button-loading"></span>
-                            <span v-else>Согласовать и принять</span>
-                        </button>
-                        <button
-                            class="reject-btn"
-                            data-testid="app-detail-button-reject"
-                            @click="handleCombinedAction('reject')"
-                            :disabled="processing"
-                        >
-                            <span v-if="processing" class="button-loading"></span>
-                            <span v-else>Отказать</span>
-                        </button>
-                    </template>
-                    <!-- Если заявка завершена -->
-                    <div v-else-if="application.status === 'Завершено'" class="status-badge status-completed-badge">
-                        Завершено
-                    </div>
-                    <!-- Если заявка отклонена окончательно -->
-                    <div v-else class="info-badge">
-                        Заявка отклонена
-                    </div>
-                </template>
+  <div class="action-buttons-wrapper">
+    <!-- Режим центра заявок -->
+    <div
+      v-if="mode === 'center'"
+      class="action-buttons"
+    >
+      <!-- Для пользователей, которые одновременно являются принимающими и ответственными -->
+      <template v-if="isApproverUser && isResponsibleUser">
+        <!-- Если пользователь еще не голосовал -->
+        <template v-if="!hasUserVoted">
+          <!-- Показываем кнопки согласования, если заявка не отклонена окончательно и не завершена -->
+          <template v-if="application.confirmation !== 'Не согласовано' && application.status !== 'Завершено'">
+            <button
+              class="accept-btn"
+              data-testid="app-detail-button-approve"
+              :disabled="processing"
+              @click="handleCombinedAction('accept')"
+            >
+              <span
+                v-if="processing"
+                class="button-loading"
+              />
+              <span v-else>Согласовать и принять</span>
+            </button>
+            <button
+              class="reject-btn"
+              data-testid="app-detail-button-reject"
+              :disabled="processing"
+              @click="handleCombinedAction('reject')"
+            >
+              <span
+                v-if="processing"
+                class="button-loading"
+              />
+              <span v-else>Отказать</span>
+            </button>
+          </template>
+          <!-- Если заявка завершена -->
+          <div
+            v-else-if="application.status === 'Завершено'"
+            class="status-badge status-completed-badge"
+          >
+            Завершено
+          </div>
+          <!-- Если заявка отклонена окончательно -->
+          <div
+            v-else
+            class="info-badge"
+          >
+            Заявка отклонена
+          </div>
+        </template>
 
-                <!-- Если пользователь уже проголосовал -->
-                <template v-else>
-                    <!-- Если заявка в работе - показываем статус и кнопку отзыва -->
-                    <template v-if="application.status === 'В работе'">
-                        <button
-                            class="subtle-btn"
-                            @click="revokeApplication"
-                            :disabled="processing"
-                        >
-                            <span v-if="processing" class="button-loading"></span>
-                            <span v-else>Отозвать из работы</span>
-                        </button>
-                        <div class="status-badge status-in-work-badge">
-                            В работе
-                        </div>
-                    </template>
-                    <!-- Если заявка отказана - показываем статус и кнопку возврата -->
-                    <template v-else-if="application.status === 'Отказано'">
-                        <button
-                            class="subtle-btn"
-                            @click="restoreApplication"
-                            :disabled="processing"
-                        >
-                            <span v-if="processing" class="button-loading"></span>
-                            <span v-else>Вернуть в работу</span>
-                        </button>
-                        <div class="status-badge status-rejected-badge">
-                            Отказано
-                        </div>
-                    </template>
-                    <!-- Если заявка завершена - просто показываем статус -->
-                    <template v-else-if="application.status === 'Завершено'">
-                        <div class="status-badge status-completed-badge">
-                            Завершено
-                        </div>
-                    </template>
-                    <!-- Если заявка не в работе, не отказана и не завершена, но согласована - показываем кнопки принять/отказать -->
-                    <template v-else-if="application.confirmation === 'Согласовано'">
-                        <button
-                            class="accept-btn"
-                            data-testid="app-detail-button-take-to-work"
-                            @click="handleApplicationAction('accept')"
-                            :disabled="processing"
-                        >
-                            <span v-if="processing" class="button-loading"></span>
-                            <span v-else>Принять</span>
-                        </button>
-                        <button
-                            class="reject-btn"
-                            data-testid="app-detail-button-reject"
-                            @click="handleApplicationAction('reject')"
-                            :disabled="processing"
-                        >
-                            <span v-if="processing" class="button-loading"></span>
-                            <span v-else>Отказать</span>
-                        </button>
-                    </template>
-                    <!-- Если пользователь проголосовал, но заявка не согласована (ждет других) -->
-                    <div v-else class="vote-status-badge" :class="userVoteStatus.class">
-                        {{ userVoteStatus.text }} (ожидание других)
-                    </div>
-                </template>
-            </template>
+        <!-- Если пользователь уже проголосовал -->
+        <template v-else>
+          <!-- Если заявка в работе - показываем статус и кнопку отзыва -->
+          <template v-if="application.status === 'В работе'">
+            <button
+              class="subtle-btn"
+              :disabled="processing"
+              @click="revokeApplication"
+            >
+              <span
+                v-if="processing"
+                class="button-loading"
+              />
+              <span v-else>Отозвать из работы</span>
+            </button>
+            <div class="status-badge status-in-work-badge">
+              В работе
+            </div>
+          </template>
+          <!-- Если заявка отказана - показываем статус и кнопку возврата -->
+          <template v-else-if="application.status === 'Отказано'">
+            <button
+              class="subtle-btn"
+              :disabled="processing"
+              @click="restoreApplication"
+            >
+              <span
+                v-if="processing"
+                class="button-loading"
+              />
+              <span v-else>Вернуть в работу</span>
+            </button>
+            <div class="status-badge status-rejected-badge">
+              Отказано
+            </div>
+          </template>
+          <!-- Если заявка завершена - просто показываем статус -->
+          <template v-else-if="application.status === 'Завершено'">
+            <div class="status-badge status-completed-badge">
+              Завершено
+            </div>
+          </template>
+          <!-- Если заявка не в работе, не отказана и не завершена, но согласована - показываем кнопки принять/отказать -->
+          <template v-else-if="application.confirmation === 'Согласовано'">
+            <button
+              class="accept-btn"
+              data-testid="app-detail-button-take-to-work"
+              :disabled="processing"
+              @click="handleApplicationAction('accept')"
+            >
+              <span
+                v-if="processing"
+                class="button-loading"
+              />
+              <span v-else>Принять</span>
+            </button>
+            <button
+              class="reject-btn"
+              data-testid="app-detail-button-reject"
+              :disabled="processing"
+              @click="handleApplicationAction('reject')"
+            >
+              <span
+                v-if="processing"
+                class="button-loading"
+              />
+              <span v-else>Отказать</span>
+            </button>
+          </template>
+          <!-- Если пользователь проголосовал, но заявка не согласована (ждет других) -->
+          <div
+            v-else
+            class="vote-status-badge"
+            :class="userVoteStatus.class"
+          >
+            {{ userVoteStatus.text }} (ожидание других)
+          </div>
+        </template>
+      </template>
 
-            <!-- Для принимающих заявки (не ответственных) -->
-            <template v-else-if="isApproverUser">
-                <!-- Если заявка в работе - показываем статус и кнопку отзыва -->
-                <template v-if="application.status === 'В работе'">
-                    <button
-                        class="subtle-btn"
-                        @click="revokeApplication"
-                        :disabled="processing"
-                    >
-                        <span v-if="processing" class="button-loading"></span>
-                        <span v-else>Отозвать из работы</span>
-                    </button>
-                    <div class="status-badge status-in-work-badge">
-                        В работе
-                    </div>
-                </template>
-                <!-- Если заявка отказана - показываем статус и кнопку возврата -->
-                <template v-else-if="application.status === 'Отказано'">
-                    <button
-                        class="subtle-btn"
-                        @click="restoreApplication"
-                        :disabled="processing"
-                    >
-                        <span v-if="processing" class="button-loading"></span>
-                        <span v-else>Вернуть в работу</span>
-                    </button>
-                    <div class="status-badge status-rejected-badge">
-                        Отказано
-                    </div>
-                </template>
-                <!-- Если заявка завершена -->
-                <template v-else-if="application.status === 'Завершено'">
-                    <div class="status-badge status-completed-badge">
-                        Завершено
-                    </div>
-                </template>
-                <!-- Если заявка не в работе и согласована - показываем кнопки принять/отказать -->
-                <template v-else-if="application.confirmation === 'Согласовано'">
-                    <button
-                        class="accept-btn"
-                        data-testid="app-detail-button-take-to-work"
-                        @click="handleApplicationAction('accept')"
-                        :disabled="processing"
-                    >
-                        <span v-if="processing" class="button-loading"></span>
-                        <span v-else>Принять</span>
-                    </button>
-                    <button
-                        class="reject-btn"
-                        data-testid="app-detail-button-reject"
-                        @click="handleApplicationAction('reject')"
-                        :disabled="processing"
-                    >
-                        <span v-if="processing" class="button-loading"></span>
-                        <span v-else>Отказать</span>
-                    </button>
-                </template>
-                <!-- Если заявка не согласована - показываем информационное сообщение -->
-                <div v-else class="info-badge">
-                    {{ getApproverStatusMessage }}
-                </div>
-            </template>
-
-            <!-- Для ответственных за согласование (не принимающих) -->
-            <template v-else-if="isResponsibleUser">
-                <!-- Если пользователь еще не голосовал -->
-                <template v-if="!hasUserVoted">
-                    <!-- Показываем кнопки согласования, когда заявка не отклонена и не завершена -->
-                    <template v-if="application.confirmation !== 'Не согласовано' && application.status !== 'Завершено'">
-                        <button
-                            class="confirm-btn"
-                            data-testid="app-detail-button-approve"
-                            @click="updateConfirmation('Согласовано')"
-                            :disabled="updatingConfirmation || processing"
-                        >
-                            <span v-if="updatingConfirmation" class="button-loading"></span>
-                            <span v-else>Согласовать</span>
-                        </button>
-                        <button
-                            class="reject-btn"
-                            data-testid="app-detail-button-reject"
-                            @click="updateConfirmation('Не согласовано')"
-                            :disabled="updatingConfirmation || processing"
-                        >
-                            <span v-if="updatingConfirmation" class="button-loading"></span>
-                            <span v-else>Отказать</span>
-                        </button>
-                    </template>
-                    <!-- Если заявка завершена -->
-                    <div v-else-if="application.status === 'Завершено'" class="status-badge status-completed-badge">
-                        Завершено
-                    </div>
-                    <!-- Если заявка отклонена окончательно -->
-                    <div v-else class="info-badge">
-                        Заявка отклонена
-                    </div>
-                </template>
-
-                <!-- Если пользователь уже проголосовал -->
-                <template v-else>
-                    <!-- Если заявка в работе - показываем только статус (нельзя отозвать) -->
-                    <template v-if="application.status === 'В работе'">
-                        <div class="vote-status-badge" :class="userVoteStatus.class">
-                            {{ userVoteStatus.text }}
-                        </div>
-                    </template>
-                    <!-- Если заявка завершена -->
-                    <template v-else-if="application.status === 'Завершено'">
-                        <div class="status-badge status-completed-badge">
-                            Завершено
-                        </div>
-                    </template>
-                    <!-- Если заявка не в работе и не завершена - показываем кнопку отзыва согласования -->
-                    <template v-else>
-                        <button
-                            class="revoke-approval-btn subtle-btn"
-                            @click="revokeOwnApproval"
-                            :disabled="processing"
-                        >
-                            <span v-if="processing" class="button-loading"></span>
-                            <span v-else>Отозвать своё решение</span>
-                        </button>
-                        <div class="vote-status-badge" :class="userVoteStatus.class">
-                            {{ userVoteStatus.text }}
-                        </div>
-                    </template>
-                </template>
-            </template>
-
-            <!-- Для остальных пользователей - только информация -->
-            <template v-else>
-                <div v-if="application.status === 'В работе'" class="status-badge status-in-work-badge">
-                    В работе
-                </div>
-                <div v-else-if="application.status === 'Отказано'" class="status-badge status-rejected-badge">
-                    Отказано
-                </div>
-                <div v-else-if="application.status === 'Завершено'" class="status-badge status-completed-badge">
-                    Завершено
-                </div>
-                <div v-else-if="application.confirmation === 'Согласовано'" class="status-badge status-approved-badge">
-                    Согласовано
-                </div>
-                <div v-else-if="application.confirmation === 'Согласование'" class="status-badge status-pending-badge">
-                    На согласовании
-                </div>
-            </template>
+      <!-- Для принимающих заявки (не ответственных) -->
+      <template v-else-if="isApproverUser">
+        <!-- Если заявка в работе - показываем статус и кнопку отзыва -->
+        <template v-if="application.status === 'В работе'">
+          <button
+            class="subtle-btn"
+            :disabled="processing"
+            @click="revokeApplication"
+          >
+            <span
+              v-if="processing"
+              class="button-loading"
+            />
+            <span v-else>Отозвать из работы</span>
+          </button>
+          <div class="status-badge status-in-work-badge">
+            В работе
+          </div>
+        </template>
+        <!-- Если заявка отказана - показываем статус и кнопку возврата -->
+        <template v-else-if="application.status === 'Отказано'">
+          <button
+            class="subtle-btn"
+            :disabled="processing"
+            @click="restoreApplication"
+          >
+            <span
+              v-if="processing"
+              class="button-loading"
+            />
+            <span v-else>Вернуть в работу</span>
+          </button>
+          <div class="status-badge status-rejected-badge">
+            Отказано
+          </div>
+        </template>
+        <!-- Если заявка завершена -->
+        <template v-else-if="application.status === 'Завершено'">
+          <div class="status-badge status-completed-badge">
+            Завершено
+          </div>
+        </template>
+        <!-- Если заявка не в работе и согласована - показываем кнопки принять/отказать -->
+        <template v-else-if="application.confirmation === 'Согласовано'">
+          <button
+            class="accept-btn"
+            data-testid="app-detail-button-take-to-work"
+            :disabled="processing"
+            @click="handleApplicationAction('accept')"
+          >
+            <span
+              v-if="processing"
+              class="button-loading"
+            />
+            <span v-else>Принять</span>
+          </button>
+          <button
+            class="reject-btn"
+            data-testid="app-detail-button-reject"
+            :disabled="processing"
+            @click="handleApplicationAction('reject')"
+          >
+            <span
+              v-if="processing"
+              class="button-loading"
+            />
+            <span v-else>Отказать</span>
+          </button>
+        </template>
+        <!-- Если заявка не согласована - показываем информационное сообщение -->
+        <div
+          v-else
+          class="info-badge"
+        >
+          {{ getApproverStatusMessage }}
         </div>
+      </template>
 
-        <!-- Режим просмотра заявок пользователя -->
-        <div v-if="mode === 'user'" class="view-buttons">
-            <slot name="user-actions"></slot>
+      <!-- Для ответственных за согласование (не принимающих) -->
+      <template v-else-if="isResponsibleUser">
+        <!-- Если пользователь еще не голосовал -->
+        <template v-if="!hasUserVoted">
+          <!-- Показываем кнопки согласования, когда заявка не отклонена и не завершена -->
+          <template v-if="application.confirmation !== 'Не согласовано' && application.status !== 'Завершено'">
+            <button
+              class="confirm-btn"
+              data-testid="app-detail-button-approve"
+              :disabled="updatingConfirmation || processing"
+              @click="updateConfirmation('Согласовано')"
+            >
+              <span
+                v-if="updatingConfirmation"
+                class="button-loading"
+              />
+              <span v-else>Согласовать</span>
+            </button>
+            <button
+              class="reject-btn"
+              data-testid="app-detail-button-reject"
+              :disabled="updatingConfirmation || processing"
+              @click="updateConfirmation('Не согласовано')"
+            >
+              <span
+                v-if="updatingConfirmation"
+                class="button-loading"
+              />
+              <span v-else>Отказать</span>
+            </button>
+          </template>
+          <!-- Если заявка завершена -->
+          <div
+            v-else-if="application.status === 'Завершено'"
+            class="status-badge status-completed-badge"
+          >
+            Завершено
+          </div>
+          <!-- Если заявка отклонена окончательно -->
+          <div
+            v-else
+            class="info-badge"
+          >
+            Заявка отклонена
+          </div>
+        </template>
+
+        <!-- Если пользователь уже проголосовал -->
+        <template v-else>
+          <!-- Если заявка в работе - показываем только статус (нельзя отозвать) -->
+          <template v-if="application.status === 'В работе'">
+            <div
+              class="vote-status-badge"
+              :class="userVoteStatus.class"
+            >
+              {{ userVoteStatus.text }}
+            </div>
+          </template>
+          <!-- Если заявка завершена -->
+          <template v-else-if="application.status === 'Завершено'">
+            <div class="status-badge status-completed-badge">
+              Завершено
+            </div>
+          </template>
+          <!-- Если заявка не в работе и не завершена - показываем кнопку отзыва согласования -->
+          <template v-else>
+            <button
+              class="revoke-approval-btn subtle-btn"
+              :disabled="processing"
+              @click="revokeOwnApproval"
+            >
+              <span
+                v-if="processing"
+                class="button-loading"
+              />
+              <span v-else>Отозвать своё решение</span>
+            </button>
+            <div
+              class="vote-status-badge"
+              :class="userVoteStatus.class"
+            >
+              {{ userVoteStatus.text }}
+            </div>
+          </template>
+        </template>
+      </template>
+
+      <!-- Для остальных пользователей - только информация -->
+      <template v-else>
+        <div
+          v-if="application.status === 'В работе'"
+          class="status-badge status-in-work-badge"
+        >
+          В работе
         </div>
+        <div
+          v-else-if="application.status === 'Отказано'"
+          class="status-badge status-rejected-badge"
+        >
+          Отказано
+        </div>
+        <div
+          v-else-if="application.status === 'Завершено'"
+          class="status-badge status-completed-badge"
+        >
+          Завершено
+        </div>
+        <div
+          v-else-if="application.confirmation === 'Согласовано'"
+          class="status-badge status-approved-badge"
+        >
+          Согласовано
+        </div>
+        <div
+          v-else-if="application.confirmation === 'Согласование'"
+          class="status-badge status-pending-badge"
+        >
+          На согласовании
+        </div>
+      </template>
     </div>
+
+    <!-- Режим просмотра заявок пользователя -->
+    <div
+      v-if="mode === 'user'"
+      class="view-buttons"
+    >
+      <slot name="user-actions" />
+    </div>
+  </div>
 </template>
 
 <script>

--- a/frontend/src/components/ApplicationDetail/ApplicationAttachmentDetail.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationAttachmentDetail.vue
@@ -1,136 +1,184 @@
 <template>
-    <div class="attachment-details">
-        <div class="attachment-header-section">
-            <h4>{{ attachment.attachment_display_name }}</h4>
+  <div class="attachment-details">
+    <div class="attachment-header-section">
+      <h4>{{ attachment.attachment_display_name }}</h4>
 
-            <!-- Даты действия -->
-            <div v-if="attachment.entry_date_from || attachment.entry_date_to" class="date-range">
-                <span class="date-label">Срок действия:</span>
-                <span class="date-value">
-                    {{ formatDateRange(attachment.entry_date_from, attachment.entry_date_to) }}
-                </span>
-            </div>
+      <!-- Даты действия -->
+      <div
+        v-if="attachment.entry_date_from || attachment.entry_date_to"
+        class="date-range"
+      >
+        <span class="date-label">Срок действия:</span>
+        <span class="date-value">
+          {{ formatDateRange(attachment.entry_date_from, attachment.entry_date_to) }}
+        </span>
+      </div>
 
-            <!-- Время действия -->
-            <div v-if="attachment.entry_time_from || attachment.entry_time_to" class="time-range">
-                <span class="time-label">Время:</span>
-                <span class="time-value">
-                    {{ formatTimeRange(attachment.entry_time_from, attachment.entry_time_to) }}
-                </span>
-            </div>
-        </div>
-
-        <div class="attachment-data-section">
-            <div class="attachment-data">
-                <!-- Автомобили -->
-                <div v-if="attachment.attachment_type === 'cars'" class="cars-section">
-                    <h5>Список автомобилей</h5>
-                    <template v-if="loading">
-                        <div class="loading-container">
-                            <div class="loading-spinner"></div>
-                            <span class="loading-text">Загрузка...</span>
-                        </div>
-                    </template>
-                    <template v-else>
-                        <div v-if="cars.length > 0" class="cars-list">
-                            <div v-for="(car, index) in cars" :key="car.id" class="car-item" @click="$emit('open-vehicle', car)">
-                                <div class="car-item-content">
-                                    <div class="item-number">
-                                        {{ index + 1 }}.
-                                    </div>
-                                    <div class="car-main-info">
-                                        <span class="car-number">{{ car.car_number }}</span>
-                                        <span class="car-brand">{{ car.car_brand }}</span>
-                                    </div>
-                                    <div v-if="car.unload_places && car.unload_places.length > 0"
-                                        class="unload-places-container"
-                                        :title="getFullPlacesList(car.unload_places)"
-                                    >
-                                        <span class="places-list">
-                                            {{ getTruncatedPlacesList(car.unload_places) }}
-                                        </span>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div v-else class="no-data">
-                            Нет данных об автомобилях
-                        </div>
-                    </template>
-                </div>
-
-                <!-- Сотрудники -->
-                <div v-if="attachment.attachment_type === 'people'" class="employees-section">
-                    <h5>Сотрудники</h5>
-                    <template v-if="loading">
-                        <div class="loading-container">
-                            <div class="loading-spinner"></div>
-                            <span class="loading-text">Загрузка...</span>
-                        </div>
-                    </template>
-                    <template v-else>
-                        <div v-if="employees.length > 0" class="employees-list">
-                            <div v-for="(employee, index) in employees" :key="employee.id" class="employee-item" @click="$emit('open-employee', employee)">
-                                <div class="employee-item-content">
-                                    <div class="item-number">
-                                        {{ index + 1 }}.
-                                    </div>
-                                    <div class="employee-main-info">
-                                        <span class="employee-name">{{ employee.last_name }} {{ employee.first_name }} {{ employee.middle_name || '' }}</span>
-                                        <span class="employee-position">{{ employee.position }}</span>
-                                    </div>
-                                    <div v-if="employee.target_tables && employee.target_tables.length > 0"
-                                        class="target-tables-container"
-                                        :title="getFullTablesList(employee.target_tables)"
-                                    >
-                                        <span class="tables-list">
-                                            {{ getTruncatedTablesList(employee.target_tables) }}
-                                        </span>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div v-else class="no-data">
-                            Нет данных о сотрудниках
-                        </div>
-                    </template>
-                </div>
-
-                <!-- ТМЦ -->
-                <div v-if="attachment.attachment_type === 'items'" class="items-section">
-                    <h5>Товарно-материальные ценности</h5>
-                    <template v-if="loading">
-                        <div class="loading-container">
-                            <div class="loading-spinner"></div>
-                            <span class="loading-text">Загрузка...</span>
-                        </div>
-                    </template>
-                    <template v-else>
-                        <div v-if="items.length > 0" class="items-list">
-                            <div v-for="(item, index) in items" :key="item.id" class="item-item">
-                                <div class="item-item-content">
-                                    <div class="item-number">
-                                        {{ index + 1 }}.
-                                    </div>
-                                    <span class="item-name">{{ item.name }}</span>
-                                    <span class="item-count">Количество: {{ item.count }}</span>
-                                </div>
-                            </div>
-                        </div>
-                        <div v-else class="no-data">
-                            Нет данных о ТМЦ
-                        </div>
-                    </template>
-                </div>
-            </div>
-        </div>
+      <!-- Время действия -->
+      <div
+        v-if="attachment.entry_time_from || attachment.entry_time_to"
+        class="time-range"
+      >
+        <span class="time-label">Время:</span>
+        <span class="time-value">
+          {{ formatTimeRange(attachment.entry_time_from, attachment.entry_time_to) }}
+        </span>
+      </div>
     </div>
+
+    <div class="attachment-data-section">
+      <div class="attachment-data">
+        <!-- Автомобили -->
+        <div
+          v-if="attachment.attachment_type === 'cars'"
+          class="cars-section"
+        >
+          <h5>Список автомобилей</h5>
+          <template v-if="loading">
+            <div class="loading-container">
+              <div class="loading-spinner" />
+              <span class="loading-text">Загрузка...</span>
+            </div>
+          </template>
+          <template v-else>
+            <div
+              v-if="cars.length > 0"
+              class="cars-list"
+            >
+              <div
+                v-for="(car, index) in cars"
+                :key="car.id"
+                class="car-item"
+                @click="$emit('open-vehicle', car)"
+              >
+                <div class="car-item-content">
+                  <div class="item-number">
+                    {{ index + 1 }}.
+                  </div>
+                  <div class="car-main-info">
+                    <span class="car-number">{{ car.car_number }}</span>
+                    <span class="car-brand">{{ car.car_brand }}</span>
+                  </div>
+                  <div
+                    v-if="car.unload_places && car.unload_places.length > 0"
+                    class="unload-places-container"
+                    :title="getFullPlacesList(car.unload_places)"
+                  >
+                    <span class="places-list">
+                      {{ getTruncatedPlacesList(car.unload_places) }}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              v-else
+              class="no-data"
+            >
+              Нет данных об автомобилях
+            </div>
+          </template>
+        </div>
+
+        <!-- Сотрудники -->
+        <div
+          v-if="attachment.attachment_type === 'people'"
+          class="employees-section"
+        >
+          <h5>Сотрудники</h5>
+          <template v-if="loading">
+            <div class="loading-container">
+              <div class="loading-spinner" />
+              <span class="loading-text">Загрузка...</span>
+            </div>
+          </template>
+          <template v-else>
+            <div
+              v-if="employees.length > 0"
+              class="employees-list"
+            >
+              <div
+                v-for="(employee, index) in employees"
+                :key="employee.id"
+                class="employee-item"
+                @click="$emit('open-employee', employee)"
+              >
+                <div class="employee-item-content">
+                  <div class="item-number">
+                    {{ index + 1 }}.
+                  </div>
+                  <div class="employee-main-info">
+                    <span class="employee-name">{{ employee.last_name }} {{ employee.first_name }} {{ employee.middle_name || '' }}</span>
+                    <span class="employee-position">{{ employee.position }}</span>
+                  </div>
+                  <div
+                    v-if="employee.target_tables && employee.target_tables.length > 0"
+                    class="target-tables-container"
+                    :title="getFullTablesList(employee.target_tables)"
+                  >
+                    <span class="tables-list">
+                      {{ getTruncatedTablesList(employee.target_tables) }}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              v-else
+              class="no-data"
+            >
+              Нет данных о сотрудниках
+            </div>
+          </template>
+        </div>
+
+        <!-- ТМЦ -->
+        <div
+          v-if="attachment.attachment_type === 'items'"
+          class="items-section"
+        >
+          <h5>Товарно-материальные ценности</h5>
+          <template v-if="loading">
+            <div class="loading-container">
+              <div class="loading-spinner" />
+              <span class="loading-text">Загрузка...</span>
+            </div>
+          </template>
+          <template v-else>
+            <div
+              v-if="items.length > 0"
+              class="items-list"
+            >
+              <div
+                v-for="(item, index) in items"
+                :key="item.id"
+                class="item-item"
+              >
+                <div class="item-item-content">
+                  <div class="item-number">
+                    {{ index + 1 }}.
+                  </div>
+                  <span class="item-name">{{ item.name }}</span>
+                  <span class="item-count">Количество: {{ item.count }}</span>
+                </div>
+              </div>
+            </div>
+            <div
+              v-else
+              class="no-data"
+            >
+              Нет данных о ТМЦ
+            </div>
+          </template>
+        </div>
+      </div>
+    </div>
+  </div>
 </template>
 
 <script>
 export default {
     name: 'ApplicationAttachmentDetail',
-    emits: ['open-vehicle', 'open-employee'],
     props: {
         attachment: {
             type: Object,
@@ -153,6 +201,7 @@ export default {
             default: false
         }
     },
+    emits: ['open-vehicle', 'open-employee'],
     methods: {
         formatDate(date) {
             if (!date) return '';

--- a/frontend/src/components/ApplicationDetail/ApplicationAttachments.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationAttachments.vue
@@ -1,43 +1,58 @@
 <template>
-    <div class="application-attachments">
-        
-        <div v-if="attachments.length === 0" class="no-attachments">
-            Вложения отсутствуют
-        </div>
-        
-        <div v-else class="attachments-list">
-            <!-- Группируем вложения по unique_attachment_id -->
-            <div 
-                v-for="(group, groupIndex) in groupedAttachments" 
-                :key="groupIndex"
-                class="attachment-group"
-            >
-                <!-- Заголовок группы (title из unique_attachments) -->
-                <div class="group-header" v-if="group.title">
-                    <h5 class="group-title">{{ group.title }}</h5>
-                </div>
-                
-                <!-- Вложения в этой группе -->
-                <div class="group-items">
-                    <div
-                        v-for="attachment in group.items"
-                        :key="attachment.id"
-                        class="attachment-item"
-                        :class="{ selected: selectedAttachment?.id === attachment.id }"
-                        @click="selectAttachment(attachment)"
-                    >
-                       
-                        <div class="attachment-name" :title="attachment.attachment_display_name">
-                            {{ attachment.attachment_display_name || truncateText(attachment.attachment_name, 25) }}
-                        </div>
-                        <div v-if="attachment.entry_date_from || attachment.entry_date_to" class="attachment-dates">
-                            {{ formatAttachmentDates(attachment) }}
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
+  <div class="application-attachments">
+    <div
+      v-if="attachments.length === 0"
+      class="no-attachments"
+    >
+      Вложения отсутствуют
     </div>
+        
+    <div
+      v-else
+      class="attachments-list"
+    >
+      <!-- Группируем вложения по unique_attachment_id -->
+      <div 
+        v-for="(group, groupIndex) in groupedAttachments" 
+        :key="groupIndex"
+        class="attachment-group"
+      >
+        <!-- Заголовок группы (title из unique_attachments) -->
+        <div
+          v-if="group.title"
+          class="group-header"
+        >
+          <h5 class="group-title">
+            {{ group.title }}
+          </h5>
+        </div>
+                
+        <!-- Вложения в этой группе -->
+        <div class="group-items">
+          <div
+            v-for="attachment in group.items"
+            :key="attachment.id"
+            class="attachment-item"
+            :class="{ selected: selectedAttachment?.id === attachment.id }"
+            @click="selectAttachment(attachment)"
+          >
+            <div
+              class="attachment-name"
+              :title="attachment.attachment_display_name"
+            >
+              {{ attachment.attachment_display_name || truncateText(attachment.attachment_name, 25) }}
+            </div>
+            <div
+              v-if="attachment.entry_date_from || attachment.entry_date_to"
+              class="attachment-dates"
+            >
+              {{ formatAttachmentDates(attachment) }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </template>
 
 <script>
@@ -86,6 +101,17 @@ export default {
 
             // Преобразуем объект в массив
             return Object.values(groups);
+        }
+    },
+    watch: {
+        attachments: {
+            immediate: true,
+            handler(newAttachments) {
+                if (newAttachments.length > 0 && !this.selectedAttachment) {
+                    this.selectedAttachment = newAttachments[0];
+                    this.$emit('attachment-selected', this.selectedAttachment);
+                }
+            }
         }
     },
     methods: {
@@ -155,17 +181,6 @@ export default {
         selectAttachment(attachment) {
             this.selectedAttachment = attachment;
             this.$emit('attachment-selected', attachment);
-        }
-    },
-    watch: {
-        attachments: {
-            immediate: true,
-            handler(newAttachments) {
-                if (newAttachments.length > 0 && !this.selectedAttachment) {
-                    this.selectedAttachment = newAttachments[0];
-                    this.$emit('attachment-selected', this.selectedAttachment);
-                }
-            }
         }
     }
 }

--- a/frontend/src/components/ApplicationDetail/ApplicationConfirmation.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationConfirmation.vue
@@ -1,64 +1,95 @@
 <template>
-    <div class="confirmation-section">
-        <div class="confirmation-header">
-            <h4>Согласование заявки</h4>
-            <div v-if="updatingConfirmation" class="confirmation-loading">
-                <LoaderSpinner size="small" :label="''" />
-            </div>
-        </div>
-        
-        <div class="confirmation-info">
-            <!-- Статус заявки -->
-            <div class="info-row">
-                <span class="info-label">Статус:</span>
-                <span class="confirmation-badge" :class="getConfirmationClass(application.confirmation)">
-                    {{ application.confirmation }}
-                </span>
-            </div>
-        </div>
-
-        <!-- Ответственные пользователи -->
-        <div v-if="sortedResponsibleUsers.length > 0" class="responsible-users-section">
-            <h5>Ответственные за согласование ({{ sortedResponsibleUsers.length }}):</h5>
-            <div class="users-list">
-                <div v-for="user in sortedResponsibleUsers" :key="user.id" class="user-item">
-                    <!-- ФИО -->
-                    <div class="user-name-block">
-                        {{ getUserDisplayName(user) }}
-                    </div>
-                    
-                    <!-- Должность -->
-                    <div v-if="user.position" class="user-position-block">
-                        {{ user.position }}
-                    </div>
-                    
-                    <!-- Ряд с бейджем и статусом -->
-                    <div class="user-badge-status-row">
-                        <div class="required-badge-container" v-if="user.required_approval">
-                            <span class="badge required-badge">Обязательно</span>
-                            <div class="required-tooltip">
-                                Согласование этого пользователя является обязательным. Без него принять заявку в работу будет невозможно.
-                            </div>
-                        </div>
-                        <span class="status-badge" :class="getStatusClass(user.approval_status)">
-                            {{ getStatusText(user.approval_status) }}
-                        </span>
-                    </div>
-                    
-                    <!-- Комментарий пользователя (только если есть) -->
-                    <div v-if="user.approval_comment" class="user-comment-block">
-                        <span class="comment-label">Комментарий:</span>
-                        <span class="comment-text">{{ user.approval_comment }}</span>
-                    </div>
-                    
-                    <!-- Время -->
-                    <div v-if="user.approval_datetime" class="user-time-block">
-                        Время: {{ formatDateTime(user.approval_datetime) }}
-                    </div>
-                </div>
-            </div>
-        </div>
+  <div class="confirmation-section">
+    <div class="confirmation-header">
+      <h4>Согласование заявки</h4>
+      <div
+        v-if="updatingConfirmation"
+        class="confirmation-loading"
+      >
+        <LoaderSpinner
+          size="small"
+          :label="''"
+        />
+      </div>
     </div>
+        
+    <div class="confirmation-info">
+      <!-- Статус заявки -->
+      <div class="info-row">
+        <span class="info-label">Статус:</span>
+        <span
+          class="confirmation-badge"
+          :class="getConfirmationClass(application.confirmation)"
+        >
+          {{ application.confirmation }}
+        </span>
+      </div>
+    </div>
+
+    <!-- Ответственные пользователи -->
+    <div
+      v-if="sortedResponsibleUsers.length > 0"
+      class="responsible-users-section"
+    >
+      <h5>Ответственные за согласование ({{ sortedResponsibleUsers.length }}):</h5>
+      <div class="users-list">
+        <div
+          v-for="user in sortedResponsibleUsers"
+          :key="user.id"
+          class="user-item"
+        >
+          <!-- ФИО -->
+          <div class="user-name-block">
+            {{ getUserDisplayName(user) }}
+          </div>
+                    
+          <!-- Должность -->
+          <div
+            v-if="user.position"
+            class="user-position-block"
+          >
+            {{ user.position }}
+          </div>
+                    
+          <!-- Ряд с бейджем и статусом -->
+          <div class="user-badge-status-row">
+            <div
+              v-if="user.required_approval"
+              class="required-badge-container"
+            >
+              <span class="badge required-badge">Обязательно</span>
+              <div class="required-tooltip">
+                Согласование этого пользователя является обязательным. Без него принять заявку в работу будет невозможно.
+              </div>
+            </div>
+            <span
+              class="status-badge"
+              :class="getStatusClass(user.approval_status)"
+            >
+              {{ getStatusText(user.approval_status) }}
+            </span>
+          </div>
+                    
+          <!-- Комментарий пользователя (только если есть) -->
+          <div
+            v-if="user.approval_comment"
+            class="user-comment-block"
+          >
+            <span class="comment-label">Комментарий:</span>
+            <span class="comment-text">{{ user.approval_comment }}</span>
+          </div>
+                    
+          <!-- Время -->
+          <div
+            v-if="user.approval_datetime"
+            class="user-time-block"
+          >
+            Время: {{ formatDateTime(user.approval_datetime) }}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </template>
 
 <script>

--- a/frontend/src/components/ApplicationDetail/ApplicationDetail.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationDetail.vue
@@ -1,243 +1,303 @@
 <template>
-    <!-- Внешний контейнер для модального окна -->
-    <div class="application-detail-overlay" @click.self="closeApplicationDetail">
-        <!-- Уведомление -->
-        <div v-if="notification.show" class="notification" :class="notification.type">
-            {{ notification.message }}
-        </div>
-
-        <!-- Модальное окно пересылки -->
-        <ForwardModal
-            v-if="showForwardModal"
-            :all-users="allUsers"
-            :responsible-users="responsibleUsers"
-            :existing-approvers="approvers"  
-            :existing-viewers="viewers"       
-            :is-sending="isForwarding"
-            @close="closeForwardModal"
-            @send="sendForwardRequest"
-        />
-
-        <div class="application-detail">
-            <!-- Заголовок и кнопки -->
-            <div class="detail-header">
-                <div class="detail-header-left">
-                    <div class="detail-title-row">
-                        <h3 class="detail-title">Заявка {{ applicationData.application_number }}</h3>
-                        <div class="detail-datetime">
-                            {{ formatDateTime(applicationData.sending_datetime) }}
-                            <span class="weekday">{{ getWeekday(applicationData.sending_datetime) }}</span>
-                        </div>
-                        <!-- Кнопка пересылки (рядом с датой) -->
-                        <button
-                            v-if="mode === 'center'"
-                            class="forward-btn"
-                            data-testid="app-detail-button-forward"
-                            @click="forwardApplication"
-                            :disabled="updatingConfirmation || processingApplication"
-                        >
-                            <span v-if="updatingConfirmation || processingApplication" class="button-loading"></span>
-                            <span v-else>Переслать</span>
-                        </button>
-                    </div>
-                </div>
-                <div class="detail-header-right">
-                    <ApplicationActionBar
-                        :application="applicationData"
-                        :current-user-id="currentUserId"
-                        :responsible-users="responsibleUsers"
-                        :approvers="approvers"
-                        :mode="mode"
-                        :processing="processingApplication"
-                        :updating-confirmation="updatingConfirmation"
-                        :action-comment="actionComment"
-                        @action-completed="handleActionCompleted"
-                        @processing-change="processingApplication = $event"
-                        @updating-confirmation-change="updatingConfirmation = $event"
-                        @comment-clear="clearCommentFromLocalStorage"
-                    >
-                        <template #user-actions>
-                            <button
-                                class="duplicate-btn"
-                                @click="duplicateApplication"
-                            >
-                                Продублировать
-                            </button>
-                        </template>
-                    </ApplicationActionBar>
-
-                    <button class="close-detail-btn" @click="close">×</button>
-                </div>
-            </div>
-
-            <div class="detail-content">
-                <!-- Левая колонка - вложения -->
-                <div class="detail-left-column" :class="{ collapsed: isLeftColumnCollapsed }">
-                    <ApplicationAttachments 
-                        :application-id="applicationData.id"
-                        :attachments="attachments"
-                        :collapsed="isLeftColumnCollapsed"
-                        @attachment-selected="selectAttachment"
-                        @toggle-collapse="toggleLeftColumn"
-                    />
-                </div>
-
-                <!-- Центральная колонка - детали -->
-                <div class="detail-main-column">
-                    <!-- Сообщение заявки -->
-                    <div class="message-section">
-                        <h4>Сообщение к заявке {{ applicationData.application_number }}</h4>
-                        <div class="message-content">
-                            {{ applicationData.message || 'Сообщение отсутствует' }}
-                        </div>
-                    </div>
-
-                    <!-- Детали выбранного вложения -->
-                    <ApplicationAttachmentDetail
-                        v-if="selectedAttachment"
-                        :attachment="selectedAttachment"
-                        :cars="attachmentCars"
-                        :employees="attachmentEmployees"
-                        :items="attachmentItems"
-                        :loading="loadingAttachmentDetails"
-                        @open-vehicle="openVehicleModal"
-                        @open-employee="openEmployeeModal"
-                    />
-                </div>
-
-                <!-- Правая колонка - информация о заявке и согласовании -->
-                <div class="detail-right-column">
-                    <!-- Основная информация -->
-                    <div class="basic-info-section">
-                        <h4>Основная информация</h4>
-                        <div class="info-grid">
-                            <div class="info-row">
-                                <span class="info-label">Организация / Отдел:</span>
-                                <span class="info-value">{{ applicationData.organization_name }}</span>
-                            </div>
-                            <div v-if="applicationData.company_name" class="info-row">
-                                <span class="info-label">Компания:</span>
-                                <span class="info-value">{{ applicationData.company_name }}</span>
-                            </div>
-                            <div class="info-row">
-                                <span class="info-label">Отправитель:</span>
-                                <span class="info-value">{{ applicationData.sender_full_name || applicationData.sender_name }}</span>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Блок статуса заявки (для принятых/отказанных/завершенных) -->
-                    <div v-if="applicationData.status === 'В работе' || applicationData.status === 'Отказано' || applicationData.status === 'Завершено'" class="application-status-section">
-                        <div class="status-header">
-                            <h4>Статус заявки</h4>
-                            <span class="status-mini-badge" :class="getStatusBadgeClass(applicationData.status)">
-                                {{ applicationData.status }}
-                            </span>
-                        </div>
-                        
-                        <!-- Для статусов В работе и Отказано -->
-                        <div class="status-info" v-if="applicationData.status === 'В работе' || applicationData.status === 'Отказано'">
-                            <div class="status-info-row" v-if="applicationData.responsible_user_id">
-                                <span class="status-info-label">{{ applicationData.status === 'В работе' ? 'Принял(-а):' : 'Отказал(а):' }}</span>
-                                <span class="status-info-value">{{ applicationData.responsible_name || 'Не указан' }}</span>
-                            </div>
-                            <div v-if="applicationData.confirmation_datetime" class="status-info-row">
-                                <span class="status-info-label">Время:</span>
-                                <span class="status-info-value">{{ formatDateTime(applicationData.confirmation_datetime) }}</span>
-                            </div>
-                            <div class="status-info-row comment-row">
-                                <span class="status-info-label">Комментарий:</span>
-                                <div class="status-info-value comment-text">{{ applicationData.responsible_comment || 'Комментария нет' }}</div>
-                            </div>
-                        </div>
-
-                        <!-- Для статуса Завершено (показываем и принятие, и завершение) -->
-                        <div class="status-info" v-else-if="applicationData.status === 'Завершено'">
-                            <!-- Информация о принятии -->
-                            <div class="status-info-row" v-if="applicationData.responsible_name">
-                                <span class="status-info-label">Принял(-а):</span>
-                                <span class="status-info-value">{{ applicationData.responsible_name }}</span>
-                            </div>
-                            <div v-if="applicationData.confirmation_datetime" class="status-info-row">
-                                <span class="status-info-label">Время принятия:</span>
-                                <span class="status-info-value">{{ formatDateTime(applicationData.confirmation_datetime) }}</span>
-                            </div>
-                            <!-- Информация о завершении -->
-                            <div class="status-info-row" v-if="applicationData.completed_by_name">
-                                <span class="status-info-label">Завершил(-а):</span>
-                                <span class="status-info-value">{{ applicationData.completed_by_name }}</span>
-                            </div>
-                            <div v-if="applicationData.completed_at" class="status-info-row">
-                                <span class="status-info-label">Время завершения:</span>
-                                <span class="status-info-value">{{ formatDateTime(applicationData.completed_at) }}</span>
-                            </div>
-                            <!-- Комментарий к завершению (или общий) -->
-                            <div class="status-info-row comment-row">
-                                <span class="status-info-label">Комментарий:</span>
-                                <div class="status-info-value comment-text">{{ applicationData.completion_comment || 'Комментария нет' }}</div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Поле для комментария (только для пользователей, которые еще не выполнили действие) -->
-                    <div v-if="canLeaveComment && !hasUserVoted && !isApproverActionDone" class="comment-action-section">
-                        <h4>Комментарий</h4>
-                        <textarea
-                            v-model="actionComment"
-                            class="comment-action-textarea"
-                            placeholder="Вы можете написать здесь комментарий (необязательно)"
-                            rows="3"
-                            @input="saveCommentToLocalStorage"
-                        ></textarea>
-                    </div>
-
-                    <!-- Компонент согласования (без информации о принявшем) -->
-                    <ApplicationConfirmation 
-                        ref="confirmationComponent"
-                        :application="applicationData"
-                        :responsible-users="responsibleUsers"
-                        :current-user-id="currentUserId"
-                        :updating-confirmation="updatingConfirmation"
-                    />
-
-                    <div class="history-button-section">
-                        <ApplicationHistory
-                            ref="historyComponent"
-                            :application-id="applicationData.id"
-                            :application-number="applicationData.application_number"
-                            :current-user-id="currentUserId"
-                            :current-user-name="currentUserName"
-                            :application-organization="applicationData.organization_name"
-                            @application-updated="handleApplicationUpdate"
-                        />
-                    </div>
-                </div>
-            </div>
-        </div>
-        <VehicleDetailsModal
-            v-if="showVehicleModal"
-            :show="showVehicleModal"
-            :vehicle="selectedVehicle"
-            :all-unloading-places="allUnloadingPlaces"
-            :license-plate-formats="licensePlateFormats"
-            :current-user-id="currentUserId"
-            :current-user-name="currentUserName"
-            :show-car-features="true"
-            :source="'application'"
-            @close="showVehicleModal = false"
-        />
-
-        <EmployeeDetailsModal
-            v-if="showEmployeeModal"
-            :show="showEmployeeModal"
-            :employee="selectedEmployee"
-            :all-tables="allTables"
-            :current-user-id="currentUserId"
-            :current-user-name="currentUserName"
-            :source="'application'"
-            @close="showEmployeeModal = false"
-        />
+  <!-- Внешний контейнер для модального окна -->
+  <div
+    class="application-detail-overlay"
+    @click.self="closeApplicationDetail"
+  >
+    <!-- Уведомление -->
+    <div
+      v-if="notification.show"
+      class="notification"
+      :class="notification.type"
+    >
+      {{ notification.message }}
     </div>
+
+    <!-- Модальное окно пересылки -->
+    <ForwardModal
+      v-if="showForwardModal"
+      :all-users="allUsers"
+      :responsible-users="responsibleUsers"
+      :existing-approvers="approvers"  
+      :existing-viewers="viewers"       
+      :is-sending="isForwarding"
+      @close="closeForwardModal"
+      @send="sendForwardRequest"
+    />
+
+    <div class="application-detail">
+      <!-- Заголовок и кнопки -->
+      <div class="detail-header">
+        <div class="detail-header-left">
+          <div class="detail-title-row">
+            <h3 class="detail-title">
+              Заявка {{ applicationData.application_number }}
+            </h3>
+            <div class="detail-datetime">
+              {{ formatDateTime(applicationData.sending_datetime) }}
+              <span class="weekday">{{ getWeekday(applicationData.sending_datetime) }}</span>
+            </div>
+            <!-- Кнопка пересылки (рядом с датой) -->
+            <button
+              v-if="mode === 'center'"
+              class="forward-btn"
+              data-testid="app-detail-button-forward"
+              :disabled="updatingConfirmation || processingApplication"
+              @click="forwardApplication"
+            >
+              <span
+                v-if="updatingConfirmation || processingApplication"
+                class="button-loading"
+              />
+              <span v-else>Переслать</span>
+            </button>
+          </div>
+        </div>
+        <div class="detail-header-right">
+          <ApplicationActionBar
+            :application="applicationData"
+            :current-user-id="currentUserId"
+            :responsible-users="responsibleUsers"
+            :approvers="approvers"
+            :mode="mode"
+            :processing="processingApplication"
+            :updating-confirmation="updatingConfirmation"
+            :action-comment="actionComment"
+            @action-completed="handleActionCompleted"
+            @processing-change="processingApplication = $event"
+            @updating-confirmation-change="updatingConfirmation = $event"
+            @comment-clear="clearCommentFromLocalStorage"
+          >
+            <template #user-actions>
+              <button
+                class="duplicate-btn"
+                @click="duplicateApplication"
+              >
+                Продублировать
+              </button>
+            </template>
+          </ApplicationActionBar>
+
+          <button
+            class="close-detail-btn"
+            @click="close"
+          >
+            ×
+          </button>
+        </div>
+      </div>
+
+      <div class="detail-content">
+        <!-- Левая колонка - вложения -->
+        <div
+          class="detail-left-column"
+          :class="{ collapsed: isLeftColumnCollapsed }"
+        >
+          <ApplicationAttachments 
+            :application-id="applicationData.id"
+            :attachments="attachments"
+            :collapsed="isLeftColumnCollapsed"
+            @attachment-selected="selectAttachment"
+            @toggle-collapse="toggleLeftColumn"
+          />
+        </div>
+
+        <!-- Центральная колонка - детали -->
+        <div class="detail-main-column">
+          <!-- Сообщение заявки -->
+          <div class="message-section">
+            <h4>Сообщение к заявке {{ applicationData.application_number }}</h4>
+            <div class="message-content">
+              {{ applicationData.message || 'Сообщение отсутствует' }}
+            </div>
+          </div>
+
+          <!-- Детали выбранного вложения -->
+          <ApplicationAttachmentDetail
+            v-if="selectedAttachment"
+            :attachment="selectedAttachment"
+            :cars="attachmentCars"
+            :employees="attachmentEmployees"
+            :items="attachmentItems"
+            :loading="loadingAttachmentDetails"
+            @open-vehicle="openVehicleModal"
+            @open-employee="openEmployeeModal"
+          />
+        </div>
+
+        <!-- Правая колонка - информация о заявке и согласовании -->
+        <div class="detail-right-column">
+          <!-- Основная информация -->
+          <div class="basic-info-section">
+            <h4>Основная информация</h4>
+            <div class="info-grid">
+              <div class="info-row">
+                <span class="info-label">Организация / Отдел:</span>
+                <span class="info-value">{{ applicationData.organization_name }}</span>
+              </div>
+              <div
+                v-if="applicationData.company_name"
+                class="info-row"
+              >
+                <span class="info-label">Компания:</span>
+                <span class="info-value">{{ applicationData.company_name }}</span>
+              </div>
+              <div class="info-row">
+                <span class="info-label">Отправитель:</span>
+                <span class="info-value">{{ applicationData.sender_full_name || applicationData.sender_name }}</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Блок статуса заявки (для принятых/отказанных/завершенных) -->
+          <div
+            v-if="applicationData.status === 'В работе' || applicationData.status === 'Отказано' || applicationData.status === 'Завершено'"
+            class="application-status-section"
+          >
+            <div class="status-header">
+              <h4>Статус заявки</h4>
+              <span
+                class="status-mini-badge"
+                :class="getStatusBadgeClass(applicationData.status)"
+              >
+                {{ applicationData.status }}
+              </span>
+            </div>
+                        
+            <!-- Для статусов В работе и Отказано -->
+            <div
+              v-if="applicationData.status === 'В работе' || applicationData.status === 'Отказано'"
+              class="status-info"
+            >
+              <div
+                v-if="applicationData.responsible_user_id"
+                class="status-info-row"
+              >
+                <span class="status-info-label">{{ applicationData.status === 'В работе' ? 'Принял(-а):' : 'Отказал(а):' }}</span>
+                <span class="status-info-value">{{ applicationData.responsible_name || 'Не указан' }}</span>
+              </div>
+              <div
+                v-if="applicationData.confirmation_datetime"
+                class="status-info-row"
+              >
+                <span class="status-info-label">Время:</span>
+                <span class="status-info-value">{{ formatDateTime(applicationData.confirmation_datetime) }}</span>
+              </div>
+              <div class="status-info-row comment-row">
+                <span class="status-info-label">Комментарий:</span>
+                <div class="status-info-value comment-text">
+                  {{ applicationData.responsible_comment || 'Комментария нет' }}
+                </div>
+              </div>
+            </div>
+
+            <!-- Для статуса Завершено (показываем и принятие, и завершение) -->
+            <div
+              v-else-if="applicationData.status === 'Завершено'"
+              class="status-info"
+            >
+              <!-- Информация о принятии -->
+              <div
+                v-if="applicationData.responsible_name"
+                class="status-info-row"
+              >
+                <span class="status-info-label">Принял(-а):</span>
+                <span class="status-info-value">{{ applicationData.responsible_name }}</span>
+              </div>
+              <div
+                v-if="applicationData.confirmation_datetime"
+                class="status-info-row"
+              >
+                <span class="status-info-label">Время принятия:</span>
+                <span class="status-info-value">{{ formatDateTime(applicationData.confirmation_datetime) }}</span>
+              </div>
+              <!-- Информация о завершении -->
+              <div
+                v-if="applicationData.completed_by_name"
+                class="status-info-row"
+              >
+                <span class="status-info-label">Завершил(-а):</span>
+                <span class="status-info-value">{{ applicationData.completed_by_name }}</span>
+              </div>
+              <div
+                v-if="applicationData.completed_at"
+                class="status-info-row"
+              >
+                <span class="status-info-label">Время завершения:</span>
+                <span class="status-info-value">{{ formatDateTime(applicationData.completed_at) }}</span>
+              </div>
+              <!-- Комментарий к завершению (или общий) -->
+              <div class="status-info-row comment-row">
+                <span class="status-info-label">Комментарий:</span>
+                <div class="status-info-value comment-text">
+                  {{ applicationData.completion_comment || 'Комментария нет' }}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Поле для комментария (только для пользователей, которые еще не выполнили действие) -->
+          <div
+            v-if="canLeaveComment && !hasUserVoted && !isApproverActionDone"
+            class="comment-action-section"
+          >
+            <h4>Комментарий</h4>
+            <textarea
+              v-model="actionComment"
+              class="comment-action-textarea"
+              placeholder="Вы можете написать здесь комментарий (необязательно)"
+              rows="3"
+              @input="saveCommentToLocalStorage"
+            />
+          </div>
+
+          <!-- Компонент согласования (без информации о принявшем) -->
+          <ApplicationConfirmation 
+            ref="confirmationComponent"
+            :application="applicationData"
+            :responsible-users="responsibleUsers"
+            :current-user-id="currentUserId"
+            :updating-confirmation="updatingConfirmation"
+          />
+
+          <div class="history-button-section">
+            <ApplicationHistory
+              ref="historyComponent"
+              :application-id="applicationData.id"
+              :application-number="applicationData.application_number"
+              :current-user-id="currentUserId"
+              :current-user-name="currentUserName"
+              :application-organization="applicationData.organization_name"
+              @application-updated="handleApplicationUpdate"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <VehicleDetailsModal
+      v-if="showVehicleModal"
+      :show="showVehicleModal"
+      :vehicle="selectedVehicle"
+      :all-unloading-places="allUnloadingPlaces"
+      :license-plate-formats="licensePlateFormats"
+      :current-user-id="currentUserId"
+      :current-user-name="currentUserName"
+      :show-car-features="true"
+      :source="'application'"
+      @close="showVehicleModal = false"
+    />
+
+    <EmployeeDetailsModal
+      v-if="showEmployeeModal"
+      :show="showEmployeeModal"
+      :employee="selectedEmployee"
+      :all-tables="allTables"
+      :current-user-id="currentUserId"
+      :current-user-name="currentUserName"
+      :source="'application'"
+      @close="showEmployeeModal = false"
+    />
+  </div>
 </template>
 
 <script>
@@ -282,6 +342,7 @@ export default {
             default: 'center'
         }
     },
+    emits: ['close', 'confirmation-updated', 'duplicate', 'application-updated', 'update-application', 'application-changed'],
     data() {
         return {
             applicationData: { ...this.application },
@@ -762,8 +823,7 @@ export default {
             };
             this.showEmployeeModal = true;
         }
-    },
-    emits: ['close', 'confirmation-updated', 'duplicate', 'application-updated', 'update-application', 'application-changed']
+    }
 }
 </script>
 

--- a/frontend/src/components/ApplicationDetail/ApplicationHistory.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationHistory.vue
@@ -1,134 +1,211 @@
 <template>
-    <div class="application-history">
-        <button class="history-toggle" @click="openModal">
-            История заявки
-        </button>
+  <div class="application-history">
+    <button
+      class="history-toggle"
+      @click="openModal"
+    >
+      История заявки
+    </button>
 
-        <!-- Модальное окно истории -->
-        <div v-if="showModal" class="history-modal-overlay" @click.self="closeModal">
-            <div class="history-modal">
-                <div class="modal-header">
-                    <h3>История заявки {{ applicationNumber }}</h3>
-                    <div class="header-actions">
-                        <button class="export-btn" @click="exportToExcel" :disabled="filteredHistory.length === 0 || isExporting">
-                            <img v-if="!isExporting" src="@/assets/icons/export.png" class="export-icon" />
-                            <span v-if="!isExporting">Экспорт</span>
-                            <div v-else class="export-loader"></div>
-                        </button>
-                        <button class="close-btn" @click="closeModal">×</button>
-                    </div>
-                </div>
-
-                <!-- Фильтры -->
-                <div class="history-filters">
-                    <div class="filter-row">
-                        <div class="user-filter">
-                            <span class="filter-label">Пользователь:</span>
-                            <div class="custom-select" @click="toggleUserDropdown">
-                                <div class="select-trigger">
-                                    <span class="selected-value">{{ selectedUserName }}</span>
-                                    <img 
-                                        src="@/assets/icons/arrow.png" 
-                                        class="select-arrow" 
-                                        :class="{ 'arrow-open': userDropdownOpen }"
-                                    />
-                                </div>
-                                <transition name="fade">
-                                    <div v-if="userDropdownOpen" class="select-dropdown">
-                                        <div 
-                                            class="select-option"
-                                            :class="{ 'selected': selectedUserId === null }"
-                                            @click="selectUser(null)"
-                                        >
-                                            Все пользователи
-                                        </div>
-                                        <div 
-                                            v-for="user in uniqueUsers" 
-                                            :key="user.id"
-                                            class="select-option"
-                                            :class="{ 'selected': selectedUserId === user.id }"
-                                            @click="selectUser(user.id)"
-                                        >
-                                            {{ user.name }}
-                                        </div>
-                                    </div>
-                                </transition>
-                            </div>
-                        </div>
-                        
-                        <div class="sort-filter">
-                            <span class="filter-label">Сортировка:</span>
-                            <button class="sort-btn" @click="toggleSortOrder">
-                                <img src="@/assets/icons/sort.png" class="sort-icon" :class="{ 'sort-asc': sortOrder === 'asc' }" />
-                                <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
-                            </button>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="modal-content" ref="scrollContainer">
-                    <div v-if="loading" class="history-loading">
-                        <LoaderSpinner label="Загрузка истории…" />
-                    </div>
-                    
-                    <div v-else-if="filteredHistory.length === 0" class="history-empty">
-                        История пуста
-                    </div>
-                    
-                    <div v-else class="history-timeline">
-                        <div 
-                            v-for="(item, index) in filteredHistory" 
-                            :key="item.id" 
-                            class="history-item"
-                        >
-                            <div class="timeline-dot" :class="getActionClass(item.action_type)"></div>
-                            <div class="timeline-line" v-if="index < filteredHistory.length - 1"></div>
-                            
-                            <div class="history-content">
-                                <div class="history-header">
-                                    <!-- Для системных действий показываем "Система" -->
-                                    <span v-if="item.action_type === 'confirmation_change' || item.action_type === 'status_change' || !item.user_id" class="user-name system-name">
-                                        Система
-                                    </span>
-                                    <span v-else class="user-name">{{ item.user_name }}</span>
-                                    <span class="action-time">{{ formatTime(item.created_at) }}</span>
-                                </div>
-                                
-                                <div class="action-text">{{ getActionText(item) }}</div>
-                                
-                                <!-- Для пересылки показываем дополнительную информацию -->
-                                <div v-if="item.action_type === 'assigned_responsible' && item.metadata?.forwarded_by" class="forward-info">
-                                    Переслано пользователем {{ item.metadata.forwarded_by }}
-                                </div>
-                                
-                                <!-- Для просмотра показываем дополнительную информацию -->
-                                <div v-if="item.action_type === 'assigned_viewer' && item.metadata?.forwarded_by" class="forward-info">
-                                    Переслано пользователем {{ item.metadata.forwarded_by }}
-                                </div>
-                                
-                                <!-- Бейдж обязательного согласования -->
-                                <div v-if="item.metadata?.required_approval" class="required-badge">
-                                    Обязательно
-                                </div>
-                                
-                                <!-- Статус изменения -->
-                                <div v-if="item.old_value && item.new_value && item.old_value !== item.new_value" class="status-change">
-                                    <span class="old-status">{{ item.old_value }}</span>
-                                    <span class="arrow">→</span>
-                                    <span class="new-status">{{ item.new_value }}</span>
-                                </div>
-                                
-                                <!-- Комментарий (если есть) -->
-                                <div v-if="item.comment && item.action_type !== 'revoke_approval'" class="action-comment">
-                                    {{ item.comment }}
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
+    <!-- Модальное окно истории -->
+    <div
+      v-if="showModal"
+      class="history-modal-overlay"
+      @click.self="closeModal"
+    >
+      <div class="history-modal">
+        <div class="modal-header">
+          <h3>История заявки {{ applicationNumber }}</h3>
+          <div class="header-actions">
+            <button
+              class="export-btn"
+              :disabled="filteredHistory.length === 0 || isExporting"
+              @click="exportToExcel"
+            >
+              <img
+                v-if="!isExporting"
+                src="@/assets/icons/export.png"
+                class="export-icon"
+              >
+              <span v-if="!isExporting">Экспорт</span>
+              <div
+                v-else
+                class="export-loader"
+              />
+            </button>
+            <button
+              class="close-btn"
+              @click="closeModal"
+            >
+              ×
+            </button>
+          </div>
         </div>
+
+        <!-- Фильтры -->
+        <div class="history-filters">
+          <div class="filter-row">
+            <div class="user-filter">
+              <span class="filter-label">Пользователь:</span>
+              <div
+                class="custom-select"
+                @click="toggleUserDropdown"
+              >
+                <div class="select-trigger">
+                  <span class="selected-value">{{ selectedUserName }}</span>
+                  <img 
+                    src="@/assets/icons/arrow.png" 
+                    class="select-arrow" 
+                    :class="{ 'arrow-open': userDropdownOpen }"
+                  >
+                </div>
+                <transition name="fade">
+                  <div
+                    v-if="userDropdownOpen"
+                    class="select-dropdown"
+                  >
+                    <div 
+                      class="select-option"
+                      :class="{ 'selected': selectedUserId === null }"
+                      @click="selectUser(null)"
+                    >
+                      Все пользователи
+                    </div>
+                    <div 
+                      v-for="user in uniqueUsers" 
+                      :key="user.id"
+                      class="select-option"
+                      :class="{ 'selected': selectedUserId === user.id }"
+                      @click="selectUser(user.id)"
+                    >
+                      {{ user.name }}
+                    </div>
+                  </div>
+                </transition>
+              </div>
+            </div>
+                        
+            <div class="sort-filter">
+              <span class="filter-label">Сортировка:</span>
+              <button
+                class="sort-btn"
+                @click="toggleSortOrder"
+              >
+                <img
+                  src="@/assets/icons/sort.png"
+                  class="sort-icon"
+                  :class="{ 'sort-asc': sortOrder === 'asc' }"
+                >
+                <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div
+          ref="scrollContainer"
+          class="modal-content"
+        >
+          <div
+            v-if="loading"
+            class="history-loading"
+          >
+            <LoaderSpinner label="Загрузка истории…" />
+          </div>
+                    
+          <div
+            v-else-if="filteredHistory.length === 0"
+            class="history-empty"
+          >
+            История пуста
+          </div>
+                    
+          <div
+            v-else
+            class="history-timeline"
+          >
+            <div 
+              v-for="(item, index) in filteredHistory" 
+              :key="item.id" 
+              class="history-item"
+            >
+              <div
+                class="timeline-dot"
+                :class="getActionClass(item.action_type)"
+              />
+              <div
+                v-if="index < filteredHistory.length - 1"
+                class="timeline-line"
+              />
+                            
+              <div class="history-content">
+                <div class="history-header">
+                  <!-- Для системных действий показываем "Система" -->
+                  <span
+                    v-if="item.action_type === 'confirmation_change' || item.action_type === 'status_change' || !item.user_id"
+                    class="user-name system-name"
+                  >
+                    Система
+                  </span>
+                  <span
+                    v-else
+                    class="user-name"
+                  >{{ item.user_name }}</span>
+                  <span class="action-time">{{ formatTime(item.created_at) }}</span>
+                </div>
+                                
+                <div class="action-text">
+                  {{ getActionText(item) }}
+                </div>
+                                
+                <!-- Для пересылки показываем дополнительную информацию -->
+                <div
+                  v-if="item.action_type === 'assigned_responsible' && item.metadata?.forwarded_by"
+                  class="forward-info"
+                >
+                  Переслано пользователем {{ item.metadata.forwarded_by }}
+                </div>
+                                
+                <!-- Для просмотра показываем дополнительную информацию -->
+                <div
+                  v-if="item.action_type === 'assigned_viewer' && item.metadata?.forwarded_by"
+                  class="forward-info"
+                >
+                  Переслано пользователем {{ item.metadata.forwarded_by }}
+                </div>
+                                
+                <!-- Бейдж обязательного согласования -->
+                <div
+                  v-if="item.metadata?.required_approval"
+                  class="required-badge"
+                >
+                  Обязательно
+                </div>
+                                
+                <!-- Статус изменения -->
+                <div
+                  v-if="item.old_value && item.new_value && item.old_value !== item.new_value"
+                  class="status-change"
+                >
+                  <span class="old-status">{{ item.old_value }}</span>
+                  <span class="arrow">→</span>
+                  <span class="new-status">{{ item.new_value }}</span>
+                </div>
+                                
+                <!-- Комментарий (если есть) -->
+                <div
+                  v-if="item.comment && item.action_type !== 'revoke_approval'"
+                  class="action-comment"
+                >
+                  {{ item.comment }}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
+  </div>
 </template>
 
 <script>
@@ -281,6 +358,12 @@ export default {
                 
             return cleanName || 'Без_организации';
         }
+    },
+    mounted() {
+        document.addEventListener('click', this.handleClickOutside);
+    },
+    beforeUnmount() {
+        document.removeEventListener('click', this.handleClickOutside);
     },
     methods: {
         openModal() {
@@ -597,12 +680,6 @@ export default {
                 this.userDropdownOpen = false;
             }
         }
-    },
-    mounted() {
-        document.addEventListener('click', this.handleClickOutside);
-    },
-    beforeUnmount() {
-        document.removeEventListener('click', this.handleClickOutside);
     }
 }
 </script>

--- a/frontend/src/components/ApplicationDetail/ForwardModal.vue
+++ b/frontend/src/components/ApplicationDetail/ForwardModal.vue
@@ -1,132 +1,167 @@
 <!-- ForwardModal.vue -->
 <template>
-    <div class="modal-overlay" @click.self="close">
-        <div class="modal">
-            <div class="modal-header">
-                <h3>Переслать заявку</h3>
-                <button class="modal-close" @click="close">×</button>
-            </div>
-            <div class="modal-content">
-                <div class="user-search-section">
-                    <input
-                        v-model="searchQuery"
-                        @input="searchUsers"
-                        @focus="onSearchFocus"
-                        @blur="onSearchBlur"
-                        class="forward-search-input"
-                        placeholder="Поиск пользователей..."
-                        type="text"
-                        ref="searchInput"
-                    />
-                    <div v-if="showDropdown && filteredUsers.length > 0" class="forward-user-dropdown">
-                        <div class="forward-user-dropdown-content">
-                            <div 
-                                v-for="user in filteredUsers" 
-                                :key="user.username"
-                                class="forward-user-item"
-                                @mousedown.prevent="addUser(user)"
-                            >
-                                <div class="forward-user-info">
-                                    <div class="forward-user-main">
-                                        <span class="forward-user-name">{{ getUserDisplayName(user) }}</span>
-                                        <span class="forward-user-username">@{{ user.username }}</span>
-                                    </div>
-                                    <div class="forward-user-details">
-                                        <span v-if="user.position" class="forward-user-position">{{ user.position }}</span>
-                                        <span v-if="user.organization" class="forward-user-organization">{{ user.organization }}</span>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div v-else-if="showDropdown && filteredUsers.length === 0" class="forward-user-dropdown no-results">
-                        <div class="forward-user-dropdown-content">
-                            <div class="no-results-message">
-                                Пользователи не найдены
-                            </div>
-                        </div>
-                    </div>
+  <div
+    class="modal-overlay"
+    @click.self="close"
+  >
+    <div class="modal">
+      <div class="modal-header">
+        <h3>Переслать заявку</h3>
+        <button
+          class="modal-close"
+          @click="close"
+        >
+          ×
+        </button>
+      </div>
+      <div class="modal-content">
+        <div class="user-search-section">
+          <input
+            v-model="searchQuery"
+            ref="searchInput"
+            class="forward-search-input"
+            placeholder="Поиск пользователей..."
+            type="text"
+            @input="searchUsers"
+            @focus="onSearchFocus"
+            @blur="onSearchBlur"
+          >
+          <div
+            v-if="showDropdown && filteredUsers.length > 0"
+            class="forward-user-dropdown"
+          >
+            <div class="forward-user-dropdown-content">
+              <div 
+                v-for="user in filteredUsers" 
+                :key="user.username"
+                class="forward-user-item"
+                @mousedown.prevent="addUser(user)"
+              >
+                <div class="forward-user-info">
+                  <div class="forward-user-main">
+                    <span class="forward-user-name">{{ getUserDisplayName(user) }}</span>
+                    <span class="forward-user-username">@{{ user.username }}</span>
+                  </div>
+                  <div class="forward-user-details">
+                    <span
+                      v-if="user.position"
+                      class="forward-user-position"
+                    >{{ user.position }}</span>
+                    <span
+                      v-if="user.organization"
+                      class="forward-user-organization"
+                    >{{ user.organization }}</span>
+                  </div>
                 </div>
-                
-                <div v-if="selectedUsers.length > 0" class="selected-forward-users">
-                    <h4>Выбранные пользователи ({{ selectedUsers.length }})</h4>
-                    <div class="forward-users-list-container">
-                        <div class="forward-users-list">
-                            <div 
-                                v-for="user in selectedUsers" 
-                                :key="user.username"
-                                class="forward-selected-user"
-                            >
-                                <div class="forward-selected-user-info">
-                                    <div class="forward-selected-user-main">
-                                        <span class="forward-selected-user-name">{{ getUserDisplayName(user) }}</span>
-                                        <span class="forward-selected-user-username">@{{ user.username }}</span>
-                                    </div>
-                                    <div class="forward-selected-user-details">
-                                        <span v-if="user.position" class="forward-selected-user-position">{{ user.position }}</span>
-                                        <span v-if="user.organization" class="forward-selected-user-organization">{{ user.organization }}</span>
-                                    </div>
-                                    
-                                    <!-- Настройки доступа -->
-                                    <div class="forward-selected-user-settings">
-                                        <!-- Тумблер "Требуется согласование" -->
-                                        <label class="setting-toggle">
-                                            <input 
-                                                type="checkbox" 
-                                                v-model="user.requires_approval"
-                                                @change="onApprovalToggle(user)"
-                                                class="setting-checkbox"
-                                            />
-                                            <span class="toggle-slider"></span>
-                                            <span class="toggle-text">Требуется согласование</span>
-                                        </label>
-
-                                        <!-- Тумблер "Согласование обязательно" (активен только если requires_approval = true) -->
-                                        <label class="setting-toggle" :class="{ 'toggle-disabled': !user.requires_approval }">
-                                            <input 
-                                                type="checkbox" 
-                                                v-model="user.required_approval"
-                                                :disabled="!user.requires_approval"
-                                                class="setting-checkbox"
-                                            />
-                                            <span class="toggle-slider"></span>
-                                            <span class="toggle-text">Согласование обязательно</span>
-                                        </label>
-                                    </div>
-                                </div>
-                                <button 
-                                    @click="removeUser(user)"
-                                    class="remove-forward-user-btn"
-                                    title="Удалить"
-                                >
-                                    ×
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                
-                <div v-else class="no-forward-users">
-                    <p>Выберите пользователей для пересылки заявки</p>
-                </div>
+              </div>
             </div>
-            <div class="modal-footer">
-                <button 
-                    class="modal-cancel-btn"
-                    @click="close"
-                >
-                    Отмена
-                </button>
-                <button 
-                    class="modal-send-btn"
-                    @click="send"
-                    :disabled="selectedUsers.length === 0 || isSending"
-                >
-                    {{ isSending ? 'Отправка...' : 'Отправить' }}
-                </button>
+          </div>
+          <div
+            v-else-if="showDropdown && filteredUsers.length === 0"
+            class="forward-user-dropdown no-results"
+          >
+            <div class="forward-user-dropdown-content">
+              <div class="no-results-message">
+                Пользователи не найдены
+              </div>
             </div>
+          </div>
         </div>
+                
+        <div
+          v-if="selectedUsers.length > 0"
+          class="selected-forward-users"
+        >
+          <h4>Выбранные пользователи ({{ selectedUsers.length }})</h4>
+          <div class="forward-users-list-container">
+            <div class="forward-users-list">
+              <div 
+                v-for="user in selectedUsers" 
+                :key="user.username"
+                class="forward-selected-user"
+              >
+                <div class="forward-selected-user-info">
+                  <div class="forward-selected-user-main">
+                    <span class="forward-selected-user-name">{{ getUserDisplayName(user) }}</span>
+                    <span class="forward-selected-user-username">@{{ user.username }}</span>
+                  </div>
+                  <div class="forward-selected-user-details">
+                    <span
+                      v-if="user.position"
+                      class="forward-selected-user-position"
+                    >{{ user.position }}</span>
+                    <span
+                      v-if="user.organization"
+                      class="forward-selected-user-organization"
+                    >{{ user.organization }}</span>
+                  </div>
+                                    
+                  <!-- Настройки доступа -->
+                  <div class="forward-selected-user-settings">
+                    <!-- Тумблер "Требуется согласование" -->
+                    <label class="setting-toggle">
+                      <input 
+                        v-model="user.requires_approval" 
+                        type="checkbox"
+                        class="setting-checkbox"
+                        @change="onApprovalToggle(user)"
+                      >
+                      <span class="toggle-slider" />
+                      <span class="toggle-text">Требуется согласование</span>
+                    </label>
+
+                    <!-- Тумблер "Согласование обязательно" (активен только если requires_approval = true) -->
+                    <label
+                      class="setting-toggle"
+                      :class="{ 'toggle-disabled': !user.requires_approval }"
+                    >
+                      <input 
+                        v-model="user.required_approval" 
+                        type="checkbox"
+                        :disabled="!user.requires_approval"
+                        class="setting-checkbox"
+                      >
+                      <span class="toggle-slider" />
+                      <span class="toggle-text">Согласование обязательно</span>
+                    </label>
+                  </div>
+                </div>
+                <button 
+                  class="remove-forward-user-btn"
+                  title="Удалить"
+                  @click="removeUser(user)"
+                >
+                  ×
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+                
+        <div
+          v-else
+          class="no-forward-users"
+        >
+          <p>Выберите пользователей для пересылки заявки</p>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button 
+          class="modal-cancel-btn"
+          @click="close"
+        >
+          Отмена
+        </button>
+        <button 
+          class="modal-send-btn"
+          :disabled="selectedUsers.length === 0 || isSending"
+          @click="send"
+        >
+          {{ isSending ? 'Отправка...' : 'Отправить' }}
+        </button>
+      </div>
     </div>
+  </div>
 </template>
 
 <script>
@@ -155,6 +190,7 @@ export default {
             default: false
         }
     },
+    emits: ['close', 'send', 'update:selected-users'],
     data() {
         return {
             searchQuery: '',
@@ -316,8 +352,7 @@ export default {
             this.searchQuery = '';
             this.showDropdown = false;
         }
-    },
-    emits: ['close', 'send', 'update:selected-users']
+    }
 }
 </script>
 

--- a/frontend/src/components/AttachmentsManagement.vue
+++ b/frontend/src/components/AttachmentsManagement.vue
@@ -1,21 +1,26 @@
 <template>
   <div class="attachments-management-container dashboard-card">
     <div class="management-header">
-      <h3 class="management-title">Вложения заявок (бланки)</h3>
+      <h3 class="management-title">
+        Вложения заявок (бланки)
+      </h3>
       <div class="header-controls">
         <button 
-          @click="toggleArchiveView" 
-          class="archive-header-button"
+          class="archive-header-button" 
           :class="{ active: showArchive }"
+          @click="toggleArchiveView"
         >
           {{ showArchive ? 'Активные' : 'Архив' }}
         </button>
         <SearchComponent
-          :title="'Поиск вложений...'"
           v-model="searchQuery"
+          :title="'Поиск вложений...'"
         />
         
-        <button @click="showAddModal = true" class="add-header-button">
+        <button
+          class="add-header-button"
+          @click="showAddModal = true"
+        >
           Создать вложение
         </button>
         <RefreshButton @refresh="refreshData" />
@@ -24,11 +29,19 @@
 
     <div class="content-container">
       <!-- Левая часть - список вложений -->
-      <div class="table-section" :class="{'with-details': selectedAttachment}">
+      <div
+        class="table-section"
+        :class="{'with-details': selectedAttachment}"
+      >
         <div class="table-container">
           <div class="table-header">
-            <div class="header-col id-col" @click="sortBy('id')">
-              <p :class="{ 'active-sort': sortField === 'id' }">ID</p>
+            <div
+              class="header-col id-col"
+              @click="sortBy('id')"
+            >
+              <p :class="{ 'active-sort': sortField === 'id' }">
+                ID
+              </p>
               <img 
                 src="@/assets/icons/sort.png" 
                 class="sort-icon" 
@@ -36,10 +49,15 @@
                   'sorted': sortField === 'id',
                   'desc': sortField === 'id' && sortDirection === 'desc'
                 }" 
-              />
+              >
             </div>
-            <div class="header-col name-col" @click="sortBy('display_name')">
-              <p :class="{ 'active-sort': sortField === 'display_name' }">Наименование</p>
+            <div
+              class="header-col name-col"
+              @click="sortBy('display_name')"
+            >
+              <p :class="{ 'active-sort': sortField === 'display_name' }">
+                Наименование
+              </p>
               <img 
                 src="@/assets/icons/sort.png" 
                 class="sort-icon" 
@@ -47,10 +65,15 @@
                   'sorted': sortField === 'display_name',
                   'desc': sortField === 'display_name' && sortDirection === 'desc'
                 }" 
-              />
+              >
             </div>
-            <div class="header-col type-col" @click="sortBy('attachment_type')">
-              <p :class="{ 'active-sort': sortField === 'attachment_type' }">Тип</p>
+            <div
+              class="header-col type-col"
+              @click="sortBy('attachment_type')"
+            >
+              <p :class="{ 'active-sort': sortField === 'attachment_type' }">
+                Тип
+              </p>
               <img 
                 src="@/assets/icons/sort.png" 
                 class="sort-icon" 
@@ -58,7 +81,7 @@
                   'sorted': sortField === 'attachment_type',
                   'desc': sortField === 'attachment_type' && sortDirection === 'desc'
                 }" 
-              />
+              >
             </div>
           </div>
 
@@ -77,13 +100,22 @@
                 <span class="cell-content id-value">{{ attachment.id }}</span>
               </div>
               <div class="table-col name-col">
-                <span class="truncate-text" :title="attachment.display_name">
+                <span
+                  class="truncate-text"
+                  :title="attachment.display_name"
+                >
                   {{ attachment.display_name }}
-                  <span v-if="!attachment.is_active" class="inactive-badge">(архив)</span>
+                  <span
+                    v-if="!attachment.is_active"
+                    class="inactive-badge"
+                  >(архив)</span>
                 </span>
               </div>
               <div class="table-col type-col">
-                <span class="type-badge" :class="attachment.attachment_type">
+                <span
+                  class="type-badge"
+                  :class="attachment.attachment_type"
+                >
                   {{ getAttachmentTypeLabel(attachment.attachment_type) }}
                 </span>
               </div>
@@ -99,16 +131,27 @@
       </div>
 
       <!-- Правая часть - детали вложения -->
-      <div v-if="selectedAttachment" class="details-section">
+      <div
+        v-if="selectedAttachment"
+        class="details-section"
+      >
         <div class="details-content">
           <div class="details-header">
             <div class="details-title-wrapper">
               <div class="attachment-info-title">
-                <h3 class="details-title">{{ selectedAttachment.display_name }}</h3>
-                <span class="attachment-type-badge" :class="selectedAttachment.attachment_type">
+                <h3 class="details-title">
+                  {{ selectedAttachment.display_name }}
+                </h3>
+                <span
+                  class="attachment-type-badge"
+                  :class="selectedAttachment.attachment_type"
+                >
                   {{ getAttachmentTypeLabel(selectedAttachment.attachment_type) }}
                 </span>
-                <span v-if="!selectedAttachment.is_active" class="archive-badge">В архиве</span>
+                <span
+                  v-if="!selectedAttachment.is_active"
+                  class="archive-badge"
+                >В архиве</span>
               </div>
               <div class="attachment-info-row">
                 <span class="system-name">{{ selectedAttachment.name }}</span>
@@ -117,17 +160,20 @@
             <div class="details-header-actions">
               <button 
                 v-if="!selectedAttachment.is_active"
-                @click="restoreAttachment(selectedAttachment)"
                 class="action-btn restore-btn"
+                @click="restoreAttachment(selectedAttachment)"
               >
                 Восстановить
               </button>
               <button 
                 v-else
-                @click="confirmDeleteAttachment(selectedAttachment)"
                 class="delete-icon-btn"
+                @click="confirmDeleteAttachment(selectedAttachment)"
               >
-                <img src="@/assets/icons/delete.png" class="delete-icon" />
+                <img
+                  src="@/assets/icons/delete.png"
+                  class="delete-icon"
+                >
               </button>
             </div>
           </div>
@@ -139,22 +185,22 @@
                   <label class="detail-label">Наименование вложения:</label>
                   <input 
                     v-model="selectedAttachment.display_name" 
-                    @change="updateAttachmentDisplayName"
                     class="form-input-sm"
                     :disabled="!selectedAttachment.is_active"
                     placeholder="Название вложения"
                     autocomplete="off"
+                    @change="updateAttachmentDisplayName"
                   >
                 </div>
                 <div class="form-group compact">
                   <label class="detail-label">Системное имя:</label>
                   <input 
                     v-model="selectedAttachment.name" 
-                    @change="updateAttachmentName"
                     class="form-input-sm"
                     :disabled="!selectedAttachment.is_active"
                     placeholder="avtozayavka"
                     autocomplete="off"
+                    @change="updateAttachmentName"
                   >
                   <span class="form-hint">Латинские буквы, цифры и подчеркивания</span>
                 </div>
@@ -165,11 +211,11 @@
                   <label class="detail-label">Заголовок:</label>
                   <input 
                     v-model="selectedAttachment.title" 
-                    @change="updateAttachmentTitle"
                     class="form-input-sm"
                     :disabled="!selectedAttachment.is_active"
                     placeholder="АВТОЗАЯВКИ"
                     autocomplete="off"
+                    @change="updateAttachmentTitle"
                   >
                   <span class="form-hint">Отображается в заголовке категории (всегда в верхнем регистре)</span>
                 </div>
@@ -179,8 +225,8 @@
                   <div class="custom-select">
                     <div 
                       class="select-header" 
-                      @click="selectedAttachment.is_active && toggleAttachmentTypeDropdown()"
                       :class="{ 'disabled': !selectedAttachment.is_active }"
+                      @click="selectedAttachment.is_active && toggleAttachmentTypeDropdown()"
                     >
                       <span class="select-value">{{ getAttachmentTypeLabel(selectedAttachment.attachment_type) }}</span>
                       <img 
@@ -188,10 +234,13 @@
                         src="@/assets/icons/arrow.png" 
                         class="select-arrow" 
                         :class="{ rotated: attachmentTypeDropdownOpen }" 
-                      />
+                      >
                     </div>
                     <transition name="dropdown-fade">
-                      <div v-if="attachmentTypeDropdownOpen" class="select-dropdown">
+                      <div
+                        v-if="attachmentTypeDropdownOpen"
+                        class="select-dropdown"
+                      >
                         <div 
                           class="select-option"
                           :class="{ active: selectedAttachment.attachment_type === 'cars' }"
@@ -222,17 +271,30 @@
               <div class="instruction-section">
                 <div class="section-header-with-actions">
                   <label class="detail-label">Инструкция к вложению:</label>
-                  <div class="editor-actions" v-if="instructionHasChanges && selectedAttachment.is_active">
-                    <button @click="cancelInstructionEdit" class="compact-btn cancel-btn">Отмена</button>
-                    <button @click="saveInstruction" class="compact-btn save-btn">Сохранить</button>
+                  <div
+                    v-if="instructionHasChanges && selectedAttachment.is_active"
+                    class="editor-actions"
+                  >
+                    <button
+                      class="compact-btn cancel-btn"
+                      @click="cancelInstructionEdit"
+                    >
+                      Отмена
+                    </button>
+                    <button
+                      class="compact-btn save-btn"
+                      @click="saveInstruction"
+                    >
+                      Сохранить
+                    </button>
                   </div>
                 </div>
                 <TextConstructor
+                  ref="instructionConstructor"
                   v-model="selectedAttachment.instruction"
                   :disabled="!selectedAttachment.is_active"
                   placeholder="Введите инструкцию для вложения..."
                   rows="8"
-                  ref="instructionConstructor"
                 />
               </div>
             </div>
@@ -240,22 +302,39 @@
         </div>
       </div>
       
-      <div v-else class="no-selection-message">
+      <div
+        v-else
+        class="no-selection-message"
+      >
         <p>{{ showArchive ? 'Выберите архивное вложение' : 'Выберите вложение для просмотра и редактирования' }}</p>
       </div>
     </div>
 
-    <div v-if="filteredAttachments.length === 0" class="no-results">
-      <div class="no-results-icon">{{ showArchive ? '🗄️' : '📄' }}</div>
+    <div
+      v-if="filteredAttachments.length === 0"
+      class="no-results"
+    >
+      <div class="no-results-icon">
+        {{ showArchive ? '🗄️' : '📄' }}
+      </div>
       <p>{{ showArchive ? 'Архив пуст' : 'Вложения не найдены' }}</p>
     </div>
 
     <!-- Модальное окно создания вложения -->
-    <div v-if="showAddModal" class="modal-overlay" @click.self="closeAddModal">
+    <div
+      v-if="showAddModal"
+      class="modal-overlay"
+      @click.self="closeAddModal"
+    >
       <div class="modal-content horizontal-modal">
         <div class="modal-header">
           <h3>Создать новое вложение</h3>
-          <button @click="closeAddModal" class="modal-close">×</button>
+          <button
+            class="modal-close"
+            @click="closeAddModal"
+          >
+            ×
+          </button>
         </div>
         
         <div class="modal-body-horizontal">
@@ -266,14 +345,20 @@
                 <label class="form-label-compact">Наименование вложения *</label>
                 <input
                   v-model="newAttachment.display_name"
-                  @input="checkExistingAttachments"
                   placeholder="Автозаявка"
                   class="input-compact"
                   :class="{ 'has-duplicate': duplicateCheck.display_name }"
+                  @input="checkExistingAttachments"
                 >
-                <div v-if="duplicateCheck.display_name" class="duplicate-alert">
+                <div
+                  v-if="duplicateCheck.display_name"
+                  class="duplicate-alert"
+                >
                   <p>Найдено похожее вложение:</p>
-                  <div class="duplicate-item" @click="restoreDuplicate(duplicateCheck.display_name)">
+                  <div
+                    class="duplicate-item"
+                    @click="restoreDuplicate(duplicateCheck.display_name)"
+                  >
                     <span>{{ duplicateCheck.display_name.display_name }}</span>
                     <span class="duplicate-status">(в архиве)</span>
                   </div>
@@ -283,12 +368,22 @@
               <div class="form-group-compact">
                 <label class="form-label-compact">Тип вложения *</label>
                 <div class="custom-select">
-                  <div class="select-header" @click="toggleNewAttachmentTypeDropdown">
+                  <div
+                    class="select-header"
+                    @click="toggleNewAttachmentTypeDropdown"
+                  >
                     <span class="select-value">{{ getAttachmentTypeLabel(newAttachment.attachment_type) }}</span>
-                    <img src="@/assets/icons/arrow.png" class="select-arrow" :class="{ rotated: newAttachmentTypeDropdownOpen }" />
+                    <img
+                      src="@/assets/icons/arrow.png"
+                      class="select-arrow"
+                      :class="{ rotated: newAttachmentTypeDropdownOpen }"
+                    >
                   </div>
                   <transition name="dropdown-fade">
-                    <div v-if="newAttachmentTypeDropdownOpen" class="select-dropdown">
+                    <div
+                      v-if="newAttachmentTypeDropdownOpen"
+                      class="select-dropdown"
+                    >
                       <div 
                         class="select-option"
                         :class="{ active: newAttachment.attachment_type === 'cars' }"
@@ -319,17 +414,26 @@
                 <label class="form-label-compact">Системное имя *</label>
                 <input
                   v-model="newAttachment.name"
-                  @input="validateSystemName"
-                  @blur="checkExistingAttachments"
                   placeholder="avtozayavka"
                   class="input-compact"
                   :class="{ 'has-duplicate': duplicateCheck.name, 'has-error': nameError }"
+                  @input="validateSystemName"
+                  @blur="checkExistingAttachments"
                 >
                 <span class="form-hint">Латинские буквы, цифры и подчеркивания</span>
-                <span v-if="nameError" class="form-error">{{ nameError }}</span>
-                <div v-if="duplicateCheck.name" class="duplicate-alert">
+                <span
+                  v-if="nameError"
+                  class="form-error"
+                >{{ nameError }}</span>
+                <div
+                  v-if="duplicateCheck.name"
+                  class="duplicate-alert"
+                >
                   <p>Найдено вложение с таким системным именем:</p>
-                  <div class="duplicate-item" @click="restoreDuplicate(duplicateCheck.name)">
+                  <div
+                    class="duplicate-item"
+                    @click="restoreDuplicate(duplicateCheck.name)"
+                  >
                     <span>{{ duplicateCheck.name.display_name }}</span>
                     <span class="duplicate-status">(в архиве)</span>
                   </div>
@@ -340,15 +444,21 @@
                 <label class="form-label-compact">Заголовок *</label>
                 <input
                   v-model="newAttachment.title"
-                  @input="checkExistingAttachments"
                   placeholder="АВТОЗАЯВКИ"
                   class="input-compact"
                   :class="{ 'has-duplicate': duplicateCheck.title }"
+                  @input="checkExistingAttachments"
                 >
                 <span class="form-hint">Отображается в заголовке категории</span>
-                <div v-if="duplicateCheck.title" class="duplicate-alert">
+                <div
+                  v-if="duplicateCheck.title"
+                  class="duplicate-alert"
+                >
                   <p>Найдено вложение с таким заголовком:</p>
-                  <div class="duplicate-item" @click="restoreDuplicate(duplicateCheck.title)">
+                  <div
+                    class="duplicate-item"
+                    @click="restoreDuplicate(duplicateCheck.title)"
+                  >
                     <span>{{ duplicateCheck.title.display_name }}</span>
                     <span class="duplicate-status">(в архиве)</span>
                   </div>
@@ -360,7 +470,9 @@
           <!-- Правая часть - инструкция -->
           <div class="modal-cells-section">
             <div class="cells-header-compact">
-              <h4 class="cells-title-compact">Инструкция к вложению</h4>
+              <h4 class="cells-title-compact">
+                Инструкция к вложению
+              </h4>
             </div>
             
             <div class="cells-scroll-container">
@@ -377,10 +489,14 @@
                 </div>
 
                 <div class="setting-item">
-                  <h5 class="fields-preview-title">Предварительный просмотр:</h5>
+                  <h5 class="fields-preview-title">
+                    Предварительный просмотр:
+                  </h5>
                   <div class="preview-card">
                     <div class="preview-header">
-                      <div class="preview-title">{{ newAttachment.title || 'ЗАГОЛОВОК' }}</div>
+                      <div class="preview-title">
+                        {{ newAttachment.title || 'ЗАГОЛОВОК' }}
+                      </div>
                     </div>
                     <div class="preview-attachment">
                       <span class="preview-attachment-name">
@@ -398,14 +514,28 @@
         </div>
         
         <div class="modal-footer">
-          <button @click="closeAddModal" class="modal-cancel">Отмена</button>
-          <button @click="createAttachment" class="modal-confirm">Создать</button>
+          <button
+            class="modal-cancel"
+            @click="closeAddModal"
+          >
+            Отмена
+          </button>
+          <button
+            class="modal-confirm"
+            @click="createAttachment"
+          >
+            Создать
+          </button>
         </div>
       </div>
     </div>
 
     <!-- Уведомления -->
-    <div v-if="notification.show" class="notification" :class="notification.type">
+    <div
+      v-if="notification.show"
+      class="notification"
+      :class="notification.type"
+    >
       <span class="notification-message">{{ notification.message }}</span>
     </div>
   </div>
@@ -521,6 +651,15 @@ export default {
     allInactiveAttachments() {
       return this.attachments.filter(attachment => !attachment.is_active);
     }
+  },
+  mounted() {
+    this.refreshData();
+    document.addEventListener('click', (e) => {
+      if (!this.$el.contains(e.target)) {
+        this.attachmentTypeDropdownOpen = false;
+        this.newAttachmentTypeDropdownOpen = false;
+      }
+    });
   },
   methods: {
     validateSystemName() {
@@ -904,15 +1043,6 @@ export default {
     hideNotification() {
       this.notification.show = false;
     }
-  },
-  mounted() {
-    this.refreshData();
-    document.addEventListener('click', (e) => {
-      if (!this.$el.contains(e.target)) {
-        this.attachmentTypeDropdownOpen = false;
-        this.newAttachmentTypeDropdownOpen = false;
-      }
-    });
   },
 };
 </script>

--- a/frontend/src/components/BlankSelector.vue
+++ b/frontend/src/components/BlankSelector.vue
@@ -1,91 +1,97 @@
 <template>
-    <div class="selector">
-        <div class="categories-container">
-            <div
-                v-for="category in uniqueCategories"
-                :key="category"
-                class="category"
-            >
-                <div class="category-header">
-                    <div class="category-title">{{ category }}</div>
-                    <span class="attachment-count">{{ getCategoryAttachments(category).length }}/10</span>
-                </div>
-
-                <transition-group name="attachment" tag="div" class="attachments-list">
-                    <div
-                        v-for="attachment in getCategoryAttachments(category)"
-                        :key="getAttachmentKey(attachment)"
-                        class="attachment"
-                        :class="{ selected: isSelected(attachment) }"
-                        @click="selectAttachment(attachment)"
-                        @mouseenter="handleMouseEnter(attachment, $event)"
-                        @mouseleave="handleMouseLeave"
-                    >
-                        <input
-                            type="checkbox"
-                            :value="getAttachmentKey(attachment)"
-                            v-model="selectedAttachments"
-                            @click.stop
-                            class="attachment-checkbox"
-                        >
-                        <span class="attachment-name">{{ attachment.display_name }}</span>
-
-                        <button
-                            v-if="hoveredAttachment === getAttachmentKey(attachment)"
-                            class="delete-btn"
-                            @click.stop="confirmDelete(attachment)"
-                        >
-                            ×
-                        </button>
-                    </div>
-                </transition-group>
-
-                <button
-                    class="add-btn"
-                    :disabled="getCategoryAttachments(category).length >= 10"
-                    @click="addAttachment(category)"
-                >
-                    Добавить
-                </button>
-            </div>
+  <div class="selector">
+    <div class="categories-container">
+      <div
+        v-for="category in uniqueCategories"
+        :key="category"
+        class="category"
+      >
+        <div class="category-header">
+          <div class="category-title">
+            {{ category }}
+          </div>
+          <span class="attachment-count">{{ getCategoryAttachments(category).length }}/10</span>
         </div>
 
-        <div class="actions">
-            <button
-                class="action-btn delete-selected"
-                :disabled="selectedAttachments.length === 0"
-                @click="confirmDeleteMultiple"
-            >
-                Удалить выбранные
-            </button>
-            <button
-                class="action-btn delete-all"
-                :disabled="attachments.length === 0"
-                @click="confirmDeleteAll"
-            >
-                Удалить все
-            </button>
-        </div>
-
-        <ConfirmationModal
-            :show="showDeleteModal"
-            title="Подтверждение удаления"
-            :message="deleteMessage"
-            confirm-text="Удалить"
-            cancel-text="Отмена"
-            :confirm-button-style="{ background: '#ff4444', borderColor: '#ff4444' }"
-            @confirm="deleteAttachments"
-            @cancel="cancelDelete"
-        />
-
-        <div
-            v-if="showTooltip"
-            class="tooltip"
-            :style="tooltipStyle"
+        <transition-group
+          name="attachment"
+          tag="div"
+          class="attachments-list"
         >
-            {{ tooltipText }}
-        </div>
+          <div
+            v-for="attachment in getCategoryAttachments(category)"
+            :key="getAttachmentKey(attachment)"
+            class="attachment"
+            :class="{ selected: isSelected(attachment) }"
+            @click="selectAttachment(attachment)"
+            @mouseenter="handleMouseEnter(attachment, $event)"
+            @mouseleave="handleMouseLeave"
+          >
+            <input
+              v-model="selectedAttachments"
+              type="checkbox"
+              :value="getAttachmentKey(attachment)"
+              class="attachment-checkbox"
+              @click.stop
+            >
+            <span class="attachment-name">{{ attachment.display_name }}</span>
+
+            <button
+              v-if="hoveredAttachment === getAttachmentKey(attachment)"
+              class="delete-btn"
+              @click.stop="confirmDelete(attachment)"
+            >
+              ×
+            </button>
+          </div>
+        </transition-group>
+
+        <button
+          class="add-btn"
+          :disabled="getCategoryAttachments(category).length >= 10"
+          @click="addAttachment(category)"
+        >
+          Добавить
+        </button>
+      </div>
     </div>
+
+    <div class="actions">
+      <button
+        class="action-btn delete-selected"
+        :disabled="selectedAttachments.length === 0"
+        @click="confirmDeleteMultiple"
+      >
+        Удалить выбранные
+      </button>
+      <button
+        class="action-btn delete-all"
+        :disabled="attachments.length === 0"
+        @click="confirmDeleteAll"
+      >
+        Удалить все
+      </button>
+    </div>
+
+    <ConfirmationModal
+      :show="showDeleteModal"
+      title="Подтверждение удаления"
+      :message="deleteMessage"
+      confirm-text="Удалить"
+      cancel-text="Отмена"
+      :confirm-button-style="{ background: '#ff4444', borderColor: '#ff4444' }"
+      @confirm="deleteAttachments"
+      @cancel="cancelDelete"
+    />
+
+    <div
+      v-if="showTooltip"
+      class="tooltip"
+      :style="tooltipStyle"
+    >
+      {{ tooltipText }}
+    </div>
+  </div>
 </template>
 
 <script>
@@ -162,6 +168,9 @@ export default {
             deep: true,
             immediate: true
         }
+    },
+    mounted() {
+        this.fetchTemplates();
     },
     methods: {
         getAttachmentKey(attachment) {
@@ -339,9 +348,6 @@ export default {
             this.selectedAttachments = [];
             this.selectedAttachment = null;
         }
-    },
-    mounted() {
-        this.fetchTemplates();
     }
 }
 </script>

--- a/frontend/src/components/CarDetailsModal.vue
+++ b/frontend/src/components/CarDetailsModal.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="modal-overlay" @mousedown="onOverlayMousedown" @mouseup="onOverlayMouseup">
+  <div
+    class="modal-overlay"
+    @mousedown="onOverlayMousedown"
+    @mouseup="onOverlayMouseup"
+  >
     <div class="modal-wrapper">
       <!-- Основное модальное окно с деталями автомобиля -->
       <div
@@ -10,13 +14,24 @@
         <div class="modal-header">
           <h3>Детали автомобиля</h3>
           <div class="header-actions">
-            <button class="history-btn" @click="openCarHistory">
+            <button
+              class="history-btn"
+              @click="openCarHistory"
+            >
               <span>История автомобиля</span>
             </button>
-            <button class="application-btn" @click="openApplication">
+            <button
+              class="application-btn"
+              @click="openApplication"
+            >
               <span>Открыть заявку</span>
             </button>
-            <button class="close-btn" @click="close">×</button>
+            <button
+              class="close-btn"
+              @click="close"
+            >
+              ×
+            </button>
           </div>
         </div>
 
@@ -61,7 +76,10 @@
                 >
                   {{ getPlaceName(placeId) }}
                 </div>
-                <div v-if="!car.unload_place_ids || car.unload_place_ids.length === 0" class="no-places">
+                <div
+                  v-if="!car.unload_place_ids || car.unload_place_ids.length === 0"
+                  class="no-places"
+                >
                   Места разгрузки не указаны
                 </div>
               </div>
@@ -69,7 +87,10 @@
 
             <div class="status-section">
               <h5>Статус</h5>
-              <div class="status-badge" :class="getStatusClass">
+              <div
+                class="status-badge"
+                :class="getStatusClass"
+              >
                 {{ getStatusText }}
               </div>
             </div>
@@ -78,29 +99,55 @@
           <div class="history-section">
             <div class="section-header">
               <h4>История въездов и выездов</h4>
-              <button class="export-btn" @click="exportHistory" :disabled="history.length === 0 || isExporting">
-                <img v-if="!isExporting" src="@/assets/icons/export.png" class="export-icon" />
+              <button
+                class="export-btn"
+                :disabled="history.length === 0 || isExporting"
+                @click="exportHistory"
+              >
+                <img
+                  v-if="!isExporting"
+                  src="@/assets/icons/export.png"
+                  class="export-icon"
+                >
                 <span v-if="!isExporting">Экспорт</span>
-                <div v-else class="export-loader"></div>
+                <div
+                  v-else
+                  class="export-loader"
+                />
               </button>
             </div>
             
-            <div v-if="loadingHistory" class="loading-container">
+            <div
+              v-if="loadingHistory"
+              class="loading-container"
+            >
               <LoaderSpinner label="Загрузка истории…" />
             </div>
             
-            <div v-else-if="history.length === 0" class="no-history">
+            <div
+              v-else-if="history.length === 0"
+              class="no-history"
+            >
               История отсутствует
             </div>
             
-            <div v-else class="history-timeline">
+            <div
+              v-else
+              class="history-timeline"
+            >
               <div 
                 v-for="(item, index) in history" 
                 :key="item.id" 
                 class="history-item"
               >
-                <div class="timeline-dot" :class="getActionClass(item.action_type)"></div>
-                <div class="timeline-line" v-if="index < history.length - 1"></div>
+                <div
+                  class="timeline-dot"
+                  :class="getActionClass(item.action_type)"
+                />
+                <div
+                  v-if="index < history.length - 1"
+                  class="timeline-line"
+                />
                 
                 <div class="history-content">
                   <div class="history-header">
@@ -108,9 +155,14 @@
                     <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
                   </div>
                   
-                  <div class="action-text">{{ getActionText(item) }}</div>
+                  <div class="action-text">
+                    {{ getActionText(item) }}
+                  </div>
                   
-                  <div v-if="item.comment" class="action-comment">
+                  <div
+                    v-if="item.comment"
+                    class="action-comment"
+                  >
                     {{ item.comment }}
                   </div>
                 </div>
@@ -125,29 +177,58 @@
         name="place-slide"
         @after-leave="onPlaceLeave"
       >
-        <div v-if="showPlaceModal" class="modal-content place-modal">
+        <div
+          v-if="showPlaceModal"
+          class="modal-content place-modal"
+        >
           <div class="modal-header">
             <div class="header-with-status">
-              <h3 class="modal-title">Информация о месте разгрузки</h3>
-              <span class="status-badge" :class="getPlaceStatusClass(selectedPlace)">
+              <h3 class="modal-title">
+                Информация о месте разгрузки
+              </h3>
+              <span
+                class="status-badge"
+                :class="getPlaceStatusClass(selectedPlace)"
+              >
                 {{ getPlaceStatusText(selectedPlace) }}
               </span>
-              <div v-if="selectedPlace && selectedPlace.status === 'active'" class="time-info">
+              <div
+                v-if="selectedPlace && selectedPlace.status === 'active'"
+                class="time-info"
+              >
                 {{ getTimeInfoText() }}
               </div>
             </div>
-            <button @click="closeUnloadPlaceDetails" class="modal-close">
-              <svg width="10" height="10" viewBox="0 0 14 14" fill="none">
-                <path d="M13 1L1 13M1 1L13 13" stroke="#666" stroke-width="2" stroke-linecap="round"/>
+            <button
+              class="modal-close"
+              @click="closeUnloadPlaceDetails"
+            >
+              <svg
+                width="10"
+                height="10"
+                viewBox="0 0 14 14"
+                fill="none"
+              >
+                <path
+                  d="M13 1L1 13M1 1L13 13"
+                  stroke="#666"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                />
               </svg>
             </button>
           </div>
 
           <div class="modal-body">
-            <div class="place-details" v-if="selectedPlace">
+            <div
+              v-if="selectedPlace"
+              class="place-details"
+            >
               <div class="details-section">
                 <div class="section-header">
-                  <h4 class="section-title">Основная информация</h4>
+                  <h4 class="section-title">
+                    Основная информация
+                  </h4>
                 </div>
                 <div class="section-body">
                   <div class="info-grid">
@@ -156,7 +237,10 @@
                       <span class="info-value">{{ selectedPlace.name }}</span>
                     </div>
                   </div>
-                  <div v-if="selectedPlace.status !== 'active' && selectedPlace.status_comment" class="comment-text">
+                  <div
+                    v-if="selectedPlace.status !== 'active' && selectedPlace.status_comment"
+                    class="comment-text"
+                  >
                     {{ selectedPlace.status_comment }}
                   </div>
                 </div>
@@ -164,17 +248,24 @@
 
               <div class="details-section">
                 <div class="section-header">
-                  <h4 class="section-title">Режим работы</h4>
+                  <h4 class="section-title">
+                    Режим работы
+                  </h4>
                 </div>
                 <div class="section-body">
-                  <div v-if="hasTimeSlots(selectedPlace)" class="schedule-grid">
+                  <div
+                    v-if="hasTimeSlots(selectedPlace)"
+                    class="schedule-grid"
+                  >
                     <div 
                       v-for="day in daysWithSlots(selectedPlace)" 
                       :key="day" 
                       class="schedule-day-card"
                       :class="{ 'current-day': isCurrentDay(day) }"
                     >
-                      <div class="day-name">{{ getFullDayName(day) }}</div>
+                      <div class="day-name">
+                        {{ getFullDayName(day) }}
+                      </div>
                       <div class="day-slots">
                         <div 
                           v-for="slot in getSlotsForDay(selectedPlace.time_slots, day)" 
@@ -182,21 +273,33 @@
                           class="slot-badge"
                           :class="{ 'active-slot': isCurrentDay(day) && isActiveSlot(slot) }"
                         >
-                          <span v-if="isRoundTheClockSlot(slot)" class="round-clock-text">круглосуточно</span>
+                          <span
+                            v-if="isRoundTheClockSlot(slot)"
+                            class="round-clock-text"
+                          >круглосуточно</span>
                           <template v-else>
                             <span class="slot-time">
                               {{ formatTime(slot.open_time) }} – {{ formatTime(slot.close_time) }}
                             </span>
                             <div class="slot-badges">
-                              <span v-if="slot.is_next_day" class="next-day-badge">+1</span>
-                              <span v-if="!slot.is_active" class="inactive-badge">неакт</span>
+                              <span
+                                v-if="slot.is_next_day"
+                                class="next-day-badge"
+                              >+1</span>
+                              <span
+                                v-if="!slot.is_active"
+                                class="inactive-badge"
+                              >неакт</span>
                             </div>
                           </template>
                         </div>
                       </div>
                     </div>
                   </div>
-                  <div v-else class="no-schedule">
+                  <div
+                    v-else
+                    class="no-schedule"
+                  >
                     Режим работы не указан
                   </div>
                 </div>
@@ -204,7 +307,9 @@
 
               <div class="details-section">
                 <div class="section-header location-header">
-                  <h4 class="section-title">Местоположение</h4>
+                  <h4 class="section-title">
+                    Местоположение
+                  </h4>
                   <a 
                     v-if="selectedPlace.map_link" 
                     :href="selectedPlace.map_link" 
@@ -215,10 +320,13 @@
                   </a>
                 </div>
                 <div class="section-body photo-body">
-                  <div v-if="selectedPlace.photos && selectedPlace.photos.length > 0" class="photo-container">
+                  <div
+                    v-if="selectedPlace.photos && selectedPlace.photos.length > 0"
+                    class="photo-container"
+                  >
                     <div 
-                      class="photo-wrapper" 
-                      ref="photoWrapper"
+                      ref="photoWrapper" 
+                      class="photo-wrapper"
                       @mousedown="startDrag"
                       @mousemove="onDrag"
                       @mouseup="stopDrag"
@@ -235,12 +343,30 @@
                       >
                     </div>
                     <div class="photo-controls">
-                      <button @click="zoomIn" class="photo-control-btn">+</button>
-                      <button @click="zoomOut" class="photo-control-btn">−</button>
-                      <button @click="resetPhoto" class="photo-control-btn">↺</button>
+                      <button
+                        class="photo-control-btn"
+                        @click="zoomIn"
+                      >
+                        +
+                      </button>
+                      <button
+                        class="photo-control-btn"
+                        @click="zoomOut"
+                      >
+                        −
+                      </button>
+                      <button
+                        class="photo-control-btn"
+                        @click="resetPhoto"
+                      >
+                        ↺
+                      </button>
                     </div>
                   </div>
-                  <div v-else class="no-photo-placeholder">
+                  <div
+                    v-else
+                    class="no-photo-placeholder"
+                  >
                     Нет фотографии
                   </div>
                 </div>
@@ -272,10 +398,6 @@ import ExcelJS from 'exceljs';
 export default {
     name: 'CarDetailsModal',
     components: { LoaderSpinner, CarHistoryModal },
-    setup(_, { emit }) {
-        const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(() => emit('close'));
-        return { onOverlayMousedown, onOverlayMouseup };
-    },
   props: {
     car: {
       type: Object,
@@ -294,6 +416,10 @@ export default {
       default: () => []
     }
   },
+    setup(_, { emit }) {
+        const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(() => emit('close'));
+        return { onOverlayMousedown, onOverlayMouseup };
+    },
   data() {
     return {
       history: [],
@@ -338,6 +464,14 @@ export default {
     },
     currentDay() {
       return new Date().getDay() === 0 ? 6 : new Date().getDay() - 1;
+    }
+  },
+  mounted() {
+    this.loadCarHistory();
+  },
+  beforeUnmount() {
+    if (this.shiftTimer) {
+      clearTimeout(this.shiftTimer);
     }
   },
   methods: {
@@ -900,14 +1034,6 @@ export default {
         clearTimeout(this.shiftTimer);
       }
       this.$emit('close');
-    }
-  },
-  mounted() {
-    this.loadCarHistory();
-  },
-  beforeUnmount() {
-    if (this.shiftTimer) {
-      clearTimeout(this.shiftTimer);
     }
   }
 };

--- a/frontend/src/components/CarHistoryModal.vue
+++ b/frontend/src/components/CarHistoryModal.vue
@@ -1,15 +1,38 @@
 <template>
-  <div class="modal-overlay" @mousedown="onOverlayMousedown" @mouseup="onOverlayMouseup">
-    <div class="car-history-modal" @mousedown.stop>
+  <div
+    class="modal-overlay"
+    @mousedown="onOverlayMousedown"
+    @mouseup="onOverlayMouseup"
+  >
+    <div
+      class="car-history-modal"
+      @mousedown.stop
+    >
       <div class="modal-header">
         <h3>История автомобиля {{ carNumber }}</h3>
         <div class="header-actions">
-          <button class="export-btn" @click="exportToExcel" :disabled="filteredHistory.length === 0 || isExporting">
-            <img v-if="!isExporting" src="@/assets/icons/export.png" class="export-icon" />
+          <button
+            class="export-btn"
+            :disabled="filteredHistory.length === 0 || isExporting"
+            @click="exportToExcel"
+          >
+            <img
+              v-if="!isExporting"
+              src="@/assets/icons/export.png"
+              class="export-icon"
+            >
             <span v-if="!isExporting">Экспорт</span>
-            <div v-else class="export-loader"></div>
+            <div
+              v-else
+              class="export-loader"
+            />
           </button>
-          <button class="close-btn" @click="close">×</button>
+          <button
+            class="close-btn"
+            @click="close"
+          >
+            ×
+          </button>
         </div>
       </div>
 
@@ -18,26 +41,32 @@
           <div class="search-filter">
             <span class="filter-label">Поиск:</span>
             <input 
-              type="text" 
               v-model="searchQuery" 
+              type="text" 
               class="search-input" 
               placeholder="Поиск по пользователю, действию..."
               @input="applyFilters"
-            />
+            >
           </div>
           <div class="user-filter">
             <span class="filter-label">Пользователь:</span>
-            <div class="custom-select" @click="toggleUserDropdown">
+            <div
+              class="custom-select"
+              @click="toggleUserDropdown"
+            >
               <div class="select-trigger">
                 <span class="selected-value">{{ selectedUserName }}</span>
                 <img 
                   src="@/assets/icons/arrow.png" 
                   class="select-arrow" 
                   :class="{ 'arrow-open': userDropdownOpen }"
-                />
+                >
               </div>
               <transition name="fade">
-                <div v-if="userDropdownOpen" class="select-dropdown">
+                <div
+                  v-if="userDropdownOpen"
+                  class="select-dropdown"
+                >
                   <div 
                     class="select-option"
                     :class="{ 'selected': selectedUserId === null }"
@@ -62,47 +91,72 @@
           <div class="date-filter">
             <span class="filter-label">Период:</span>
             <input 
-              type="date" 
               v-model="dateFrom" 
+              type="date" 
               class="date-input"
               @change="applyFilters"
-            />
+            >
             <span class="date-separator">—</span>
             <input 
-              type="date" 
               v-model="dateTo" 
+              type="date" 
               class="date-input"
               @change="applyFilters"
-            />
+            >
           </div>
           
           <div class="sort-filter">
             <span class="filter-label">Сортировка:</span>
-            <button class="sort-btn" @click="toggleSortOrder">
-              <img src="@/assets/icons/sort.png" class="sort-icon" :class="{ 'sort-asc': sortOrder === 'asc' }" />
+            <button
+              class="sort-btn"
+              @click="toggleSortOrder"
+            >
+              <img
+                src="@/assets/icons/sort.png"
+                class="sort-icon"
+                :class="{ 'sort-asc': sortOrder === 'asc' }"
+              >
               <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
             </button>
           </div>
         </div>
       </div>
 
-      <div class="modal-content" ref="scrollContainer">
-        <div v-if="loading" class="history-loading">
+      <div
+        ref="scrollContainer"
+        class="modal-content"
+      >
+        <div
+          v-if="loading"
+          class="history-loading"
+        >
           <LoaderSpinner label="Загрузка истории…" />
         </div>
         
-        <div v-else-if="filteredHistory.length === 0" class="history-empty">
+        <div
+          v-else-if="filteredHistory.length === 0"
+          class="history-empty"
+        >
           История пуста
         </div>
         
-        <div v-else class="history-timeline">
+        <div
+          v-else
+          class="history-timeline"
+        >
           <div 
             v-for="(item, index) in filteredHistory" 
             :key="item.id" 
             class="history-item"
           >
-            <div class="timeline-dot" :class="getActionClass(item.action_type)"></div>
-            <div class="timeline-line" v-if="index < filteredHistory.length - 1"></div>
+            <div
+              class="timeline-dot"
+              :class="getActionClass(item.action_type)"
+            />
+            <div
+              v-if="index < filteredHistory.length - 1"
+              class="timeline-line"
+            />
             
             <div class="history-content">
               <div class="history-header">
@@ -110,27 +164,44 @@
                 <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
               </div>
               
-              <div class="action-text">{{ getActionText(item) }}</div>
+              <div class="action-text">
+                {{ getActionText(item) }}
+              </div>
               
-              <div class="action-comment" v-if="item.action_type === 'entry' || item.action_type === 'exit'">
+              <div
+                v-if="item.action_type === 'entry' || item.action_type === 'exit'"
+                class="action-comment"
+              >
                 {{ getActionComment(item) }}
               </div>
               
-              <div v-if="item.comment && item.action_type !== 'entry' && item.action_type !== 'exit'" class="action-comment">
+              <div
+                v-if="item.comment && item.action_type !== 'entry' && item.action_type !== 'exit'"
+                class="action-comment"
+              >
                 {{ item.comment }}
               </div>
               
-              <div v-if="item.old_value && item.new_value && item.old_value !== item.new_value" class="value-change">
+              <div
+                v-if="item.old_value && item.new_value && item.old_value !== item.new_value"
+                class="value-change"
+              >
                 <span class="old-value">{{ item.old_value }}</span>
                 <span class="arrow">→</span>
                 <span class="new-value">{{ item.new_value }}</span>
               </div>
               
-              <div v-if="item.field_name" class="field-name">
+              <div
+                v-if="item.field_name"
+                class="field-name"
+              >
                 Поле: {{ item.field_name }}
               </div>
               
-              <div v-if="item.table_name" class="place-name">
+              <div
+                v-if="item.table_name"
+                class="place-name"
+              >
                 {{ item.table_name }}
               </div>
             </div>
@@ -150,10 +221,6 @@ import ExcelJS from 'exceljs';
 export default {
   name: 'CarHistoryModal',
   components: { LoaderSpinner },
-  setup(_, { emit }) {
-    const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(() => emit('close'));
-    return { onOverlayMousedown, onOverlayMouseup };
-  },
   props: {
     carId: {
       type: Number,
@@ -191,6 +258,10 @@ export default {
       type: String,
       default: ''
     }
+  },
+  setup(_, { emit }) {
+    const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(() => emit('close'));
+    return { onOverlayMousedown, onOverlayMouseup };
   },
   data() {
     return {
@@ -315,6 +386,19 @@ export default {
     safeCarNumber() {
       return this.carNumber.replace(/[\\/:"*?<>|]/g, '_').replace(/\s+/g, '_') || 'Avtomobil';
     }
+  },
+  mounted() {
+    this.loadHistory();
+    console.log('CarHistoryModal получил пропсы:', {
+      carNumber: this.carNumber,
+      carBrand: this.carBrand,
+      organizationId: this.organizationId,
+      companyId: this.companyId
+    });
+    document.addEventListener('click', this.handleClickOutside);
+  },
+  beforeUnmount() {
+    document.removeEventListener('click', this.handleClickOutside);
   },
   methods: {
     async loadHistory() {
@@ -642,19 +726,6 @@ export default {
     close() {
       this.$emit('close');
     }
-  },
-  mounted() {
-    this.loadHistory();
-    console.log('CarHistoryModal получил пропсы:', {
-      carNumber: this.carNumber,
-      carBrand: this.carBrand,
-      organizationId: this.organizationId,
-      companyId: this.companyId
-    });
-    document.addEventListener('click', this.handleClickOutside);
-  },
-  beforeUnmount() {
-    document.removeEventListener('click', this.handleClickOutside);
   }
 };
 </script>

--- a/frontend/src/components/CarsFact.vue
+++ b/frontend/src/components/CarsFact.vue
@@ -2,7 +2,9 @@
   <div class="cars-fact-card">
     <div class="card-header">
       <div class="card-header__title">
-        <h3 class="card-title">Автомобили <span class="highlight-text">по факту</span></h3>
+        <h3 class="card-title">
+          Автомобили <span class="highlight-text">по факту</span>
+        </h3>
       </div>
       <div class="card-header__settings">
         <RefreshButton @refresh="fetchCars" />
@@ -16,8 +18,13 @@
           <div class="header-col checkbox-col">
             <!-- Пустой заголовок для чекбокса -->
           </div>
-          <div class="header-col organization-col" @click="sortBy('organization')">
-            <p :class="{ 'active-sort': sortField === 'organization' }">Организация</p>
+          <div
+            class="header-col organization-col"
+            @click="sortBy('organization')"
+          >
+            <p :class="{ 'active-sort': sortField === 'organization' }">
+              Организация
+            </p>
             <img 
               src="@/assets/icons/sort.png" 
               class="sort-icon" 
@@ -25,10 +32,15 @@
                 'sorted': sortField === 'organization',
                 'desc': sortField === 'organization' && sortDirection === 'desc'
               }" 
-            />
+            >
           </div>
-          <div class="header-col place-col" @click="sortBy('unload_place')">
-            <p :class="{ 'active-sort': sortField === 'unload_place' }">Место разгрузки</p>
+          <div
+            class="header-col place-col"
+            @click="sortBy('unload_place')"
+          >
+            <p :class="{ 'active-sort': sortField === 'unload_place' }">
+              Место разгрузки
+            </p>
             <img 
               src="@/assets/icons/sort.png" 
               class="sort-icon" 
@@ -36,10 +48,15 @@
                 'sorted': sortField === 'unload_place',
                 'desc': sortField === 'unload_place' && sortDirection === 'desc'
               }" 
-            />
+            >
           </div>
-          <div class="header-col date-col" @click="sortBy('entry_date_to')">
-            <p :class="{ 'active-sort': sortField === 'entry_date_to' }">Действует до</p>
+          <div
+            class="header-col date-col"
+            @click="sortBy('entry_date_to')"
+          >
+            <p :class="{ 'active-sort': sortField === 'entry_date_to' }">
+              Действует до
+            </p>
             <img 
               src="@/assets/icons/sort.png" 
               class="sort-icon" 
@@ -47,10 +64,15 @@
                 'sorted': sortField === 'entry_date_to',
                 'desc': sortField === 'entry_date_to' && sortDirection === 'desc'
               }" 
-            />
+            >
           </div>
-          <div class="header-col time-col" @click="sortBy('entry_time')">
-            <p :class="{ 'active-sort': sortField === 'entry_time' }">Время</p>
+          <div
+            class="header-col time-col"
+            @click="sortBy('entry_time')"
+          >
+            <p :class="{ 'active-sort': sortField === 'entry_time' }">
+              Время
+            </p>
             <img 
               src="@/assets/icons/sort.png" 
               class="sort-icon" 
@@ -58,10 +80,15 @@
                 'sorted': sortField === 'entry_time',
                 'desc': sortField === 'entry_time' && sortDirection === 'desc'
               }" 
-            />
+            >
           </div>
-          <div class="header-col status-col" @click="sortBy('status')">
-            <p :class="{ 'active-sort': sortField === 'status' }">Статус</p>
+          <div
+            class="header-col status-col"
+            @click="sortBy('status')"
+          >
+            <p :class="{ 'active-sort': sortField === 'status' }">
+              Статус
+            </p>
             <img 
               src="@/assets/icons/sort.png" 
               class="sort-icon" 
@@ -69,7 +96,7 @@
                 'sorted': sortField === 'status',
                 'desc': sortField === 'status' && sortDirection === 'desc'
               }" 
-            />
+            >
           </div>
           <div class="header-col actions-col">
             <!-- Пустой заголовок для действий -->
@@ -79,8 +106,14 @@
       
       <!-- Тело таблицы -->
       <div class="cars-container">
-        <div v-if="filteredCars.length > 0" class="cars-body">
-          <transition-group name="fade-list" tag="div">
+        <div
+          v-if="filteredCars.length > 0"
+          class="cars-body"
+        >
+          <transition-group
+            name="fade-list"
+            tag="div"
+          >
             <div 
               v-for="(car, index) in sortedCars" 
               :key="car.id" 
@@ -90,10 +123,10 @@
               <div class="car-row">
                 <div class="car-col checkbox-col">
                   <input 
-                    type="checkbox" 
-                    v-model="car.checked"
+                    v-model="car.checked" 
+                    type="checkbox"
                     class="checkbox-input"
-                  />
+                  >
                 </div>
                 <div class="car-col organization-col">
                   {{ car.organization }}
@@ -114,21 +147,24 @@
                 </div>
                 <div class="car-col actions-col">
                   <button 
-                    @click="deleteCar(car)" 
-                    class="delete-btn"
+                    class="delete-btn" 
+                    @click="deleteCar(car)"
                   >
                     <img 
                       src="@/assets/icons/trashcan.png" 
                       alt="Удалить" 
                       class="delete-icon"
-                    />
+                    >
                   </button>
                 </div>
               </div>
             </div>
           </transition-group>
         </div>
-        <p v-else class="no-data-message">
+        <p
+          v-else
+          class="no-data-message"
+        >
           {{ hasActiveFilters ? 'Нет данных по выбранным фильтрам' : 'Заявок на машины по факту нет' }}
         </p>
       </div>
@@ -144,7 +180,6 @@ export default {
   components: {
     RefreshButton
   },
-  emits: ['refresh-cars'],
   props: {
     searchQuery: {
       type: String,
@@ -171,6 +206,7 @@ export default {
       default: null
     }
   },
+  emits: ['refresh-cars'],
   data() {
     return {
       sortField: null,
@@ -279,6 +315,17 @@ export default {
         (this.dateRangeStart && this.dateRangeEnd)
       );
     }
+  },
+  mounted() {
+    this.fetchUnloadingPlaces().then(() => {
+      this.fetchCars();
+    });
+    
+    setTimeout(() => {
+      document.querySelectorAll('.car-item').forEach(item => {
+        item.classList.add('animate-in');
+      });
+    }, 100);
   },
   methods: {
     async fetchUnloadingPlaces() {
@@ -451,17 +498,6 @@ export default {
       
       return hours * 60 + minutes;
     }
-  },
-  mounted() {
-    this.fetchUnloadingPlaces().then(() => {
-      this.fetchCars();
-    });
-    
-    setTimeout(() => {
-      document.querySelectorAll('.car-item').forEach(item => {
-        item.classList.add('animate-in');
-      });
-    }, 100);
   }
 };
 </script>

--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -1,10 +1,21 @@
 <template>
-  <div class="selected-table-card" data-testid="cars-table">
+  <div
+    class="selected-table-card"
+    data-testid="cars-table"
+  >
     <transition name="slide-down">
-      <div v-if="notification.message" class="notification">
+      <div
+        v-if="notification.message"
+        class="notification"
+      >
         <span>{{ notification.message }}</span>
-        <button @click="undoDelete">Отменить</button>
-        <div class="progress-bar" :style="{ width: `${progress}%` }"></div>
+        <button @click="undoDelete">
+          Отменить
+        </button>
+        <div
+          class="progress-bar"
+          :style="{ width: `${progress}%` }"
+        />
       </div>
     </transition>
 
@@ -17,11 +28,17 @@
       <div class="card-header__settings">
         <span class="items-count">
           Машин на территории: {{ carsOnTerritory }}
-          <button class="history-btn" @click="openCarsTableHistory">
+          <button
+            class="history-btn"
+            @click="openCarsTableHistory"
+          >
             История
           </button>
         </span>
-        <RefreshButton @refresh="loadData" :disabled="isLoading" />
+        <RefreshButton
+          :disabled="isLoading"
+          @refresh="loadData"
+        />
       </div>
     </div>
     
@@ -29,50 +46,129 @@
       <div class="items-header">
         <div class="header-row">
           <!-- Въезд - отдельная колонка -->
-          <div class="col entry-col">Въезд</div>
+          <div class="col entry-col">
+            Въезд
+          </div>
           <!-- Выезд - отдельная колонка -->
-          <div class="col exit-col">Выезд</div>
-          <div class="col number-col" @click="sortBy('car_number')">
-            <p :class="{ 'active-sort': sortField === 'car_number' }">Номер Т/С</p>
-            <img src="@/assets/icons/sort.png" class="sort-icon" :class="{ 'sorted': sortField === 'car_number', 'desc': sortField === 'car_number' && sortDirection === 'desc' }" />
+          <div class="col exit-col">
+            Выезд
           </div>
-          <div class="col brand-col" @click="sortBy('car_brand')">
-            <p :class="{ 'active-sort': sortField === 'car_brand' }">Марка</p>
-            <img src="@/assets/icons/sort.png" class="sort-icon" :class="{ 'sorted': sortField === 'car_brand', 'desc': sortField === 'car_brand' && sortDirection === 'desc' }" />
+          <div
+            class="col number-col"
+            @click="sortBy('car_number')"
+          >
+            <p :class="{ 'active-sort': sortField === 'car_number' }">
+              Номер Т/С
+            </p>
+            <img
+              src="@/assets/icons/sort.png"
+              class="sort-icon"
+              :class="{ 'sorted': sortField === 'car_number', 'desc': sortField === 'car_number' && sortDirection === 'desc' }"
+            >
           </div>
-          <div class="col organization-col" @click="sortBy('organization')">
-            <p :class="{ 'active-sort': sortField === 'organization' }">Организация</p>
-            <img src="@/assets/icons/sort.png" class="sort-icon" :class="{ 'sorted': sortField === 'organization', 'desc': sortField === 'organization' && sortDirection === 'desc' }" />
+          <div
+            class="col brand-col"
+            @click="sortBy('car_brand')"
+          >
+            <p :class="{ 'active-sort': sortField === 'car_brand' }">
+              Марка
+            </p>
+            <img
+              src="@/assets/icons/sort.png"
+              class="sort-icon"
+              :class="{ 'sorted': sortField === 'car_brand', 'desc': sortField === 'car_brand' && sortDirection === 'desc' }"
+            >
+          </div>
+          <div
+            class="col organization-col"
+            @click="sortBy('organization')"
+          >
+            <p :class="{ 'active-sort': sortField === 'organization' }">
+              Организация
+            </p>
+            <img
+              src="@/assets/icons/sort.png"
+              class="sort-icon"
+              :class="{ 'sorted': sortField === 'organization', 'desc': sortField === 'organization' && sortDirection === 'desc' }"
+            >
           </div>
           <!-- Компания скрыта, но класс оставлен для возможного использования -->
-          <div class="col company-col" style="display: none;"></div>
-          <div class="col place-col" @click="sortBy('unload_place')">
-            <p :class="{ 'active-sort': sortField === 'unload_place' }">Место разгрузки</p>
-            <img src="@/assets/icons/sort.png" class="sort-icon" :class="{ 'sorted': sortField === 'unload_place', 'desc': sortField === 'unload_place' && sortDirection === 'desc' }" />
+          <div
+            class="col company-col"
+            style="display: none;"
+          />
+          <div
+            class="col place-col"
+            @click="sortBy('unload_place')"
+          >
+            <p :class="{ 'active-sort': sortField === 'unload_place' }">
+              Место разгрузки
+            </p>
+            <img
+              src="@/assets/icons/sort.png"
+              class="sort-icon"
+              :class="{ 'sorted': sortField === 'unload_place', 'desc': sortField === 'unload_place' && sortDirection === 'desc' }"
+            >
           </div>
-          <div class="col date-col" @click="sortBy('entry_date_to')">
-            <p :class="{ 'active-sort': sortField === 'entry_date_to' }">Действует до</p>
-            <img src="@/assets/icons/sort.png" class="sort-icon" :class="{ 'sorted': sortField === 'entry_date_to', 'desc': sortField === 'entry_date_to' && sortDirection === 'desc' }" />
+          <div
+            class="col date-col"
+            @click="sortBy('entry_date_to')"
+          >
+            <p :class="{ 'active-sort': sortField === 'entry_date_to' }">
+              Действует до
+            </p>
+            <img
+              src="@/assets/icons/sort.png"
+              class="sort-icon"
+              :class="{ 'sorted': sortField === 'entry_date_to', 'desc': sortField === 'entry_date_to' && sortDirection === 'desc' }"
+            >
           </div>
-          <div class="col time-col" @click="sortBy('entry_time')">
-            <p :class="{ 'active-sort': sortField === 'entry_time' }">Время</p>
-            <img src="@/assets/icons/sort.png" class="sort-icon" :class="{ 'sorted': sortField === 'entry_time', 'desc': sortField === 'entry_time' && sortDirection === 'desc' }" />
+          <div
+            class="col time-col"
+            @click="sortBy('entry_time')"
+          >
+            <p :class="{ 'active-sort': sortField === 'entry_time' }">
+              Время
+            </p>
+            <img
+              src="@/assets/icons/sort.png"
+              class="sort-icon"
+              :class="{ 'sorted': sortField === 'entry_time', 'desc': sortField === 'entry_time' && sortDirection === 'desc' }"
+            >
           </div>
-          <div class="col status-col" @click="sortBy('status')">
-            <p :class="{ 'active-sort': sortField === 'status' }">Статус</p>
-            <img src="@/assets/icons/sort.png" class="sort-icon" :class="{ 'sorted': sortField === 'status', 'desc': sortField === 'status' && sortDirection === 'desc' }" />
+          <div
+            class="col status-col"
+            @click="sortBy('status')"
+          >
+            <p :class="{ 'active-sort': sortField === 'status' }">
+              Статус
+            </p>
+            <img
+              src="@/assets/icons/sort.png"
+              class="sort-icon"
+              :class="{ 'sorted': sortField === 'status', 'desc': sortField === 'status' && sortDirection === 'desc' }"
+            >
           </div>
-          <div class="col actions-col"></div>
+          <div class="col actions-col" />
         </div>
       </div>
       
       <div class="items-container">
-        <div v-if="isLoading" class="loading-message">
+        <div
+          v-if="isLoading"
+          class="loading-message"
+        >
           <LoaderSpinner label="Загрузка машин…" />
         </div>
         
-        <div v-else-if="displayItems.length > 0" class="items-body">
-          <transition-group name="fade-list" tag="div">
+        <div
+          v-else-if="displayItems.length > 0"
+          class="items-body"
+        >
+          <transition-group
+            name="fade-list"
+            tag="div"
+          >
             <div 
               v-for="(item, index) in displayItems" 
               :key="item.id" 
@@ -82,7 +178,10 @@
             >
               <div class="item-data">
                 <!-- Въезд - кнопка -->
-                <div class="col entry-col" @click.stop>
+                <div
+                  class="col entry-col"
+                  @click.stop
+                >
                   <button 
                     class="action-btn entry-btn" 
                     :class="{ 'active': item.entry_checked }"
@@ -93,7 +192,10 @@
                   </button>
                 </div>
                 <!-- Выезд - кнопка -->
-                <div class="col exit-col" @click.stop>
+                <div
+                  class="col exit-col"
+                  @click.stop
+                >
                   <button 
                     class="action-btn exit-btn" 
                     :class="{ 'active': item.exit_checked }"
@@ -103,20 +205,46 @@
                     Выезд
                   </button>
                 </div>
-                <div class="col number-col">{{ item.car_number }}</div>
-                <div class="col brand-col">{{ item.car_brand }}</div>
-                <div class="col organization-col">{{ item.organization_name }}</div>
+                <div class="col number-col">
+                  {{ item.car_number }}
+                </div>
+                <div class="col brand-col">
+                  {{ item.car_brand }}
+                </div>
+                <div class="col organization-col">
+                  {{ item.organization_name }}
+                </div>
                 <!-- Компания скрыта -->
-                <div class="col company-col" style="display: none;"></div>
-                <div class="col place-col">{{ formatUnloadPlaces(item) }}</div>
-                <div class="col date-col">{{ formatDate(item.entry_date_to) }}</div>
-                <div class="col time-col">{{ formatTimeRange(item.entry_time_from, item.entry_time_to) }}</div>
+                <div
+                  class="col company-col"
+                  style="display: none;"
+                />
+                <div class="col place-col">
+                  {{ formatUnloadPlaces(item) }}
+                </div>
+                <div class="col date-col">
+                  {{ formatDate(item.entry_date_to) }}
+                </div>
+                <div class="col time-col">
+                  {{ formatTimeRange(item.entry_time_from, item.entry_time_to) }}
+                </div>
                 <div class="col status-col">
                   <span class="status-text">{{ item.status }}</span>
                 </div>
-                <div class="col actions-col" @click.stop>
-                  <button @click="removeItemWithNotification(item)" class="delete-btn" :disabled="isLoading">
-                    <img src="@/assets/icons/trashcan.png" alt="Удалить" class="delete-icon" />
+                <div
+                  class="col actions-col"
+                  @click.stop
+                >
+                  <button
+                    class="delete-btn"
+                    :disabled="isLoading"
+                    @click="removeItemWithNotification(item)"
+                  >
+                    <img
+                      src="@/assets/icons/trashcan.png"
+                      alt="Удалить"
+                      class="delete-icon"
+                    >
                   </button>
                 </div>
               </div>
@@ -124,7 +252,10 @@
           </transition-group>
         </div>
         
-        <div v-else class="no-data-message">
+        <div
+          v-else
+          class="no-data-message"
+        >
           {{ hasActiveFilters ? 'Нет данных по выбранным фильтрам' : 'Нет активных автомобилей' }}
         </div>
       </div>
@@ -284,6 +415,24 @@ export default {
         (this.dateRangeStart && this.dateRangeEnd)
       );
     }
+  },
+  watch: {
+    tableName: {
+      immediate: true,
+      handler(newVal) {
+        if (newVal) {
+          this.stopPolling();
+          this.startPolling();
+        }
+      }
+    }
+  },
+  mounted() {
+    this.startPolling();
+  },
+  beforeUnmount() {
+    this.stopPolling();
+    if (this.progressInterval) clearInterval(this.progressInterval);
   },
   methods: {
     // Основной метод загрузки данных с флагом silent (без показа лоадера)
@@ -644,24 +793,6 @@ export default {
         this.pollingInterval = null;
       }
     }
-  },
-  mounted() {
-    this.startPolling();
-  },
-  watch: {
-    tableName: {
-      immediate: true,
-      handler(newVal) {
-        if (newVal) {
-          this.stopPolling();
-          this.startPolling();
-        }
-      }
-    }
-  },
-  beforeUnmount() {
-    this.stopPolling();
-    if (this.progressInterval) clearInterval(this.progressInterval);
   }
 };
 </script>

--- a/frontend/src/components/CarsTableHistoryModal.vue
+++ b/frontend/src/components/CarsTableHistoryModal.vue
@@ -1,15 +1,34 @@
 <template>
-  <div class="modal-overlay" @click.self="close">
+  <div
+    class="modal-overlay"
+    @click.self="close"
+  >
     <div class="cars-history-modal">
       <div class="modal-header">
         <h3>История въездов и выездов всех автомобилей</h3>
         <div class="header-actions">
-          <button class="export-btn" @click="exportToExcel" :disabled="filteredHistory.length === 0 || isExporting">
-            <img v-if="!isExporting" src="@/assets/icons/export.png" class="export-icon" />
+          <button
+            class="export-btn"
+            :disabled="filteredHistory.length === 0 || isExporting"
+            @click="exportToExcel"
+          >
+            <img
+              v-if="!isExporting"
+              src="@/assets/icons/export.png"
+              class="export-icon"
+            >
             <span v-if="!isExporting">Экспорт</span>
-            <div v-else class="export-loader"></div>
+            <div
+              v-else
+              class="export-loader"
+            />
           </button>
-          <button class="close-btn" @click="close">×</button>
+          <button
+            class="close-btn"
+            @click="close"
+          >
+            ×
+          </button>
         </div>
       </div>
 
@@ -18,26 +37,32 @@
           <div class="search-filter">
             <span class="filter-label">Поиск:</span>
             <input 
-              type="text" 
               v-model="searchQuery" 
+              type="text" 
               class="search-input" 
               placeholder="Поиск по автомобилю, номеру, организации..."
               @input="applyFilters"
-            />
+            >
           </div>
           <div class="user-filter">
             <span class="filter-label">Пользователь:</span>
-            <div class="custom-select" @click="toggleUserDropdown">
+            <div
+              class="custom-select"
+              @click="toggleUserDropdown"
+            >
               <div class="select-trigger">
                 <span class="selected-value">{{ selectedUserName }}</span>
                 <img 
                   src="@/assets/icons/arrow.png" 
                   class="select-arrow" 
                   :class="{ 'arrow-open': userDropdownOpen }"
-                />
+                >
               </div>
               <transition name="fade">
-                <div v-if="userDropdownOpen" class="select-dropdown">
+                <div
+                  v-if="userDropdownOpen"
+                  class="select-dropdown"
+                >
                   <div 
                     class="select-option"
                     :class="{ 'selected': selectedUserId === null }"
@@ -61,17 +86,23 @@
           
           <div class="car-filter">
             <span class="filter-label">Автомобиль:</span>
-            <div class="custom-select" @click="toggleCarDropdown">
+            <div
+              class="custom-select"
+              @click="toggleCarDropdown"
+            >
               <div class="select-trigger">
                 <span class="selected-value">{{ selectedCarName }}</span>
                 <img 
                   src="@/assets/icons/arrow.png" 
                   class="select-arrow" 
                   :class="{ 'arrow-open': carDropdownOpen }"
-                />
+                >
               </div>
               <transition name="fade">
-                <div v-if="carDropdownOpen" class="select-dropdown">
+                <div
+                  v-if="carDropdownOpen"
+                  class="select-dropdown"
+                >
                   <div 
                     class="select-option"
                     :class="{ 'selected': selectedCarId === null }"
@@ -96,47 +127,72 @@
           <div class="date-filter">
             <span class="filter-label">Период:</span>
             <input 
-              type="date" 
               v-model="dateFrom" 
+              type="date" 
               class="date-input"
               @change="applyFilters"
-            />
+            >
             <span class="date-separator">—</span>
             <input 
-              type="date" 
               v-model="dateTo" 
+              type="date" 
               class="date-input"
               @change="applyFilters"
-            />
+            >
           </div>
           
           <div class="sort-filter">
             <span class="filter-label">Сортировка:</span>
-            <button class="sort-btn" @click="toggleSortOrder">
-              <img src="@/assets/icons/sort.png" class="sort-icon" :class="{ 'sort-asc': sortOrder === 'asc' }" />
+            <button
+              class="sort-btn"
+              @click="toggleSortOrder"
+            >
+              <img
+                src="@/assets/icons/sort.png"
+                class="sort-icon"
+                :class="{ 'sort-asc': sortOrder === 'asc' }"
+              >
               <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
             </button>
           </div>
         </div>
       </div>
 
-      <div class="modal-content" ref="scrollContainer">
-        <div v-if="loading" class="history-loading">
+      <div
+        ref="scrollContainer"
+        class="modal-content"
+      >
+        <div
+          v-if="loading"
+          class="history-loading"
+        >
           <LoaderSpinner label="Загрузка истории…" />
         </div>
         
-        <div v-else-if="filteredHistory.length === 0" class="history-empty">
+        <div
+          v-else-if="filteredHistory.length === 0"
+          class="history-empty"
+        >
           История пуста
         </div>
         
-        <div v-else class="history-timeline">
+        <div
+          v-else
+          class="history-timeline"
+        >
           <div 
             v-for="(item, index) in filteredHistory" 
             :key="item.id" 
             class="history-item"
           >
-            <div class="timeline-dot" :class="getActionClass(item.action_type)"></div>
-            <div class="timeline-line" v-if="index < filteredHistory.length - 1"></div>
+            <div
+              class="timeline-dot"
+              :class="getActionClass(item.action_type)"
+            />
+            <div
+              v-if="index < filteredHistory.length - 1"
+              class="timeline-line"
+            />
             
             <div class="history-content">
               <div class="history-header">
@@ -145,17 +201,28 @@
                 <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
               </div>
               
-              <div class="action-text">{{ getActionText(item) }}</div>
+              <div class="action-text">
+                {{ getActionText(item) }}
+              </div>
               
-              <div class="action-comment" v-if="item.action_type === 'entry' || item.action_type === 'exit'">
+              <div
+                v-if="item.action_type === 'entry' || item.action_type === 'exit'"
+                class="action-comment"
+              >
                 {{ getActionComment(item) }}
               </div>
               
-              <div v-if="item.comment && item.action_type !== 'entry' && item.action_type !== 'exit'" class="action-comment">
+              <div
+                v-if="item.comment && item.action_type !== 'entry' && item.action_type !== 'exit'"
+                class="action-comment"
+              >
                 {{ item.comment }}
               </div>
 
-              <div v-if="item.table_name" class="place-name">
+              <div
+                v-if="item.table_name"
+                class="place-name"
+              >
                 {{ item.table_name }}
               </div>
             </div>
@@ -308,6 +375,17 @@ export default {
       const parts = this.currentUserName.split(' ').filter(part => part && part !== 'null' && part !== 'undefined');
       return parts.length > 0 ? parts.join(' ') : 'Пользователь';
     }
+  },
+  mounted() {
+    this.loadHistory();
+    document.addEventListener('click', this.handleClickOutside);
+    
+    this.cars.forEach(car => {
+      this.carsMap[car.id] = this.formatCarName(car);
+    });
+  },
+  beforeUnmount() {
+    document.removeEventListener('click', this.handleClickOutside);
   },
   methods: {
     formatCarName(car) {
@@ -571,17 +649,6 @@ export default {
     close() {
       this.$emit('close');
     }
-  },
-  mounted() {
-    this.loadHistory();
-    document.addEventListener('click', this.handleClickOutside);
-    
-    this.cars.forEach(car => {
-      this.carsMap[car.id] = this.formatCarName(car);
-    });
-  },
-  beforeUnmount() {
-    document.removeEventListener('click', this.handleClickOutside);
   }
 };
 </script>

--- a/frontend/src/components/CitizenshipManagement.vue
+++ b/frontend/src/components/CitizenshipManagement.vue
@@ -1,13 +1,18 @@
 <template>
   <div class="citizenship-container dashboard-card">
     <div class="management-header">
-      <h3 class="management-title">Управление гражданствами</h3>
+      <h3 class="management-title">
+        Управление гражданствами
+      </h3>
       <div class="header-controls">
         <SearchComponent
-          :title="'Поиск гражданств...'"
           v-model="searchQuery"
+          :title="'Поиск гражданств...'"
         />
-        <button @click="showAddModal = true" class="add-header-button">
+        <button
+          class="add-header-button"
+          @click="showAddModal = true"
+        >
           Добавить
         </button>
         <RefreshButton @refresh="refreshData" />
@@ -16,11 +21,19 @@
 
     <div class="content-container">
       <!-- Левая часть - таблица гражданств -->
-      <div class="table-section" :class="{'with-details': selectedCitizenship}">
+      <div
+        class="table-section"
+        :class="{'with-details': selectedCitizenship}"
+      >
         <div class="table-container">
           <div class="table-header">
-            <div class="header-col id-col" @click="sortBy('id')">
-              <p :class="{ 'active-sort': sortField === 'id' }">ID</p>
+            <div
+              class="header-col id-col"
+              @click="sortBy('id')"
+            >
+              <p :class="{ 'active-sort': sortField === 'id' }">
+                ID
+              </p>
               <img 
                 src="@/assets/icons/sort.png" 
                 class="sort-icon" 
@@ -28,10 +41,15 @@
                   'sorted': sortField === 'id',
                   'desc': sortField === 'id' && sortDirection === 'desc'
                 }" 
-              />
+              >
             </div>
-            <div class="header-col name-col" @click="sortBy('name')">
-              <p :class="{ 'active-sort': sortField === 'name' }">Наименование</p>
+            <div
+              class="header-col name-col"
+              @click="sortBy('name')"
+            >
+              <p :class="{ 'active-sort': sortField === 'name' }">
+                Наименование
+              </p>
               <img 
                 src="@/assets/icons/sort.png" 
                 class="sort-icon" 
@@ -39,10 +57,15 @@
                   'sorted': sortField === 'name',
                   'desc': sortField === 'name' && sortDirection === 'desc'
                 }" 
-              />
+              >
             </div>
-            <div class="header-col status-col" @click="sortBy('is_active')">
-              <p :class="{ 'active-sort': sortField === 'is_active' }">Статус</p>
+            <div
+              class="header-col status-col"
+              @click="sortBy('is_active')"
+            >
+              <p :class="{ 'active-sort': sortField === 'is_active' }">
+                Статус
+              </p>
               <img 
                 src="@/assets/icons/sort.png" 
                 class="sort-icon" 
@@ -50,7 +73,7 @@
                   'sorted': sortField === 'is_active',
                   'desc': sortField === 'is_active' && sortDirection === 'desc'
                 }" 
-              />
+              >
             </div>
           </div>
 
@@ -66,13 +89,22 @@
                 <span class="cell-content id-value">{{ citizenship.id }}</span>
               </div>
               <div class="table-col name-col">
-                <span class="truncate-text" :title="citizenship.name">
+                <span
+                  class="truncate-text"
+                  :title="citizenship.name"
+                >
                   {{ citizenship.name }}
-                  <span v-if="citizenship.is_default" class="default-badge">По умолчанию</span>
+                  <span
+                    v-if="citizenship.is_default"
+                    class="default-badge"
+                  >По умолчанию</span>
                 </span>
               </div>
               <div class="table-col status-col">
-                <span class="status-badge" :class="citizenship.is_active ? 'active' : 'inactive'">
+                <span
+                  class="status-badge"
+                  :class="citizenship.is_active ? 'active' : 'inactive'"
+                >
                   {{ citizenship.is_active ? 'Активно' : 'Неактивно' }}
                 </span>
               </div>
@@ -86,19 +118,33 @@
       </div>
 
       <!-- Правая часть - детали гражданства -->
-      <div v-if="selectedCitizenship" class="details-section">
+      <div
+        v-if="selectedCitizenship"
+        class="details-section"
+      >
         <div class="details-content">
           <div class="details-header">
             <div class="details-title-wrapper">
-                <h3 class="details-title">{{ selectedCitizenship.name }}</h3>
-                <div class="timestamps-header">
-                  <span class="timestamp">Создано: {{ formatDate(selectedCitizenship.created_at) }}</span>
-                  <span v-if="selectedCitizenship.updated_at" class="timestamp">Обновлено: {{ formatDate(selectedCitizenship.updated_at) }}</span>
-                </div>
+              <h3 class="details-title">
+                {{ selectedCitizenship.name }}
+              </h3>
+              <div class="timestamps-header">
+                <span class="timestamp">Создано: {{ formatDate(selectedCitizenship.created_at) }}</span>
+                <span
+                  v-if="selectedCitizenship.updated_at"
+                  class="timestamp"
+                >Обновлено: {{ formatDate(selectedCitizenship.updated_at) }}</span>
+              </div>
             </div>
             <div class="details-header-actions">
-              <button @click="confirmDeleteCitizenship(selectedCitizenship)" class="delete-icon-btn">
-                <img src="@/assets/icons/delete.png" class="delete-icon" />
+              <button
+                class="delete-icon-btn"
+                @click="confirmDeleteCitizenship(selectedCitizenship)"
+              >
+                <img
+                  src="@/assets/icons/delete.png"
+                  class="delete-icon"
+                >
               </button>
             </div>
           </div>
@@ -109,21 +155,21 @@
                 <label class="detail-label">Наименование:</label>
                 <input 
                   v-model="selectedCitizenship.name" 
-                  @change="updateCitizenship(selectedCitizenship)"
                   class="form-input-sm"
                   placeholder="Название гражданства"
                   autocomplete="off"
+                  @change="updateCitizenship(selectedCitizenship)"
                 >
               </div>
 
               <div class="checkbox-section">
                 <label class="checkbox-label">
                   <input 
-                    type="checkbox" 
-                    v-model="selectedCitizenship.is_active"
-                    @change="updateCitizenship(selectedCitizenship)"
+                    v-model="selectedCitizenship.is_active" 
+                    type="checkbox"
                     class="checkbox"
-                  />
+                    @change="updateCitizenship(selectedCitizenship)"
+                  >
                   <span class="checkbox-text">Активное гражданство</span>
                 </label>
                 <span class="checkbox-hint">
@@ -134,11 +180,11 @@
               <div class="checkbox-section">
                 <label class="checkbox-label">
                   <input 
-                    type="checkbox" 
-                    v-model="selectedCitizenship.is_default"
-                    @change="handleDefaultCitizenshipChange"
+                    v-model="selectedCitizenship.is_default" 
+                    type="checkbox"
                     class="checkbox"
-                  />
+                    @change="handleDefaultCitizenshipChange"
+                  >
                   <span class="checkbox-text">Гражданство по умолчанию</span>
                 </label>
                 <span class="checkbox-hint">
@@ -149,11 +195,11 @@
               <div class="checkbox-section">
                 <label class="checkbox-label">
                   <input 
-                    type="checkbox" 
-                    v-model="selectedCitizenship.patent_required"
-                    @change="updateCitizenship(selectedCitizenship)"
+                    v-model="selectedCitizenship.patent_required" 
+                    type="checkbox"
                     class="checkbox"
-                  />
+                    @change="updateCitizenship(selectedCitizenship)"
+                  >
                   <span class="checkbox-text">Требуется патент</span>
                 </label>
                 <span class="checkbox-hint">
@@ -165,22 +211,39 @@
         </div>
       </div>
       
-      <div v-else class="no-selection-message">
+      <div
+        v-else
+        class="no-selection-message"
+      >
         <p>Выберите гражданство для просмотра</p>
       </div>
     </div>
 
-    <div v-if="filteredCitizenships.length === 0" class="no-results">
-      <div class="no-results-icon">🌍</div>
+    <div
+      v-if="filteredCitizenships.length === 0"
+      class="no-results"
+    >
+      <div class="no-results-icon">
+        🌍
+      </div>
       <p>Гражданства не найдены</p>
     </div>
 
     <!-- Модальное окно добавления гражданства -->
-    <div v-if="showAddModal" class="modal-overlay" @click.self="showAddModal = false">
+    <div
+      v-if="showAddModal"
+      class="modal-overlay"
+      @click.self="showAddModal = false"
+    >
       <div class="modal-content small-modal">
         <div class="modal-header">
           <h3>Добавить гражданство</h3>
-          <button @click="showAddModal = false" class="modal-close">×</button>
+          <button
+            class="modal-close"
+            @click="showAddModal = false"
+          >
+            ×
+          </button>
         </div>
         
         <div class="modal-body">
@@ -197,10 +260,10 @@
           <div class="checkbox-group">
             <label class="checkbox-label">
               <input 
-                type="checkbox" 
-                v-model="newCitizenship.is_default"
+                v-model="newCitizenship.is_default" 
+                type="checkbox"
                 class="checkbox"
-              />
+              >
               <span class="checkbox-text">Гражданство по умолчанию</span>
             </label>
           </div>
@@ -208,18 +271,28 @@
           <div class="checkbox-group">
             <label class="checkbox-label">
               <input 
-                type="checkbox" 
-                v-model="newCitizenship.patent_required"
+                v-model="newCitizenship.patent_required" 
+                type="checkbox"
                 class="checkbox"
-              />
+              >
               <span class="checkbox-text">Требуется патент</span>
             </label>
           </div>
         </div>
         
         <div class="modal-footer">
-          <button @click="showAddModal = false" class="modal-cancel">Отмена</button>
-          <button @click="addCitizenship" class="modal-confirm">Добавить</button>
+          <button
+            class="modal-cancel"
+            @click="showAddModal = false"
+          >
+            Отмена
+          </button>
+          <button
+            class="modal-confirm"
+            @click="addCitizenship"
+          >
+            Добавить
+          </button>
         </div>
       </div>
     </div>
@@ -296,6 +369,9 @@ export default {
         return 0;
       });
     }
+  },
+  mounted() {
+    this.refreshData();
   },
   methods: {
     async refreshData() {
@@ -488,9 +564,6 @@ export default {
         notification.remove();
       }, 3000);
     }
-  },
-  mounted() {
-    this.refreshData();
   },
 };
 </script>

--- a/frontend/src/components/CompaniesManagement.vue
+++ b/frontend/src/components/CompaniesManagement.vue
@@ -1,13 +1,18 @@
 <template>
   <div class="companies-management dashboard-card">
     <div class="management-header">
-      <h3 class="management-title">Управление компаниями</h3>
+      <h3 class="management-title">
+        Управление компаниями
+      </h3>
       <div class="header-controls">
         <SearchComponent
-          :title="'Поиск компаний...'"
           v-model="searchQuery"
+          :title="'Поиск компаний...'"
         />
-        <button @click="showAddModal = true" class="add-header-button">
+        <button
+          class="add-header-button"
+          @click="showAddModal = true"
+        >
           Добавить
         </button>
         <RefreshButton @refresh="refreshData" />
@@ -19,8 +24,13 @@
       <div class="table-section">
         <div class="table-container">
           <div class="table-header">
-            <div class="header-col id-col" @click="sortBy('id')">
-              <p :class="{ 'active-sort': sortField === 'id' }">ID</p>
+            <div
+              class="header-col id-col"
+              @click="sortBy('id')"
+            >
+              <p :class="{ 'active-sort': sortField === 'id' }">
+                ID
+              </p>
               <img 
                 src="@/assets/icons/sort.png" 
                 class="sort-icon" 
@@ -28,10 +38,15 @@
                   'sorted': sortField === 'id',
                   'desc': sortField === 'id' && sortDirection === 'desc'
                 }" 
-              />
+              >
             </div>
-            <div class="header-col name-col" @click="sortBy('name')">
-              <p :class="{ 'active-sort': sortField === 'name' }">Наименование</p>
+            <div
+              class="header-col name-col"
+              @click="sortBy('name')"
+            >
+              <p :class="{ 'active-sort': sortField === 'name' }">
+                Наименование
+              </p>
               <img 
                 src="@/assets/icons/sort.png" 
                 class="sort-icon" 
@@ -39,10 +54,15 @@
                   'sorted': sortField === 'name',
                   'desc': sortField === 'name' && sortDirection === 'desc'
                 }" 
-              />
+              >
             </div>
-            <div class="header-col users-col" @click="sortBy('user_count')">
-              <p :class="{ 'active-sort': sortField === 'user_count' }">Пользователи</p>
+            <div
+              class="header-col users-col"
+              @click="sortBy('user_count')"
+            >
+              <p :class="{ 'active-sort': sortField === 'user_count' }">
+                Пользователи
+              </p>
               <img 
                 src="@/assets/icons/sort.png" 
                 class="sort-icon" 
@@ -50,7 +70,7 @@
                   'sorted': sortField === 'user_count',
                   'desc': sortField === 'user_count' && sortDirection === 'desc'
                 }" 
-              />
+              >
             </div>
           </div>
 
@@ -66,7 +86,10 @@
                 <span class="cell-content id-value">{{ comp.id }}</span>
               </div>
               <div class="table-col name-col">
-                <span class="truncate-text" :title="comp.name">
+                <span
+                  class="truncate-text"
+                  :title="comp.name"
+                >
                   {{ comp.name }}
                 </span>
               </div>
@@ -85,15 +108,26 @@
       </div>
 
       <!-- Средняя часть - детали компании -->
-      <div v-if="selectedCompany" class="details-section">
+      <div
+        v-if="selectedCompany"
+        class="details-section"
+      >
         <div class="details-content">
           <div class="details-header">
             <div class="details-title-wrapper">
-              <h3 class="details-title">{{ selectedCompany.name }}</h3>
+              <h3 class="details-title">
+                {{ selectedCompany.name }}
+              </h3>
             </div>
             <div class="details-header-actions">
-              <button @click="confirmDeleteCompany(selectedCompany)" class="delete-icon-btn">
-                <img src="@/assets/icons/delete.png" class="delete-icon" />
+              <button
+                class="delete-icon-btn"
+                @click="confirmDeleteCompany(selectedCompany)"
+              >
+                <img
+                  src="@/assets/icons/delete.png"
+                  class="delete-icon"
+                >
               </button>
             </div>
           </div>
@@ -106,10 +140,10 @@
                   <label class="detail-label">Наименование:</label>
                   <input 
                     v-model="selectedCompany.name" 
-                    @change="updateCompany(selectedCompany)"
                     class="form-input-sm"
                     placeholder="Введите название компании"
                     autocomplete="off"
+                    @change="updateCompany(selectedCompany)"
                   >
                 </div>
               </div>
@@ -138,31 +172,54 @@
       </div>
       
       <!-- Правая часть - ответственные лица -->
-      <div class="responsible-section" :class="{'with-details': selectedCompany}">
-        <div v-if="selectedCompany" class="responsible-content">
+      <div
+        class="responsible-section"
+        :class="{'with-details': selectedCompany}"
+      >
+        <div
+          v-if="selectedCompany"
+          class="responsible-content"
+        >
           <ResponsibleUsersSection
             :entity="selectedCompany"
             :entity-type="'company'"
             @users-updated="handleUsersUpdated"
           />
         </div>
-        <div v-else class="no-selection-message">
+        <div
+          v-else
+          class="no-selection-message"
+        >
           <p>Выберите компанию для просмотра</p>
         </div>
       </div>
     </div>
 
-    <div v-if="filteredCompanies.length === 0" class="no-results">
-      <div class="no-results-icon">🏭</div>
+    <div
+      v-if="filteredCompanies.length === 0"
+      class="no-results"
+    >
+      <div class="no-results-icon">
+        🏭
+      </div>
       <p>Компании не найдены</p>
     </div>
 
     <!-- Модальное окно добавления -->
-    <div v-if="showAddModal" class="modal-overlay" @click.self="showAddModal = false">
+    <div
+      v-if="showAddModal"
+      class="modal-overlay"
+      @click.self="showAddModal = false"
+    >
       <div class="modal-content">
         <div class="modal-header">
           <h3>Добавить компанию</h3>
-          <button @click="showAddModal = false" class="modal-close">×</button>
+          <button
+            class="modal-close"
+            @click="showAddModal = false"
+          >
+            ×
+          </button>
         </div>
         <div class="modal-body">
           <input
@@ -173,14 +230,24 @@
           >
         </div>
         <div class="modal-footer">
-          <button @click="showAddModal = false" class="modal-cancel">Отмена</button>
-          <button @click="addCompany" class="modal-confirm">Добавить</button>
+          <button
+            class="modal-cancel"
+            @click="showAddModal = false"
+          >
+            Отмена
+          </button>
+          <button
+            class="modal-confirm"
+            @click="addCompany"
+          >
+            Добавить
+          </button>
         </div>
       </div>
     </div>
 
     <!-- Модальное окно подтверждения удаления -->
-     <ConfirmationModal
+    <ConfirmationModal
       :show="showDeleteModal"
       title="Подтверждение удаления"
       :message="deleteMessage"
@@ -273,6 +340,18 @@ export default {
     deleteMessage() {
       return `Вы точно хотите удалить компанию "${this.companyToDelete?.name}"?`;
     }
+  },
+  watch: {
+    showAddModal(newVal) {
+      if (newVal) {
+        this.$nextTick(() => {
+          this.$refs.nameInput?.focus();
+        });
+      }
+    }
+  },
+  mounted() {
+    this.refreshData();
   },
   methods: {
     async refreshData() {
@@ -444,18 +523,6 @@ export default {
       setTimeout(() => {
         notification.remove();
       }, 3000);
-    }
-  },
-  mounted() {
-    this.refreshData();
-  },
-  watch: {
-    showAddModal(newVal) {
-      if (newVal) {
-        this.$nextTick(() => {
-          this.$refs.nameInput?.focus();
-        });
-      }
     }
   }
 };

--- a/frontend/src/components/ConfirmationModal.vue
+++ b/frontend/src/components/ConfirmationModal.vue
@@ -1,30 +1,36 @@
 <template>
-    <transition name="modal-fade">
-        <div v-if="show" class="modal-overlay" @click.self="handleCancel">
-            <div class="modal">
-                <div class="modal-header">{{ title }}</div>
-                <div class="modal-content">
-                    {{ message }}
-                </div>
-                <div class="modal-actions">
-                    <button 
-                        class="cancel-btn" 
-                        @click="handleCancel"
-                        :style="cancelButtonStyle"
-                    >
-                        {{ cancelText }}
-                    </button>
-                    <button 
-                        class="confirm-btn" 
-                        @click="handleConfirm"
-                        :style="confirmButtonStyle"
-                    >
-                        {{ confirmText }}
-                    </button>
-                </div>
-            </div>
+  <transition name="modal-fade">
+    <div
+      v-if="show"
+      class="modal-overlay"
+      @click.self="handleCancel"
+    >
+      <div class="modal">
+        <div class="modal-header">
+          {{ title }}
         </div>
-    </transition>
+        <div class="modal-content">
+          {{ message }}
+        </div>
+        <div class="modal-actions">
+          <button 
+            class="cancel-btn" 
+            :style="cancelButtonStyle"
+            @click="handleCancel"
+          >
+            {{ cancelText }}
+          </button>
+          <button 
+            class="confirm-btn" 
+            :style="confirmButtonStyle"
+            @click="handleConfirm"
+          >
+            {{ confirmText }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </transition>
 </template>
 
 <script>

--- a/frontend/src/components/CreateApplication/ApplicationSuccessModal.vue
+++ b/frontend/src/components/CreateApplication/ApplicationSuccessModal.vue
@@ -1,102 +1,177 @@
 <template>
-    <transition name="modal-fade">
-        <div v-if="show" class="modal-overlay" @click.self="handleClose">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <button class="modal-close" @click="handleClose">
-                        <svg width="10" height="10" viewBox="0 0 14 14" fill="none">
-                            <path d="M13 1L1 13M1 1L13 13" stroke="#666" stroke-width="2" stroke-linecap="round"/>
-                        </svg>
-                    </button>
-                </div>
-
-                <div class="modal-body">
-                    <h2 class="modal-title">Заявка успешно оформлена!</h2>
-
-                    <div class="application-number">
-                        <span class="label">Номер заявки:</span>
-                        <strong class="number">{{ applicationNumber }}</strong>
-                    </div>
-
-                    <div class="info-message">
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
-                            <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z" fill="#4F5BDF"/>
-                        </svg>
-                        <span>Скоро мы начнём её обрабатывать</span>
-                    </div>
-
-                    <div class="progress-container">
-                        <div class="progress-steps">
-                            <div
-                                v-for="(step, index) in steps"
-                                :key="index"
-                                class="progress-step"
-                                :class="{
-                                    completed: index < currentStep,
-                                    active: index === currentStep
-                                }"
-                            >
-                                <div class="step-icon">
-                                    <div class="step-circle">
-                                        <span v-if="index < currentStep" class="check-icon">+</span>
-                                        <span v-else class="step-number">{{ index + 1 }}</span>
-                                    </div>
-                                    <div class="step-glow"></div>
-                                </div>
-                                <div class="step-label">{{ step }}</div>
-                            </div>
-                        </div>
-                        <div class="progress-track">
-                            <div class="progress-fill" :style="{ width: progressWidth + '%' }">
-                                <div class="progress-sparkle"></div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="attachments-section">
-                        <div class="section-header">
-                            <h3 class="section-title">Вложения в заявке</h3>
-                            <span class="attachments-count">{{ attachmentsData.length }}</span>
-                        </div>
-
-                        <div v-if="attachmentsData.length === 0" class="no-attachments">
-                            <p>Нет вложений</p>
-                        </div>
-
-                        <div v-else class="attachments-list">
-                            <div
-                                v-for="(att, idx) in attachmentsData"
-                                :key="idx"
-                                class="attachment-item"
-                            >
-                                <div class="attachment-content">
-                                    <div class="attachment-name">{{ att.display_name }}</div>
-                                    <div class="attachment-details">
-                                        <span v-if="att.period" class="attachment-period">
-                                            <svg width="12" height="12" viewBox="0 0 24 24" fill="none">
-                                                <path d="M19 3h-1V1h-2v2H8V1H6v2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V9h14v10z" fill="#a2a2a2"/>
-                                            </svg>
-                                            {{ att.period }}
-                                        </span>
-                                        <span v-if="att.time" class="attachment-time">
-                                            <svg width="12" height="12" viewBox="0 0 24 24" fill="none">
-                                                <path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z" fill="#a2a2a2"/>
-                                            </svg>
-                                            {{ att.time }}
-                                        </span>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="modal-footer">
-                    <button class="btn close-btn" @click="handleClose">Закрыть</button>
-                </div>
-            </div>
+  <transition name="modal-fade">
+    <div
+      v-if="show"
+      class="modal-overlay"
+      @click.self="handleClose"
+    >
+      <div class="modal-content">
+        <div class="modal-header">
+          <button
+            class="modal-close"
+            @click="handleClose"
+          >
+            <svg
+              width="10"
+              height="10"
+              viewBox="0 0 14 14"
+              fill="none"
+            >
+              <path
+                d="M13 1L1 13M1 1L13 13"
+                stroke="#666"
+                stroke-width="2"
+                stroke-linecap="round"
+              />
+            </svg>
+          </button>
         </div>
-    </transition>
+
+        <div class="modal-body">
+          <h2 class="modal-title">
+            Заявка успешно оформлена!
+          </h2>
+
+          <div class="application-number">
+            <span class="label">Номер заявки:</span>
+            <strong class="number">{{ applicationNumber }}</strong>
+          </div>
+
+          <div class="info-message">
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+                fill="#4F5BDF"
+              />
+            </svg>
+            <span>Скоро мы начнём её обрабатывать</span>
+          </div>
+
+          <div class="progress-container">
+            <div class="progress-steps">
+              <div
+                v-for="(step, index) in steps"
+                :key="index"
+                class="progress-step"
+                :class="{
+                  completed: index < currentStep,
+                  active: index === currentStep
+                }"
+              >
+                <div class="step-icon">
+                  <div class="step-circle">
+                    <span
+                      v-if="index < currentStep"
+                      class="check-icon"
+                    >+</span>
+                    <span
+                      v-else
+                      class="step-number"
+                    >{{ index + 1 }}</span>
+                  </div>
+                  <div class="step-glow" />
+                </div>
+                <div class="step-label">
+                  {{ step }}
+                </div>
+              </div>
+            </div>
+            <div class="progress-track">
+              <div
+                class="progress-fill"
+                :style="{ width: progressWidth + '%' }"
+              >
+                <div class="progress-sparkle" />
+              </div>
+            </div>
+          </div>
+
+          <div class="attachments-section">
+            <div class="section-header">
+              <h3 class="section-title">
+                Вложения в заявке
+              </h3>
+              <span class="attachments-count">{{ attachmentsData.length }}</span>
+            </div>
+
+            <div
+              v-if="attachmentsData.length === 0"
+              class="no-attachments"
+            >
+              <p>Нет вложений</p>
+            </div>
+
+            <div
+              v-else
+              class="attachments-list"
+            >
+              <div
+                v-for="(att, idx) in attachmentsData"
+                :key="idx"
+                class="attachment-item"
+              >
+                <div class="attachment-content">
+                  <div class="attachment-name">
+                    {{ att.display_name }}
+                  </div>
+                  <div class="attachment-details">
+                    <span
+                      v-if="att.period"
+                      class="attachment-period"
+                    >
+                      <svg
+                        width="12"
+                        height="12"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                      >
+                        <path
+                          d="M19 3h-1V1h-2v2H8V1H6v2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V9h14v10z"
+                          fill="#a2a2a2"
+                        />
+                      </svg>
+                      {{ att.period }}
+                    </span>
+                    <span
+                      v-if="att.time"
+                      class="attachment-time"
+                    >
+                      <svg
+                        width="12"
+                        height="12"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                      >
+                        <path
+                          d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"
+                          fill="#a2a2a2"
+                        />
+                      </svg>
+                      {{ att.time }}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="modal-footer">
+          <button
+            class="btn close-btn"
+            @click="handleClose"
+          >
+            Закрыть
+          </button>
+        </div>
+      </div>
+    </div>
+  </transition>
 </template>
 
 <script>

--- a/frontend/src/components/CreateApplication/CarsBindingModal.vue
+++ b/frontend/src/components/CreateApplication/CarsBindingModal.vue
@@ -1,86 +1,126 @@
 <template>
-    <div class="modal-overlay" @click="$emit('close')">
-        <div class="modal-content" @click.stop>
-            <div class="modal-header">
-                <div class="modal-header__top">
-                    <h3>Привязка новых автомобилей</h3>
-                </div>
-                <button class="modal-close" @click="$emit('close')">×</button>
-            </div>
-            <div class="modal-body">
-                <div class="binding-info">
-                    <p class="binding-description">
-                        Все добавленные автомобили ниже <strong>автоматически привязываются</strong> к вашему аккаунту.
-                        Вы можете выбрать и привязать автомобили к организации и/или компании для использования <strong>другими сотрудниками</strong>:
-                    </p>
-                    
-                    <div class="cars-list-section">
-                        <p class="section-title">Список новых автомобилей:</p>
-                        <div class="cars-list">
-                            <div 
-                                v-for="car in newCarsToBind" 
-                                :key="car.plateNumber"
-                                class="car-item"
-                                :class="{ 'car-item--shared': car.bindToEntity }"
-                                @click="$emit('toggle-car-binding', car)"
-                            >
-                                <div class="car-selector">
-                                    <div class="selector-checkbox">
-                                        <div class="checkbox" :class="{ 'checkbox--checked': car.bindToEntity }"></div>
-                                    </div>
-                                    <div class="car-info">
-                                        <span class="car-number">{{ car.plateNumber }}</span>
-                                        <span class="car-mark">{{ car.mark }}</span>
-                                    </div>
-                                </div>
-                                <div class="car-binding-status">
-                                    <span v-if="car.bindToEntity" class="status-shared">
-                                        Будет доступна
-                                    </span>
-                                    <span v-else class="status-private">
-                                        Привязка только к вам
-                                    </span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="binding-options-section">
-                        <p class="section-title">Привязать выбранные автомобили к:</p>
-                        <div class="binding-options">
-                            <label class="binding-option" v-if="hasOrganization">
-                                <input 
-                                    type="checkbox" 
-                                    v-model="bindToOrganization"
-                                    :disabled="bindToCompany"
-                                />
-                                <span class="option-text">К организации "{{ organization }}"</span>
-                            </label>
-                            <label class="binding-option" v-if="hasCompany">
-                                <input 
-                                    type="checkbox" 
-                                    v-model="bindToCompany"
-                                    :disabled="bindToOrganization"
-                                />
-                                <span class="option-text">К компании "{{ company }}"</span>
-                            </label>
-                        </div>
-                    </div>
-
-                    <div class="warning-section">
-                        <p class="warning-text">
-                            <strong class="red">Внимание!</strong> При привязке автомобиля к организации или компании, он будет доступен для отображения и использования для всех сотрудников, привязанных к организации/компании.
-                        </p>
-                    </div>
-                </div>
-                
-                <div class="modal-actions">
-                    <button class="cancel-btn" @click="$emit('skip-binding')">Пропустить</button>
-                    <button class="confirm-btn" @click="$emit('confirm-binding')">Привязать и отправить</button>
-                </div>
-            </div>
+  <div
+    class="modal-overlay"
+    @click="$emit('close')"
+  >
+    <div
+      class="modal-content"
+      @click.stop
+    >
+      <div class="modal-header">
+        <div class="modal-header__top">
+          <h3>Привязка новых автомобилей</h3>
         </div>
+        <button
+          class="modal-close"
+          @click="$emit('close')"
+        >
+          ×
+        </button>
+      </div>
+      <div class="modal-body">
+        <div class="binding-info">
+          <p class="binding-description">
+            Все добавленные автомобили ниже <strong>автоматически привязываются</strong> к вашему аккаунту.
+            Вы можете выбрать и привязать автомобили к организации и/или компании для использования <strong>другими сотрудниками</strong>:
+          </p>
+                    
+          <div class="cars-list-section">
+            <p class="section-title">
+              Список новых автомобилей:
+            </p>
+            <div class="cars-list">
+              <div 
+                v-for="car in newCarsToBind" 
+                :key="car.plateNumber"
+                class="car-item"
+                :class="{ 'car-item--shared': car.bindToEntity }"
+                @click="$emit('toggle-car-binding', car)"
+              >
+                <div class="car-selector">
+                  <div class="selector-checkbox">
+                    <div
+                      class="checkbox"
+                      :class="{ 'checkbox--checked': car.bindToEntity }"
+                    />
+                  </div>
+                  <div class="car-info">
+                    <span class="car-number">{{ car.plateNumber }}</span>
+                    <span class="car-mark">{{ car.mark }}</span>
+                  </div>
+                </div>
+                <div class="car-binding-status">
+                  <span
+                    v-if="car.bindToEntity"
+                    class="status-shared"
+                  >
+                    Будет доступна
+                  </span>
+                  <span
+                    v-else
+                    class="status-private"
+                  >
+                    Привязка только к вам
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="binding-options-section">
+            <p class="section-title">
+              Привязать выбранные автомобили к:
+            </p>
+            <div class="binding-options">
+              <label
+                v-if="hasOrganization"
+                class="binding-option"
+              >
+                <input 
+                  v-model="bindToOrganization" 
+                  type="checkbox"
+                  :disabled="bindToCompany"
+                >
+                <span class="option-text">К организации "{{ organization }}"</span>
+              </label>
+              <label
+                v-if="hasCompany"
+                class="binding-option"
+              >
+                <input 
+                  v-model="bindToCompany" 
+                  type="checkbox"
+                  :disabled="bindToOrganization"
+                >
+                <span class="option-text">К компании "{{ company }}"</span>
+              </label>
+            </div>
+          </div>
+
+          <div class="warning-section">
+            <p class="warning-text">
+              <strong class="red">Внимание!</strong> При привязке автомобиля к организации или компании, он будет доступен для отображения и использования для всех сотрудников, привязанных к организации/компании.
+            </p>
+          </div>
+        </div>
+                
+        <div class="modal-actions">
+          <button
+            class="cancel-btn"
+            @click="$emit('skip-binding')"
+          >
+            Пропустить
+          </button>
+          <button
+            class="confirm-btn"
+            @click="$emit('confirm-binding')"
+          >
+            Привязать и отправить
+          </button>
+        </div>
+      </div>
     </div>
+  </div>
 </template>
 
 <script>

--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -1,247 +1,285 @@
 <template>
-    <div class="create">
-        <div class="create__header">
-            <div class="create__title">
-                <h3>Оформление и подача заявки</h3>
-                <button class="tables__instruction">
-                    <img src="@/assets/icons/instruction.png" class="tables__icon" />
-                    <p class="instruction__text">Инструкция</p>
-                </button>
-            </div>
-            <h4>{{ currentFormTitle }}</h4>
-        </div>
-        <div class="create__container">
-            <BlankSelector
-                ref="blankSelector"
-                :attachments="attachments"
-                :current-application-data="currentApplicationData"
-                @attachment-selected="handleAttachmentSelected"
-                @attachment-added="handleAttachmentAdded"
-                @attachment-removed="handleAttachmentRemoved"
-            />
-            
-            <div v-if="selectedAttachment" class="create__form">
-                <!-- 1 ряд: Письмо сопроводительное, Согласие, Отправка -->
-                <div class="form__header">
-                    <div class="header__content">
-                        <textarea 
-                            placeholder="Введите сопроводительное письмо / сообщение" 
-                            class="form__textarea"
-                            v-model="message"
-                        ></textarea>
-                        <div class="header__right">
-                            <div class="consent-section">
-                                <div class="consent-checkbox">
-                                    <input
-                                        type="checkbox"
-                                        id="consent"
-                                        data-testid="create-app-consent-checkbox"
-                                        v-model="consentGiven"
-                                        required
-                                    />
-                                    <label for="consent">
-                                        Даю <span class="blue">согласие</span> на обработку, хранение, передачу
-                                        персональных данных, изложенных в заявке
-                                    </label>
-                                </div>
-                                <div
-                                    class="submit-button-container"
-                                    :data-testid="'create-app-submit-wrapper'"
-                                    @mouseenter="tooltipMouseEnter"
-                                    @mouseleave="tooltipMouseLeave"
-                                >
-                                    <button class="send-all-btn" data-testid="create-app-button-submit" @click="submitApplication" :disabled="!canSubmit">
-                                        Отправить заявку
-                                    </button>
-                                    <div
-                                        v-if="showSubmitTooltip && !canSubmit && tooltipSections.length"
-                                        class="submit-tooltip"
-                                        @mouseenter="tooltipMouseEnter"
-                                        @mouseleave="tooltipMouseLeave"
-                                        @click="handleTooltipClick"
-                                    >
-                                        <div class="tooltip-content">
-                                            <div v-for="(section, idx) in tooltipSections" :key="idx" class="tooltip-section">
-                                                <div v-if="section.type === 'global'" class="tooltip-global">
-                                                    <div class="tooltip-section-title">Необходимо заполнить:</div>
-                                                    <ul>
-                                                        <li v-for="(msg, i) in section.messages" :key="i">{{ msg }}</li>
-                                                    </ul>
-                                                </div>
-                                                <div v-else-if="section.type === 'attachment'" class="tooltip-attachment">
-                                                    <div class="tooltip-attachment-title">
-                                                        <span
-                                                            class="attachment-clickable"
-                                                            :data-attachment-key="section.attachmentKey"
-                                                            @click="handleTooltipAttachmentClick(section)"
-                                                        >
-                                                            Вложение "{{ section.attachmentName }}"
-                                                        </span>
-                                                    </div>
-                                                    <ul>
-                                                        <li v-for="(msg, i) in section.messages" :key="i">{{ msg }}</li>
-                                                    </ul>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- 2 ряд: Организация, Компания, Ответственное лицо -->
-                <UserInfoRow 
-                    :organization="organization"
-                    :company="company"
-                    :responsible-person="responsiblePerson"
-                    :phone-number="phoneNumber"
-                    :errors="errors"
-                    @update:organization="organization = $event"
-                    @update:company="company = $event"
-                    @update:responsible-person="responsiblePerson = $event"
-                    @update:phone-number="phoneNumber = $event"
-                    @validate-field="validateField"
-                    @format-phone="handleFormatPhoneNumber"
-                    @clear-phone="handleClearPhoneFormat"
-                />
-
-                <!-- 3 ряд: Заголовок, Дата действия, Время пребывания (теперь индивидуально для вложения) -->
-                <div class="form__info-row">
-                    <DateRangeSection
-                        :is-one-day="currentAttachmentData.isOneDay"
-                        :start-date="currentAttachmentData.startDate"
-                        :end-date="currentAttachmentData.endDate"
-                        :single-date="currentAttachmentData.singleDate"
-                        :start-time="currentAttachmentData.startTime"
-                        :end-time="currentAttachmentData.endTime"
-                        :roof-access="currentAttachmentData.roofAccess"
-                        :free-parking="currentAttachmentData.freeParking"
-                        :notify-situation-center="currentAttachmentData.notifySituationCenter"
-                        :errors="currentAttachmentErrors"
-                        @update:is-one-day="updateAttachmentData('isOneDay', $event)"
-                        @update:start-date="updateAttachmentData('startDate', $event)"
-                        @update:end-date="updateAttachmentData('endDate', $event)"
-                        @update:single-date="updateAttachmentData('singleDate', $event)"
-                        @update:start-time="updateAttachmentData('startTime', $event)"
-                        @update:end-time="updateAttachmentData('endTime', $event)"
-                        @update:roof-access="updateAttachmentData('roofAccess', $event)"
-                        @update:free-parking="updateAttachmentData('freeParking', $event)"
-                        @update:notify-situation-center="updateAttachmentData('notifySituationCenter', $event)"
-                        @validate-field="validateAttachmentField"
-                        @validate-date-range="validateAttachmentDateRange"
-                        @validate-time-range="validateAttachmentTimeRange"
-                    />
-                </div>
-
-                <!-- 4 ряд: Динамические формы в зависимости от типа вложения -->
-                <div class="form__data">
-                    <!-- Для автомобилей -->
-                    <template v-if="selectedAttachment && selectedAttachment.attachment_type === 'cars'">
-                        <VehicleForm 
-                            :user-organization="organization"
-                            :user-organization-id="organizationId"
-                            :user-company="company"
-                            :user-company-id="companyId"
-                            :existing-vehicles="vehicles"
-                            :key="vehicleFormKey"
-                            @vehicle-added="handleVehicleAdded"
-                            @vehicles-added="handleVehiclesAdded"
-                            @vehicle-updated="handleVehicleUpdated"
-                            @edit-cancelled="handleVehicleEditCancelled"
-                            ref="vehicleForm"
-                        />
-                        <VehiclesList 
-                            :vehicles="sortedVehicles"
-                            :sort-field="sortField"
-                            :sort-direction="sortDirection"
-                            :all-unloading-places="allUnloadingPlaces"
-                            :license-plate-formats="licensePlateFormats"
-                            @sort="sortBy"
-                            @edit-vehicle="editVehicle"
-                            @delete-vehicle="deleteVehicle"
-                        />
-                    </template>
-
-                    <!-- Для людей/сотрудников -->
-                    <template v-else-if="selectedAttachment && selectedAttachment.attachment_type === 'people'">
-                        <EmployeeForm 
-                            :user-organization="organization"
-                            :user-organization-id="organizationId"
-                            :user-company="company"
-                            :user-company-id="companyId"
-                            :existing-employees="employees"
-                            :key="employeeFormKey"
-                            @employee-added="handleEmployeeAdded"
-                            @employees-added="handleEmployeesAdded"
-                            @employee-updated="handleEmployeeUpdated"
-                            @edit-cancelled="handleEmployeeEditCancelled"
-                            ref="employeeForm"
-                        />
-                        <EmployeesList 
-                            :employees="sortedEmployees"
-                            :sort-field="sortField"
-                            :sort-direction="sortDirection"
-                            :all-tables="allPassageTables"
-                            @sort="sortBy"
-                            @edit-employee="editEmployee"
-                            @delete-employee="deleteEmployee"
-                        />
-                    </template>
-
-                    <!-- Для ТМЦ -->
-                    <template v-else-if="selectedAttachment && selectedAttachment.attachment_type === 'items'">
-                        <ItemsForm 
-                            :existing-items="items"
-                            :key="itemsFormKey"
-                            @item-added="handleItemAdded"
-                            @items-added="handleItemsAdded"
-                            @item-updated="handleItemUpdated"
-                            @edit-cancelled="handleItemEditCancelled"
-                            ref="itemsForm"
-                        />
-                        <ItemsList 
-                            :items="sortedItems"
-                            :sort-field="sortField"
-                            :sort-direction="sortDirection"
-                            @sort="sortBy"
-                            @edit-item="editItem"
-                            @delete-item="deleteItem"
-                        />
-                    </template>
-                </div>
-            </div>
-            
-            <!-- Заглушка для формы, когда вложение не выбрано -->
-            <div v-else class="form-placeholder">
-                <div class="placeholder-content">
-                    <p>Добавьте или выберите вложение для начала работы</p>
-                </div>
-            </div>
-        </div>
-
-        <!-- Универсальное модальное окно привязки -->
-        <UniversalBindingModal
-            v-if="showBindingModal"
-            :new-vehicles-to-bind="newVehiclesToBind"
-            :new-employees-to-bind="newEmployeesToBind"
-            :organization="organization"
-            :company="company"
-            :has-organization="hasOrganization"
-            :has-company="hasCompany"
-            @confirm-binding="confirmBinding"
-            @skip-binding="skipBinding"
-            @close="closeBindingModal"
-        />
-
-        <ApplicationSuccessModal
-            :show="showSuccessModal"
-            :application-number="createdApplicationNumber"
-            :attachments-data="createdAttachmentsData"
-            @close="showSuccessModal = false; clearAllAttachments()"
-        />
+  <div class="create">
+    <div class="create__header">
+      <div class="create__title">
+        <h3>Оформление и подача заявки</h3>
+        <button class="tables__instruction">
+          <img
+            src="@/assets/icons/instruction.png"
+            class="tables__icon"
+          >
+          <p class="instruction__text">
+            Инструкция
+          </p>
+        </button>
+      </div>
+      <h4>{{ currentFormTitle }}</h4>
     </div>
+    <div class="create__container">
+      <BlankSelector
+        ref="blankSelector"
+        :attachments="attachments"
+        :current-application-data="currentApplicationData"
+        @attachment-selected="handleAttachmentSelected"
+        @attachment-added="handleAttachmentAdded"
+        @attachment-removed="handleAttachmentRemoved"
+      />
+            
+      <div
+        v-if="selectedAttachment"
+        class="create__form"
+      >
+        <!-- 1 ряд: Письмо сопроводительное, Согласие, Отправка -->
+        <div class="form__header">
+          <div class="header__content">
+            <textarea 
+              v-model="message" 
+              placeholder="Введите сопроводительное письмо / сообщение"
+              class="form__textarea"
+            />
+            <div class="header__right">
+              <div class="consent-section">
+                <div class="consent-checkbox">
+                  <input
+                    id="consent"
+                    v-model="consentGiven"
+                    type="checkbox"
+                    data-testid="create-app-consent-checkbox"
+                    required
+                  >
+                  <label for="consent">
+                    Даю <span class="blue">согласие</span> на обработку, хранение, передачу
+                    персональных данных, изложенных в заявке
+                  </label>
+                </div>
+                <div
+                  class="submit-button-container"
+                  :data-testid="'create-app-submit-wrapper'"
+                  @mouseenter="tooltipMouseEnter"
+                  @mouseleave="tooltipMouseLeave"
+                >
+                  <button
+                    class="send-all-btn"
+                    data-testid="create-app-button-submit"
+                    :disabled="!canSubmit"
+                    @click="submitApplication"
+                  >
+                    Отправить заявку
+                  </button>
+                  <div
+                    v-if="showSubmitTooltip && !canSubmit && tooltipSections.length"
+                    class="submit-tooltip"
+                    @mouseenter="tooltipMouseEnter"
+                    @mouseleave="tooltipMouseLeave"
+                    @click="handleTooltipClick"
+                  >
+                    <div class="tooltip-content">
+                      <div
+                        v-for="(section, idx) in tooltipSections"
+                        :key="idx"
+                        class="tooltip-section"
+                      >
+                        <div
+                          v-if="section.type === 'global'"
+                          class="tooltip-global"
+                        >
+                          <div class="tooltip-section-title">
+                            Необходимо заполнить:
+                          </div>
+                          <ul>
+                            <li
+                              v-for="(msg, i) in section.messages"
+                              :key="i"
+                            >
+                              {{ msg }}
+                            </li>
+                          </ul>
+                        </div>
+                        <div
+                          v-else-if="section.type === 'attachment'"
+                          class="tooltip-attachment"
+                        >
+                          <div class="tooltip-attachment-title">
+                            <span
+                              class="attachment-clickable"
+                              :data-attachment-key="section.attachmentKey"
+                              @click="handleTooltipAttachmentClick(section)"
+                            >
+                              Вложение "{{ section.attachmentName }}"
+                            </span>
+                          </div>
+                          <ul>
+                            <li
+                              v-for="(msg, i) in section.messages"
+                              :key="i"
+                            >
+                              {{ msg }}
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- 2 ряд: Организация, Компания, Ответственное лицо -->
+        <UserInfoRow 
+          :organization="organization"
+          :company="company"
+          :responsible-person="responsiblePerson"
+          :phone-number="phoneNumber"
+          :errors="errors"
+          @update:organization="organization = $event"
+          @update:company="company = $event"
+          @update:responsible-person="responsiblePerson = $event"
+          @update:phone-number="phoneNumber = $event"
+          @validate-field="validateField"
+          @format-phone="handleFormatPhoneNumber"
+          @clear-phone="handleClearPhoneFormat"
+        />
+
+        <!-- 3 ряд: Заголовок, Дата действия, Время пребывания (теперь индивидуально для вложения) -->
+        <div class="form__info-row">
+          <DateRangeSection
+            :is-one-day="currentAttachmentData.isOneDay"
+            :start-date="currentAttachmentData.startDate"
+            :end-date="currentAttachmentData.endDate"
+            :single-date="currentAttachmentData.singleDate"
+            :start-time="currentAttachmentData.startTime"
+            :end-time="currentAttachmentData.endTime"
+            :roof-access="currentAttachmentData.roofAccess"
+            :free-parking="currentAttachmentData.freeParking"
+            :notify-situation-center="currentAttachmentData.notifySituationCenter"
+            :errors="currentAttachmentErrors"
+            @update:is-one-day="updateAttachmentData('isOneDay', $event)"
+            @update:start-date="updateAttachmentData('startDate', $event)"
+            @update:end-date="updateAttachmentData('endDate', $event)"
+            @update:single-date="updateAttachmentData('singleDate', $event)"
+            @update:start-time="updateAttachmentData('startTime', $event)"
+            @update:end-time="updateAttachmentData('endTime', $event)"
+            @update:roof-access="updateAttachmentData('roofAccess', $event)"
+            @update:free-parking="updateAttachmentData('freeParking', $event)"
+            @update:notify-situation-center="updateAttachmentData('notifySituationCenter', $event)"
+            @validate-field="validateAttachmentField"
+            @validate-date-range="validateAttachmentDateRange"
+            @validate-time-range="validateAttachmentTimeRange"
+          />
+        </div>
+
+        <!-- 4 ряд: Динамические формы в зависимости от типа вложения -->
+        <div class="form__data">
+          <!-- Для автомобилей -->
+          <template v-if="selectedAttachment && selectedAttachment.attachment_type === 'cars'">
+            <VehicleForm 
+              :key="vehicleFormKey"
+              ref="vehicleForm"
+              :user-organization="organization"
+              :user-organization-id="organizationId"
+              :user-company="company"
+              :user-company-id="companyId"
+              :existing-vehicles="vehicles"
+              @vehicle-added="handleVehicleAdded"
+              @vehicles-added="handleVehiclesAdded"
+              @vehicle-updated="handleVehicleUpdated"
+              @edit-cancelled="handleVehicleEditCancelled"
+            />
+            <VehiclesList 
+              :vehicles="sortedVehicles"
+              :sort-field="sortField"
+              :sort-direction="sortDirection"
+              :all-unloading-places="allUnloadingPlaces"
+              :license-plate-formats="licensePlateFormats"
+              @sort="sortBy"
+              @edit-vehicle="editVehicle"
+              @delete-vehicle="deleteVehicle"
+            />
+          </template>
+
+          <!-- Для людей/сотрудников -->
+          <template v-else-if="selectedAttachment && selectedAttachment.attachment_type === 'people'">
+            <EmployeeForm 
+              :key="employeeFormKey"
+              ref="employeeForm"
+              :user-organization="organization"
+              :user-organization-id="organizationId"
+              :user-company="company"
+              :user-company-id="companyId"
+              :existing-employees="employees"
+              @employee-added="handleEmployeeAdded"
+              @employees-added="handleEmployeesAdded"
+              @employee-updated="handleEmployeeUpdated"
+              @edit-cancelled="handleEmployeeEditCancelled"
+            />
+            <EmployeesList 
+              :employees="sortedEmployees"
+              :sort-field="sortField"
+              :sort-direction="sortDirection"
+              :all-tables="allPassageTables"
+              @sort="sortBy"
+              @edit-employee="editEmployee"
+              @delete-employee="deleteEmployee"
+            />
+          </template>
+
+          <!-- Для ТМЦ -->
+          <template v-else-if="selectedAttachment && selectedAttachment.attachment_type === 'items'">
+            <ItemsForm 
+              :key="itemsFormKey"
+              ref="itemsForm"
+              :existing-items="items"
+              @item-added="handleItemAdded"
+              @items-added="handleItemsAdded"
+              @item-updated="handleItemUpdated"
+              @edit-cancelled="handleItemEditCancelled"
+            />
+            <ItemsList 
+              :items="sortedItems"
+              :sort-field="sortField"
+              :sort-direction="sortDirection"
+              @sort="sortBy"
+              @edit-item="editItem"
+              @delete-item="deleteItem"
+            />
+          </template>
+        </div>
+      </div>
+            
+      <!-- Заглушка для формы, когда вложение не выбрано -->
+      <div
+        v-else
+        class="form-placeholder"
+      >
+        <div class="placeholder-content">
+          <p>Добавьте или выберите вложение для начала работы</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Универсальное модальное окно привязки -->
+    <UniversalBindingModal
+      v-if="showBindingModal"
+      :new-vehicles-to-bind="newVehiclesToBind"
+      :new-employees-to-bind="newEmployeesToBind"
+      :organization="organization"
+      :company="company"
+      :has-organization="hasOrganization"
+      :has-company="hasCompany"
+      @confirm-binding="confirmBinding"
+      @skip-binding="skipBinding"
+      @close="closeBindingModal"
+    />
+
+    <ApplicationSuccessModal
+      :show="showSuccessModal"
+      :application-number="createdApplicationNumber"
+      :attachments-data="createdAttachmentsData"
+      @close="showSuccessModal = false; clearAllAttachments()"
+    />
+  </div>
 </template>
 
 <script>
@@ -603,6 +641,21 @@ export default {
                 return 0;
             });
         }
+    },
+    mounted() {
+        this.restoreFromLocalStorage();
+        this.loadUserData();
+        this.loadAllUnloadingPlaces();
+        this.loadLicensePlateFormats();
+        this.loadPassageTables();
+        
+        window.addEventListener('beforeunload', () => {
+            this.saveCurrentAttachmentData();
+            this.saveToLocalStorage();
+        });
+    },
+    beforeUnmount() {
+        window.removeEventListener('beforeunload', this.saveToLocalStorage);
     },
     methods: {
         
@@ -1951,21 +2004,6 @@ export default {
             const [year, month, day] = dateStr.split('-');
             return `${day}.${month}.${year}`;
         }
-    },
-    mounted() {
-        this.restoreFromLocalStorage();
-        this.loadUserData();
-        this.loadAllUnloadingPlaces();
-        this.loadLicensePlateFormats();
-        this.loadPassageTables();
-        
-        window.addEventListener('beforeunload', () => {
-            this.saveCurrentAttachmentData();
-            this.saveToLocalStorage();
-        });
-    },
-    beforeUnmount() {
-        window.removeEventListener('beforeunload', this.saveToLocalStorage);
     }
 }
 </script>

--- a/frontend/src/components/CreateApplication/DateRangeSection.vue
+++ b/frontend/src/components/CreateApplication/DateRangeSection.vue
@@ -1,209 +1,349 @@
 <template>
-    <div class="date-range-section">
-        <div class="date__input">
-            <label class="input__label">Дата действия <span class="required">*</span></label>
-            <div class="date-container">
-                <div class="date" v-if="!isOneDay">
-                    <p class="date__text">с</p>
-                    <div class="datepicker-wrapper">
-                        <input
-                            ref="startDateInput"
-                            class="input__date"
-                            placeholder="дд.мм.гггг"
-                            :value="startDate"
-                            @input="onStartDateInput"
-                            @focus="openDatepicker('start')"
-                            @blur="handleDateBlur('start')"
-                            @keydown="preventNonNumeric"
-                            @keydown.tab="onTabFromStart"
-                            @paste="preventNonNumericPaste"
-                            :class="{ 'input--error': errors.startDate }"
-                            maxlength="10"
-                        />
-                        <transition name="calendar">
-                            <div v-if="showStartDatepicker" class="datepicker" @click.stop>
-                                <div class="datepicker__header">
-                                    <button @click="prevMonth" class="datepicker__nav" tabindex="-1">
-                                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none">
-                                            <path d="M15 18L9 12L15 6" stroke="#4F5BDF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                                        </svg>
-                                    </button>
-                                    <span class="datepicker__month">{{ currentMonth }} {{ currentYear }}</span>
-                                    <button @click="nextMonth" class="datepicker__nav" tabindex="-1">
-                                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none">
-                                            <path d="M9 18L15 12L9 6" stroke="#4F5BDF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                                        </svg>
-                                    </button>
-                                </div>
-                                <div class="datepicker__weekdays">
-                                    <div v-for="day in weekdays" :key="day" class="datepicker__weekday">{{ day }}</div>
-                                </div>
-                                <div class="datepicker__days">
-                                    <div
-                                        v-for="day in calendarDays"
-                                        :key="day.date"
-                                        class="datepicker__day"
-                                        :class="getDayClass(day, startDate)"
-                                        @click="selectStartDate(day)"
-                                    >
-                                        {{ day.day }}
-                                    </div>
-                                </div>
-                            </div>
-                        </transition>
-                    </div>
-                    <p class="date__text">по</p>
-                    <div class="datepicker-wrapper">
-                        <input
-                            ref="endDateInput"
-                            class="input__date"
-                            placeholder="дд.мм.гггг"
-                            :value="endDate"
-                            @input="onEndDateInput"
-                            @focus="openDatepicker('end')"
-                            @blur="handleDateBlur('end')"
-                            @keydown="preventNonNumeric"
-                            @paste="preventNonNumericPaste"
-                            :class="{ 'input--error': errors.endDate }"
-                            maxlength="10"
-                        />
-                        <transition name="calendar">
-                            <div v-if="showEndDatepicker" class="datepicker" @click.stop>
-                                <div class="datepicker__header">
-                                    <button @click="prevMonth" class="datepicker__nav" tabindex="-1">
-                                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none">
-                                            <path d="M15 18L9 12L15 6" stroke="#4F5BDF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                                        </svg>
-                                    </button>
-                                    <span class="datepicker__month">{{ currentMonth }} {{ currentYear }}</span>
-                                    <button @click="nextMonth" class="datepicker__nav" tabindex="-1">
-                                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none">
-                                            <path d="M9 18L15 12L9 6" stroke="#4F5BDF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                                        </svg>
-                                    </button>
-                                </div>
-                                <div class="datepicker__weekdays">
-                                    <div v-for="day in weekdays" :key="day" class="datepicker__weekday">{{ day }}</div>
-                                </div>
-                                <div class="datepicker__days">
-                                    <div
-                                        v-for="day in calendarDays"
-                                        :key="day.date"
-                                        class="datepicker__day"
-                                        :class="getDayClass(day, endDate)"
-                                        @click="selectEndDate(day)"
-                                    >
-                                        {{ day.day }}
-                                    </div>
-                                </div>
-                            </div>
-                        </transition>
-                    </div>
+  <div class="date-range-section">
+    <div class="date__input">
+      <label class="input__label">Дата действия <span class="required">*</span></label>
+      <div class="date-container">
+        <div
+          v-if="!isOneDay"
+          class="date"
+        >
+          <p class="date__text">
+            с
+          </p>
+          <div class="datepicker-wrapper">
+            <input
+              ref="startDateInput"
+              class="input__date"
+              placeholder="дд.мм.гггг"
+              :value="startDate"
+              :class="{ 'input--error': errors.startDate }"
+              maxlength="10"
+              @input="onStartDateInput"
+              @focus="openDatepicker('start')"
+              @blur="handleDateBlur('start')"
+              @keydown="preventNonNumeric"
+              @keydown.tab="onTabFromStart"
+              @paste="preventNonNumericPaste"
+            >
+            <transition name="calendar">
+              <div
+                v-if="showStartDatepicker"
+                class="datepicker"
+                @click.stop
+              >
+                <div class="datepicker__header">
+                  <button
+                    class="datepicker__nav"
+                    tabindex="-1"
+                    @click="prevMonth"
+                  >
+                    <svg
+                      width="12"
+                      height="12"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                    >
+                      <path
+                        d="M15 18L9 12L15 6"
+                        stroke="#4F5BDF"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                  </button>
+                  <span class="datepicker__month">{{ currentMonth }} {{ currentYear }}</span>
+                  <button
+                    class="datepicker__nav"
+                    tabindex="-1"
+                    @click="nextMonth"
+                  >
+                    <svg
+                      width="12"
+                      height="12"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                    >
+                      <path
+                        d="M9 18L15 12L9 6"
+                        stroke="#4F5BDF"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                  </button>
                 </div>
-                <div v-else class="single-date">
-                    <div class="datepicker-wrapper">
-                        <input
-                            ref="singleDateInput"
-                            class="input__date"
-                            placeholder="дд.мм.гггг"
-                            :value="singleDate"
-                            @input="onSingleDateInput"
-                            @focus="openDatepicker('single')"
-                            @blur="handleDateBlur('single')"
-                            @keydown="preventNonNumeric"
-                            @paste="preventNonNumericPaste"
-                            :class="{ 'input--error': errors.singleDate }"
-                            maxlength="10"
-                        />
-                        <transition name="calendar">
-                            <div v-if="showSingleDatepicker" class="datepicker" @click.stop>
-                                <div class="datepicker__header">
-                                    <button @click="prevMonth" class="datepicker__nav" tabindex="-1">
-                                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none">
-                                            <path d="M15 18L9 12L15 6" stroke="#4F5BDF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                                        </svg>
-                                    </button>
-                                    <span class="datepicker__month">{{ currentMonth }} {{ currentYear }}</span>
-                                    <button @click="nextMonth" class="datepicker__nav" tabindex="-1">
-                                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none">
-                                            <path d="M9 18L15 12L9 6" stroke="#4F5BDF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                                        </svg>
-                                    </button>
-                                </div>
-                                <div class="datepicker__weekdays">
-                                    <div v-for="day in weekdays" :key="day" class="datepicker__weekday">{{ day }}</div>
-                                </div>
-                                <div class="datepicker__days">
-                                    <div
-                                        v-for="day in calendarDays"
-                                        :key="day.date"
-                                        class="datepicker__day"
-                                        :class="getDayClass(day, singleDate)"
-                                        @click="selectSingleDate(day)"
-                                    >
-                                        {{ day.day }}
-                                    </div>
-                                </div>
-                            </div>
-                        </transition>
-                    </div>
+                <div class="datepicker__weekdays">
+                  <div
+                    v-for="day in weekdays"
+                    :key="day"
+                    class="datepicker__weekday"
+                  >
+                    {{ day }}
+                  </div>
                 </div>
-                <div v-if="errors.startDate || errors.endDate || errors.singleDate" class="error-message date-error">
-                    {{ errors.startDate || errors.endDate || errors.singleDate }}
+                <div class="datepicker__days">
+                  <div
+                    v-for="day in calendarDays"
+                    :key="day.date"
+                    class="datepicker__day"
+                    :class="getDayClass(day, startDate)"
+                    @click="selectStartDate(day)"
+                  >
+                    {{ day.day }}
+                  </div>
                 </div>
-            </div>
-            <div class="one-day">
-                <input
-                    type="checkbox"
-                    class="one-day__checkbox"
-                    :checked="isOneDay"
-                    @change="onCheckboxChange"
-                />
-                <p>однодневная заявка</p>
-            </div>
+              </div>
+            </transition>
+          </div>
+          <p class="date__text">
+            по
+          </p>
+          <div class="datepicker-wrapper">
+            <input
+              ref="endDateInput"
+              class="input__date"
+              placeholder="дд.мм.гггг"
+              :value="endDate"
+              :class="{ 'input--error': errors.endDate }"
+              maxlength="10"
+              @input="onEndDateInput"
+              @focus="openDatepicker('end')"
+              @blur="handleDateBlur('end')"
+              @keydown="preventNonNumeric"
+              @paste="preventNonNumericPaste"
+            >
+            <transition name="calendar">
+              <div
+                v-if="showEndDatepicker"
+                class="datepicker"
+                @click.stop
+              >
+                <div class="datepicker__header">
+                  <button
+                    class="datepicker__nav"
+                    tabindex="-1"
+                    @click="prevMonth"
+                  >
+                    <svg
+                      width="12"
+                      height="12"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                    >
+                      <path
+                        d="M15 18L9 12L15 6"
+                        stroke="#4F5BDF"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                  </button>
+                  <span class="datepicker__month">{{ currentMonth }} {{ currentYear }}</span>
+                  <button
+                    class="datepicker__nav"
+                    tabindex="-1"
+                    @click="nextMonth"
+                  >
+                    <svg
+                      width="12"
+                      height="12"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                    >
+                      <path
+                        d="M9 18L15 12L9 6"
+                        stroke="#4F5BDF"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                  </button>
+                </div>
+                <div class="datepicker__weekdays">
+                  <div
+                    v-for="day in weekdays"
+                    :key="day"
+                    class="datepicker__weekday"
+                  >
+                    {{ day }}
+                  </div>
+                </div>
+                <div class="datepicker__days">
+                  <div
+                    v-for="day in calendarDays"
+                    :key="day.date"
+                    class="datepicker__day"
+                    :class="getDayClass(day, endDate)"
+                    @click="selectEndDate(day)"
+                  >
+                    {{ day.day }}
+                  </div>
+                </div>
+              </div>
+            </transition>
+          </div>
         </div>
-        <div class="date__input time-section">
-            <label class="input__label">Время пребывания (проезда) <span class="required">*</span></label>
-            <div class="time-wrapper">
-                <div class="time-input-group">
-                    <p class="date__text">с</p>
-                    <input
-                        ref="startTimeInput"
-                        class="input__time"
-                        placeholder="чч:мм"
-                        :value="startTime"
-                        @input="onStartTimeInput"
-                        @blur="formatTimeField('start')"
-                        @keydown="preventNonNumeric"
-                        @paste="preventNonNumericPaste"
-                        :class="{ 'input--error': errors.startTime }"
-                        inputmode="numeric"
-                        maxlength="5"
-                    />
+        <div
+          v-else
+          class="single-date"
+        >
+          <div class="datepicker-wrapper">
+            <input
+              ref="singleDateInput"
+              class="input__date"
+              placeholder="дд.мм.гггг"
+              :value="singleDate"
+              :class="{ 'input--error': errors.singleDate }"
+              maxlength="10"
+              @input="onSingleDateInput"
+              @focus="openDatepicker('single')"
+              @blur="handleDateBlur('single')"
+              @keydown="preventNonNumeric"
+              @paste="preventNonNumericPaste"
+            >
+            <transition name="calendar">
+              <div
+                v-if="showSingleDatepicker"
+                class="datepicker"
+                @click.stop
+              >
+                <div class="datepicker__header">
+                  <button
+                    class="datepicker__nav"
+                    tabindex="-1"
+                    @click="prevMonth"
+                  >
+                    <svg
+                      width="12"
+                      height="12"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                    >
+                      <path
+                        d="M15 18L9 12L15 6"
+                        stroke="#4F5BDF"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                  </button>
+                  <span class="datepicker__month">{{ currentMonth }} {{ currentYear }}</span>
+                  <button
+                    class="datepicker__nav"
+                    tabindex="-1"
+                    @click="nextMonth"
+                  >
+                    <svg
+                      width="12"
+                      height="12"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                    >
+                      <path
+                        d="M9 18L15 12L9 6"
+                        stroke="#4F5BDF"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                  </button>
                 </div>
-                <div class="time-input-group">
-                    <p class="date__text">по</p>
-                    <input
-                        ref="endTimeInput"
-                        class="input__time"
-                        placeholder="чч:мм"
-                        :value="endTime"
-                        @input="onEndTimeInput"
-                        @blur="formatTimeField('end')"
-                        @keydown="preventNonNumeric"
-                        @paste="preventNonNumericPaste"
-                        :class="{ 'input--error': errors.endTime }"
-                        inputmode="numeric"
-                        maxlength="5"
-                    />
+                <div class="datepicker__weekdays">
+                  <div
+                    v-for="day in weekdays"
+                    :key="day"
+                    class="datepicker__weekday"
+                  >
+                    {{ day }}
+                  </div>
                 </div>
-            </div>
-            <p class="time-message"></p>
-            <div v-if="errors.startTime || errors.endTime" class="error-message time-error">
-                {{ errors.startTime || errors.endTime }}
-            </div>
+                <div class="datepicker__days">
+                  <div
+                    v-for="day in calendarDays"
+                    :key="day.date"
+                    class="datepicker__day"
+                    :class="getDayClass(day, singleDate)"
+                    @click="selectSingleDate(day)"
+                  >
+                    {{ day.day }}
+                  </div>
+                </div>
+              </div>
+            </transition>
+          </div>
         </div>
+        <div
+          v-if="errors.startDate || errors.endDate || errors.singleDate"
+          class="error-message date-error"
+        >
+          {{ errors.startDate || errors.endDate || errors.singleDate }}
+        </div>
+      </div>
+      <div class="one-day">
+        <input
+          type="checkbox"
+          class="one-day__checkbox"
+          :checked="isOneDay"
+          @change="onCheckboxChange"
+        >
+        <p>однодневная заявка</p>
+      </div>
     </div>
+    <div class="date__input time-section">
+      <label class="input__label">Время пребывания (проезда) <span class="required">*</span></label>
+      <div class="time-wrapper">
+        <div class="time-input-group">
+          <p class="date__text">
+            с
+          </p>
+          <input
+            ref="startTimeInput"
+            class="input__time"
+            placeholder="чч:мм"
+            :value="startTime"
+            :class="{ 'input--error': errors.startTime }"
+            inputmode="numeric"
+            maxlength="5"
+            @input="onStartTimeInput"
+            @blur="formatTimeField('start')"
+            @keydown="preventNonNumeric"
+            @paste="preventNonNumericPaste"
+          >
+        </div>
+        <div class="time-input-group">
+          <p class="date__text">
+            по
+          </p>
+          <input
+            ref="endTimeInput"
+            class="input__time"
+            placeholder="чч:мм"
+            :value="endTime"
+            :class="{ 'input--error': errors.endTime }"
+            inputmode="numeric"
+            maxlength="5"
+            @input="onEndTimeInput"
+            @blur="formatTimeField('end')"
+            @keydown="preventNonNumeric"
+            @paste="preventNonNumericPaste"
+          >
+        </div>
+      </div>
+      <p class="time-message" />
+      <div
+        v-if="errors.startTime || errors.endTime"
+        class="error-message time-error"
+      >
+        {{ errors.startTime || errors.endTime }}
+      </div>
+    </div>
+  </div>
 </template>
 
 <script>
@@ -300,6 +440,42 @@ export default {
 
             return days;
         }
+    },
+    watch: {
+        startDate(newVal) {
+            if (this.internalToggle) return;
+            if (newVal && this.endDate && newVal === this.endDate && !this.isOneDay) {
+                this.toggleOneDay(true);
+            }
+        },
+        endDate(newVal) {
+            if (this.internalToggle) return;
+            if (newVal && this.startDate && newVal === this.startDate && !this.isOneDay) {
+                this.toggleOneDay(true);
+            }
+        },
+        singleDate() {
+            if (this.internalToggle) return;
+            this.$emit('validate-field', 'singleDate');
+            this.validateTimeCrossing();
+        },
+        startTime() {
+            if (this.internalToggle) return;
+            this.validateTimeCrossing();
+        },
+        endTime() {
+            if (this.internalToggle) return;
+            this.validateTimeCrossing();
+        }
+    },
+    mounted() {
+        document.addEventListener('click', (e) => {
+            if (!e.target.closest('.datepicker-wrapper')) {
+                this.closeDatepicker();
+            }
+        });
+        this.validateDateRange();
+        this.validateTimeCrossing();
     },
     methods: {
         onTabFromStart(e) {
@@ -731,42 +907,6 @@ export default {
 
         nextMonth() {
             this.currentDate = new Date(this.currentDate.getFullYear(), this.currentDate.getMonth() + 1, 1);
-        }
-    },
-    mounted() {
-        document.addEventListener('click', (e) => {
-            if (!e.target.closest('.datepicker-wrapper')) {
-                this.closeDatepicker();
-            }
-        });
-        this.validateDateRange();
-        this.validateTimeCrossing();
-    },
-    watch: {
-        startDate(newVal) {
-            if (this.internalToggle) return;
-            if (newVal && this.endDate && newVal === this.endDate && !this.isOneDay) {
-                this.toggleOneDay(true);
-            }
-        },
-        endDate(newVal) {
-            if (this.internalToggle) return;
-            if (newVal && this.startDate && newVal === this.startDate && !this.isOneDay) {
-                this.toggleOneDay(true);
-            }
-        },
-        singleDate() {
-            if (this.internalToggle) return;
-            this.$emit('validate-field', 'singleDate');
-            this.validateTimeCrossing();
-        },
-        startTime() {
-            if (this.internalToggle) return;
-            this.validateTimeCrossing();
-        },
-        endTime() {
-            if (this.internalToggle) return;
-            this.validateTimeCrossing();
         }
     }
 }

--- a/frontend/src/components/CreateApplication/EmployeeBindingModal.vue
+++ b/frontend/src/components/CreateApplication/EmployeeBindingModal.vue
@@ -1,70 +1,94 @@
 <template>
-    <div class="modal-overlay" @click="$emit('close')">
-        <div class="modal-content" @click.stop>
-            <div class="modal-header">
-                <div class="modal-header__top">
-                    <h3>Привязка новых сотрудников</h3>
-                </div>
-                <button class="modal-close" @click="$emit('close')">×</button>
-            </div>
-            <div class="modal-body">
-                <div class="binding-info">
-                    <p class="binding-description">
-                        Все добавленные сотрудники будут <strong>автоматически привязаны</strong> к вашему аккаунту.
-                        Вы можете дополнительно привязать их к организации и/или компании для использования <strong>другими сотрудниками</strong>:
-                    </p>
-                    
-                    <div class="employees-list-section">
-                        <p class="section-title">Новые сотрудники ({{ newEmployeesToBind.length }}):</p>
-                        <div class="employees-list">
-                            <div 
-                                v-for="employee in newEmployeesToBind" 
-                                :key="employee.passportSeriesNumber"
-                                class="employee-item"
-                            >
-                                <div class="employee-info">
-                                    <span class="employee-name">{{ formatFullName(employee) }}</span>
-                                    <span class="employee-position">{{ employee.position }}</span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="binding-options-section">
-                        <p class="section-title">Привязать всех сотрудников к:</p>
-                        <div class="binding-options">
-                            <label class="binding-option" v-if="hasOrganization">
-                                <input 
-                                    type="checkbox" 
-                                    v-model="bindToOrganization"
-                                />
-                                <span class="option-text">Организации "{{ organization }}"</span>
-                            </label>
-                            <label class="binding-option" v-if="hasCompany">
-                                <input 
-                                    type="checkbox" 
-                                    v-model="bindToCompany"
-                                />
-                                <span class="option-text">Компании "{{ company }}"</span>
-                            </label>
-                        </div>
-                    </div>
-
-                    <div class="warning-section">
-                        <p class="warning-text">
-                            <strong class="red">Внимание!</strong> При привязке сотрудника к организации или компании, он будет доступен для отображения и использования для всех сотрудников, привязанных к организации/компании.
-                        </p>
-                    </div>
-                </div>
-                
-                <div class="modal-actions">
-                    <button class="confirm-btn" @click="handleConfirm">
-                        {{ buttonText }}
-                    </button>
-                </div>
-            </div>
+  <div
+    class="modal-overlay"
+    @click="$emit('close')"
+  >
+    <div
+      class="modal-content"
+      @click.stop
+    >
+      <div class="modal-header">
+        <div class="modal-header__top">
+          <h3>Привязка новых сотрудников</h3>
         </div>
+        <button
+          class="modal-close"
+          @click="$emit('close')"
+        >
+          ×
+        </button>
+      </div>
+      <div class="modal-body">
+        <div class="binding-info">
+          <p class="binding-description">
+            Все добавленные сотрудники будут <strong>автоматически привязаны</strong> к вашему аккаунту.
+            Вы можете дополнительно привязать их к организации и/или компании для использования <strong>другими сотрудниками</strong>:
+          </p>
+                    
+          <div class="employees-list-section">
+            <p class="section-title">
+              Новые сотрудники ({{ newEmployeesToBind.length }}):
+            </p>
+            <div class="employees-list">
+              <div 
+                v-for="employee in newEmployeesToBind" 
+                :key="employee.passportSeriesNumber"
+                class="employee-item"
+              >
+                <div class="employee-info">
+                  <span class="employee-name">{{ formatFullName(employee) }}</span>
+                  <span class="employee-position">{{ employee.position }}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="binding-options-section">
+            <p class="section-title">
+              Привязать всех сотрудников к:
+            </p>
+            <div class="binding-options">
+              <label
+                v-if="hasOrganization"
+                class="binding-option"
+              >
+                <input 
+                  v-model="bindToOrganization" 
+                  type="checkbox"
+                >
+                <span class="option-text">Организации "{{ organization }}"</span>
+              </label>
+              <label
+                v-if="hasCompany"
+                class="binding-option"
+              >
+                <input 
+                  v-model="bindToCompany" 
+                  type="checkbox"
+                >
+                <span class="option-text">Компании "{{ company }}"</span>
+              </label>
+            </div>
+          </div>
+
+          <div class="warning-section">
+            <p class="warning-text">
+              <strong class="red">Внимание!</strong> При привязке сотрудника к организации или компании, он будет доступен для отображения и использования для всех сотрудников, привязанных к организации/компании.
+            </p>
+          </div>
+        </div>
+                
+        <div class="modal-actions">
+          <button
+            class="confirm-btn"
+            @click="handleConfirm"
+          >
+            {{ buttonText }}
+          </button>
+        </div>
+      </div>
     </div>
+  </div>
 </template>
 
 <script>

--- a/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
@@ -1,246 +1,339 @@
 <template>
-    <transition name="modal-fade">
-        <div v-if="show" class="modal-overlay" @click.self="close">
-            <div class="modal-wrapper">
-                <!-- Основное модальное окно с деталями сотрудника -->
-                <div 
-                    class="modal-content compact-modal main-modal"
-                    :class="{ 'shifted': isMainShifted }"
-                >
-                    <div class="modal-header">
-                        <h3 class="modal-title">{{ modalTitle }}</h3>
-                        <div class="header-actions">
-                            <button class="history-btn" @click="openFullHistory">
-                                <span>Полная история</span>
-                            </button>
-                            <button 
-                                v-if="source !== 'application' && employee?.applicationId" 
-                                class="application-btn" 
-                                @click="openApplication"
-                            >
-                                <span>Открыть заявку</span>
-                            </button>
-                        </div>
-                        <button @click="close" class="modal-close">
-                            <svg width="10" height="10" viewBox="0 0 14 14" fill="none">
-                                <path d="M13 1L1 13M1 1L13 13" stroke="#666" stroke-width="2" stroke-linecap="round"/>
-                            </svg>
-                        </button>
-                    </div>
-                    
-                    <div class="modal-body">
-                        <div class="employee-details" v-if="employee">
-                            <!-- Основная информация -->
-                            <div class="details-section">
-                                <div class="section-header">
-                                    <h4 class="section-title">Основная информация</h4>
-                                </div>
-                                <div class="section-body">
-                                    <div class="details-grid two-columns">
-                                        <div class="detail-item">
-                                            <span class="detail-label">Фамилия:</span>
-                                            <span class="detail-value">{{ employee.last_name || 'Не указано' }}</span>
-                                        </div>
-                                        <div class="detail-item">
-                                            <span class="detail-label">Имя:</span>
-                                            <span class="detail-value">{{ employee.first_name || 'Не указано' }}</span>
-                                        </div>
-                                        <div class="detail-item">
-                                            <span class="detail-label">Отчество:</span>
-                                            <span class="detail-value">{{ employee.middle_name || '-' }}</span>
-                                        </div>
-                                        <div class="detail-item">
-                                            <span class="detail-label">Должность:</span>
-                                            <span class="detail-value">{{ employee.position || 'Не указана' }}</span>
-                                        </div>
-                                        <div class="detail-item">
-                                            <span class="detail-label">Гражданство:</span>
-                                            <span class="detail-value">{{ employee.citizenshipName || 'Не указано' }}</span>
-                                        </div>
-                                        <div class="detail-item" v-if="employee.organization">
-                                            <span class="detail-label">Организация:</span>
-                                            <span class="detail-value">{{ employee.organization }}</span>
-                                        </div>
-                                        <div class="detail-item" v-if="employee.company">
-                                            <span class="detail-label">Компания:</span>
-                                            <span class="detail-value">{{ employee.company }}</span>
-                                        </div>
-                                        <div class="detail-item">
-                                            <span class="detail-label">Действует до:</span>
-                                            <span class="detail-value">{{ formatDate(employee.entry_date_to) || '-' }}</span>
-                                        </div>
-                                        <div class="detail-item">
-                                            <span class="detail-label">Время прохода:</span>
-                                            <span class="detail-value">{{ employee.pass_time || '-' }}</span>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <!-- Документы (чувствительные данные) -->
-                            <div class="details-section">
-                                <div class="section-header">
-                                    <h4 class="section-title">Документы</h4>
-                                </div>
-                                <div class="section-body">
-                                    <div class="details-grid two-columns">
-                                        <div class="detail-item">
-                                            <span class="detail-label">Серия и номер паспорта:</span>
-                                            <div class="sensitive-data">
-                                                <span 
-                                                    class="data-text"
-                                                    :class="{ 'hidden-data': !showFullPassport }"
-                                                >
-                                                    {{ employee.passport_series_number || 'Не указан' }}
-                                                </span>
-                                                <button 
-                                                    v-if="employee.passport_series_number"
-                                                    @click="togglePassport"
-                                                    class="show-more-btn"
-                                                >
-                                                    {{ showFullPassport ? 'Скрыть' : 'Показать' }}
-                                                </button>
-                                            </div>
-                                        </div>
-                                        <div v-if="employee.patent_number" class="detail-item">
-                                            <span class="detail-label">Номер патента:</span>
-                                            <div class="sensitive-data">
-                                                <span 
-                                                    class="data-text"
-                                                    :class="{ 'hidden-data': !showFullPatent }"
-                                                >
-                                                    {{ employee.patent_number }}
-                                                </span>
-                                                <button 
-                                                    @click="togglePatent"
-                                                    class="show-more-btn"
-                                                >
-                                                    {{ showFullPatent ? 'Скрыть' : 'Показать' }}
-                                                </button>
-                                            </div>
-                                        </div>
-                                        <div v-if="employee.other_permission" class="detail-item full-width">
-                                            <span class="detail-label">Иное разрешение:</span>
-                                            <span class="detail-value">{{ employee.other_permission }}</span>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <!-- Места прохода (таблицы) -->
-                            <div class="details-section">
-                                <div class="section-header">
-                                    <h4 class="section-title">Места прохода</h4>
-                                </div>
-                                <div class="section-body">
-                                    <div class="places-list">
-                                        <div 
-                                            v-for="tableId in employee.target_tables" 
-                                            :key="tableId"
-                                            class="place-item"
-                                            :class="{ 'active': showPlaceModal && selectedTable && selectedTable.id === tableId }"
-                                            @click="showTableDetails(tableId)"
-                                        >
-                                            {{ getTableName(tableId) }}
-                                        </div>
-                                        <div v-if="!employee.target_tables || employee.target_tables.length === 0" class="no-places">
-                                            Места прохода не указаны
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <!-- Статус территории (скрыт только для employeeslist) -->
-                            <div v-if="showStatusSection" class="details-section">
-                                <div class="section-header">
-                                    <h4 class="section-title">Статус</h4>
-                                </div>
-                                <div class="section-body">
-                                    <div class="status-badge" :class="getStatusClass">
-                                        {{ getStatusText }}
-                                    </div>
-                                </div>
-                            </div>
-
-                            <!-- История проходов (скрыта только для employeeslist) -->
-                            <div v-if="showHistorySection" class="details-section">
-                                <div class="section-header">
-                                    <h4 class="section-title">История проходов</h4>
-                                    <button class="export-btn" @click="exportHistory" :disabled="entryExitHistory.length === 0 || isExporting">
-                                        <img v-if="!isExporting" src="@/assets/icons/export.png" class="export-icon" />
-                                        <span v-if="!isExporting">Экспорт</span>
-                                        <div v-else class="export-loader"></div>
-                                    </button>
-                                </div>
-                                <div class="section-body">
-                                    <div v-if="loadingHistory" class="loading-container">
-                                        <div class="loader"></div>
-                                        <span>Загрузка истории...</span>
-                                    </div>
-                                    
-                                    <div v-else-if="entryExitHistory.length === 0" class="no-history">
-                                        История проходов отсутствует
-                                    </div>
-                                    
-                                    <div v-else class="history-timeline">
-                                        <div 
-                                            v-for="(item, index) in entryExitHistory" 
-                                            :key="item.id" 
-                                            class="history-item"
-                                        >
-                                            <div class="timeline-dot" :class="getActionClass(item)"></div>
-                                            <div class="timeline-line" v-if="index < entryExitHistory.length - 1"></div>
-                                            
-                                            <div class="history-content">
-                                                <div class="history-header">
-                                                    <span class="user-name">{{ item.user_name || 'Система' }}</span>
-                                                    <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
-                                                </div>
-                                                
-                                                <div class="action-text">{{ getActionText(item) }}</div>
-                                                
-                                                <div class="action-comment">
-                                                    {{ item.comment || getActionComment(item) }}
-                                                </div>
-                                                <div v-if="item.table_name" class="place-name">
-                                                    {{ item.table_name }}
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Дополнительное модальное окно с деталями места прохода -->
-                <transition 
-                    name="place-slide"
-                    @after-leave="onPlaceLeave"
-                >
-                    <div v-if="showPlaceModal" class="place-modal-container">
-                        <TableInfoModal
-                            :table="selectedTable"
-                            :all-tables="allTables"
-                            @close="closeTableDetails"
-                        />
-                    </div>
-                </transition>
+  <transition name="modal-fade">
+    <div
+      v-if="show"
+      class="modal-overlay"
+      @click.self="close"
+    >
+      <div class="modal-wrapper">
+        <!-- Основное модальное окно с деталями сотрудника -->
+        <div 
+          class="modal-content compact-modal main-modal"
+          :class="{ 'shifted': isMainShifted }"
+        >
+          <div class="modal-header">
+            <h3 class="modal-title">
+              {{ modalTitle }}
+            </h3>
+            <div class="header-actions">
+              <button
+                class="history-btn"
+                @click="openFullHistory"
+              >
+                <span>Полная история</span>
+              </button>
+              <button 
+                v-if="source !== 'application' && employee?.applicationId" 
+                class="application-btn" 
+                @click="openApplication"
+              >
+                <span>Открыть заявку</span>
+              </button>
             </div>
-        </div>
-    </transition>
+            <button
+              class="modal-close"
+              @click="close"
+            >
+              <svg
+                width="10"
+                height="10"
+                viewBox="0 0 14 14"
+                fill="none"
+              >
+                <path
+                  d="M13 1L1 13M1 1L13 13"
+                  stroke="#666"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                />
+              </svg>
+            </button>
+          </div>
+                    
+          <div class="modal-body">
+            <div
+              v-if="employee"
+              class="employee-details"
+            >
+              <!-- Основная информация -->
+              <div class="details-section">
+                <div class="section-header">
+                  <h4 class="section-title">
+                    Основная информация
+                  </h4>
+                </div>
+                <div class="section-body">
+                  <div class="details-grid two-columns">
+                    <div class="detail-item">
+                      <span class="detail-label">Фамилия:</span>
+                      <span class="detail-value">{{ employee.last_name || 'Не указано' }}</span>
+                    </div>
+                    <div class="detail-item">
+                      <span class="detail-label">Имя:</span>
+                      <span class="detail-value">{{ employee.first_name || 'Не указано' }}</span>
+                    </div>
+                    <div class="detail-item">
+                      <span class="detail-label">Отчество:</span>
+                      <span class="detail-value">{{ employee.middle_name || '-' }}</span>
+                    </div>
+                    <div class="detail-item">
+                      <span class="detail-label">Должность:</span>
+                      <span class="detail-value">{{ employee.position || 'Не указана' }}</span>
+                    </div>
+                    <div class="detail-item">
+                      <span class="detail-label">Гражданство:</span>
+                      <span class="detail-value">{{ employee.citizenshipName || 'Не указано' }}</span>
+                    </div>
+                    <div
+                      v-if="employee.organization"
+                      class="detail-item"
+                    >
+                      <span class="detail-label">Организация:</span>
+                      <span class="detail-value">{{ employee.organization }}</span>
+                    </div>
+                    <div
+                      v-if="employee.company"
+                      class="detail-item"
+                    >
+                      <span class="detail-label">Компания:</span>
+                      <span class="detail-value">{{ employee.company }}</span>
+                    </div>
+                    <div class="detail-item">
+                      <span class="detail-label">Действует до:</span>
+                      <span class="detail-value">{{ formatDate(employee.entry_date_to) || '-' }}</span>
+                    </div>
+                    <div class="detail-item">
+                      <span class="detail-label">Время прохода:</span>
+                      <span class="detail-value">{{ employee.pass_time || '-' }}</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
 
-    <!-- Модальное окно полной истории сотрудника -->
-    <EmployeeHistoryModal
-        v-if="showFullHistoryModal"
-        :last-name="employee?.last_name"
-        :first-name="employee?.first_name"
-        :middle-name="employee?.middle_name"
-        :current-user-id="currentUserId"
-        :current-user-name="currentUserName"
-        @close="showFullHistoryModal = false"
-    />
+              <!-- Документы (чувствительные данные) -->
+              <div class="details-section">
+                <div class="section-header">
+                  <h4 class="section-title">
+                    Документы
+                  </h4>
+                </div>
+                <div class="section-body">
+                  <div class="details-grid two-columns">
+                    <div class="detail-item">
+                      <span class="detail-label">Серия и номер паспорта:</span>
+                      <div class="sensitive-data">
+                        <span 
+                          class="data-text"
+                          :class="{ 'hidden-data': !showFullPassport }"
+                        >
+                          {{ employee.passport_series_number || 'Не указан' }}
+                        </span>
+                        <button 
+                          v-if="employee.passport_series_number"
+                          class="show-more-btn"
+                          @click="togglePassport"
+                        >
+                          {{ showFullPassport ? 'Скрыть' : 'Показать' }}
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      v-if="employee.patent_number"
+                      class="detail-item"
+                    >
+                      <span class="detail-label">Номер патента:</span>
+                      <div class="sensitive-data">
+                        <span 
+                          class="data-text"
+                          :class="{ 'hidden-data': !showFullPatent }"
+                        >
+                          {{ employee.patent_number }}
+                        </span>
+                        <button 
+                          class="show-more-btn"
+                          @click="togglePatent"
+                        >
+                          {{ showFullPatent ? 'Скрыть' : 'Показать' }}
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      v-if="employee.other_permission"
+                      class="detail-item full-width"
+                    >
+                      <span class="detail-label">Иное разрешение:</span>
+                      <span class="detail-value">{{ employee.other_permission }}</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Места прохода (таблицы) -->
+              <div class="details-section">
+                <div class="section-header">
+                  <h4 class="section-title">
+                    Места прохода
+                  </h4>
+                </div>
+                <div class="section-body">
+                  <div class="places-list">
+                    <div 
+                      v-for="tableId in employee.target_tables" 
+                      :key="tableId"
+                      class="place-item"
+                      :class="{ 'active': showPlaceModal && selectedTable && selectedTable.id === tableId }"
+                      @click="showTableDetails(tableId)"
+                    >
+                      {{ getTableName(tableId) }}
+                    </div>
+                    <div
+                      v-if="!employee.target_tables || employee.target_tables.length === 0"
+                      class="no-places"
+                    >
+                      Места прохода не указаны
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Статус территории (скрыт только для employeeslist) -->
+              <div
+                v-if="showStatusSection"
+                class="details-section"
+              >
+                <div class="section-header">
+                  <h4 class="section-title">
+                    Статус
+                  </h4>
+                </div>
+                <div class="section-body">
+                  <div
+                    class="status-badge"
+                    :class="getStatusClass"
+                  >
+                    {{ getStatusText }}
+                  </div>
+                </div>
+              </div>
+
+              <!-- История проходов (скрыта только для employeeslist) -->
+              <div
+                v-if="showHistorySection"
+                class="details-section"
+              >
+                <div class="section-header">
+                  <h4 class="section-title">
+                    История проходов
+                  </h4>
+                  <button
+                    class="export-btn"
+                    :disabled="entryExitHistory.length === 0 || isExporting"
+                    @click="exportHistory"
+                  >
+                    <img
+                      v-if="!isExporting"
+                      src="@/assets/icons/export.png"
+                      class="export-icon"
+                    >
+                    <span v-if="!isExporting">Экспорт</span>
+                    <div
+                      v-else
+                      class="export-loader"
+                    />
+                  </button>
+                </div>
+                <div class="section-body">
+                  <div
+                    v-if="loadingHistory"
+                    class="loading-container"
+                  >
+                    <div class="loader" />
+                    <span>Загрузка истории...</span>
+                  </div>
+                                    
+                  <div
+                    v-else-if="entryExitHistory.length === 0"
+                    class="no-history"
+                  >
+                    История проходов отсутствует
+                  </div>
+                                    
+                  <div
+                    v-else
+                    class="history-timeline"
+                  >
+                    <div 
+                      v-for="(item, index) in entryExitHistory" 
+                      :key="item.id" 
+                      class="history-item"
+                    >
+                      <div
+                        class="timeline-dot"
+                        :class="getActionClass(item)"
+                      />
+                      <div
+                        v-if="index < entryExitHistory.length - 1"
+                        class="timeline-line"
+                      />
+                                            
+                      <div class="history-content">
+                        <div class="history-header">
+                          <span class="user-name">{{ item.user_name || 'Система' }}</span>
+                          <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                        </div>
+                                                
+                        <div class="action-text">
+                          {{ getActionText(item) }}
+                        </div>
+                                                
+                        <div class="action-comment">
+                          {{ item.comment || getActionComment(item) }}
+                        </div>
+                        <div
+                          v-if="item.table_name"
+                          class="place-name"
+                        >
+                          {{ item.table_name }}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Дополнительное модальное окно с деталями места прохода -->
+        <transition 
+          name="place-slide"
+          @after-leave="onPlaceLeave"
+        >
+          <div
+            v-if="showPlaceModal"
+            class="place-modal-container"
+          >
+            <TableInfoModal
+              :table="selectedTable"
+              :all-tables="allTables"
+              @close="closeTableDetails"
+            />
+          </div>
+        </transition>
+      </div>
+    </div>
+  </transition>
+
+  <!-- Модальное окно полной истории сотрудника -->
+  <EmployeeHistoryModal
+    v-if="showFullHistoryModal"
+    :last-name="employee?.last_name"
+    :first-name="employee?.first_name"
+    :middle-name="employee?.middle_name"
+    :current-user-id="currentUserId"
+    :current-user-name="currentUserName"
+    @close="showFullHistoryModal = false"
+  />
 </template>
 
 <script>
@@ -326,6 +419,29 @@ export default {
         },
         showHistorySection() {
             return this.source !== 'employeeslist';
+        }
+    },
+    watch: {
+        show: {
+        immediate: true,
+        handler(val) {
+            if (val) {
+                this.loadHistory();
+                this.loadEmployeeStatus(); // для EmployeeDetailsModal
+                // для VehicleDetailsModal: this.loadCarStatus(); this.loadCarHistory();
+            } else {
+                this.close(); // вместо this.closeTableDetails()
+            }
+        }
+    },
+        employee: {
+            deep: true,
+            handler(newVal) {
+                if (newVal && this.show) {
+                    this.loadHistory();
+                    this.loadEmployeeStatus();
+                }
+            }
         }
     },
     methods: {
@@ -573,29 +689,6 @@ export default {
         openApplication() {
             if (this.employee?.applicationId) {
                 this.$emit('open-application', this.employee.applicationId);
-            }
-        }
-    },
-    watch: {
-        show: {
-        immediate: true,
-        handler(val) {
-            if (val) {
-                this.loadHistory();
-                this.loadEmployeeStatus(); // для EmployeeDetailsModal
-                // для VehicleDetailsModal: this.loadCarStatus(); this.loadCarHistory();
-            } else {
-                this.close(); // вместо this.closeTableDetails()
-            }
-        }
-    },
-        employee: {
-            deep: true,
-            handler(newVal) {
-                if (newVal && this.show) {
-                    this.loadHistory();
-                    this.loadEmployeeStatus();
-                }
             }
         }
     }

--- a/frontend/src/components/CreateApplication/EmployeeForm.vue
+++ b/frontend/src/components/CreateApplication/EmployeeForm.vue
@@ -1,262 +1,352 @@
 <template>
-    <div class="data__completion">
-        <div class="completion__header">
-            <h3>Новый сотрудник</h3>
-            <button class="completion__button" @click="openExistingEmployeesModal">
-                Добавить существующего(-их)
-            </button>
-        </div>
-
-        <div v-if="selectedExistingEmployees.length > 0" class="existing-employees-info">
-            <div class="existing-employees-header">
-                <span class="existing-employees-count">Сотрудников добавлено: {{ selectedExistingEmployees.length }}</span>
-                <div class="existing-employees-actions">
-                    <button class="view-employees-btn" @click="openExistingEmployeesModal">Просмотреть</button>
-                    <button class="add-existing-btn" @click="addExistingEmployees" :disabled="!canAddExistingEmployees">
-                        Добавить
-                    </button>
-                </div>
-            </div>
-        </div>
-
-        <div v-else>
-            <div class="completion__citizenship">
-                <div class="citizenship__header">
-                    <label class="citizenship__label">Гражданство <span class="required">*</span></label>
-                    <div class="citizenship-actions">
-                        <button class="cancel-edit-btn" @click="cancelEdit" v-if="editingEmployee">
-                            Отменить
-                        </button>
-                        <button 
-                            class="add-button" 
-                            @click="addEmployee"
-                            :disabled="!canAddEmployee"
-                            @mouseenter="showTooltip = true"
-                            @mouseleave="showTooltip = false"
-                        >
-                            {{ editingEmployee ? 'Применить' : 'Добавить' }}
-                        </button>
-                        <div v-if="showTooltip && !canAddEmployee" class="tooltip">
-                            <div class="tooltip-content">
-                                {{ getTooltipMessage }}
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="citizenship__dropdown">
-                    <button 
-                        class="dropdown__button" 
-                        @click="toggleCitizenshipDropdown"
-                        :disabled="editingEmployee && editingEmployee.isExisting"
-                    >
-                        <div class="button__content">
-                            <span class="button__text">{{ selectedCitizenshipText }}</span>
-                            <img src="@/assets/icons/arrow.png" class="button__arrow" :class="{ 'button__arrow--open': isCitizenshipDropdownOpen }" />
-                        </div>
-                    </button>
-                    <transition name="dropdown">
-                        <div v-if="isCitizenshipDropdownOpen" class="dropdown__menu">
-                            <div 
-                                v-for="citizenship in availableCitizenships" 
-                                :key="citizenship.id"
-                                class="dropdown__item" 
-                                @click="selectCitizenship(citizenship)"
-                            >
-                                <span class="item__text">{{ citizenship.name }}</span>
-                                <span v-if="citizenship.patent_required" class="patent-required-badge">Требуется патент</span>
-                            </div>
-                        </div>
-                    </transition>
-                </div>
-            </div>
-            
-            <div class="completion__fields">
-                <div class="completion__name-row">
-                    <div class="completion__last-name">
-                        <div class="completion__last-name-header">
-                            <label class="input__label">Фамилия <span class="required">*</span></label>
-                        </div>
-                        <input 
-                            class="name__input" 
-                            placeholder="Введите фамилию"
-                            v-model="lastName"
-                            @blur="formatNameField('lastName')"
-                            :disabled="editingEmployee && editingEmployee.isExisting"
-                        />
-                    </div>
-                    <div class="completion__first-name">
-                        <div class="completion__first-name-header">
-                            <label class="input__label">Имя <span class="required">*</span></label>
-                        </div>
-                        <input 
-                            class="name__input" 
-                            placeholder="Введите имя"
-                            v-model="firstName"
-                            @blur="formatNameField('firstName')"
-                            :disabled="editingEmployee && editingEmployee.isExisting"
-                        />
-                    </div>
-                </div>
-                
-                <div class="completion__name-row">
-                    <div class="completion__middle-name">
-                        <div class="completion__middle-name-header">
-                            <label class="input__label">Отчество</label>
-                        </div>
-                        <input 
-                            class="name__input" 
-                            placeholder="Введите отчество"
-                            v-model="middleName"
-                            @blur="formatNameField('middleName')"
-                            :disabled="editingEmployee && editingEmployee.isExisting"
-                        />
-                    </div>
-                    <div class="completion__position">
-                        <div class="completion__position-header">
-                            <label class="input__label">Должность <span class="required">*</span></label>
-                        </div>
-                        <input 
-                            class="name__input" 
-                            placeholder="Введите должность"
-                            v-model="position"
-                            @blur="formatNameField('position')"
-                            :disabled="editingEmployee && editingEmployee.isExisting"
-                        />
-                    </div>
-                </div>
-                
-                <div class="completion__name-row">
-                    <div class="completion__passport">
-                        <div class="completion__passport-header">
-                            <label class="input__label">Паспортные данные <span class="required">*</span></label>
-                        </div>
-                        <input 
-                            class="name__input" 
-                            placeholder="Введите паспортные данные"
-                            v-model="passportSeriesNumber"
-                            :disabled="editingEmployee && editingEmployee.isExisting"
-                        />
-                    </div>
-                    <div class="completion__patent" :class="{ 'disabled-field': !isPatentRequired }">
-                        <div class="completion__patent-header">
-                            <label class="input__label">Номер патента</label>
-                        </div>
-                        <input 
-                            class="name__input" 
-                            :placeholder="isPatentRequired ? 'Номер патента' : 'Не требуется'"
-                            v-model="patentNumber"
-                            :disabled="!isPatentRequired || patentFieldDisabled || (editingEmployee && editingEmployee.isExisting)"
-                            @input="handlePatentInput"
-                        />
-                    </div>
-                </div>
-                
-                <div class="completion__permission" :class="{ 'disabled-field': !isPatentRequired }">
-                    <div class="completion__permission-header">
-                        <label class="input__label">Иное разрешение на работы</label>
-                    </div>
-                    <div class="permission__dropdown">
-                        <button class="permission__dropdown-button" 
-                                @click="togglePermissionDropdown" 
-                                :disabled="!isPatentRequired || permissionFieldDisabled || (editingEmployee && editingEmployee.isExisting)">
-                            <div class="permission__button-content">
-                                <span class="permission__button-text">{{ selectedPermission || (isPatentRequired ? 'Выберите разрешение' : 'Не требуется') }}</span>
-                                <img src="@/assets/icons/arrow.png" class="permission__button-arrow" :class="{ 'permission__button-arrow--open': isPermissionDropdownOpen }" />
-                            </div>
-                        </button>
-                        <transition name="dropdown">
-                            <div v-if="isPermissionDropdownOpen" class="permission__dropdown-menu">
-                                <div 
-                                    v-for="permission in availablePermissions" 
-                                    :key="permission"
-                                    class="permission__dropdown-item"
-                                    @click="selectPermission(permission)"
-                                >
-                                    <span class="permission__item-text">{{ permission }}</span>
-                                </div>
-                            </div>
-                        </transition>
-                    </div>
-                </div>
-                
-                <div class="completion__files" v-if="isPatentRequired">
-                    <div class="completion__files-header">
-                        <label class="input__label">Фото, скан документа(-ов), подтверждающее иное разрешение на работы</label>
-                    </div>
-                    <div class="files__upload">
-                        <input 
-                            type="file" 
-                            ref="fileInput"
-                            @change="handleFileUpload"
-                            multiple
-                            accept="image/*,.pdf,.doc,.docx,.xlsx,.xls"
-                            class="file-input"
-                            :disabled="editingEmployee && editingEmployee.isExisting"
-                        />
-                        <button class="upload-button" @click="triggerFileInput" :disabled="editingEmployee && editingEmployee.isExisting">
-                            Загрузить
-                        </button>
-                    </div>
-                    <div v-if="uploadedFiles.length > 0" class="uploaded-files">
-                        <div v-for="(file, index) in uploadedFiles" :key="index" class="uploaded-file">
-                            <div class="file-preview">
-                                <img v-if="file.type === 'image'" :src="file.preview" class="file-preview-image" />
-                                <img v-else :src="getFileIcon(file.extension)" class="file-icon" />
-                            </div>
-                            <span class="file-name">{{ file.name }}</span>
-                            <button @click="removeFile(index)" class="remove-file-btn" :disabled="editingEmployee && editingEmployee.isExisting">×</button>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <div class="completion__passage">
-            <label class="input__label">Места прохода (целевые таблицы) <span class="required">*</span></label>
-            <div class="passage__grid" v-if="!loadingPassageTables && filteredPassageTables.length > 0">
-                <div 
-                    v-for="table in filteredPassageTables" 
-                    :key="table.table.id"
-                    class="passage__item"
-                    :class="{ 
-                        'passage__item--active': selectedPassageTables.includes(table.table.id) && table.table.status === 'active',
-                        'passage__item--attached': attachedTablesIds.includes(table.table.id),
-                        'passage__item--inactive': table.table.status !== 'active'
-                    }"
-                    @click="togglePassageTable(table)"
-                    @mouseenter="showTableTooltip(table, $event)"
-                    @mouseleave="hideTableTooltip"
-                >
-                    {{ table.table.display_name }}
-                </div>
-            </div>
-            <div v-else-if="loadingPassageTables" class="loading-message">
-                Загрузка мест прохода...
-            </div>
-            <div v-else class="no-tables-message">
-                Нет доступных мест прохода
-            </div>
-            <div v-if="errors.passageTables" class="error-message">{{ errors.passageTables }}</div>
-        </div>
-
-        <div v-if="tableTooltip.visible" 
-             class="inactive-tooltip"
-             :style="{ top: tableTooltip.y + 'px', left: tableTooltip.x + 'px' }"
-        >
-            <div class="inactive-tooltip-content">
-                {{ tableTooltip.text }}
-            </div>
-        </div>
-
-        <ExistingEmployeesModal
-            :visible="showExistingEmployeesModal"
-            :already-added-employees="existingEmployees"
-            :user-organization-id="userOrganizationId"
-            :initial-selected-employees="selectedExistingEmployees"
-            @employees-selected="onEmployeesSelected"
-            @close="closeExistingEmployeesModal"
-        />
+  <div class="data__completion">
+    <div class="completion__header">
+      <h3>Новый сотрудник</h3>
+      <button
+        class="completion__button"
+        @click="openExistingEmployeesModal"
+      >
+        Добавить существующего(-их)
+      </button>
     </div>
+
+    <div
+      v-if="selectedExistingEmployees.length > 0"
+      class="existing-employees-info"
+    >
+      <div class="existing-employees-header">
+        <span class="existing-employees-count">Сотрудников добавлено: {{ selectedExistingEmployees.length }}</span>
+        <div class="existing-employees-actions">
+          <button
+            class="view-employees-btn"
+            @click="openExistingEmployeesModal"
+          >
+            Просмотреть
+          </button>
+          <button
+            class="add-existing-btn"
+            :disabled="!canAddExistingEmployees"
+            @click="addExistingEmployees"
+          >
+            Добавить
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div v-else>
+      <div class="completion__citizenship">
+        <div class="citizenship__header">
+          <label class="citizenship__label">Гражданство <span class="required">*</span></label>
+          <div class="citizenship-actions">
+            <button
+              v-if="editingEmployee"
+              class="cancel-edit-btn"
+              @click="cancelEdit"
+            >
+              Отменить
+            </button>
+            <button 
+              class="add-button" 
+              :disabled="!canAddEmployee"
+              @click="addEmployee"
+              @mouseenter="showTooltip = true"
+              @mouseleave="showTooltip = false"
+            >
+              {{ editingEmployee ? 'Применить' : 'Добавить' }}
+            </button>
+            <div
+              v-if="showTooltip && !canAddEmployee"
+              class="tooltip"
+            >
+              <div class="tooltip-content">
+                {{ getTooltipMessage }}
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="citizenship__dropdown">
+          <button 
+            class="dropdown__button" 
+            :disabled="editingEmployee && editingEmployee.isExisting"
+            @click="toggleCitizenshipDropdown"
+          >
+            <div class="button__content">
+              <span class="button__text">{{ selectedCitizenshipText }}</span>
+              <img
+                src="@/assets/icons/arrow.png"
+                class="button__arrow"
+                :class="{ 'button__arrow--open': isCitizenshipDropdownOpen }"
+              >
+            </div>
+          </button>
+          <transition name="dropdown">
+            <div
+              v-if="isCitizenshipDropdownOpen"
+              class="dropdown__menu"
+            >
+              <div 
+                v-for="citizenship in availableCitizenships" 
+                :key="citizenship.id"
+                class="dropdown__item" 
+                @click="selectCitizenship(citizenship)"
+              >
+                <span class="item__text">{{ citizenship.name }}</span>
+                <span
+                  v-if="citizenship.patent_required"
+                  class="patent-required-badge"
+                >Требуется патент</span>
+              </div>
+            </div>
+          </transition>
+        </div>
+      </div>
+            
+      <div class="completion__fields">
+        <div class="completion__name-row">
+          <div class="completion__last-name">
+            <div class="completion__last-name-header">
+              <label class="input__label">Фамилия <span class="required">*</span></label>
+            </div>
+            <input 
+              v-model="lastName" 
+              class="name__input"
+              placeholder="Введите фамилию"
+              :disabled="editingEmployee && editingEmployee.isExisting"
+              @blur="formatNameField('lastName')"
+            >
+          </div>
+          <div class="completion__first-name">
+            <div class="completion__first-name-header">
+              <label class="input__label">Имя <span class="required">*</span></label>
+            </div>
+            <input 
+              v-model="firstName" 
+              class="name__input"
+              placeholder="Введите имя"
+              :disabled="editingEmployee && editingEmployee.isExisting"
+              @blur="formatNameField('firstName')"
+            >
+          </div>
+        </div>
+                
+        <div class="completion__name-row">
+          <div class="completion__middle-name">
+            <div class="completion__middle-name-header">
+              <label class="input__label">Отчество</label>
+            </div>
+            <input 
+              v-model="middleName" 
+              class="name__input"
+              placeholder="Введите отчество"
+              :disabled="editingEmployee && editingEmployee.isExisting"
+              @blur="formatNameField('middleName')"
+            >
+          </div>
+          <div class="completion__position">
+            <div class="completion__position-header">
+              <label class="input__label">Должность <span class="required">*</span></label>
+            </div>
+            <input 
+              v-model="position" 
+              class="name__input"
+              placeholder="Введите должность"
+              :disabled="editingEmployee && editingEmployee.isExisting"
+              @blur="formatNameField('position')"
+            >
+          </div>
+        </div>
+                
+        <div class="completion__name-row">
+          <div class="completion__passport">
+            <div class="completion__passport-header">
+              <label class="input__label">Паспортные данные <span class="required">*</span></label>
+            </div>
+            <input 
+              v-model="passportSeriesNumber" 
+              class="name__input"
+              placeholder="Введите паспортные данные"
+              :disabled="editingEmployee && editingEmployee.isExisting"
+            >
+          </div>
+          <div
+            class="completion__patent"
+            :class="{ 'disabled-field': !isPatentRequired }"
+          >
+            <div class="completion__patent-header">
+              <label class="input__label">Номер патента</label>
+            </div>
+            <input 
+              v-model="patentNumber" 
+              class="name__input"
+              :placeholder="isPatentRequired ? 'Номер патента' : 'Не требуется'"
+              :disabled="!isPatentRequired || patentFieldDisabled || (editingEmployee && editingEmployee.isExisting)"
+              @input="handlePatentInput"
+            >
+          </div>
+        </div>
+                
+        <div
+          class="completion__permission"
+          :class="{ 'disabled-field': !isPatentRequired }"
+        >
+          <div class="completion__permission-header">
+            <label class="input__label">Иное разрешение на работы</label>
+          </div>
+          <div class="permission__dropdown">
+            <button
+              class="permission__dropdown-button" 
+              :disabled="!isPatentRequired || permissionFieldDisabled || (editingEmployee && editingEmployee.isExisting)" 
+              @click="togglePermissionDropdown"
+            >
+              <div class="permission__button-content">
+                <span class="permission__button-text">{{ selectedPermission || (isPatentRequired ? 'Выберите разрешение' : 'Не требуется') }}</span>
+                <img
+                  src="@/assets/icons/arrow.png"
+                  class="permission__button-arrow"
+                  :class="{ 'permission__button-arrow--open': isPermissionDropdownOpen }"
+                >
+              </div>
+            </button>
+            <transition name="dropdown">
+              <div
+                v-if="isPermissionDropdownOpen"
+                class="permission__dropdown-menu"
+              >
+                <div 
+                  v-for="permission in availablePermissions" 
+                  :key="permission"
+                  class="permission__dropdown-item"
+                  @click="selectPermission(permission)"
+                >
+                  <span class="permission__item-text">{{ permission }}</span>
+                </div>
+              </div>
+            </transition>
+          </div>
+        </div>
+                
+        <div
+          v-if="isPatentRequired"
+          class="completion__files"
+        >
+          <div class="completion__files-header">
+            <label class="input__label">Фото, скан документа(-ов), подтверждающее иное разрешение на работы</label>
+          </div>
+          <div class="files__upload">
+            <input 
+              ref="fileInput" 
+              type="file"
+              multiple
+              accept="image/*,.pdf,.doc,.docx,.xlsx,.xls"
+              class="file-input"
+              :disabled="editingEmployee && editingEmployee.isExisting"
+              @change="handleFileUpload"
+            >
+            <button
+              class="upload-button"
+              :disabled="editingEmployee && editingEmployee.isExisting"
+              @click="triggerFileInput"
+            >
+              Загрузить
+            </button>
+          </div>
+          <div
+            v-if="uploadedFiles.length > 0"
+            class="uploaded-files"
+          >
+            <div
+              v-for="(file, index) in uploadedFiles"
+              :key="index"
+              class="uploaded-file"
+            >
+              <div class="file-preview">
+                <img
+                  v-if="file.type === 'image'"
+                  :src="file.preview"
+                  class="file-preview-image"
+                >
+                <img
+                  v-else
+                  :src="getFileIcon(file.extension)"
+                  class="file-icon"
+                >
+              </div>
+              <span class="file-name">{{ file.name }}</span>
+              <button
+                class="remove-file-btn"
+                :disabled="editingEmployee && editingEmployee.isExisting"
+                @click="removeFile(index)"
+              >
+                ×
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="completion__passage">
+      <label class="input__label">Места прохода (целевые таблицы) <span class="required">*</span></label>
+      <div
+        v-if="!loadingPassageTables && filteredPassageTables.length > 0"
+        class="passage__grid"
+      >
+        <div 
+          v-for="table in filteredPassageTables" 
+          :key="table.table.id"
+          class="passage__item"
+          :class="{ 
+            'passage__item--active': selectedPassageTables.includes(table.table.id) && table.table.status === 'active',
+            'passage__item--attached': attachedTablesIds.includes(table.table.id),
+            'passage__item--inactive': table.table.status !== 'active'
+          }"
+          @click="togglePassageTable(table)"
+          @mouseenter="showTableTooltip(table, $event)"
+          @mouseleave="hideTableTooltip"
+        >
+          {{ table.table.display_name }}
+        </div>
+      </div>
+      <div
+        v-else-if="loadingPassageTables"
+        class="loading-message"
+      >
+        Загрузка мест прохода...
+      </div>
+      <div
+        v-else
+        class="no-tables-message"
+      >
+        Нет доступных мест прохода
+      </div>
+      <div
+        v-if="errors.passageTables"
+        class="error-message"
+      >
+        {{ errors.passageTables }}
+      </div>
+    </div>
+
+    <div
+      v-if="tableTooltip.visible" 
+      class="inactive-tooltip"
+      :style="{ top: tableTooltip.y + 'px', left: tableTooltip.x + 'px' }"
+    >
+      <div class="inactive-tooltip-content">
+        {{ tableTooltip.text }}
+      </div>
+    </div>
+
+    <ExistingEmployeesModal
+      :visible="showExistingEmployeesModal"
+      :already-added-employees="existingEmployees"
+      :user-organization-id="userOrganizationId"
+      :initial-selected-employees="selectedExistingEmployees"
+      @employees-selected="onEmployeesSelected"
+      @close="closeExistingEmployeesModal"
+    />
+  </div>
 </template>
 
 <script>
@@ -410,6 +500,22 @@ export default {
                 }
             });
         }
+    },
+    async mounted() {
+        await Promise.all([
+            this.loadCitizenships(),
+            this.loadPassageTables()
+        ]);
+
+        document.addEventListener('click', (e) => {
+            if (!e.target.closest('.citizenship__dropdown')) {
+                this.isCitizenshipDropdownOpen = false;
+            }
+            
+            if (!e.target.closest('.permission__dropdown')) {
+                this.isPermissionDropdownOpen = false;
+            }
+        });
     },
     methods: {
         async loadCitizenships() {
@@ -878,22 +984,6 @@ export default {
         removeFile(index) {
             this.uploadedFiles.splice(index, 1);
         }
-    },
-    async mounted() {
-        await Promise.all([
-            this.loadCitizenships(),
-            this.loadPassageTables()
-        ]);
-
-        document.addEventListener('click', (e) => {
-            if (!e.target.closest('.citizenship__dropdown')) {
-                this.isCitizenshipDropdownOpen = false;
-            }
-            
-            if (!e.target.closest('.permission__dropdown')) {
-                this.isPermissionDropdownOpen = false;
-            }
-        });
     }
 }
 </script>

--- a/frontend/src/components/CreateApplication/EmployeeHistoryModal.vue
+++ b/frontend/src/components/CreateApplication/EmployeeHistoryModal.vue
@@ -1,15 +1,34 @@
 <template>
-  <div class="modal-overlay" @click.self="close">
+  <div
+    class="modal-overlay"
+    @click.self="close"
+  >
     <div class="employee-history-modal">
       <div class="modal-header">
         <h3>История сотрудника {{ fullName }}</h3>
         <div class="header-actions">
-          <button class="export-btn" @click="exportToExcel" :disabled="filteredHistory.length === 0 || isExporting">
-            <img v-if="!isExporting" src="@/assets/icons/export.png" class="export-icon" />
+          <button
+            class="export-btn"
+            :disabled="filteredHistory.length === 0 || isExporting"
+            @click="exportToExcel"
+          >
+            <img
+              v-if="!isExporting"
+              src="@/assets/icons/export.png"
+              class="export-icon"
+            >
             <span v-if="!isExporting">Экспорт</span>
-            <div v-else class="export-loader"></div>
+            <div
+              v-else
+              class="export-loader"
+            />
           </button>
-          <button class="close-btn" @click="close">×</button>
+          <button
+            class="close-btn"
+            @click="close"
+          >
+            ×
+          </button>
         </div>
       </div>
 
@@ -18,26 +37,32 @@
           <div class="search-filter">
             <span class="filter-label">Поиск:</span>
             <input 
-              type="text" 
               v-model="searchQuery" 
+              type="text" 
               class="search-input" 
               placeholder="Поиск по пользователю, действию..."
               @input="applyFilters"
-            />
+            >
           </div>
           <div class="user-filter">
             <span class="filter-label">Пользователь:</span>
-            <div class="custom-select" @click="toggleUserDropdown">
+            <div
+              class="custom-select"
+              @click="toggleUserDropdown"
+            >
               <div class="select-trigger">
                 <span class="selected-value">{{ selectedUserName }}</span>
                 <img 
                   src="@/assets/icons/arrow.png" 
                   class="select-arrow" 
                   :class="{ 'arrow-open': userDropdownOpen }"
-                />
+                >
               </div>
               <transition name="fade">
-                <div v-if="userDropdownOpen" class="select-dropdown">
+                <div
+                  v-if="userDropdownOpen"
+                  class="select-dropdown"
+                >
                   <div 
                     class="select-option"
                     :class="{ 'selected': selectedUserId === null }"
@@ -61,17 +86,23 @@
           
           <div class="place-filter">
             <span class="filter-label">Место прохода:</span>
-            <div class="custom-select" @click="togglePlaceDropdown">
+            <div
+              class="custom-select"
+              @click="togglePlaceDropdown"
+            >
               <div class="select-trigger">
                 <span class="selected-value">{{ selectedPlaceName }}</span>
                 <img 
                   src="@/assets/icons/arrow.png" 
                   class="select-arrow" 
                   :class="{ 'arrow-open': placeDropdownOpen }"
-                />
+                >
               </div>
               <transition name="fade">
-                <div v-if="placeDropdownOpen" class="select-dropdown">
+                <div
+                  v-if="placeDropdownOpen"
+                  class="select-dropdown"
+                >
                   <div 
                     class="select-option"
                     :class="{ 'selected': selectedPlaceId === null }"
@@ -96,47 +127,72 @@
           <div class="date-filter">
             <span class="filter-label">Период:</span>
             <input 
-              type="date" 
               v-model="dateFrom" 
+              type="date" 
               class="date-input"
               @change="applyFilters"
-            />
+            >
             <span class="date-separator">—</span>
             <input 
-              type="date" 
               v-model="dateTo" 
+              type="date" 
               class="date-input"
               @change="applyFilters"
-            />
+            >
           </div>
           
           <div class="sort-filter">
             <span class="filter-label">Сортировка:</span>
-            <button class="sort-btn" @click="toggleSortOrder">
-              <img src="@/assets/icons/sort.png" class="sort-icon" :class="{ 'sort-asc': sortOrder === 'asc' }" />
+            <button
+              class="sort-btn"
+              @click="toggleSortOrder"
+            >
+              <img
+                src="@/assets/icons/sort.png"
+                class="sort-icon"
+                :class="{ 'sort-asc': sortOrder === 'asc' }"
+              >
               <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
             </button>
           </div>
         </div>
       </div>
 
-      <div class="modal-content" ref="scrollContainer">
-        <div v-if="loading" class="history-loading">
-          <div class="loader"></div>
+      <div
+        ref="scrollContainer"
+        class="modal-content"
+      >
+        <div
+          v-if="loading"
+          class="history-loading"
+        >
+          <div class="loader" />
         </div>
         
-        <div v-else-if="filteredHistory.length === 0" class="history-empty">
+        <div
+          v-else-if="filteredHistory.length === 0"
+          class="history-empty"
+        >
           История пуста
         </div>
         
-        <div v-else class="history-timeline">
+        <div
+          v-else
+          class="history-timeline"
+        >
           <div 
             v-for="(item, index) in filteredHistory" 
             :key="item.id" 
             class="history-item"
           >
-            <div class="timeline-dot" :class="getActionClass(item.action_type)"></div>
-            <div class="timeline-line" v-if="index < filteredHistory.length - 1"></div>
+            <div
+              class="timeline-dot"
+              :class="getActionClass(item.action_type)"
+            />
+            <div
+              v-if="index < filteredHistory.length - 1"
+              class="timeline-line"
+            />
             
             <div class="history-content">
               <div class="history-header">
@@ -144,26 +200,43 @@
                 <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
               </div>
               
-              <div class="action-text">{{ getActionText(item) }}</div>
+              <div class="action-text">
+                {{ getActionText(item) }}
+              </div>
               
-              <div class="action-comment" v-if="item.action_type === 'entry' || item.action_type === 'exit'">
+              <div
+                v-if="item.action_type === 'entry' || item.action_type === 'exit'"
+                class="action-comment"
+              >
                 {{ getActionComment(item) }}
               </div>
               
-              <div v-if="item.comment && item.action_type !== 'entry' && item.action_type !== 'exit'" class="action-comment">
+              <div
+                v-if="item.comment && item.action_type !== 'entry' && item.action_type !== 'exit'"
+                class="action-comment"
+              >
                 {{ item.comment }}
               </div>
               
-              <div v-if="item.old_value && item.new_value && item.old_value !== item.new_value" class="value-change">
+              <div
+                v-if="item.old_value && item.new_value && item.old_value !== item.new_value"
+                class="value-change"
+              >
                 <span class="old-value">{{ item.old_value }}</span>
                 <span class="arrow">→</span>
                 <span class="new-value">{{ item.new_value }}</span>
               </div>
               
-              <div v-if="item.field_name" class="field-name">
+              <div
+                v-if="item.field_name"
+                class="field-name"
+              >
                 Поле: {{ item.field_name }}
               </div>
-              <div v-if="item.table_name" class="place-name">
+              <div
+                v-if="item.table_name"
+                class="place-name"
+              >
                 {{ item.table_name }}
               </div>
             </div>
@@ -339,6 +412,13 @@ export default {
     safeFileName() {
       return this.fullName.replace(/[\\/:"*?<>|]/g, '_').replace(/\s+/g, '_') || 'Sotrudnik';
     }
+  },
+  mounted() {
+    this.loadHistory();
+    document.addEventListener('click', this.handleClickOutside);
+  },
+  beforeUnmount() {
+    document.removeEventListener('click', this.handleClickOutside);
   },
   methods: {
     async loadHistory() {
@@ -639,13 +719,6 @@ export default {
     close() {
       this.$emit('close');
     }
-  },
-  mounted() {
-    this.loadHistory();
-    document.addEventListener('click', this.handleClickOutside);
-  },
-  beforeUnmount() {
-    document.removeEventListener('click', this.handleClickOutside);
   }
 };
 </script>

--- a/frontend/src/components/CreateApplication/EmployeesList.vue
+++ b/frontend/src/components/CreateApplication/EmployeesList.vue
@@ -1,120 +1,145 @@
 <template>
-    <div class="data__list">
-        <div class="header-with-badge">
-            <h4>Список сотрудников</h4>
-            <span class="employees-badge">{{ employees.length }}</span>
-        </div>
-        <div class="employees-table">
-            <div class="table-header">
-                <div class="header-col number-col" @click="$emit('sort', 'number')">
-                    <p :class="{ 'active-sort': sortField === 'number' }">№</p>
-                    <img 
-                        src="@/assets/icons/sort.png" 
-                        class="sort-icon" 
-                        :class="{ 
-                            'desc': sortField === 'number' && sortDirection === 'desc'
-                        }" 
-                    />
-                </div>
-                <div class="header-col lastName-col" @click="$emit('sort', 'lastName')">
-                    <p :class="{ 'active-sort': sortField === 'lastName' }">Фамилия</p>
-                    <img 
-                        src="@/assets/icons/sort.png" 
-                        class="sort-icon" 
-                        :class="{ 
-                            'desc': sortField === 'lastName' && sortDirection === 'desc'
-                        }" 
-                    />
-                </div>
-                <div class="header-col firstName-col" @click="$emit('sort', 'firstName')">
-                    <p :class="{ 'active-sort': sortField === 'firstName' }">Имя</p>
-                    <img 
-                        src="@/assets/icons/sort.png" 
-                        class="sort-icon" 
-                        :class="{ 
-                            'desc': sortField === 'firstName' && sortDirection === 'desc'
-                        }" 
-                    />
-                </div>
-                <div class="header-col middleName-col" @click="$emit('sort', 'middleName')">
-                    <p :class="{ 'active-sort': sortField === 'middleName' }">Отчество</p>
-                    <img 
-                        src="@/assets/icons/sort.png" 
-                        class="sort-icon" 
-                        :class="{ 
-                            'desc': sortField === 'middleName' && sortDirection === 'desc'
-                        }" 
-                    />
-                </div>
-                <div class="header-col actions-col">
-                    Действия
-                </div>
-            </div>
-            <div class="table-body">
-                <div 
-                    v-for="(employee, index) in employees" 
-                    :key="employee.id"
-                    class="table-row"
-                >
-                    <div class="table-col number-col">{{ index + 1 }}</div>
-                    <div class="table-col lastName-col">
-                        {{ employee.lastName || 'Не указано' }}
-                    </div>
-                    <div class="table-col firstName-col">
-                        {{ employee.firstName || 'Не указано' }}
-                    </div>
-                    <div class="table-col middleName-col">
-                        {{ employee.middleName || 'Не указано' }}
-                    </div>
-                    <div class="table-col actions-col">
-                        <button 
-                            class="details-btn"
-                            @click="showEmployeeDetails(employee)"
-                            title="Детали"
-                        >
-                            <img 
-                                src="@/assets/icons/info.png" 
-                                alt="Детали" 
-                                class="details-icon"
-                            />
-                        </button>
-                        <button 
-                            class="edit-btn"
-                            @click="$emit('edit-employee', employee)"
-                            title="Редактировать"
-                        >
-                            <img 
-                                src="@/assets/icons/edit.png" 
-                                alt="Редактировать" 
-                                class="edit-icon"
-                            />
-                        </button>
-                        <button 
-                            class="delete-btn"
-                            @click="$emit('delete-employee', employee.id)"
-                        >
-                            <img 
-                                src="@/assets/icons/trashcan.png" 
-                                alt="Удалить" 
-                                class="delete-icon"
-                            />
-                        </button>
-                    </div>
-                </div>
-                <div v-if="employees.length === 0" class="no-employees">
-                    Нет добавленных сотрудников
-                </div>
-            </div>
-        </div>
-
-        <!-- Модальное окно деталей сотрудника -->
-        <EmployeeDetailsModal
-            :show="showDetailsModal"
-            :employee="selectedEmployee"
-            :all-tables="allTables"
-            @close="closeDetailsModal"
-        />
+  <div class="data__list">
+    <div class="header-with-badge">
+      <h4>Список сотрудников</h4>
+      <span class="employees-badge">{{ employees.length }}</span>
     </div>
+    <div class="employees-table">
+      <div class="table-header">
+        <div
+          class="header-col number-col"
+          @click="$emit('sort', 'number')"
+        >
+          <p :class="{ 'active-sort': sortField === 'number' }">
+            №
+          </p>
+          <img 
+            src="@/assets/icons/sort.png" 
+            class="sort-icon" 
+            :class="{ 
+              'desc': sortField === 'number' && sortDirection === 'desc'
+            }" 
+          >
+        </div>
+        <div
+          class="header-col lastName-col"
+          @click="$emit('sort', 'lastName')"
+        >
+          <p :class="{ 'active-sort': sortField === 'lastName' }">
+            Фамилия
+          </p>
+          <img 
+            src="@/assets/icons/sort.png" 
+            class="sort-icon" 
+            :class="{ 
+              'desc': sortField === 'lastName' && sortDirection === 'desc'
+            }" 
+          >
+        </div>
+        <div
+          class="header-col firstName-col"
+          @click="$emit('sort', 'firstName')"
+        >
+          <p :class="{ 'active-sort': sortField === 'firstName' }">
+            Имя
+          </p>
+          <img 
+            src="@/assets/icons/sort.png" 
+            class="sort-icon" 
+            :class="{ 
+              'desc': sortField === 'firstName' && sortDirection === 'desc'
+            }" 
+          >
+        </div>
+        <div
+          class="header-col middleName-col"
+          @click="$emit('sort', 'middleName')"
+        >
+          <p :class="{ 'active-sort': sortField === 'middleName' }">
+            Отчество
+          </p>
+          <img 
+            src="@/assets/icons/sort.png" 
+            class="sort-icon" 
+            :class="{ 
+              'desc': sortField === 'middleName' && sortDirection === 'desc'
+            }" 
+          >
+        </div>
+        <div class="header-col actions-col">
+          Действия
+        </div>
+      </div>
+      <div class="table-body">
+        <div 
+          v-for="(employee, index) in employees" 
+          :key="employee.id"
+          class="table-row"
+        >
+          <div class="table-col number-col">
+            {{ index + 1 }}
+          </div>
+          <div class="table-col lastName-col">
+            {{ employee.lastName || 'Не указано' }}
+          </div>
+          <div class="table-col firstName-col">
+            {{ employee.firstName || 'Не указано' }}
+          </div>
+          <div class="table-col middleName-col">
+            {{ employee.middleName || 'Не указано' }}
+          </div>
+          <div class="table-col actions-col">
+            <button 
+              class="details-btn"
+              title="Детали"
+              @click="showEmployeeDetails(employee)"
+            >
+              <img 
+                src="@/assets/icons/info.png" 
+                alt="Детали" 
+                class="details-icon"
+              >
+            </button>
+            <button 
+              class="edit-btn"
+              title="Редактировать"
+              @click="$emit('edit-employee', employee)"
+            >
+              <img 
+                src="@/assets/icons/edit.png" 
+                alt="Редактировать" 
+                class="edit-icon"
+              >
+            </button>
+            <button 
+              class="delete-btn"
+              @click="$emit('delete-employee', employee.id)"
+            >
+              <img 
+                src="@/assets/icons/trashcan.png" 
+                alt="Удалить" 
+                class="delete-icon"
+              >
+            </button>
+          </div>
+        </div>
+        <div
+          v-if="employees.length === 0"
+          class="no-employees"
+        >
+          Нет добавленных сотрудников
+        </div>
+      </div>
+    </div>
+
+    <!-- Модальное окно деталей сотрудника -->
+    <EmployeeDetailsModal
+      :show="showDetailsModal"
+      :employee="selectedEmployee"
+      :all-tables="allTables"
+      @close="closeDetailsModal"
+    />
+  </div>
 </template>
 
 <script>

--- a/frontend/src/components/CreateApplication/EmployeesTableHistoryModal.vue
+++ b/frontend/src/components/CreateApplication/EmployeesTableHistoryModal.vue
@@ -1,15 +1,34 @@
 <template>
-  <div class="modal-overlay" @click.self="close">
+  <div
+    class="modal-overlay"
+    @click.self="close"
+  >
     <div class="employees-history-modal">
       <div class="modal-header">
         <h3>История проходов сотрудников (таблица)</h3>
         <div class="header-actions">
-          <button class="export-btn" @click="exportToExcel" :disabled="filteredHistory.length === 0 || isExporting">
-            <img v-if="!isExporting" src="@/assets/icons/export.png" class="export-icon" />
+          <button
+            class="export-btn"
+            :disabled="filteredHistory.length === 0 || isExporting"
+            @click="exportToExcel"
+          >
+            <img
+              v-if="!isExporting"
+              src="@/assets/icons/export.png"
+              class="export-icon"
+            >
             <span v-if="!isExporting">Экспорт</span>
-            <div v-else class="export-loader"></div>
+            <div
+              v-else
+              class="export-loader"
+            />
           </button>
-          <button class="close-btn" @click="close">×</button>
+          <button
+            class="close-btn"
+            @click="close"
+          >
+            ×
+          </button>
         </div>
       </div>
 
@@ -18,26 +37,32 @@
           <div class="search-filter">
             <span class="filter-label">Поиск:</span>
             <input 
-              type="text" 
               v-model="searchQuery" 
+              type="text" 
               class="search-input" 
               placeholder="Поиск по сотруднику, пользователю..."
               @input="applyFilters"
-            />
+            >
           </div>
           <div class="user-filter">
             <span class="filter-label">Пользователь:</span>
-            <div class="custom-select" @click="toggleUserDropdown">
+            <div
+              class="custom-select"
+              @click="toggleUserDropdown"
+            >
               <div class="select-trigger">
                 <span class="selected-value">{{ selectedUserName }}</span>
                 <img 
                   src="@/assets/icons/arrow.png" 
                   class="select-arrow" 
                   :class="{ 'arrow-open': userDropdownOpen }"
-                />
+                >
               </div>
               <transition name="fade">
-                <div v-if="userDropdownOpen" class="select-dropdown">
+                <div
+                  v-if="userDropdownOpen"
+                  class="select-dropdown"
+                >
                   <div 
                     class="select-option"
                     :class="{ 'selected': selectedUserId === null }"
@@ -61,17 +86,23 @@
           
           <div class="employee-filter">
             <span class="filter-label">Сотрудник:</span>
-            <div class="custom-select" @click="toggleEmployeeDropdown">
+            <div
+              class="custom-select"
+              @click="toggleEmployeeDropdown"
+            >
               <div class="select-trigger">
                 <span class="selected-value">{{ selectedEmployeeName }}</span>
                 <img 
                   src="@/assets/icons/arrow.png" 
                   class="select-arrow" 
                   :class="{ 'arrow-open': employeeDropdownOpen }"
-                />
+                >
               </div>
               <transition name="fade">
-                <div v-if="employeeDropdownOpen" class="select-dropdown">
+                <div
+                  v-if="employeeDropdownOpen"
+                  class="select-dropdown"
+                >
                   <div 
                     class="select-option"
                     :class="{ 'selected': selectedEmployeeId === null }"
@@ -96,57 +127,87 @@
           <div class="date-filter">
             <span class="filter-label">Период:</span>
             <input 
-              type="date" 
               v-model="dateFrom" 
+              type="date" 
               class="date-input"
               @change="applyFilters"
-            />
+            >
             <span class="date-separator">—</span>
             <input 
-              type="date" 
               v-model="dateTo" 
+              type="date" 
               class="date-input"
               @change="applyFilters"
-            />
+            >
           </div>
           
           <div class="sort-filter">
             <span class="filter-label">Сортировка:</span>
-            <button class="sort-btn" @click="toggleSortOrder">
-              <img src="@/assets/icons/sort.png" class="sort-icon" :class="{ 'sort-asc': sortOrder === 'asc' }" />
+            <button
+              class="sort-btn"
+              @click="toggleSortOrder"
+            >
+              <img
+                src="@/assets/icons/sort.png"
+                class="sort-icon"
+                :class="{ 'sort-asc': sortOrder === 'asc' }"
+              >
               <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
             </button>
           </div>
         </div>
       </div>
 
-      <div class="modal-content" ref="scrollContainer">
-        <div v-if="loading" class="history-loading">
-          <div class="loader"></div>
+      <div
+        ref="scrollContainer"
+        class="modal-content"
+      >
+        <div
+          v-if="loading"
+          class="history-loading"
+        >
+          <div class="loader" />
         </div>
         
-        <div v-else-if="filteredHistory.length === 0" class="history-empty">
+        <div
+          v-else-if="filteredHistory.length === 0"
+          class="history-empty"
+        >
           История пуста
         </div>
         
-        <div v-else class="history-timeline">
+        <div
+          v-else
+          class="history-timeline"
+        >
           <div 
             v-for="(item, index) in filteredHistory" 
             :key="item.id" 
             class="history-item"
           >
-            <div class="timeline-dot" :class="getActionClass(item.action_type)"></div>
-            <div class="timeline-line" v-if="index < filteredHistory.length - 1"></div>
+            <div
+              class="timeline-dot"
+              :class="getActionClass(item.action_type)"
+            />
+            <div
+              v-if="index < filteredHistory.length - 1"
+              class="timeline-line"
+            />
             
             <div class="history-content">
               <div class="history-header">
                 <span class="employee-info">{{ getEmployeeName(item) }}</span>
-                <span v-if="item.table_name" class="table-name">{{ item.table_name }}</span>
+                <span
+                  v-if="item.table_name"
+                  class="table-name"
+                >{{ item.table_name }}</span>
                 <span class="user-name">{{ item.user_name || 'Система' }}</span>
                 <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
               </div>
               
-              <div class="action-text">{{ getActionText(item) }}</div>
+              <div class="action-text">
+                {{ getActionText(item) }}
+              </div>
               
               <div class="action-comment">
                 {{ item.comment || getActionComment(item) }}
@@ -307,6 +368,13 @@ export default {
       const parts = this.currentUserName.split(' ').filter(part => part && part !== 'null' && part !== 'undefined');
       return parts.length > 0 ? parts.join(' ') : 'Пользователь';
     }
+  },
+  mounted() {
+    this.loadHistory();
+    document.addEventListener('click', this.handleClickOutside);
+  },
+  beforeUnmount() {
+    document.removeEventListener('click', this.handleClickOutside);
   },
   methods: {
     async loadHistory() {
@@ -549,13 +617,6 @@ export default {
     close() {
       this.$emit('close');
     }
-  },
-  mounted() {
-    this.loadHistory();
-    document.addEventListener('click', this.handleClickOutside);
-  },
-  beforeUnmount() {
-    document.removeEventListener('click', this.handleClickOutside);
   }
 };
 </script>

--- a/frontend/src/components/CreateApplication/ExistingCarsModal.vue
+++ b/frontend/src/components/CreateApplication/ExistingCarsModal.vue
@@ -1,132 +1,173 @@
 <template>
-    <div v-if="visible" class="modal-overlay" @click="$emit('close')">
-        <div class="modal-content" @click.stop>
-            <!-- Заголовок модалки -->
-            <div class="modal-header">
-                <h3>Выбор существующих автомобилей</h3>
-                <div class="header-right">
-                    <SearchComponent
-                        title="Поиск автомобилей..."
-                        v-model="searchQuery"
-                        @update:modelValue="handleSearch"
-                    />
-                </div>
-                <button class="modal-close" @click="$emit('close')">×</button>
-            </div>
-
-            <!-- Фильтры -->
-            <div class="filter-section">
-                <div class="filter-tabs">
-                    <button
-                        class="filter-tab"
-                        :class="{ 'filter-tab--active': currentFilter === 'all' }"
-                        @click="switchFilter('all')"
-                    >
-                        Все машины
-                    </button>
-                    <button
-                        v-if="userOrganizationId"
-                        class="filter-tab"
-                        :class="{ 'filter-tab--active': currentFilter === 'organization' }"
-                        @click="switchFilter('organization')"
-                    >
-                        Организация
-                    </button>
-                    <button
-                        v-if="userCompanyId"
-                        class="filter-tab"
-                        :class="{ 'filter-tab--active': currentFilter === 'company' }"
-                        @click="switchFilter('company')"
-                    >
-                        Компания
-                    </button>
-                    <button
-                        class="filter-tab"
-                        :class="{ 'filter-tab--active': currentFilter === 'user' }"
-                        @click="switchFilter('user')"
-                    >
-                        Мои
-                    </button>
-                </div>
-                <div v-if="tempSelectedCars.length > 0" class="selected-counter">
-                    Выбрано: <span class="selected-count">{{ tempSelectedCars.length }}</span>
-                </div>
-            </div>
-
-            <!-- Список машин -->
-            <div class="cars-table-container">
-                <div class="cars-table">
-                    <!-- Заголовки таблицы -->
-                    <div class="table-header">
-                        <div class="header-cell select-cell"></div>
-                        <div class="header-cell number-cell">№</div>
-                        <div class="header-cell plate-cell">Номер</div>
-                        <div class="header-cell mark-cell">Марка</div>
-                        <div class="header-cell status-cell">Статус</div>
-                    </div>
-
-                    <!-- Тело таблицы -->
-                    <div class="table-body">
-                        <div
-                            v-for="car in displayedCars"
-                            :key="car.id"
-                            class="table-row"
-                            :class="{
-                                'table-row--disabled': isCarDisabled(car),
-                                'table-row--selected': isCarSelected(car)
-                            }"
-                            @click="handleRowClick(car)"
-                        >
-                            <div class="table-cell select-cell" @click.stop>
-                                <input
-                                    type="checkbox"
-                                    :checked="isCarSelected(car)"
-                                    :disabled="isCarDisabled(car)"
-                                    @change="toggleCarSelection(car)"
-                                />
-                            </div>
-                            <div class="table-cell number-cell">{{ car.id }}</div>
-                            <div class="table-cell plate-cell">{{ car.number }}</div>
-                            <div class="table-cell mark-cell">{{ car.mark }}</div>
-                            <div class="table-cell status-cell">
-                                <span
-                                    class="status-badge"
-                                    :class="{
-                                        'status-active': car.status,
-                                        'status-inactive': !car.status
-                                    }"
-                                >
-                                    {{ car.status ? 'Активна' : 'Неактивна' }}
-                                </span>
-                            </div>
-                        </div>
-
-                        <!-- Состояния загрузки/пусто -->
-                        <div v-if="loadingCars" class="loading-state">
-                            <LoaderSpinner label="Загрузка машин…" />
-                        </div>
-                        <div v-else-if="displayedCars.length === 0" class="empty-state">
-                            {{ searchQuery ? 'Ничего не найдено' : 'Нет доступных автомобилей' }}
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Кнопки действий -->
-            <div class="modal-actions">
-                <button class="btn btn-secondary" @click="$emit('close')">
-                    Отмена
-                </button>
-                <button
-                    class="btn btn-primary"
-                    @click="confirmSelection"
-                    :disabled="tempSelectedCars.length === 0"
-                >
-                    {{ tempSelectedCars.length > 0 ? `Выбрать (${tempSelectedCars.length})` : 'Выбрать' }}
-                </button>
-            </div>
+  <div
+    v-if="visible"
+    class="modal-overlay"
+    @click="$emit('close')"
+  >
+    <div
+      class="modal-content"
+      @click.stop
+    >
+      <!-- Заголовок модалки -->
+      <div class="modal-header">
+        <h3>Выбор существующих автомобилей</h3>
+        <div class="header-right">
+          <SearchComponent
+            v-model="searchQuery"
+            title="Поиск автомобилей..."
+            @update:model-value="handleSearch"
+          />
         </div>
+        <button
+          class="modal-close"
+          @click="$emit('close')"
+        >
+          ×
+        </button>
+      </div>
+
+      <!-- Фильтры -->
+      <div class="filter-section">
+        <div class="filter-tabs">
+          <button
+            class="filter-tab"
+            :class="{ 'filter-tab--active': currentFilter === 'all' }"
+            @click="switchFilter('all')"
+          >
+            Все машины
+          </button>
+          <button
+            v-if="userOrganizationId"
+            class="filter-tab"
+            :class="{ 'filter-tab--active': currentFilter === 'organization' }"
+            @click="switchFilter('organization')"
+          >
+            Организация
+          </button>
+          <button
+            v-if="userCompanyId"
+            class="filter-tab"
+            :class="{ 'filter-tab--active': currentFilter === 'company' }"
+            @click="switchFilter('company')"
+          >
+            Компания
+          </button>
+          <button
+            class="filter-tab"
+            :class="{ 'filter-tab--active': currentFilter === 'user' }"
+            @click="switchFilter('user')"
+          >
+            Мои
+          </button>
+        </div>
+        <div
+          v-if="tempSelectedCars.length > 0"
+          class="selected-counter"
+        >
+          Выбрано: <span class="selected-count">{{ tempSelectedCars.length }}</span>
+        </div>
+      </div>
+
+      <!-- Список машин -->
+      <div class="cars-table-container">
+        <div class="cars-table">
+          <!-- Заголовки таблицы -->
+          <div class="table-header">
+            <div class="header-cell select-cell" />
+            <div class="header-cell number-cell">
+              №
+            </div>
+            <div class="header-cell plate-cell">
+              Номер
+            </div>
+            <div class="header-cell mark-cell">
+              Марка
+            </div>
+            <div class="header-cell status-cell">
+              Статус
+            </div>
+          </div>
+
+          <!-- Тело таблицы -->
+          <div class="table-body">
+            <div
+              v-for="car in displayedCars"
+              :key="car.id"
+              class="table-row"
+              :class="{
+                'table-row--disabled': isCarDisabled(car),
+                'table-row--selected': isCarSelected(car)
+              }"
+              @click="handleRowClick(car)"
+            >
+              <div
+                class="table-cell select-cell"
+                @click.stop
+              >
+                <input
+                  type="checkbox"
+                  :checked="isCarSelected(car)"
+                  :disabled="isCarDisabled(car)"
+                  @change="toggleCarSelection(car)"
+                >
+              </div>
+              <div class="table-cell number-cell">
+                {{ car.id }}
+              </div>
+              <div class="table-cell plate-cell">
+                {{ car.number }}
+              </div>
+              <div class="table-cell mark-cell">
+                {{ car.mark }}
+              </div>
+              <div class="table-cell status-cell">
+                <span
+                  class="status-badge"
+                  :class="{
+                    'status-active': car.status,
+                    'status-inactive': !car.status
+                  }"
+                >
+                  {{ car.status ? 'Активна' : 'Неактивна' }}
+                </span>
+              </div>
+            </div>
+
+            <!-- Состояния загрузки/пусто -->
+            <div
+              v-if="loadingCars"
+              class="loading-state"
+            >
+              <LoaderSpinner label="Загрузка машин…" />
+            </div>
+            <div
+              v-else-if="displayedCars.length === 0"
+              class="empty-state"
+            >
+              {{ searchQuery ? 'Ничего не найдено' : 'Нет доступных автомобилей' }}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Кнопки действий -->
+      <div class="modal-actions">
+        <button
+          class="btn btn-secondary"
+          @click="$emit('close')"
+        >
+          Отмена
+        </button>
+        <button
+          class="btn btn-primary"
+          :disabled="tempSelectedCars.length === 0"
+          @click="confirmSelection"
+        >
+          {{ tempSelectedCars.length > 0 ? `Выбрать (${tempSelectedCars.length})` : 'Выбрать' }}
+        </button>
+      </div>
     </div>
+  </div>
 </template>
 
 <script>

--- a/frontend/src/components/CreateApplication/ExistingEmployeesModal.vue
+++ b/frontend/src/components/CreateApplication/ExistingEmployeesModal.vue
@@ -1,119 +1,164 @@
 <template>
-    <div v-if="visible" class="modal-overlay" @click="$emit('close')">
-        <div class="modal-content" @click.stop>
-            <div class="modal-header">
-                <h3>Выбор существующих сотрудников</h3>
-                <div class="header-right">
-                    <SearchComponent
-                        title="Поиск сотрудников..."
-                        v-model="searchQuery"
-                        @update:modelValue="handleSearch"
-                    />
-                </div>
-                <button class="modal-close" @click="$emit('close')">×</button>
-            </div>
-
-            <div class="filter-section">
-                <div class="filter-tabs">
-                    <button
-                        class="filter-tab"
-                        :class="{ 'filter-tab--active': currentFilter === 'all' }"
-                        @click="switchFilter('all')"
-                    >
-                        Все сотрудники
-                    </button>
-                    <button
-                        v-if="userOrganizationId"
-                        class="filter-tab"
-                        :class="{ 'filter-tab--active': currentFilter === 'organization' }"
-                        @click="switchFilter('organization')"
-                    >
-                        Организация
-                    </button>
-                    <button
-                        class="filter-tab"
-                        :class="{ 'filter-tab--active': currentFilter === 'user' }"
-                        @click="switchFilter('user')"
-                    >
-                        Мои
-                    </button>
-                </div>
-                <div v-if="tempSelectedEmployees.length > 0" class="selected-counter">
-                    Выбрано: <span class="selected-count">{{ tempSelectedEmployees.length }}</span>
-                </div>
-            </div>
-
-            <div class="employees-table-container">
-                <div class="employees-table">
-                    <div class="table-header">
-                        <div class="header-cell select-cell"></div>
-                        <div class="header-cell number-cell">№</div>
-                        <div class="header-cell name-col">ФИО</div>
-                        <div class="header-cell position-col">Должность</div>
-                        <div class="header-cell citizenship-col">Гражданство</div>
-                        <div class="header-cell status-cell">Статус</div>
-                    </div>
-
-                    <div class="table-body">
-                        <div
-                            v-for="employee in displayedEmployees"
-                            :key="employee.id"
-                            class="table-row"
-                            :class="{
-                                'table-row--disabled': isEmployeeDisabled(employee),
-                                'table-row--selected': isEmployeeSelected(employee)
-                            }"
-                            @click="handleRowClick(employee)"
-                        >
-                            <div class="table-cell select-cell" @click.stop>
-                                <input
-                                    type="checkbox"
-                                    :checked="isEmployeeSelected(employee)"
-                                    :disabled="isEmployeeDisabled(employee)"
-                                    @change="toggleEmployeeSelection(employee)"
-                                />
-                            </div>
-                            <div class="table-cell number-cell">{{ employee.id }}</div>
-                            <div class="table-cell name-col">{{ formatFullName(employee) }}</div>
-                            <div class="table-cell position-col">{{ employee.position || 'Не указана' }}</div>
-                            <div class="table-cell citizenship-col">{{ employee.citizenship_name || 'Не указано' }}</div>
-                            <div class="table-cell status-cell">
-                                <span
-                                    class="status-badge"
-                                    :class="{
-                                        'status-active': employee.status,
-                                        'status-inactive': !employee.status
-                                    }"
-                                >
-                                    {{ employee.status ? 'Активен' : 'Неактивен' }}
-                                </span>
-                            </div>
-                        </div>
-
-                        <div v-if="loadingEmployees" class="loading-state">
-                            <LoaderSpinner label="Загрузка сотрудников…" />
-                        </div>
-                        <div v-else-if="displayedEmployees.length === 0" class="empty-state">
-                            {{ searchQuery ? 'Ничего не найдено' : 'Нет доступных сотрудников' }}
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <div class="modal-actions">
-                <button class="btn btn-secondary" @click="$emit('close')">
-                    Отмена
-                </button>
-                <button
-                    class="btn btn-primary"
-                    @click="confirmSelection"
-                    :disabled="tempSelectedEmployees.length === 0"
-                >
-                    {{ tempSelectedEmployees.length > 0 ? `Добавить (${tempSelectedEmployees.length})` : 'Добавить' }}
-                </button>
-            </div>
+  <div
+    v-if="visible"
+    class="modal-overlay"
+    @click="$emit('close')"
+  >
+    <div
+      class="modal-content"
+      @click.stop
+    >
+      <div class="modal-header">
+        <h3>Выбор существующих сотрудников</h3>
+        <div class="header-right">
+          <SearchComponent
+            v-model="searchQuery"
+            title="Поиск сотрудников..."
+            @update:model-value="handleSearch"
+          />
         </div>
+        <button
+          class="modal-close"
+          @click="$emit('close')"
+        >
+          ×
+        </button>
+      </div>
+
+      <div class="filter-section">
+        <div class="filter-tabs">
+          <button
+            class="filter-tab"
+            :class="{ 'filter-tab--active': currentFilter === 'all' }"
+            @click="switchFilter('all')"
+          >
+            Все сотрудники
+          </button>
+          <button
+            v-if="userOrganizationId"
+            class="filter-tab"
+            :class="{ 'filter-tab--active': currentFilter === 'organization' }"
+            @click="switchFilter('organization')"
+          >
+            Организация
+          </button>
+          <button
+            class="filter-tab"
+            :class="{ 'filter-tab--active': currentFilter === 'user' }"
+            @click="switchFilter('user')"
+          >
+            Мои
+          </button>
+        </div>
+        <div
+          v-if="tempSelectedEmployees.length > 0"
+          class="selected-counter"
+        >
+          Выбрано: <span class="selected-count">{{ tempSelectedEmployees.length }}</span>
+        </div>
+      </div>
+
+      <div class="employees-table-container">
+        <div class="employees-table">
+          <div class="table-header">
+            <div class="header-cell select-cell" />
+            <div class="header-cell number-cell">
+              №
+            </div>
+            <div class="header-cell name-col">
+              ФИО
+            </div>
+            <div class="header-cell position-col">
+              Должность
+            </div>
+            <div class="header-cell citizenship-col">
+              Гражданство
+            </div>
+            <div class="header-cell status-cell">
+              Статус
+            </div>
+          </div>
+
+          <div class="table-body">
+            <div
+              v-for="employee in displayedEmployees"
+              :key="employee.id"
+              class="table-row"
+              :class="{
+                'table-row--disabled': isEmployeeDisabled(employee),
+                'table-row--selected': isEmployeeSelected(employee)
+              }"
+              @click="handleRowClick(employee)"
+            >
+              <div
+                class="table-cell select-cell"
+                @click.stop
+              >
+                <input
+                  type="checkbox"
+                  :checked="isEmployeeSelected(employee)"
+                  :disabled="isEmployeeDisabled(employee)"
+                  @change="toggleEmployeeSelection(employee)"
+                >
+              </div>
+              <div class="table-cell number-cell">
+                {{ employee.id }}
+              </div>
+              <div class="table-cell name-col">
+                {{ formatFullName(employee) }}
+              </div>
+              <div class="table-cell position-col">
+                {{ employee.position || 'Не указана' }}
+              </div>
+              <div class="table-cell citizenship-col">
+                {{ employee.citizenship_name || 'Не указано' }}
+              </div>
+              <div class="table-cell status-cell">
+                <span
+                  class="status-badge"
+                  :class="{
+                    'status-active': employee.status,
+                    'status-inactive': !employee.status
+                  }"
+                >
+                  {{ employee.status ? 'Активен' : 'Неактивен' }}
+                </span>
+              </div>
+            </div>
+
+            <div
+              v-if="loadingEmployees"
+              class="loading-state"
+            >
+              <LoaderSpinner label="Загрузка сотрудников…" />
+            </div>
+            <div
+              v-else-if="displayedEmployees.length === 0"
+              class="empty-state"
+            >
+              {{ searchQuery ? 'Ничего не найдено' : 'Нет доступных сотрудников' }}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="modal-actions">
+        <button
+          class="btn btn-secondary"
+          @click="$emit('close')"
+        >
+          Отмена
+        </button>
+        <button
+          class="btn btn-primary"
+          :disabled="tempSelectedEmployees.length === 0"
+          @click="confirmSelection"
+        >
+          {{ tempSelectedEmployees.length > 0 ? `Добавить (${tempSelectedEmployees.length})` : 'Добавить' }}
+        </button>
+      </div>
     </div>
+  </div>
 </template>
 
 <script>

--- a/frontend/src/components/CreateApplication/ItemsForm.vue
+++ b/frontend/src/components/CreateApplication/ItemsForm.vue
@@ -1,101 +1,111 @@
 <template>
-    <div class="data__completion">
-        <div class="completion__header">
-            <h3>Новые ТМЦ</h3>
-            <div class="completion__actions">
-                <button 
-                    class="cancel-edit-btn" 
-                    @click="cancelEdit" 
-                    v-if="editingItem"
-                >
-                    Отменить
-                </button>
-                <button 
-                    class="add-button" 
-                    @click="addItems"
-                    :disabled="!canAddItems"
-                    @mouseenter="showTooltip = true"
-                    @mouseleave="showTooltip = false"
-                >
-                    {{ editingItem ? 'Применить' : 'Добавить' }}
-                </button>
-                <!-- Подсказка для кнопки -->
-                <div v-if="showTooltip && !canAddItems" class="tooltip">
-                    <div class="tooltip-content">
-                        {{ getTooltipMessage }}
-                    </div>
-                </div>
-            </div>
+  <div class="data__completion">
+    <div class="completion__header">
+      <h3>Новые ТМЦ</h3>
+      <div class="completion__actions">
+        <button 
+          v-if="editingItem" 
+          class="cancel-edit-btn" 
+          @click="cancelEdit"
+        >
+          Отменить
+        </button>
+        <button 
+          class="add-button" 
+          :disabled="!canAddItems"
+          @click="addItems"
+          @mouseenter="showTooltip = true"
+          @mouseleave="showTooltip = false"
+        >
+          {{ editingItem ? 'Применить' : 'Добавить' }}
+        </button>
+        <!-- Подсказка для кнопки -->
+        <div
+          v-if="showTooltip && !canAddItems"
+          class="tooltip"
+        >
+          <div class="tooltip-content">
+            {{ getTooltipMessage }}
+          </div>
         </div>
-
-        <!-- Форма для добавления новых ТМЦ -->
-        <div class="items-form-container">
-            <!-- Таблица для ввода ТМЦ -->
-            <div class="items-table-wrapper">
-                <div class="items-table">
-                    <div class="table-header">
-                        <div class="header-cell number-header">
-                            <label class="input__label">№</label>
-                        </div>
-                        <div class="header-cell name-header">
-                            <label class="input__label">Наименование ТМЦ <span class="required">*</span></label>
-                        </div>
-                        <div class="header-cell quantity-header">
-                            <label class="input__label">Количество <span class="required">*</span></label>
-                        </div>
-                        <div class="header-cell actions-header"></div>
-                    </div>
-                    
-                    <div class="table-body">
-                        <div v-for="(item, index) in tempItems" :key="item.key" class="table-row">
-                            <div class="table-cell number-cell">
-                                <span class="item-number">{{ index + 1 }}</span>
-                            </div>
-                            <div class="table-cell name-cell">
-                                <input 
-                                    type="text" 
-                                    v-model="item.itemName"
-                                    placeholder="Введите наименование"
-                                    class="name__input"
-                                    :class="{ 'input--error': !item.itemName && submitted }"
-                                    @input="updateItem(index, $event.target.value, 'itemName')"
-                                />
-                            </div>
-                            <div class="table-cell quantity-cell">
-                                <input 
-                                    type="number" 
-                                    v-model.number="item.quantity"
-                                    min="1"
-                                    placeholder="1"
-                                    class="name__input"
-                                    :class="{ 'input--error': (!item.quantity || item.quantity < 1) && submitted }"
-                                    @input="updateItem(index, parseInt($event.target.value) || 1, 'quantity')"
-                                />
-                            </div>
-                            <div class="table-cell actions-cell">
-                                <button 
-                                    class="remove-row-btn"
-                                    @click="removeRow(index)"
-                                    :disabled="tempItems.length <= 1"
-                                >
-                                    ×
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                
-                <div class="table-actions">
-                    <button class="add-row-btn" @click="addRow">
-                        + Добавить строку
-                    </button>
-                    <div class="total-items">
-                        Всего позиций: {{ tempItems.length }}
-                    </div>
-                </div>
-            </div>
-        </div>
+      </div>
     </div>
+
+    <!-- Форма для добавления новых ТМЦ -->
+    <div class="items-form-container">
+      <!-- Таблица для ввода ТМЦ -->
+      <div class="items-table-wrapper">
+        <div class="items-table">
+          <div class="table-header">
+            <div class="header-cell number-header">
+              <label class="input__label">№</label>
+            </div>
+            <div class="header-cell name-header">
+              <label class="input__label">Наименование ТМЦ <span class="required">*</span></label>
+            </div>
+            <div class="header-cell quantity-header">
+              <label class="input__label">Количество <span class="required">*</span></label>
+            </div>
+            <div class="header-cell actions-header" />
+          </div>
+                    
+          <div class="table-body">
+            <div
+              v-for="(item, index) in tempItems"
+              :key="item.key"
+              class="table-row"
+            >
+              <div class="table-cell number-cell">
+                <span class="item-number">{{ index + 1 }}</span>
+              </div>
+              <div class="table-cell name-cell">
+                <input 
+                  v-model="item.itemName" 
+                  type="text"
+                  placeholder="Введите наименование"
+                  class="name__input"
+                  :class="{ 'input--error': !item.itemName && submitted }"
+                  @input="updateItem(index, $event.target.value, 'itemName')"
+                >
+              </div>
+              <div class="table-cell quantity-cell">
+                <input 
+                  v-model.number="item.quantity" 
+                  type="number"
+                  min="1"
+                  placeholder="1"
+                  class="name__input"
+                  :class="{ 'input--error': (!item.quantity || item.quantity < 1) && submitted }"
+                  @input="updateItem(index, parseInt($event.target.value) || 1, 'quantity')"
+                >
+              </div>
+              <div class="table-cell actions-cell">
+                <button 
+                  class="remove-row-btn"
+                  :disabled="tempItems.length <= 1"
+                  @click="removeRow(index)"
+                >
+                  ×
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+                
+        <div class="table-actions">
+          <button
+            class="add-row-btn"
+            @click="addRow"
+          >
+            + Добавить строку
+          </button>
+          <div class="total-items">
+            Всего позиций: {{ tempItems.length }}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </template>
 
 <script>
@@ -146,6 +156,17 @@ export default {
             }
             
             return '';
+        }
+    },
+    watch: {
+        // Следим за изменениями в tempItems и сбрасываем submitted при изменении
+        tempItems: {
+            handler() {
+                if (this.submitted) {
+                    this.submitted = false;
+                }
+            },
+            deep: true
         }
     },
     methods: {
@@ -269,17 +290,6 @@ export default {
             
             // Эмитируем событие отмены
             this.$emit('edit-cancelled');
-        }
-    },
-    watch: {
-        // Следим за изменениями в tempItems и сбрасываем submitted при изменении
-        tempItems: {
-            handler() {
-                if (this.submitted) {
-                    this.submitted = false;
-                }
-            },
-            deep: true
         }
     }
 }

--- a/frontend/src/components/CreateApplication/ItemsList.vue
+++ b/frontend/src/components/CreateApplication/ItemsList.vue
@@ -1,90 +1,113 @@
 <template>
-    <div class="data__list">
-        <div class="header-with-badge">
-            <h4>Список ТМЦ</h4>
-            <span class="items-badge">{{ items.length }}</span>
-        </div>
-        <div class="items-table">
-            <div class="table-header">
-                <div class="header-col number-col" @click="$emit('sort', 'number')">
-                    <p :class="{ 'active-sort': sortField === 'number' }">№</p>
-                    <img 
-                        src="@/assets/icons/sort.png" 
-                        class="sort-icon" 
-                        :class="{ 
-                            'desc': sortField === 'number' && sortDirection === 'desc'
-                        }" 
-                    />
-                </div>
-                <div class="header-col name-col" @click="$emit('sort', 'name')">
-                    <p :class="{ 'active-sort': sortField === 'name' }">Наименование</p>
-                    <img 
-                        src="@/assets/icons/sort.png" 
-                        class="sort-icon" 
-                        :class="{ 
-                            'desc': sortField === 'name' && sortDirection === 'desc'
-                        }" 
-                    />
-                </div>
-                <div class="header-col quantity-col" @click="$emit('sort', 'quantity')">
-                    <p :class="{ 'active-sort': sortField === 'quantity' }">Количество</p>
-                    <img 
-                        src="@/assets/icons/sort.png" 
-                        class="sort-icon" 
-                        :class="{ 
-                            'desc': sortField === 'quantity' && sortDirection === 'desc'
-                        }" 
-                    />
-                </div>
-                <div class="header-col actions-col">
-                    Действия
-                </div>
-            </div>
-            <div class="table-body">
-                <transition-group name="fade" tag="div">
-                    <div 
-                        v-for="(item, index) in items" 
-                        :key="item.id"
-                        class="table-row"
-                    >
-                        <div class="table-col number-col">{{ index + 1 }}</div>
-                        <div class="table-col name-col">
-                            {{ item.itemName || 'Не указано' }}
-                        </div>
-                        <div class="table-col quantity-col">
-                            {{ item.quantity || 0 }}
-                        </div>
-                        <div class="table-col actions-col">
-                            <button 
-                                class="edit-btn"
-                                @click="$emit('edit-item', item)"
-                                title="Редактировать"
-                            >
-                                <img 
-                                    src="@/assets/icons/edit.png" 
-                                    alt="Редактировать" 
-                                    class="edit-icon"
-                                />
-                            </button>
-                            <button 
-                                class="delete-btn"
-                                @click="deleteItemWithAnimation(item.id)"
-                            >
-                                <img 
-                                    src="@/assets/icons/trashcan.png" 
-                                    alt="Удалить" 
-                                    class="delete-icon"
-                                />
-                            </button>
-                        </div>
-                    </div>
-                </transition-group>
-                <div v-if="items.length === 0" class="no-items">
-                    Нет добавленных ТМЦ
-                </div>
-            </div>
-        </div>
+  <div class="data__list">
+    <div class="header-with-badge">
+      <h4>Список ТМЦ</h4>
+      <span class="items-badge">{{ items.length }}</span>
     </div>
+    <div class="items-table">
+      <div class="table-header">
+        <div
+          class="header-col number-col"
+          @click="$emit('sort', 'number')"
+        >
+          <p :class="{ 'active-sort': sortField === 'number' }">
+            №
+          </p>
+          <img 
+            src="@/assets/icons/sort.png" 
+            class="sort-icon" 
+            :class="{ 
+              'desc': sortField === 'number' && sortDirection === 'desc'
+            }" 
+          >
+        </div>
+        <div
+          class="header-col name-col"
+          @click="$emit('sort', 'name')"
+        >
+          <p :class="{ 'active-sort': sortField === 'name' }">
+            Наименование
+          </p>
+          <img 
+            src="@/assets/icons/sort.png" 
+            class="sort-icon" 
+            :class="{ 
+              'desc': sortField === 'name' && sortDirection === 'desc'
+            }" 
+          >
+        </div>
+        <div
+          class="header-col quantity-col"
+          @click="$emit('sort', 'quantity')"
+        >
+          <p :class="{ 'active-sort': sortField === 'quantity' }">
+            Количество
+          </p>
+          <img 
+            src="@/assets/icons/sort.png" 
+            class="sort-icon" 
+            :class="{ 
+              'desc': sortField === 'quantity' && sortDirection === 'desc'
+            }" 
+          >
+        </div>
+        <div class="header-col actions-col">
+          Действия
+        </div>
+      </div>
+      <div class="table-body">
+        <transition-group
+          name="fade"
+          tag="div"
+        >
+          <div 
+            v-for="(item, index) in items" 
+            :key="item.id"
+            class="table-row"
+          >
+            <div class="table-col number-col">
+              {{ index + 1 }}
+            </div>
+            <div class="table-col name-col">
+              {{ item.itemName || 'Не указано' }}
+            </div>
+            <div class="table-col quantity-col">
+              {{ item.quantity || 0 }}
+            </div>
+            <div class="table-col actions-col">
+              <button 
+                class="edit-btn"
+                title="Редактировать"
+                @click="$emit('edit-item', item)"
+              >
+                <img 
+                  src="@/assets/icons/edit.png" 
+                  alt="Редактировать" 
+                  class="edit-icon"
+                >
+              </button>
+              <button 
+                class="delete-btn"
+                @click="deleteItemWithAnimation(item.id)"
+              >
+                <img 
+                  src="@/assets/icons/trashcan.png" 
+                  alt="Удалить" 
+                  class="delete-icon"
+                >
+              </button>
+            </div>
+          </div>
+        </transition-group>
+        <div
+          v-if="items.length === 0"
+          class="no-items"
+        >
+          Нет добавленных ТМЦ
+        </div>
+      </div>
+    </div>
+  </div>
 </template>
 
 <script>

--- a/frontend/src/components/CreateApplication/TableInfoModal.vue
+++ b/frontend/src/components/CreateApplication/TableInfoModal.vue
@@ -1,136 +1,210 @@
 <template>
-    <div class="modal-content-inner">
-        <div class="modal-header">
-            <div class="header-with-status">
-                <h3 class="modal-title">Информация о месте прохода</h3>
-                <span class="status-badge" :class="getTableStatusClass">
-                    {{ getTableStatusText }}
-                </span>
-                <div v-if="table && table.table && table.table.status === 'active'" class="time-info">
-                    {{ getTableTimeInfoText() }}
-                </div>
-            </div>
-            <button @click="close" class="modal-close">
-                <svg width="10" height="10" viewBox="0 0 14 14" fill="none">
-                    <path d="M13 1L1 13M1 1L13 13" stroke="#666" stroke-width="2" stroke-linecap="round"/>
-                </svg>
-            </button>
+  <div class="modal-content-inner">
+    <div class="modal-header">
+      <div class="header-with-status">
+        <h3 class="modal-title">
+          Информация о месте прохода
+        </h3>
+        <span
+          class="status-badge"
+          :class="getTableStatusClass"
+        >
+          {{ getTableStatusText }}
+        </span>
+        <div
+          v-if="table && table.table && table.table.status === 'active'"
+          class="time-info"
+        >
+          {{ getTableTimeInfoText() }}
         </div>
-
-        <div class="modal-body">
-            <div class="place-details" v-if="table && table.table">
-                <!-- Секция Основная информация -->
-                <div class="details-section">
-                    <div class="section-header">
-                        <h4 class="section-title">Основная информация</h4>
-                    </div>
-                    <div class="section-body">
-                        <div class="info-grid">
-                            <div class="info-row">
-                                <span class="info-label">Наименование:</span>
-                                <span class="info-value">{{ table.table.display_name }}</span>
-                            </div>
-                            <div class="info-row">
-                                <span class="info-label">Тип:</span>
-                                <span class="info-value">{{ getTableTypeLabel }}</span>
-                            </div>
-                        </div>
-                        <div v-if="table.table.status !== 'active' && table.table.status_comment" class="comment-text">
-                            {{ table.table.status_comment }}
-                        </div>
-                        <div v-if="table.table.location_description" class="location-description">
-                            {{ table.table.location_description }}
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Секция Режим работы -->
-                <div class="details-section">
-                    <div class="section-header">
-                        <h4 class="section-title">Режим работы</h4>
-                    </div>
-                    <div class="section-body">
-                        <div v-if="hasTimeSlots" class="schedule-grid">
-                            <div 
-                                v-for="day in daysWithSlots" 
-                                :key="day" 
-                                class="schedule-day-card"
-                                :class="{ 'current-day': isCurrentDay(day) }"
-                            >
-                                <div class="day-name">{{ getFullDayName(day) }}</div>
-                                <div class="day-slots">
-                                    <div 
-                                        v-for="slot in getSlotsForDay(day)" 
-                                        :key="slot.id" 
-                                        class="slot-badge"
-                                        :class="{ 
-                                            'active-slot': isCurrentDay(day) && isActiveSlot(slot)
-                                        }"
-                                    >
-                                        <span v-if="isRoundTheClockSlot(slot)" class="round-clock-text">круглосуточно</span>
-                                        <template v-else>
-                                            <span class="slot-time">
-                                                {{ formatTime(slot.open_time) }} – {{ formatTime(slot.close_time) }}
-                                            </span>
-                                            <div class="slot-badges">
-                                                <span v-if="slot.is_next_day" class="next-day-badge">+1</span>
-                                                <span v-if="!slot.is_active" class="inactive-badge">неакт</span>
-                                            </div>
-                                        </template>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div v-else class="no-schedule">
-                            Режим работы не указан
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Секция Местоположение -->
-                <div class="details-section">
-                    <div class="section-header location-header">
-                        <h4 class="section-title">Местоположение</h4>
-                        <a 
-                            v-if="table.table.map_link" 
-                            :href="table.table.map_link" 
-                            target="_blank" 
-                            class="map-link-btn"
-                        >
-                            Как добраться?
-                        </a>
-                    </div>
-                    <div class="section-body photo-body">
-                        <div v-if="table.photos && table.photos.length > 0" class="photo-container">
-                            <div 
-                                class="photo-wrapper"
-                                ref="photoWrapper"
-                                @mousedown="startDrag"
-                                @wheel="onZoom"
-                            >
-                                <img 
-                                    :src="getMainPhotoUrl" 
-                                    alt="Место прохода"
-                                    class="place-photo"
-                                    :style="photoStyle"
-                                    draggable="false"
-                                    @load="updateImageDimensions"
-                                >
-                            </div>
-                            <div class="photo-controls">
-                                <button @click="zoomIn" class="photo-control-btn">+</button>
-                                <button @click="zoomOut" class="photo-control-btn">−</button>
-                                <button @click="resetPhoto" class="photo-control-btn">↺</button>
-                            </div>
-                        </div>
-                        <div v-else class="no-photo-placeholder">
-                            Нет фотографии
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
+      </div>
+      <button
+        class="modal-close"
+        @click="close"
+      >
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 14 14"
+          fill="none"
+        >
+          <path
+            d="M13 1L1 13M1 1L13 13"
+            stroke="#666"
+            stroke-width="2"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
     </div>
+
+    <div class="modal-body">
+      <div
+        v-if="table && table.table"
+        class="place-details"
+      >
+        <!-- Секция Основная информация -->
+        <div class="details-section">
+          <div class="section-header">
+            <h4 class="section-title">
+              Основная информация
+            </h4>
+          </div>
+          <div class="section-body">
+            <div class="info-grid">
+              <div class="info-row">
+                <span class="info-label">Наименование:</span>
+                <span class="info-value">{{ table.table.display_name }}</span>
+              </div>
+              <div class="info-row">
+                <span class="info-label">Тип:</span>
+                <span class="info-value">{{ getTableTypeLabel }}</span>
+              </div>
+            </div>
+            <div
+              v-if="table.table.status !== 'active' && table.table.status_comment"
+              class="comment-text"
+            >
+              {{ table.table.status_comment }}
+            </div>
+            <div
+              v-if="table.table.location_description"
+              class="location-description"
+            >
+              {{ table.table.location_description }}
+            </div>
+          </div>
+        </div>
+
+        <!-- Секция Режим работы -->
+        <div class="details-section">
+          <div class="section-header">
+            <h4 class="section-title">
+              Режим работы
+            </h4>
+          </div>
+          <div class="section-body">
+            <div
+              v-if="hasTimeSlots"
+              class="schedule-grid"
+            >
+              <div 
+                v-for="day in daysWithSlots" 
+                :key="day" 
+                class="schedule-day-card"
+                :class="{ 'current-day': isCurrentDay(day) }"
+              >
+                <div class="day-name">
+                  {{ getFullDayName(day) }}
+                </div>
+                <div class="day-slots">
+                  <div 
+                    v-for="slot in getSlotsForDay(day)" 
+                    :key="slot.id" 
+                    class="slot-badge"
+                    :class="{ 
+                      'active-slot': isCurrentDay(day) && isActiveSlot(slot)
+                    }"
+                  >
+                    <span
+                      v-if="isRoundTheClockSlot(slot)"
+                      class="round-clock-text"
+                    >круглосуточно</span>
+                    <template v-else>
+                      <span class="slot-time">
+                        {{ formatTime(slot.open_time) }} – {{ formatTime(slot.close_time) }}
+                      </span>
+                      <div class="slot-badges">
+                        <span
+                          v-if="slot.is_next_day"
+                          class="next-day-badge"
+                        >+1</span>
+                        <span
+                          v-if="!slot.is_active"
+                          class="inactive-badge"
+                        >неакт</span>
+                      </div>
+                    </template>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              v-else
+              class="no-schedule"
+            >
+              Режим работы не указан
+            </div>
+          </div>
+        </div>
+
+        <!-- Секция Местоположение -->
+        <div class="details-section">
+          <div class="section-header location-header">
+            <h4 class="section-title">
+              Местоположение
+            </h4>
+            <a 
+              v-if="table.table.map_link" 
+              :href="table.table.map_link" 
+              target="_blank" 
+              class="map-link-btn"
+            >
+              Как добраться?
+            </a>
+          </div>
+          <div class="section-body photo-body">
+            <div
+              v-if="table.photos && table.photos.length > 0"
+              class="photo-container"
+            >
+              <div 
+                ref="photoWrapper"
+                class="photo-wrapper"
+                @mousedown="startDrag"
+                @wheel="onZoom"
+              >
+                <img 
+                  :src="getMainPhotoUrl" 
+                  alt="Место прохода"
+                  class="place-photo"
+                  :style="photoStyle"
+                  draggable="false"
+                  @load="updateImageDimensions"
+                >
+              </div>
+              <div class="photo-controls">
+                <button
+                  class="photo-control-btn"
+                  @click="zoomIn"
+                >
+                  +
+                </button>
+                <button
+                  class="photo-control-btn"
+                  @click="zoomOut"
+                >
+                  −
+                </button>
+                <button
+                  class="photo-control-btn"
+                  @click="resetPhoto"
+                >
+                  ↺
+                </button>
+              </div>
+            </div>
+            <div
+              v-else
+              class="no-photo-placeholder"
+            >
+              Нет фотографии
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </template>
 
 <script>
@@ -205,6 +279,22 @@ export default {
                 transform: `translate(${this.photoTranslateX}px, ${this.photoTranslateY}px) scale(${this.photoScale})`,
                 cursor: this.isDragging ? 'grabbing' : 'grab'
             };
+        }
+    },
+    watch: {
+        table(newVal) {
+            if (newVal) {
+                this.$nextTick(() => {
+                    this.updateContainerDimensions();
+                });
+                this.resetPhoto();
+            }
+        }
+    },
+    beforeUnmount() {
+        if (this.windowMouseMoveHandler) {
+            window.removeEventListener('mousemove', this.windowMouseMoveHandler);
+            window.removeEventListener('mouseup', this.windowMouseUpHandler);
         }
     },
     methods: {
@@ -474,22 +564,6 @@ export default {
             this.photoScale = 1.5;
             this.photoTranslateX = 0;
             this.photoTranslateY = 0;
-        }
-    },
-    watch: {
-        table(newVal) {
-            if (newVal) {
-                this.$nextTick(() => {
-                    this.updateContainerDimensions();
-                });
-                this.resetPhoto();
-            }
-        }
-    },
-    beforeUnmount() {
-        if (this.windowMouseMoveHandler) {
-            window.removeEventListener('mousemove', this.windowMouseMoveHandler);
-            window.removeEventListener('mouseup', this.windowMouseUpHandler);
         }
     }
 };

--- a/frontend/src/components/CreateApplication/UniversalBindingModal.vue
+++ b/frontend/src/components/CreateApplication/UniversalBindingModal.vue
@@ -1,119 +1,207 @@
 <template>
-    <div class="modal-overlay" @click.self="closeModal">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h3 class="modal-title">Привязка новых данных</h3>
-                <button class="modal-close" @click="closeModal">
-                    <svg width="10" height="10" viewBox="0 0 14 14" fill="none">
-                        <path d="M13 1L1 13M1 1L13 13" stroke="#666" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </button>
-            </div>
+  <div
+    class="modal-overlay"
+    @click.self="closeModal"
+  >
+    <div class="modal-content">
+      <div class="modal-header">
+        <h3 class="modal-title">
+          Привязка новых данных
+        </h3>
+        <button
+          class="modal-close"
+          @click="closeModal"
+        >
+          <svg
+            width="10"
+            height="10"
+            viewBox="0 0 14 14"
+            fill="none"
+          >
+            <path
+              d="M13 1L1 13M1 1L13 13"
+              stroke="#666"
+              stroke-width="2"
+              stroke-linecap="round"
+            />
+          </svg>
+        </button>
+      </div>
 
-            <div class="modal-body">
-                <div class="binding-description">
-                    Все добавленные данные будут <strong>автоматически привязаны</strong> к вашему аккаунту.
-                    Вы можете дополнительно привязать их к организации и/или компании для использования <strong>другими сотрудниками</strong>:
-                </div>
-
-                <div v-if="newVehiclesToBind.length > 0" class="data-section">
-                    <div class="section-header">
-                        <h4 class="section-title">Новые автомобили</h4>
-                        <span class="count-badge">{{ newVehiclesToBind.length }}</span>
-                    </div>
-                    <div class="section-body">
-                        <div class="items-list">
-                            <div
-                                v-for="vehicle in newVehiclesToBind"
-                                :key="vehicle.id"
-                                class="item"
-                                :class="{ 'item-fact': isVehicleByFact(vehicle) }"
-                            >
-                                <div class="item-info">
-                                    <span class="item-number">{{ vehicle.plateNumber }}</span>
-                                    <span class="item-detail">{{ vehicle.mark }}</span>
-                                    <span v-if="isVehicleByFact(vehicle)" class="fact-badge">По факту</span>
-                                </div>
-                            </div>
-                        </div>
-
-                        <div v-if="hasVehiclesForBinding" class="binding-options">
-                            <p class="options-title">Привязать автомобили к:</p>
-                            <div class="options-group">
-                                <label v-if="hasOrganization" class="binding-option">
-                                    <input type="checkbox" v-model="vehiclesBindToOrganization" />
-                                    <span>Организации "{{ organization }}"</span>
-                                </label>
-                                <label v-if="hasCompany" class="binding-option">
-                                    <input type="checkbox" v-model="vehiclesBindToCompany" />
-                                    <span>Компании "{{ company }}"</span>
-                                </label>
-                            </div>
-                        </div>
-                        <div v-else class="no-binding-message">
-                            Автомобили "По факту" не требуют привязки к организации/компании
-                        </div>
-                    </div>
-                </div>
-
-                <div v-if="newEmployeesToBind.length > 0" class="data-section">
-                    <div class="section-header">
-                        <h4 class="section-title">Новые сотрудники</h4>
-                        <span class="count-badge">{{ newEmployeesToBind.length }}</span>
-                    </div>
-                    <div class="section-body">
-                        <div class="items-list">
-                            <div
-                                v-for="employee in newEmployeesToBind"
-                                :key="employee.id"
-                                class="item"
-                                :class="{ 'item-fact': isEmployeeByFact(employee) }"
-                            >
-                                <div class="item-info">
-                                    <span class="item-name">{{ formatFullName(employee) }}</span>
-                                    <span class="item-detail">{{ employee.position }}</span>
-                                    <span v-if="isEmployeeByFact(employee)" class="fact-badge">По факту</span>
-                                </div>
-                            </div>
-                        </div>
-
-                        <div v-if="hasEmployeesForBinding" class="binding-options">
-                            <p class="options-title">Привязать сотрудников к:</p>
-                            <div class="options-group">
-                                <label v-if="hasOrganization" class="binding-option">
-                                    <input type="checkbox" v-model="employeesBindToOrganization" />
-                                    <span>Организации "{{ organization }}"</span>
-                                </label>
-                                <label v-if="hasCompany" class="binding-option">
-                                    <input type="checkbox" v-model="employeesBindToCompany" />
-                                    <span>Компании "{{ company }}"</span>
-                                </label>
-                            </div>
-                        </div>
-                        <div v-else class="no-binding-message">
-                            Сотрудники "По факту" не требуют привязки к организации/компании
-                        </div>
-                    </div>
-                </div>
-
-                <div class="warning-section">
-                    <p class="warning-text">
-                        <strong class="warning-strong">Внимание!</strong> При привязке данных к организации или компании,
-                        они будут доступны для отображения и использования <strong>всем</strong> сотрудникам, которые в них числятся.
-                    </p>
-                </div>
-
-                <div class="modal-actions">
-                    <button class="btn skip-btn" @click="handleSkip">Отправить без привязки</button>
-                    <button class="btn confirm-btn" @click="handleConfirm">
-                        <transition name="fade" mode="out-in">
-                            <span :key="buttonText" class="button-text">{{ buttonText }}</span>
-                        </transition>
-                    </button>
-                </div>
-            </div>
+      <div class="modal-body">
+        <div class="binding-description">
+          Все добавленные данные будут <strong>автоматически привязаны</strong> к вашему аккаунту.
+          Вы можете дополнительно привязать их к организации и/или компании для использования <strong>другими сотрудниками</strong>:
         </div>
+
+        <div
+          v-if="newVehiclesToBind.length > 0"
+          class="data-section"
+        >
+          <div class="section-header">
+            <h4 class="section-title">
+              Новые автомобили
+            </h4>
+            <span class="count-badge">{{ newVehiclesToBind.length }}</span>
+          </div>
+          <div class="section-body">
+            <div class="items-list">
+              <div
+                v-for="vehicle in newVehiclesToBind"
+                :key="vehicle.id"
+                class="item"
+                :class="{ 'item-fact': isVehicleByFact(vehicle) }"
+              >
+                <div class="item-info">
+                  <span class="item-number">{{ vehicle.plateNumber }}</span>
+                  <span class="item-detail">{{ vehicle.mark }}</span>
+                  <span
+                    v-if="isVehicleByFact(vehicle)"
+                    class="fact-badge"
+                  >По факту</span>
+                </div>
+              </div>
+            </div>
+
+            <div
+              v-if="hasVehiclesForBinding"
+              class="binding-options"
+            >
+              <p class="options-title">
+                Привязать автомобили к:
+              </p>
+              <div class="options-group">
+                <label
+                  v-if="hasOrganization"
+                  class="binding-option"
+                >
+                  <input
+                    v-model="vehiclesBindToOrganization"
+                    type="checkbox"
+                  >
+                  <span>Организации "{{ organization }}"</span>
+                </label>
+                <label
+                  v-if="hasCompany"
+                  class="binding-option"
+                >
+                  <input
+                    v-model="vehiclesBindToCompany"
+                    type="checkbox"
+                  >
+                  <span>Компании "{{ company }}"</span>
+                </label>
+              </div>
+            </div>
+            <div
+              v-else
+              class="no-binding-message"
+            >
+              Автомобили "По факту" не требуют привязки к организации/компании
+            </div>
+          </div>
+        </div>
+
+        <div
+          v-if="newEmployeesToBind.length > 0"
+          class="data-section"
+        >
+          <div class="section-header">
+            <h4 class="section-title">
+              Новые сотрудники
+            </h4>
+            <span class="count-badge">{{ newEmployeesToBind.length }}</span>
+          </div>
+          <div class="section-body">
+            <div class="items-list">
+              <div
+                v-for="employee in newEmployeesToBind"
+                :key="employee.id"
+                class="item"
+                :class="{ 'item-fact': isEmployeeByFact(employee) }"
+              >
+                <div class="item-info">
+                  <span class="item-name">{{ formatFullName(employee) }}</span>
+                  <span class="item-detail">{{ employee.position }}</span>
+                  <span
+                    v-if="isEmployeeByFact(employee)"
+                    class="fact-badge"
+                  >По факту</span>
+                </div>
+              </div>
+            </div>
+
+            <div
+              v-if="hasEmployeesForBinding"
+              class="binding-options"
+            >
+              <p class="options-title">
+                Привязать сотрудников к:
+              </p>
+              <div class="options-group">
+                <label
+                  v-if="hasOrganization"
+                  class="binding-option"
+                >
+                  <input
+                    v-model="employeesBindToOrganization"
+                    type="checkbox"
+                  >
+                  <span>Организации "{{ organization }}"</span>
+                </label>
+                <label
+                  v-if="hasCompany"
+                  class="binding-option"
+                >
+                  <input
+                    v-model="employeesBindToCompany"
+                    type="checkbox"
+                  >
+                  <span>Компании "{{ company }}"</span>
+                </label>
+              </div>
+            </div>
+            <div
+              v-else
+              class="no-binding-message"
+            >
+              Сотрудники "По факту" не требуют привязки к организации/компании
+            </div>
+          </div>
+        </div>
+
+        <div class="warning-section">
+          <p class="warning-text">
+            <strong class="warning-strong">Внимание!</strong> При привязке данных к организации или компании,
+            они будут доступны для отображения и использования <strong>всем</strong> сотрудникам, которые в них числятся.
+          </p>
+        </div>
+
+        <div class="modal-actions">
+          <button
+            class="btn skip-btn"
+            @click="handleSkip"
+          >
+            Отправить без привязки
+          </button>
+          <button
+            class="btn confirm-btn"
+            @click="handleConfirm"
+          >
+            <transition
+              name="fade"
+              mode="out-in"
+            >
+              <span
+                :key="buttonText"
+                class="button-text"
+              >{{ buttonText }}</span>
+            </transition>
+          </button>
+        </div>
+      </div>
     </div>
+  </div>
 </template>
 
 <script>

--- a/frontend/src/components/CreateApplication/UnloadPlaceModal.vue
+++ b/frontend/src/components/CreateApplication/UnloadPlaceModal.vue
@@ -1,130 +1,201 @@
 <template>
-    <div class="modal-content-inner">
-        <div class="modal-header">
-            <div class="header-with-status">
-                <h3 class="modal-title">Информация о месте разгрузки</h3>
-                <span class="status-badge" :class="getPlaceStatusClass(place)">
-                    {{ getPlaceStatusText(place) }}
-                </span>
-                <!-- Информация о времени до открытия/закрытия -->
-                <div v-if="place && place.status === 'active'" class="time-info">
-                    {{ getTimeInfoText() }}
-                </div>
-            </div>
-            <button @click="close" class="modal-close">
-                <svg width="10" height="10" viewBox="0 0 14 14" fill="none">
-                    <path d="M13 1L1 13M1 1L13 13" stroke="#666" stroke-width="2" stroke-linecap="round"/>
-                </svg>
-            </button>
+  <div class="modal-content-inner">
+    <div class="modal-header">
+      <div class="header-with-status">
+        <h3 class="modal-title">
+          Информация о месте разгрузки
+        </h3>
+        <span
+          class="status-badge"
+          :class="getPlaceStatusClass(place)"
+        >
+          {{ getPlaceStatusText(place) }}
+        </span>
+        <!-- Информация о времени до открытия/закрытия -->
+        <div
+          v-if="place && place.status === 'active'"
+          class="time-info"
+        >
+          {{ getTimeInfoText() }}
         </div>
-
-        <div class="modal-body">
-            <div class="place-details" v-if="place">
-                <!-- Секция Основная информация (без статуса) -->
-                <div class="details-section">
-                    <div class="section-header">
-                        <h4 class="section-title">Основная информация</h4>
-                    </div>
-                    <div class="section-body">
-                        <div class="info-grid">
-                            <div class="info-row">
-                                <span class="info-label">Наименование:</span>
-                                <span class="info-value">{{ place.name }}</span>
-                            </div>
-                        </div>
-                        <div v-if="place.status !== 'active' && place.status_comment" class="comment-text">
-                            {{ place.status_comment }}
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Секция Режим работы -->
-                <div class="details-section">
-                    <div class="section-header">
-                        <h4 class="section-title">Режим работы</h4>
-                    </div>
-                    <div class="section-body">
-                        <div v-if="hasTimeSlots(place)" class="schedule-grid">
-                            <div 
-                                v-for="day in daysWithSlots(place)" 
-                                :key="day" 
-                                class="schedule-day-card"
-                                :class="{ 'current-day': isCurrentDay(day) }"
-                            >
-                                <div class="day-name">{{ getFullDayName(day) }}</div>
-                                <div class="day-slots">
-                                    <div 
-                                        v-for="slot in getSlotsForDay(place.time_slots, day)" 
-                                        :key="slot.id" 
-                                        class="slot-badge"
-                                        :class="{ 
-                                            'active-slot': isCurrentDay(day) && isActiveSlot(slot)
-                                        }"
-                                    >
-                                        <span v-if="isRoundTheClockSlot(slot)" class="round-clock-text">круглосуточно</span>
-                                        <template v-else>
-                                            <span class="slot-time">
-                                                {{ formatTime(slot.open_time) }} – {{ formatTime(slot.close_time) }}
-                                            </span>
-                                            <div class="slot-badges">
-                                                <span v-if="slot.is_next_day" class="next-day-badge">+1</span>
-                                                <span v-if="!slot.is_active" class="inactive-badge">неакт</span>
-                                            </div>
-                                        </template>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div v-else class="no-schedule">
-                            Режим работы не указан
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Секция Местоположение -->
-                <div class="details-section">
-                    <div class="section-header location-header">
-                        <h4 class="section-title">Местоположение</h4>
-                        <a 
-                            v-if="place.map_link" 
-                            :href="place.map_link" 
-                            target="_blank" 
-                            class="map-link-btn"
-                        >
-                            Как добраться?
-                        </a>
-                    </div>
-                    <div class="section-body photo-body">
-                        <div v-if="place.photos && place.photos.length > 0" class="photo-container">
-                            <div 
-                                class="photo-wrapper"
-                                ref="photoWrapper"
-                                @mousedown="startDrag"
-                                @wheel="onZoom"
-                            >
-                                <img 
-                                    :src="getMainPhotoUrl(place.photos)" 
-                                    alt="Место разгрузки"
-                                    class="place-photo"
-                                    :style="photoStyle"
-                                    draggable="false"
-                                    @load="updateImageDimensions"
-                                >
-                            </div>
-                            <div class="photo-controls">
-                                <button @click="zoomIn" class="photo-control-btn">+</button>
-                                <button @click="zoomOut" class="photo-control-btn">−</button>
-                                <button @click="resetPhoto" class="photo-control-btn">↺</button>
-                            </div>
-                        </div>
-                        <div v-else class="no-photo-placeholder">
-                            Нет фотографии
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
+      </div>
+      <button
+        class="modal-close"
+        @click="close"
+      >
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 14 14"
+          fill="none"
+        >
+          <path
+            d="M13 1L1 13M1 1L13 13"
+            stroke="#666"
+            stroke-width="2"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
     </div>
+
+    <div class="modal-body">
+      <div
+        v-if="place"
+        class="place-details"
+      >
+        <!-- Секция Основная информация (без статуса) -->
+        <div class="details-section">
+          <div class="section-header">
+            <h4 class="section-title">
+              Основная информация
+            </h4>
+          </div>
+          <div class="section-body">
+            <div class="info-grid">
+              <div class="info-row">
+                <span class="info-label">Наименование:</span>
+                <span class="info-value">{{ place.name }}</span>
+              </div>
+            </div>
+            <div
+              v-if="place.status !== 'active' && place.status_comment"
+              class="comment-text"
+            >
+              {{ place.status_comment }}
+            </div>
+          </div>
+        </div>
+
+        <!-- Секция Режим работы -->
+        <div class="details-section">
+          <div class="section-header">
+            <h4 class="section-title">
+              Режим работы
+            </h4>
+          </div>
+          <div class="section-body">
+            <div
+              v-if="hasTimeSlots(place)"
+              class="schedule-grid"
+            >
+              <div 
+                v-for="day in daysWithSlots(place)" 
+                :key="day" 
+                class="schedule-day-card"
+                :class="{ 'current-day': isCurrentDay(day) }"
+              >
+                <div class="day-name">
+                  {{ getFullDayName(day) }}
+                </div>
+                <div class="day-slots">
+                  <div 
+                    v-for="slot in getSlotsForDay(place.time_slots, day)" 
+                    :key="slot.id" 
+                    class="slot-badge"
+                    :class="{ 
+                      'active-slot': isCurrentDay(day) && isActiveSlot(slot)
+                    }"
+                  >
+                    <span
+                      v-if="isRoundTheClockSlot(slot)"
+                      class="round-clock-text"
+                    >круглосуточно</span>
+                    <template v-else>
+                      <span class="slot-time">
+                        {{ formatTime(slot.open_time) }} – {{ formatTime(slot.close_time) }}
+                      </span>
+                      <div class="slot-badges">
+                        <span
+                          v-if="slot.is_next_day"
+                          class="next-day-badge"
+                        >+1</span>
+                        <span
+                          v-if="!slot.is_active"
+                          class="inactive-badge"
+                        >неакт</span>
+                      </div>
+                    </template>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              v-else
+              class="no-schedule"
+            >
+              Режим работы не указан
+            </div>
+          </div>
+        </div>
+
+        <!-- Секция Местоположение -->
+        <div class="details-section">
+          <div class="section-header location-header">
+            <h4 class="section-title">
+              Местоположение
+            </h4>
+            <a 
+              v-if="place.map_link" 
+              :href="place.map_link" 
+              target="_blank" 
+              class="map-link-btn"
+            >
+              Как добраться?
+            </a>
+          </div>
+          <div class="section-body photo-body">
+            <div
+              v-if="place.photos && place.photos.length > 0"
+              class="photo-container"
+            >
+              <div 
+                ref="photoWrapper"
+                class="photo-wrapper"
+                @mousedown="startDrag"
+                @wheel="onZoom"
+              >
+                <img 
+                  :src="getMainPhotoUrl(place.photos)" 
+                  alt="Место разгрузки"
+                  class="place-photo"
+                  :style="photoStyle"
+                  draggable="false"
+                  @load="updateImageDimensions"
+                >
+              </div>
+              <div class="photo-controls">
+                <button
+                  class="photo-control-btn"
+                  @click="zoomIn"
+                >
+                  +
+                </button>
+                <button
+                  class="photo-control-btn"
+                  @click="zoomOut"
+                >
+                  −
+                </button>
+                <button
+                  class="photo-control-btn"
+                  @click="resetPhoto"
+                >
+                  ↺
+                </button>
+              </div>
+            </div>
+            <div
+              v-else
+              class="no-photo-placeholder"
+            >
+              Нет фотографии
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </template>
 
 <script>
@@ -170,6 +241,22 @@ export default {
         },
         currentDay() {
             return new Date().getDay() === 0 ? 6 : new Date().getDay() - 1;
+        }
+    },
+    watch: {
+        place(newVal) {
+            if (newVal) {
+                this.$nextTick(() => {
+                    this.updateContainerDimensions();
+                });
+                this.resetPhoto();
+            }
+        }
+    },
+    beforeUnmount() {
+        if (this.windowMouseMoveHandler) {
+            window.removeEventListener('mousemove', this.windowMouseMoveHandler);
+            window.removeEventListener('mouseup', this.windowMouseUpHandler);
         }
     },
     methods: {
@@ -470,22 +557,6 @@ export default {
             this.photoScale = 1.5;
             this.photoTranslateX = 0;
             this.photoTranslateY = 0;
-        }
-    },
-    watch: {
-        place(newVal) {
-            if (newVal) {
-                this.$nextTick(() => {
-                    this.updateContainerDimensions();
-                });
-                this.resetPhoto();
-            }
-        }
-    },
-    beforeUnmount() {
-        if (this.windowMouseMoveHandler) {
-            window.removeEventListener('mousemove', this.windowMouseMoveHandler);
-            window.removeEventListener('mouseup', this.windowMouseUpHandler);
         }
     }
 }

--- a/frontend/src/components/CreateApplication/UserInfoRow.vue
+++ b/frontend/src/components/CreateApplication/UserInfoRow.vue
@@ -1,52 +1,75 @@
 <template>
-    <div class="user-info-row">
-        <div class="user__input">
-            <label class="input__label">Организация / Отдел <span class="required">*</span></label>
-            <input 
-                class="input" 
-                placeholder="Введите организацию" 
-                :value="organization"
-                @input="$emit('update:organization', $event.target.value)"
-                @blur="$emit('validate-field', 'organization')"
-                :class="{ 'input--error': errors.organization }"
-            />
-            <div v-if="errors.organization" class="error-message">{{ errors.organization }}</div>
-        </div>
-        <div class="user__input">
-            <label class="input__label">Компания <span class="required">*</span></label>
-            <input 
-                class="input" 
-                placeholder="Введите компанию" 
-                :value="company"
-                @input="$emit('update:company', $event.target.value)"
-                @blur="$emit('validate-field', 'company')"
-                :class="{ 'input--error': errors.company }"
-            />
-            <div v-if="errors.company" class="error-message">{{ errors.company }}</div>
-        </div>
-        <div class="user__input responsible">
-            <label class="input__label responsible">Ответственное лицо <span class="required">*</span></label>
-            <div class="input contacts" :class="{ 'input--error': errors.responsiblePerson || errors.phone }">
-                <input 
-                    class="contact-input" 
-                    placeholder="Введите ФИО" 
-                    :value="responsiblePerson"
-                    @input="$emit('update:responsible-person', $event.target.value)"
-                    @blur="$emit('validate-field', 'responsiblePerson')"
-                />
-                <input 
-                    class="contact-input phone" 
-                    placeholder="Номер телефона"
-                    :value="phoneNumber"
-                    @input="handlePhoneInput($event)"
-                    @blur="$emit('format-phone')"
-                    @focus="$emit('clear-phone')"
-                />
-            </div>
-            <div v-if="errors.responsiblePerson" class="error-message">{{ errors.responsiblePerson }}</div>
-            <div v-if="errors.phone" class="error-message">{{ errors.phone }}</div>
-        </div>
+  <div class="user-info-row">
+    <div class="user__input">
+      <label class="input__label">Организация / Отдел <span class="required">*</span></label>
+      <input 
+        class="input" 
+        placeholder="Введите организацию" 
+        :value="organization"
+        :class="{ 'input--error': errors.organization }"
+        @input="$emit('update:organization', $event.target.value)"
+        @blur="$emit('validate-field', 'organization')"
+      >
+      <div
+        v-if="errors.organization"
+        class="error-message"
+      >
+        {{ errors.organization }}
+      </div>
     </div>
+    <div class="user__input">
+      <label class="input__label">Компания <span class="required">*</span></label>
+      <input 
+        class="input" 
+        placeholder="Введите компанию" 
+        :value="company"
+        :class="{ 'input--error': errors.company }"
+        @input="$emit('update:company', $event.target.value)"
+        @blur="$emit('validate-field', 'company')"
+      >
+      <div
+        v-if="errors.company"
+        class="error-message"
+      >
+        {{ errors.company }}
+      </div>
+    </div>
+    <div class="user__input responsible">
+      <label class="input__label responsible">Ответственное лицо <span class="required">*</span></label>
+      <div
+        class="input contacts"
+        :class="{ 'input--error': errors.responsiblePerson || errors.phone }"
+      >
+        <input 
+          class="contact-input" 
+          placeholder="Введите ФИО" 
+          :value="responsiblePerson"
+          @input="$emit('update:responsible-person', $event.target.value)"
+          @blur="$emit('validate-field', 'responsiblePerson')"
+        >
+        <input 
+          class="contact-input phone" 
+          placeholder="Номер телефона"
+          :value="phoneNumber"
+          @input="handlePhoneInput($event)"
+          @blur="$emit('format-phone')"
+          @focus="$emit('clear-phone')"
+        >
+      </div>
+      <div
+        v-if="errors.responsiblePerson"
+        class="error-message"
+      >
+        {{ errors.responsiblePerson }}
+      </div>
+      <div
+        v-if="errors.phone"
+        class="error-message"
+      >
+        {{ errors.phone }}
+      </div>
+    </div>
+  </div>
 </template>
 
 <script>

--- a/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
@@ -1,203 +1,310 @@
 <template>
-    <transition name="modal-fade">
-        <div v-if="show" class="modal-overlay" @mousedown="onOverlayMousedown" @mouseup="onOverlayMouseup">
-            <div class="modal-wrapper">
-                <!-- Основное модальное окно с деталями ТС -->
-                <div
-                    class="modal-content compact-modal main-modal"
-                    :class="{ 'shifted': isMainShifted }"
-                    @mousedown.stop
-                >
-                    <div class="modal-header">
-                        <h3 class="modal-title">{{ modalTitle }}</h3>
-                        <div class="header-actions" v-if="showCarFeatures">
-                            <button class="history-btn" @click="openCarHistory">
-                                <span>Полная история</span>
-                            </button>
-                            <button v-if="source !== 'application'" class="application-btn" @click="openApplication">
-                                <span>Открыть заявку</span>
-                            </button>
-                        </div>
-                        <button @click="close" class="modal-close">
-                            <svg width="10" height="10" viewBox="0 0 14 14" fill="none">
-                                <path d="M13 1L1 13M1 1L13 13" stroke="#666" stroke-width="2" stroke-linecap="round"/>
-                            </svg>
-                        </button>
-                    </div>
-                    
-                    <div class="modal-body">
-                        <!-- Блок предупреждения об активной заявке -->
-                        <div v-if="activeInfo" class="active-warning-section">
-                            <div class="warning-content">
-                                <div class="warning-text">
-                                    <p class="warning-title">На это авто уже есть активная заявка!</p>
-                                    <p class="warning-details">
-                                        Действует до: {{ formatDate(activeInfo.entry_date_to) }} {{ formatTime(activeInfo.entry_time_to) }}<br>
-                                        Заявка №{{ activeInfo.application_number }}<br>
-                                        Организация: {{ activeInfo.organization_name || 'Не указана' }}<br>
-                                        Компания: {{ activeInfo.company_name || 'Не указана' }}
-                                    </p>
-                                </div>
-                            </div>
-                        </div>
-
-                        <div class="vehicle-details" v-if="vehicle">
-                            <!-- Секция Основная информация -->
-                            <div class="details-section">
-                                <div class="section-header">
-                                    <h4 class="section-title">Основная информация</h4>
-                                </div>
-                                <div class="section-body">
-                                    <div class="details-grid two-columns">
-                                        <div class="detail-item">
-                                            <span class="detail-label">Номер Т/С:</span>
-                                            <span class="detail-value">{{ vehicle.plateNumber || 'Не указано' }}</span>
-                                        </div>
-                                        <div class="detail-item">
-                                            <span class="detail-label">Марка:</span>
-                                            <span class="detail-value">{{ vehicle.mark || 'Не указано' }}</span>
-                                        </div>
-                                        <div v-if="getFormatName(vehicle.formatId)" class="detail-item full-width">
-                                            <span class="detail-label">Формат номера:</span>
-                                            <span class="detail-value">{{ getFormatName(vehicle.formatId) }}</span>
-                                        </div>
-                                        <div v-if="vehicle.organization" class="detail-item">
-                                            <span class="detail-label">Организация:</span>
-                                            <span class="detail-value">{{ vehicle.organization }}</span>
-                                        </div>
-                                        <div v-if="vehicle.company" class="detail-item">
-                                            <span class="detail-label">Компания:</span>
-                                            <span class="detail-value">{{ vehicle.company }}</span>
-                                        </div>
-                                        <div v-if="vehicle.entry_date_to" class="detail-item">
-                                            <span class="detail-label">Действует до:</span>
-                                            <span class="detail-value">{{ formatDate(vehicle.entry_date_to) }}</span>
-                                        </div>
-                                        <div v-if="vehicle.entry_time_from || vehicle.entry_time_to" class="detail-item">
-                                            <span class="detail-label">Время пребывания:</span>
-                                            <span class="detail-value">{{ formatTimeRange(vehicle.entry_time_from, vehicle.entry_time_to) }}</span>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <!-- Секция Места разгрузки -->
-                            <div class="details-section">
-                                <div class="section-header">
-                                    <h4 class="section-title">Места разгрузки</h4>
-                                </div>
-                                <div class="section-body">
-                                    <div class="places-list">
-                                        <div 
-                                            v-for="placeId in vehicle.unloadPlaces" 
-                                            :key="placeId"
-                                            class="place-item"
-                                            :class="{ 'active': showPlaceModal && selectedUnloadPlace && selectedUnloadPlace.id === placeId }"
-                                            @click="showUnloadPlaceDetails(placeId)"
-                                        >
-                                            {{ getPlaceName(placeId) }}
-                                        </div>
-                                        <div v-if="!vehicle.unloadPlaces || vehicle.unloadPlaces.length === 0" class="no-places">
-                                            Места разгрузки не указаны
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <!-- Секция Статус (только для автомобилей) -->
-                            <div v-if="showCarFeatures" class="details-section">
-                                <div class="section-header">
-                                    <h4 class="section-title">Статус</h4>
-                                </div>
-                                <div class="section-body">
-                                    <div class="status-badge" :class="getStatusClass">
-                                        {{ getStatusText }}
-                                    </div>
-                                </div>
-                            </div>
-
-                            <!-- Секция История въездов и выездов (только entry/exit) -->
-                            <div v-if="showCarFeatures" class="details-section">
-                                <div class="section-header">
-                                    <h4 class="section-title">История въездов и выездов</h4>
-                                    <button class="export-btn" @click="exportHistory" :disabled="entryExitHistory.length === 0 || isExporting">
-                                        <img v-if="!isExporting" src="@/assets/icons/export.png" class="export-icon" />
-                                        <span v-if="!isExporting">Экспорт</span>
-                                        <div v-else class="export-loader"></div>
-                                    </button>
-                                </div>
-                                <div class="section-body">
-                                    <div v-if="loadingHistory" class="loading-container">
-                                        <LoaderSpinner label="Загрузка истории…" />
-                                    </div>
-                                    
-                                    <div v-else-if="entryExitHistory.length === 0" class="no-history">
-                                        История въездов и выездов отсутствует
-                                    </div>
-                                    
-                                    <div v-else class="history-timeline">
-                                        <div 
-                                            v-for="(item, index) in entryExitHistory" 
-                                            :key="item.id" 
-                                            class="history-item"
-                                        >
-                                            <div class="timeline-dot" :class="getActionClass(item)"></div>
-                                            <div class="timeline-line" v-if="index < entryExitHistory.length - 1"></div>
-                                            
-                                            <div class="history-content">
-                                                <div class="history-header">
-                                                    <span class="user-name">{{ item.user_name || 'Система' }}</span>
-                                                    <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
-                                                </div>
-                                                
-                                                <div class="action-text">{{ getActionText(item) }}</div>
-                                                
-                                                <div class="action-comment">
-                                                    {{ getActionComment(item) }}
-                                                </div>
-                                                <div v-if="item.table_name" class="place-name">
-                                                    {{ item.table_name }}
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Дополнительное модальное окно с деталями места разгрузки -->
-                <transition 
-                    name="place-slide"
-                    @after-leave="onPlaceLeave"
-                >
-                    <div v-if="showPlaceModal" class="place-modal-container">
-                        <UnloadPlaceModal
-                            :place="selectedUnloadPlace"
-                            :all-unloading-places="allUnloadingPlaces"
-                            @close="closeUnloadPlaceDetails"
-                        />
-                    </div>
-                </transition>
+  <transition name="modal-fade">
+    <div
+      v-if="show"
+      class="modal-overlay"
+      @mousedown="onOverlayMousedown"
+      @mouseup="onOverlayMouseup"
+    >
+      <div class="modal-wrapper">
+        <!-- Основное модальное окно с деталями ТС -->
+        <div
+          class="modal-content compact-modal main-modal"
+          :class="{ 'shifted': isMainShifted }"
+          @mousedown.stop
+        >
+          <div class="modal-header">
+            <h3 class="modal-title">
+              {{ modalTitle }}
+            </h3>
+            <div
+              v-if="showCarFeatures"
+              class="header-actions"
+            >
+              <button
+                class="history-btn"
+                @click="openCarHistory"
+              >
+                <span>Полная история</span>
+              </button>
+              <button
+                v-if="source !== 'application'"
+                class="application-btn"
+                @click="openApplication"
+              >
+                <span>Открыть заявку</span>
+              </button>
             </div>
-        </div>
-    </transition>
+            <button
+              class="modal-close"
+              @click="close"
+            >
+              <svg
+                width="10"
+                height="10"
+                viewBox="0 0 14 14"
+                fill="none"
+              >
+                <path
+                  d="M13 1L1 13M1 1L13 13"
+                  stroke="#666"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                />
+              </svg>
+            </button>
+          </div>
+                    
+          <div class="modal-body">
+            <!-- Блок предупреждения об активной заявке -->
+            <div
+              v-if="activeInfo"
+              class="active-warning-section"
+            >
+              <div class="warning-content">
+                <div class="warning-text">
+                  <p class="warning-title">
+                    На это авто уже есть активная заявка!
+                  </p>
+                  <p class="warning-details">
+                    Действует до: {{ formatDate(activeInfo.entry_date_to) }} {{ formatTime(activeInfo.entry_time_to) }}<br>
+                    Заявка №{{ activeInfo.application_number }}<br>
+                    Организация: {{ activeInfo.organization_name || 'Не указана' }}<br>
+                    Компания: {{ activeInfo.company_name || 'Не указана' }}
+                  </p>
+                </div>
+              </div>
+            </div>
 
-    <!-- Модальное окно полной истории автомобиля -->
-    <CarHistoryModal
-        v-if="showCarHistoryModal"
-        :car-id="vehicle?.id"
-        :car-number="vehicle?.plateNumber || vehicle?.car_number || 'по факту'"
-        :car-brand="vehicle?.mark || vehicle?.car_brand || ''"
-        :organization-id="vehicle?.organizationId"
-        :organization-name="vehicle?.organization"
-        :company-id="vehicle?.companyId"
-        :company-name="vehicle?.company"
-        :current-user-id="currentUserId"
-        :current-user-name="currentUserName"
-        @close="showCarHistoryModal = false"
-    />
+            <div
+              v-if="vehicle"
+              class="vehicle-details"
+            >
+              <!-- Секция Основная информация -->
+              <div class="details-section">
+                <div class="section-header">
+                  <h4 class="section-title">
+                    Основная информация
+                  </h4>
+                </div>
+                <div class="section-body">
+                  <div class="details-grid two-columns">
+                    <div class="detail-item">
+                      <span class="detail-label">Номер Т/С:</span>
+                      <span class="detail-value">{{ vehicle.plateNumber || 'Не указано' }}</span>
+                    </div>
+                    <div class="detail-item">
+                      <span class="detail-label">Марка:</span>
+                      <span class="detail-value">{{ vehicle.mark || 'Не указано' }}</span>
+                    </div>
+                    <div
+                      v-if="getFormatName(vehicle.formatId)"
+                      class="detail-item full-width"
+                    >
+                      <span class="detail-label">Формат номера:</span>
+                      <span class="detail-value">{{ getFormatName(vehicle.formatId) }}</span>
+                    </div>
+                    <div
+                      v-if="vehicle.organization"
+                      class="detail-item"
+                    >
+                      <span class="detail-label">Организация:</span>
+                      <span class="detail-value">{{ vehicle.organization }}</span>
+                    </div>
+                    <div
+                      v-if="vehicle.company"
+                      class="detail-item"
+                    >
+                      <span class="detail-label">Компания:</span>
+                      <span class="detail-value">{{ vehicle.company }}</span>
+                    </div>
+                    <div
+                      v-if="vehicle.entry_date_to"
+                      class="detail-item"
+                    >
+                      <span class="detail-label">Действует до:</span>
+                      <span class="detail-value">{{ formatDate(vehicle.entry_date_to) }}</span>
+                    </div>
+                    <div
+                      v-if="vehicle.entry_time_from || vehicle.entry_time_to"
+                      class="detail-item"
+                    >
+                      <span class="detail-label">Время пребывания:</span>
+                      <span class="detail-value">{{ formatTimeRange(vehicle.entry_time_from, vehicle.entry_time_to) }}</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Секция Места разгрузки -->
+              <div class="details-section">
+                <div class="section-header">
+                  <h4 class="section-title">
+                    Места разгрузки
+                  </h4>
+                </div>
+                <div class="section-body">
+                  <div class="places-list">
+                    <div 
+                      v-for="placeId in vehicle.unloadPlaces" 
+                      :key="placeId"
+                      class="place-item"
+                      :class="{ 'active': showPlaceModal && selectedUnloadPlace && selectedUnloadPlace.id === placeId }"
+                      @click="showUnloadPlaceDetails(placeId)"
+                    >
+                      {{ getPlaceName(placeId) }}
+                    </div>
+                    <div
+                      v-if="!vehicle.unloadPlaces || vehicle.unloadPlaces.length === 0"
+                      class="no-places"
+                    >
+                      Места разгрузки не указаны
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Секция Статус (только для автомобилей) -->
+              <div
+                v-if="showCarFeatures"
+                class="details-section"
+              >
+                <div class="section-header">
+                  <h4 class="section-title">
+                    Статус
+                  </h4>
+                </div>
+                <div class="section-body">
+                  <div
+                    class="status-badge"
+                    :class="getStatusClass"
+                  >
+                    {{ getStatusText }}
+                  </div>
+                </div>
+              </div>
+
+              <!-- Секция История въездов и выездов (только entry/exit) -->
+              <div
+                v-if="showCarFeatures"
+                class="details-section"
+              >
+                <div class="section-header">
+                  <h4 class="section-title">
+                    История въездов и выездов
+                  </h4>
+                  <button
+                    class="export-btn"
+                    :disabled="entryExitHistory.length === 0 || isExporting"
+                    @click="exportHistory"
+                  >
+                    <img
+                      v-if="!isExporting"
+                      src="@/assets/icons/export.png"
+                      class="export-icon"
+                    >
+                    <span v-if="!isExporting">Экспорт</span>
+                    <div
+                      v-else
+                      class="export-loader"
+                    />
+                  </button>
+                </div>
+                <div class="section-body">
+                  <div
+                    v-if="loadingHistory"
+                    class="loading-container"
+                  >
+                    <LoaderSpinner label="Загрузка истории…" />
+                  </div>
+                                    
+                  <div
+                    v-else-if="entryExitHistory.length === 0"
+                    class="no-history"
+                  >
+                    История въездов и выездов отсутствует
+                  </div>
+                                    
+                  <div
+                    v-else
+                    class="history-timeline"
+                  >
+                    <div 
+                      v-for="(item, index) in entryExitHistory" 
+                      :key="item.id" 
+                      class="history-item"
+                    >
+                      <div
+                        class="timeline-dot"
+                        :class="getActionClass(item)"
+                      />
+                      <div
+                        v-if="index < entryExitHistory.length - 1"
+                        class="timeline-line"
+                      />
+                                            
+                      <div class="history-content">
+                        <div class="history-header">
+                          <span class="user-name">{{ item.user_name || 'Система' }}</span>
+                          <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                        </div>
+                                                
+                        <div class="action-text">
+                          {{ getActionText(item) }}
+                        </div>
+                                                
+                        <div class="action-comment">
+                          {{ getActionComment(item) }}
+                        </div>
+                        <div
+                          v-if="item.table_name"
+                          class="place-name"
+                        >
+                          {{ item.table_name }}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Дополнительное модальное окно с деталями места разгрузки -->
+        <transition 
+          name="place-slide"
+          @after-leave="onPlaceLeave"
+        >
+          <div
+            v-if="showPlaceModal"
+            class="place-modal-container"
+          >
+            <UnloadPlaceModal
+              :place="selectedUnloadPlace"
+              :all-unloading-places="allUnloadingPlaces"
+              @close="closeUnloadPlaceDetails"
+            />
+          </div>
+        </transition>
+      </div>
+    </div>
+  </transition>
+
+  <!-- Модальное окно полной истории автомобиля -->
+  <CarHistoryModal
+    v-if="showCarHistoryModal"
+    :car-id="vehicle?.id"
+    :car-number="vehicle?.plateNumber || vehicle?.car_number || 'по факту'"
+    :car-brand="vehicle?.mark || vehicle?.car_brand || ''"
+    :organization-id="vehicle?.organizationId"
+    :organization-name="vehicle?.organization"
+    :company-id="vehicle?.companyId"
+    :company-name="vehicle?.company"
+    :current-user-id="currentUserId"
+    :current-user-name="currentUserName"
+    @close="showCarHistoryModal = false"
+  />
 </template>
 
 <script>
@@ -214,10 +321,6 @@ export default {
         UnloadPlaceModal,
         CarHistoryModal,
         LoaderSpinner
-    },
-    setup(_, { emit }) {
-        const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(() => emit('close'));
-        return { onOverlayMousedown, onOverlayMouseup };
     },
     props: {
         show: {
@@ -258,6 +361,10 @@ export default {
         }
     },
     emits: ['close', 'open-application'],
+    setup(_, { emit }) {
+        const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(() => emit('close'));
+        return { onOverlayMousedown, onOverlayMouseup };
+    },
     data() {
         return {
             selectedUnloadPlace: null,
@@ -292,6 +399,41 @@ export default {
         // Только события въезда/выезда
         entryExitHistory() {
             return this.history.filter(item => item.action_type === 'entry' || item.action_type === 'exit');
+        }
+    },
+    watch: {
+        show: {
+            immediate: true,
+            handler(newVal) {
+                if (newVal) {
+                    this.loadCarStatus();
+                    if (this.showCarFeatures && this.vehicle?.id) {
+                        this.loadCarHistory();
+                    }
+                } else {
+                    this.closeUnloadPlaceDetails();
+                    if (this.shiftTimer) {
+                        clearTimeout(this.shiftTimer);
+                        this.shiftTimer = null;
+                    }
+                    this.isMainShifted = false;
+                    this.selectedUnloadPlace = null;
+                }
+            }
+        },
+        vehicle: {
+            deep: true,
+            handler(newVal) {
+                if (newVal && this.show && this.showCarFeatures) {
+                    this.loadCarStatus();
+                    this.loadCarHistory();
+                }
+            }
+        }
+    },
+    beforeUnmount() {
+        if (this.shiftTimer) {
+            clearTimeout(this.shiftTimer);
         }
     },
     methods: {
@@ -639,41 +781,6 @@ export default {
             if (applicationId) {
                 this.$emit('open-application', applicationId);
             }
-        }
-    },
-    watch: {
-        show: {
-            immediate: true,
-            handler(newVal) {
-                if (newVal) {
-                    this.loadCarStatus();
-                    if (this.showCarFeatures && this.vehicle?.id) {
-                        this.loadCarHistory();
-                    }
-                } else {
-                    this.closeUnloadPlaceDetails();
-                    if (this.shiftTimer) {
-                        clearTimeout(this.shiftTimer);
-                        this.shiftTimer = null;
-                    }
-                    this.isMainShifted = false;
-                    this.selectedUnloadPlace = null;
-                }
-            }
-        },
-        vehicle: {
-            deep: true,
-            handler(newVal) {
-                if (newVal && this.show && this.showCarFeatures) {
-                    this.loadCarStatus();
-                    this.loadCarHistory();
-                }
-            }
-        }
-    },
-    beforeUnmount() {
-        if (this.shiftTimer) {
-            clearTimeout(this.shiftTimer);
         }
     }
 }

--- a/frontend/src/components/CreateApplication/VehicleForm.vue
+++ b/frontend/src/components/CreateApplication/VehicleForm.vue
@@ -1,242 +1,317 @@
 <template>
-    <div class="data__completion">
-        <div class="completion__header">
-            <h3>Добавление Т/С</h3>
-            <button class="completion__button" @click="openExistingCarsModal">
-                Добавить существующую(-ие)
-            </button>
-        </div>
-
-        <!-- Отображение количества выбранных существующих машин -->
-        <div v-if="selectedExistingCars.length > 0" class="existing-cars-info">
-            <div class="existing-cars-header">
-                <span class="existing-cars-count">Машин добавлено: {{ selectedExistingCars.length }}</span>
-                <div class="existing-cars-actions">
-                    <button class="view-cars-btn" @click="openExistingCarsModal">Просмотреть</button>
-                    <button class="add-existing-btn" @click="addExistingCars" :disabled="!canAddExistingCars">
-                        Добавить
-                    </button>
-                </div>
-            </div>
-        </div>
-
-        <!-- Форма для добавления новой машины -->
-        <div v-else>
-            <div class="completion__format">
-                <div class="format__header">
-                    <label class="format__label">Формат номеров</label>
-                    <div class="format-actions">
-                        <button class="cancel-edit-btn" @click="cancelEdit" v-if="editingVehicle">
-                            Отменить
-                        </button>
-                        <button 
-                            class="add-button" 
-                            @click="addVehicle"
-                            :disabled="!canAddVehicle"
-                            @mouseenter="showTooltip = true"
-                            @mouseleave="showTooltip = false"
-                        >
-                            {{ editingVehicle ? 'Применить' : 'Добавить' }}
-                        </button>
-                        <!-- Подсказка для кнопки -->
-                        <div v-if="showTooltip && !canAddVehicle" class="tooltip">
-                            <div class="tooltip-content">
-                                {{ getTooltipMessage }}
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="format__dropdown">
-                    <button 
-                        class="dropdown__button" 
-                        @click="toggleFormatDropdown"
-                        :disabled="editingVehicle && editingVehicle.isExisting"
-                    >
-                        <div class="button__content">
-                            <span class="button__text">{{ selectedFormatText }}</span>
-                            <img src="@/assets/icons/arrow.png" class="button__arrow" :class="{ 'button__arrow--open': isFormatDropdownOpen }" />
-                        </div>
-                    </button>
-                    <transition name="dropdown">
-                        <div v-if="isFormatDropdownOpen" class="dropdown__menu">
-                            <div 
-                                v-for="format in availableFormats" 
-                                :key="format.format.id"
-                                class="dropdown__item" 
-                                @click="selectFormat(format)"
-                            >
-                                <span class="item__text">{{ format.format.name }}</span>
-                            </div>
-                        </div>
-                    </transition>
-                </div>
-            </div>
-            <div class="completion__fields">
-                <div class="completion__number">
-                    <div class="completion__number-header">
-                        <label class="input__label">Номер Т/C <span class="required">*</span></label>
-                        <div class="number-fact">
-                            <input 
-                                class="fact-checkbox" 
-                                type="checkbox" 
-                                v-model="isNumberByFact"
-                                @change="handleNumberByFactChange"
-                                :disabled="editingVehicle && editingVehicle.isExisting"
-                            />
-                            <p class="fact-text">по факту</p>
-                        </div>
-                    </div>
-                    <!-- Поле "по факту" -->
-                    <div class="number__field number__field--fact" v-if="isNumberByFact">
-                        <input 
-                            class="number__input number__input--fact" 
-                            value="По факту"
-                            readonly
-                        />
-                    </div>
-                    
-                    <!-- Динамический формат из базы данных -->
-                    <div class="number__field" v-else-if="selectedFormat">
-                        <input 
-                            v-for="(cell, index) in selectedFormat.cells" 
-                            :key="index"
-                            class="number__input" 
-                            :placeholder="getPlaceholder(cell)"
-                            v-model="numberParts[index]"
-                            @input="validatePart(index, $event, cell)"
-                            @blur="formatPart(index, cell)"
-                            :maxlength="cell.max_length"
-                            :style="{ width: getInputWidth(cell) }"
-                            :disabled="editingVehicle && editingVehicle.isExisting"
-                        />
-                    </div>
-                    <div v-else class="no-format-message">
-                        Выберите формат номера
-                    </div>
-
-                    <!-- Блок предупреждения об активной заявке для номера -->
-                    
-                </div>
-                
-                <div class="completion__mark">
-                    <div class="completion__mark-header">
-                        <label class="input__label">Марка Т/С <span class="required">*</span></label>
-                        <div class="mark-fact">
-                            <input 
-                                class="fact-checkbox" 
-                                type="checkbox" 
-                                v-model="isMarkByFact"
-                                @change="handleMarkByFactChange"
-                            />
-                            <p class="fact-text">по факту</p>
-                        </div>
-                    </div>
-                    <div class="mark__field mark__field--fact" v-if="isMarkByFact">
-                        <input 
-                            class="mark__input mark__input--fact" 
-                            value="По факту"
-                            readonly
-                        />
-                    </div>
-                    <div class="mark__field" v-else>
-                        <div class="mark__dropdown">
-                            <button class="mark__dropdown-button" @click="toggleMarkDropdown">
-                                <div class="mark__button-content">
-                                    <span class="mark__button-text">{{ selectedMark || 'Выберите марку' }}</span>
-                                    <img src="@/assets/icons/arrow.png" class="mark__button-arrow" :class="{ 'mark__button-arrow--open': isMarkDropdownOpen }" />
-                                </div>
-                            </button>
-                            <transition name="dropdown">
-                                <div v-if="isMarkDropdownOpen" class="mark__dropdown-menu">
-                                    <div class="mark__search">
-                                        <input 
-                                            class="mark__search-input" 
-                                            placeholder="Поиск марки..."
-                                            v-model="markSearch"
-                                            @input="filterMarks"
-                                        />
-                                    </div>
-                                    <div class="mark__dropdown-list">
-                                        <div 
-                                            v-for="mark in filteredMarks" 
-                                            :key="mark"
-                                            class="mark__dropdown-item"
-                                            @click="selectMark(mark)"
-                                        >
-                                            <span class="mark__item-text">{{ mark }}</span>
-                                        </div>
-                                    </div>
-                                </div>
-                            </transition>
-                        </div>
-                    </div>
-                </div>
-                
-            </div>
-            <div v-if="activeCarInfo && !isNumberByFact" class="active-warning">
-                     
-                        <div class="warning-text">
-                            <p class="warning-title">На это авто уже есть активная заявка!</p>
-                            <p class="warning-details">
-                                Действует до: {{ formatDate(activeCarInfo.entry_date_to) }} {{ formatTime(activeCarInfo.entry_time_to) }}<br>
-                                Заявка {{ activeCarInfo.application_number }}<br>
-                                Организация: {{ activeCarInfo.organization_name || 'Не указана' }}<br>
-                                Компания: {{ activeCarInfo.company_name || 'Не указана' }}
-                            </p>
-                        </div>
-                    </div>
-        </div>
-
-        <!-- Места разгрузки -->
-        <div class="completion__unloading">
-            <label class="input__label">Места разгрузки (выбор) <span class="required">*</span></label>
-            <div class="unloading__grid" v-if="!loadingUnloadingPlaces && allUnloadingPlaces.length > 0">
-                <div 
-                    v-for="place in allUnloadingPlaces" 
-                    :key="place.id"
-                    class="unloading__item"
-                    :class="{ 
-                        'unloading__item--active': selectedUnloadingPlaces.includes(place.id) && place.status === 'active',
-                        'unloading__item--attached': attachedPlacesIds.includes(place.id),
-                        'unloading__item--inactive': place.status !== 'active'
-                    }"
-                    @click="toggleUnloadingPlace(place)"
-                    @mouseenter="showInactiveTooltip(place, $event)"
-                    @mouseleave="hideInactiveTooltip"
-                >
-                    {{ place.name }}
-                </div>
-            </div>
-            <div v-else-if="loadingUnloadingPlaces" class="loading-message">
-                Загрузка мест разгрузки...
-            </div>
-            <div v-else class="no-places-message">
-                Нет доступных мест разгрузки
-            </div>
-            <div v-if="errors.unloadingPlaces" class="error-message">{{ errors.unloadingPlaces }}</div>
-        </div>
-
-        <!-- Tooltip для неактивных мест -->
-        <div v-if="inactiveTooltip.visible" 
-             class="inactive-tooltip"
-             :style="{ top: inactiveTooltip.y + 'px', left: inactiveTooltip.x + 'px' }"
-        >
-            <div class="inactive-tooltip-content">
-                {{ inactiveTooltip.text }}
-            </div>
-        </div>
-
-        <!-- Модальное окно выбора существующих машин -->
-        <ExistingCarsModal
-            :visible="showExistingCarsModal"
-            :already-added-vehicles="existingVehicles"
-            :user-organization-id="userOrganizationId"
-            :user-company-id="userCompanyId"
-            :initial-selected-cars="selectedExistingCars"
-            @cars-selected="onExistingCarsSelected"
-            @close="closeExistingCarsModal"
-        />
+  <div class="data__completion">
+    <div class="completion__header">
+      <h3>Добавление Т/С</h3>
+      <button
+        class="completion__button"
+        @click="openExistingCarsModal"
+      >
+        Добавить существующую(-ие)
+      </button>
     </div>
+
+    <!-- Отображение количества выбранных существующих машин -->
+    <div
+      v-if="selectedExistingCars.length > 0"
+      class="existing-cars-info"
+    >
+      <div class="existing-cars-header">
+        <span class="existing-cars-count">Машин добавлено: {{ selectedExistingCars.length }}</span>
+        <div class="existing-cars-actions">
+          <button
+            class="view-cars-btn"
+            @click="openExistingCarsModal"
+          >
+            Просмотреть
+          </button>
+          <button
+            class="add-existing-btn"
+            :disabled="!canAddExistingCars"
+            @click="addExistingCars"
+          >
+            Добавить
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Форма для добавления новой машины -->
+    <div v-else>
+      <div class="completion__format">
+        <div class="format__header">
+          <label class="format__label">Формат номеров</label>
+          <div class="format-actions">
+            <button
+              v-if="editingVehicle"
+              class="cancel-edit-btn"
+              @click="cancelEdit"
+            >
+              Отменить
+            </button>
+            <button 
+              class="add-button" 
+              :disabled="!canAddVehicle"
+              @click="addVehicle"
+              @mouseenter="showTooltip = true"
+              @mouseleave="showTooltip = false"
+            >
+              {{ editingVehicle ? 'Применить' : 'Добавить' }}
+            </button>
+            <!-- Подсказка для кнопки -->
+            <div
+              v-if="showTooltip && !canAddVehicle"
+              class="tooltip"
+            >
+              <div class="tooltip-content">
+                {{ getTooltipMessage }}
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="format__dropdown">
+          <button 
+            class="dropdown__button" 
+            :disabled="editingVehicle && editingVehicle.isExisting"
+            @click="toggleFormatDropdown"
+          >
+            <div class="button__content">
+              <span class="button__text">{{ selectedFormatText }}</span>
+              <img
+                src="@/assets/icons/arrow.png"
+                class="button__arrow"
+                :class="{ 'button__arrow--open': isFormatDropdownOpen }"
+              >
+            </div>
+          </button>
+          <transition name="dropdown">
+            <div
+              v-if="isFormatDropdownOpen"
+              class="dropdown__menu"
+            >
+              <div 
+                v-for="format in availableFormats" 
+                :key="format.format.id"
+                class="dropdown__item" 
+                @click="selectFormat(format)"
+              >
+                <span class="item__text">{{ format.format.name }}</span>
+              </div>
+            </div>
+          </transition>
+        </div>
+      </div>
+      <div class="completion__fields">
+        <div class="completion__number">
+          <div class="completion__number-header">
+            <label class="input__label">Номер Т/C <span class="required">*</span></label>
+            <div class="number-fact">
+              <input 
+                v-model="isNumberByFact" 
+                class="fact-checkbox" 
+                type="checkbox"
+                :disabled="editingVehicle && editingVehicle.isExisting"
+                @change="handleNumberByFactChange"
+              >
+              <p class="fact-text">
+                по факту
+              </p>
+            </div>
+          </div>
+          <!-- Поле "по факту" -->
+          <div
+            v-if="isNumberByFact"
+            class="number__field number__field--fact"
+          >
+            <input 
+              class="number__input number__input--fact" 
+              value="По факту"
+              readonly
+            >
+          </div>
+                    
+          <!-- Динамический формат из базы данных -->
+          <div
+            v-else-if="selectedFormat"
+            class="number__field"
+          >
+            <input 
+              v-for="(cell, index) in selectedFormat.cells" 
+              :key="index"
+              v-model="numberParts[index]" 
+              class="number__input"
+              :placeholder="getPlaceholder(cell)"
+              :maxlength="cell.max_length"
+              :style="{ width: getInputWidth(cell) }"
+              :disabled="editingVehicle && editingVehicle.isExisting"
+              @input="validatePart(index, $event, cell)"
+              @blur="formatPart(index, cell)"
+            >
+          </div>
+          <div
+            v-else
+            class="no-format-message"
+          >
+            Выберите формат номера
+          </div>
+
+          <!-- Блок предупреждения об активной заявке для номера -->
+        </div>
+                
+        <div class="completion__mark">
+          <div class="completion__mark-header">
+            <label class="input__label">Марка Т/С <span class="required">*</span></label>
+            <div class="mark-fact">
+              <input 
+                v-model="isMarkByFact" 
+                class="fact-checkbox" 
+                type="checkbox"
+                @change="handleMarkByFactChange"
+              >
+              <p class="fact-text">
+                по факту
+              </p>
+            </div>
+          </div>
+          <div
+            v-if="isMarkByFact"
+            class="mark__field mark__field--fact"
+          >
+            <input 
+              class="mark__input mark__input--fact" 
+              value="По факту"
+              readonly
+            >
+          </div>
+          <div
+            v-else
+            class="mark__field"
+          >
+            <div class="mark__dropdown">
+              <button
+                class="mark__dropdown-button"
+                @click="toggleMarkDropdown"
+              >
+                <div class="mark__button-content">
+                  <span class="mark__button-text">{{ selectedMark || 'Выберите марку' }}</span>
+                  <img
+                    src="@/assets/icons/arrow.png"
+                    class="mark__button-arrow"
+                    :class="{ 'mark__button-arrow--open': isMarkDropdownOpen }"
+                  >
+                </div>
+              </button>
+              <transition name="dropdown">
+                <div
+                  v-if="isMarkDropdownOpen"
+                  class="mark__dropdown-menu"
+                >
+                  <div class="mark__search">
+                    <input 
+                      v-model="markSearch" 
+                      class="mark__search-input"
+                      placeholder="Поиск марки..."
+                      @input="filterMarks"
+                    >
+                  </div>
+                  <div class="mark__dropdown-list">
+                    <div 
+                      v-for="mark in filteredMarks" 
+                      :key="mark"
+                      class="mark__dropdown-item"
+                      @click="selectMark(mark)"
+                    >
+                      <span class="mark__item-text">{{ mark }}</span>
+                    </div>
+                  </div>
+                </div>
+              </transition>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        v-if="activeCarInfo && !isNumberByFact"
+        class="active-warning"
+      >
+        <div class="warning-text">
+          <p class="warning-title">
+            На это авто уже есть активная заявка!
+          </p>
+          <p class="warning-details">
+            Действует до: {{ formatDate(activeCarInfo.entry_date_to) }} {{ formatTime(activeCarInfo.entry_time_to) }}<br>
+            Заявка {{ activeCarInfo.application_number }}<br>
+            Организация: {{ activeCarInfo.organization_name || 'Не указана' }}<br>
+            Компания: {{ activeCarInfo.company_name || 'Не указана' }}
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Места разгрузки -->
+    <div class="completion__unloading">
+      <label class="input__label">Места разгрузки (выбор) <span class="required">*</span></label>
+      <div
+        v-if="!loadingUnloadingPlaces && allUnloadingPlaces.length > 0"
+        class="unloading__grid"
+      >
+        <div 
+          v-for="place in allUnloadingPlaces" 
+          :key="place.id"
+          class="unloading__item"
+          :class="{ 
+            'unloading__item--active': selectedUnloadingPlaces.includes(place.id) && place.status === 'active',
+            'unloading__item--attached': attachedPlacesIds.includes(place.id),
+            'unloading__item--inactive': place.status !== 'active'
+          }"
+          @click="toggleUnloadingPlace(place)"
+          @mouseenter="showInactiveTooltip(place, $event)"
+          @mouseleave="hideInactiveTooltip"
+        >
+          {{ place.name }}
+        </div>
+      </div>
+      <div
+        v-else-if="loadingUnloadingPlaces"
+        class="loading-message"
+      >
+        Загрузка мест разгрузки...
+      </div>
+      <div
+        v-else
+        class="no-places-message"
+      >
+        Нет доступных мест разгрузки
+      </div>
+      <div
+        v-if="errors.unloadingPlaces"
+        class="error-message"
+      >
+        {{ errors.unloadingPlaces }}
+      </div>
+    </div>
+
+    <!-- Tooltip для неактивных мест -->
+    <div
+      v-if="inactiveTooltip.visible" 
+      class="inactive-tooltip"
+      :style="{ top: inactiveTooltip.y + 'px', left: inactiveTooltip.x + 'px' }"
+    >
+      <div class="inactive-tooltip-content">
+        {{ inactiveTooltip.text }}
+      </div>
+    </div>
+
+    <!-- Модальное окно выбора существующих машин -->
+    <ExistingCarsModal
+      :visible="showExistingCarsModal"
+      :already-added-vehicles="existingVehicles"
+      :user-organization-id="userOrganizationId"
+      :user-company-id="userCompanyId"
+      :initial-selected-cars="selectedExistingCars"
+      @cars-selected="onExistingCarsSelected"
+      @close="closeExistingCarsModal"
+    />
+  </div>
 </template>
 
 <script>
@@ -366,6 +441,38 @@ export default {
             
             return this.selectedExistingCars.length > 0 && this.selectedUnloadingPlaces.length > 0 && !hasInactiveSelected;
         },
+    },
+    watch: {
+        // Следим за изменениями частей номера для проверки активности
+        numberParts: {
+            deep: true,
+            handler() {
+                this.checkVehicleActive();
+            }
+        }
+    },
+    async mounted() {
+        await Promise.all([
+            this.loadLicensePlateFormats(),
+            this.loadUnloadingPlaces()
+        ]);
+        
+        this.filteredMarks = this.marks;
+
+        document.addEventListener('click', (e) => {
+            if (!e.target.closest('.format__dropdown')) {
+                this.isFormatDropdownOpen = false;
+            }
+            
+            if (!e.target.closest('.mark__dropdown')) {
+                this.isMarkDropdownOpen = false;
+            }
+        });
+    },
+    beforeUnmount() {
+        if (this.checkingTimeout) {
+            clearTimeout(this.checkingTimeout);
+        }
     },
     methods: {
         // Новый метод для проверки активной заявки
@@ -797,38 +904,6 @@ export default {
 
             // Проверяем активность после смены формата
             this.checkVehicleActive();
-        }
-    },
-    watch: {
-        // Следим за изменениями частей номера для проверки активности
-        numberParts: {
-            deep: true,
-            handler() {
-                this.checkVehicleActive();
-            }
-        }
-    },
-    async mounted() {
-        await Promise.all([
-            this.loadLicensePlateFormats(),
-            this.loadUnloadingPlaces()
-        ]);
-        
-        this.filteredMarks = this.marks;
-
-        document.addEventListener('click', (e) => {
-            if (!e.target.closest('.format__dropdown')) {
-                this.isFormatDropdownOpen = false;
-            }
-            
-            if (!e.target.closest('.mark__dropdown')) {
-                this.isMarkDropdownOpen = false;
-            }
-        });
-    },
-    beforeUnmount() {
-        if (this.checkingTimeout) {
-            clearTimeout(this.checkingTimeout);
         }
     }
 }

--- a/frontend/src/components/CreateApplication/VehiclesList.vue
+++ b/frontend/src/components/CreateApplication/VehiclesList.vue
@@ -1,118 +1,136 @@
 <template>
-    <div class="data__list">
-        <div class="header-with-badge">
-            <h4>Список транспортных средств</h4>
-            <span class="vehicles-badge">{{ vehicles.length }}</span>
-        </div>
-        <div class="vehicles-table">
-            <div class="table-header">
-                <div class="header-col number-col" @click="$emit('sort', 'number')">
-                    <p :class="{ 'active-sort': sortField === 'number' }">№</p>
-                    <img 
-                        src="@/assets/icons/sort.png" 
-                        class="sort-icon" 
-                        :class="{ 
-                            'desc': sortField === 'number' && sortDirection === 'desc'
-                        }" 
-                    />
-                </div>
-                <div class="header-col plate-col" @click="$emit('sort', 'plate')">
-                    <p :class="{ 'active-sort': sortField === 'plate' }">Номер</p>
-                    <img 
-                        src="@/assets/icons/sort.png" 
-                        class="sort-icon" 
-                        :class="{ 
-                            'desc': sortField === 'plate' && sortDirection === 'desc'
-                        }" 
-                    />
-                </div>
-                <div class="header-col mark-col" @click="$emit('sort', 'mark')">
-                    <p :class="{ 'active-sort': sortField === 'mark' }">Марка</p>
-                    <img 
-                        src="@/assets/icons/sort.png" 
-                        class="sort-icon" 
-                        :class="{ 
-                            'desc': sortField === 'mark' && sortDirection === 'desc'
-                        }" 
-                    />
-                </div>
-                <div class="header-col actions-col">
-                    Действия
-                </div>
-            </div>
-            <div class="table-body">
-                <div 
-                    v-for="(vehicle, index) in vehicles" 
-                    :key="vehicle.id"
-                    class="table-row"
-                    :class="{ 'has-active': vehicle.activeInfo }"
-                >
-                    <div class="table-col number-col">{{ index + 1 }}</div>
-                    <div class="table-col plate-col">
-                        <div class="cell-with-icon">
-                            {{ vehicle.plateNumber || 'Не указано' }}
-                            
-                        </div>
-                    </div>
-                    <div class="table-col mark-col">
-                        <div class="cell-with-icon">
-                            {{ vehicle.mark || 'Не указано' }}
-                            
-                        </div>
-                    </div>
-                    <div class="table-col actions-col">
-                        <button 
-                            class="details-btn"
-                            @click="showVehicleDetails(vehicle)"
-                            title="Детали"
-                        >
-                            <img 
-                                src="@/assets/icons/info.png" 
-                                alt="Детали" 
-                                class="details-icon"
-                            />
-                        </button>
-                        <button 
-                            class="edit-btn"
-                            @click="$emit('edit-vehicle', vehicle)"
-                            title="Редактировать"
-                        >
-                            <img 
-                                src="@/assets/icons/edit.png" 
-                                alt="Редактировать" 
-                                class="edit-icon"
-                            />
-                        </button>
-                        <button 
-                            class="delete-btn"
-                            @click="$emit('delete-vehicle', vehicle.id)"
-                            title="Удалить"
-                        >
-                            <img 
-                                src="@/assets/icons/trashcan.png" 
-                                alt="Удалить" 
-                                class="delete-icon"
-                            />
-                        </button>
-                    </div>
-                </div>
-                <div v-if="vehicles.length === 0" class="no-vehicles">
-                    Нет добавленных транспортных средств
-                </div>
-            </div>
-        </div>
-
-        <!-- Модальное окно деталей транспортного средства -->
-        <VehicleDetailsModal
-            :show="showDetailsModal"
-            :vehicle="selectedVehicle"
-            :all-unloading-places="allUnloadingPlaces"
-            :license-plate-formats="licensePlateFormats"
-            :show-car-features="false"
-            :active-info="selectedVehicle?.activeInfo"
-            @close="closeDetailsModal"
-        />
+  <div class="data__list">
+    <div class="header-with-badge">
+      <h4>Список транспортных средств</h4>
+      <span class="vehicles-badge">{{ vehicles.length }}</span>
     </div>
+    <div class="vehicles-table">
+      <div class="table-header">
+        <div
+          class="header-col number-col"
+          @click="$emit('sort', 'number')"
+        >
+          <p :class="{ 'active-sort': sortField === 'number' }">
+            №
+          </p>
+          <img 
+            src="@/assets/icons/sort.png" 
+            class="sort-icon" 
+            :class="{ 
+              'desc': sortField === 'number' && sortDirection === 'desc'
+            }" 
+          >
+        </div>
+        <div
+          class="header-col plate-col"
+          @click="$emit('sort', 'plate')"
+        >
+          <p :class="{ 'active-sort': sortField === 'plate' }">
+            Номер
+          </p>
+          <img 
+            src="@/assets/icons/sort.png" 
+            class="sort-icon" 
+            :class="{ 
+              'desc': sortField === 'plate' && sortDirection === 'desc'
+            }" 
+          >
+        </div>
+        <div
+          class="header-col mark-col"
+          @click="$emit('sort', 'mark')"
+        >
+          <p :class="{ 'active-sort': sortField === 'mark' }">
+            Марка
+          </p>
+          <img 
+            src="@/assets/icons/sort.png" 
+            class="sort-icon" 
+            :class="{ 
+              'desc': sortField === 'mark' && sortDirection === 'desc'
+            }" 
+          >
+        </div>
+        <div class="header-col actions-col">
+          Действия
+        </div>
+      </div>
+      <div class="table-body">
+        <div 
+          v-for="(vehicle, index) in vehicles" 
+          :key="vehicle.id"
+          class="table-row"
+          :class="{ 'has-active': vehicle.activeInfo }"
+        >
+          <div class="table-col number-col">
+            {{ index + 1 }}
+          </div>
+          <div class="table-col plate-col">
+            <div class="cell-with-icon">
+              {{ vehicle.plateNumber || 'Не указано' }}
+            </div>
+          </div>
+          <div class="table-col mark-col">
+            <div class="cell-with-icon">
+              {{ vehicle.mark || 'Не указано' }}
+            </div>
+          </div>
+          <div class="table-col actions-col">
+            <button 
+              class="details-btn"
+              title="Детали"
+              @click="showVehicleDetails(vehicle)"
+            >
+              <img 
+                src="@/assets/icons/info.png" 
+                alt="Детали" 
+                class="details-icon"
+              >
+            </button>
+            <button 
+              class="edit-btn"
+              title="Редактировать"
+              @click="$emit('edit-vehicle', vehicle)"
+            >
+              <img 
+                src="@/assets/icons/edit.png" 
+                alt="Редактировать" 
+                class="edit-icon"
+              >
+            </button>
+            <button 
+              class="delete-btn"
+              title="Удалить"
+              @click="$emit('delete-vehicle', vehicle.id)"
+            >
+              <img 
+                src="@/assets/icons/trashcan.png" 
+                alt="Удалить" 
+                class="delete-icon"
+              >
+            </button>
+          </div>
+        </div>
+        <div
+          v-if="vehicles.length === 0"
+          class="no-vehicles"
+        >
+          Нет добавленных транспортных средств
+        </div>
+      </div>
+    </div>
+
+    <!-- Модальное окно деталей транспортного средства -->
+    <VehicleDetailsModal
+      :show="showDetailsModal"
+      :vehicle="selectedVehicle"
+      :all-unloading-places="allUnloadingPlaces"
+      :license-plate-formats="licensePlateFormats"
+      :show-car-features="false"
+      :active-info="selectedVehicle?.activeInfo"
+      @close="closeDetailsModal"
+    />
+  </div>
 </template>
 
 <script>

--- a/frontend/src/components/CreateUserModal.vue
+++ b/frontend/src/components/CreateUserModal.vue
@@ -1,22 +1,32 @@
 <template>
-  <div class="modal-overlay" @click.self="$emit('close')">
+  <div
+    class="modal-overlay"
+    @click.self="$emit('close')"
+  >
     <div class="modal-container">
       <div class="modal-header">
-        <h3 class="modal-title">Создать новую учётную запись</h3>
-        <button @click="$emit('close')" class="modal-close-btn">
+        <h3 class="modal-title">
+          Создать новую учётную запись
+        </h3>
+        <button
+          class="modal-close-btn"
+          @click="$emit('close')"
+        >
           &times;
         </button>
       </div>
       
       <div class="modal-body">
         <div class="form-section">
-          <h4 class="section-title">Основные данные</h4>
+          <h4 class="section-title">
+            Основные данные
+          </h4>
           <div class="form-grid">
             <div class="form-group">
               <label class="form-label">Логин:</label>
               <input 
-                type="text" 
                 v-model="newUser.username" 
+                type="text" 
                 placeholder="Введите логин"
                 class="form-input"
                 required
@@ -24,14 +34,14 @@
                 autocorrect="off"
                 autocapitalize="off"
                 spellcheck="false"
-              />
+              >
             </div>
 
             <div class="form-group">
               <label class="form-label">Пароль:</label>
               <input 
-                type="password" 
                 v-model="newUser.password" 
+                type="password" 
                 placeholder="Введите пароль"
                 class="form-input"
                 required
@@ -39,7 +49,7 @@
                 autocorrect="off"
                 autocapitalize="off"
                 spellcheck="false"
-              />
+              >
             </div>
 
             <div class="form-group">
@@ -49,8 +59,17 @@
                 required 
                 class="form-select"
               >
-                <option :value="null" disabled>Выберите тип</option>
-                <option v-for="type in userTypes" :key="type.id" :value="type.id">
+                <option
+                  :value="null"
+                  disabled
+                >
+                  Выберите тип
+                </option>
+                <option
+                  v-for="type in userTypes"
+                  :key="type.id"
+                  :value="type.id"
+                >
                   {{ type.name }}
                 </option>
               </select>
@@ -59,96 +78,100 @@
         </div>
 
         <div class="form-section">
-          <h4 class="section-title">Персональные данные</h4>
+          <h4 class="section-title">
+            Персональные данные
+          </h4>
           <div class="form-grid">
             <div class="form-group">
               <label class="form-label">Фамилия:</label>
               <input 
-                type="text" 
                 v-model="newUser.last_name" 
+                type="text" 
                 placeholder="Введите фамилию"
                 class="form-input"
                 autocomplete="off"
                 autocorrect="off"
                 autocapitalize="off"
                 spellcheck="false"
-              />
+              >
             </div>
 
             <div class="form-group">
               <label class="form-label">Имя:</label>
               <input 
-                type="text" 
                 v-model="newUser.first_name" 
+                type="text" 
                 placeholder="Введите имя"
                 class="form-input"
                 autocomplete="off"
                 autocorrect="off"
                 autocapitalize="off"
                 spellcheck="false"
-              />
+              >
             </div>
 
             <div class="form-group">
               <label class="form-label">Отчество:</label>
               <input 
-                type="text" 
                 v-model="newUser.middle_name" 
+                type="text" 
                 placeholder="Введите отчество"
                 class="form-input"
                 autocomplete="off"
                 autocorrect="off"
                 autocapitalize="off"
                 spellcheck="false"
-              />
+              >
             </div>
 
             <div class="form-group">
               <label class="form-label">Должность:</label>
               <input 
-                type="text" 
                 v-model="newUser.position" 
+                type="text" 
                 placeholder="Введите должность"
                 class="form-input"
                 autocomplete="off"
                 autocorrect="off"
                 autocapitalize="off"
                 spellcheck="false"
-              />
+              >
             </div>
 
             <div class="form-group">
               <label class="form-label">Email:</label>
               <input 
-                type="email" 
                 v-model="newUser.email" 
+                type="email" 
                 placeholder="Введите email"
                 class="form-input"
                 autocomplete="off"
                 autocorrect="off"
                 autocapitalize="off"
                 spellcheck="false"
-              />
+              >
             </div>
 
             <div class="form-group">
               <label class="form-label">Телефон:</label>
               <input 
-                type="tel" 
                 v-model="newUser.phone" 
+                type="tel" 
                 placeholder="Введите телефон"
                 class="form-input"
                 autocomplete="off"
                 autocorrect="off"
                 autocapitalize="off"
                 spellcheck="false"
-              />
+              >
             </div>
           </div>
         </div>
 
         <div class="form-section">
-          <h4 class="section-title">Организационные данные</h4>
+          <h4 class="section-title">
+            Организационные данные
+          </h4>
           <div class="form-grid">
             <div class="form-group">
               <label class="form-label">Компания:</label>
@@ -157,8 +180,17 @@
                 required 
                 class="form-select"
               >
-                <option :value="null" disabled>Выберите компанию</option>
-                <option v-for="comp in companies" :key="comp.id" :value="comp.id">
+                <option
+                  :value="null"
+                  disabled
+                >
+                  Выберите компанию
+                </option>
+                <option
+                  v-for="comp in companies"
+                  :key="comp.id"
+                  :value="comp.id"
+                >
                   {{ comp.name }}
                 </option>
               </select>
@@ -171,8 +203,17 @@
                 required 
                 class="form-select"
               >
-                <option :value="null" disabled>Выберите организацию</option>
-                <option v-for="org in organizations" :key="org.id" :value="org.id">
+                <option
+                  :value="null"
+                  disabled
+                >
+                  Выберите организацию
+                </option>
+                <option
+                  v-for="org in organizations"
+                  :key="org.id"
+                  :value="org.id"
+                >
                   {{ org.name }}
                 </option>
               </select>
@@ -182,13 +223,16 @@
       </div>
 
       <div class="modal-footer">
-        <button @click="$emit('close')" class="modal-cancel-btn">
+        <button
+          class="modal-cancel-btn"
+          @click="$emit('close')"
+        >
           Отмена
         </button>
         <button 
-          @click="createNewUser" 
-          :disabled="!isFormValid"
+          :disabled="!isFormValid" 
           class="modal-confirm-btn"
+          @click="createNewUser"
         >
           Создать
         </button>

--- a/frontend/src/components/DateFilter.vue
+++ b/frontend/src/components/DateFilter.vue
@@ -1,150 +1,250 @@
 <template>
-    <div class="date-filter">
-        <div class="date-field" @click="toggleCalendar">
-            <div class="field-wrapper">
-                <div class="field-input">
-                    {{ displayText }}
-                </div>
-                <img src="@/assets/icons/calendar.png" class="field-icon" />
-            </div>
-            
-            <transition name="calendar-slide">
-                <div v-if="showCalendar" class="calendar-modal" @click.stop>
-                    <div class="calendar-container">
-                        <!-- Header -->
-                        <div class="calendar-header">
-                            <div class="header-actions">
-                                <button @click="prevMonth" class="nav-btn prev-btn">
-                                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none">
-                                        <path d="M15 18L9 12L15 6" stroke="#4F5BDF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                                    </svg>
-                                </button>
-                                <div class="date-display">
-                                    <span class="current-month-year">{{ capitalizeFirstLetter(currentMonthYear) }}</span>
-                                </div>
-                                <button @click="nextMonth" class="nav-btn next-btn">
-                                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none">
-                                        <path d="M9 18L15 12L9 6" stroke="#4F5BDF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                                    </svg>
-                                </button>
-                            </div>
-                        </div>
-                        
-                        <div class="calendar-body">
-                            <!-- Quick selection слева -->
-                            <div class="quick-selection">
-                                <div class="quick-buttons-list">
-                                    <button @click="setQuickDate('today')" class="quick-btn" :class="{ 'active': isQuickActive('today') }">
-                                        Сегодня
-                                    </button>
-                                    <button @click="setQuickDate('yesterday')" class="quick-btn" :class="{ 'active': isQuickActive('yesterday') }">
-                                        Вчера
-                                    </button>
-                                    <button @click="setQuickDate('tomorrow')" class="quick-btn" :class="{ 'active': isQuickActive('tomorrow') }">
-                                        Завтра
-                                    </button>
-                                    <button @click="setQuickDate('dayBeforeYesterday')" class="quick-btn" :class="{ 'active': isQuickActive('dayBeforeYesterday') }">
-                                        Позавчера
-                                    </button>
-                                    <button @click="setQuickDate('dayAfterTomorrow')" class="quick-btn" :class="{ 'active': isQuickActive('dayAfterTomorrow') }">
-                                        Послезавтра
-                                    </button>
-                                    <button @click="setQuickDate('thisWeek')" class="quick-btn" :class="{ 'active': isQuickActive('thisWeek') }">
-                                        Эта неделя
-                                    </button>
-                                    <button @click="setQuickDate('lastWeek')" class="quick-btn" :class="{ 'active': isQuickActive('lastWeek') }">
-                                        Прошлая неделя
-                                    </button>
-                                    <button @click="setQuickDate('nextWeek')" class="quick-btn" :class="{ 'active': isQuickActive('nextWeek') }">
-                                        Следующая неделя
-                                    </button>
-                                    <button @click="setQuickDate('thisMonth')" class="quick-btn" :class="{ 'active': isQuickActive('thisMonth') }">
-                                        Этот месяц
-                                    </button>
-                                    <button @click="setQuickDate('lastMonth')" class="quick-btn" :class="{ 'active': isQuickActive('lastMonth') }">
-                                        Прошлый месяц
-                                    </button>
-                                    <button @click="setQuickDate('nextMonth')" class="quick-btn" :class="{ 'active': isQuickActive('nextMonth') }">
-                                        Следующий месяц
-                                    </button>
-                                    <button @click="setQuickDate('thisYear')" class="quick-btn" :class="{ 'active': isQuickActive('thisYear') }">
-                                        Этот год
-                                    </button>
-                                    <button @click="setQuickDate('lastYear')" class="quick-btn" :class="{ 'active': isQuickActive('lastYear') }">
-                                        Прошлый год
-                                    </button>
-                                </div>
-                            </div>
-                            
-                            <!-- Calendar справа -->
-                            <div class="calendar-main">
-                                <div class="calendar-mode-switch">
-                                    <button 
-                                        class="mode-btn" 
-                                        :class="{ 'active': !selectingRange }"
-                                        @click="setMode('single')"
-                                    >
-                                        Один день
-                                    </button>
-                                    <button 
-                                        class="mode-btn" 
-                                        :class="{ 'active': selectingRange }"
-                                        @click="setMode('range')"
-                                    >
-                                        Период
-                                    </button>
-                                </div>
-                                
-                                <div class="weekdays">
-                                    <div v-for="day in weekdays" :key="day" class="weekday">
-                                        {{ day }}
-                                    </div>
-                                </div>
-                                
-                                <div class="days-grid">
-                                    <div 
-                                        v-for="day in daysInMonth" 
-                                        :key="day.date ? day.date.getTime() : `empty-${day.index}`"
-                                        class="day"
-                                        :class="getDayClass(day)"
-                                        @click="selectDay(day)"
-                                    >
-                                        <span class="day-number">{{ day.number }}</span>
-                                    </div>
-                                </div>
-                                
-                                <!-- Selected range display - всегда отображается -->
-                                <div class="selected-range">
-                                    <div class="range-display">
-                                        <template v-if="!selectingRange">
-                                            <span class="range-label">Отобразить дату:</span>
-                                            <span class="range-date">{{ formatDateForDisplay(internalSelectedDate) || '...' }}</span>
-                                        </template>
-                                        <template v-else>
-                                            <span class="range-label">Отобразить с</span>
-                                            <span class="range-date">{{ formatDateForDisplay(internalRangeStart) || '...' }}</span>
-                                            <span class="range-label">по</span>
-                                            <span class="range-date">{{ formatDateForDisplay(internalRangeEnd) || '...' }}</span>
-                                        </template>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        
-                        <!-- Actions -->
-                        <div class="calendar-actions">
-                            <button @click="clearSelection" class="action-btn action-btn--clear">
-                                Очистить
-                            </button>
-                            <button @click="applySelection" class="action-btn action-btn--apply">
-                                Применить
-                            </button>
-                        </div>
-                    </div>
-                </div>
-            </transition>
+  <div class="date-filter">
+    <div
+      class="date-field"
+      @click="toggleCalendar"
+    >
+      <div class="field-wrapper">
+        <div class="field-input">
+          {{ displayText }}
         </div>
+        <img
+          src="@/assets/icons/calendar.png"
+          class="field-icon"
+        >
+      </div>
+            
+      <transition name="calendar-slide">
+        <div
+          v-if="showCalendar"
+          class="calendar-modal"
+          @click.stop
+        >
+          <div class="calendar-container">
+            <!-- Header -->
+            <div class="calendar-header">
+              <div class="header-actions">
+                <button
+                  class="nav-btn prev-btn"
+                  @click="prevMonth"
+                >
+                  <svg
+                    width="12"
+                    height="12"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                  >
+                    <path
+                      d="M15 18L9 12L15 6"
+                      stroke="#4F5BDF"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </svg>
+                </button>
+                <div class="date-display">
+                  <span class="current-month-year">{{ capitalizeFirstLetter(currentMonthYear) }}</span>
+                </div>
+                <button
+                  class="nav-btn next-btn"
+                  @click="nextMonth"
+                >
+                  <svg
+                    width="12"
+                    height="12"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                  >
+                    <path
+                      d="M9 18L15 12L9 6"
+                      stroke="#4F5BDF"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+                        
+            <div class="calendar-body">
+              <!-- Quick selection слева -->
+              <div class="quick-selection">
+                <div class="quick-buttons-list">
+                  <button
+                    class="quick-btn"
+                    :class="{ 'active': isQuickActive('today') }"
+                    @click="setQuickDate('today')"
+                  >
+                    Сегодня
+                  </button>
+                  <button
+                    class="quick-btn"
+                    :class="{ 'active': isQuickActive('yesterday') }"
+                    @click="setQuickDate('yesterday')"
+                  >
+                    Вчера
+                  </button>
+                  <button
+                    class="quick-btn"
+                    :class="{ 'active': isQuickActive('tomorrow') }"
+                    @click="setQuickDate('tomorrow')"
+                  >
+                    Завтра
+                  </button>
+                  <button
+                    class="quick-btn"
+                    :class="{ 'active': isQuickActive('dayBeforeYesterday') }"
+                    @click="setQuickDate('dayBeforeYesterday')"
+                  >
+                    Позавчера
+                  </button>
+                  <button
+                    class="quick-btn"
+                    :class="{ 'active': isQuickActive('dayAfterTomorrow') }"
+                    @click="setQuickDate('dayAfterTomorrow')"
+                  >
+                    Послезавтра
+                  </button>
+                  <button
+                    class="quick-btn"
+                    :class="{ 'active': isQuickActive('thisWeek') }"
+                    @click="setQuickDate('thisWeek')"
+                  >
+                    Эта неделя
+                  </button>
+                  <button
+                    class="quick-btn"
+                    :class="{ 'active': isQuickActive('lastWeek') }"
+                    @click="setQuickDate('lastWeek')"
+                  >
+                    Прошлая неделя
+                  </button>
+                  <button
+                    class="quick-btn"
+                    :class="{ 'active': isQuickActive('nextWeek') }"
+                    @click="setQuickDate('nextWeek')"
+                  >
+                    Следующая неделя
+                  </button>
+                  <button
+                    class="quick-btn"
+                    :class="{ 'active': isQuickActive('thisMonth') }"
+                    @click="setQuickDate('thisMonth')"
+                  >
+                    Этот месяц
+                  </button>
+                  <button
+                    class="quick-btn"
+                    :class="{ 'active': isQuickActive('lastMonth') }"
+                    @click="setQuickDate('lastMonth')"
+                  >
+                    Прошлый месяц
+                  </button>
+                  <button
+                    class="quick-btn"
+                    :class="{ 'active': isQuickActive('nextMonth') }"
+                    @click="setQuickDate('nextMonth')"
+                  >
+                    Следующий месяц
+                  </button>
+                  <button
+                    class="quick-btn"
+                    :class="{ 'active': isQuickActive('thisYear') }"
+                    @click="setQuickDate('thisYear')"
+                  >
+                    Этот год
+                  </button>
+                  <button
+                    class="quick-btn"
+                    :class="{ 'active': isQuickActive('lastYear') }"
+                    @click="setQuickDate('lastYear')"
+                  >
+                    Прошлый год
+                  </button>
+                </div>
+              </div>
+                            
+              <!-- Calendar справа -->
+              <div class="calendar-main">
+                <div class="calendar-mode-switch">
+                  <button 
+                    class="mode-btn" 
+                    :class="{ 'active': !selectingRange }"
+                    @click="setMode('single')"
+                  >
+                    Один день
+                  </button>
+                  <button 
+                    class="mode-btn" 
+                    :class="{ 'active': selectingRange }"
+                    @click="setMode('range')"
+                  >
+                    Период
+                  </button>
+                </div>
+                                
+                <div class="weekdays">
+                  <div
+                    v-for="day in weekdays"
+                    :key="day"
+                    class="weekday"
+                  >
+                    {{ day }}
+                  </div>
+                </div>
+                                
+                <div class="days-grid">
+                  <div 
+                    v-for="day in daysInMonth" 
+                    :key="day.date ? day.date.getTime() : `empty-${day.index}`"
+                    class="day"
+                    :class="getDayClass(day)"
+                    @click="selectDay(day)"
+                  >
+                    <span class="day-number">{{ day.number }}</span>
+                  </div>
+                </div>
+                                
+                <!-- Selected range display - всегда отображается -->
+                <div class="selected-range">
+                  <div class="range-display">
+                    <template v-if="!selectingRange">
+                      <span class="range-label">Отобразить дату:</span>
+                      <span class="range-date">{{ formatDateForDisplay(internalSelectedDate) || '...' }}</span>
+                    </template>
+                    <template v-else>
+                      <span class="range-label">Отобразить с</span>
+                      <span class="range-date">{{ formatDateForDisplay(internalRangeStart) || '...' }}</span>
+                      <span class="range-label">по</span>
+                      <span class="range-date">{{ formatDateForDisplay(internalRangeEnd) || '...' }}</span>
+                    </template>
+                  </div>
+                </div>
+              </div>
+            </div>
+                        
+            <!-- Actions -->
+            <div class="calendar-actions">
+              <button
+                class="action-btn action-btn--clear"
+                @click="clearSelection"
+              >
+                Очистить
+              </button>
+              <button
+                class="action-btn action-btn--apply"
+                @click="applySelection"
+              >
+                Применить
+              </button>
+            </div>
+          </div>
+        </div>
+      </transition>
     </div>
+  </div>
 </template>
 
 <script>

--- a/frontend/src/components/DatePicker.vue
+++ b/frontend/src/components/DatePicker.vue
@@ -1,88 +1,165 @@
 <template>
-    <div class="date-picker-container">
-        <div class="date-field" @click="toggleDropdown">
-            <span class="select-text">{{ displayText }}</span>
-            <img 
-                src="@/assets/icons/calendar.png" 
-                class="select-icon" 
-                :class="{ 'select-icon--rotated': isOpen }" 
-            />
+  <div class="date-picker-container">
+    <div
+      class="date-field"
+      @click="toggleDropdown"
+    >
+      <span class="select-text">{{ displayText }}</span>
+      <img 
+        src="@/assets/icons/calendar.png" 
+        class="select-icon" 
+        :class="{ 'select-icon--rotated': isOpen }" 
+      >
             
-            <transition name="dropdown">
-                <div 
-                    class="custom-datepicker"
-                    v-if="isOpen"
-                    @click.stop
-                >
-                    <div class="datepicker-header">
-                        <h4 class="datepicker-title">Выберите период</h4>
-                        <button class="datepicker-close" @click="closeDatePicker">×</button>
-                    </div>
+      <transition name="dropdown">
+        <div 
+          v-if="isOpen"
+          class="custom-datepicker"
+          @click.stop
+        >
+          <div class="datepicker-header">
+            <h4 class="datepicker-title">
+              Выберите период
+            </h4>
+            <button
+              class="datepicker-close"
+              @click="closeDatePicker"
+            >
+              ×
+            </button>
+          </div>
                     
-                    <div class="quick-buttons">
-                        <button @click="setQuickDate('today')" class="quick-btn">Сегодня</button>
-                        <button @click="setQuickDate('yesterday')" class="quick-btn">Вчера</button>
-                        <button @click="setQuickDate('tomorrow')" class="quick-btn">Завтра</button>
-                        <button @click="setQuickDate('thisWeek')" class="quick-btn">Эта неделя</button>
-                        <button @click="setQuickDate('lastWeek')" class="quick-btn">Прошлая неделя</button>
-                        <button @click="setQuickDate('thisMonth')" class="quick-btn">Этот месяц</button>
-                        <button @click="setQuickDate('lastMonth')" class="quick-btn">Прошлый месяц</button>
-                        <button @click="setQuickDate('thisYear')" class="quick-btn">Этот год</button>
-                    </div>
+          <div class="quick-buttons">
+            <button
+              class="quick-btn"
+              @click="setQuickDate('today')"
+            >
+              Сегодня
+            </button>
+            <button
+              class="quick-btn"
+              @click="setQuickDate('yesterday')"
+            >
+              Вчера
+            </button>
+            <button
+              class="quick-btn"
+              @click="setQuickDate('tomorrow')"
+            >
+              Завтра
+            </button>
+            <button
+              class="quick-btn"
+              @click="setQuickDate('thisWeek')"
+            >
+              Эта неделя
+            </button>
+            <button
+              class="quick-btn"
+              @click="setQuickDate('lastWeek')"
+            >
+              Прошлая неделя
+            </button>
+            <button
+              class="quick-btn"
+              @click="setQuickDate('thisMonth')"
+            >
+              Этот месяц
+            </button>
+            <button
+              class="quick-btn"
+              @click="setQuickDate('lastMonth')"
+            >
+              Прошлый месяц
+            </button>
+            <button
+              class="quick-btn"
+              @click="setQuickDate('thisYear')"
+            >
+              Этот год
+            </button>
+          </div>
                     
-                    <div class="date-range-section">
-                        <div class="date-input-group">
-                            <label>С:</label>
-                            <input 
-                                type="date" 
-                                v-model="dateRangeStartInput"
-                                @change="updateDateRange"
-                                class="date-input"
-                            />
-                        </div>
-                        <div class="date-input-group">
-                            <label>ПО:</label>
-                            <input 
-                                type="date" 
-                                v-model="dateRangeEndInput"
-                                @change="updateDateRange"
-                                class="date-input"
-                            />
-                        </div>
-                    </div>
+          <div class="date-range-section">
+            <div class="date-input-group">
+              <label>С:</label>
+              <input 
+                v-model="dateRangeStartInput" 
+                type="date"
+                class="date-input"
+                @change="updateDateRange"
+              >
+            </div>
+            <div class="date-input-group">
+              <label>ПО:</label>
+              <input 
+                v-model="dateRangeEndInput" 
+                type="date"
+                class="date-input"
+                @change="updateDateRange"
+              >
+            </div>
+          </div>
                     
-                    <div class="calendar-section" v-if="showCalendar">
-                        <div class="calendar-header">
-                            <button class="calendar-nav-btn" @click="prevMonth">&lt;</button>
-                            <span class="current-month">{{ monthNames[currentMonth] }} {{ currentYear }}</span>
-                            <button class="calendar-nav-btn" @click="nextMonth">&gt;</button>
-                        </div>
-                        <div class="calendar-weekdays">
-                            <div v-for="day in ['Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб', 'Вс']" :key="day" class="weekday">
-                                {{ day }}
-                            </div>
-                        </div>
-                        <div class="calendar-days">
-                            <div 
-                                v-for="day in calendarDays" 
-                                :key="day.date"
-                                class="calendar-day"
-                                :class="getDayClasses(day)"
-                                @click="selectCalendarDate(day)"
-                            >
-                                {{ day.day }}
-                            </div>
-                        </div>
-                    </div>
+          <div
+            v-if="showCalendar"
+            class="calendar-section"
+          >
+            <div class="calendar-header">
+              <button
+                class="calendar-nav-btn"
+                @click="prevMonth"
+              >
+                &lt;
+              </button>
+              <span class="current-month">{{ monthNames[currentMonth] }} {{ currentYear }}</span>
+              <button
+                class="calendar-nav-btn"
+                @click="nextMonth"
+              >
+                &gt;
+              </button>
+            </div>
+            <div class="calendar-weekdays">
+              <div
+                v-for="day in ['Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб', 'Вс']"
+                :key="day"
+                class="weekday"
+              >
+                {{ day }}
+              </div>
+            </div>
+            <div class="calendar-days">
+              <div 
+                v-for="day in calendarDays" 
+                :key="day.date"
+                class="calendar-day"
+                :class="getDayClasses(day)"
+                @click="selectCalendarDate(day)"
+              >
+                {{ day.day }}
+              </div>
+            </div>
+          </div>
                     
-                    <div class="datepicker-actions">
-                        <button @click="applyDateRange" class="apply-btn">Применить</button>
-                        <button @click="clearDateRange" class="clear-btn">Очистить</button>
-                    </div>
-                </div>
-            </transition>
+          <div class="datepicker-actions">
+            <button
+              class="apply-btn"
+              @click="applyDateRange"
+            >
+              Применить
+            </button>
+            <button
+              class="clear-btn"
+              @click="clearDateRange"
+            >
+              Очистить
+            </button>
+          </div>
         </div>
+      </transition>
     </div>
+  </div>
 </template>
 
 <script>
@@ -207,6 +284,9 @@ export default {
                 this.removeClickOutside();
             }
         }
+    },
+    beforeUnmount() {
+        this.removeClickOutside();
     },
     methods: {
         toggleDropdown() {
@@ -419,9 +499,6 @@ export default {
         reset() {
             this.clearDateRange();
         }
-    },
-    beforeUnmount() {
-        this.removeClickOutside();
     }
 };
 </script>

--- a/frontend/src/components/EmployeeEditModal.vue
+++ b/frontend/src/components/EmployeeEditModal.vue
@@ -1,210 +1,284 @@
 <template>
-    <div v-if="visible" class="modal-overlay" @click="$emit('close')">
-        <div class="modal-content" @click.stop>
-            <div class="modal-header">
-                <div class="modal-header__top">
-                    <h3>{{ editingEmployee ? 'Редактирование' : 'Добавление сотрудника' }}</h3>
-                    <div v-if="notification.show" class="notification-badge" :class="notification.type">
-                        {{ notification.message }}
-                    </div>
-                </div>
-                <button class="modal-close" @click="$emit('close')">×</button>
-            </div>
-            <div class="modal-body">
-                <div class="data__completion">
-                    <div class="completion__citizenship">
-                        <div class="citizenship__header">
-                            <label class="citizenship__label">Гражданство <span class="required">*</span></label>
-                            <button class="add-button" @click="saveEmployee" :disabled="!canSaveEmployee">
-                                {{ editingEmployee ? 'Сохранить' : 'Добавить' }}
-                            </button>
-                        </div>
-                        <div class="citizenship__dropdown">
-                            <button class="dropdown__button" @click="toggleCitizenshipDropdown">
-                                <div class="button__content">
-                                    <span class="button__text">{{ selectedCitizenshipText }}</span>
-                                    <img src="@/assets/icons/arrow.png" class="button__arrow" :class="{ 'button__arrow--open': isCitizenshipDropdownOpen }" />
-                                </div>
-                            </button>
-                            <transition name="dropdown">
-                                <div v-if="isCitizenshipDropdownOpen" class="dropdown__menu">
-                                    <div
-                                        v-for="citizenship in citizenships"
-                                        :key="citizenship.id"
-                                        class="dropdown__item"
-                                        @click="selectCitizenship(citizenship)"
-                                    >
-                                        <span class="item__text">{{ citizenship.name }}</span>
-                                        <span v-if="citizenship.patent_required" class="patent-required-badge">Требуется патент</span>
-                                    </div>
-                                </div>
-                            </transition>
-                        </div>
-                    </div>
-
-                    <div class="completion__fields">
-                        <!-- Первая строка: Фамилия и Имя -->
-                        <div class="completion__name-row">
-                            <div class="completion__last-name">
-                                <div class="completion__last-name-header">
-                                    <label class="input__label">Фамилия <span class="required">*</span></label>
-                                </div>
-                                <input
-                                    class="name__input"
-                                    placeholder="Введите фамилию"
-                                    v-model="lastName"
-                                />
-                            </div>
-                            <div class="completion__first-name">
-                                <div class="completion__first-name-header">
-                                    <label class="input__label">Имя <span class="required">*</span></label>
-                                </div>
-                                <input
-                                    class="name__input"
-                                    placeholder="Введите имя"
-                                    v-model="firstName"
-                                />
-                            </div>
-                        </div>
-
-                        <!-- Вторая строка: Отчество и Должность -->
-                        <div class="completion__name-row">
-                            <div class="completion__middle-name">
-                                <div class="completion__middle-name-header">
-                                    <label class="input__label">Отчество</label>
-                                </div>
-                                <input
-                                    class="name__input"
-                                    placeholder="Введите отчество"
-                                    v-model="middleName"
-                                />
-                            </div>
-                            <div class="completion__position">
-                                <div class="completion__position-header">
-                                    <label class="input__label">Должность <span class="required">*</span></label>
-                                </div>
-                                <input
-                                    class="name__input"
-                                    placeholder="Введите должность"
-                                    v-model="position"
-                                />
-                            </div>
-                        </div>
-
-                        <!-- Третья строка: Паспорт и Номер патента -->
-                        <div class="completion__name-row">
-                            <div class="completion__passport">
-                                <div class="completion__passport-header">
-                                    <label class="input__label">Серия и номер паспорта <span class="required">*</span></label>
-                                </div>
-                                <input
-                                    class="name__input"
-                                    placeholder="XXXX XXXXXX"
-                                    v-model="passportSeriesNumber"
-                                    @input="formatPassport"
-                                />
-                            </div>
-                            <div class="completion__patent" :class="{ 'disabled-field': !isPatentRequired }">
-                                <div class="completion__patent-header">
-                                    <label class="input__label">Номер патента</label>
-                                </div>
-                                <input
-                                    class="name__input"
-                                    placeholder="Введите номер патента"
-                                    v-model="patentNumber"
-                                    :disabled="!isPatentRequired || selectedPermission !== 'Не выбрано'"
-                                    @input="handlePatentInput"
-                                />
-                            </div>
-                        </div>
-
-                        <!-- Четвертая строка: Иное разрешение -->
-                        <div class="completion__permission" :class="{ 'disabled-field': !isPatentRequired }">
-                            <div class="completion__permission-header">
-                                <label class="input__label">Иное разрешение на работы</label>
-                            </div>
-                            <div class="permission__dropdown">
-                                <button class="permission__dropdown-button" @click="togglePermissionDropdown" :disabled="!isPatentRequired || patentNumber.trim() !== ''">
-                                    <div class="permission__button-content">
-                                        <span class="permission__button-text">{{ selectedPermission || 'Не выбрано' }}</span>
-                                        <img src="@/assets/icons/arrow.png" class="permission__button-arrow" :class="{ 'permission__button-arrow--open': isPermissionDropdownOpen }" />
-                                    </div>
-                                </button>
-                                <transition name="dropdown">
-                                    <div v-if="isPermissionDropdownOpen" class="permission__dropdown-menu">
-                                        <div
-                                            v-for="permission in availablePermissions"
-                                            :key="permission"
-                                            class="permission__dropdown-item"
-                                            @click="selectPermission(permission)"
-                                        >
-                                            <span class="permission__item-text">{{ permission }}</span>
-                                        </div>
-                                    </div>
-                                </transition>
-                            </div>
-                        </div>
-
-                        <!-- Загрузка файлов -->
-                        <div class="completion__files" v-if="isPatentRequired">
-                            <div class="completion__files-header">
-                                <label class="input__label">Фото, скан документа(-ов), подтверждающее иное разрешение на работы</label>
-                            </div>
-                            <div class="files__upload">
-                                <input
-                                    type="file"
-                                    ref="fileInput"
-                                    @change="handleFileUpload"
-                                    multiple
-                                    accept="image/*,.pdf,.doc,.docx"
-                                    class="file-input"
-                                />
-                                <button class="upload-button" @click="triggerFileInput">
-                                    Загрузить
-                                </button>
-                            </div>
-                            <div v-if="uploadedFiles.length > 0" class="uploaded-files">
-                                <div v-for="(file, index) in uploadedFiles" :key="index" class="uploaded-file">
-                                    <span class="file-name">{{ truncateText(file.name, 30) }}</span>
-                                    <button @click="removeFile(index)" class="remove-file-btn">×</button>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Привязка -->
-                    <div class="completion__binding">
-                        <label class="input__label">Привязка</label>
-                        <div class="binding-info">
-                            <p class="binding-note">
-                                <strong>Добавляемый сотрудник автоматически привязывается к аккаунту пользователя.</strong>
-                                Сотрудника можно привязать к организации или компании, для использования <strong>другими сотрудниками</strong>:
-                            </p>
-                        </div>
-                        <div class="binding-options">
-                            <label class="binding-option" v-if="ownershipInfo && ownershipInfo.has_organization">
-                                <input
-                                    type="checkbox"
-                                    v-model="bindToOrganization"
-                                />
-                                <span>Привязать к организации</span>
-                            </label>
-                            <label class="binding-option" v-if="ownershipInfo && ownershipInfo.has_company">
-                                <input
-                                    type="checkbox"
-                                    v-model="bindToCompany"
-                                />
-                                <span>Привязать к компании</span>
-                            </label>
-                            <div class="user-binding">
-                                <span class="user-binding-text"><strong class="red">Внимание!</strong> При привязке сотрудника к организации или компании, он будет доступен для отображения и использования для всех сотрудников, привязанных к организации/компании. </span>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
+  <div
+    v-if="visible"
+    class="modal-overlay"
+    @click="$emit('close')"
+  >
+    <div
+      class="modal-content"
+      @click.stop
+    >
+      <div class="modal-header">
+        <div class="modal-header__top">
+          <h3>{{ editingEmployee ? 'Редактирование' : 'Добавление сотрудника' }}</h3>
+          <div
+            v-if="notification.show"
+            class="notification-badge"
+            :class="notification.type"
+          >
+            {{ notification.message }}
+          </div>
         </div>
+        <button
+          class="modal-close"
+          @click="$emit('close')"
+        >
+          ×
+        </button>
+      </div>
+      <div class="modal-body">
+        <div class="data__completion">
+          <div class="completion__citizenship">
+            <div class="citizenship__header">
+              <label class="citizenship__label">Гражданство <span class="required">*</span></label>
+              <button
+                class="add-button"
+                :disabled="!canSaveEmployee"
+                @click="saveEmployee"
+              >
+                {{ editingEmployee ? 'Сохранить' : 'Добавить' }}
+              </button>
+            </div>
+            <div class="citizenship__dropdown">
+              <button
+                class="dropdown__button"
+                @click="toggleCitizenshipDropdown"
+              >
+                <div class="button__content">
+                  <span class="button__text">{{ selectedCitizenshipText }}</span>
+                  <img
+                    src="@/assets/icons/arrow.png"
+                    class="button__arrow"
+                    :class="{ 'button__arrow--open': isCitizenshipDropdownOpen }"
+                  >
+                </div>
+              </button>
+              <transition name="dropdown">
+                <div
+                  v-if="isCitizenshipDropdownOpen"
+                  class="dropdown__menu"
+                >
+                  <div
+                    v-for="citizenship in citizenships"
+                    :key="citizenship.id"
+                    class="dropdown__item"
+                    @click="selectCitizenship(citizenship)"
+                  >
+                    <span class="item__text">{{ citizenship.name }}</span>
+                    <span
+                      v-if="citizenship.patent_required"
+                      class="patent-required-badge"
+                    >Требуется патент</span>
+                  </div>
+                </div>
+              </transition>
+            </div>
+          </div>
+
+          <div class="completion__fields">
+            <!-- Первая строка: Фамилия и Имя -->
+            <div class="completion__name-row">
+              <div class="completion__last-name">
+                <div class="completion__last-name-header">
+                  <label class="input__label">Фамилия <span class="required">*</span></label>
+                </div>
+                <input
+                  v-model="lastName"
+                  class="name__input"
+                  placeholder="Введите фамилию"
+                >
+              </div>
+              <div class="completion__first-name">
+                <div class="completion__first-name-header">
+                  <label class="input__label">Имя <span class="required">*</span></label>
+                </div>
+                <input
+                  v-model="firstName"
+                  class="name__input"
+                  placeholder="Введите имя"
+                >
+              </div>
+            </div>
+
+            <!-- Вторая строка: Отчество и Должность -->
+            <div class="completion__name-row">
+              <div class="completion__middle-name">
+                <div class="completion__middle-name-header">
+                  <label class="input__label">Отчество</label>
+                </div>
+                <input
+                  v-model="middleName"
+                  class="name__input"
+                  placeholder="Введите отчество"
+                >
+              </div>
+              <div class="completion__position">
+                <div class="completion__position-header">
+                  <label class="input__label">Должность <span class="required">*</span></label>
+                </div>
+                <input
+                  v-model="position"
+                  class="name__input"
+                  placeholder="Введите должность"
+                >
+              </div>
+            </div>
+
+            <!-- Третья строка: Паспорт и Номер патента -->
+            <div class="completion__name-row">
+              <div class="completion__passport">
+                <div class="completion__passport-header">
+                  <label class="input__label">Серия и номер паспорта <span class="required">*</span></label>
+                </div>
+                <input
+                  v-model="passportSeriesNumber"
+                  class="name__input"
+                  placeholder="XXXX XXXXXX"
+                  @input="formatPassport"
+                >
+              </div>
+              <div
+                class="completion__patent"
+                :class="{ 'disabled-field': !isPatentRequired }"
+              >
+                <div class="completion__patent-header">
+                  <label class="input__label">Номер патента</label>
+                </div>
+                <input
+                  v-model="patentNumber"
+                  class="name__input"
+                  placeholder="Введите номер патента"
+                  :disabled="!isPatentRequired || selectedPermission !== 'Не выбрано'"
+                  @input="handlePatentInput"
+                >
+              </div>
+            </div>
+
+            <!-- Четвертая строка: Иное разрешение -->
+            <div
+              class="completion__permission"
+              :class="{ 'disabled-field': !isPatentRequired }"
+            >
+              <div class="completion__permission-header">
+                <label class="input__label">Иное разрешение на работы</label>
+              </div>
+              <div class="permission__dropdown">
+                <button
+                  class="permission__dropdown-button"
+                  :disabled="!isPatentRequired || patentNumber.trim() !== ''"
+                  @click="togglePermissionDropdown"
+                >
+                  <div class="permission__button-content">
+                    <span class="permission__button-text">{{ selectedPermission || 'Не выбрано' }}</span>
+                    <img
+                      src="@/assets/icons/arrow.png"
+                      class="permission__button-arrow"
+                      :class="{ 'permission__button-arrow--open': isPermissionDropdownOpen }"
+                    >
+                  </div>
+                </button>
+                <transition name="dropdown">
+                  <div
+                    v-if="isPermissionDropdownOpen"
+                    class="permission__dropdown-menu"
+                  >
+                    <div
+                      v-for="permission in availablePermissions"
+                      :key="permission"
+                      class="permission__dropdown-item"
+                      @click="selectPermission(permission)"
+                    >
+                      <span class="permission__item-text">{{ permission }}</span>
+                    </div>
+                  </div>
+                </transition>
+              </div>
+            </div>
+
+            <!-- Загрузка файлов -->
+            <div
+              v-if="isPatentRequired"
+              class="completion__files"
+            >
+              <div class="completion__files-header">
+                <label class="input__label">Фото, скан документа(-ов), подтверждающее иное разрешение на работы</label>
+              </div>
+              <div class="files__upload">
+                <input
+                  ref="fileInput"
+                  type="file"
+                  multiple
+                  accept="image/*,.pdf,.doc,.docx"
+                  class="file-input"
+                  @change="handleFileUpload"
+                >
+                <button
+                  class="upload-button"
+                  @click="triggerFileInput"
+                >
+                  Загрузить
+                </button>
+              </div>
+              <div
+                v-if="uploadedFiles.length > 0"
+                class="uploaded-files"
+              >
+                <div
+                  v-for="(file, index) in uploadedFiles"
+                  :key="index"
+                  class="uploaded-file"
+                >
+                  <span class="file-name">{{ truncateText(file.name, 30) }}</span>
+                  <button
+                    class="remove-file-btn"
+                    @click="removeFile(index)"
+                  >
+                    ×
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Привязка -->
+          <div class="completion__binding">
+            <label class="input__label">Привязка</label>
+            <div class="binding-info">
+              <p class="binding-note">
+                <strong>Добавляемый сотрудник автоматически привязывается к аккаунту пользователя.</strong>
+                Сотрудника можно привязать к организации или компании, для использования <strong>другими сотрудниками</strong>:
+              </p>
+            </div>
+            <div class="binding-options">
+              <label
+                v-if="ownershipInfo && ownershipInfo.has_organization"
+                class="binding-option"
+              >
+                <input
+                  v-model="bindToOrganization"
+                  type="checkbox"
+                >
+                <span>Привязать к организации</span>
+              </label>
+              <label
+                v-if="ownershipInfo && ownershipInfo.has_company"
+                class="binding-option"
+              >
+                <input
+                  v-model="bindToCompany"
+                  type="checkbox"
+                >
+                <span>Привязать к компании</span>
+              </label>
+              <div class="user-binding">
+                <span class="user-binding-text"><strong class="red">Внимание!</strong> При привязке сотрудника к организации или компании, он будет доступен для отображения и использования для всех сотрудников, привязанных к организации/компании. </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
+  </div>
 </template>
 
 <script>
@@ -329,6 +403,20 @@ export default {
             if (newVal !== 'Не выбрано' && newVal !== '') {
                 this.patentNumber = '';
             }
+        }
+    },
+    mounted() {
+        document.addEventListener('click', (e) => {
+            if (!e.target.closest('.citizenship__dropdown')) {
+                this.isCitizenshipDropdownOpen = false;
+            }
+            if (!e.target.closest('.permission__dropdown')) {
+                this.isPermissionDropdownOpen = false;
+            }
+        });
+
+        if (this.visible) {
+            this.initForm();
         }
     },
     methods: {
@@ -618,20 +706,6 @@ export default {
             } catch (error) {
                 console.error('Ошибка при загрузке файлов:', error);
             }
-        }
-    },
-    mounted() {
-        document.addEventListener('click', (e) => {
-            if (!e.target.closest('.citizenship__dropdown')) {
-                this.isCitizenshipDropdownOpen = false;
-            }
-            if (!e.target.closest('.permission__dropdown')) {
-                this.isPermissionDropdownOpen = false;
-            }
-        });
-
-        if (this.visible) {
-            this.initForm();
         }
     }
 }

--- a/frontend/src/components/FactTable.vue
+++ b/frontend/src/components/FactTable.vue
@@ -1,8 +1,13 @@
 <template>
-  <div class="fact-table-card" data-testid="fact-table">
+  <div
+    class="fact-table-card"
+    data-testid="fact-table"
+  >
     <div class="card-header">
       <div class="card-header__title">
-        <h3 class="card-title">{{ tableType === 'cars' ? 'Автомобили' : 'Люди' }} <span class="highlight-text">по факту</span></h3>
+        <h3 class="card-title">
+          {{ tableType === 'cars' ? 'Автомобили' : 'Люди' }} <span class="highlight-text">по факту</span>
+        </h3>
       </div>
       <div class="card-header__settings">
         <RefreshButton @refresh="fetchData" />
@@ -14,11 +19,26 @@
       <div class="fact-header">
         <div class="header-row">
           <!-- Въезд - отдельная колонка (только для машин) -->
-          <div class="col entry-col" v-if="tableType === 'cars'">Въезд</div>
+          <div
+            v-if="tableType === 'cars'"
+            class="col entry-col"
+          >
+            Въезд
+          </div>
           <!-- Выезд - отдельная колонка (только для машин) -->
-          <div class="col exit-col" v-if="tableType === 'cars'">Выезд</div>
-          <div class="col organization-col" @click="sortBy('organization')">
-            <p :class="{ 'active-sort': sortField === 'organization' }">Организация</p>
+          <div
+            v-if="tableType === 'cars'"
+            class="col exit-col"
+          >
+            Выезд
+          </div>
+          <div
+            class="col organization-col"
+            @click="sortBy('organization')"
+          >
+            <p :class="{ 'active-sort': sortField === 'organization' }">
+              Организация
+            </p>
             <img 
               src="@/assets/icons/sort.png" 
               class="sort-icon" 
@@ -26,10 +46,16 @@
                 'sorted': sortField === 'organization',
                 'desc': sortField === 'organization' && sortDirection === 'desc'
               }" 
-            />
+            >
           </div>
-          <div class="col brand-col" v-if="tableType === 'cars'" @click="sortBy('car_brand')">
-            <p :class="{ 'active-sort': sortField === 'car_brand' }">Марка</p>
+          <div
+            v-if="tableType === 'cars'"
+            class="col brand-col"
+            @click="sortBy('car_brand')"
+          >
+            <p :class="{ 'active-sort': sortField === 'car_brand' }">
+              Марка
+            </p>
             <img 
               src="@/assets/icons/sort.png" 
               class="sort-icon" 
@@ -37,10 +63,14 @@
                 'sorted': sortField === 'car_brand',
                 'desc': sortField === 'car_brand' && sortDirection === 'desc'
               }" 
-            />
+            >
           </div>
           <!-- Компания скрыта -->
-          <div class="col company-col" v-if="tableType === 'cars'" style="display: none;"></div>
+          <div
+            v-if="tableType === 'cars'"
+            class="col company-col"
+            style="display: none;"
+          />
           <!-- Место разгрузки – закомментировано по требованию
           <div class="col place-col" @click="sortBy('unload_place')" v-if="tableType === 'cars'">
             <p :class="{ 'active-sort': sortField === 'unload_place' }">Место разгрузки</p>
@@ -54,8 +84,13 @@
             />
           </div>
           -->
-          <div class="col date-col" @click="sortBy('entry_date_to')">
-            <p :class="{ 'active-sort': sortField === 'entry_date_to' }">Действует до</p>
+          <div
+            class="col date-col"
+            @click="sortBy('entry_date_to')"
+          >
+            <p :class="{ 'active-sort': sortField === 'entry_date_to' }">
+              Действует до
+            </p>
             <img 
               src="@/assets/icons/sort.png" 
               class="sort-icon" 
@@ -63,10 +98,15 @@
                 'sorted': sortField === 'entry_date_to',
                 'desc': sortField === 'entry_date_to' && sortDirection === 'desc'
               }" 
-            />
+            >
           </div>
-          <div class="col time-col" @click="sortBy('entry_time')">
-            <p :class="{ 'active-sort': sortField === 'entry_time' }">{{ tableType === 'cars' ? 'Время' : 'Время прохода' }}</p>
+          <div
+            class="col time-col"
+            @click="sortBy('entry_time')"
+          >
+            <p :class="{ 'active-sort': sortField === 'entry_time' }">
+              {{ tableType === 'cars' ? 'Время' : 'Время прохода' }}
+            </p>
             <img 
               src="@/assets/icons/sort.png" 
               class="sort-icon" 
@@ -74,7 +114,7 @@
                 'sorted': sortField === 'entry_time',
                 'desc': sortField === 'entry_time' && sortDirection === 'desc'
               }" 
-            />
+            >
           </div>
           <!--<div class="col status-col" @click="sortBy('status')">
             <p :class="{ 'active-sort': sortField === 'status' }">Статус</p>
@@ -95,8 +135,14 @@
       
       <!-- Тело таблицы -->
       <div class="fact-container">
-        <div v-if="filteredData.length > 0" class="fact-body">
-          <transition-group name="fade-list" tag="div">
+        <div
+          v-if="filteredData.length > 0"
+          class="fact-body"
+        >
+          <transition-group
+            name="fade-list"
+            tag="div"
+          >
             <div 
               v-for="(item, index) in sortedData" 
               :key="item.id" 
@@ -106,7 +152,11 @@
             >
               <div class="fact-row">
                 <!-- Въезд - кнопка (только для машин) -->
-                <div v-if="tableType === 'cars'" class="col entry-col" @click.stop>
+                <div
+                  v-if="tableType === 'cars'"
+                  class="col entry-col"
+                  @click.stop
+                >
                   <button 
                     class="action-btn entry-btn" 
                     :class="{ 'active': item.entry_checked }"
@@ -117,7 +167,11 @@
                   </button>
                 </div>
                 <!-- Выезд - кнопка (только для машин) -->
-                <div v-if="tableType === 'cars'" class="col exit-col" @click.stop>
+                <div
+                  v-if="tableType === 'cars'"
+                  class="col exit-col"
+                  @click.stop
+                >
                   <button 
                     class="action-btn exit-btn" 
                     :class="{ 'active': item.exit_checked }"
@@ -130,11 +184,18 @@
                 <div class="col organization-col">
                   {{ item.organization_name }}
                 </div>
-                <div v-if="tableType === 'cars'" class="col brand-col">
+                <div
+                  v-if="tableType === 'cars'"
+                  class="col brand-col"
+                >
                   {{ item.car_brand || '-' }}
                 </div>
                 <!-- Компания скрыта -->
-                <div v-if="tableType === 'cars'" class="col company-col" style="display: none;"></div>
+                <div
+                  v-if="tableType === 'cars'"
+                  class="col company-col"
+                  style="display: none;"
+                />
                 <!-- Место разгрузки – закомментировано по требованию
                 <div v-if="tableType === 'cars'" class="col place-col">
                   {{ formatUnloadPlaces(item) }}
@@ -154,23 +215,29 @@
                     {{ item.status }}
                   </span>
                 </div>-->
-                <div class="col actions-col" @click.stop>
+                <div
+                  class="col actions-col"
+                  @click.stop
+                >
                   <button 
-                    @click="deleteItem(item)" 
-                    class="delete-btn"
+                    class="delete-btn" 
+                    @click="deleteItem(item)"
                   >
                     <img 
                       src="@/assets/icons/trashcan.png" 
                       alt="Удалить" 
                       class="delete-icon"
-                    />
+                    >
                   </button>
                 </div>
               </div>
             </div>
           </transition-group>
         </div>
-        <p v-else class="no-data-message">
+        <p
+          v-else
+          class="no-data-message"
+        >
           {{ hasActiveFilters ? 'Нет данных по выбранным фильтрам' : `Заявок ${tableType === 'cars' ? 'на машины' : 'на людей'} по факту нет` }}
         </p>
       </div>
@@ -317,6 +384,21 @@ export default {
         (this.dateRangeStart && this.dateRangeEnd)
       );
     }
+  },
+  watch: {
+    tableType: {
+      handler() {
+        this.stopPolling();
+        this.startPolling();
+      },
+      immediate: true
+    }
+  },
+  mounted() {
+    this.startPolling();
+  },
+  beforeUnmount() {
+    this.stopPolling();
   },
   methods: {
     async _loadData() {
@@ -625,21 +707,6 @@ export default {
         this.pollingInterval = null;
       }
     }
-  },
-  mounted() {
-    this.startPolling();
-  },
-  watch: {
-    tableType: {
-      handler() {
-        this.stopPolling();
-        this.startPolling();
-      },
-      immediate: true
-    }
-  },
-  beforeUnmount() {
-    this.stopPolling();
   }
 };
 </script>

--- a/frontend/src/components/FeedbackModal.vue
+++ b/frontend/src/components/FeedbackModal.vue
@@ -1,42 +1,57 @@
 <template>
   <teleport to="body">
-    <transition name="modal-overlay" @after-leave="handleAfterLeave">
+    <transition
+      name="modal-overlay"
+      @after-leave="handleAfterLeave"
+    >
       <div
         v-if="show"
         class="modal-overlay"
         @mousedown="onOverlayMousedown"
         @mouseup="onOverlayMouseup"
       >
-        <transition name="modal" @after-leave="emitClose">
+        <transition
+          name="modal"
+          @after-leave="emitClose"
+        >
           <div
             v-if="showContent"
             class="modal"
             @mousedown.stop
           >
             <div class="modal__header">
-              <h3 class="modal__title">Сообщить о проблеме</h3>
-              <button class="modal__close" @click="handleCloseClick" aria-label="Закрыть">
+              <h3 class="modal__title">
+                Сообщить о проблеме
+              </h3>
+              <button
+                class="modal__close"
+                aria-label="Закрыть"
+                @click="handleCloseClick"
+              >
                 <span class="close-icon">&times;</span>
               </button>
             </div>
             <div class="modal__body">
               <div class="modal__content">
-                <label for="feedback-textarea" class="textarea-label">
-                    Ниже вы можете дать обратную связь по работе системы. Расскажите о вашей проблеме, что не работает, с чем вам нужна помощь. Вы можете оставить предложение по улучшению работы системы.
+                <label
+                  for="feedback-textarea"
+                  class="textarea-label"
+                >
+                  Ниже вы можете дать обратную связь по работе системы. Расскажите о вашей проблеме, что не работает, с чем вам нужна помощь. Вы можете оставить предложение по улучшению работы системы.
                 </label>
                 <div class="textarea-wrapper">
                   <textarea 
-                    v-model="message" 
-                    id="feedback-textarea"
+                    id="feedback-textarea" 
+                    ref="textareaRef"
+                    v-model="message"
                     placeholder="Например: не работает кнопка отправки формы на странице..."
                     class="feedback-textarea"
                     :class="{ 'feedback-textarea--error': hasError }"
                     rows="6"
-                    ref="textareaRef"
+                    :disabled="isSubmitting"
                     @keydown.enter.prevent="handleEnterKey"
                     @input="handleInput"
-                    :disabled="isSubmitting"
-                  ></textarea>
+                  />
                   <div 
                     class="textarea-counter-wrapper"
                     :class="{ 
@@ -47,7 +62,11 @@
                     {{ message.length }}/{{ maxLength }}
                   </div>
                 </div>
-                <div v-if="error" class="error-message" role="alert">
+                <div
+                  v-if="error"
+                  class="error-message"
+                  role="alert"
+                >
                   <span class="error-icon">⚠</span>
                   {{ error }}
                 </div>
@@ -56,22 +75,28 @@
             <div class="modal__footer">
               <button 
                 class="modal-btn modal-btn--cancel" 
-                @click="handleCancelClick"
                 :disabled="isSubmitting"
+                @click="handleCancelClick"
               >
                 Отмена
               </button>
               <button 
                 class="modal-btn modal-btn--submit" 
-                @click="submitFeedback" 
-                :disabled="isSubmitDisabled"
+                :disabled="isSubmitDisabled" 
                 :class="{ 
                   'modal-btn--disabled': isSubmitDisabled,
                   'modal-btn--loading': isSubmitting 
                 }"
+                @click="submitFeedback"
               >
-                <span v-if="isSubmitting" class="submit-spinner"></span>
-                <span v-else class="submit-text">
+                <span
+                  v-if="isSubmitting"
+                  class="submit-spinner"
+                />
+                <span
+                  v-else
+                  class="submit-text"
+                >
                   {{ submitButtonText }}
                 </span>
               </button>
@@ -198,6 +223,25 @@ export default {
   
   created() {
     this.message = this.savedMessage;
+  },
+  
+  mounted() {
+    
+    this.$watch(
+      () => this.show,
+      (newVal) => {
+        if (newVal) {
+          document.body.style.overflow = 'hidden';
+        }
+      },
+      { immediate: true }
+    );
+  },
+  
+  beforeUnmount() {
+    this.removeEscListener();
+    document.body.style.overflow = '';
+    if (this.notificationTimer) clearTimeout(this.notificationTimer);
   },
   
   methods: {
@@ -374,25 +418,6 @@ export default {
         this.escListener = null;
       }
     }
-  },
-  
-  mounted() {
-    
-    this.$watch(
-      () => this.show,
-      (newVal) => {
-        if (newVal) {
-          document.body.style.overflow = 'hidden';
-        }
-      },
-      { immediate: true }
-    );
-  },
-  
-  beforeUnmount() {
-    this.removeEscListener();
-    document.body.style.overflow = '';
-    if (this.notificationTimer) clearTimeout(this.notificationTimer);
   }
 };
 </script>

--- a/frontend/src/components/LoginComponent.vue
+++ b/frontend/src/components/LoginComponent.vue
@@ -1,115 +1,220 @@
 <template>
-    <div class="login" @mousemove="handleMouseMove">
-        <div class="login-background">
-            <div class="floating-shape shape-1"></div>
-            <div class="floating-shape shape-2"></div>
-            <div class="floating-shape shape-3"></div>
-            <div class="floating-shape shape-4"></div>
-            <div class="floating-shape shape-5"></div>
-            <div class="floating-shape shape-6"></div>
-            <div class="floating-shape shape-7"></div>
-        </div>
-        
-        <div class="background-image" :style="parallaxStyle"></div>
-        
-        <div class="login__container">
-            <div class="login__active">
-                <div class="login__header">
-                    <h1 class="login__title" :style="titleStyle">Войдите в аккаунт</h1>
-                    <h3 class="login__subtitle" :style="subtitleStyle">для продолжения</h3>
-                </div>
-                <form class="login__form" data-testid="login-form" @submit.prevent="handleSubmit">
-                    <div class="inputs">
-                        <div class="login__input" :style="input1Style">
-                            <img src="@/assets/icons/login.png" alt="" class="input__icon" />
-                            <input v-model="formData.username" class="input" type="text"
-                                data-testid="login-input-username"
-                                autocomplete="off"
-                                autocorrect="off"
-                                autocapitalize="off"
-                                spellcheck="false"
-                                placeholder="Логин"
-                                aria-label="Имя пользователя"
-                                @keyup.enter="handleSubmit" />
-                        </div>
-                        <div class="login__input" :style="input2Style">
-                            <img src="@/assets/icons/password.png" alt="" class="input__icon" />
-                            <input v-model="formData.password" class="input" type="password"
-                                data-testid="login-input-password"
-                                autocomplete="new-password"
-                                autocorrect="off"
-                                autocapitalize="off"
-                                spellcheck="false"
-                                placeholder="Пароль"
-                                aria-label="Пароль"
-                                @keyup.enter="handleSubmit" />
-                        </div>
-                    </div>
-                    
-                    <a href="#" class="remember-password" :style="linkStyle" @click.prevent="showPasswordRecovery = true">Забыли пароль?</a>
-                    
-                    <div class="login__footer" :style="footerStyle">
-                        <div class="error-container">
-                            <transition name="fade">
-                                <div v-if="showError" class="error-message" data-testid="login-error-message">
-                                    {{ errors.general }}
-                                </div>
-                            </transition>
-                        </div>
-                        
-                        <div class="footer__button">
-                            <button class="login__button" data-testid="login-button-submit" :class="{'loading': isLoading, 'success': isSuccess}" :disabled="isLoading || isSuccess">
-                                <p class="button__text">{{ getButtonText }}</p>
-                                <img v-if="!isLoading && !isSuccess" src="@/assets/icons/key-blue.png" alt="" class="input__icon"/>
-                                <div v-if="isLoading" class="spinner"></div>
-                            </button>
-                            <div class="custom-lock" :class="{'error': hasError, 'shaking': isShaking, 'success': isSuccess}">
-                                <div class="lock-arc"></div>
-                                <div class="lock-body"></div>
-                            </div>
-                        </div>
-                    </div>
-                </form>
-            </div>
-            <div class="login__info" :style="infoStyle">
-                <div class="info-notifications">
-                    <transition name="notification" mode="out-in">
-                        <div v-if="showNotification" class="notification" :key="notificationText" data-testid="login-copy-notification">
-                            {{ notificationText }}
-                        </div>
-                    </transition>
-                </div>
-
-                <h2 class="info__title">Добро пожаловать!</h2>
-                <p class="info__text">
-                    Для продолжения, необходимо войти в аккаунт,
-                    используя выданные данные.
-                </p>
-                <h3 class="info__title help">Помощь и поддержка</h3>
-                <p class="info__text">
-                  Обратитесь к нам, чтобы получить учётную запись, восстановить доступ или решить другие проблемы:
-                </p>
-                <div class="info__contacts">
-                    <div class="contact" @click="copyEmail">
-                        <img src="@/assets/icons/email-blue.png" class="contact__icon" alt="" />
-                        <p class="contact__text">buropropuskov@dreamisland.ru</p>
-                    </div>
-                    <div class="contact" @click="copyPhone">
-                        <img src="@/assets/icons/phone-blue.png" class="contact__icon" alt="" />
-                        <p class="contact__text">+7 (910) 083 00-55</p>
-                    </div>
-                    <p class="time">
-                        ПН-ПТ: <strong>08:00 - 22:00</strong> СБ-ВС и ПРАЗДНИКИ: <strong>08:00 - 20:00</strong>
-                    </p>
-                </div>
-            </div>
-        </div>
-
-        <PasswordRecoveryModal
-            :show="showPasswordRecovery"
-            @close="showPasswordRecovery = false"
-        />
+  <div
+    class="login"
+    @mousemove="handleMouseMove"
+  >
+    <div class="login-background">
+      <div class="floating-shape shape-1" />
+      <div class="floating-shape shape-2" />
+      <div class="floating-shape shape-3" />
+      <div class="floating-shape shape-4" />
+      <div class="floating-shape shape-5" />
+      <div class="floating-shape shape-6" />
+      <div class="floating-shape shape-7" />
     </div>
+        
+    <div
+      class="background-image"
+      :style="parallaxStyle"
+    />
+        
+    <div class="login__container">
+      <div class="login__active">
+        <div class="login__header">
+          <h1
+            class="login__title"
+            :style="titleStyle"
+          >
+            Войдите в аккаунт
+          </h1>
+          <h3
+            class="login__subtitle"
+            :style="subtitleStyle"
+          >
+            для продолжения
+          </h3>
+        </div>
+        <form
+          class="login__form"
+          data-testid="login-form"
+          @submit.prevent="handleSubmit"
+        >
+          <div class="inputs">
+            <div
+              class="login__input"
+              :style="input1Style"
+            >
+              <img
+                src="@/assets/icons/login.png"
+                alt=""
+                class="input__icon"
+              >
+              <input
+                v-model="formData.username"
+                class="input"
+                type="text"
+                data-testid="login-input-username"
+                autocomplete="off"
+                autocorrect="off"
+                autocapitalize="off"
+                spellcheck="false"
+                placeholder="Логин"
+                aria-label="Имя пользователя"
+                @keyup.enter="handleSubmit"
+              >
+            </div>
+            <div
+              class="login__input"
+              :style="input2Style"
+            >
+              <img
+                src="@/assets/icons/password.png"
+                alt=""
+                class="input__icon"
+              >
+              <input
+                v-model="formData.password"
+                class="input"
+                type="password"
+                data-testid="login-input-password"
+                autocomplete="new-password"
+                autocorrect="off"
+                autocapitalize="off"
+                spellcheck="false"
+                placeholder="Пароль"
+                aria-label="Пароль"
+                @keyup.enter="handleSubmit"
+              >
+            </div>
+          </div>
+                    
+          <a
+            href="#"
+            class="remember-password"
+            :style="linkStyle"
+            @click.prevent="showPasswordRecovery = true"
+          >Забыли пароль?</a>
+                    
+          <div
+            class="login__footer"
+            :style="footerStyle"
+          >
+            <div class="error-container">
+              <transition name="fade">
+                <div
+                  v-if="showError"
+                  class="error-message"
+                  data-testid="login-error-message"
+                >
+                  {{ errors.general }}
+                </div>
+              </transition>
+            </div>
+                        
+            <div class="footer__button">
+              <button
+                class="login__button"
+                data-testid="login-button-submit"
+                :class="{'loading': isLoading, 'success': isSuccess}"
+                :disabled="isLoading || isSuccess"
+              >
+                <p class="button__text">
+                  {{ getButtonText }}
+                </p>
+                <img
+                  v-if="!isLoading && !isSuccess"
+                  src="@/assets/icons/key-blue.png"
+                  alt=""
+                  class="input__icon"
+                >
+                <div
+                  v-if="isLoading"
+                  class="spinner"
+                />
+              </button>
+              <div
+                class="custom-lock"
+                :class="{'error': hasError, 'shaking': isShaking, 'success': isSuccess}"
+              >
+                <div class="lock-arc" />
+                <div class="lock-body" />
+              </div>
+            </div>
+          </div>
+        </form>
+      </div>
+      <div
+        class="login__info"
+        :style="infoStyle"
+      >
+        <div class="info-notifications">
+          <transition
+            name="notification"
+            mode="out-in"
+          >
+            <div
+              v-if="showNotification"
+              :key="notificationText"
+              class="notification"
+              data-testid="login-copy-notification"
+            >
+              {{ notificationText }}
+            </div>
+          </transition>
+        </div>
+
+        <h2 class="info__title">
+          Добро пожаловать!
+        </h2>
+        <p class="info__text">
+          Для продолжения, необходимо войти в аккаунт,
+          используя выданные данные.
+        </p>
+        <h3 class="info__title help">
+          Помощь и поддержка
+        </h3>
+        <p class="info__text">
+          Обратитесь к нам, чтобы получить учётную запись, восстановить доступ или решить другие проблемы:
+        </p>
+        <div class="info__contacts">
+          <div
+            class="contact"
+            @click="copyEmail"
+          >
+            <img
+              src="@/assets/icons/email-blue.png"
+              class="contact__icon"
+              alt=""
+            >
+            <p class="contact__text">
+              buropropuskov@dreamisland.ru
+            </p>
+          </div>
+          <div
+            class="contact"
+            @click="copyPhone"
+          >
+            <img
+              src="@/assets/icons/phone-blue.png"
+              class="contact__icon"
+              alt=""
+            >
+            <p class="contact__text">
+              +7 (910) 083 00-55
+            </p>
+          </div>
+          <p class="time">
+            ПН-ПТ: <strong>08:00 - 22:00</strong> СБ-ВС и ПРАЗДНИКИ: <strong>08:00 - 20:00</strong>
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <PasswordRecoveryModal
+      :show="showPasswordRecovery"
+      @close="showPasswordRecovery = false"
+    />
+  </div>
 </template>
 
 <script>
@@ -217,6 +322,17 @@ export default {
         setTimeout(() => {
             this.elementsVisible = true;
         }, 100);
+    },
+    beforeUnmount() {
+        if (this.animationTimeout) {
+            clearTimeout(this.animationTimeout);
+        }
+        if (this.errorTimeout) {
+            clearTimeout(this.errorTimeout);
+        }
+        if (this.notificationTimeout) {
+            clearTimeout(this.notificationTimeout);
+        }
     },
     methods: {
         handleMouseMove(e) {
@@ -415,17 +531,6 @@ export default {
                 }, 300);
             }, 700);
         },
-    },
-    beforeUnmount() {
-        if (this.animationTimeout) {
-            clearTimeout(this.animationTimeout);
-        }
-        if (this.errorTimeout) {
-            clearTimeout(this.errorTimeout);
-        }
-        if (this.notificationTimeout) {
-            clearTimeout(this.notificationTimeout);
-        }
     }
 }
 </script>

--- a/frontend/src/components/NavMenu.vue
+++ b/frontend/src/components/NavMenu.vue
@@ -11,16 +11,32 @@
     <div class="nav-content">
       <!-- ЗАЯВКИ -->
       <div class="nav-section">
-        <div class="section-title">ЗАЯВКИ</div>
-        <div class="nav-item" data-testid="nav-link-center" @click="navigateToCenter">
+        <div class="section-title">
+          ЗАЯВКИ
+        </div>
+        <div
+          class="nav-item"
+          data-testid="nav-link-center"
+          @click="navigateToCenter"
+        >
           <div class="nav-icon-wrapper">
-            <img src="@/assets/icons/envelope.png" alt="Центр заявок" class="nav-icon">
-            <span v-if="newApplicationsCount > 0" class="icon-badge">
+            <img
+              src="@/assets/icons/envelope.png"
+              alt="Центр заявок"
+              class="nav-icon"
+            >
+            <span
+              v-if="newApplicationsCount > 0"
+              class="icon-badge"
+            >
               {{ newApplicationsCount > 9 ? '9+' : newApplicationsCount }}
             </span>
           </div>
           <span class="nav-text">Центр заявок</span>
-          <span v-if="newApplicationsCount > 0" class="notification-badge">
+          <span
+            v-if="newApplicationsCount > 0"
+            class="notification-badge"
+          >
             {{ newApplicationsCount > 9 ? '9+' : newApplicationsCount }}
           </span>
         </div>
@@ -28,7 +44,9 @@
 
       <!-- УПРАВЛЕНИЕ ДАННЫМИ -->
       <div class="nav-section">
-        <div class="section-title">УПРАВЛЕНИЕ ДАННЫМИ</div>
+        <div class="section-title">
+          УПРАВЛЕНИЕ ДАННЫМИ
+        </div>
         
         <!-- Элемент с выпадающим списком таблиц -->
         <div class="nav-item-container">
@@ -38,10 +56,19 @@
             @mouseleave="handleDropdownLeave('tables')"
           >
             <div class="nav-item-content">
-              <img src="@/assets/icons/table.png" alt="Таблицы" class="nav-icon">
+              <img
+                src="@/assets/icons/table.png"
+                alt="Таблицы"
+                class="nav-icon"
+              >
               <span class="nav-text">Таблицы</span>
             </div>
-            <img src="@/assets/icons/arrow.png" alt="▼" class="dropdown-arrow" :class="{ rotated: dropdowns.tables }">
+            <img
+              src="@/assets/icons/arrow.png"
+              alt="▼"
+              class="dropdown-arrow"
+              :class="{ rotated: dropdowns.tables }"
+            >
           </div>
           
           <!-- Выпадающий список таблиц (справа от меню) -->
@@ -60,7 +87,10 @@
               >
                 {{ getTableDisplayName(table) }}
               </div>
-              <div v-if="systemTables.length === 0" class="dropdown-item disabled">
+              <div
+                v-if="systemTables.length === 0"
+                class="dropdown-item disabled"
+              >
                 Нет доступных таблиц
               </div>
             </div>
@@ -68,34 +98,70 @@
         </div>
 
         <!-- Элемент с выпадающим списком сотрудников -->
-        <div class="nav-item" data-testid="nav-link-employees" @click="navigateToEmployeesView">
-          <img src="@/assets/icons/employees.png" alt="Сотрудники" class="nav-icon">
+        <div
+          class="nav-item"
+          data-testid="nav-link-employees"
+          @click="navigateToEmployeesView"
+        >
+          <img
+            src="@/assets/icons/employees.png"
+            alt="Сотрудники"
+            class="nav-icon"
+          >
           <span class="nav-text">Сотрудники</span>
         </div>
-        <div class="nav-item" data-testid="nav-link-cars" @click="navigateToCarsView">
-          <img src="@/assets/icons/car.png" alt="Автомобили" class="nav-icon">
+        <div
+          class="nav-item"
+          data-testid="nav-link-cars"
+          @click="navigateToCarsView"
+        >
+          <img
+            src="@/assets/icons/car.png"
+            alt="Автомобили"
+            class="nav-icon"
+          >
           <span class="nav-text">Автомобили</span>
         </div>
       </div>
 
       <!-- АНАЛИТИКА -->
       <div class="nav-section">
-        <div class="section-title">АНАЛИТИКА</div>
+        <div class="section-title">
+          АНАЛИТИКА
+        </div>
         <div class="nav-item disabled">
-          <img src="@/assets/icons/stats.png" alt="Статистика" class="nav-icon">
+          <img
+            src="@/assets/icons/stats.png"
+            alt="Статистика"
+            class="nav-icon"
+          >
           <span class="nav-text disabled ">Статистика</span>
         </div>
         <div class="nav-item disabled">
-          <img src="@/assets/icons/clipboard.png" alt="Отчёты" class="nav-icon">
+          <img
+            src="@/assets/icons/clipboard.png"
+            alt="Отчёты"
+            class="nav-icon"
+          >
           <span class="nav-text disabled">Отчёты</span>
         </div>
       </div>
 
       <!-- ПОЛЬЗОВАТЕЛЬ (в нижней части) -->
       <div class="nav-section user-section">
-        <div class="section-title">ПОЛЬЗОВАТЕЛЬ</div>
-        <div class="nav-item" data-testid="nav-link-news" @click="navigateToNews">
-          <img src="@/assets/icons/newspaper.png" alt="Новости" class="nav-icon">
+        <div class="section-title">
+          ПОЛЬЗОВАТЕЛЬ
+        </div>
+        <div
+          class="nav-item"
+          data-testid="nav-link-news"
+          @click="navigateToNews"
+        >
+          <img
+            src="@/assets/icons/newspaper.png"
+            alt="Новости"
+            class="nav-icon"
+          >
           <span class="nav-text">Обзор и новости</span>
         </div>
         
@@ -107,10 +173,19 @@
             @mouseleave="handleDropdownLeave('admin')"
           >
             <div class="nav-item-content">
-              <img src="@/assets/settings.png" alt="Админка" class="nav-icon">
+              <img
+                src="@/assets/settings.png"
+                alt="Админка"
+                class="nav-icon"
+              >
               <span class="nav-text">Админка</span>
             </div>
-            <img src="@/assets/icons/arrow.png" alt="▼" class="dropdown-arrow" :class="{ rotated: dropdowns.admin }">
+            <img
+              src="@/assets/icons/arrow.png"
+              alt="▼"
+              class="dropdown-arrow"
+              :class="{ rotated: dropdowns.admin }"
+            >
           </div>
           
           <!-- Выпадающий список админки (справа от меню) -->
@@ -149,12 +224,28 @@
           </transition>
         </div>
         
-        <div class="nav-item" data-testid="nav-link-cabinet" @click="navigateToAccount">
-          <img src="@/assets/icons/user.png" alt="Личный кабинет" class="nav-icon">
+        <div
+          class="nav-item"
+          data-testid="nav-link-cabinet"
+          @click="navigateToAccount"
+        >
+          <img
+            src="@/assets/icons/user.png"
+            alt="Личный кабинет"
+            class="nav-icon"
+          >
           <span class="nav-text">Личный кабинет</span>
         </div>
-        <div class="nav-item" data-testid="nav-button-logout" @click="logout">
-          <img src="@/assets/icons/logout.png" alt="Выйти" class="nav-icon">
+        <div
+          class="nav-item"
+          data-testid="nav-button-logout"
+          @click="logout"
+        >
+          <img
+            src="@/assets/icons/logout.png"
+            alt="Выйти"
+            class="nav-icon"
+          >
           <span class="nav-text exit">Выйти</span>
         </div>
       </div>
@@ -182,6 +273,26 @@ export default {
       applicationsPollingInterval: null,
       tablesPollingInterval: null
     };
+  },
+  async mounted() {
+    document.body.classList.add('auth-active');
+    await this.fetchSystemTables();
+    this.startApplicationsPolling();
+    this.startTablesPolling();
+  },
+  beforeUnmount() {
+    document.body.classList.remove('auth-active');
+    this.stopApplicationsPolling();
+    
+    if (this.hoverTimeout) {
+      clearTimeout(this.hoverTimeout);
+    }
+    if (this.dropdownTimeout) {
+      clearTimeout(this.dropdownTimeout);
+    }
+    if (this.dropdownLeaveTimeout) {
+      clearTimeout(this.dropdownLeaveTimeout);
+    }
   },
   methods: {
     expandMenu() {
@@ -353,26 +464,6 @@ export default {
     logout() {
       this.stopApplicationsPolling();
       this.$emit('logout');
-    }
-  },
-  async mounted() {
-    document.body.classList.add('auth-active');
-    await this.fetchSystemTables();
-    this.startApplicationsPolling();
-    this.startTablesPolling();
-  },
-  beforeUnmount() {
-    document.body.classList.remove('auth-active');
-    this.stopApplicationsPolling();
-    
-    if (this.hoverTimeout) {
-      clearTimeout(this.hoverTimeout);
-    }
-    if (this.dropdownTimeout) {
-      clearTimeout(this.dropdownTimeout);
-    }
-    if (this.dropdownLeaveTimeout) {
-      clearTimeout(this.dropdownLeaveTimeout);
     }
   }
 };

--- a/frontend/src/components/NumberFormat.vue
+++ b/frontend/src/components/NumberFormat.vue
@@ -1,13 +1,18 @@
 <template>
   <div class="number-format-container dashboard-card">
     <div class="management-header">
-      <h3 class="management-title">Управление форматами номеров</h3>
+      <h3 class="management-title">
+        Управление форматами номеров
+      </h3>
       <div class="header-controls">
         <SearchComponent
-          :title="'Поиск форматов...'"
           v-model="searchQuery"
+          :title="'Поиск форматов...'"
         />
-        <button @click="showAddModal = true" class="add-header-button">
+        <button
+          class="add-header-button"
+          @click="showAddModal = true"
+        >
           Добавить
         </button>
         <RefreshButton @refresh="refreshData" />
@@ -16,11 +21,19 @@
 
     <div class="content-container">
       <!-- Левая часть - таблица форматов -->
-      <div class="table-section" :class="{'with-details': selectedFormat}">
+      <div
+        class="table-section"
+        :class="{'with-details': selectedFormat}"
+      >
         <div class="table-container">
           <div class="table-header">
-            <div class="header-col id-col" @click="sortBy('id')">
-              <p :class="{ 'active-sort': sortField === 'id' }">ID</p>
+            <div
+              class="header-col id-col"
+              @click="sortBy('id')"
+            >
+              <p :class="{ 'active-sort': sortField === 'id' }">
+                ID
+              </p>
               <img 
                 src="@/assets/icons/sort.png" 
                 class="sort-icon" 
@@ -28,10 +41,15 @@
                   'sorted': sortField === 'id',
                   'desc': sortField === 'id' && sortDirection === 'desc'
                 }" 
-              />
+              >
             </div>
-            <div class="header-col name-col" @click="sortBy('name')">
-              <p :class="{ 'active-sort': sortField === 'name' }">Наименование</p>
+            <div
+              class="header-col name-col"
+              @click="sortBy('name')"
+            >
+              <p :class="{ 'active-sort': sortField === 'name' }">
+                Наименование
+              </p>
               <img 
                 src="@/assets/icons/sort.png" 
                 class="sort-icon" 
@@ -39,7 +57,7 @@
                   'sorted': sortField === 'name',
                   'desc': sortField === 'name' && sortDirection === 'desc'
                 }" 
-              />
+              >
             </div>
           </div>
 
@@ -55,7 +73,10 @@
                 <span class="cell-content id-value">{{ format.format.id }}</span>
               </div>
               <div class="table-col name-col">
-                <span class="truncate-text" :title="format.format.name">
+                <span
+                  class="truncate-text"
+                  :title="format.format.name"
+                >
                   {{ format.format.name }}
                 </span>
               </div>
@@ -69,16 +90,27 @@
       </div>
 
       <!-- Правая часть - детали формата -->
-      <div v-if="selectedFormat" class="details-section">
+      <div
+        v-if="selectedFormat"
+        class="details-section"
+      >
         <div class="details-content">
           <div class="details-header">
             <div class="details-title-wrapper">
-                <h3 class="details-title">{{ selectedFormat.format.name }}</h3>
-                <span class="format-preview">{{ getFormatPreview(selectedFormat) }}</span>
+              <h3 class="details-title">
+                {{ selectedFormat.format.name }}
+              </h3>
+              <span class="format-preview">{{ getFormatPreview(selectedFormat) }}</span>
             </div>
             <div class="details-header-actions">
-              <button @click="confirmDeleteFormat(selectedFormat.format)" class="delete-icon-btn">
-                <img src="@/assets/icons/delete.png" class="delete-icon" />
+              <button
+                class="delete-icon-btn"
+                @click="confirmDeleteFormat(selectedFormat.format)"
+              >
+                <img
+                  src="@/assets/icons/delete.png"
+                  class="delete-icon"
+                >
               </button>
             </div>
           </div>
@@ -90,20 +122,20 @@
                   <label class="detail-label">Наименование:</label>
                   <input 
                     v-model="selectedFormat.format.name" 
-                    @change="updateFormat(selectedFormat)"
                     class="form-input-sm"
                     placeholder="Название формата"
                     autocomplete="off"
+                    @change="updateFormat(selectedFormat)"
                   >
                 </div>
                 <div class="form-group compact">
                   <label class="detail-label">Код страны:</label>
                   <input 
                     v-model="selectedFormat.format.country_code" 
-                    @change="updateFormat(selectedFormat)"
                     class="form-input-sm"
                     placeholder="RU, AZ, KZ"
                     autocomplete="off"
+                    @change="updateFormat(selectedFormat)"
                   >
                 </div>
               </div>
@@ -111,11 +143,11 @@
               <div class="default-checkbox-section">
                 <label class="default-checkbox-label">
                   <input 
-                    type="checkbox" 
-                    v-model="selectedFormat.format.is_default"
-                    @change="handleDefaultFormatChange"
+                    v-model="selectedFormat.format.is_default" 
+                    type="checkbox"
                     class="default-checkbox"
-                  />
+                    @change="handleDefaultFormatChange"
+                  >
                   <span class="default-checkbox-text">Формат по умолчанию</span>
                 </label>
                 <span class="default-checkbox-hint">
@@ -134,16 +166,26 @@
                   >
                     <div class="cell-horizontal-header">
                       <span class="cell-badge">Клетка №{{ index + 1 }}</span>
-                      <span class="cell-type-badge" :class="cell.cell_type">
+                      <span
+                        class="cell-type-badge"
+                        :class="cell.cell_type"
+                      >
                         {{ getCellTypeLabel(cell.cell_type) }}
                       </span>
                     </div>
                     <div class="cell-horizontal-details">
                       <span class="cell-length">{{ cell.min_length }}-{{ cell.max_length }} симв.</span>
-                      <span v-if="cell.allowed_letters" class="cell-letters" :title="cell.allowed_letters">
+                      <span
+                        v-if="cell.allowed_letters"
+                        class="cell-letters"
+                        :title="cell.allowed_letters"
+                      >
                         {{ truncateLetters(cell.allowed_letters) }}
                       </span>
-                      <span v-if="cell.cell_type === 'numbers'" class="cell-padding">
+                      <span
+                        v-if="cell.cell_type === 'numbers'"
+                        class="cell-padding"
+                      >
                         Дополнение: {{ cell.padding_side === 'left' ? 'слева' : 'справа' }}
                       </span>
                     </div>
@@ -155,22 +197,39 @@
         </div>
       </div>
       
-      <div v-else class="no-selection-message">
+      <div
+        v-else
+        class="no-selection-message"
+      >
         <p>Выберите формат номеров для просмотра</p>
       </div>
     </div>
 
-    <div v-if="filteredFormats.length === 0" class="no-results">
-      <div class="no-results-icon">🚗</div>
+    <div
+      v-if="filteredFormats.length === 0"
+      class="no-results"
+    >
+      <div class="no-results-icon">
+        🚗
+      </div>
       <p>Форматы номеров не найдены</p>
     </div>
 
     <!-- Модальное окно добавления формата -->
-    <div v-if="showAddModal" class="modal-overlay" @click.self="showAddModal = false">
+    <div
+      v-if="showAddModal"
+      class="modal-overlay"
+      @click.self="showAddModal = false"
+    >
       <div class="modal-content horizontal-modal">
         <div class="modal-header">
           <h3>Добавить формат номеров</h3>
-          <button @click="showAddModal = false" class="modal-close">×</button>
+          <button
+            class="modal-close"
+            @click="showAddModal = false"
+          >
+            ×
+          </button>
         </div>
         
         <div class="modal-body-horizontal">
@@ -198,10 +257,10 @@
               <div class="default-checkbox-modal">
                 <label class="default-checkbox-label-modal">
                   <input 
-                    type="checkbox" 
-                    v-model="newFormat.is_default"
+                    v-model="newFormat.is_default" 
+                    type="checkbox"
                     class="default-checkbox"
-                  />
+                  >
                   <span class="default-checkbox-text-modal">Формат по умолчанию</span>
                 </label>
                 <span class="default-checkbox-hint-modal">
@@ -214,8 +273,13 @@
           <!-- Правая часть - клетки -->
           <div class="modal-cells-section">
             <div class="cells-header-compact">
-              <h4 class="cells-title-compact">Клетки формата</h4>
-              <button @click="addCell" class="add-cell-btn-header">
+              <h4 class="cells-title-compact">
+                Клетки формата
+              </h4>
+              <button
+                class="add-cell-btn-header"
+                @click="addCell"
+              >
                 + Добавить клетку
               </button>
             </div>
@@ -231,9 +295,9 @@
                     <span class="cell-number-mini">Клетка №{{ index + 1 }}</span>
                     <button 
                       v-if="newFormat.cells.length > 1"
-                      @click="removeCell(index)"
                       class="remove-cell-btn-mini"
                       title="Удалить клетку"
+                      @click="removeCell(index)"
                     >
                       ×
                     </button>
@@ -242,10 +306,19 @@
                   <div class="cell-config-mini">
                     <div class="config-group-mini">
                       <label>Тип</label>
-                      <select v-model="cell.cell_type" class="select-mini">
-                        <option value="letters">Буквы</option>
-                        <option value="numbers">Цифры</option>
-                        <option value="mixed">Смешанный</option>
+                      <select
+                        v-model="cell.cell_type"
+                        class="select-mini"
+                      >
+                        <option value="letters">
+                          Буквы
+                        </option>
+                        <option value="numbers">
+                          Цифры
+                        </option>
+                        <option value="mixed">
+                          Смешанный
+                        </option>
                       </select>
                     </div>
                     
@@ -272,24 +345,49 @@
                       </div>
                     </div>
 
-                    <div v-if="cell.cell_type !== 'numbers'" class="config-group-mini">
+                    <div
+                      v-if="cell.cell_type !== 'numbers'"
+                      class="config-group-mini"
+                    >
                       <label>Алфавит</label>
-                      <select v-model="cell.alphabet_type" class="select-mini">
-                        <option value="cyrillic">Кириллица</option>
-                        <option value="latin">Латиница</option>
-                        <option value="both">Оба</option>
+                      <select
+                        v-model="cell.alphabet_type"
+                        class="select-mini"
+                      >
+                        <option value="cyrillic">
+                          Кириллица
+                        </option>
+                        <option value="latin">
+                          Латиница
+                        </option>
+                        <option value="both">
+                          Оба
+                        </option>
                       </select>
                     </div>
                     
-                    <div v-if="cell.cell_type === 'numbers'" class="config-group-mini">
+                    <div
+                      v-if="cell.cell_type === 'numbers'"
+                      class="config-group-mini"
+                    >
                       <label>Дополнение</label>
-                      <select v-model="cell.padding_side" class="select-mini">
-                        <option value="left">Слева</option>
-                        <option value="right">Справа</option>
+                      <select
+                        v-model="cell.padding_side"
+                        class="select-mini"
+                      >
+                        <option value="left">
+                          Слева
+                        </option>
+                        <option value="right">
+                          Справа
+                        </option>
                       </select>
                     </div>
 
-                    <div v-if="cell.cell_type !== 'numbers'" class="config-group-full-mini">
+                    <div
+                      v-if="cell.cell_type !== 'numbers'"
+                      class="config-group-full-mini"
+                    >
                       <label>Разрешенные буквы</label>
                       <input 
                         v-model="cell.allowed_letters"
@@ -305,18 +403,37 @@
         </div>
         
         <div class="modal-footer">
-          <button @click="showAddModal = false" class="modal-cancel">Отмена</button>
-          <button @click="addFormat" class="modal-confirm">Добавить</button>
+          <button
+            class="modal-cancel"
+            @click="showAddModal = false"
+          >
+            Отмена
+          </button>
+          <button
+            class="modal-confirm"
+            @click="addFormat"
+          >
+            Добавить
+          </button>
         </div>
       </div>
     </div>
 
     <!-- Модальное окно редактирования клетки -->
-    <div v-if="showCellEditModal" class="modal-overlay" @click.self="showCellEditModal = false">
+    <div
+      v-if="showCellEditModal"
+      class="modal-overlay"
+      @click.self="showCellEditModal = false"
+    >
       <div class="modal-content horizontal-modal cell-edit-modal">
         <div class="modal-header">
           <h3>Редактировать клетку {{ editingCellIndex + 1 }}</h3>
-          <button @click="showCellEditModal = false" class="modal-close">×</button>
+          <button
+            class="modal-close"
+            @click="showCellEditModal = false"
+          >
+            ×
+          </button>
         </div>
         
         <div class="modal-body-horizontal">
@@ -325,10 +442,19 @@
             <div class="main-fields">
               <div class="form-group-compact">
                 <label class="form-label-compact">Тип клетки</label>
-                <select v-model="editingCell.cell_type" class="select-mini">
-                  <option value="letters">Буквы</option>
-                  <option value="numbers">Цифры</option>
-                  <option value="mixed">Смешанный</option>
+                <select
+                  v-model="editingCell.cell_type"
+                  class="select-mini"
+                >
+                  <option value="letters">
+                    Буквы
+                  </option>
+                  <option value="numbers">
+                    Цифры
+                  </option>
+                  <option value="mixed">
+                    Смешанный
+                  </option>
                 </select>
               </div>
               
@@ -355,20 +481,42 @@
                 </div>
               </div>
 
-              <div v-if="editingCell.cell_type !== 'numbers'" class="form-group-compact">
+              <div
+                v-if="editingCell.cell_type !== 'numbers'"
+                class="form-group-compact"
+              >
                 <label class="form-label-compact">Алфавит</label>
-                <select v-model="editingCell.alphabet_type" class="select-mini">
-                  <option value="cyrillic">Кириллица</option>
-                  <option value="latin">Латиница</option>
-                  <option value="both">Оба</option>
+                <select
+                  v-model="editingCell.alphabet_type"
+                  class="select-mini"
+                >
+                  <option value="cyrillic">
+                    Кириллица
+                  </option>
+                  <option value="latin">
+                    Латиница
+                  </option>
+                  <option value="both">
+                    Оба
+                  </option>
                 </select>
               </div>
               
-              <div v-if="editingCell.cell_type === 'numbers'" class="form-group-compact">
+              <div
+                v-if="editingCell.cell_type === 'numbers'"
+                class="form-group-compact"
+              >
                 <label class="form-label-compact">Дополнение нулями</label>
-                <select v-model="editingCell.padding_side" class="select-mini">
-                  <option value="left">Слева</option>
-                  <option value="right">Справа</option>
+                <select
+                  v-model="editingCell.padding_side"
+                  class="select-mini"
+                >
+                  <option value="left">
+                    Слева
+                  </option>
+                  <option value="right">
+                    Справа
+                  </option>
                 </select>
               </div>
             </div>
@@ -377,12 +525,17 @@
           <!-- Правая часть - дополнительные настройки -->
           <div class="modal-cells-section">
             <div class="cells-header-compact">
-              <h4 class="cells-title-compact">Дополнительные настройки</h4>
+              <h4 class="cells-title-compact">
+                Дополнительные настройки
+              </h4>
             </div>
             
             <div class="cells-scroll-container">
               <div class="cell-edit-details">
-                <div v-if="editingCell.cell_type !== 'numbers'" class="form-group-compact">
+                <div
+                  v-if="editingCell.cell_type !== 'numbers'"
+                  class="form-group-compact"
+                >
                   <label class="form-label-compact">Разрешенные буквы</label>
                   <input 
                     v-model="editingCell.allowed_letters"
@@ -395,7 +548,9 @@
                 </div>
                 
                 <div class="cell-preview-section">
-                  <h5 class="preview-title">Предпросмотр клетки</h5>
+                  <h5 class="preview-title">
+                    Предпросмотр клетки
+                  </h5>
                   <div class="preview-content">
                     <div class="preview-example">
                       {{ getCellPreview(editingCell) }}
@@ -404,7 +559,10 @@
                       <span class="preview-length">
                         Длина: {{ editingCell.min_length }}-{{ editingCell.max_length }} символов
                       </span>
-                      <span v-if="editingCell.allowed_letters" class="preview-letters">
+                      <span
+                        v-if="editingCell.allowed_letters"
+                        class="preview-letters"
+                      >
                         Разрешённые символы: {{ editingCell.allowed_letters }}
                       </span>
                     </div>
@@ -416,8 +574,18 @@
         </div>
         
         <div class="modal-footer">
-          <button @click="showCellEditModal = false" class="modal-cancel">Отмена</button>
-          <button @click="saveCellEdit" class="modal-confirm">Сохранить</button>
+          <button
+            class="modal-cancel"
+            @click="showCellEditModal = false"
+          >
+            Отмена
+          </button>
+          <button
+            class="modal-confirm"
+            @click="saveCellEdit"
+          >
+            Сохранить
+          </button>
         </div>
       </div>
     </div>
@@ -505,6 +673,9 @@ export default {
         return 0;
       });
     }
+  },
+  mounted() {
+    this.refreshData();
   },
   methods: {
     async refreshData() {
@@ -824,9 +995,6 @@ export default {
         notification.remove();
       }, 3000);
     }
-  },
-  mounted() {
-    this.refreshData();
   },
 };
 </script>

--- a/frontend/src/components/OrganizationCompanyManagement.vue
+++ b/frontend/src/components/OrganizationCompanyManagement.vue
@@ -1,11 +1,13 @@
 <template>
   <div class="organization-management dashboard-card">
     <div class="management-header">
-      <h3 class="management-title">Управление организациями и компаниями</h3>
+      <h3 class="management-title">
+        Управление организациями и компаниями
+      </h3>
       <div class="search-container">
         <SearchComponent
-          :title="'Поиск...'"
           v-model="searchQuery"
+          :title="'Поиск...'"
         />
         <RefreshButton @refresh="refreshData" />
       </div>
@@ -15,9 +17,9 @@
       <button
         v-for="tab in tabs"
         :key="tab.id"
-        @click="activeTab = tab.id"
         :class="{ active: activeTab === tab.id }"
         class="tab-button"
+        @click="activeTab = tab.id"
       >
         {{ tab.label }}
       </button>
@@ -25,7 +27,10 @@
 
     <div class="tab-content">
       <!-- Организации -->
-      <div v-if="activeTab === 'organizations'" class="tab-pane">
+      <div
+        v-if="activeTab === 'organizations'"
+        class="tab-pane"
+      >
         <div class="add-item-section">
           <div class="add-item-form">
             <input
@@ -34,7 +39,10 @@
               class="form-input"
               @keyup.enter="addOrganization"
             >
-            <button @click="addOrganization" class="add-button">
+            <button
+              class="add-button"
+              @click="addOrganization"
+            >
               <span class="button-icon">+</span>
               Добавить
             </button>
@@ -46,9 +54,15 @@
           <div class="table-section">
             <div class="table-container">
               <div class="table-header-row">
-                <div class="table-col id-col">ID</div>
-                <div class="table-col name-col">Наименование</div>
-                <div class="table-col users-col">Кол-во пользователей</div>
+                <div class="table-col id-col">
+                  ID
+                </div>
+                <div class="table-col name-col">
+                  Наименование
+                </div>
+                <div class="table-col users-col">
+                  Кол-во пользователей
+                </div>
               </div>
 
               <div class="table-body">
@@ -63,9 +77,9 @@
                   <div class="table-col name-col">
                     <input
                       v-model="org.name"
-                      @change="updateOrganization(org)"
                       class="editable-input"
                       :class="{ 'editing': org.name !== org.originalName }"
+                      @change="updateOrganization(org)"
                     >
                   </div>
                   <div class="table-col users-col">
@@ -85,20 +99,32 @@
           <!-- Правая часть - детали (пока пустая) -->
           <div class="details-section">
             <div class="empty-details">
-              <div class="empty-icon">🏢</div>
-              <p class="empty-text">Выберите организацию для просмотра деталей</p>
+              <div class="empty-icon">
+                🏢
+              </div>
+              <p class="empty-text">
+                Выберите организацию для просмотра деталей
+              </p>
             </div>
           </div>
         </div>
 
-        <div v-if="filteredOrganizations.length === 0" class="no-results">
-          <div class="no-results-icon">🏢</div>
+        <div
+          v-if="filteredOrganizations.length === 0"
+          class="no-results"
+        >
+          <div class="no-results-icon">
+            🏢
+          </div>
           <p>Организации не найдены</p>
         </div>
       </div>
 
       <!-- Компании -->
-      <div v-if="activeTab === 'companies'" class="tab-pane">
+      <div
+        v-if="activeTab === 'companies'"
+        class="tab-pane"
+      >
         <div class="add-item-section">
           <div class="add-item-form">
             <input
@@ -107,7 +133,10 @@
               class="form-input"
               @keyup.enter="addCompany"
             >
-            <button @click="addCompany" class="add-button">
+            <button
+              class="add-button"
+              @click="addCompany"
+            >
               <span class="button-icon">+</span>
               Добавить
             </button>
@@ -119,9 +148,15 @@
           <div class="table-section">
             <div class="table-container">
               <div class="table-header-row">
-                <div class="table-col id-col">ID</div>
-                <div class="table-col name-col">Наименование</div>
-                <div class="table-col users-col">Кол-во пользователей</div>
+                <div class="table-col id-col">
+                  ID
+                </div>
+                <div class="table-col name-col">
+                  Наименование
+                </div>
+                <div class="table-col users-col">
+                  Кол-во пользователей
+                </div>
               </div>
 
               <div class="table-body">
@@ -136,9 +171,9 @@
                   <div class="table-col name-col">
                     <input
                       v-model="comp.name"
-                      @change="updateCompany(comp)"
                       class="editable-input"
                       :class="{ 'editing': comp.name !== comp.originalName }"
+                      @change="updateCompany(comp)"
                     >
                   </div>
                   <div class="table-col users-col">
@@ -158,14 +193,23 @@
           <!-- Правая часть - детали (пока пустая) -->
           <div class="details-section">
             <div class="empty-details">
-              <div class="empty-icon">🏭</div>
-              <p class="empty-text">Выберите компанию для просмотра деталей</p>
+              <div class="empty-icon">
+                🏭
+              </div>
+              <p class="empty-text">
+                Выберите компанию для просмотра деталей
+              </p>
             </div>
           </div>
         </div>
 
-        <div v-if="filteredCompanies.length === 0" class="no-results">
-          <div class="no-results-icon">🏭</div>
+        <div
+          v-if="filteredCompanies.length === 0"
+          class="no-results"
+        >
+          <div class="no-results-icon">
+            🏭
+          </div>
           <p>Компании не найдены</p>
         </div>
       </div>
@@ -214,6 +258,9 @@ export default {
         comp.id.toString().includes(query)
       );
     }
+  },
+  mounted() {
+    this.refreshData();
   },
   methods: {
     async refreshData() {
@@ -434,9 +481,6 @@ export default {
         notification.remove();
       }, 3000);
     }
-  },
-  mounted() {
-    this.refreshData();
   },
 };
 </script>

--- a/frontend/src/components/OrganizationFilter.vue
+++ b/frontend/src/components/OrganizationFilter.vue
@@ -1,60 +1,72 @@
 <template>
-    <div class="field field--select" @click="toggleDropdown">
-        <span class="select-text">{{ displayText }}</span>
-        <img 
-            src="@/assets/icons/arrow.png" 
-            class="select-icon" 
-            :class="{ 'select-icon--rotated': isOpen }" 
-        />
+  <div
+    class="field field--select"
+    @click="toggleDropdown"
+  >
+    <span class="select-text">{{ displayText }}</span>
+    <img 
+      src="@/assets/icons/arrow.png" 
+      class="select-icon" 
+      :class="{ 'select-icon--rotated': isOpen }" 
+    >
         
-        <transition name="dropdown">
-            <div 
-                class="custom-dropdown"
-                v-if="isOpen"
-                @click.stop
-            >
-                <div class="dropdown-search">
-                    <input 
-                        type="text" 
-                        placeholder="Поиск..." 
-                        v-model="searchQuery"
-                        @click.stop
-                        class="dropdown-search__input"
-                        ref="searchInput"
-                        @input="handleSearchInput"
-                    />
-                </div>
+    <transition name="dropdown">
+      <div 
+        v-if="isOpen"
+        class="custom-dropdown"
+        @click.stop
+      >
+        <div class="dropdown-search">
+          <input 
+            ref="searchInput" 
+            v-model="searchQuery" 
+            type="text"
+            placeholder="Поиск..."
+            class="dropdown-search__input"
+            @click.stop
+            @input="handleSearchInput"
+          >
+        </div>
                 
-                <div class="dropdown-list" ref="listContainer">
-                    <div 
-                        class="dropdown-item"
-                        :class="{ 'dropdown-item--selected': !internalValue }"
-                        @click="selectItem(null, 'Все организации')"
-                    >
-                        <span class="item-text" title="Все организации">Все организации</span>
-                    </div>
+        <div
+          ref="listContainer"
+          class="dropdown-list"
+        >
+          <div 
+            class="dropdown-item"
+            :class="{ 'dropdown-item--selected': !internalValue }"
+            @click="selectItem(null, 'Все организации')"
+          >
+            <span
+              class="item-text"
+              title="Все организации"
+            >Все организации</span>
+          </div>
                     
-                    <div 
-                        v-for="org in filteredOrganizations"
-                        :key="org.id"
-                        class="dropdown-item"
-                        :class="{ 'dropdown-item--selected': internalValue === org.id }"
-                        @click="selectItem(org.id, org.name)"
-                    >
-                        <span class="item-text" :title="org.name">{{ org.name }}</span>
-                    </div>
+          <div 
+            v-for="org in filteredOrganizations"
+            :key="org.id"
+            class="dropdown-item"
+            :class="{ 'dropdown-item--selected': internalValue === org.id }"
+            @click="selectItem(org.id, org.name)"
+          >
+            <span
+              class="item-text"
+              :title="org.name"
+            >{{ org.name }}</span>
+          </div>
                     
-                    <div 
-                        v-if="filteredOrganizations.length === 0" 
-                        class="dropdown-no-results"
-                        :class="{ 'with-border': searchQuery }"
-                    >
-                        Ничего не найдено
-                    </div>
-                </div>
-            </div>
-        </transition>
-    </div>
+          <div 
+            v-if="filteredOrganizations.length === 0" 
+            class="dropdown-no-results"
+            :class="{ 'with-border': searchQuery }"
+          >
+            Ничего не найдено
+          </div>
+        </div>
+      </div>
+    </transition>
+  </div>
 </template>
 
 <script>
@@ -126,6 +138,9 @@ export default {
     mounted() {
         this.updateSelectedName();
     },
+    beforeUnmount() {
+        this.removeClickOutside();
+    },
     methods: {
         toggleDropdown() {
             this.isOpen = !this.isOpen;
@@ -192,9 +207,6 @@ export default {
             this.$emit('input', null);
             this.$emit('change', { id: null, name: '' });
         }
-    },
-    beforeUnmount() {
-        this.removeClickOutside();
     }
 };
 </script>

--- a/frontend/src/components/OrganizationsManagement.vue
+++ b/frontend/src/components/OrganizationsManagement.vue
@@ -1,13 +1,18 @@
 <template>
   <div class="organizations-management dashboard-card">
     <div class="management-header">
-      <h3 class="management-title">Управление организациями / отделами</h3>
+      <h3 class="management-title">
+        Управление организациями / отделами
+      </h3>
       <div class="header-controls">
         <SearchComponent
-          :title="'Поиск организаций...'"
           v-model="searchQuery"
+          :title="'Поиск организаций...'"
         />
-        <button @click="showAddModal = true" class="add-header-button">
+        <button
+          class="add-header-button"
+          @click="showAddModal = true"
+        >
           Добавить
         </button>
         <RefreshButton @refresh="refreshData" />
@@ -19,8 +24,13 @@
       <div class="table-section">
         <div class="table-container">
           <div class="table-header">
-            <div class="header-col id-col" @click="sortBy('id')">
-              <p :class="{ 'active-sort': sortField === 'id' }">ID</p>
+            <div
+              class="header-col id-col"
+              @click="sortBy('id')"
+            >
+              <p :class="{ 'active-sort': sortField === 'id' }">
+                ID
+              </p>
               <img 
                 src="@/assets/icons/sort.png" 
                 class="sort-icon" 
@@ -28,10 +38,15 @@
                   'sorted': sortField === 'id',
                   'desc': sortField === 'id' && sortDirection === 'desc'
                 }" 
-              />
+              >
             </div>
-            <div class="header-col name-col" @click="sortBy('name')">
-              <p :class="{ 'active-sort': sortField === 'name' }">Наименование</p>
+            <div
+              class="header-col name-col"
+              @click="sortBy('name')"
+            >
+              <p :class="{ 'active-sort': sortField === 'name' }">
+                Наименование
+              </p>
               <img 
                 src="@/assets/icons/sort.png" 
                 class="sort-icon" 
@@ -39,10 +54,15 @@
                   'sorted': sortField === 'name',
                   'desc': sortField === 'name' && sortDirection === 'desc'
                 }" 
-              />
+              >
             </div>
-            <div class="header-col users-col" @click="sortBy('user_count')">
-              <p :class="{ 'active-sort': sortField === 'user_count' }">Пользователи</p>
+            <div
+              class="header-col users-col"
+              @click="sortBy('user_count')"
+            >
+              <p :class="{ 'active-sort': sortField === 'user_count' }">
+                Пользователи
+              </p>
               <img 
                 src="@/assets/icons/sort.png" 
                 class="sort-icon" 
@@ -50,7 +70,7 @@
                   'sorted': sortField === 'user_count',
                   'desc': sortField === 'user_count' && sortDirection === 'desc'
                 }" 
-              />
+              >
             </div>
           </div>
 
@@ -66,7 +86,10 @@
                 <span class="cell-content id-value">{{ org.id }}</span>
               </div>
               <div class="table-col name-col">
-                <span class="truncate-text" :title="org.name">
+                <span
+                  class="truncate-text"
+                  :title="org.name"
+                >
                   {{ org.name }}
                 </span>
               </div>
@@ -85,15 +108,26 @@
       </div>
 
       <!-- Средняя часть - детали организации -->
-      <div v-if="selectedOrganization" class="details-section">
+      <div
+        v-if="selectedOrganization"
+        class="details-section"
+      >
         <div class="details-content">
           <div class="details-header">
             <div class="details-title-wrapper">
-              <h3 class="details-title">{{ selectedOrganization.name }}</h3>
+              <h3 class="details-title">
+                {{ selectedOrganization.name }}
+              </h3>
             </div>
             <div class="details-header-actions">
-              <button @click="confirmDeleteOrganization(selectedOrganization)" class="delete-icon-btn">
-                <img src="@/assets/icons/delete.png" class="delete-icon" />
+              <button
+                class="delete-icon-btn"
+                @click="confirmDeleteOrganization(selectedOrganization)"
+              >
+                <img
+                  src="@/assets/icons/delete.png"
+                  class="delete-icon"
+                >
               </button>
             </div>
           </div>
@@ -106,10 +140,10 @@
                   <label class="detail-label">Наименование:</label>
                   <input 
                     v-model="selectedOrganization.name" 
-                    @change="updateOrganization(selectedOrganization)"
                     class="form-input-sm"
                     placeholder="Введите название организации"
                     autocomplete="off"
+                    @change="updateOrganization(selectedOrganization)"
                   >
                 </div>
               </div>
@@ -138,34 +172,67 @@
       </div>
       
       <!-- Правая часть - ответственные лица -->
-      <div class="responsible-section" :class="{'with-details': selectedOrganization}">
-        <div v-if="selectedOrganization" class="responsible-content">
+      <div
+        class="responsible-section"
+        :class="{'with-details': selectedOrganization}"
+      >
+        <div
+          v-if="selectedOrganization"
+          class="responsible-content"
+        >
           <ResponsibleUsersSection
             :entity="selectedOrganization"
             :entity-type="'organization'"
             @users-updated="handleUsersUpdated"
           />
         </div>
-        <div v-else class="no-selection-message">
+        <div
+          v-else
+          class="no-selection-message"
+        >
           <p>Выберите организацию для просмотра</p>
         </div>
       </div>
     </div>
 
-    <div v-if="filteredOrganizations.length === 0" class="no-results">
-      <div class="no-results-icon">🏢</div>
+    <div
+      v-if="filteredOrganizations.length === 0"
+      class="no-results"
+    >
+      <div class="no-results-icon">
+        🏢
+      </div>
       <p>Организации не найдены</p>
     </div>
 
     <!-- Модальное окно добавления -->
     <transition name="modal-fade">
-      <div v-if="showAddModal" class="modal-overlay" @click.self="closeModal">
+      <div
+        v-if="showAddModal"
+        class="modal-overlay"
+        @click.self="closeModal"
+      >
         <div class="modal-content">
           <div class="modal-header">
-            <h3 class="modal-title">Добавить организацию</h3>
-            <button @click="closeModal" class="modal-close">
-              <svg width="10" height="10" viewBox="0 0 14 14" fill="none">
-                <path d="M13 1L1 13M1 1L13 13" stroke="#666" stroke-width="2" stroke-linecap="round"/>
+            <h3 class="modal-title">
+              Добавить организацию
+            </h3>
+            <button
+              class="modal-close"
+              @click="closeModal"
+            >
+              <svg
+                width="10"
+                height="10"
+                viewBox="0 0 14 14"
+                fill="none"
+              >
+                <path
+                  d="M13 1L1 13M1 1L13 13"
+                  stroke="#666"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                />
               </svg>
             </button>
           </div>
@@ -174,23 +241,30 @@
             <div class="input-group">
               <label class="input-label">Название организации</label>
               <input
+                ref="nameInput"
                 v-model="newOrganizationName"
                 placeholder="Введите название организации"
                 class="modal-input"
                 @keyup.enter="addOrganization"
-                ref="nameInput"
               >
-              <div class="input-hint">Обязательное поле</div>
+              <div class="input-hint">
+                Обязательное поле
+              </div>
             </div>
           </div>
           
           <div class="modal-footer">
-            <button @click="closeModal" class="modal-btn modal-btn--cancel">Отмена</button>
+            <button
+              class="modal-btn modal-btn--cancel"
+              @click="closeModal"
+            >
+              Отмена
+            </button>
             <button 
-              @click="addOrganization" 
-              class="modal-btn modal-btn--confirm"
+              class="modal-btn modal-btn--confirm" 
               :disabled="!newOrganizationName.trim()"
               :class="{'modal-btn--disabled': !newOrganizationName.trim()}"
+              @click="addOrganization"
             >
               Создать
             </button>
@@ -201,15 +275,15 @@
 
     <!-- Модальное окно подтверждения удаления -->
     <ConfirmationModal
-    :show="showDeleteModal"
-    title="Подтверждение удаления"
-    :message="deleteMessage"
-    confirm-text="Удалить"
-    cancel-text="Отмена"
-    :confirm-button-style="{ background: '#ff4444', borderColor: '#ff4444' }"
-    @confirm="deleteOrganization"
-    @cancel="cancelDelete"
-/>
+      :show="showDeleteModal"
+      title="Подтверждение удаления"
+      :message="deleteMessage"
+      confirm-text="Удалить"
+      cancel-text="Отмена"
+      :confirm-button-style="{ background: '#ff4444', borderColor: '#ff4444' }"
+      @confirm="deleteOrganization"
+      @cancel="cancelDelete"
+    />
   </div>
 </template>
 
@@ -293,6 +367,18 @@ export default {
     deleteMessage() {
       return `Вы точно хотите удалить организацию "${this.organizationToDelete?.name}"?`;
     }
+  },
+  watch: {
+    showAddModal(newVal) {
+      if (newVal) {
+        this.$nextTick(() => {
+          this.$refs.nameInput?.focus();
+        });
+      }
+    }
+  },
+  mounted() {
+    this.refreshData();
   },
   methods: {
     async refreshData() {
@@ -478,18 +564,6 @@ export default {
       setTimeout(() => {
         notification.remove();
       }, 3000);
-    }
-  },
-  mounted() {
-    this.refreshData();
-  },
-  watch: {
-    showAddModal(newVal) {
-      if (newVal) {
-        this.$nextTick(() => {
-          this.$refs.nameInput?.focus();
-        });
-      }
     }
   }
 };

--- a/frontend/src/components/PasswordRecoveryModal.vue
+++ b/frontend/src/components/PasswordRecoveryModal.vue
@@ -6,7 +6,9 @@
     @close="$emit('close')"
   >
     <template #header>
-      <h2 class="recovery-title">Восстановление доступа</h2>
+      <h2 class="recovery-title">
+        Восстановление доступа
+      </h2>
     </template>
 
     <p class="recovery-text">
@@ -14,26 +16,57 @@
     </p>
 
     <div class="recovery-contacts">
-      <button type="button" class="recovery-contact" @click.stop="copyEmail" data-testid="recovery-copy-email">
-        <img src="@/assets/icons/email-blue.png" class="recovery-contact__icon" alt="" />
+      <button
+        type="button"
+        class="recovery-contact"
+        data-testid="recovery-copy-email"
+        @click.stop="copyEmail"
+      >
+        <img
+          src="@/assets/icons/email-blue.png"
+          class="recovery-contact__icon"
+          alt=""
+        >
         <span class="recovery-contact__text">buropropuskov@dreamisland.ru</span>
       </button>
-      <button type="button" class="recovery-contact" @click.stop="copyPhone" data-testid="recovery-copy-phone">
-        <img src="@/assets/icons/phone-blue.png" class="recovery-contact__icon" alt="" />
+      <button
+        type="button"
+        class="recovery-contact"
+        data-testid="recovery-copy-phone"
+        @click.stop="copyPhone"
+      >
+        <img
+          src="@/assets/icons/phone-blue.png"
+          class="recovery-contact__icon"
+          alt=""
+        >
         <span class="recovery-contact__text">+7 (910) 083 00-55</span>
       </button>
     </div>
 
     <div class="recovery-notifications">
-      <transition name="recovery-notification" mode="out-in">
-        <div v-if="showNotification" :key="notificationText" class="recovery-notification" data-testid="recovery-notification">
+      <transition
+        name="recovery-notification"
+        mode="out-in"
+      >
+        <div
+          v-if="showNotification"
+          :key="notificationText"
+          class="recovery-notification"
+          data-testid="recovery-notification"
+        >
           {{ notificationText }}
         </div>
       </transition>
     </div>
 
     <template #actions>
-      <button type="button" class="recovery-button" @click="$emit('close')" data-testid="recovery-close">
+      <button
+        type="button"
+        class="recovery-button"
+        data-testid="recovery-close"
+        @click="$emit('close')"
+      >
         Понятно
       </button>
     </template>
@@ -61,6 +94,12 @@ export default {
       showNotification: false,
       notificationText: '',
       notificationTimeout: null,
+    }
+  },
+
+  beforeUnmount() {
+    if (this.notificationTimeout) {
+      clearTimeout(this.notificationTimeout)
     }
   },
 
@@ -102,12 +141,6 @@ export default {
       await this.copyToClipboard('+7 (910) 083 00-55')
       this.showNotificationMessage('Номер телефона скопирован')
     },
-  },
-
-  beforeUnmount() {
-    if (this.notificationTimeout) {
-      clearTimeout(this.notificationTimeout)
-    }
   },
 }
 </script>

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -1,10 +1,18 @@
 <template>
   <div class="selected-table-card">
     <transition name="slide-down">
-      <div v-if="notification.message" class="notification">
+      <div
+        v-if="notification.message"
+        class="notification"
+      >
         <span>{{ notification.message }}</span>
-        <button @click="undoDelete">Отменить</button>
-        <div class="progress-bar" :style="{ width: `${progress}%` }"></div>
+        <button @click="undoDelete">
+          Отменить
+        </button>
+        <div
+          class="progress-bar"
+          :style="{ width: `${progress}%` }"
+        />
       </div>
     </transition>
 
@@ -17,57 +25,139 @@
       <div class="card-header__settings">
         <span class="items-count">
           Людей зашло: {{ peopleOnTerritory }}
-          <button class="history-btn" @click="openEmployeesHistory">История</button>
+          <button
+            class="history-btn"
+            @click="openEmployeesHistory"
+          >История</button>
         </span>
-        <RefreshButton @refresh="loadData" :disabled="isLoading" />
+        <RefreshButton
+          :disabled="isLoading"
+          @refresh="loadData"
+        />
       </div>
     </div>
     
     <div class="card-content">
       <div class="items-header">
         <div class="header-row">
-          <div class="col entry-col">Вход</div>
-          <div class="col exit-col">Выход</div>
-          <div class="col last-name-col" @click="sortBy('last_name')">
-            <p :class="{ 'active-sort': sortField === 'last_name' }">Фамилия</p>
-            <img src="@/assets/icons/sort.png" class="sort-icon" :class="{ 'sorted': sortField === 'last_name', 'desc': sortField === 'last_name' && sortDirection === 'desc' }" />
+          <div class="col entry-col">
+            Вход
           </div>
-          <div class="col first-name-col" @click="sortBy('first_name')">
-            <p :class="{ 'active-sort': sortField === 'first_name' }">Имя</p>
-            <img src="@/assets/icons/sort.png" class="sort-icon" :class="{ 'sorted': sortField === 'first_name', 'desc': sortField === 'first_name' && sortDirection === 'desc' }" />
+          <div class="col exit-col">
+            Выход
           </div>
-          <div class="col middle-name-col" @click="sortBy('middle_name')">
-            <p :class="{ 'active-sort': sortField === 'middle_name' }">Отчество</p>
-            <img src="@/assets/icons/sort.png" class="sort-icon" :class="{ 'sorted': sortField === 'middle_name', 'desc': sortField === 'middle_name' && sortDirection === 'desc' }" />
+          <div
+            class="col last-name-col"
+            @click="sortBy('last_name')"
+          >
+            <p :class="{ 'active-sort': sortField === 'last_name' }">
+              Фамилия
+            </p>
+            <img
+              src="@/assets/icons/sort.png"
+              class="sort-icon"
+              :class="{ 'sorted': sortField === 'last_name', 'desc': sortField === 'last_name' && sortDirection === 'desc' }"
+            >
           </div>
-          <div class="col organization-col" @click="sortBy('organization')">
-            <p :class="{ 'active-sort': sortField === 'organization' }">Организация</p>
-            <img src="@/assets/icons/sort.png" class="sort-icon" :class="{ 'sorted': sortField === 'organization', 'desc': sortField === 'organization' && sortDirection === 'desc' }" />
+          <div
+            class="col first-name-col"
+            @click="sortBy('first_name')"
+          >
+            <p :class="{ 'active-sort': sortField === 'first_name' }">
+              Имя
+            </p>
+            <img
+              src="@/assets/icons/sort.png"
+              class="sort-icon"
+              :class="{ 'sorted': sortField === 'first_name', 'desc': sortField === 'first_name' && sortDirection === 'desc' }"
+            >
           </div>
-          <div class="col date-col" @click="sortBy('entry_date_to')">
-            <p :class="{ 'active-sort': sortField === 'entry_date_to' }">Действует до</p>
-            <img src="@/assets/icons/sort.png" class="sort-icon" :class="{ 'sorted': sortField === 'entry_date_to', 'desc': sortField === 'entry_date_to' && sortDirection === 'desc' }" />
+          <div
+            class="col middle-name-col"
+            @click="sortBy('middle_name')"
+          >
+            <p :class="{ 'active-sort': sortField === 'middle_name' }">
+              Отчество
+            </p>
+            <img
+              src="@/assets/icons/sort.png"
+              class="sort-icon"
+              :class="{ 'sorted': sortField === 'middle_name', 'desc': sortField === 'middle_name' && sortDirection === 'desc' }"
+            >
           </div>
-          <div class="col time-col" @click="sortBy('pass_time')">
-            <p :class="{ 'active-sort': sortField === 'pass_time' }">Время прохода</p>
-            <img src="@/assets/icons/sort.png" class="sort-icon" :class="{ 'sorted': sortField === 'pass_time', 'desc': sortField === 'pass_time' && sortDirection === 'desc' }" />
+          <div
+            class="col organization-col"
+            @click="sortBy('organization')"
+          >
+            <p :class="{ 'active-sort': sortField === 'organization' }">
+              Организация
+            </p>
+            <img
+              src="@/assets/icons/sort.png"
+              class="sort-icon"
+              :class="{ 'sorted': sortField === 'organization', 'desc': sortField === 'organization' && sortDirection === 'desc' }"
+            >
           </div>
-          <div class="col status-col" @click="sortBy('status')">
-            <p :class="{ 'active-sort': sortField === 'status' }">Статус</p>
-            <img src="@/assets/icons/sort.png" class="sort-icon" :class="{ 'sorted': sortField === 'status', 'desc': sortField === 'status' && sortDirection === 'desc' }" />
+          <div
+            class="col date-col"
+            @click="sortBy('entry_date_to')"
+          >
+            <p :class="{ 'active-sort': sortField === 'entry_date_to' }">
+              Действует до
+            </p>
+            <img
+              src="@/assets/icons/sort.png"
+              class="sort-icon"
+              :class="{ 'sorted': sortField === 'entry_date_to', 'desc': sortField === 'entry_date_to' && sortDirection === 'desc' }"
+            >
           </div>
-          <div class="col actions-col"></div>
+          <div
+            class="col time-col"
+            @click="sortBy('pass_time')"
+          >
+            <p :class="{ 'active-sort': sortField === 'pass_time' }">
+              Время прохода
+            </p>
+            <img
+              src="@/assets/icons/sort.png"
+              class="sort-icon"
+              :class="{ 'sorted': sortField === 'pass_time', 'desc': sortField === 'pass_time' && sortDirection === 'desc' }"
+            >
+          </div>
+          <div
+            class="col status-col"
+            @click="sortBy('status')"
+          >
+            <p :class="{ 'active-sort': sortField === 'status' }">
+              Статус
+            </p>
+            <img
+              src="@/assets/icons/sort.png"
+              class="sort-icon"
+              :class="{ 'sorted': sortField === 'status', 'desc': sortField === 'status' && sortDirection === 'desc' }"
+            >
+          </div>
+          <div class="col actions-col" />
         </div>
       </div>
       
       <div class="items-container">
-        <div v-if="isLoading" class="loading-message">
-          <div class="loader"></div>
+        <div
+          v-if="isLoading"
+          class="loading-message"
+        >
+          <div class="loader" />
           <p>Загрузка сотрудников...</p>
         </div>
         
-        <div v-else-if="displayItems.length > 0" class="items-body">
-          <transition-group name="fade-list" tag="div">
+        <div
+          v-else-if="displayItems.length > 0"
+          class="items-body"
+        >
+          <transition-group
+            name="fade-list"
+            tag="div"
+          >
             <div 
               v-for="(item, index) in displayItems" 
               :key="item.id" 
@@ -76,7 +166,10 @@
               @click="openEmployeeDetails(item)"
             >
               <div class="item-data">
-                <div class="col entry-col" @click.stop>
+                <div
+                  class="col entry-col"
+                  @click.stop
+                >
                   <button 
                     class="action-btn entry-btn" 
                     :class="{ 'active': item.entry_checked }"
@@ -86,7 +179,10 @@
                     Вход
                   </button>
                 </div>
-                <div class="col exit-col" @click.stop>
+                <div
+                  class="col exit-col"
+                  @click.stop
+                >
                   <button 
                     class="action-btn exit-btn" 
                     :class="{ 'active': item.exit_checked }"
@@ -96,18 +192,41 @@
                     Выход
                   </button>
                 </div>
-                <div class="col last-name-col">{{ item.last_name }}</div>
-                <div class="col first-name-col">{{ item.first_name }}</div>
-                <div class="col middle-name-col">{{ item.middle_name || '-' }}</div>
-                <div class="col organization-col">{{ item.organization_name }}</div>
-                <div class="col date-col">{{ formatDate(item.entry_date_to) }}</div>
-                <div class="col time-col">{{ formatPassTime(item.pass_time) }}</div>
+                <div class="col last-name-col">
+                  {{ item.last_name }}
+                </div>
+                <div class="col first-name-col">
+                  {{ item.first_name }}
+                </div>
+                <div class="col middle-name-col">
+                  {{ item.middle_name || '-' }}
+                </div>
+                <div class="col organization-col">
+                  {{ item.organization_name }}
+                </div>
+                <div class="col date-col">
+                  {{ formatDate(item.entry_date_to) }}
+                </div>
+                <div class="col time-col">
+                  {{ formatPassTime(item.pass_time) }}
+                </div>
                 <div class="col status-col">
                   <span class="status-text">{{ item.status }}</span>
                 </div>
-                <div class="col actions-col" @click.stop>
-                  <button @click="removeItemWithNotification(item)" class="delete-btn" :disabled="isLoading">
-                    <img src="@/assets/icons/trashcan.png" alt="Удалить" class="delete-icon" />
+                <div
+                  class="col actions-col"
+                  @click.stop
+                >
+                  <button
+                    class="delete-btn"
+                    :disabled="isLoading"
+                    @click="removeItemWithNotification(item)"
+                  >
+                    <img
+                      src="@/assets/icons/trashcan.png"
+                      alt="Удалить"
+                      class="delete-icon"
+                    >
                   </button>
                 </div>
               </div>
@@ -115,7 +234,10 @@
           </transition-group>
         </div>
         
-        <div v-else class="no-data-message">
+        <div
+          v-else
+          class="no-data-message"
+        >
           {{ hasActiveFilters ? 'Нет данных по выбранным фильтрам' : 'Нет активных сотрудников' }}
         </div>
       </div>
@@ -134,13 +256,13 @@
       @open-application="openApplicationDetail"
     />
 
-   <EmployeesTableHistoryModal
-    v-if="showEmployeesHistory"
-    :table-id="currentTableId"
-    :current-user-id="currentUserId"
-    :current-user-name="currentUserName"
-    @close="showEmployeesHistory = false"
-   />
+    <EmployeesTableHistoryModal
+      v-if="showEmployeesHistory"
+      :table-id="currentTableId"
+      :current-user-id="currentUserId"
+      :current-user-name="currentUserName"
+      @close="showEmployeesHistory = false"
+    />
   </div>
 </template>
 
@@ -300,6 +422,22 @@ export default {
         (this.dateRangeStart && this.dateRangeEnd)
       );
     }
+  },
+  watch: {
+    tableName: {
+      handler() {
+        this.stopPolling();
+        this.startPolling();
+      },
+      immediate: true
+    }
+  },
+  mounted() {
+    this.startPolling();
+  },
+  beforeUnmount() {
+    this.stopPolling();
+    if (this.progressInterval) clearInterval(this.progressInterval);
   },
   methods: {
     async _loadData(silent = false) {
@@ -600,22 +738,6 @@ export default {
         this.pollingInterval = null;
       }
     }
-  },
-  mounted() {
-    this.startPolling();
-  },
-  watch: {
-    tableName: {
-      handler() {
-        this.stopPolling();
-        this.startPolling();
-      },
-      immediate: true
-    }
-  },
-  beforeUnmount() {
-    this.stopPolling();
-    if (this.progressInterval) clearInterval(this.progressInterval);
   }
 };
 </script>

--- a/frontend/src/components/PermissionTree.vue
+++ b/frontend/src/components/PermissionTree.vue
@@ -1,37 +1,64 @@
 <template>
   <div class="permission-tree">
-    <div v-for="group in groupedTree" :key="group.category" class="permission-group">
-      <div class="group-header" @click="toggleGroup(group.category)">
+    <div
+      v-for="group in groupedTree"
+      :key="group.category"
+      class="permission-group"
+    >
+      <div
+        class="group-header"
+        @click="toggleGroup(group.category)"
+      >
         <span class="group-toggle">{{ expandedGroups[group.category] ? '▼' : '▶' }}</span>
         <span class="group-name">{{ group.category }}</span>
       </div>
 
-      <div v-if="expandedGroups[group.category]" class="group-items">
-        <div v-for="node in group.items" :key="node.key" class="permission-item">
+      <div
+        v-if="expandedGroups[group.category]"
+        class="group-items"
+      >
+        <div
+          v-for="node in group.items"
+          :key="node.key"
+          class="permission-item"
+        >
           <label class="permission-label">
             <input
               type="checkbox"
               :checked="selected[node.key] === 'allow'"
               :disabled="readonly"
               @change="onToggle(node)"
-            />
+            >
             <span class="permission-name">{{ node.display_name }}</span>
-            <span v-if="node.granted_by_name" class="granted-by">
+            <span
+              v-if="node.granted_by_name"
+              class="granted-by"
+            >
               ({{ node.granted_by_name }})
             </span>
           </label>
 
-          <div v-if="node.children && node.children.length" class="permission-children">
-            <div v-for="child in node.children" :key="child.key" class="permission-item child">
+          <div
+            v-if="node.children && node.children.length"
+            class="permission-children"
+          >
+            <div
+              v-for="child in node.children"
+              :key="child.key"
+              class="permission-item child"
+            >
               <label class="permission-label">
                 <input
                   type="checkbox"
                   :checked="selected[child.key] === 'allow'"
                   :disabled="readonly"
                   @change="onToggle(child)"
-                />
+                >
                 <span class="permission-name">{{ child.display_name }}</span>
-                <span v-if="child.granted_by_name" class="granted-by">
+                <span
+                  v-if="child.granted_by_name"
+                  class="granted-by"
+                >
                   ({{ child.granted_by_name }})
                 </span>
               </label>
@@ -41,7 +68,12 @@
       </div>
     </div>
 
-    <p v-if="!tree || tree.length === 0" class="empty-message">Нет доступных разрешений</p>
+    <p
+      v-if="!tree || tree.length === 0"
+      class="empty-message"
+    >
+      Нет доступных разрешений
+    </p>
   </div>
 </template>
 

--- a/frontend/src/components/RealTimeChart.vue
+++ b/frontend/src/components/RealTimeChart.vue
@@ -1,7 +1,13 @@
 <template>
-  <div class="realtime-chart" :style="{ height: height + 'px' }">
-    <canvas ref="canvas"></canvas>
-    <div v-if="!data.length" class="chart-empty">
+  <div
+    class="realtime-chart"
+    :style="{ height: height + 'px' }"
+  >
+    <canvas ref="canvas" />
+    <div
+      v-if="!data.length"
+      class="chart-empty"
+    >
       <span>Нет данных для отображения</span>
     </div>
   </div>

--- a/frontend/src/components/RefreshButton.vue
+++ b/frontend/src/components/RefreshButton.vue
@@ -1,8 +1,16 @@
 <template>
-    <button @click="handleRefresh" class="refresh-btn">
-        <img src="@/assets/icons/refresh.png" class="refresh-btn__icon" />
-        <p class="refresh-btn__text">Обновить</p>
-    </button>
+  <button
+    class="refresh-btn"
+    @click="handleRefresh"
+  >
+    <img
+      src="@/assets/icons/refresh.png"
+      class="refresh-btn__icon"
+    >
+    <p class="refresh-btn__text">
+      Обновить
+    </p>
+  </button>
 </template>
 <script>
 export default {

--- a/frontend/src/components/ResponsibleUsersSection.vue
+++ b/frontend/src/components/ResponsibleUsersSection.vue
@@ -5,20 +5,26 @@
         <div class="header-content">
           <div class="title-with-count">
             <label class="detail-label">Ответственные:</label>
-            <span v-if="selectedUsers.length > 0" class="count-badge">{{ selectedUsers.length }}</span>
+            <span
+              v-if="selectedUsers.length > 0"
+              class="count-badge"
+            >{{ selectedUsers.length }}</span>
           </div>
-          <div v-if="hasSelectedUsers" class="users-actions">
+          <div
+            v-if="hasSelectedUsers"
+            class="users-actions"
+          >
             <button 
-              @click="saveResponsibleUsers" 
-              class="save-users-btn"
+              class="save-users-btn" 
               :disabled="isSavingUsers"
+              @click="saveResponsibleUsers"
             >
               {{ isSavingUsers ? 'Сохранение...' : 'Сохранить' }}
             </button>
             <button 
-              @click="cancelResponsibleUsersChanges" 
-              class="cancel-users-btn"
+              class="cancel-users-btn" 
               :disabled="isSavingUsers"
+              @click="cancelResponsibleUsersChanges"
             >
               Отмена
             </button>
@@ -31,14 +37,17 @@
         <div class="user-search-container">
           <input
             v-model="userSearchQuery"
-            @focus="showUserDropdown = true"
-            @blur="onUserSearchBlur"
-            @input="handleSearchInput"
             class="user-search-input"
             placeholder="Добавить ответственного"
             type="text"
-          />
-          <div v-if="showUserDropdown && sortedAvailableUsers.length > 0" class="user-dropdown">
+            @focus="showUserDropdown = true"
+            @blur="onUserSearchBlur"
+            @input="handleSearchInput"
+          >
+          <div
+            v-if="showUserDropdown && sortedAvailableUsers.length > 0"
+            class="user-dropdown"
+          >
             <div class="user-dropdown-content">
               <div 
                 v-for="user in sortedAvailableUsers" 
@@ -52,15 +61,27 @@
                     <span class="user-username">@{{ user.username }}</span>
                   </div>
                   <div class="user-details">
-                    <span v-if="user.position" class="user-tag position-tag">{{ user.position }}</span>
-                    <span v-if="user.organization" class="user-tag org-tag">{{ user.organization }}</span>
-                    <span v-if="user.company" class="user-tag company-tag">{{ user.company }}</span>
+                    <span
+                      v-if="user.position"
+                      class="user-tag position-tag"
+                    >{{ user.position }}</span>
+                    <span
+                      v-if="user.organization"
+                      class="user-tag org-tag"
+                    >{{ user.organization }}</span>
+                    <span
+                      v-if="user.company"
+                      class="user-tag company-tag"
+                    >{{ user.company }}</span>
                   </div>
                 </div>
               </div>
             </div>
           </div>
-          <div v-if="showUserDropdown && userSearchQuery && sortedAvailableUsers.length === 0" class="user-dropdown">
+          <div
+            v-if="showUserDropdown && userSearchQuery && sortedAvailableUsers.length === 0"
+            class="user-dropdown"
+          >
             <div class="no-users-dropdown">
               Пользователи не найдены
             </div>
@@ -68,7 +89,10 @@
         </div>
 
         <!-- Список ответственных -->
-        <div v-if="selectedUsers.length > 0" class="users-list-section">
+        <div
+          v-if="selectedUsers.length > 0"
+          class="users-list-section"
+        >
           <div class="selected-users-list">
             <div 
               v-for="user in sortedUsers" 
@@ -78,22 +102,31 @@
             >
               <div class="selected-user-info">
                 <div class="selected-user-main">
-                    <span class="selected-user-name">{{ getUserDisplayName(user) }}</span>
+                  <span class="selected-user-name">{{ getUserDisplayName(user) }}</span>
                   <span class="selected-user-username">@{{ user.username }}</span>
                 </div>
                 <div class="selected-user-details">
-                  <span v-if="user.position" class="user-tag position-tag">{{ user.position }}</span>
-                  <span v-if="user.organization" class="user-tag org-tag">{{ user.organization }}</span>
-                  <span v-if="user.company" class="user-tag company-tag">{{ user.company }}</span>
+                  <span
+                    v-if="user.position"
+                    class="user-tag position-tag"
+                  >{{ user.position }}</span>
+                  <span
+                    v-if="user.organization"
+                    class="user-tag org-tag"
+                  >{{ user.organization }}</span>
+                  <span
+                    v-if="user.company"
+                    class="user-tag company-tag"
+                  >{{ user.company }}</span>
                 </div>
                 <div class="user-settings">
                   <label class="toggle-switch">
                     <input 
-                      type="checkbox" 
-                      v-model="user.required_approval"
+                      v-model="user.required_approval" 
+                      type="checkbox"
                       @change="updateUserRequiredApproval(user)"
-                    />
-                    <span class="toggle-slider"></span>
+                    >
+                    <span class="toggle-slider" />
                   </label>
                   <span class="toggle-label-text">Обязательное согласование</span>
                 </div>
@@ -101,24 +134,24 @@
               <div class="selected-user-actions">
                 <button 
                   v-if="!user.is_primary"
-                  @click="setAsPrimary(user)"
                   class="primary-btn"
                   title="Сделать главным"
+                  @click="setAsPrimary(user)"
                 >
                   ↑
                 </button>
                 <button 
                   v-if="user.is_primary"
-                  @click="removePrimaryUser(user)"
                   class="unprimary-btn"
                   title="Убрать главного"
+                  @click="removePrimaryUser(user)"
                 >
                   ↓
                 </button>
                 <button 
-                  @click="removeResponsibleUser(user)"
                   class="remove-btn"
                   title="Удалить"
+                  @click="removeResponsibleUser(user)"
                 >
                   ×
                 </button>
@@ -127,7 +160,10 @@
           </div>
         </div>
 
-        <div v-if="selectedUsers.length === 0" class="no-selected-users">
+        <div
+          v-if="selectedUsers.length === 0"
+          class="no-selected-users"
+        >
           <p>Нет ответственных</p>
         </div>
       </div>
@@ -227,6 +263,13 @@ export default {
           this.fetchEntityUsers(newEntity.id);
         }
       }
+    }
+  },
+  async mounted() {
+    await this.fetchAllUsers();
+    
+    if (this.entity && this.entity.id) {
+      await this.fetchEntityUsers(this.entity.id);
     }
   },
   methods: {
@@ -441,13 +484,6 @@ export default {
       setTimeout(() => {
         notification.remove();
       }, 3000);
-    }
-  },
-  async mounted() {
-    await this.fetchAllUsers();
-    
-    if (this.entity && this.entity.id) {
-      await this.fetchEntityUsers(this.entity.id);
     }
   },
 };

--- a/frontend/src/components/ScrollTopButton.vue
+++ b/frontend/src/components/ScrollTopButton.vue
@@ -3,8 +3,8 @@
     <button
       v-show="visible"
       class="scroll-top-btn"
-      @click="scrollToTop"
       aria-label="Наверх"
+      @click="scrollToTop"
     >
       <svg
         width="20"
@@ -32,6 +32,15 @@ export default {
     }
   },
 
+  mounted() {
+    this._scrollHandler = this.handleScroll.bind(this)
+    window.addEventListener('scroll', this._scrollHandler, { passive: true })
+  },
+
+  beforeUnmount() {
+    window.removeEventListener('scroll', this._scrollHandler)
+  },
+
   methods: {
     handleScroll() {
       this.visible = window.scrollY > 150
@@ -40,15 +49,6 @@ export default {
     scrollToTop() {
       window.scrollTo({ top: 0, behavior: 'smooth' })
     },
-  },
-
-  mounted() {
-    this._scrollHandler = this.handleScroll.bind(this)
-    window.addEventListener('scroll', this._scrollHandler, { passive: true })
-  },
-
-  beforeUnmount() {
-    window.removeEventListener('scroll', this._scrollHandler)
   },
 }
 </script>

--- a/frontend/src/components/SearchComponent.vue
+++ b/frontend/src/components/SearchComponent.vue
@@ -1,14 +1,17 @@
 <template>
-    <div class="search">
-        <input 
-            type="text" 
-            :placeholder="title" 
-            class="search__input"
-            :value="modelValue"
-            @input="handleInput"
-        />
-        <img src="@/assets/icons/search.png" class="search__icon" />
-    </div>
+  <div class="search">
+    <input 
+      type="text" 
+      :placeholder="title" 
+      class="search__input"
+      :value="modelValue"
+      @input="handleInput"
+    >
+    <img
+      src="@/assets/icons/search.png"
+      class="search__icon"
+    >
+  </div>
 </template>
 
 <script>

--- a/frontend/src/components/SelectTables.vue
+++ b/frontend/src/components/SelectTables.vue
@@ -3,18 +3,21 @@
     <div class="detail-group">
       <div class="select-tables__header">
         <label class="detail-label">Целевые таблицы (по умолчанию):</label>
-        <div v-if="hasSelectedTables" class="tables-actions">
+        <div
+          v-if="hasSelectedTables"
+          class="tables-actions"
+        >
           <button 
-            @click="saveOrganizationTables" 
-            class="save-tables-btn"
+            class="save-tables-btn" 
             :disabled="isSaving"
+            @click="saveOrganizationTables"
           >
             {{ isSaving ? 'Сохранение...' : 'Сохранить' }}
           </button>
           <button 
-            @click="cancelTablesChanges" 
-            class="cancel-tables-btn"
+            class="cancel-tables-btn" 
             :disabled="isSaving"
+            @click="cancelTablesChanges"
           >
             Отмена
           </button>
@@ -36,7 +39,10 @@
           </div>
         </div>
 
-        <div v-if="filteredTables.length === 0" class="no-tables-message">
+        <div
+          v-if="filteredTables.length === 0"
+          class="no-tables-message"
+        >
           <p>Нет доступных таблиц для людей</p>
         </div>
       </div>
@@ -89,6 +95,13 @@ export default {
           this.fetchEntityTables(newEntity.id);
         }
       }
+    }
+  },
+  async mounted() {
+    await this.fetchAllTables();
+    
+    if (this.entity && this.entity.id) {
+      await this.fetchEntityTables(this.entity.id);
     }
   },
   methods: {
@@ -266,13 +279,6 @@ export default {
       setTimeout(() => {
         notification.remove();
       }, 3000);
-    }
-  },
-  async mounted() {
-    await this.fetchAllTables();
-    
-    if (this.entity && this.entity.id) {
-      await this.fetchEntityTables(this.entity.id);
     }
   },
 };

--- a/frontend/src/components/SelectUnloadPlaces.vue
+++ b/frontend/src/components/SelectUnloadPlaces.vue
@@ -3,18 +3,21 @@
     <div class="detail-group">
       <div class="unload-places__header">
         <label class="detail-label">Места разгрузки (по умолчанию):</label>
-        <div v-if="hasSelectedPlaces" class="places-actions">
+        <div
+          v-if="hasSelectedPlaces"
+          class="places-actions"
+        >
           <button 
-            @click="saveUnloadPlaces" 
-            class="save-places-btn"
+            class="save-places-btn" 
             :disabled="isSaving"
+            @click="saveUnloadPlaces"
           >
             {{ isSaving ? 'Сохранение...' : 'Сохранить' }}
           </button>
           <button 
-            @click="cancelUnloadPlacesChanges" 
-            class="cancel-places-btn"
+            class="cancel-places-btn" 
             :disabled="isSaving"
+            @click="cancelUnloadPlacesChanges"
           >
             Отмена
           </button>
@@ -37,7 +40,10 @@
           </div>
         </div>
 
-        <div v-if="allUnloadPlaces.length === 0" class="no-places-message">
+        <div
+          v-if="allUnloadPlaces.length === 0"
+          class="no-places-message"
+        >
           <p>Нет доступных мест разгрузки</p>
         </div>
       </div>
@@ -82,6 +88,13 @@ export default {
           this.fetchEntityUnloadPlaces(newEntity.id);
         }
       }
+    }
+  },
+  async mounted() {
+    await this.fetchAllUnloadPlaces();
+    
+    if (this.entity && this.entity.id) {
+      await this.fetchEntityUnloadPlaces(this.entity.id);
     }
   },
   methods: {
@@ -198,13 +211,6 @@ export default {
       setTimeout(() => {
         notification.remove();
       }, 3000);
-    }
-  },
-  async mounted() {
-    await this.fetchAllUnloadPlaces();
-    
-    if (this.entity && this.entity.id) {
-      await this.fetchEntityUnloadPlaces(this.entity.id);
     }
   },
 };

--- a/frontend/src/components/SessionExpiredModal.vue
+++ b/frontend/src/components/SessionExpiredModal.vue
@@ -1,16 +1,26 @@
 <template>
-  <div class="modal-overlay" @click.self="handleOverlayClick">
+  <div
+    class="modal-overlay"
+    @click.self="handleOverlayClick"
+  >
     <div class="session-expired-modal">
       <div class="modal-header">
-        <h2 class="modal-title">Ваш сеанс скоро закончится</h2>
+        <h2 class="modal-title">
+          Ваш сеанс скоро закончится
+        </h2>
       </div>
       
       <div class="modal-body">
-        <div class="time-remaining">{{ formattedTime }}</div>
+        <div class="time-remaining">
+          {{ formattedTime }}
+        </div>
         
         <div class="countdown">
           <div class="countdown-bar">
-            <div class="countdown-progress" :style="progressStyle"></div>
+            <div
+              class="countdown-progress"
+              :style="progressStyle"
+            />
           </div>
         </div>
         
@@ -20,10 +30,16 @@
       </div>
       
       <div class="modal-footer">
-        <button class="btn btn-secondary" @click="logout">
+        <button
+          class="btn btn-secondary"
+          @click="logout"
+        >
           Выйти
         </button>
-        <button class="btn btn-primary" @click="extendSession">
+        <button
+          class="btn btn-primary"
+          @click="extendSession"
+        >
           Продлить сеанс
         </button>
       </div>

--- a/frontend/src/components/SubmitForm.vue
+++ b/frontend/src/components/SubmitForm.vue
@@ -4,27 +4,48 @@
     <form @submit.prevent="submitApplication">
       <div class="form-group">
         <label>Организация:</label>
-        <input type="text" v-model="formData.organization" required disabled />
+        <input
+          v-model="formData.organization"
+          type="text"
+          required
+          disabled
+        >
       </div>
 
       <div class="form-group">
         <label>Ответственное лицо:</label>
-        <input type="text" v-model="formData.responsible_person" required />
+        <input
+          v-model="formData.responsible_person"
+          type="text"
+          required
+        >
       </div>
 
       <div class="form-group">
         <label>Контактный телефон:</label>
-        <input type="tel" v-model="formData.contact_phone" required />
+        <input
+          v-model="formData.contact_phone"
+          type="tel"
+          required
+        >
       </div>
 
       <div class="form-group">
         <label>Дата въезда:</label>
-        <input type="date" v-model="formData.entry_date" required />
+        <input
+          v-model="formData.entry_date"
+          type="date"
+          required
+        >
       </div>
 
       <div class="form-group">
         <label>Время пребывания:</label>
-        <input type="time" v-model="formData.entry_time" required />
+        <input
+          v-model="formData.entry_time"
+          type="time"
+          required
+        >
       </div>
 
       <div class="form-group">
@@ -32,36 +53,36 @@
         <div class="car-boxes">
           <input 
             v-model="carNumber.part1" 
-            @input="formatPart1" 
             maxlength="1" 
             placeholder="X" 
             :required="isCarNumberRequired" 
             pattern="[А-ЯA-Za-z]" 
-          />
+            @input="formatPart1" 
+          >
           <input 
             v-model="carNumber.part2" 
-            @input="formatPart2" 
             maxlength="3" 
             placeholder="123" 
             :required="isCarNumberRequired" 
             pattern="[0-9]{3}" 
-          />
+            @input="formatPart2" 
+          >
           <input 
             v-model="carNumber.part3" 
-            @input="formatPart3" 
             maxlength="2" 
             placeholder="AB" 
             :required="isCarNumberRequired" 
             pattern="[А-ЯA-Za-z]{2}" 
-          />
+            @input="formatPart3" 
+          >
           <input 
             v-model="carNumber.part4" 
-            @input="formatPart4" 
             maxlength="3" 
             placeholder="123" 
             :required="isCarNumberRequired" 
             pattern="[0-9]{3}" 
-          />
+            @input="formatPart4" 
+          >
         </div>
       </div>
 
@@ -72,15 +93,20 @@
           :options="carBrands" 
           :filterable="true"
           placeholder="Выберите или введите марку"
-          @search="filterBrands"
           :required="isCarNumberRequired"
+          @search="filterBrands"
         />
       </div>
 
       <div class="form-group">
         <label>Место разгрузки:</label>
         <select v-model="unloadPlace">
-          <option value="" disabled>Выберите место разгрузки</option>
+          <option
+            value=""
+            disabled
+          >
+            Выберите место разгрузки
+          </option>
           <option>1 дебаркадер</option>
           <option>2 дебаркадер</option>
           <option>3 дебаркадер</option>
@@ -91,19 +117,29 @@
         </select>
       </div>
 
-      <button @click.prevent="addCar">Добавить автомобиль</button>
+      <button @click.prevent="addCar">
+        Добавить автомобиль
+      </button>
     </form>
 
     <div class="car-list">
       <h3>Добавленные автомобили</h3>
       <ul>
-        <li v-for="(car, index) in formData.cars" :key="index">
+        <li
+          v-for="(car, index) in formData.cars"
+          :key="index"
+        >
           {{ car.car_number }} | {{ car.car_brand }} | {{ car.unload_place }}
         </li>
       </ul>
     </div>
 
-    <button @click.prevent="submitApplication" :disabled="formData.cars.length === 0">Отправить заявку</button>
+    <button
+      :disabled="formData.cars.length === 0"
+      @click.prevent="submitApplication"
+    >
+      Отправить заявку
+    </button>
   </div>
 </template>
 
@@ -144,6 +180,9 @@ export default {
     fullCarNumber() {
       return `${this.carNumber.part1} ${this.carNumber.part2} ${this.carNumber.part3} ${this.carNumber.part4}`;
     }
+  },
+  async mounted() {
+    await this.fetchOrganization();
   },
   methods: {
     formatPart1() {
@@ -279,9 +318,6 @@ export default {
       };
       this.resetCarForm();
     }
-  },
-  async mounted() {
-    await this.fetchOrganization();
   }
 };
 </script>

--- a/frontend/src/components/SystemTableScheduleTab.vue
+++ b/frontend/src/components/SystemTableScheduleTab.vue
@@ -1,14 +1,24 @@
 <template>
   <div class="schedule-tab">
     <div class="schedule-header">
-      <h4 class="schedule-title">Рабочее время</h4>
-      <button @click="openAddModal" class="add-btn" :disabled="isLoading">
+      <h4 class="schedule-title">
+        Рабочее время
+      </h4>
+      <button
+        class="add-btn"
+        :disabled="isLoading"
+        @click="openAddModal"
+      >
         + Добавить окно
       </button>
     </div>
 
     <div class="days-list">
-      <div v-for="day in 7" :key="day" class="day-group">
+      <div
+        v-for="day in 7"
+        :key="day"
+        class="day-group"
+      >
         <div class="day-header">
           <span class="day-name">{{ getFullDayName(day - 1) }}</span>
           <div class="round-control">
@@ -17,20 +27,26 @@
               <input
                 type="checkbox"
                 :checked="hasRoundTheClock(day - 1)"
-                @change="toggleRoundTheClock(day - 1, $event)"
                 :disabled="isLoading"
-              />
-              <span class="switch-slider"></span>
+                @change="toggleRoundTheClock(day - 1, $event)"
+              >
+              <span class="switch-slider" />
             </label>
           </div>
         </div>
 
         <div class="day-content">
-          <div v-if="hasActiveRoundTheClock(day - 1)" class="round-badge">
+          <div
+            v-if="hasActiveRoundTheClock(day - 1)"
+            class="round-badge"
+          >
             Круглосуточно (24/7)
           </div>
 
-          <div v-else class="slots-wrapper">
+          <div
+            v-else
+            class="slots-wrapper"
+          >
             <div
               v-for="slot in getActiveSlotsForDay(day - 1)"
               :key="slot.id"
@@ -38,19 +54,39 @@
             >
               <span class="slot-time">
                 {{ formatTime(slot.open_time) }} – {{ formatTime(slot.close_time) }}
-                <span v-if="slot.is_next_day" class="next-mark">(след. день)</span>
+                <span
+                  v-if="slot.is_next_day"
+                  class="next-mark"
+                >(след. день)</span>
               </span>
               <div class="slot-actions">
-                <button @click="editSlot(slot)" class="icon-btn" title="Редактировать">
-                  <img src="@/assets/icons/edit.png" class="icon" />
+                <button
+                  class="icon-btn"
+                  title="Редактировать"
+                  @click="editSlot(slot)"
+                >
+                  <img
+                    src="@/assets/icons/edit.png"
+                    class="icon"
+                  >
                 </button>
-                <button @click="deleteSlot(slot)" class="icon-btn" title="Удалить">
-                  <img src="@/assets/icons/trashcan.png" class="icon" />
+                <button
+                  class="icon-btn"
+                  title="Удалить"
+                  @click="deleteSlot(slot)"
+                >
+                  <img
+                    src="@/assets/icons/trashcan.png"
+                    class="icon"
+                  >
                 </button>
               </div>
             </div>
 
-            <div v-if="getActiveSlotsForDay(day - 1).length === 0" class="empty-text">
+            <div
+              v-if="getActiveSlotsForDay(day - 1).length === 0"
+              class="empty-text"
+            >
               Нет временных окон
             </div>
           </div>
@@ -60,15 +96,31 @@
 
     <!-- Модальное окно добавления/редактирования -->
     <transition name="modal-fade">
-      <div v-if="modalOpen" class="modal-overlay" @click.self="closeModal">
+      <div
+        v-if="modalOpen"
+        class="modal-overlay"
+        @click.self="closeModal"
+      >
         <div class="modal-content">
           <div class="modal-header">
             <h3 class="modal-title">
               {{ editingSlotId ? 'Редактировать временнОе окно' : 'Добавить временнОе окно' }}
             </h3>
-            <button @click="closeModal" class="modal-close">
-              <svg width="10" height="10" viewBox="0 0 14 14">
-                <path d="M13 1L1 13M1 1L13 13" stroke="#666" stroke-width="2" stroke-linecap="round"/>
+            <button
+              class="modal-close"
+              @click="closeModal"
+            >
+              <svg
+                width="10"
+                height="10"
+                viewBox="0 0 14 14"
+              >
+                <path
+                  d="M13 1L1 13M1 1L13 13"
+                  stroke="#666"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                />
               </svg>
             </button>
           </div>
@@ -76,7 +128,11 @@
           <div class="modal-body">
             <div class="field">
               <label class="field-label">День недели *</label>
-              <div class="custom-select" @click="toggleDayDropdown" ref="selectRef">
+              <div
+                ref="selectRef"
+                class="custom-select"
+                @click="toggleDayDropdown"
+              >
                 <div class="select-trigger">
                   <span>{{ getFullDayName(modalDay) }}</span>
                   <img
@@ -85,10 +141,13 @@
                     :class="{ open: dayDropdownOpen }"
                     width="9"
                     height="9"
-                  />
+                  >
                 </div>
                 <transition name="dropdown">
-                  <div v-if="dayDropdownOpen" class="select-dropdown">
+                  <div
+                    v-if="dayDropdownOpen"
+                    class="select-dropdown"
+                  >
                     <div
                       v-for="(dayName, idx) in fullDayNames"
                       :key="idx"
@@ -106,29 +165,50 @@
             <div class="time-fields">
               <div class="field time-field">
                 <label class="field-label">Открытие *</label>
-                <input type="time" v-model="modalOpenTime" class="modal-input" @change="validateTimes" />
+                <input
+                  v-model="modalOpenTime"
+                  type="time"
+                  class="modal-input"
+                  @change="validateTimes"
+                >
               </div>
               <div class="field time-field">
                 <label class="field-label">Закрытие *</label>
-                <input type="time" v-model="modalCloseTime" class="modal-input" @change="validateTimes" />
+                <input
+                  v-model="modalCloseTime"
+                  type="time"
+                  class="modal-input"
+                  @change="validateTimes"
+                >
               </div>
             </div>
 
-            <div v-if="timeConflictError" class="error-hint">
+            <div
+              v-if="timeConflictError"
+              class="error-hint"
+            >
               ⚠️ {{ timeConflictError }}
             </div>
 
-            <div v-if="modalNextDay && !timeConflictError" class="next-day-hint">
+            <div
+              v-if="modalNextDay && !timeConflictError"
+              class="next-day-hint"
+            >
               ⏰ Закрытие на следующий день
             </div>
           </div>
 
           <div class="modal-footer">
-            <button @click="closeModal" class="modal-btn cancel">Отмена</button>
             <button
-              @click="saveSlot"
+              class="modal-btn cancel"
+              @click="closeModal"
+            >
+              Отмена
+            </button>
+            <button
               class="modal-btn confirm"
               :disabled="!modalOpenTime || !modalCloseTime || isLoading || !!timeConflictError"
+              @click="saveSlot"
             >
               {{ editingSlotId ? 'Сохранить' : 'Добавить' }}
             </button>

--- a/frontend/src/components/TableComponent.vue
+++ b/frontend/src/components/TableComponent.vue
@@ -1,59 +1,145 @@
 <template>
   <div class="table-container">
     <transition name="slide-down">
-      <div v-if="notification.message" class="notification">
+      <div
+        v-if="notification.message"
+        class="notification"
+      >
         <span>{{ notification.message }}</span>
-        <button @click="undoDelete">Отменить</button>
-        <div class="progress-bar" :style="{ width: `${progress}%` }"></div>
+        <button @click="undoDelete">
+          Отменить
+        </button>
+        <div
+          class="progress-bar"
+          :style="{ width: `${progress}%` }"
+        />
       </div>
     </transition>
     <div class="header-container">
       <h2>Таблица автомобилей КПП №4</h2>
       <!-- Поле поиска и кнопка для массового удаления -->
       <div class="search-controls">
-        <input type="text" v-model="searchQuery" placeholder="Поиск" class="search-input" />
-        <button class="delete-all" @click="deleteSelectedCars" :disabled="selectedCars.length === 0">Удалить выбранные</button>
+        <input
+          v-model="searchQuery"
+          type="text"
+          placeholder="Поиск"
+          class="search-input"
+        >
+        <button
+          class="delete-all"
+          :disabled="selectedCars.length === 0"
+          @click="deleteSelectedCars"
+        >
+          Удалить выбранные
+        </button>
       </div>
     </div>
 
     <table>
       <thead>
         <tr>
-          <th style="width: 40px;"><input type="checkbox" @change="toggleSelectAll" /></th>
-          <th style="width: 120px; cursor: pointer;" @click="sortBy('car_number')">
+          <th style="width: 40px;">
+            <input
+              type="checkbox"
+              @change="toggleSelectAll"
+            >
+          </th>
+          <th
+            style="width: 120px; cursor: pointer;"
+            @click="sortBy('car_number')"
+          >
             Номер<span v-if="sortKey === 'car_number'">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
           </th>
-          <th style="width: 120px; cursor: pointer;" @click="sortBy('car_brand')">
+          <th
+            style="width: 120px; cursor: pointer;"
+            @click="sortBy('car_brand')"
+          >
             Марка <span v-if="sortKey === 'car_brand'">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
           </th>
-          <th style="width: 150px; cursor: pointer;" @click="sortBy('organization')">
+          <th
+            style="width: 150px; cursor: pointer;"
+            @click="sortBy('organization')"
+          >
             Организация <span v-if="sortKey === 'organization'">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
           </th>
-          <th style="width: 150px;">Место разгрузки</th>
-          <th style="width: 100px; cursor: pointer;" @click="sortBy('entry_date')">
+          <th style="width: 150px;">
+            Место разгрузки
+          </th>
+          <th
+            style="width: 100px; cursor: pointer;"
+            @click="sortBy('entry_date')"
+          >
             Дата <span v-if="sortKey === 'entry_date'">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
           </th>
-          <th style="width: 80px;">Время</th>
-          <th style="width: 100px;">Действия</th>
+          <th style="width: 80px;">
+            Время
+          </th>
+          <th style="width: 100px;">
+            Действия
+          </th>
         </tr>
       </thead>
       <tbody>
         <template v-if="filteredCars.length > 0">
-          <tr v-for="carData in filteredCars" :key="carData.car.id" :class="{ overdue: isOverdue(carData.application) }">
-            <td><input type="checkbox" v-model="selectedCars" :value="carData.car.id" /></td>
-            <td><input v-model="carData.car.car_number" @blur="updateCar(carData.application.id, carData.car)" placeholder="Номер авто" /></td>
-            <td><input v-model="carData.car.car_brand" @blur="updateCar(carData.application.id, carData.car)" placeholder="Марка авто" /></td>
-            <td>{{ carData.application.organization }}</td>
-            <td><input v-model="carData.car.unload_place" @blur="updateCar(carData.application.id, carData.car)" placeholder="Место разгрузки" /></td>
-            <td><input type="date" v-model="carData.application.entry_date" @blur="updateApplication(carData.application)" /></td>
-            <td><input type="time" v-model="carData.application.entry_time" @blur="updateApplication(carData.application)" /></td>
+          <tr
+            v-for="carData in filteredCars"
+            :key="carData.car.id"
+            :class="{ overdue: isOverdue(carData.application) }"
+          >
             <td>
-              <button @click="removeCarWithNotification(carData.application.id, carData.car)">Удалить</button>
+              <input
+                v-model="selectedCars"
+                type="checkbox"
+                :value="carData.car.id"
+              >
+            </td>
+            <td>
+              <input
+                v-model="carData.car.car_number"
+                placeholder="Номер авто"
+                @blur="updateCar(carData.application.id, carData.car)"
+              >
+            </td>
+            <td>
+              <input
+                v-model="carData.car.car_brand"
+                placeholder="Марка авто"
+                @blur="updateCar(carData.application.id, carData.car)"
+              >
+            </td>
+            <td>{{ carData.application.organization }}</td>
+            <td>
+              <input
+                v-model="carData.car.unload_place"
+                placeholder="Место разгрузки"
+                @blur="updateCar(carData.application.id, carData.car)"
+              >
+            </td>
+            <td>
+              <input
+                v-model="carData.application.entry_date"
+                type="date"
+                @blur="updateApplication(carData.application)"
+              >
+            </td>
+            <td>
+              <input
+                v-model="carData.application.entry_time"
+                type="time"
+                @blur="updateApplication(carData.application)"
+              >
+            </td>
+            <td>
+              <button @click="removeCarWithNotification(carData.application.id, carData.car)">
+                Удалить
+              </button>
             </td>
           </tr>
         </template>
         <tr v-else>
-          <td colspan="8">Ничего не найдено</td>
+          <td colspan="8">
+            Ничего не найдено
+          </td>
         </tr>
       </tbody>
     </table>
@@ -90,6 +176,9 @@ export default {
         )
         .sort((a, b) => this.sortFunction(a, b));
     }
+  },
+  mounted() {
+    this.fetchApplications();
   },
   methods: {
     async actuallyDeleteCar(applicationId, car) {
@@ -235,9 +324,6 @@ export default {
   }
   this.notification = { message: null, car: null };
 }
-  },
-  mounted() {
-    this.fetchApplications();
   }
 };
 </script>

--- a/frontend/src/components/TableConstructor.vue
+++ b/frontend/src/components/TableConstructor.vue
@@ -1,13 +1,18 @@
 <template>
   <div class="table-constructor-container dashboard-card">
     <div class="management-header">
-      <h3 class="management-title">Таблицы системы</h3>
+      <h3 class="management-title">
+        Таблицы системы
+      </h3>
       <div class="header-controls">
         <SearchComponent
-          :title="'Поиск таблиц...'"
           v-model="searchQuery"
+          :title="'Поиск таблиц...'"
         />
-        <button @click="showAddModal = true" class="add-header-button">
+        <button
+          class="add-header-button"
+          @click="showAddModal = true"
+        >
           Создать таблицу
         </button>
         <RefreshButton @refresh="refreshData" />
@@ -16,11 +21,19 @@
 
     <div class="content-container">
       <!-- Левая часть - список таблиц -->
-      <div class="table-section" :class="{'with-details': selectedTable}">
+      <div
+        class="table-section"
+        :class="{'with-details': selectedTable}"
+      >
         <div class="table-container">
           <div class="table-header">
-            <div class="header-col id-col" @click="sortBy('id')">
-              <p :class="{ 'active-sort': sortField === 'id' }">ID</p>
+            <div
+              class="header-col id-col"
+              @click="sortBy('id')"
+            >
+              <p :class="{ 'active-sort': sortField === 'id' }">
+                ID
+              </p>
               <img 
                 src="@/assets/icons/sort.png" 
                 class="sort-icon" 
@@ -28,10 +41,15 @@
                   'sorted': sortField === 'id',
                   'desc': sortField === 'id' && sortDirection === 'desc'
                 }" 
-              />
+              >
             </div>
-            <div class="header-col name-col" @click="sortBy('name')">
-              <p :class="{ 'active-sort': sortField === 'name' }">Наименование</p>
+            <div
+              class="header-col name-col"
+              @click="sortBy('name')"
+            >
+              <p :class="{ 'active-sort': sortField === 'name' }">
+                Наименование
+              </p>
               <img 
                 src="@/assets/icons/sort.png" 
                 class="sort-icon" 
@@ -39,10 +57,15 @@
                   'sorted': sortField === 'name',
                   'desc': sortField === 'name' && sortDirection === 'desc'
                 }" 
-              />
+              >
             </div>
-            <div class="header-col type-col" @click="sortBy('type')">
-              <p :class="{ 'active-sort': sortField === 'type' }">Тип</p>
+            <div
+              class="header-col type-col"
+              @click="sortBy('type')"
+            >
+              <p :class="{ 'active-sort': sortField === 'type' }">
+                Тип
+              </p>
               <img 
                 src="@/assets/icons/sort.png" 
                 class="sort-icon" 
@@ -50,7 +73,7 @@
                   'sorted': sortField === 'type',
                   'desc': sortField === 'type' && sortDirection === 'desc'
                 }" 
-              />
+              >
             </div>
             <div class="header-col status-col">
               <p>Статус</p>
@@ -69,17 +92,26 @@
                 <span class="cell-content id-value">{{ table.table.id }}</span>
               </div>
               <div class="table-col name-col">
-                <span class="truncate-text" :title="table.table.display_name">
+                <span
+                  class="truncate-text"
+                  :title="table.table.display_name"
+                >
                   {{ table.table.display_name }}
                 </span>
               </div>
               <div class="table-col type-col">
-                <span class="type-badge" :class="table.table.table_type">
+                <span
+                  class="type-badge"
+                  :class="table.table.table_type"
+                >
                   {{ getTableTypeLabel(table.table.table_type) }}
                 </span>
               </div>
               <div class="table-col status-col">
-                <span class="status-badge" :class="getTableStatusClass(table)">
+                <span
+                  class="status-badge"
+                  :class="getTableStatusClass(table)"
+                >
                   {{ getTableStatusText(table) }}
                 </span>
               </div>
@@ -93,7 +125,10 @@
       </div>
 
       <!-- Правая часть - детали таблицы -->
-      <div v-if="selectedTable" class="details-section">
+      <div
+        v-if="selectedTable"
+        class="details-section"
+      >
         <div class="details-tabs">
           <button 
             class="tab-btn" 
@@ -119,28 +154,48 @@
         </div>
 
         <!-- Вкладка Основное -->
-        <div v-if="activeTab === 'main'" class="tab-content">
+        <div
+          v-if="activeTab === 'main'"
+          class="tab-content"
+        >
           <div class="details-header">
             <div class="details-title-wrapper">
               <div class="table-info-title">
-                <h3 class="details-title">{{ selectedTable.table.display_name }}</h3>
-                <span class="table-type-badge" :class="selectedTable.table.table_type">
+                <h3 class="details-title">
+                  {{ selectedTable.table.display_name }}
+                </h3>
+                <span
+                  class="table-type-badge"
+                  :class="selectedTable.table.table_type"
+                >
                   {{ getTableTypeLabel(selectedTable.table.table_type) }}
                 </span>
               </div>
               <div class="table-info-row">
                 <span class="system-name">{{ selectedTable.table.name }}</span>
-                <span class="current-status-badge" :class="getTableCurrentStatusClass(selectedTable)">
+                <span
+                  class="current-status-badge"
+                  :class="getTableCurrentStatusClass(selectedTable)"
+                >
                   {{ getTableCurrentStatusText(selectedTable) }}
                 </span>
               </div>
             </div>
             <div class="details-header-actions">
-              <button @click="openTable" class="action-btn view-btn">
+              <button
+                class="action-btn view-btn"
+                @click="openTable"
+              >
                 Открыть
               </button>
-              <button @click="confirmDeleteTable(selectedTable)" class="delete-icon-btn">
-                <img src="@/assets/icons/delete.png" class="delete-icon" />
+              <button
+                class="delete-icon-btn"
+                @click="confirmDeleteTable(selectedTable)"
+              >
+                <img
+                  src="@/assets/icons/delete.png"
+                  class="delete-icon"
+                >
               </button>
             </div>
           </div>
@@ -152,21 +207,31 @@
                   <label class="detail-label">Наименование таблицы:</label>
                   <input 
                     v-model="selectedTable.table.display_name" 
-                    @change="updateTableField('display_name')"
                     class="form-input-sm"
                     placeholder="Название таблицы"
                     autocomplete="off"
+                    @change="updateTableField('display_name')"
                   >
                 </div>
                 <div class="form-group compact">
                   <label class="detail-label">Тип таблицы:</label>
                   <div class="custom-select">
-                    <div class="select-header" @click="toggleTableTypeDropdown">
+                    <div
+                      class="select-header"
+                      @click="toggleTableTypeDropdown"
+                    >
                       <span class="select-value">{{ getTableTypeLabel(selectedTable.table.table_type) }}</span>
-                      <img src="@/assets/icons/arrow.png" class="select-arrow" :class="{ rotated: tableTypeDropdownOpen }" />
+                      <img
+                        src="@/assets/icons/arrow.png"
+                        class="select-arrow"
+                        :class="{ rotated: tableTypeDropdownOpen }"
+                      >
                     </div>
                     <transition name="dropdown-fade">
-                      <div v-if="tableTypeDropdownOpen" class="select-dropdown">
+                      <div
+                        v-if="tableTypeDropdownOpen"
+                        class="select-dropdown"
+                      >
                         <div 
                           class="select-option"
                           :class="{ active: selectedTable.table.table_type === 'cars' }"
@@ -216,15 +281,18 @@
               </div>
 
               <!-- Комментарий к статусу (только для неактивных) -->
-              <div v-if="selectedTable.table.status !== 'active'" class="form-group">
+              <div
+                v-if="selectedTable.table.status !== 'active'"
+                class="form-group"
+              >
                 <label class="detail-label">Причина:</label>
                 <textarea 
                   v-model="selectedTable.table.status_comment" 
-                  @change="updateTableField('status_comment')"
                   class="form-textarea"
                   placeholder="Укажите причину"
                   rows="2"
-                ></textarea>
+                  @change="updateTableField('status_comment')"
+                />
               </div>
 
               <div class="settings-section">
@@ -233,28 +301,44 @@
                 <div class="checkbox-group">
                   <label class="checkbox-label">
                     <input 
-                      type="checkbox" 
-                      v-model="selectedTable.table.show_fact_table"
-                      @change="updateTableField('show_fact_table')"
+                      v-model="selectedTable.table.show_fact_table" 
+                      type="checkbox"
                       class="checkbox-input"
-                    />
+                      @change="updateTableField('show_fact_table')"
+                    >
                     <span class="checkbox-text">Отображать таблицу "по факту"</span>
                   </label>
                 </div>
 
-                <div v-if="selectedTable.table.show_fact_table" class="hint-section">
+                <div
+                  v-if="selectedTable.table.show_fact_table"
+                  class="hint-section"
+                >
                   <div class="section-header-with-actions">
                     <label class="detail-label">Подсказка для таблицы "по факту":</label>
-                    <div class="editor-actions" v-if="hintHasChanges">
-                      <button @click="cancelHintEdit" class="compact-btn cancel-btn">Отмена</button>
-                      <button @click="saveHint" class="compact-btn save-btn">Сохранить</button>
+                    <div
+                      v-if="hintHasChanges"
+                      class="editor-actions"
+                    >
+                      <button
+                        class="compact-btn cancel-btn"
+                        @click="cancelHintEdit"
+                      >
+                        Отмена
+                      </button>
+                      <button
+                        class="compact-btn save-btn"
+                        @click="saveHint"
+                      >
+                        Сохранить
+                      </button>
                     </div>
                   </div>
                   <TextConstructor
+                    ref="hintConstructor"
                     v-model="selectedTable.table.fact_table_hint"
                     :placeholder="getDefaultHint(selectedTable.table.table_type)"
                     rows="4"
-                    ref="hintConstructor"
                   />
                 </div>
               </div>
@@ -262,16 +346,29 @@
               <div class="instruction-section">
                 <div class="section-header-with-actions">
                   <label class="detail-label">Инструкция к таблице:</label>
-                  <div class="editor-actions" v-if="instructionHasChanges">
-                    <button @click="cancelInstructionEdit" class="compact-btn cancel-btn">Отмена</button>
-                    <button @click="saveInstruction" class="compact-btn save-btn">Сохранить</button>
+                  <div
+                    v-if="instructionHasChanges"
+                    class="editor-actions"
+                  >
+                    <button
+                      class="compact-btn cancel-btn"
+                      @click="cancelInstructionEdit"
+                    >
+                      Отмена
+                    </button>
+                    <button
+                      class="compact-btn save-btn"
+                      @click="saveInstruction"
+                    >
+                      Сохранить
+                    </button>
                   </div>
                 </div>
                 <TextConstructor
+                  ref="instructionConstructor"
                   v-model="selectedTable.table.instruction"
                   placeholder="Введите инструкцию для таблицы..."
                   rows="4"
-                  ref="instructionConstructor"
                 />
               </div>
 
@@ -293,7 +390,10 @@
         </div>
 
         <!-- Вкладка Расписание -->
-        <div v-if="activeTab === 'schedule'" class="tab-content">
+        <div
+          v-if="activeTab === 'schedule'"
+          class="tab-content"
+        >
           <SystemTableScheduleTab 
             :table-id="selectedTable.table.id"
             :time-slots="selectedTable.time_slots"
@@ -302,27 +402,34 @@
         </div>
 
         <!-- Вкладка Местоположение -->
-        <div v-if="activeTab === 'location'" class="tab-content">
+        <div
+          v-if="activeTab === 'location'"
+          class="tab-content"
+        >
           <div class="location-section">
-            <h4 class="section-title">Описание местоположения</h4>
+            <h4 class="section-title">
+              Описание местоположения
+            </h4>
             <textarea 
               v-model="selectedTable.table.location_description" 
-              @change="updateTableField('location_description')"
               class="form-textarea"
               placeholder="Введите описание местоположения..."
               rows="3"
-            ></textarea>
+              @change="updateTableField('location_description')"
+            />
           </div>
 
           <div class="location-section">
-            <h4 class="section-title">Ссылка на карту</h4>
+            <h4 class="section-title">
+              Ссылка на карту
+            </h4>
             <div class="map-link-group">
               <input 
                 v-model="selectedTable.table.map_link" 
-                @change="updateTableField('map_link')"
                 class="form-input"
                 placeholder="https://maps.google.com/..."
                 autocomplete="off"
+                @change="updateTableField('map_link')"
               >
               <a 
                 v-if="selectedTable.table.map_link" 
@@ -343,13 +450,21 @@
         </div>
       </div>
       
-      <div v-else class="no-selection-message">
+      <div
+        v-else
+        class="no-selection-message"
+      >
         <p>Выберите таблицу для просмотра и редактирования</p>
       </div>
     </div>
 
-    <div v-if="filteredTables.length === 0" class="no-results">
-      <div class="no-results-icon">📊</div>
+    <div
+      v-if="filteredTables.length === 0"
+      class="no-results"
+    >
+      <div class="no-results-icon">
+        📊
+      </div>
       <p>Таблицы не найдены</p>
     </div>
 
@@ -361,7 +476,11 @@
     />
 
     <!-- Уведомления -->
-    <div v-if="notification.show" class="notification" :class="notification.type">
+    <div
+      v-if="notification.show"
+      class="notification"
+      :class="notification.type"
+    >
       <span class="notification-message">{{ notification.message }}</span>
     </div>
   </div>

--- a/frontend/src/components/TableConstructorCreateModal.vue
+++ b/frontend/src/components/TableConstructorCreateModal.vue
@@ -1,139 +1,180 @@
 <template>
-  <div class="modal-overlay" @click.self="handleClose">
-      <div class="modal-content horizontal-modal">
-        <div class="modal-header">
-          <h3>Создать новую таблицу</h3>
-          <button @click="handleClose" class="modal-close">
-            <svg width="10" height="10" viewBox="0 0 14 14" fill="none">
-              <path d="M13 1L1 13M1 1L13 13" stroke="#666" stroke-width="2" stroke-linecap="round"/>
-            </svg>
-          </button>
-        </div>
-
-        <div class="modal-body-horizontal">
-          <!-- Левая часть - основная информация -->
-          <div class="modal-main-info">
-            <div class="main-fields">
-              <div class="form-group-compact">
-                <label class="form-label-compact">Наименование таблицы *</label>
-                <input
-                  v-model="newTable.display_name"
-                  placeholder="ПОСТ №27"
-                  class="input-compact"
-                >
-              </div>
-
-              <div class="form-group-compact">
-                <label class="form-label-compact">Системное имя *</label>
-                <input
-                  v-model="newTable.name"
-                  @input="validateSystemName"
-                  placeholder="post_27"
-                  class="input-compact"
-                >
-                <span class="form-hint">Латинские буквы, цифры и подчеркивания</span>
-                <span v-if="nameError" class="form-error">{{ nameError }}</span>
-              </div>
-
-              <div class="form-group-compact">
-                <label class="form-label-compact">Тип таблицы *</label>
-                <div class="custom-select">
-                  <div class="select-header" @click="toggleTypeDropdown">
-                    <span class="select-value">{{ getTableTypeLabel(newTable.table_type) }}</span>
-                    <img src="@/assets/icons/arrow.png" class="select-arrow" :class="{ rotated: typeDropdownOpen }" />
-                  </div>
-                  <transition name="dropdown-fade">
-                    <div v-if="typeDropdownOpen" class="select-dropdown">
-                      <div
-                        class="select-option"
-                        :class="{ active: newTable.table_type === 'cars' }"
-                        @click="selectType('cars')"
-                      >
-                        Машины
-                      </div>
-                      <div
-                        class="select-option"
-                        :class="{ active: newTable.table_type === 'people' }"
-                        @click="selectType('people')"
-                      >
-                        Люди
-                      </div>
-                    </div>
-                  </transition>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <!-- Правая часть - настройки -->
-          <div class="modal-cells-section">
-            <div class="cells-header-compact">
-              <h4 class="cells-title-compact">Настройки отображения</h4>
-            </div>
-
-            <div class="cells-scroll-container">
-              <div class="settings-grid">
-                <div class="setting-item">
-                  <label class="setting-label">
-                    <input
-                      type="checkbox"
-                      v-model="newTable.show_fact_table"
-                      class="setting-checkbox"
-                    />
-                    <span class="setting-text">Отображать таблицу "по факту"</span>
-                  </label>
-                  <span class="setting-hint">
-                    Будет показана дополнительная таблица с данными "по факту"
-                  </span>
-                </div>
-
-                <div v-if="newTable.show_fact_table" class="setting-item">
-                  <label class="form-label-compact">Подсказка для таблицы "по факту"</label>
-                  <TextConstructor
-                    v-model="newTable.fact_table_hint"
-                    :placeholder="getDefaultHint(newTable.table_type)"
-                    rows="3"
-                  />
-                </div>
-
-                <div class="setting-item">
-                  <label class="form-label-compact">Инструкция к таблице</label>
-                  <TextConstructor
-                    v-model="newTable.instruction"
-                    placeholder="Введите инструкцию для таблицы..."
-                    rows="4"
-                  />
-                </div>
-
-                <div class="setting-item">
-                  <h5 class="fields-preview-title">Поля таблицы:</h5>
-                  <div class="fields-preview">
-                    <div
-                      v-for="field in getTableFields(newTable.table_type)"
-                      :key="field.name"
-                      class="preview-field"
-                    >
-                      <span class="preview-field-name">{{ field.displayName }}</span>
-                      <span class="preview-field-type">{{ field.type }}</span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="modal-footer">
-          <button @click="handleClose" class="modal-btn modal-btn--cancel">Отмена</button>
-          <button
-            @click="createTable"
-            class="modal-btn modal-btn--confirm"
+  <div
+    class="modal-overlay"
+    @click.self="handleClose"
+  >
+    <div class="modal-content horizontal-modal">
+      <div class="modal-header">
+        <h3>Создать новую таблицу</h3>
+        <button
+          class="modal-close"
+          @click="handleClose"
+        >
+          <svg
+            width="10"
+            height="10"
+            viewBox="0 0 14 14"
+            fill="none"
           >
-            Создать
-          </button>
+            <path
+              d="M13 1L1 13M1 1L13 13"
+              stroke="#666"
+              stroke-width="2"
+              stroke-linecap="round"
+            />
+          </svg>
+        </button>
+      </div>
+
+      <div class="modal-body-horizontal">
+        <!-- Левая часть - основная информация -->
+        <div class="modal-main-info">
+          <div class="main-fields">
+            <div class="form-group-compact">
+              <label class="form-label-compact">Наименование таблицы *</label>
+              <input
+                v-model="newTable.display_name"
+                placeholder="ПОСТ №27"
+                class="input-compact"
+              >
+            </div>
+
+            <div class="form-group-compact">
+              <label class="form-label-compact">Системное имя *</label>
+              <input
+                v-model="newTable.name"
+                placeholder="post_27"
+                class="input-compact"
+                @input="validateSystemName"
+              >
+              <span class="form-hint">Латинские буквы, цифры и подчеркивания</span>
+              <span
+                v-if="nameError"
+                class="form-error"
+              >{{ nameError }}</span>
+            </div>
+
+            <div class="form-group-compact">
+              <label class="form-label-compact">Тип таблицы *</label>
+              <div class="custom-select">
+                <div
+                  class="select-header"
+                  @click="toggleTypeDropdown"
+                >
+                  <span class="select-value">{{ getTableTypeLabel(newTable.table_type) }}</span>
+                  <img
+                    src="@/assets/icons/arrow.png"
+                    class="select-arrow"
+                    :class="{ rotated: typeDropdownOpen }"
+                  >
+                </div>
+                <transition name="dropdown-fade">
+                  <div
+                    v-if="typeDropdownOpen"
+                    class="select-dropdown"
+                  >
+                    <div
+                      class="select-option"
+                      :class="{ active: newTable.table_type === 'cars' }"
+                      @click="selectType('cars')"
+                    >
+                      Машины
+                    </div>
+                    <div
+                      class="select-option"
+                      :class="{ active: newTable.table_type === 'people' }"
+                      @click="selectType('people')"
+                    >
+                      Люди
+                    </div>
+                  </div>
+                </transition>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Правая часть - настройки -->
+        <div class="modal-cells-section">
+          <div class="cells-header-compact">
+            <h4 class="cells-title-compact">
+              Настройки отображения
+            </h4>
+          </div>
+
+          <div class="cells-scroll-container">
+            <div class="settings-grid">
+              <div class="setting-item">
+                <label class="setting-label">
+                  <input
+                    v-model="newTable.show_fact_table"
+                    type="checkbox"
+                    class="setting-checkbox"
+                  >
+                  <span class="setting-text">Отображать таблицу "по факту"</span>
+                </label>
+                <span class="setting-hint">
+                  Будет показана дополнительная таблица с данными "по факту"
+                </span>
+              </div>
+
+              <div
+                v-if="newTable.show_fact_table"
+                class="setting-item"
+              >
+                <label class="form-label-compact">Подсказка для таблицы "по факту"</label>
+                <TextConstructor
+                  v-model="newTable.fact_table_hint"
+                  :placeholder="getDefaultHint(newTable.table_type)"
+                  rows="3"
+                />
+              </div>
+
+              <div class="setting-item">
+                <label class="form-label-compact">Инструкция к таблице</label>
+                <TextConstructor
+                  v-model="newTable.instruction"
+                  placeholder="Введите инструкцию для таблицы..."
+                  rows="4"
+                />
+              </div>
+
+              <div class="setting-item">
+                <h5 class="fields-preview-title">
+                  Поля таблицы:
+                </h5>
+                <div class="fields-preview">
+                  <div
+                    v-for="field in getTableFields(newTable.table_type)"
+                    :key="field.name"
+                    class="preview-field"
+                  >
+                    <span class="preview-field-name">{{ field.displayName }}</span>
+                    <span class="preview-field-type">{{ field.type }}</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
+
+      <div class="modal-footer">
+        <button
+          class="modal-btn modal-btn--cancel"
+          @click="handleClose"
+        >
+          Отмена
+        </button>
+        <button
+          class="modal-btn modal-btn--confirm"
+          @click="createTable"
+        >
+          Создать
+        </button>
+      </div>
     </div>
+  </div>
 </template>
 
 <script>

--- a/frontend/src/components/TableConstructorPhotoSection.vue
+++ b/frontend/src/components/TableConstructorPhotoSection.vue
@@ -1,53 +1,108 @@
 <template>
   <div class="location-section">
     <div class="photos-header">
-      <h4 class="section-title">Фотографии места</h4>
+      <h4 class="section-title">
+        Фотографии места
+      </h4>
       <label class="upload-photo-btn">
         + Загрузить
         <input
           type="file"
           accept="image/*"
           multiple
-          @change="uploadPhotos"
           style="display: none"
+          @change="uploadPhotos"
         >
       </label>
     </div>
 
     <div class="photos-grid">
-      <div v-for="photo in photos" :key="photo.id" class="photo-item" :class="{ 'main-photo': photo.is_main }">
-        <div class="photo-preview" @click="viewPhoto(photo)">
-          <img :src="photo.photo_url" :alt="photo.file_name">
+      <div
+        v-for="photo in photos"
+        :key="photo.id"
+        class="photo-item"
+        :class="{ 'main-photo': photo.is_main }"
+      >
+        <div
+          class="photo-preview"
+          @click="viewPhoto(photo)"
+        >
+          <img
+            :src="photo.photo_url"
+            :alt="photo.file_name"
+          >
         </div>
         <div class="photo-actions">
-          <button v-if="!photo.is_main" @click="setMainPhoto(photo)" class="photo-main-btn" title="Сделать главной">
+          <button
+            v-if="!photo.is_main"
+            class="photo-main-btn"
+            title="Сделать главной"
+            @click="setMainPhoto(photo)"
+          >
             ★
           </button>
-          <span v-else class="photo-main-badge" title="Главная фотография">★</span>
-          <button @click="deletePhoto(photo)" class="photo-delete-btn" title="Удалить">
-            <img src="@/assets/icons/trashcan.png" class="action-icon-small" />
+          <span
+            v-else
+            class="photo-main-badge"
+            title="Главная фотография"
+          >★</span>
+          <button
+            class="photo-delete-btn"
+            title="Удалить"
+            @click="deletePhoto(photo)"
+          >
+            <img
+              src="@/assets/icons/trashcan.png"
+              class="action-icon-small"
+            >
           </button>
         </div>
       </div>
-      <div v-if="!photos || photos.length === 0" class="no-photos">
+      <div
+        v-if="!photos || photos.length === 0"
+        class="no-photos"
+      >
         <p>Фотографии не загружены</p>
       </div>
     </div>
 
     <!-- Модальное окно просмотра фото -->
     <transition name="modal-fade">
-      <div v-if="showPhotoModal" class="modal-overlay" @click.self="showPhotoModal = false">
+      <div
+        v-if="showPhotoModal"
+        class="modal-overlay"
+        @click.self="showPhotoModal = false"
+      >
         <div class="modal-content photo-view-modal">
           <div class="modal-header">
-            <h3 class="modal-title">{{ viewingPhoto?.file_name }}</h3>
-            <button @click="showPhotoModal = false" class="modal-close">
-              <svg width="10" height="10" viewBox="0 0 14 14" fill="none">
-                <path d="M13 1L1 13M1 1L13 13" stroke="#666" stroke-width="2" stroke-linecap="round"/>
+            <h3 class="modal-title">
+              {{ viewingPhoto?.file_name }}
+            </h3>
+            <button
+              class="modal-close"
+              @click="showPhotoModal = false"
+            >
+              <svg
+                width="10"
+                height="10"
+                viewBox="0 0 14 14"
+                fill="none"
+              >
+                <path
+                  d="M13 1L1 13M1 1L13 13"
+                  stroke="#666"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                />
               </svg>
             </button>
           </div>
           <div class="modal-body photo-view-body">
-            <img :src="viewingPhoto?.photo_url" class="full-photo" alt="Full size">
+            <img
+              :src="viewingPhoto?.photo_url"
+              class="full-photo"
+              alt="Full size"
+            >
           </div>
         </div>
       </div>

--- a/frontend/src/components/TablesComponent.vue
+++ b/frontend/src/components/TablesComponent.vue
@@ -1,153 +1,205 @@
 <template>
-    <div class="tables">
-        <div class="tables__header">
-            <h1 class="tables__title">Таблица <span class="table-name">{{ tableDisplayName }}</span></h1>
-            <button class="tables__instruction" @click="showInstruction = true">
-                <img src="@/assets/icons/instruction.png" class="tables__icon" />
-                <p class="instruction__text">Инструкция</p>
-            </button>
-        </div>
-        
-        <!-- Модальное окно с инструкцией -->
-        <div v-if="showInstruction" class="modal-overlay" @click.self="showInstruction = false">
-            <div class="instruction-modal-large">
-                <div class="modal-header">
-                    <h3>Инструкция по использованию таблицы <span class="blue">{{ tableDisplayName }}</span></h3>
-                    <button @click="showInstruction = false" class="modal-close">×</button>
-                </div>
-                <div class="instruction-content">
-                    <div v-if="tableInstruction" class="text-constructor-content" v-html="sanitizedInstruction"></div>
-                    <div v-else class="no-instruction">
-                        <div class="no-instruction-icon">📝</div>
-                        <h4>Инструкция не добавлена</h4>
-                        <p>Для этой таблицы пока не создана и не написана инструкция.</p>
-                        <p>Обратитесь к Бюро пропусков для добавления инструкции.</p>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <div class="tables__filters">
-            <div class="filters__fields">
-                <!-- Поиск -->
-                <div class="field search">
-                    <input 
-                        placeholder="Поиск.." 
-                        type="text" 
-                        class="field__input search" 
-                        v-model="searchQuery"
-                        @input="applyFilters"
-                    />
-                    <img src="@/assets/icons/search.png" class="tables__icon" />
-                </div>
-                
-                <!-- Организация через компонент -->
-                <OrganizationFilter
-                    v-if="showOrganizationFilter"
-                    ref="organizationFilter"
-                    v-model="selectedOrganizationId"
-                    :organizations="organizations"
-                    @change="handleOrganizationChange"
-                />
-
-                <!-- Место разгрузки через компонент -->
-                <UnloadingPlaceFilter
-                    v-if="showUnloadingFilter"
-                    ref="unloadingPlaceFilter"
-                    v-model="selectedUnloadingPlaceId"
-                    @change="handleUnloadingPlaceChange"
-                />
-
-                <!-- Новый DateFilter -->
-                <DateFilter
-                    ref="dateFilter"
-                    :mode="'range'"
-                    :selected-date="selectedDate"
-                    :date-range-start="dateRangeStart"
-                    :date-range-end="dateRangeEnd"
-                    @update:selectedDate="updateSelectedDate"
-                    @update:dateRangeStart="updateDateRangeStart"
-                    @update:dateRangeEnd="updateDateRangeEnd"
-                    @apply="applyDateFilters"
-                    @clear="clearDate"
-                />
-            </div>
-            <div class="filters__options">
-                <img src="@/assets/icons/trashcan.png" class="options__icon" @click="clearFilters" />
-                <img src="@/assets/icons/recent-changes.png" class="options__icon" />
-                <button class="options__export">
-                    <img src="@/assets/icons/export.png" class="tables__icon" />
-                    <p class="options__text">Экспорт</p>
-                </button>
-                <RefreshButton @refresh="refreshData" />
-            </div>
-        </div>
-
-        <div class="tables__content">
-            <!-- Таблица по факту с подсказкой -->
-            <div v-if="showFactTable" class="fact-section">
-                <FactTable 
-                    v-if="currentUserId" 
-                    :table-type="tableType"
-                    :search-query="searchQuery"
-                    :selected-organization="selectedOrganizationName"
-                    :selected-unloading-place="selectedUnloadingPlaceName"
-                    :date-range-start="dateRangeStart"
-                    :date-range-end="dateRangeEnd"
-                    :selected-date="selectedDate"
-                    :current-user-id="currentUserId"
-                    :current-user-name="currentUserName"
-                    @refresh-data="refreshData"
-                />
-                <!-- Подсказка на синем фоне -->
-                <div class="fact-hint-card" v-if="tableFactHint">
-                    <div class="text-constructor-content hint-content" v-html="sanitizedHint"></div>
-                </div>
-            </div>
-            
-            <!-- Основная таблица - разные компоненты для разных типов -->
-            <CarsTable
-                v-if="tableType === 'cars' && currentUserId"
-                :table-name="tableSystemName"
-                :table-id="tableData?.table?.id"
-                :search-query="searchQuery"
-                :selected-organization-id="selectedOrganizationId"
-                :selected-unloading-place-id="selectedUnloadingPlaceId"
-                :date-range-start="dateRangeStart"
-                :date-range-end="dateRangeEnd"
-                :selected-date="selectedDate"
-                :current-user-id="currentUserId"
-                :current-user-name="currentUserName"
-                @refresh-data="refreshData"
-                @open-application="handleOpenApplication"
-            />
-            
-            <PeopleTable
-                v-if="tableType === 'people'"
-                :table-name="tableSystemName"
-                :search-query="searchQuery"
-                :selected-organization-id="selectedOrganizationId"
-                :selected-unloading-place-id="selectedUnloadingPlaceId"
-                :date-range-start="dateRangeStart"
-                :date-range-end="dateRangeEnd"
-                :selected-date="selectedDate"
-                :current-user-id="currentUserId"
-                :current-user-name="currentUserName"
-                @refresh-data="refreshData"
-                @open-application="handleOpenApplication"
-            />
-        </div>
-
-        <ApplicationDetail
-            v-if="showApplicationDetail"
-            :application="selectedApplication"
-            :current-user-id="currentUserId"
-            :current-user-name="currentUserName"
-            :mode="'center'"
-            @close="closeApplicationDetail"
-            @application-changed="handleApplicationChanged"
-        />
+  <div class="tables">
+    <div class="tables__header">
+      <h1 class="tables__title">
+        Таблица <span class="table-name">{{ tableDisplayName }}</span>
+      </h1>
+      <button
+        class="tables__instruction"
+        @click="showInstruction = true"
+      >
+        <img
+          src="@/assets/icons/instruction.png"
+          class="tables__icon"
+        >
+        <p class="instruction__text">
+          Инструкция
+        </p>
+      </button>
     </div>
+        
+    <!-- Модальное окно с инструкцией -->
+    <div
+      v-if="showInstruction"
+      class="modal-overlay"
+      @click.self="showInstruction = false"
+    >
+      <div class="instruction-modal-large">
+        <div class="modal-header">
+          <h3>Инструкция по использованию таблицы <span class="blue">{{ tableDisplayName }}</span></h3>
+          <button
+            class="modal-close"
+            @click="showInstruction = false"
+          >
+            ×
+          </button>
+        </div>
+        <div class="instruction-content">
+          <div
+            v-if="tableInstruction"
+            class="text-constructor-content"
+            v-html="sanitizedInstruction"
+          />
+          <div
+            v-else
+            class="no-instruction"
+          >
+            <div class="no-instruction-icon">
+              📝
+            </div>
+            <h4>Инструкция не добавлена</h4>
+            <p>Для этой таблицы пока не создана и не написана инструкция.</p>
+            <p>Обратитесь к Бюро пропусков для добавления инструкции.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="tables__filters">
+      <div class="filters__fields">
+        <!-- Поиск -->
+        <div class="field search">
+          <input 
+            v-model="searchQuery" 
+            placeholder="Поиск.." 
+            type="text" 
+            class="field__input search"
+            @input="applyFilters"
+          >
+          <img
+            src="@/assets/icons/search.png"
+            class="tables__icon"
+          >
+        </div>
+                
+        <!-- Организация через компонент -->
+        <OrganizationFilter
+          v-if="showOrganizationFilter"
+          ref="organizationFilter"
+          v-model="selectedOrganizationId"
+          :organizations="organizations"
+          @change="handleOrganizationChange"
+        />
+
+        <!-- Место разгрузки через компонент -->
+        <UnloadingPlaceFilter
+          v-if="showUnloadingFilter"
+          ref="unloadingPlaceFilter"
+          v-model="selectedUnloadingPlaceId"
+          @change="handleUnloadingPlaceChange"
+        />
+
+        <!-- Новый DateFilter -->
+        <DateFilter
+          ref="dateFilter"
+          :mode="'range'"
+          :selected-date="selectedDate"
+          :date-range-start="dateRangeStart"
+          :date-range-end="dateRangeEnd"
+          @update:selected-date="updateSelectedDate"
+          @update:date-range-start="updateDateRangeStart"
+          @update:date-range-end="updateDateRangeEnd"
+          @apply="applyDateFilters"
+          @clear="clearDate"
+        />
+      </div>
+      <div class="filters__options">
+        <img
+          src="@/assets/icons/trashcan.png"
+          class="options__icon"
+          @click="clearFilters"
+        >
+        <img
+          src="@/assets/icons/recent-changes.png"
+          class="options__icon"
+        >
+        <button class="options__export">
+          <img
+            src="@/assets/icons/export.png"
+            class="tables__icon"
+          >
+          <p class="options__text">
+            Экспорт
+          </p>
+        </button>
+        <RefreshButton @refresh="refreshData" />
+      </div>
+    </div>
+
+    <div class="tables__content">
+      <!-- Таблица по факту с подсказкой -->
+      <div
+        v-if="showFactTable"
+        class="fact-section"
+      >
+        <FactTable 
+          v-if="currentUserId" 
+          :table-type="tableType"
+          :search-query="searchQuery"
+          :selected-organization="selectedOrganizationName"
+          :selected-unloading-place="selectedUnloadingPlaceName"
+          :date-range-start="dateRangeStart"
+          :date-range-end="dateRangeEnd"
+          :selected-date="selectedDate"
+          :current-user-id="currentUserId"
+          :current-user-name="currentUserName"
+          @refresh-data="refreshData"
+        />
+        <!-- Подсказка на синем фоне -->
+        <div
+          v-if="tableFactHint"
+          class="fact-hint-card"
+        >
+          <div
+            class="text-constructor-content hint-content"
+            v-html="sanitizedHint"
+          />
+        </div>
+      </div>
+            
+      <!-- Основная таблица - разные компоненты для разных типов -->
+      <CarsTable
+        v-if="tableType === 'cars' && currentUserId"
+        :table-name="tableSystemName"
+        :table-id="tableData?.table?.id"
+        :search-query="searchQuery"
+        :selected-organization-id="selectedOrganizationId"
+        :selected-unloading-place-id="selectedUnloadingPlaceId"
+        :date-range-start="dateRangeStart"
+        :date-range-end="dateRangeEnd"
+        :selected-date="selectedDate"
+        :current-user-id="currentUserId"
+        :current-user-name="currentUserName"
+        @refresh-data="refreshData"
+        @open-application="handleOpenApplication"
+      />
+            
+      <PeopleTable
+        v-if="tableType === 'people'"
+        :table-name="tableSystemName"
+        :search-query="searchQuery"
+        :selected-organization-id="selectedOrganizationId"
+        :selected-unloading-place-id="selectedUnloadingPlaceId"
+        :date-range-start="dateRangeStart"
+        :date-range-end="dateRangeEnd"
+        :selected-date="selectedDate"
+        :current-user-id="currentUserId"
+        :current-user-name="currentUserName"
+        @refresh-data="refreshData"
+        @open-application="handleOpenApplication"
+      />
+    </div>
+
+    <ApplicationDetail
+      v-if="showApplicationDetail"
+      :application="selectedApplication"
+      :current-user-id="currentUserId"
+      :current-user-name="currentUserName"
+      :mode="'center'"
+      @close="closeApplicationDetail"
+      @application-changed="handleApplicationChanged"
+    />
+  </div>
 </template>
 
 <script>
@@ -245,6 +297,19 @@ export default {
                    !!this.selectedDate ||
                    (this.dateRangeStart && this.dateRangeEnd);
         }
+    },
+    watch: {
+        '$route.params.tableName': {
+            handler() {
+                this.fetchTableData();
+                this.clearFilters();
+            },
+            immediate: true
+        }
+    },
+    async mounted() {
+        await this.fetchCurrentUser();  // Ждём загрузки пользователя
+        this.fetchTableData();          // потом таблицы
     },
     methods: {
         handleApplicationUpdate(updatedApp) {
@@ -404,19 +469,6 @@ export default {
 
         handleApplicationChanged() {
             this.refreshData();
-        }
-    },
-    async mounted() {
-        await this.fetchCurrentUser();  // Ждём загрузки пользователя
-        this.fetchTableData();          // потом таблицы
-    },
-    watch: {
-        '$route.params.tableName': {
-            handler() {
-                this.fetchTableData();
-                this.clearFilters();
-            },
-            immediate: true
         }
     }
 }

--- a/frontend/src/components/TextConstructor.vue
+++ b/frontend/src/components/TextConstructor.vue
@@ -4,18 +4,18 @@
       <div class="toolbar-group">
         <!-- УБРАН КНОПКА "B" -->
         <button 
-          @click="formatText('italic')" 
           type="button" 
-          class="toolbar-btn"
+          class="toolbar-btn" 
           data-tooltip="Курсив"
+          @click="formatText('italic')"
         >
           <em>I</em>
         </button>
         <button 
-          @click="formatText('underline')" 
           type="button" 
-          class="toolbar-btn"
+          class="toolbar-btn" 
           data-tooltip="Подчеркивание"
+          @click="formatText('underline')"
         >
           <u>U</u>
         </button>
@@ -23,26 +23,26 @@
 
       <div class="toolbar-group lists-group">
         <button 
-          @click="insertList('ul')" 
           type="button" 
-          class="toolbar-btn"
+          class="toolbar-btn" 
           data-tooltip="Маркированный список"
+          @click="insertList('ul')"
         >
           • L
         </button>
         <button 
-          @click="insertList('ol')" 
           type="button" 
-          class="toolbar-btn"
+          class="toolbar-btn" 
           data-tooltip="Нумерованный список"
+          @click="insertList('ol')"
         >
           1. L
         </button>
         <button 
-          @click="insertListItem()" 
           type="button" 
-          class="toolbar-btn"
+          class="toolbar-btn" 
           data-tooltip="Добавить элемент списка"
+          @click="insertListItem()"
         >
           Li
         </button>
@@ -50,34 +50,45 @@
 
       <div class="toolbar-group">
         <button 
-          @click="insertHeading('h1')" 
           type="button" 
-          class="toolbar-btn"
+          class="toolbar-btn" 
           data-tooltip="Заголовок h1"
+          @click="insertHeading('h1')"
         >
           h1
         </button>
         <button 
-          @click="insertHeading('h2')" 
           type="button" 
-          class="toolbar-btn"
+          class="toolbar-btn" 
           data-tooltip="Заголовок h2"
+          @click="insertHeading('h2')"
         >
           h2
         </button>
       </div>
 
       <div class="toolbar-group">
-        <div class="custom-select" @mouseenter="showTooltip = true" @mouseleave="showTooltip = false">
+        <div
+          class="custom-select"
+          @mouseenter="showTooltip = true"
+          @mouseleave="showTooltip = false"
+        >
           <div 
             class="select-header" 
-            @click="toggleFontSizeDropdown" 
-            :data-tooltip="fontSizeDropdownOpen ? '' : 'Размер шрифта'"
+            :data-tooltip="fontSizeDropdownOpen ? '' : 'Размер шрифта'" 
+            @click="toggleFontSizeDropdown"
           >
             <span class="select-value">{{ selectedFontSize }}</span>
-            <img src="@/assets/icons/arrow.png" class="select-arrow" :class="{ rotated: fontSizeDropdownOpen }" />
+            <img
+              src="@/assets/icons/arrow.png"
+              class="select-arrow"
+              :class="{ rotated: fontSizeDropdownOpen }"
+            >
           </div>
-          <div v-if="fontSizeDropdownOpen" class="select-dropdown">
+          <div
+            v-if="fontSizeDropdownOpen"
+            class="select-dropdown"
+          >
             <div 
               v-for="size in fontSizes" 
               :key="size"
@@ -92,16 +103,27 @@
       </div>
 
       <div class="toolbar-group">
-        <div class="custom-select fixed-width-select" @mouseenter="showTooltip = true" @mouseleave="showTooltip = false">
+        <div
+          class="custom-select fixed-width-select"
+          @mouseenter="showTooltip = true"
+          @mouseleave="showTooltip = false"
+        >
           <div 
             class="select-header" 
-            @click="toggleFontWeightDropdown" 
-            :data-tooltip="fontWeightDropdownOpen ? '' : 'Жирность шрифта'"
+            :data-tooltip="fontWeightDropdownOpen ? '' : 'Жирность шрифта'" 
+            @click="toggleFontWeightDropdown"
           >
             <span class="select-value">{{ selectedFontWeight.label }}</span>
-            <img src="@/assets/icons/arrow.png" class="select-arrow" :class="{ rotated: fontWeightDropdownOpen }" />
+            <img
+              src="@/assets/icons/arrow.png"
+              class="select-arrow"
+              :class="{ rotated: fontWeightDropdownOpen }"
+            >
           </div>
-          <div v-if="fontWeightDropdownOpen" class="select-dropdown">
+          <div
+            v-if="fontWeightDropdownOpen"
+            class="select-dropdown"
+          >
             <div 
               v-for="weight in fontWeights" 
               :key="weight.value"
@@ -118,34 +140,34 @@
 
       <div class="toolbar-group">
         <button 
-          @click="insertColor('black-text')" 
           type="button" 
-          class="toolbar-btn color-btn black-text"
+          class="toolbar-btn color-btn black-text" 
           data-tooltip="Черный"
+          @click="insertColor('black-text')"
         >
           A
         </button>
         <button 
-          @click="insertColor('red-text')" 
           type="button" 
-          class="toolbar-btn color-btn red-text"
+          class="toolbar-btn color-btn red-text" 
           data-tooltip="Красный"
+          @click="insertColor('red-text')"
         >
           A
         </button>
         <button 
-          @click="insertColor('green-text')" 
           type="button" 
-          class="toolbar-btn color-btn green-text"
+          class="toolbar-btn color-btn green-text" 
           data-tooltip="Зеленый"
+          @click="insertColor('green-text')"
         >
           A
         </button>
         <button 
-          @click="insertColor('blue-text')" 
           type="button" 
-          class="toolbar-btn color-btn blue-text"
+          class="toolbar-btn color-btn blue-text" 
           data-tooltip="Синий"
+          @click="insertColor('blue-text')"
         >
           A
         </button>
@@ -153,10 +175,10 @@
 
       <div class="toolbar-group">
         <button 
-          @click="insertBreak()" 
           type="button" 
-          class="toolbar-btn"
+          class="toolbar-btn" 
           data-tooltip="Отступ"
+          @click="insertBreak()"
         >
           ↵
         </button>
@@ -164,11 +186,11 @@
 
       <div class="toolbar-group">
         <button 
-          @click="undo()" 
           type="button" 
-          class="toolbar-btn undo-btn"
+          class="toolbar-btn undo-btn" 
           data-tooltip="Назад (Ctrl+Z)"
           :disabled="historyIndex === 0"
+          @click="undo()"
         >
           ↶
         </button>
@@ -177,24 +199,37 @@
 
     <div class="textarea-container">
       <textarea 
+        ref="textarea"
         :value="modelValue"
-        @input="handleInput"
-        @keydown.ctrl.z.prevent="handleCtrlZ"
         :placeholder="placeholder"
         :rows="rows"
         class="constructor-textarea"
-        ref="textarea"
-      ></textarea>
-      <div class="resize-handle" @mousedown="startResize"></div>
+        @input="handleInput"
+        @keydown.ctrl.z.prevent="handleCtrlZ"
+      />
+      <div
+        class="resize-handle"
+        @mousedown="startResize"
+      />
     </div>
 
-    <div class="editor-preview" v-if="modelValue">
+    <div
+      v-if="modelValue"
+      class="editor-preview"
+    >
       <div class="preview-header">
         <h5>Предпросмотр:</h5>
       </div>
       <div class="preview-content-container">
-        <div class="preview-content" ref="previewContent" v-html="sanitizedContent"></div>
-        <div class="resize-handle preview-resize" @mousedown="startPreviewResize"></div>
+        <div
+          ref="previewContent"
+          class="preview-content"
+          v-html="sanitizedContent"
+        />
+        <div
+          class="resize-handle preview-resize"
+          @mousedown="startPreviewResize"
+        />
       </div>
     </div>
   </div>
@@ -250,6 +285,38 @@ export default {
     sanitizedContent() {
       return sanitizeHtml(this.modelValue);
     }
+  },
+  watch: {
+    modelValue(newValue) {
+      // Обновляем историю при изменении modelValue извне
+      if (this.history[this.historyIndex] !== newValue) {
+        this.history = [newValue];
+        this.historyIndex = 0;
+      }
+    }
+  },
+  mounted() {
+    // Инициализируем историю с текущим значением
+    this.history = [this.modelValue];
+    this.historyIndex = 0;
+    
+    // Устанавливаем начальную высоту для preview
+    this.$nextTick(() => {
+      if (this.$refs.previewContent) {
+        this.$refs.previewContent.style.height = this.previewMinHeight + 'px';
+        this.$refs.previewContent.style.minHeight = this.previewMinHeight + 'px';
+        this.$refs.previewContent.style.maxHeight = this.previewMaxHeight + 'px';
+      }
+    });
+    
+    // Закрываем dropdown при клике вне его
+    document.addEventListener('click', (e) => {
+      if (!this.$el.contains(e.target)) {
+        this.fontSizeDropdownOpen = false;
+        this.fontWeightDropdownOpen = false;
+        this.showTooltip = true;
+      }
+    });
   },
   methods: {
     handleInput(event) {
@@ -587,38 +654,6 @@ export default {
         // Восстанавливаем позицию скролла
         textarea.scrollTop = currentScrollPos;
       });
-    }
-  },
-  mounted() {
-    // Инициализируем историю с текущим значением
-    this.history = [this.modelValue];
-    this.historyIndex = 0;
-    
-    // Устанавливаем начальную высоту для preview
-    this.$nextTick(() => {
-      if (this.$refs.previewContent) {
-        this.$refs.previewContent.style.height = this.previewMinHeight + 'px';
-        this.$refs.previewContent.style.minHeight = this.previewMinHeight + 'px';
-        this.$refs.previewContent.style.maxHeight = this.previewMaxHeight + 'px';
-      }
-    });
-    
-    // Закрываем dropdown при клике вне его
-    document.addEventListener('click', (e) => {
-      if (!this.$el.contains(e.target)) {
-        this.fontSizeDropdownOpen = false;
-        this.fontWeightDropdownOpen = false;
-        this.showTooltip = true;
-      }
-    });
-  },
-  watch: {
-    modelValue(newValue) {
-      // Обновляем историю при изменении modelValue извне
-      if (this.history[this.historyIndex] !== newValue) {
-        this.history = [newValue];
-        this.historyIndex = 0;
-      }
     }
   }
 };

--- a/frontend/src/components/TheHeader/TheHeader.vue
+++ b/frontend/src/components/TheHeader/TheHeader.vue
@@ -1,18 +1,33 @@
 <template>
-  <header class="header" ref="header">
+  <header
+    ref="header"
+    class="header"
+  >
     <div class="header__title">
       <template v-if="loading">
-        <SkeletonLine width="200px" height="20px" />
-        <SkeletonLine width="150px" height="14px" />
+        <SkeletonLine
+          width="200px"
+          height="20px"
+        />
+        <SkeletonLine
+          width="150px"
+          height="14px"
+        />
       </template>
       <template v-else>
         <h3>Добрый день, {{ displayName }}!</h3>
-        <p class="header__subtitle">Мы рады, что вы здесь!</p>
+        <p class="header__subtitle">
+          Мы рады, что вы здесь!
+        </p>
       </template>
     </div>
 
     <div class="header__info">
-      <button class="feedback-btn" data-testid="header-button-feedback" @click="openFeedbackModal">
+      <button
+        class="feedback-btn"
+        data-testid="header-button-feedback"
+        @click="openFeedbackModal"
+      >
         Сообщить о проблеме
       </button>
       <button
@@ -27,18 +42,35 @@
         {{ currentDateTime }}
       </p>
       <div class="language-selector">
-        <p class="current-language">RU</p>
+        <p class="current-language">
+          RU
+        </p>
       </div>
-      <div class="user__notifications" @click="showNotifications = !showNotifications">
-        <img src="@/assets/icons/messages.png" class="notifications__icon" alt="Сообщения" />
-        <span v-if="unreadCount > 0" class="notifications__badge">{{ unreadCount }}</span>
+      <div
+        class="user__notifications"
+        @click="showNotifications = !showNotifications"
+      >
+        <img
+          src="@/assets/icons/messages.png"
+          class="notifications__icon"
+          alt="Сообщения"
+        >
+        <span
+          v-if="unreadCount > 0"
+          class="notifications__badge"
+        >{{ unreadCount }}</span>
       </div>
       <UserNotifications
         :show="showNotifications"
         @update:unread-count="unreadCount = $event"
       />
       <div class="appl-btn__container">
-        <button class="appl-btn" data-testid="header-button-submit-app" @click="navigateToSubmit" :class="{ 'appl-btn--fixed': isHeaderHidden }">
+        <button
+          class="appl-btn"
+          data-testid="header-button-submit-app"
+          :class="{ 'appl-btn--fixed': isHeaderHidden }"
+          @click="navigateToSubmit"
+        >
           Подать заявку
         </button>
       </div>
@@ -97,6 +129,23 @@ export default {
   watch: {
     '$route'() {
       this.fetchUserData();
+    }
+  },
+  mounted() {
+    this.fetchUserData();
+    this.fetchActiveAnnouncement();
+    this.startDateTimeTimer();
+    this.$nextTick(() => {
+      this.initIntersectionObserver();
+    });
+  },
+  beforeUnmount() {
+    if (this.timer) {
+      clearInterval(this.timer);
+    }
+    
+    if (this.observer) {
+      this.observer.disconnect();
     }
   },
   methods: {
@@ -180,23 +229,6 @@ export default {
       if (this.$refs.header) {
         this.observer.observe(this.$refs.header);
       }
-    }
-  },
-  mounted() {
-    this.fetchUserData();
-    this.fetchActiveAnnouncement();
-    this.startDateTimeTimer();
-    this.$nextTick(() => {
-      this.initIntersectionObserver();
-    });
-  },
-  beforeUnmount() {
-    if (this.timer) {
-      clearInterval(this.timer);
-    }
-    
-    if (this.observer) {
-      this.observer.disconnect();
     }
   },
 }

--- a/frontend/src/components/ToastContainer.vue
+++ b/frontend/src/components/ToastContainer.vue
@@ -14,7 +14,12 @@
           <template v-else>&#8505;</template>
         </span>
         <span class="toast-message">{{ toast.message }}</span>
-        <button class="toast-close" @click="removeToast(toast.id)">&times;</button>
+        <button
+          class="toast-close"
+          @click="removeToast(toast.id)"
+        >
+          &times;
+        </button>
       </div>
     </transition-group>
   </div>

--- a/frontend/src/components/UnloadPlaces/ScheduleTab.vue
+++ b/frontend/src/components/UnloadPlaces/ScheduleTab.vue
@@ -2,15 +2,25 @@
   <div class="schedule-tab">
     <!-- Заголовок и кнопка добавления -->
     <div class="schedule-header">
-      <h4 class="schedule-title">Рабочее время</h4>
-      <button @click="openAddModal" class="add-btn" :disabled="isLoading">
+      <h4 class="schedule-title">
+        Рабочее время
+      </h4>
+      <button
+        class="add-btn"
+        :disabled="isLoading"
+        @click="openAddModal"
+      >
         + Добавить окно
       </button>
     </div>
 
     <!-- Список дней -->
     <div class="days-list">
-      <div v-for="day in 7" :key="day" class="day-group">
+      <div
+        v-for="day in 7"
+        :key="day"
+        class="day-group"
+      >
         <!-- Заголовок дня с переключателем -->
         <div class="day-header">
           <span class="day-name">{{ getFullDayName(day - 1) }}</span>
@@ -20,10 +30,10 @@
               <input
                 type="checkbox"
                 :checked="hasRoundTheClock(day - 1)"
-                @change="toggleRoundTheClock(day - 1, $event)"
                 :disabled="isLoading"
-              />
-              <span class="switch-slider"></span>
+                @change="toggleRoundTheClock(day - 1, $event)"
+              >
+              <span class="switch-slider" />
             </label>
           </div>
         </div>
@@ -31,12 +41,18 @@
         <!-- Контент дня -->
         <div class="day-content">
           <!-- Если есть активное круглосуточное окно - показываем заглушку -->
-          <div v-if="hasActiveRoundTheClock(day - 1)" class="round-badge">
+          <div
+            v-if="hasActiveRoundTheClock(day - 1)"
+            class="round-badge"
+          >
             Круглосуточно (24/7)
           </div>
 
           <!-- Иначе показываем все активные окна для этого дня -->
-          <div v-else class="slots-wrapper">
+          <div
+            v-else
+            class="slots-wrapper"
+          >
             <div
               v-for="slot in getActiveSlotsForDay(day - 1)"
               :key="slot.id"
@@ -44,20 +60,40 @@
             >
               <span class="slot-time">
                 {{ formatTime(slot.open_time) }} – {{ formatTime(slot.close_time) }}
-                <span v-if="slot.is_next_day" class="next-mark">(след. день)</span>
+                <span
+                  v-if="slot.is_next_day"
+                  class="next-mark"
+                >(след. день)</span>
               </span>
               <div class="slot-actions">
-                <button @click="editSlot(slot)" class="icon-btn" title="Редактировать">
-                  <img src="@/assets/icons/edit.png" class="icon" />
+                <button
+                  class="icon-btn"
+                  title="Редактировать"
+                  @click="editSlot(slot)"
+                >
+                  <img
+                    src="@/assets/icons/edit.png"
+                    class="icon"
+                  >
                 </button>
-                <button @click="deleteSlot(slot)" class="icon-btn" title="Удалить">
-                  <img src="@/assets/icons/trashcan.png" class="icon" />
+                <button
+                  class="icon-btn"
+                  title="Удалить"
+                  @click="deleteSlot(slot)"
+                >
+                  <img
+                    src="@/assets/icons/trashcan.png"
+                    class="icon"
+                  >
                 </button>
               </div>
             </div>
 
             <!-- Пусто -->
-            <div v-if="getActiveSlotsForDay(day - 1).length === 0" class="empty-text">
+            <div
+              v-if="getActiveSlotsForDay(day - 1).length === 0"
+              class="empty-text"
+            >
               Нет временных окон
             </div>
           </div>
@@ -67,15 +103,31 @@
 
     <!-- Модальное окно -->
     <transition name="modal-fade">
-      <div v-if="modalOpen" class="modal-overlay" @click.self="closeModal">
+      <div
+        v-if="modalOpen"
+        class="modal-overlay"
+        @click.self="closeModal"
+      >
         <div class="modal-content">
           <div class="modal-header">
             <h3 class="modal-title">
               {{ editingSlotId ? 'Редактировать временнОе окно' : 'Добавить временнОе окно' }}
             </h3>
-            <button @click="closeModal" class="modal-close">
-              <svg width="10" height="10" viewBox="0 0 14 14">
-                <path d="M13 1L1 13M1 1L13 13" stroke="#666" stroke-width="2" stroke-linecap="round"/>
+            <button
+              class="modal-close"
+              @click="closeModal"
+            >
+              <svg
+                width="10"
+                height="10"
+                viewBox="0 0 14 14"
+              >
+                <path
+                  d="M13 1L1 13M1 1L13 13"
+                  stroke="#666"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                />
               </svg>
             </button>
           </div>
@@ -84,7 +136,11 @@
             <!-- Выбор дня с кастомным селектом -->
             <div class="field">
               <label class="field-label">День недели *</label>
-              <div class="custom-select" @click="toggleDayDropdown" ref="selectRef">
+              <div
+                ref="selectRef"
+                class="custom-select"
+                @click="toggleDayDropdown"
+              >
                 <div class="select-trigger">
                   <span>{{ getFullDayName(modalDay) }}</span>
                   <img
@@ -93,10 +149,13 @@
                     :class="{ open: dayDropdownOpen }"
                     width="9"
                     height="9"
-                  />
+                  >
                 </div>
                 <transition name="dropdown">
-                  <div v-if="dayDropdownOpen" class="select-dropdown">
+                  <div
+                    v-if="dayDropdownOpen"
+                    class="select-dropdown"
+                  >
                     <div
                       v-for="(dayName, idx) in fullDayNames"
                       :key="idx"
@@ -115,31 +174,52 @@
             <div class="time-fields">
               <div class="field time-field">
                 <label class="field-label">Открытие *</label>
-                <input type="time" v-model="modalOpenTime" class="modal-input" @change="validateTimes" />
+                <input
+                  v-model="modalOpenTime"
+                  type="time"
+                  class="modal-input"
+                  @change="validateTimes"
+                >
               </div>
               <div class="field time-field">
                 <label class="field-label">Закрытие *</label>
-                <input type="time" v-model="modalCloseTime" class="modal-input" @change="validateTimes" />
+                <input
+                  v-model="modalCloseTime"
+                  type="time"
+                  class="modal-input"
+                  @change="validateTimes"
+                >
               </div>
             </div>
 
             <!-- Сообщение об ошибке пересечения -->
-            <div v-if="timeConflictError" class="error-hint">
+            <div
+              v-if="timeConflictError"
+              class="error-hint"
+            >
               ⚠️ {{ timeConflictError }}
             </div>
 
             <!-- Подсказка о следующем дне -->
-            <div v-if="modalNextDay && !timeConflictError" class="next-day-hint">
+            <div
+              v-if="modalNextDay && !timeConflictError"
+              class="next-day-hint"
+            >
               ⏰ Закрытие на следующий день
             </div>
           </div>
 
           <div class="modal-footer">
-            <button @click="closeModal" class="modal-btn cancel">Отмена</button>
             <button
-              @click="saveSlot"
+              class="modal-btn cancel"
+              @click="closeModal"
+            >
+              Отмена
+            </button>
+            <button
               class="modal-btn confirm"
               :disabled="!modalOpenTime || !modalCloseTime || isLoading || !!timeConflictError"
+              @click="saveSlot"
             >
               {{ editingSlotId ? 'Сохранить' : 'Добавить' }}
             </button>

--- a/frontend/src/components/UnloadPlaces/UnloadPlacesContainer.vue
+++ b/frontend/src/components/UnloadPlaces/UnloadPlacesContainer.vue
@@ -1,13 +1,18 @@
 <template>
   <div class="unload-places-container dashboard-card">
     <div class="management-header">
-      <h3 class="management-title">Управление местами разгрузки</h3>
+      <h3 class="management-title">
+        Управление местами разгрузки
+      </h3>
       <div class="header-controls">
         <SearchComponent
-          :title="'Поиск мест разгрузки...'"
           v-model="searchQuery"
+          :title="'Поиск мест разгрузки...'"
         />
-        <button @click="showAddModal = true" class="add-header-button">
+        <button
+          class="add-header-button"
+          @click="showAddModal = true"
+        >
           Добавить
         </button>
         <RefreshButton @refresh="refreshData" />
@@ -16,11 +21,19 @@
 
     <div class="content-container">
       <!-- Левая часть - таблица мест разгрузки -->
-      <div class="table-section" :class="{'with-details': selectedPlace}">
+      <div
+        class="table-section"
+        :class="{'with-details': selectedPlace}"
+      >
         <div class="table-container">
           <div class="table-header">
-            <div class="header-col id-col" @click="sortBy('id')">
-              <p :class="{ 'active-sort': sortField === 'id' }">ID</p>
+            <div
+              class="header-col id-col"
+              @click="sortBy('id')"
+            >
+              <p :class="{ 'active-sort': sortField === 'id' }">
+                ID
+              </p>
               <img 
                 src="@/assets/icons/sort.png" 
                 class="sort-icon" 
@@ -28,10 +41,15 @@
                   'sorted': sortField === 'id',
                   'desc': sortField === 'id' && sortDirection === 'desc'
                 }" 
-              />
+              >
             </div>
-            <div class="header-col name-col" @click="sortBy('name')">
-              <p :class="{ 'active-sort': sortField === 'name' }">Наименование</p>
+            <div
+              class="header-col name-col"
+              @click="sortBy('name')"
+            >
+              <p :class="{ 'active-sort': sortField === 'name' }">
+                Наименование
+              </p>
               <img 
                 src="@/assets/icons/sort.png" 
                 class="sort-icon" 
@@ -39,7 +57,7 @@
                   'sorted': sortField === 'name',
                   'desc': sortField === 'name' && sortDirection === 'desc'
                 }" 
-              />
+              >
             </div>
             <div class="header-col status-col">
               <p>Статус</p>
@@ -58,12 +76,18 @@
                 <span class="cell-content id-value">{{ place.id }}</span>
               </div>
               <div class="table-col name-col">
-                <span class="truncate-text" :title="place.name">
+                <span
+                  class="truncate-text"
+                  :title="place.name"
+                >
                   {{ place.name }}
                 </span>
               </div>
               <div class="table-col status-col">
-                <span class="status-badge" :class="getStatusClass(place)">
+                <span
+                  class="status-badge"
+                  :class="getStatusClass(place)"
+                >
                   {{ getStatusText(place) }}
                 </span>
               </div>
@@ -77,7 +101,10 @@
       </div>
 
       <!-- Правая часть - детали места разгрузки -->
-      <div v-if="selectedPlace" class="details-section">
+      <div
+        v-if="selectedPlace"
+        class="details-section"
+      >
         <div class="details-tabs">
           <button 
             class="tab-btn" 
@@ -103,17 +130,31 @@
         </div>
 
         <!-- Вкладка Основное -->
-        <div v-if="activeTab === 'main'" class="tab-content">
+        <div
+          v-if="activeTab === 'main'"
+          class="tab-content"
+        >
           <div class="details-header">
             <div class="details-title-wrapper">
-              <h3 class="details-title">{{ selectedPlace.name }}</h3>
-              <span class="current-status-badge" :class="getCurrentStatusClass(selectedPlace)">
+              <h3 class="details-title">
+                {{ selectedPlace.name }}
+              </h3>
+              <span
+                class="current-status-badge"
+                :class="getCurrentStatusClass(selectedPlace)"
+              >
                 {{ getCurrentStatusText(selectedPlace) }}
               </span>
             </div>
             <div class="details-header-actions">
-              <button @click="confirmDeletePlace(selectedPlace)" class="delete-icon-btn">
-                <img src="@/assets/icons/delete.png" class="delete-icon" />
+              <button
+                class="delete-icon-btn"
+                @click="confirmDeletePlace(selectedPlace)"
+              >
+                <img
+                  src="@/assets/icons/delete.png"
+                  class="delete-icon"
+                >
               </button>
             </div>
           </div>
@@ -123,10 +164,10 @@
               <label class="detail-label">Наименование:</label>
               <input 
                 v-model="selectedPlace.name" 
-                @change="updatePlace(selectedPlace)"
                 class="form-input"
                 placeholder="Введите название места"
                 autocomplete="off"
+                @change="updatePlace(selectedPlace)"
               >
             </div>
 
@@ -134,11 +175,11 @@
               <label class="detail-label">Описание:</label>
               <textarea 
                 v-model="selectedPlace.description" 
-                @change="updatePlace(selectedPlace)"
                 class="form-textarea"
                 placeholder="Введите описание"
                 rows="2"
-              ></textarea>
+                @change="updatePlace(selectedPlace)"
+              />
             </div>
 
             <!-- Статус в виде кнопок -->
@@ -163,21 +204,27 @@
             </div>
 
             <!-- Комментарий к статусу (только для неактивных) -->
-            <div v-if="selectedPlace.status !== 'active'" class="detail-group">
+            <div
+              v-if="selectedPlace.status !== 'active'"
+              class="detail-group"
+            >
               <label class="detail-label">Причина:</label>
               <textarea 
                 v-model="selectedPlace.status_comment" 
-                @change="updatePlace(selectedPlace)"
                 class="form-textarea"
                 placeholder="Укажите причину закрытия"
                 rows="2"
-              ></textarea>
+                @change="updatePlace(selectedPlace)"
+              />
             </div>
           </div>
         </div>
 
         <!-- Вкладка Расписание -->
-        <div v-if="activeTab === 'schedule'" class="tab-content">
+        <div
+          v-if="activeTab === 'schedule'"
+          class="tab-content"
+        >
           <ScheduleTab 
             :place-id="selectedPlace.id"
             :time-slots="selectedPlace.time_slots"
@@ -186,16 +233,21 @@
         </div>
 
         <!-- Вкладка Маршрут -->
-        <div v-if="activeTab === 'route'" class="tab-content">
+        <div
+          v-if="activeTab === 'route'"
+          class="tab-content"
+        >
           <div class="route-section">
-            <h4 class="section-title">Ссылка на локацию на карте</h4>
+            <h4 class="section-title">
+              Ссылка на локацию на карте
+            </h4>
             <div class="map-link-group">
               <input 
                 v-model="selectedPlace.map_link" 
-                @change="updatePlace(selectedPlace)"
                 class="form-input"
                 placeholder="https://maps.google.com/..."
                 autocomplete="off"
+                @change="updatePlace(selectedPlace)"
               >
               <a 
                 v-if="selectedPlace.map_link" 
@@ -210,35 +262,67 @@
 
           <div class="route-section">
             <div class="photos-header">
-              <h4 class="section-title">Изображение(-я)</h4>
+              <h4 class="section-title">
+                Изображение(-я)
+              </h4>
               <label class="upload-photo-btn">
                 + Загрузить
                 <input 
                   type="file" 
                   accept="image/*" 
                   multiple 
-                  @change="uploadPhotos"
                   style="display: none"
+                  @change="uploadPhotos"
                 >
               </label>
             </div>
 
             <div class="photos-grid">
-              <div v-for="photo in selectedPlace.photos" :key="photo.id" class="photo-item" :class="{ 'main-photo': photo.is_main }">
-                <div class="photo-preview" @click="viewPhoto(photo)">
-                  <img :src="photo.photo_url" :alt="photo.file_name">
+              <div
+                v-for="photo in selectedPlace.photos"
+                :key="photo.id"
+                class="photo-item"
+                :class="{ 'main-photo': photo.is_main }"
+              >
+                <div
+                  class="photo-preview"
+                  @click="viewPhoto(photo)"
+                >
+                  <img
+                    :src="photo.photo_url"
+                    :alt="photo.file_name"
+                  >
                 </div>
                 <div class="photo-actions">
-                  <button v-if="!photo.is_main" @click="setMainPhoto(photo)" class="photo-main-btn" title="Сделать главной">
+                  <button
+                    v-if="!photo.is_main"
+                    class="photo-main-btn"
+                    title="Сделать главной"
+                    @click="setMainPhoto(photo)"
+                  >
                     ★
                   </button>
-                  <span v-else class="photo-main-badge" title="Главная фотография">★</span>
-                  <button @click="deletePhoto(photo)" class="photo-delete-btn" title="Удалить">
-                    <img src="@/assets/icons/trashcan.png" class="action-icon-small" />
+                  <span
+                    v-else
+                    class="photo-main-badge"
+                    title="Главная фотография"
+                  >★</span>
+                  <button
+                    class="photo-delete-btn"
+                    title="Удалить"
+                    @click="deletePhoto(photo)"
+                  >
+                    <img
+                      src="@/assets/icons/trashcan.png"
+                      class="action-icon-small"
+                    >
                   </button>
                 </div>
               </div>
-              <div v-if="!selectedPlace.photos || selectedPlace.photos.length === 0" class="no-photos">
+              <div
+                v-if="!selectedPlace.photos || selectedPlace.photos.length === 0"
+                class="no-photos"
+              >
                 <p>Фотографии не загружены</p>
               </div>
             </div>
@@ -246,25 +330,52 @@
         </div>
       </div>
       
-      <div v-else class="no-selection-message">
+      <div
+        v-else
+        class="no-selection-message"
+      >
         <p>Выберите место разгрузки для просмотра</p>
       </div>
     </div>
 
-    <div v-if="filteredUnloadPlaces.length === 0" class="no-results">
-      <div class="no-results-icon">📍</div>
+    <div
+      v-if="filteredUnloadPlaces.length === 0"
+      class="no-results"
+    >
+      <div class="no-results-icon">
+        📍
+      </div>
       <p>Места разгрузки не найдены</p>
     </div>
 
     <!-- Модальное окно добавления места -->
     <transition name="modal-fade">
-      <div v-if="showAddModal" class="modal-overlay" @click.self="closeModal">
+      <div
+        v-if="showAddModal"
+        class="modal-overlay"
+        @click.self="closeModal"
+      >
         <div class="modal-content">
           <div class="modal-header">
-            <h3 class="modal-title">Добавить место разгрузки</h3>
-            <button @click="closeModal" class="modal-close">
-              <svg width="10" height="10" viewBox="0 0 14 14" fill="none">
-                <path d="M13 1L1 13M1 1L13 13" stroke="#666" stroke-width="2" stroke-linecap="round"/>
+            <h3 class="modal-title">
+              Добавить место разгрузки
+            </h3>
+            <button
+              class="modal-close"
+              @click="closeModal"
+            >
+              <svg
+                width="10"
+                height="10"
+                viewBox="0 0 14 14"
+                fill="none"
+              >
+                <path
+                  d="M13 1L1 13M1 1L13 13"
+                  stroke="#666"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                />
               </svg>
             </button>
           </div>
@@ -273,11 +384,11 @@
             <div class="input-group">
               <label class="input-label">Наименование *</label>
               <input
+                ref="nameInput"
                 v-model="newPlaceName"
                 placeholder="Введите название места"
                 class="modal-input"
                 @keyup.enter="addPlace"
-                ref="nameInput"
               >
             </div>
             
@@ -288,17 +399,22 @@
                 placeholder="Введите описание (необязательно)"
                 class="modal-textarea"
                 rows="3"
-              ></textarea>
+              />
             </div>
           </div>
           
           <div class="modal-footer">
-            <button @click="closeModal" class="modal-btn modal-btn--cancel">Отмена</button>
+            <button
+              class="modal-btn modal-btn--cancel"
+              @click="closeModal"
+            >
+              Отмена
+            </button>
             <button 
-              @click="addPlace" 
-              class="modal-btn modal-btn--confirm"
+              class="modal-btn modal-btn--confirm" 
               :disabled="!newPlaceName.trim()"
               :class="{'modal-btn--disabled': !newPlaceName.trim()}"
+              @click="addPlace"
             >
               Добавить
             </button>
@@ -309,25 +425,52 @@
 
     <!-- Модальное окно просмотра фото -->
     <transition name="modal-fade">
-      <div v-if="showPhotoModal" class="modal-overlay" @click.self="showPhotoModal = false">
+      <div
+        v-if="showPhotoModal"
+        class="modal-overlay"
+        @click.self="showPhotoModal = false"
+      >
         <div class="modal-content photo-view-modal">
           <div class="modal-header">
-            <h3 class="modal-title">{{ viewingPhoto?.file_name }}</h3>
-            <button @click="showPhotoModal = false" class="modal-close">
-              <svg width="10" height="10" viewBox="0 0 14 14" fill="none">
-                <path d="M13 1L1 13M1 1L13 13" stroke="#666" stroke-width="2" stroke-linecap="round"/>
+            <h3 class="modal-title">
+              {{ viewingPhoto?.file_name }}
+            </h3>
+            <button
+              class="modal-close"
+              @click="showPhotoModal = false"
+            >
+              <svg
+                width="10"
+                height="10"
+                viewBox="0 0 14 14"
+                fill="none"
+              >
+                <path
+                  d="M13 1L1 13M1 1L13 13"
+                  stroke="#666"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                />
               </svg>
             </button>
           </div>
           <div class="modal-body photo-view-body">
-            <img :src="viewingPhoto?.photo_url" class="full-photo" alt="Full size">
+            <img
+              :src="viewingPhoto?.photo_url"
+              class="full-photo"
+              alt="Full size"
+            >
           </div>
         </div>
       </div>
     </transition>
 
     <!-- Уведомления -->
-    <div v-if="notification.show" class="notification" :class="notification.type">
+    <div
+      v-if="notification.show"
+      class="notification"
+      :class="notification.type"
+    >
       <span class="notification-message">{{ notification.message }}</span>
     </div>
   </div>
@@ -405,6 +548,15 @@ export default {
         }
         return 0;
       });
+    }
+  },
+  watch: {
+    showAddModal(newVal) {
+      if (newVal) {
+        this.$nextTick(() => {
+          this.$refs.nameInput?.focus();
+        });
+      }
     }
   },
   mounted() {
@@ -763,15 +915,6 @@ async uploadPhotos(event) {
     
     hideNotification() {
       this.notification.show = false;
-    }
-  },
-  watch: {
-    showAddModal(newVal) {
-      if (newVal) {
-        this.$nextTick(() => {
-          this.$refs.nameInput?.focus();
-        });
-      }
     }
   }
 };

--- a/frontend/src/components/UnloadingPlaceFilter.vue
+++ b/frontend/src/components/UnloadingPlaceFilter.vue
@@ -1,60 +1,72 @@
 <template>
-    <div class="field field--select" @click="toggleDropdown">
-        <span class="select-text">{{ displayText }}</span>
-        <img 
-            src="@/assets/icons/arrow.png" 
-            class="select-icon" 
-            :class="{ 'select-icon--rotated': isOpen }" 
-        />
+  <div
+    class="field field--select"
+    @click="toggleDropdown"
+  >
+    <span class="select-text">{{ displayText }}</span>
+    <img 
+      src="@/assets/icons/arrow.png" 
+      class="select-icon" 
+      :class="{ 'select-icon--rotated': isOpen }" 
+    >
         
-        <transition name="dropdown">
-            <div 
-                class="custom-dropdown"
-                v-if="isOpen"
-                @click.stop
-            >
-                <div class="dropdown-search">
-                    <input 
-                        type="text" 
-                        placeholder="Поиск..." 
-                        v-model="searchQuery"
-                        @click.stop
-                        class="dropdown-search__input"
-                        ref="searchInput"
-                        @input="handleSearchInput"
-                    />
-                </div>
+    <transition name="dropdown">
+      <div 
+        v-if="isOpen"
+        class="custom-dropdown"
+        @click.stop
+      >
+        <div class="dropdown-search">
+          <input 
+            ref="searchInput" 
+            v-model="searchQuery" 
+            type="text"
+            placeholder="Поиск..."
+            class="dropdown-search__input"
+            @click.stop
+            @input="handleSearchInput"
+          >
+        </div>
                 
-                <div class="dropdown-list" ref="listContainer">
-                    <div 
-                        class="dropdown-item"
-                        :class="{ 'dropdown-item--selected': !internalValue }"
-                        @click="selectItem(null, 'Все места разгрузки')"
-                    >
-                        <span class="item-text" title="Все места разгрузки">Все места разгрузки</span>
-                    </div>
+        <div
+          ref="listContainer"
+          class="dropdown-list"
+        >
+          <div 
+            class="dropdown-item"
+            :class="{ 'dropdown-item--selected': !internalValue }"
+            @click="selectItem(null, 'Все места разгрузки')"
+          >
+            <span
+              class="item-text"
+              title="Все места разгрузки"
+            >Все места разгрузки</span>
+          </div>
                     
-                    <div 
-                        v-for="place in filteredPlaces"
-                        :key="place.id"
-                        class="dropdown-item"
-                        :class="{ 'dropdown-item--selected': internalValue === place.id }"
-                        @click="selectItem(place.id, place.name)"
-                    >
-                        <span class="item-text" :title="place.name">{{ place.name }}</span>
-                    </div>
+          <div 
+            v-for="place in filteredPlaces"
+            :key="place.id"
+            class="dropdown-item"
+            :class="{ 'dropdown-item--selected': internalValue === place.id }"
+            @click="selectItem(place.id, place.name)"
+          >
+            <span
+              class="item-text"
+              :title="place.name"
+            >{{ place.name }}</span>
+          </div>
                     
-                    <div 
-                        v-if="filteredPlaces.length === 0" 
-                        class="dropdown-no-results"
-                        :class="{ 'with-border': searchQuery }"
-                    >
-                        Ничего не найдено
-                    </div>
-                </div>
-            </div>
-        </transition>
-    </div>
+          <div 
+            v-if="filteredPlaces.length === 0" 
+            class="dropdown-no-results"
+            :class="{ 'with-border': searchQuery }"
+          >
+            Ничего не найдено
+          </div>
+        </div>
+      </div>
+    </transition>
+  </div>
 </template>
 
 <script>
@@ -119,6 +131,9 @@ export default {
     mounted() {
         this.fetchUnloadingPlaces();
         this.updateSelectedName();
+    },
+    beforeUnmount() {
+        this.removeClickOutside();
     },
     methods: {
         async fetchUnloadingPlaces() {
@@ -209,9 +224,6 @@ export default {
             this.$emit('input', null);
             this.$emit('change', { id: null, name: '' });
         }
-    },
-    beforeUnmount() {
-        this.removeClickOutside();
     }
 };
 </script>

--- a/frontend/src/components/UserApplications.vue
+++ b/frontend/src/components/UserApplications.vue
@@ -2,7 +2,9 @@
   <div class="applications-card">
     <div class="card-header">
       <div class="card-header__title">
-        <h3 class="card-title">Список заявок</h3>
+        <h3 class="card-title">
+          Список заявок
+        </h3>
         
         <!-- Кнопки фильтров в шапке -->
         <div class="filter-tabs">
@@ -26,8 +28,8 @@
       
       <div class="card-header__settings">
         <SearchComponent
-          :title="'Поиск заявок..'"
           v-model="searchQuery"
+          :title="'Поиск заявок..'"
         />
         <RefreshButton @refresh="fetchUserApplications" />
       </div>
@@ -40,8 +42,13 @@
           <!-- Заголовок таблицы -->
           <div class="applications-header">
             <div class="header-row">
-              <div class="header-col id-col" @click="sortBy('application_number')">
-                <p :class="{ 'active-sort': sortField === 'application_number' }">Номер заявки</p>
+              <div
+                class="header-col id-col"
+                @click="sortBy('application_number')"
+              >
+                <p :class="{ 'active-sort': sortField === 'application_number' }">
+                  Номер заявки
+                </p>
                 <img 
                   src="@/assets/icons/sort.png" 
                   class="sort-icon" 
@@ -49,10 +56,15 @@
                     'sorted': sortField === 'application_number',
                     'desc': sortField === 'application_number' && sortDirection === 'desc'
                   }" 
-                />
+                >
               </div>
-              <div class="header-col date-col" @click="sortBy('sending_datetime')">
-                <p :class="{ 'active-sort': sortField === 'sending_datetime' }">Дата и время</p>
+              <div
+                class="header-col date-col"
+                @click="sortBy('sending_datetime')"
+              >
+                <p :class="{ 'active-sort': sortField === 'sending_datetime' }">
+                  Дата и время
+                </p>
                 <img 
                   src="@/assets/icons/sort.png" 
                   class="sort-icon" 
@@ -60,10 +72,15 @@
                     'sorted': sortField === 'sending_datetime',
                     'desc': sortField === 'sending_datetime' && sortDirection === 'desc'
                   }" 
-                />
+                >
               </div>
-              <div class="header-col sender-col" @click="sortBy('sender_name')">
-                <p :class="{ 'active-sort': sortField === 'sender_name' }">Отправитель</p>
+              <div
+                class="header-col sender-col"
+                @click="sortBy('sender_name')"
+              >
+                <p :class="{ 'active-sort': sortField === 'sender_name' }">
+                  Отправитель
+                </p>
                 <img 
                   src="@/assets/icons/sort.png" 
                   class="sort-icon" 
@@ -71,10 +88,15 @@
                     'sorted': sortField === 'sender_name',
                     'desc': sortField === 'sender_name' && sortDirection === 'desc'
                   }" 
-                />
+                >
               </div>
-              <div class="header-col confirmation-col" @click="sortBy('confirmation')">
-                <p :class="{ 'active-sort': sortField === 'confirmation' }">Подтверждение</p>
+              <div
+                class="header-col confirmation-col"
+                @click="sortBy('confirmation')"
+              >
+                <p :class="{ 'active-sort': sortField === 'confirmation' }">
+                  Подтверждение
+                </p>
                 <img 
                   src="@/assets/icons/sort.png" 
                   class="sort-icon" 
@@ -82,10 +104,15 @@
                     'sorted': sortField === 'confirmation',
                     'desc': sortField === 'confirmation' && sortDirection === 'desc'
                   }" 
-                />
+                >
               </div>
-              <div class="header-col status-col" @click="sortBy('status')">
-                <p :class="{ 'active-sort': sortField === 'status' }">Статус</p>
+              <div
+                class="header-col status-col"
+                @click="sortBy('status')"
+              >
+                <p :class="{ 'active-sort': sortField === 'status' }">
+                  Статус
+                </p>
                 <img 
                   src="@/assets/icons/sort.png" 
                   class="sort-icon" 
@@ -93,20 +120,30 @@
                     'sorted': sortField === 'status',
                     'desc': sortField === 'status' && sortDirection === 'desc'
                   }" 
-                />
+                >
               </div>
             </div>
           </div>
           
           <!-- Тело таблицы -->
           <div class="applications-body">
-            <div v-if="isLoading" class="loading-message">
+            <div
+              v-if="isLoading"
+              class="loading-message"
+            >
               <LoaderSpinner label="Загрузка заявок…" />
             </div>
             
             <template v-else>
-              <div v-if="filteredApplications.length > 0" class="applications-list-content">
-                <transition-group name="fade-list" tag="div" class="applications-transition-group">
+              <div
+                v-if="filteredApplications.length > 0"
+                class="applications-list-content"
+              >
+                <transition-group
+                  name="fade-list"
+                  tag="div"
+                  class="applications-transition-group"
+                >
                   <div 
                     v-for="(application) in sortedApplications" 
                     :key="application.id" 
@@ -144,9 +181,15 @@
                 </transition-group>
               </div>
               
-              <div v-else class="no-data-message">
+              <div
+                v-else
+                class="no-data-message"
+              >
                 <p>{{ searchQuery ? 'Заявки не найдены' : 'Заявок нет' }}</p>
-                <p class="hint" v-if="!searchQuery">
+                <p
+                  v-if="!searchQuery"
+                  class="hint"
+                >
                   {{ getNoDataHint() }}
                 </p>
               </div>
@@ -289,6 +332,48 @@ export default {
         return 0;
       });
     }
+  },
+  watch: {
+    searchQuery() {
+      this.fetchUserApplications();
+    },
+    userId() {
+      this.fetchUserApplications();
+    }
+  },
+  mounted() {
+    this.fetchUserApplications();
+    this.getCurrentUser();
+    
+    // Добавляем стили для анимации уведомлений
+    const style = document.createElement('style');
+    style.textContent = `
+      @keyframes slideDown {
+        from {
+          transform: translate(-50%, -100%);
+          opacity: 0;
+        }
+        to {
+          transform: translate(-50%, 0);
+          opacity: 1;
+        }
+      }
+      @keyframes slideUp {
+        from {
+          transform: translate(-50%, 0);
+          opacity: 1;
+        }
+        to {
+          transform: translate(-50%, -100%);
+          opacity: 0;
+        }
+      }
+    `;
+    document.head.appendChild(style);
+  },
+  beforeUnmount() {
+    // Восстанавливаем скролл при размонтировании компонента
+    document.body.style.overflow = '';
   },
   methods: {
     async fetchUserApplications() {
@@ -502,48 +587,6 @@ export default {
           notification.parentNode.removeChild(notification);
         }
       }, 3000);
-    }
-  },
-  mounted() {
-    this.fetchUserApplications();
-    this.getCurrentUser();
-    
-    // Добавляем стили для анимации уведомлений
-    const style = document.createElement('style');
-    style.textContent = `
-      @keyframes slideDown {
-        from {
-          transform: translate(-50%, -100%);
-          opacity: 0;
-        }
-        to {
-          transform: translate(-50%, 0);
-          opacity: 1;
-        }
-      }
-      @keyframes slideUp {
-        from {
-          transform: translate(-50%, 0);
-          opacity: 1;
-        }
-        to {
-          transform: translate(-50%, -100%);
-          opacity: 0;
-        }
-      }
-    `;
-    document.head.appendChild(style);
-  },
-  beforeUnmount() {
-    // Восстанавливаем скролл при размонтировании компонента
-    document.body.style.overflow = '';
-  },
-  watch: {
-    searchQuery() {
-      this.fetchUserApplications();
-    },
-    userId() {
-      this.fetchUserApplications();
     }
   }
 };

--- a/frontend/src/components/UserControl.vue
+++ b/frontend/src/components/UserControl.vue
@@ -1,13 +1,18 @@
 <template>
   <div class="user-management dashboard-card">
     <div class="management-header">
-      <h3 class="management-title">Учётные записи пользователей</h3>
+      <h3 class="management-title">
+        Учётные записи пользователей
+      </h3>
       <div class="search-container">
         <SearchComponent
-          :title="'Поиск пользователей...'"
           v-model="userSearch"
+          :title="'Поиск пользователей...'"
         />
-        <button @click="openCreateModal" class="create-btn">
+        <button
+          class="create-btn"
+          @click="openCreateModal"
+        >
           Создать
         </button>
         <RefreshButton @refresh="refreshAllData" />
@@ -16,12 +21,20 @@
 
     <div class="users-container">
       <!-- Левая часть - таблица пользователей -->
-      <div class="users-list" :class="{'with-details': selectedUser}">
+      <div
+        class="users-list"
+        :class="{'with-details': selectedUser}"
+      >
         <!-- Заголовок таблицы -->
         <div class="users-header">
           <div class="header-row">
-            <div class="header-col login-col" @click="sortBy('username')">
-              <p :class="{ 'active-sort': sortField === 'username' }">Логин</p>
+            <div
+              class="header-col login-col"
+              @click="sortBy('username')"
+            >
+              <p :class="{ 'active-sort': sortField === 'username' }">
+                Логин
+              </p>
               <img 
                 src="@/assets/icons/sort.png" 
                 class="sort-icon" 
@@ -29,10 +42,15 @@
                   'sorted': sortField === 'username',
                   'desc': sortField === 'username' && sortDirection === 'desc'
                 }" 
-              />
+              >
             </div>
-            <div class="header-col name-col" @click="sortBy('full_name')">
-              <p :class="{ 'active-sort': sortField === 'full_name' }">Фамилия И.О.</p>
+            <div
+              class="header-col name-col"
+              @click="sortBy('full_name')"
+            >
+              <p :class="{ 'active-sort': sortField === 'full_name' }">
+                Фамилия И.О.
+              </p>
               <img 
                 src="@/assets/icons/sort.png" 
                 class="sort-icon" 
@@ -40,10 +58,15 @@
                   'sorted': sortField === 'full_name',
                   'desc': sortField === 'full_name' && sortDirection === 'desc'
                 }" 
-              />
+              >
             </div>
-            <div class="header-col org-col" @click="sortBy('organization')">
-              <p :class="{ 'active-sort': sortField === 'organization' }">Организация / Отдел</p>
+            <div
+              class="header-col org-col"
+              @click="sortBy('organization')"
+            >
+              <p :class="{ 'active-sort': sortField === 'organization' }">
+                Организация / Отдел
+              </p>
               <img 
                 src="@/assets/icons/sort.png" 
                 class="sort-icon" 
@@ -51,10 +74,15 @@
                   'sorted': sortField === 'organization',
                   'desc': sortField === 'organization' && sortDirection === 'desc'
                 }" 
-              />
+              >
             </div>
-            <div class="header-col company-col" @click="sortBy('company')">
-              <p :class="{ 'active-sort': sortField === 'company' }">Компания</p>
+            <div
+              class="header-col company-col"
+              @click="sortBy('company')"
+            >
+              <p :class="{ 'active-sort': sortField === 'company' }">
+                Компания
+              </p>
               <img 
                 src="@/assets/icons/sort.png" 
                 class="sort-icon" 
@@ -62,10 +90,15 @@
                   'sorted': sortField === 'company',
                   'desc': sortField === 'company' && sortDirection === 'desc'
                 }" 
-              />
+              >
             </div>
-            <div class="header-col type-col" @click="sortBy('user_type')">
-              <p :class="{ 'active-sort': sortField === 'user_type' }">Тип</p>
+            <div
+              class="header-col type-col"
+              @click="sortBy('user_type')"
+            >
+              <p :class="{ 'active-sort': sortField === 'user_type' }">
+                Тип
+              </p>
               <img 
                 src="@/assets/icons/sort.png" 
                 class="sort-icon" 
@@ -73,7 +106,7 @@
                   'sorted': sortField === 'user_type',
                   'desc': sortField === 'user_type' && sortDirection === 'desc'
                 }" 
-              />
+              >
             </div>
           </div>
         </div>
@@ -95,12 +128,18 @@
                 {{ formatUserName(user) }}
               </div>
               <div class="user-col org-col">
-                <span class="truncate-text" :title="user.organization || '-'">
+                <span
+                  class="truncate-text"
+                  :title="user.organization || '-'"
+                >
                   {{ user.organization || '-' }}
                 </span>
               </div>
               <div class="user-col company-col">
-                <span class="truncate-text" :title="user.company || '-'">
+                <span
+                  class="truncate-text"
+                  :title="user.company || '-'"
+                >
                   {{ user.company || '-' }}
                 </span>
               </div>
@@ -113,20 +152,39 @@
       </div>
       
       <!-- Правая часть - детали выбранного пользователя -->
-      <div v-if="selectedUser" class="user-details-panel">
+      <div
+        v-if="selectedUser"
+        class="user-details-panel"
+      >
         <div class="details-content">
           <div class="details-header">
             <div class="details-title-wrapper">
-              <h3 class="details-title">Редактирование</h3>
-              <p class="details-subtitle">учётной записи <strong>{{ selectedUser.username }}</strong></p>
+              <h3 class="details-title">
+                Редактирование
+              </h3>
+              <p class="details-subtitle">
+                учётной записи <strong>{{ selectedUser.username }}</strong>
+              </p>
             </div>
             <div class="details-header-actions">
-              <button @click="openPermissions(selectedUser)" class="access-rights-btn">
-                <img src="@/assets/icons/access.png" class="access-icon" />
+              <button
+                class="access-rights-btn"
+                @click="openPermissions(selectedUser)"
+              >
+                <img
+                  src="@/assets/icons/access.png"
+                  class="access-icon"
+                >
                 Права доступа
               </button>
-              <button @click="confirmDeleteUser(selectedUser)" class="delete-icon-btn">
-                <img src="@/assets/icons/delete.png" class="delete-icon" />
+              <button
+                class="delete-icon-btn"
+                @click="confirmDeleteUser(selectedUser)"
+              >
+                <img
+                  src="@/assets/icons/delete.png"
+                  class="delete-icon"
+                >
               </button>
             </div>
           </div>
@@ -139,13 +197,13 @@
                   <label class="detail-label">Фамилия:</label>
                   <input 
                     v-model="selectedUser.last_name" 
-                    @change="updateUserInfo(selectedUser)"
                     class="form-input-sm"
                     placeholder="Введите фамилию"
                     autocomplete="new-password"
                     autocorrect="off"
                     autocapitalize="off"
                     spellcheck="false"
+                    @change="updateUserInfo(selectedUser)"
                   >
                 </div>
                 
@@ -153,19 +211,22 @@
                   <label class="detail-label">Отчество:</label>
                   <input 
                     v-model="selectedUser.middle_name" 
-                    @change="updateUserInfo(selectedUser)"
                     class="form-input-sm"
                     placeholder="Введите отчество"
                     autocomplete="new-password"
                     autocorrect="off"
                     autocapitalize="off"
                     spellcheck="false"
+                    @change="updateUserInfo(selectedUser)"
                   >
                 </div>
                 
                 <div class="detail-group">
                   <label class="detail-label">Организация:</label>
-                  <div class="custom-select" @click="toggleOrgDropdown">
+                  <div
+                    class="custom-select"
+                    @click="toggleOrgDropdown"
+                  >
                     <div class="select-trigger">
                       <span>{{ getOrganizationName(selectedUser.organization_id) || 'Не выбрано' }}</span>
                       <img 
@@ -174,10 +235,13 @@
                         :class="{ 'open': orgDropdownOpen }"
                         width="12"
                         height="12"
-                      />
+                      >
                     </div>
                     <transition name="dropdown">
-                      <div v-if="orgDropdownOpen" class="select-dropdown">
+                      <div
+                        v-if="orgDropdownOpen"
+                        class="select-dropdown"
+                      >
                         <div 
                           v-for="org in organizations" 
                           :key="org.id"
@@ -196,13 +260,13 @@
                   <label class="detail-label">Должность:</label>
                   <input 
                     v-model="selectedUser.position" 
-                    @change="updateUserInfo(selectedUser)"
                     class="form-input-sm"
                     placeholder="Введите должность"
                     autocomplete="new-password"
                     autocorrect="off"
                     autocapitalize="off"
                     spellcheck="false"
+                    @change="updateUserInfo(selectedUser)"
                   >
                 </div>
               </div>
@@ -213,13 +277,13 @@
                   <label class="detail-label">Имя:</label>
                   <input 
                     v-model="selectedUser.first_name" 
-                    @change="updateUserInfo(selectedUser)"
                     class="form-input-sm"
                     placeholder="Введите имя"
                     autocomplete="new-password"
                     autocorrect="off"
                     autocapitalize="off"
                     spellcheck="false"
+                    @change="updateUserInfo(selectedUser)"
                   >
                 </div>
                 
@@ -227,7 +291,6 @@
                   <label class="detail-label">Телефон:</label>
                   <input 
                     v-model="selectedUser.phone" 
-                    @change="updateUserInfo(selectedUser)"
                     class="form-input-sm"
                     placeholder="Введите телефон"
                     type="tel"
@@ -235,12 +298,16 @@
                     autocorrect="off"
                     autocapitalize="off"
                     spellcheck="false"
+                    @change="updateUserInfo(selectedUser)"
                   >
                 </div>
                 
                 <div class="detail-group">
                   <label class="detail-label">Компания:</label>
-                  <div class="custom-select" @click="toggleCompanyDropdown">
+                  <div
+                    class="custom-select"
+                    @click="toggleCompanyDropdown"
+                  >
                     <div class="select-trigger">
                       <span>{{ getCompanyName(selectedUser.company_id) || 'Не выбрано' }}</span>
                       <img 
@@ -249,10 +316,13 @@
                         :class="{ 'open': companyDropdownOpen }"
                         width="12"
                         height="12"
-                      />
+                      >
                     </div>
                     <transition name="dropdown">
-                      <div v-if="companyDropdownOpen" class="select-dropdown">
+                      <div
+                        v-if="companyDropdownOpen"
+                        class="select-dropdown"
+                      >
                         <div 
                           v-for="comp in companies" 
                           :key="comp.id"
@@ -271,7 +341,6 @@
                   <label class="detail-label">Email:</label>
                   <input 
                     v-model="selectedUser.email" 
-                    @change="updateUserInfo(selectedUser)"
                     class="form-input-sm"
                     placeholder="Введите email"
                     type="email"
@@ -279,6 +348,7 @@
                     autocorrect="off"
                     autocapitalize="off"
                     spellcheck="false"
+                    @change="updateUserInfo(selectedUser)"
                   >
                 </div>
               </div>
@@ -288,7 +358,10 @@
             <div class="full-width-groups">
               <div class="detail-group">
                 <label class="detail-label">Тип пользователя:</label>
-                <div class="custom-select full-width" @click="toggleTypeDropdown">
+                <div
+                  class="custom-select full-width"
+                  @click="toggleTypeDropdown"
+                >
                   <div class="select-trigger">
                     <span>{{ getUserTypeName(selectedUser.type_id) || 'Не выбрано' }}</span>
                     <img 
@@ -297,10 +370,13 @@
                       :class="{ 'open': typeDropdownOpen }"
                       width="12"
                       height="12"
-                    />
+                    >
                   </div>
                   <transition name="dropdown">
-                    <div v-if="typeDropdownOpen" class="select-dropdown">
+                    <div
+                      v-if="typeDropdownOpen"
+                      class="select-dropdown"
+                    >
                       <div 
                         v-for="type in userTypes" 
                         :key="type.id"
@@ -319,37 +395,46 @@
                 <label class="detail-label">Новый пароль:</label>
                 <div class="password-input-container">
                   <input 
-                    :type="showNewPass ? 'text' : 'password'" 
                     v-model="selectedUser.newPassword" 
-                    @keyup="checkInputLanguage($event)"
-                    @keyup.enter="changeUserPassword(selectedUser)"
+                    :type="showNewPass ? 'text' : 'password'" 
                     class="password-input-sm"
                     placeholder="Новый пароль"
                     autocomplete="new-password"
                     autocorrect="off"
                     autocapitalize="off"
                     spellcheck="false"
+                    @keyup="checkInputLanguage($event)"
+                    @keyup.enter="changeUserPassword(selectedUser)"
                   >
                   <div class="password-actions">
                     <button 
-                      @click="generatePassword(selectedUser)" 
-                      class="generate-password-btn"
+                      class="generate-password-btn" 
                       type="button"
+                      @click="generatePassword(selectedUser)"
                     >
-                      <img src="@/assets/icons/random.png" class="generate-icon" />
+                      <img
+                        src="@/assets/icons/random.png"
+                        class="generate-icon"
+                      >
                       Генерировать
                     </button>
                     <button 
-                      @click="changeUserPassword(selectedUser)" 
-                      :disabled="!selectedUser.newPassword"
+                      :disabled="!selectedUser.newPassword" 
                       class="save-password-btn"
+                      @click="changeUserPassword(selectedUser)"
                     >
-                      <img src="@/assets/icons/save.png" class="save-icon" />
+                      <img
+                        src="@/assets/icons/save.png"
+                        class="save-icon"
+                      >
                     </button>
                   </div>
                 </div>
                 <div class="input-hints">
-                  <span class="language-hint" :class="{ 'warning': isCapsLockOn }">
+                  <span
+                    class="language-hint"
+                    :class="{ 'warning': isCapsLockOn }"
+                  >
                     {{ currentLanguage }} {{ isCapsLockOn ? '| CAPS LOCK' : '' }}
                   </span>
                 </div>
@@ -359,59 +444,92 @@
         </div>
       </div>
       
-      <div v-else class="no-selection-message">
+      <div
+        v-else
+        class="no-selection-message"
+      >
         <p>Выберите пользователя для просмотра</p>
       </div>
     </div>
 
-    <div v-if="filteredUsers.length === 0" class="no-users">
+    <div
+      v-if="filteredUsers.length === 0"
+      class="no-users"
+    >
       <p>{{ userSearch ? 'Пользователи не найдены' : 'Пользователи отсутствуют' }}</p>
     </div>
 
     <!-- Модальное окно создания пользователя - на уровне body через Teleport -->
     <Teleport to="body">
       <transition name="modal-fade">
-        <div v-if="showCreateModal" class="modal-overlay" @click.self="closeCreateModal">
+        <div
+          v-if="showCreateModal"
+          class="modal-overlay"
+          @click.self="closeCreateModal"
+        >
           <div class="modal-content">
             <div class="modal-header">
-              <h3 class="modal-title">Создание пользователя</h3>
-              <button @click="closeCreateModal" class="modal-close">
-                <svg width="10" height="10" viewBox="0 0 14 14" fill="none">
-                  <path d="M13 1L1 13M1 1L13 13" stroke="#666" stroke-width="2" stroke-linecap="round"/>
+              <h3 class="modal-title">
+                Создание пользователя
+              </h3>
+              <button
+                class="modal-close"
+                @click="closeCreateModal"
+              >
+                <svg
+                  width="10"
+                  height="10"
+                  viewBox="0 0 14 14"
+                  fill="none"
+                >
+                  <path
+                    d="M13 1L1 13M1 1L13 13"
+                    stroke="#666"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                  />
                 </svg>
               </button>
             </div>
             
             <div class="modal-body">
-              <div v-if="!hasOrgOrCompany" class="form-hint form-hint--warning">
+              <div
+                v-if="!hasOrgOrCompany"
+                class="form-hint form-hint--warning"
+              >
                 Укажите организацию или компанию - хотя бы одно из двух обязательно.
               </div>
               <div class="form-wrap">
                 <div class="input-group half">
                   <label class="input-label">Логин <span class="required">*</span></label>
                   <input
+                    ref="usernameInput"
                     v-model="newUser.username"
                     placeholder="Введите логин"
                     class="modal-input"
-                    ref="usernameInput"
                     @input="saveDraft"
                   >
                 </div>
                 <div class="input-group half">
                   <label class="input-label">Пароль <span class="required">*</span></label>
                   <input
-                    type="password"
                     v-model="newUser.password"
+                    type="password"
                     placeholder="Введите пароль"
                     class="modal-input"
                     @keyup="checkNewUserInputLanguage"
                     @input="saveDraft"
                   >
-                  <div class="input-hint">Минимум 6 символов</div>
+                  <div class="input-hint">
+                    Минимум 6 символов
+                  </div>
                 </div>
                 <div class="input-group half">
                   <label class="input-label">Организация <span class="required">*</span></label>
-                  <div class="custom-select" @click="toggleNewUserOrgDropdown">
+                  <div
+                    class="custom-select"
+                    @click="toggleNewUserOrgDropdown"
+                  >
                     <div class="select-trigger">
                       <span>{{ getOrganizationName(newUser.organization_id) || 'Не выбрано' }}</span>
                       <img
@@ -420,10 +538,13 @@
                         :class="{ 'open': newUserOrgDropdownOpen }"
                         width="12"
                         height="12"
-                      />
+                      >
                     </div>
                     <transition name="dropdown">
-                      <div v-if="newUserOrgDropdownOpen" class="select-dropdown">
+                      <div
+                        v-if="newUserOrgDropdownOpen"
+                        class="select-dropdown"
+                      >
                         <div
                           class="select-option"
                           :class="{ 'selected': newUser.organization_id === null }"
@@ -446,7 +567,10 @@
                 </div>
                 <div class="input-group half">
                   <label class="input-label">Компания <span class="required">*</span></label>
-                  <div class="custom-select" @click="toggleNewUserCompanyDropdown">
+                  <div
+                    class="custom-select"
+                    @click="toggleNewUserCompanyDropdown"
+                  >
                     <div class="select-trigger">
                       <span>{{ getCompanyName(newUser.company_id) || 'Не выбрано' }}</span>
                       <img
@@ -455,10 +579,13 @@
                         :class="{ 'open': newUserCompanyDropdownOpen }"
                         width="12"
                         height="12"
-                      />
+                      >
                     </div>
                     <transition name="dropdown">
-                      <div v-if="newUserCompanyDropdownOpen" class="select-dropdown">
+                      <div
+                        v-if="newUserCompanyDropdownOpen"
+                        class="select-dropdown"
+                      >
                         <div
                           class="select-option"
                           :class="{ 'selected': newUser.company_id === null }"
@@ -481,7 +608,10 @@
                 </div>
                 <div class="input-group half">
                   <label class="input-label">Тип пользователя <span class="required">*</span></label>
-                  <div class="custom-select" @click="toggleNewUserTypeDropdown">
+                  <div
+                    class="custom-select"
+                    @click="toggleNewUserTypeDropdown"
+                  >
                     <div class="select-trigger">
                       <span>{{ getUserTypeName(newUser.type_id) || 'Выберите тип' }}</span>
                       <img
@@ -490,10 +620,13 @@
                         :class="{ 'open': newUserTypeDropdownOpen }"
                         width="12"
                         height="12"
-                      />
+                      >
                     </div>
                     <transition name="dropdown">
-                      <div v-if="newUserTypeDropdownOpen" class="select-dropdown">
+                      <div
+                        v-if="newUserTypeDropdownOpen"
+                        class="select-dropdown"
+                      >
                         <div
                           v-for="type in userTypes"
                           :key="type.id"
@@ -567,12 +700,17 @@
             </div>
             
             <div class="modal-footer">
-              <button @click="closeCreateModal" class="modal-btn modal-btn--cancel">Отмена</button>
+              <button
+                class="modal-btn modal-btn--cancel"
+                @click="closeCreateModal"
+              >
+                Отмена
+              </button>
               <button 
-                @click="createUser" 
-                class="modal-btn modal-btn--confirm"
+                class="modal-btn modal-btn--confirm" 
                 :disabled="!canCreateUser"
                 :class="{'modal-btn--disabled': !canCreateUser}"
+                @click="createUser"
               >
                 Создать
               </button>
@@ -585,15 +723,32 @@
     <!-- Модальное окно прав доступа -->
     <Teleport to="body">
       <transition name="modal-fade">
-        <div v-if="showPermissionsModal" class="modal-overlay" @click.self="showPermissionsModal = false">
+        <div
+          v-if="showPermissionsModal"
+          class="modal-overlay"
+          @click.self="showPermissionsModal = false"
+        >
           <div class="modal-content">
             <div class="modal-header">
               <h3 class="modal-title">
                 Права: {{ selectedUserForPermissions ? selectedUserForPermissions.username : '' }}
               </h3>
-              <button @click="showPermissionsModal = false" class="modal-close">
-                <svg width="10" height="10" viewBox="0 0 14 14" fill="none">
-                  <path d="M13 1L1 13M1 1L13 13" stroke="#666" stroke-width="2" stroke-linecap="round"/>
+              <button
+                class="modal-close"
+                @click="showPermissionsModal = false"
+              >
+                <svg
+                  width="10"
+                  height="10"
+                  viewBox="0 0 14 14"
+                  fill="none"
+                >
+                  <path
+                    d="M13 1L1 13M1 1L13 13"
+                    stroke="#666"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                  />
                 </svg>
               </button>
             </div>
@@ -607,12 +762,17 @@
             </div>
 
             <div class="modal-footer">
-              <button @click="showPermissionsModal = false" class="modal-btn modal-btn--cancel">Отмена</button>
               <button
-                @click="savePermissions"
+                class="modal-btn modal-btn--cancel"
+                @click="showPermissionsModal = false"
+              >
+                Отмена
+              </button>
+              <button
                 :disabled="savingPermissions"
                 class="modal-btn modal-btn--confirm"
                 :class="{'modal-btn--disabled': savingPermissions}"
+                @click="savePermissions"
               >
                 {{ savingPermissions ? 'Сохранение...' : 'Сохранить' }}
               </button>
@@ -685,22 +845,6 @@ export default {
       selectedUserForPermissions: null,
       savingPermissions: false
     };
-  },
-  async created() {
-    await Promise.all([
-      this.fetchOrganizations(), 
-      this.fetchCompanies(),
-      this.fetchUserTypes()
-    ]);
-    
-    // Слушаем события обновления организаций и компаний
-    window.addEventListener('organization-updated', this.fetchOrganizations);
-    window.addEventListener('company-updated', this.fetchCompanies);
-  },
-  beforeUnmount() {
-    window.removeEventListener('organization-updated', this.fetchOrganizations);
-    window.removeEventListener('company-updated', this.fetchCompanies);
-    document.removeEventListener('click', this.handleClickOutside);
   },
   computed: {
     filteredUsers() {
@@ -781,6 +925,22 @@ export default {
     hasOrgOrCompany() {
       return Boolean(this.newUser.organization_id || this.newUser.company_id);
     }
+  },
+  async created() {
+    await Promise.all([
+      this.fetchOrganizations(), 
+      this.fetchCompanies(),
+      this.fetchUserTypes()
+    ]);
+    
+    // Слушаем события обновления организаций и компаний
+    window.addEventListener('organization-updated', this.fetchOrganizations);
+    window.addEventListener('company-updated', this.fetchCompanies);
+  },
+  beforeUnmount() {
+    window.removeEventListener('organization-updated', this.fetchOrganizations);
+    window.removeEventListener('company-updated', this.fetchCompanies);
+    document.removeEventListener('click', this.handleClickOutside);
   },
   mounted() {
     this.fetchAllUsers();

--- a/frontend/src/components/UserNotifications.vue
+++ b/frontend/src/components/UserNotifications.vue
@@ -1,10 +1,17 @@
 <template>
   <transition name="panel-slide">
-    <div v-if="show" class="notifications" @click.stop>
+    <div
+      v-if="show"
+      class="notifications"
+      @click.stop
+    >
       <header class="notifications__header">
         <h3 class="notifications__title">
           Уведомления
-          <span v-if="unreadCount > 0" class="notifications__unread-count">({{ unreadCount }})</span>
+          <span
+            v-if="unreadCount > 0"
+            class="notifications__unread-count"
+          >({{ unreadCount }})</span>
         </h3>
         <button
           v-if="notifications.length > 0"
@@ -15,15 +22,27 @@
         </button>
       </header>
 
-      <div v-if="loading && notifications.length === 0" class="notifications__loading">
-        <div class="notifications__spinner"></div>
+      <div
+        v-if="loading && notifications.length === 0"
+        class="notifications__loading"
+      >
+        <div class="notifications__spinner" />
       </div>
 
-      <div v-else-if="notifications.length === 0" class="notifications__empty">
-        <p class="notifications__empty-text">Нет уведомлений</p>
+      <div
+        v-else-if="notifications.length === 0"
+        class="notifications__empty"
+      >
+        <p class="notifications__empty-text">
+          Нет уведомлений
+        </p>
       </div>
 
-      <ul v-else class="notifications__list" role="list">
+      <ul
+        v-else
+        class="notifications__list"
+        role="list"
+      >
         <li
           v-for="item in notifications"
           :key="item.id"
@@ -34,15 +53,25 @@
         >
           <div class="notification-item__content">
             <div class="notification-item__top">
-              <p v-if="item.title" class="notification-item__title">{{ item.title }}</p>
+              <p
+                v-if="item.title"
+                class="notification-item__title"
+              >
+                {{ item.title }}
+              </p>
               <time class="notification-item__time">{{ timeAgo(item.created_at) }}</time>
             </div>
-            <p v-if="item.message" class="notification-item__message">{{ item.message }}</p>
+            <p
+              v-if="item.message"
+              class="notification-item__message"
+            >
+              {{ item.message }}
+            </p>
           </div>
           <button
             class="notification-item__delete"
-            @click.stop="deleteNotification(item.id)"
             aria-label="Удалить уведомление"
+            @click.stop="deleteNotification(item.id)"
           >
             &times;
           </button>

--- a/frontend/src/components/UserNotificationsInline.vue
+++ b/frontend/src/components/UserNotificationsInline.vue
@@ -1,9 +1,17 @@
 <template>
-  <div class="notifications" data-testid="cabinet-notifications">
+  <div
+    class="notifications"
+    data-testid="cabinet-notifications"
+  >
     <div class="notifications__header">
       <div class="notifications__header-left">
-        <h3 class="notifications__title">Уведомления</h3>
-        <span v-if="unreadCount > 0" class="notification-badge">{{ unreadCount }}</span>
+        <h3 class="notifications__title">
+          Уведомления
+        </h3>
+        <span
+          v-if="unreadCount > 0"
+          class="notification-badge"
+        >{{ unreadCount }}</span>
         <div class="filters">
           <button
             type="button"
@@ -36,14 +44,26 @@
       </button>
     </div>
 
-    <div class="notifications__list" :class="{ 'empty-list': filteredNotifications.length === 0 && !loading }">
-      <div v-if="loading && filteredNotifications.length === 0" class="notifications__loading">
+    <div
+      class="notifications__list"
+      :class="{ 'empty-list': filteredNotifications.length === 0 && !loading }"
+    >
+      <div
+        v-if="loading && filteredNotifications.length === 0"
+        class="notifications__loading"
+      >
         <LoaderSpinner />
       </div>
-      <div v-else-if="filteredNotifications.length === 0" class="notifications__empty">
+      <div
+        v-else-if="filteredNotifications.length === 0"
+        class="notifications__empty"
+      >
         <p>Уведомлений нет</p>
       </div>
-      <div v-else class="notifications__items">
+      <div
+        v-else
+        class="notifications__items"
+      >
         <div
           v-for="notif in filteredNotifications"
           :key="notif.id"
@@ -52,15 +72,27 @@
         >
           <div class="notification-dot-wrapper">
             <transition name="dot-fade">
-              <div v-if="!notif.is_read" class="notification-dot"></div>
+              <div
+                v-if="!notif.is_read"
+                class="notification-dot"
+              />
             </transition>
           </div>
-          <div class="notification-content" @click="markRead(notif)">
+          <div
+            class="notification-content"
+            @click="markRead(notif)"
+          >
             <div class="notification-header">
-              <div class="notification-title">{{ notif.title }}</div>
-              <div class="notification-date">{{ formatDate(notif.created_at) }}</div>
+              <div class="notification-title">
+                {{ notif.title }}
+              </div>
+              <div class="notification-date">
+                {{ formatDate(notif.created_at) }}
+              </div>
             </div>
-            <div class="notification-message">{{ notif.message }}</div>
+            <div class="notification-message">
+              {{ notif.message }}
+            </div>
           </div>
           <button
             type="button"
@@ -68,8 +100,19 @@
             :aria-label="`Удалить уведомление ${notif.title || ''}`"
             @click.stop="deleteNotification(notif.id)"
           >
-            <svg width="10" height="10" viewBox="0 0 14 14" fill="none" aria-hidden="true">
-              <path d="M13 1L1 13M1 1L13 13" stroke="#a2a2a2" stroke-width="2" stroke-linecap="round"/>
+            <svg
+              width="10"
+              height="10"
+              viewBox="0 0 14 14"
+              fill="none"
+              aria-hidden="true"
+            >
+              <path
+                d="M13 1L1 13M1 1L13 13"
+                stroke="#a2a2a2"
+                stroke-width="2"
+                stroke-linecap="round"
+              />
             </svg>
           </button>
         </div>

--- a/frontend/src/components/UserProfileHeader.vue
+++ b/frontend/src/components/UserProfileHeader.vue
@@ -4,15 +4,29 @@
       <!-- Основная информация -->
       <div class="main-info">
         <div class="name-and-type">
-          <h2 class="user-name" data-testid="cabinet-text-username">{{ displayName }}</h2>
+          <h2
+            class="user-name"
+            data-testid="cabinet-text-username"
+          >
+            {{ displayName }}
+          </h2>
           <span class="user-type-badge">{{ userTypeDisplay }}</span>
         </div>
         <div class="org-company-block">
-          <h3 class="user-organization" v-if="fullName && organization">
+          <h3
+            v-if="fullName && organization"
+            class="user-organization"
+          >
             {{ organization }}
           </h3>
-          <div class="user-company" v-if="company">
-            <svg class="icon" viewBox="0 0 24 24">
+          <div
+            v-if="company"
+            class="user-company"
+          >
+            <svg
+              class="icon"
+              viewBox="0 0 24 24"
+            >
               <path d="M18,15H16V17H18M18,11H16V13H18M20,19H12V17H14V15H12V13H14V11H12V9H20M10,7H8V5H10M10,11H8V9H10M10,15H8V13H10M10,19H8V17H10M6,7H4V5H6M6,11H4V9H6M6,15H4V13H6M6,19H4V17H6M12,7V3H2V21H22V7H12Z" />
             </svg>
             {{ company }}
@@ -21,48 +35,93 @@
       </div>
       
       <!-- Дополнительные данные -->
-      <div class="user-details-row" v-if="hasContactDetails">
-        <div class="user-detail" v-if="position">
+      <div
+        v-if="hasContactDetails"
+        class="user-details-row"
+      >
+        <div
+          v-if="position"
+          class="user-detail"
+        >
           <span class="detail-badge position-badge">
-            <svg class="icon" viewBox="0 0 24 24">
+            <svg
+              class="icon"
+              viewBox="0 0 24 24"
+            >
               <path d="M12,3L2,12H5V20H19V12H22L12,3M12,7.7C14.1,7.7 15.8,9.4 15.8,11.5C15.8,14.5 12,18 12,18C12,18 8.2,14.5 8.2,11.5C8.2,9.4 9.9,7.7 12,7.7M12,10A1.5,1.5 0 0,0 10.5,11.5A1.5,1.5 0 0,0 12,13A1.5,1.5 0 0,0 13.5,11.5A1.5,1.5 0 0,0 12,10Z" />
             </svg>
             {{ position }}
           </span>
         </div>
-        <div class="user-detail" v-if="email" @click="copyEmail">
+        <div
+          v-if="email"
+          class="user-detail"
+          @click="copyEmail"
+        >
           <span
-            class="detail-badge email-badge clickable"
             ref="emailBadge"
+            class="detail-badge email-badge clickable"
             :style="{ width: emailBadgeWidth ? emailBadgeWidth + 'px' : null }"
           >
-            <transition name="fade" mode="out-in">
-              <div v-if="!copiedEmail" key="original" class="badge-content">
-                <svg class="icon" viewBox="0 0 24 24">
+            <transition
+              name="fade"
+              mode="out-in"
+            >
+              <div
+                v-if="!copiedEmail"
+                key="original"
+                class="badge-content"
+              >
+                <svg
+                  class="icon"
+                  viewBox="0 0 24 24"
+                >
                   <path d="M22 6C22 4.9 21.1 4 20 4H4C2.9 4 2 4.9 2 6V18C2 19.1 2.9 20 4 20H20C21.1 20 22 19.1 22 18V6M20 6L12 11L4 6H20M20 18H4V8L12 13L20 8V18Z" />
                 </svg>
                 <span class="badge-text">{{ email }}</span>
               </div>
-              <div v-else key="copied" class="badge-content">
+              <div
+                v-else
+                key="copied"
+                class="badge-content"
+              >
                 <span class="badge-text">Почта скопирована!</span>
               </div>
             </transition>
           </span>
         </div>
-        <div class="user-detail" v-if="phone" @click="copyPhone">
+        <div
+          v-if="phone"
+          class="user-detail"
+          @click="copyPhone"
+        >
           <span
-            class="detail-badge phone-badge clickable"
             ref="phoneBadge"
+            class="detail-badge phone-badge clickable"
             :style="{ width: phoneBadgeWidth ? phoneBadgeWidth + 'px' : null }"
           >
-            <transition name="fade" mode="out-in">
-              <div v-if="!copiedPhone" key="original" class="badge-content">
-                <svg class="icon" viewBox="0 0 24 24">
+            <transition
+              name="fade"
+              mode="out-in"
+            >
+              <div
+                v-if="!copiedPhone"
+                key="original"
+                class="badge-content"
+              >
+                <svg
+                  class="icon"
+                  viewBox="0 0 24 24"
+                >
                   <path d="M6.62,10.79C8.06,13.62 10.38,15.94 13.21,17.38L15.41,15.18C15.69,14.9 16.08,14.82 16.43,14.93C17.55,15.3 18.75,15.5 20,15.5A1,1 0 0,1 21,16.5V20A1,1 0 0,1 20,21A17,17 0 0,1 3,4A1,1 0 0,1 4,3H7.5A1,1 0 0,1 8.5,4C8.5,5.25 8.7,6.45 9.07,7.57C9.18,7.92 9.1,8.31 8.82,8.59L6.62,10.79Z" />
                 </svg>
                 <span class="badge-text">{{ formattedPhone }}</span>
               </div>
-              <div v-else key="copied" class="badge-content">
+              <div
+                v-else
+                key="copied"
+                class="badge-content"
+              >
                 <span class="badge-text">Скопировано!</span>
               </div>
             </transition>
@@ -137,11 +196,6 @@ export default {
       return this.phone;
     }
   },
-  mounted() {
-    this.$nextTick(() => {
-      this.updateBadgeWidths();
-    });
-  },
   watch: {
     email: {
       handler() {
@@ -159,6 +213,15 @@ export default {
       },
       immediate: false
     }
+  },
+  mounted() {
+    this.$nextTick(() => {
+      this.updateBadgeWidths();
+    });
+  },
+  beforeUnmount() {
+    if (this.timeoutEmail) clearTimeout(this.timeoutEmail);
+    if (this.timeoutPhone) clearTimeout(this.timeoutPhone);
   },
   methods: {
     updateBadgeWidths() {
@@ -233,10 +296,6 @@ export default {
         console.error('Ошибка копирования телефона:', err);
       });
     }
-  },
-  beforeUnmount() {
-    if (this.timeoutEmail) clearTimeout(this.timeoutEmail);
-    if (this.timeoutPhone) clearTimeout(this.timeoutPhone);
   }
 };
 </script>

--- a/frontend/src/components/UserTypes.vue
+++ b/frontend/src/components/UserTypes.vue
@@ -1,13 +1,18 @@
 <template>
   <div class="user-types-container dashboard-card">
     <div class="management-header">
-      <h3 class="management-title">Типы пользователей</h3>
+      <h3 class="management-title">
+        Типы пользователей
+      </h3>
       <div class="header-controls">
         <SearchComponent
-          :title="'Поиск типов...'"
           v-model="searchQuery"
+          :title="'Поиск типов...'"
         />
-        <button @click="showAddModal = true" class="add-header-button">
+        <button
+          class="add-header-button"
+          @click="showAddModal = true"
+        >
           Создать тип
         </button>
         <RefreshButton @refresh="refreshData" />
@@ -16,11 +21,19 @@
 
     <div class="content-container">
       <!-- Левая часть - список типов -->
-      <div class="types-section" :class="{'with-details': selectedType}">
+      <div
+        class="types-section"
+        :class="{'with-details': selectedType}"
+      >
         <div class="table-container">
           <div class="table-header">
-            <div class="header-col id-col" @click="sortBy('id')">
-              <p :class="{ 'active-sort': sortField === 'id' }">ID</p>
+            <div
+              class="header-col id-col"
+              @click="sortBy('id')"
+            >
+              <p :class="{ 'active-sort': sortField === 'id' }">
+                ID
+              </p>
               <img 
                 src="@/assets/icons/sort.png" 
                 class="sort-icon" 
@@ -28,10 +41,15 @@
                   'sorted': sortField === 'id',
                   'desc': sortField === 'id' && sortDirection === 'desc'
                 }" 
-              />
+              >
             </div>
-            <div class="header-col name-col" @click="sortBy('name')">
-              <p :class="{ 'active-sort': sortField === 'name' }">Наименование</p>
+            <div
+              class="header-col name-col"
+              @click="sortBy('name')"
+            >
+              <p :class="{ 'active-sort': sortField === 'name' }">
+                Наименование
+              </p>
               <img 
                 src="@/assets/icons/sort.png" 
                 class="sort-icon" 
@@ -39,10 +57,15 @@
                   'sorted': sortField === 'name',
                   'desc': sortField === 'name' && sortDirection === 'desc'
                 }" 
-              />
+              >
             </div>
-            <div class="header-col users-col" @click="sortBy('users_count')">
-              <p :class="{ 'active-sort': sortField === 'users_count' }">Пользователи</p>
+            <div
+              class="header-col users-col"
+              @click="sortBy('users_count')"
+            >
+              <p :class="{ 'active-sort': sortField === 'users_count' }">
+                Пользователи
+              </p>
               <img 
                 src="@/assets/icons/sort.png" 
                 class="sort-icon" 
@@ -50,7 +73,7 @@
                   'sorted': sortField === 'users_count',
                   'desc': sortField === 'users_count' && sortDirection === 'desc'
                 }" 
-              />
+              >
             </div>
           </div>
 
@@ -66,7 +89,10 @@
                 <span class="cell-content id-value">{{ type.id }}</span>
               </div>
               <div class="table-col name-col">
-                <span class="truncate-text" :title="type.name">
+                <span
+                  class="truncate-text"
+                  :title="type.name"
+                >
                   {{ type.name }}
                 </span>
               </div>
@@ -83,19 +109,30 @@
       </div>
 
       <!-- Правая часть - детали типа -->
-      <div v-if="selectedType" class="details-section">
+      <div
+        v-if="selectedType"
+        class="details-section"
+      >
         <div class="details-content">
           <div class="details-header">
             <div class="details-title-wrapper">
-              <h3 class="details-title">{{ selectedType.name }}</h3>
+              <h3 class="details-title">
+                {{ selectedType.name }}
+              </h3>
               <div class="type-info-row">
                 <span class="system-name">{{ selectedType.code }}</span>
                 <span class="users-count-badge">Пользователей: {{ selectedType.users_count }}</span>
               </div>
             </div>
             <div class="details-header-actions">
-              <button @click="confirmDeleteType(selectedType)" class="delete-icon-btn">
-                <img src="@/assets/icons/delete.png" class="delete-icon" />
+              <button
+                class="delete-icon-btn"
+                @click="confirmDeleteType(selectedType)"
+              >
+                <img
+                  src="@/assets/icons/delete.png"
+                  class="delete-icon"
+                >
               </button>
             </div>
           </div>
@@ -107,10 +144,10 @@
                   <label class="detail-label">Наименование типа:</label>
                   <input 
                     v-model="selectedType.name" 
-                    @change="updateTypeName"
                     class="form-input-sm"
                     placeholder="Название типа"
                     autocomplete="off"
+                    @change="updateTypeName"
                   >
                 </div>
                 <div class="form-group compact">
@@ -128,25 +165,52 @@
         </div>
       </div>
       
-      <div v-else class="no-selection-message">
+      <div
+        v-else
+        class="no-selection-message"
+      >
         <p>Выберите тип пользователя для просмотра и редактирования</p>
       </div>
     </div>
 
-    <div v-if="filteredTypes.length === 0" class="no-results">
-      <div class="no-results-icon">👥</div>
+    <div
+      v-if="filteredTypes.length === 0"
+      class="no-results"
+    >
+      <div class="no-results-icon">
+        👥
+      </div>
       <p>Типы пользователей не найдены</p>
     </div>
 
     <!-- Модальное окно создания типа -->
     <transition name="modal-fade">
-      <div v-if="showAddModal" class="modal-overlay" @click.self="closeModal">
+      <div
+        v-if="showAddModal"
+        class="modal-overlay"
+        @click.self="closeModal"
+      >
         <div class="modal-content">
           <div class="modal-header">
-            <h3 class="modal-title">Создать новый тип пользователя</h3>
-            <button @click="closeModal" class="modal-close">
-              <svg width="10" height="10" viewBox="0 0 14 14" fill="none">
-                <path d="M13 1L1 13M1 1L13 13" stroke="#666" stroke-width="2" stroke-linecap="round"/>
+            <h3 class="modal-title">
+              Создать новый тип пользователя
+            </h3>
+            <button
+              class="modal-close"
+              @click="closeModal"
+            >
+              <svg
+                width="10"
+                height="10"
+                viewBox="0 0 14 14"
+                fill="none"
+              >
+                <path
+                  d="M13 1L1 13M1 1L13 13"
+                  stroke="#666"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                />
               </svg>
             </button>
           </div>
@@ -155,36 +219,48 @@
             <div class="input-group">
               <label class="input-label">Наименование типа *</label>
               <input
+                ref="nameInput"
                 v-model="newType.name"
                 placeholder="Менеджер"
                 class="modal-input"
                 @keyup.enter="createType"
-                ref="nameInput"
               >
-              <div class="input-hint">Обязательное поле</div>
+              <div class="input-hint">
+                Обязательное поле
+              </div>
             </div>
             
             <div class="input-group">
               <label class="input-label">Системное имя *</label>
               <input
                 v-model="newType.code"
-                @input="validateSystemName"
                 placeholder="manager"
                 class="modal-input"
+                @input="validateSystemName"
                 @keyup.enter="createType"
               >
-              <div class="input-hint">Латинские буквы, цифры и подчеркивания</div>
-              <span v-if="nameError" class="form-error">{{ nameError }}</span>
+              <div class="input-hint">
+                Латинские буквы, цифры и подчеркивания
+              </div>
+              <span
+                v-if="nameError"
+                class="form-error"
+              >{{ nameError }}</span>
             </div>
           </div>
           
           <div class="modal-footer">
-            <button @click="closeModal" class="modal-btn modal-btn--cancel">Отмена</button>
+            <button
+              class="modal-btn modal-btn--cancel"
+              @click="closeModal"
+            >
+              Отмена
+            </button>
             <button 
-              @click="createType" 
-              class="modal-btn modal-btn--confirm"
+              class="modal-btn modal-btn--confirm" 
               :disabled="!isFormValid"
               :class="{'modal-btn--disabled': !isFormValid}"
+              @click="createType"
             >
               Создать
             </button>
@@ -206,7 +282,11 @@
     />
 
     <!-- Уведомления -->
-    <div v-if="notification.show" class="notification" :class="notification.type">
+    <div
+      v-if="notification.show"
+      class="notification"
+      :class="notification.type"
+    >
       <span class="notification-message">{{ notification.message }}</span>
     </div>
   </div>
@@ -302,6 +382,18 @@ export default {
              !this.nameError &&
              !this.isLoading;
     }
+  },
+  watch: {
+    showAddModal(newVal) {
+      if (newVal) {
+        this.$nextTick(() => {
+          this.$refs.nameInput?.focus();
+        });
+      }
+    }
+  },
+  mounted() {
+    this.refreshData();
   },
   methods: {
     validateSystemName() {
@@ -461,18 +553,6 @@ export default {
     
     hideNotification() {
       this.notification.show = false;
-    }
-  },
-  mounted() {
-    this.refreshData();
-  },
-  watch: {
-    showAddModal(newVal) {
-      if (newVal) {
-        this.$nextTick(() => {
-          this.$refs.nameInput?.focus();
-        });
-      }
     }
   }
 };

--- a/frontend/src/components/ui/BaseDropdown.vue
+++ b/frontend/src/components/ui/BaseDropdown.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="base-dropdown" ref="dropdown">
+  <div
+    ref="dropdown"
+    class="base-dropdown"
+  >
     <button
       type="button"
       class="base-dropdown__button"
@@ -7,8 +10,15 @@
       :disabled="disabled"
       @click="toggle"
     >
-      <span class="base-dropdown__text" :class="{ 'base-dropdown__text--placeholder': !selectedOption }">
-        <slot name="selected" v-if="selectedOption" :option="selectedOption">
+      <span
+        class="base-dropdown__text"
+        :class="{ 'base-dropdown__text--placeholder': !selectedOption }"
+      >
+        <slot
+          v-if="selectedOption"
+          name="selected"
+          :option="selectedOption"
+        >
           {{ selectedOption[labelKey] }}
         </slot>
         <template v-else>{{ placeholder }}</template>
@@ -20,13 +30,25 @@
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <path d="M1 1L5 5L9 1" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+        <path
+          d="M1 1L5 5L9 1"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
       </svg>
     </button>
 
     <transition name="dropdown">
-      <div v-if="isOpen" class="base-dropdown__menu">
-        <div v-if="searchable" class="base-dropdown__search">
+      <div
+        v-if="isOpen"
+        class="base-dropdown__menu"
+      >
+        <div
+          v-if="searchable"
+          class="base-dropdown__search"
+        >
           <input
             ref="searchInput"
             v-model="searchQuery"
@@ -34,7 +56,7 @@
             class="base-dropdown__search-input"
             placeholder="Поиск..."
             @click.stop
-          />
+          >
         </div>
         <div class="base-dropdown__options">
           <div
@@ -44,11 +66,17 @@
             :class="{ 'base-dropdown__item--selected': isSelected(option) }"
             @click="select(option)"
           >
-            <slot name="option" :option="option">
+            <slot
+              name="option"
+              :option="option"
+            >
               <span class="base-dropdown__item-text">{{ option[labelKey] }}</span>
             </slot>
           </div>
-          <div v-if="filteredOptions.length === 0" class="base-dropdown__empty">
+          <div
+            v-if="filteredOptions.length === 0"
+            class="base-dropdown__empty"
+          >
             Ничего не найдено
           </div>
         </div>
@@ -109,6 +137,12 @@ export default {
       );
     },
   },
+  mounted() {
+    document.addEventListener('click', this.handleClickOutside);
+  },
+  beforeUnmount() {
+    document.removeEventListener('click', this.handleClickOutside);
+  },
   methods: {
     toggle() {
       if (this.disabled) return;
@@ -136,12 +170,6 @@ export default {
         this.searchQuery = '';
       }
     },
-  },
-  mounted() {
-    document.addEventListener('click', this.handleClickOutside);
-  },
-  beforeUnmount() {
-    document.removeEventListener('click', this.handleClickOutside);
   },
 };
 </script>

--- a/frontend/src/components/ui/BaseModal.vue
+++ b/frontend/src/components/ui/BaseModal.vue
@@ -1,19 +1,49 @@
 <template>
   <teleport to="body">
     <transition name="modal-fade">
-      <div v-if="show" class="base-modal-overlay" @mousedown="handleOverlayMousedown" @mouseup="handleOverlayMouseup">
-        <div ref="modal" class="base-modal" :style="{ maxWidth: width }" @click.stop @mousedown.stop role="dialog" aria-modal="true" :aria-label="title">
-          <div class="base-modal__header" v-if="title || $slots.header || closable">
+      <div
+        v-if="show"
+        class="base-modal-overlay"
+        @mousedown="handleOverlayMousedown"
+        @mouseup="handleOverlayMouseup"
+      >
+        <div
+          ref="modal"
+          class="base-modal"
+          :style="{ maxWidth: width }"
+          role="dialog"
+          aria-modal="true"
+          :aria-label="title"
+          @click.stop
+          @mousedown.stop
+        >
+          <div
+            v-if="title || $slots.header || closable"
+            class="base-modal__header"
+          >
             <slot name="header">
-              <h3 class="base-modal__title">{{ title }}</h3>
+              <h3 class="base-modal__title">
+                {{ title }}
+              </h3>
             </slot>
-            <button v-if="closable" class="base-modal__close" data-testid="modal-button-close" @click="$emit('close')" aria-label="Закрыть">&times;</button>
+            <button
+              v-if="closable"
+              class="base-modal__close"
+              data-testid="modal-button-close"
+              aria-label="Закрыть"
+              @click="$emit('close')"
+            >
+              &times;
+            </button>
           </div>
           <div class="base-modal__body">
-            <slot></slot>
+            <slot />
           </div>
-          <div class="base-modal__actions" v-if="$slots.actions">
-            <slot name="actions"></slot>
+          <div
+            v-if="$slots.actions"
+            class="base-modal__actions"
+          >
+            <slot name="actions" />
           </div>
         </div>
       </div>
@@ -51,6 +81,18 @@ export default {
     return {
       overlayMousedown: false,
     };
+  },
+  watch: {
+    show(val) {
+      document.body.style.overflow = val ? 'hidden' : '';
+    },
+  },
+  mounted() {
+    document.addEventListener('keydown', this.handleKeydown);
+  },
+  beforeUnmount() {
+    document.removeEventListener('keydown', this.handleKeydown);
+    document.body.style.overflow = '';
   },
   methods: {
     handleOverlayMousedown(e) {
@@ -93,18 +135,6 @@ export default {
         first.focus();
       }
     },
-  },
-  watch: {
-    show(val) {
-      document.body.style.overflow = val ? 'hidden' : '';
-    },
-  },
-  mounted() {
-    document.addEventListener('keydown', this.handleKeydown);
-  },
-  beforeUnmount() {
-    document.removeEventListener('keydown', this.handleKeydown);
-    document.body.style.overflow = '';
   },
 };
 </script>

--- a/frontend/src/components/ui/FormField.vue
+++ b/frontend/src/components/ui/FormField.vue
@@ -1,14 +1,27 @@
 <template>
-  <div class="form-field" :class="{ 'form-field--error': error }">
-    <label v-if="label" class="form-field__label">
+  <div
+    class="form-field"
+    :class="{ 'form-field--error': error }"
+  >
+    <label
+      v-if="label"
+      class="form-field__label"
+    >
       {{ label }}
-      <span v-if="required" class="form-field__required">*</span>
+      <span
+        v-if="required"
+        class="form-field__required"
+      >*</span>
     </label>
     <div class="form-field__control">
-      <slot></slot>
+      <slot />
     </div>
     <transition name="error-fade">
-      <div v-if="error" class="form-field__error" role="alert">
+      <div
+        v-if="error"
+        class="form-field__error"
+        role="alert"
+      >
         {{ error }}
       </div>
     </transition>

--- a/frontend/src/components/ui/GridSelector.vue
+++ b/frontend/src/components/ui/GridSelector.vue
@@ -1,7 +1,15 @@
 <template>
   <div class="grid-selector">
-    <div v-if="loading" class="grid-selector__loading">Загрузка...</div>
-    <div v-else class="grid-selector__grid">
+    <div
+      v-if="loading"
+      class="grid-selector__loading"
+    >
+      Загрузка...
+    </div>
+    <div
+      v-else
+      class="grid-selector__grid"
+    >
       <div
         v-for="item in items"
         :key="item[itemKey]"
@@ -18,7 +26,12 @@
         {{ item[itemLabel] }}
       </div>
     </div>
-    <div v-if="errorMessage" class="grid-selector__error">{{ errorMessage }}</div>
+    <div
+      v-if="errorMessage"
+      class="grid-selector__error"
+    >
+      {{ errorMessage }}
+    </div>
 
     <div
       v-if="tooltip.visible"

--- a/frontend/src/components/ui/LoaderSpinner.vue
+++ b/frontend/src/components/ui/LoaderSpinner.vue
@@ -5,8 +5,14 @@
     role="status"
     :aria-label="label"
   >
-    <span class="loader-spinner__circle" aria-hidden="true"></span>
-    <span v-if="label" class="loader-spinner__label">{{ label }}</span>
+    <span
+      class="loader-spinner__circle"
+      aria-hidden="true"
+    />
+    <span
+      v-if="label"
+      class="loader-spinner__label"
+    >{{ label }}</span>
   </div>
 </template>
 

--- a/frontend/src/components/ui/SelectionModal.vue
+++ b/frontend/src/components/ui/SelectionModal.vue
@@ -1,13 +1,24 @@
 <template>
-  <BaseModal :show="show" :title="title" width="900px" @close="$emit('close')">
+  <BaseModal
+    :show="show"
+    :title="title"
+    width="900px"
+    @close="$emit('close')"
+  >
     <div class="selection-modal">
       <!-- Search -->
       <div class="selection-modal__search">
-        <SearchComponent :title="searchPlaceholder" @search="handleSearch" />
+        <SearchComponent
+          :title="searchPlaceholder"
+          @search="handleSearch"
+        />
       </div>
 
       <!-- Filter tabs -->
-      <div v-if="tabs.length" class="selection-modal__filters">
+      <div
+        v-if="tabs.length"
+        class="selection-modal__filters"
+      >
         <div class="selection-modal__tabs">
           <button
             v-for="tab in visibleTabs"
@@ -19,7 +30,10 @@
             {{ tab.label }}
           </button>
         </div>
-        <span class="selection-modal__count" v-if="tempSelected.length">
+        <span
+          v-if="tempSelected.length"
+          class="selection-modal__count"
+        >
           Выбрано: {{ tempSelected.length }}
         </span>
       </div>
@@ -27,15 +41,25 @@
       <!-- Table -->
       <div class="selection-modal__table">
         <div class="selection-modal__header">
-          <div class="selection-modal__cell selection-modal__cell--checkbox"></div>
-          <slot name="columns"></slot>
+          <div class="selection-modal__cell selection-modal__cell--checkbox" />
+          <slot name="columns" />
         </div>
         <div class="selection-modal__body">
-          <div v-if="loading" class="selection-modal__loading">Загрузка...</div>
-          <div v-else-if="!items.length" class="selection-modal__empty">{{ emptyText }}</div>
           <div
-            v-else
+            v-if="loading"
+            class="selection-modal__loading"
+          >
+            Загрузка...
+          </div>
+          <div
+            v-else-if="!items.length"
+            class="selection-modal__empty"
+          >
+            {{ emptyText }}
+          </div>
+          <div
             v-for="item in items"
+            v-else
             :key="item.id"
             class="selection-modal__row"
             :class="{
@@ -49,16 +73,26 @@
                 type="checkbox"
                 :checked="isSelected(item)"
                 :disabled="isDisabled(item)"
-              />
+              >
             </div>
-            <slot name="row" :item="item" :isSelected="isSelected(item)" :isDisabled="isDisabled(item)"></slot>
+            <slot
+              name="row"
+              :item="item"
+              :is-selected="isSelected(item)"
+              :is-disabled="isDisabled(item)"
+            />
           </div>
         </div>
       </div>
     </div>
 
     <template #actions>
-      <button class="selection-modal__cancel" @click="$emit('close')">Отмена</button>
+      <button
+        class="selection-modal__cancel"
+        @click="$emit('close')"
+      >
+        Отмена
+      </button>
       <button
         class="selection-modal__confirm"
         :disabled="!tempSelected.length"

--- a/frontend/src/components/ui/SkeletonCard.vue
+++ b/frontend/src/components/ui/SkeletonCard.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="skeleton-card">
-    <SkeletonLine width="45%" height="16px" />
+    <SkeletonLine
+      width="45%"
+      height="16px"
+    />
     <div class="skeleton-card__body">
       <SkeletonLine
         v-for="i in lines"
@@ -9,7 +12,11 @@
         height="12px"
       />
     </div>
-    <SkeletonLine v-if="showBadge" width="80px" height="10px" />
+    <SkeletonLine
+      v-if="showBadge"
+      width="80px"
+      height="10px"
+    />
   </div>
 </template>
 

--- a/frontend/src/components/ui/SkeletonTransition.vue
+++ b/frontend/src/components/ui/SkeletonTransition.vue
@@ -1,9 +1,18 @@
 <template>
-  <transition name="skeleton-fade" mode="out-in">
-    <div v-if="showSkeleton" key="skeleton">
+  <transition
+    name="skeleton-fade"
+    mode="out-in"
+  >
+    <div
+      v-if="showSkeleton"
+      key="skeleton"
+    >
       <slot name="skeleton" />
     </div>
-    <div v-else key="content">
+    <div
+      v-else
+      key="content"
+    >
       <slot />
     </div>
   </transition>

--- a/frontend/src/components/ui/StatusBadge.vue
+++ b/frontend/src/components/ui/StatusBadge.vue
@@ -1,6 +1,12 @@
 <template>
-  <span class="status-badge" :class="[variantClass, colorClass]">
-    <span v-if="variant === 'dot'" class="status-badge__dot"></span>
+  <span
+    class="status-badge"
+    :class="[variantClass, colorClass]"
+  >
+    <span
+      v-if="variant === 'dot'"
+      class="status-badge__dot"
+    />
     {{ status }}
   </span>
 </template>

--- a/frontend/src/views/AdminSettings.vue
+++ b/frontend/src/views/AdminSettings.vue
@@ -1,17 +1,23 @@
 <template>
   <section class="admin-settings">
     <header class="admin-settings__header">
-      <h2 class="admin-settings__title">Настройки системы</h2>
+      <h2 class="admin-settings__title">
+        Настройки системы
+      </h2>
     </header>
 
     <div class="admin-settings__layout">
-      <nav class="admin-settings__sidebar" role="navigation" aria-label="Разделы настроек">
+      <nav
+        class="admin-settings__sidebar"
+        role="navigation"
+        aria-label="Разделы настроек"
+      >
         <div
           class="sidebar-item"
           :class="{ 'sidebar-item--active': activeSection === 'upload' }"
-          @click="activeSection = 'upload'"
           role="button"
           tabindex="0"
+          @click="activeSection = 'upload'"
           @keydown.enter="activeSection = 'upload'"
         >
           Загрузка файлов
@@ -19,9 +25,9 @@
         <div
           class="sidebar-item"
           :class="{ 'sidebar-item--active': activeSection === 'pagination' }"
-          @click="activeSection = 'pagination'"
           role="button"
           tabindex="0"
+          @click="activeSection = 'pagination'"
           @keydown.enter="activeSection = 'pagination'"
         >
           Пагинация
@@ -29,9 +35,9 @@
         <div
           class="sidebar-item"
           :class="{ 'sidebar-item--active': activeSection === 'notifications' }"
-          @click="activeSection = 'notifications'"
           role="button"
           tabindex="0"
+          @click="activeSection = 'notifications'"
           @keydown.enter="activeSection = 'notifications'"
         >
           Уведомления
@@ -42,171 +48,224 @@
         <SkeletonTransition :loading="loading">
           <template #skeleton>
             <div style="display: flex; flex-direction: column; gap: 16px;">
-              <SkeletonLine width="40%" height="16px" />
-              <SkeletonBlock height="40px" radius="var(--radius-sm)" />
-              <SkeletonBlock height="80px" radius="var(--radius-sm)" />
-              <SkeletonBlock height="80px" radius="var(--radius-sm)" />
-              <SkeletonLine width="120px" height="36px" />
+              <SkeletonLine
+                width="40%"
+                height="16px"
+              />
+              <SkeletonBlock
+                height="40px"
+                radius="var(--radius-sm)"
+              />
+              <SkeletonBlock
+                height="80px"
+                radius="var(--radius-sm)"
+              />
+              <SkeletonBlock
+                height="80px"
+                radius="var(--radius-sm)"
+              />
+              <SkeletonLine
+                width="120px"
+                height="36px"
+              />
             </div>
           </template>
 
-        <div v-if="loadError" class="error-state">
-          <p class="error-message">{{ loadError }}</p>
-          <button class="btn btn--primary" @click="fetchSettings">Повторить</button>
-        </div>
-
-        <!-- Загрузка файлов -->
-        <div v-else-if="activeSection === 'upload'" class="settings-section">
-          <h3 class="section-title">Загрузка файлов</h3>
-
-          <div class="form-group">
-            <label class="form-label" for="max-file-size">
-              Максимальный размер файла: <strong>{{ fileSizeMB }} МБ</strong>
-            </label>
-            <input
-              id="max-file-size"
-              type="range"
-              class="form-range"
-              :min="1"
-              :max="50"
-              :step="1"
-              :value="fileSizeMB"
-              @input="settings.max_file_size = $event.target.value * 1024 * 1024"
+          <div
+            v-if="loadError"
+            class="error-state"
+          >
+            <p class="error-message">
+              {{ loadError }}
+            </p>
+            <button
+              class="btn btn--primary"
+              @click="fetchSettings"
             >
-            <div class="range-labels">
-              <span>1 МБ</span>
-              <span>50 МБ</span>
-            </div>
+              Повторить
+            </button>
           </div>
 
-          <div class="form-group">
-            <span class="form-label">Разрешённые типы изображений</span>
-            <div class="checkbox-group">
+          <!-- Загрузка файлов -->
+          <div
+            v-else-if="activeSection === 'upload'"
+            class="settings-section"
+          >
+            <h3 class="section-title">
+              Загрузка файлов
+            </h3>
+
+            <div class="form-group">
               <label
-                v-for="imgType in availableImageTypes"
-                :key="imgType"
-                class="checkbox-label"
+                class="form-label"
+                for="max-file-size"
               >
-                <input
-                  type="checkbox"
-                  :value="imgType"
-                  :checked="selectedImageTypes.includes(imgType)"
-                  @change="toggleImageType(imgType)"
+                Максимальный размер файла: <strong>{{ fileSizeMB }} МБ</strong>
+              </label>
+              <input
+                id="max-file-size"
+                type="range"
+                class="form-range"
+                :min="1"
+                :max="50"
+                :step="1"
+                :value="fileSizeMB"
+                @input="settings.max_file_size = $event.target.value * 1024 * 1024"
+              >
+              <div class="range-labels">
+                <span>1 МБ</span>
+                <span>50 МБ</span>
+              </div>
+            </div>
+
+            <div class="form-group">
+              <span class="form-label">Разрешённые типы изображений</span>
+              <div class="checkbox-group">
+                <label
+                  v-for="imgType in availableImageTypes"
+                  :key="imgType"
+                  class="checkbox-label"
                 >
-                <span class="checkbox-text">{{ imgType }}</span>
+                  <input
+                    type="checkbox"
+                    :value="imgType"
+                    :checked="selectedImageTypes.includes(imgType)"
+                    @change="toggleImageType(imgType)"
+                  >
+                  <span class="checkbox-text">{{ imgType }}</span>
+                </label>
+              </div>
+            </div>
+
+            <div class="form-group">
+              <span class="form-label">Разрешённые типы документов</span>
+              <div class="checkbox-group">
+                <label
+                  v-for="docType in availableDocTypes"
+                  :key="docType"
+                  class="checkbox-label"
+                >
+                  <input
+                    type="checkbox"
+                    :value="docType"
+                    :checked="selectedDocTypes.includes(docType)"
+                    @change="toggleDocType(docType)"
+                  >
+                  <span class="checkbox-text">{{ docType }}</span>
+                </label>
+              </div>
+            </div>
+
+            <button
+              class="btn btn--primary"
+              :disabled="saving"
+              @click="saveUploadSettings"
+            >
+              {{ saving ? 'Сохранение...' : 'Сохранить' }}
+            </button>
+          </div>
+
+          <!-- Пагинация -->
+          <div
+            v-else-if="activeSection === 'pagination'"
+            class="settings-section"
+          >
+            <h3 class="section-title">
+              Пагинация
+            </h3>
+
+            <div class="form-group">
+              <label
+                class="form-label"
+                for="max-per-page"
+              >
+                Записей на странице
+              </label>
+              <input
+                id="max-per-page"
+                v-model.number="settings.max_per_page"
+                type="number"
+                class="form-input"
+                :min="10"
+                :max="500"
+              >
+              <span class="form-hint">От 10 до 500</span>
+            </div>
+
+            <button
+              class="btn btn--primary"
+              :disabled="saving"
+              @click="savePaginationSettings"
+            >
+              {{ saving ? 'Сохранение...' : 'Сохранить' }}
+            </button>
+          </div>
+
+          <!-- Уведомления -->
+          <div
+            v-else-if="activeSection === 'notifications'"
+            class="settings-section"
+          >
+            <h3 class="section-title">
+              Уведомления
+            </h3>
+
+            <div class="form-group">
+              <label class="switch-label">
+                <span class="switch-text">Уведомления включены</span>
+                <span
+                  class="switch"
+                  :class="{ 'switch--on': settings.notifications_enabled }"
+                  role="switch"
+                  :aria-checked="String(settings.notifications_enabled)"
+                  tabindex="0"
+                  @click="settings.notifications_enabled = !settings.notifications_enabled"
+                  @keydown.enter="settings.notifications_enabled = !settings.notifications_enabled"
+                  @keydown.space.prevent="settings.notifications_enabled = !settings.notifications_enabled"
+                >
+                  <span class="switch__thumb" />
+                </span>
               </label>
             </div>
-          </div>
 
-          <div class="form-group">
-            <span class="form-label">Разрешённые типы документов</span>
-            <div class="checkbox-group">
+            <div class="form-group">
               <label
-                v-for="docType in availableDocTypes"
-                :key="docType"
-                class="checkbox-label"
+                class="form-label"
+                for="poll-interval"
               >
-                <input
-                  type="checkbox"
-                  :value="docType"
-                  :checked="selectedDocTypes.includes(docType)"
-                  @change="toggleDocType(docType)"
-                >
-                <span class="checkbox-text">{{ docType }}</span>
+                Интервал опроса (секунды)
               </label>
-            </div>
-          </div>
-
-          <button
-            class="btn btn--primary"
-            :disabled="saving"
-            @click="saveUploadSettings"
-          >
-            {{ saving ? 'Сохранение...' : 'Сохранить' }}
-          </button>
-        </div>
-
-        <!-- Пагинация -->
-        <div v-else-if="activeSection === 'pagination'" class="settings-section">
-          <h3 class="section-title">Пагинация</h3>
-
-          <div class="form-group">
-            <label class="form-label" for="max-per-page">
-              Записей на странице
-            </label>
-            <input
-              id="max-per-page"
-              type="number"
-              class="form-input"
-              v-model.number="settings.max_per_page"
-              :min="10"
-              :max="500"
-            >
-            <span class="form-hint">От 10 до 500</span>
-          </div>
-
-          <button
-            class="btn btn--primary"
-            :disabled="saving"
-            @click="savePaginationSettings"
-          >
-            {{ saving ? 'Сохранение...' : 'Сохранить' }}
-          </button>
-        </div>
-
-        <!-- Уведомления -->
-        <div v-else-if="activeSection === 'notifications'" class="settings-section">
-          <h3 class="section-title">Уведомления</h3>
-
-          <div class="form-group">
-            <label class="switch-label">
-              <span class="switch-text">Уведомления включены</span>
-              <span
-                class="switch"
-                :class="{ 'switch--on': settings.notifications_enabled }"
-                role="switch"
-                :aria-checked="String(settings.notifications_enabled)"
-                tabindex="0"
-                @click="settings.notifications_enabled = !settings.notifications_enabled"
-                @keydown.enter="settings.notifications_enabled = !settings.notifications_enabled"
-                @keydown.space.prevent="settings.notifications_enabled = !settings.notifications_enabled"
+              <input
+                id="poll-interval"
+                v-model.number="settings.notifications_poll_interval"
+                type="number"
+                class="form-input"
+                :min="10"
+                :max="120"
+                :disabled="!settings.notifications_enabled"
               >
-                <span class="switch__thumb"></span>
-              </span>
-            </label>
-          </div>
+              <span class="form-hint">От 10 до 120 секунд</span>
+            </div>
 
-          <div class="form-group">
-            <label class="form-label" for="poll-interval">
-              Интервал опроса (секунды)
-            </label>
-            <input
-              id="poll-interval"
-              type="number"
-              class="form-input"
-              v-model.number="settings.notifications_poll_interval"
-              :min="10"
-              :max="120"
-              :disabled="!settings.notifications_enabled"
+            <button
+              class="btn btn--primary"
+              :disabled="saving"
+              @click="saveNotificationSettings"
             >
-            <span class="form-hint">От 10 до 120 секунд</span>
+              {{ saving ? 'Сохранение...' : 'Сохранить' }}
+            </button>
           </div>
-
-          <button
-            class="btn btn--primary"
-            :disabled="saving"
-            @click="saveNotificationSettings"
-          >
-            {{ saving ? 'Сохранение...' : 'Сохранить' }}
-          </button>
-        </div>
         </SkeletonTransition>
       </div>
     </div>
 
     <!-- Toast-уведомление -->
     <transition name="toast-fade">
-      <div v-if="toast.visible" class="toast" :class="'toast--' + toast.type">
+      <div
+        v-if="toast.visible"
+        class="toast"
+        :class="'toast--' + toast.type"
+      >
         {{ toast.message }}
       </div>
     </transition>
@@ -270,6 +329,14 @@ export default {
         return this.settings.allowed_doc_types.split(',').map(t => t.trim()).filter(Boolean);
       }
     },
+  },
+  mounted() {
+    this.fetchSettings();
+  },
+  beforeUnmount() {
+    if (this.toast.timer) {
+      clearTimeout(this.toast.timer);
+    }
   },
   methods: {
     async fetchSettings() {
@@ -397,14 +464,6 @@ export default {
         this.toast.visible = false;
       }, 3000);
     },
-  },
-  mounted() {
-    this.fetchSettings();
-  },
-  beforeUnmount() {
-    if (this.toast.timer) {
-      clearTimeout(this.toast.timer);
-    }
   },
 };
 </script>

--- a/frontend/src/views/AdminUsers.vue
+++ b/frontend/src/views/AdminUsers.vue
@@ -1,7 +1,9 @@
 <template>
   <section class="admin-users">
     <header class="admin-users__header">
-      <h2 class="admin-users__title">Управление пользователями</h2>
+      <h2 class="admin-users__title">
+        Управление пользователями
+      </h2>
       <span class="admin-users__count">{{ filteredUsers.length }} из {{ users.length }}</span>
     </header>
 
@@ -15,17 +17,28 @@
             class="admin-users__search-input"
             placeholder="Поиск по логину, ФИО, организации..."
             aria-label="Поиск пользователей"
-          />
+          >
         </div>
 
         <div class="admin-users__table-wrap">
-          <table class="admin-users__table" aria-label="Список пользователей">
+          <table
+            class="admin-users__table"
+            aria-label="Список пользователей"
+          >
             <thead>
               <tr>
-                <th class="admin-users__th">Логин</th>
-                <th class="admin-users__th">ФИО</th>
-                <th class="admin-users__th">Организация</th>
-                <th class="admin-users__th admin-users__th--type">Тип</th>
+                <th class="admin-users__th">
+                  Логин
+                </th>
+                <th class="admin-users__th">
+                  ФИО
+                </th>
+                <th class="admin-users__th">
+                  Организация
+                </th>
+                <th class="admin-users__th admin-users__th--type">
+                  Тип
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -38,17 +51,29 @@
                 @click="selectUser(user)"
                 @keydown.enter="selectUser(user)"
               >
-                <td class="admin-users__td">{{ user.username }}</td>
-                <td class="admin-users__td">{{ formatUserName(user) }}</td>
-                <td class="admin-users__td">{{ user.organization || '—' }}</td>
+                <td class="admin-users__td">
+                  {{ user.username }}
+                </td>
+                <td class="admin-users__td">
+                  {{ formatUserName(user) }}
+                </td>
+                <td class="admin-users__td">
+                  {{ user.organization || '—' }}
+                </td>
                 <td class="admin-users__td admin-users__td--type">
-                  <StatusBadge :status="user.user_type || 'Неизвестно'" variant="badge" />
+                  <StatusBadge
+                    :status="user.user_type || 'Неизвестно'"
+                    variant="badge"
+                  />
                 </td>
               </tr>
             </tbody>
           </table>
 
-          <div v-if="filteredUsers.length === 0 && !loading" class="admin-users__empty">
+          <div
+            v-if="filteredUsers.length === 0 && !loading"
+            class="admin-users__empty"
+          >
             <p class="admin-users__empty-text">
               {{ searchQuery ? 'Пользователи не найдены' : 'Нет пользователей' }}
             </p>
@@ -56,23 +81,36 @@
 
           <SkeletonTransition :loading="loading">
             <template #skeleton>
-              <SkeletonTable :rows="8" :columns="4" />
+              <SkeletonTable
+                :rows="8"
+                :columns="4"
+              />
             </template>
-            <span></span>
+            <span />
           </SkeletonTransition>
         </div>
       </div>
 
       <!-- Правая панель: детали -->
       <div class="admin-users__detail-panel">
-        <div v-if="!selectedUser" class="admin-users__no-selection">
-          <p class="admin-users__no-selection-text">Выберите пользователя из списка</p>
+        <div
+          v-if="!selectedUser"
+          class="admin-users__no-selection"
+        >
+          <p class="admin-users__no-selection-text">
+            Выберите пользователя из списка
+          </p>
         </div>
 
         <template v-else>
           <div class="admin-users__detail-header">
-            <h3 class="admin-users__detail-title">{{ selectedUser.username }}</h3>
-            <StatusBadge :status="getUserTypeName(editForm.type_id) || 'Неизвестно'" variant="badge" />
+            <h3 class="admin-users__detail-title">
+              {{ selectedUser.username }}
+            </h3>
+            <StatusBadge
+              :status="getUserTypeName(editForm.type_id) || 'Неизвестно'"
+              variant="badge"
+            />
           </div>
 
           <div class="admin-users__tabs">
@@ -93,38 +131,65 @@
           </div>
 
           <!-- Таб "Основные" -->
-          <div v-if="activeTab === 'info'" class="admin-users__tab-content">
+          <div
+            v-if="activeTab === 'info'"
+            class="admin-users__tab-content"
+          >
             <div class="admin-users__form">
               <div class="admin-users__form-row admin-users__form-row--three">
                 <div class="admin-users__field">
                   <label class="admin-users__label">Фамилия</label>
-                  <input v-model="editForm.last_name" type="text" class="admin-users__input" />
+                  <input
+                    v-model="editForm.last_name"
+                    type="text"
+                    class="admin-users__input"
+                  >
                 </div>
                 <div class="admin-users__field">
                   <label class="admin-users__label">Имя</label>
-                  <input v-model="editForm.first_name" type="text" class="admin-users__input" />
+                  <input
+                    v-model="editForm.first_name"
+                    type="text"
+                    class="admin-users__input"
+                  >
                 </div>
                 <div class="admin-users__field">
                   <label class="admin-users__label">Отчество</label>
-                  <input v-model="editForm.middle_name" type="text" class="admin-users__input" />
+                  <input
+                    v-model="editForm.middle_name"
+                    type="text"
+                    class="admin-users__input"
+                  >
                 </div>
               </div>
 
               <div class="admin-users__form-row">
                 <div class="admin-users__field">
                   <label class="admin-users__label">Должность</label>
-                  <input v-model="editForm.position" type="text" class="admin-users__input" />
+                  <input
+                    v-model="editForm.position"
+                    type="text"
+                    class="admin-users__input"
+                  >
                 </div>
               </div>
 
               <div class="admin-users__form-row admin-users__form-row--two">
                 <div class="admin-users__field">
                   <label class="admin-users__label">Email</label>
-                  <input v-model="editForm.email" type="email" class="admin-users__input" />
+                  <input
+                    v-model="editForm.email"
+                    type="email"
+                    class="admin-users__input"
+                  >
                 </div>
                 <div class="admin-users__field">
                   <label class="admin-users__label">Телефон</label>
-                  <input v-model="editForm.phone" type="tel" class="admin-users__input" />
+                  <input
+                    v-model="editForm.phone"
+                    type="tel"
+                    class="admin-users__input"
+                  >
                 </div>
               </div>
 
@@ -188,49 +253,86 @@
           </div>
 
           <!-- Таб "Разрешения" -->
-          <div v-if="activeTab === 'permissions'" class="admin-users__tab-content">
+          <div
+            v-if="activeTab === 'permissions'"
+            class="admin-users__tab-content"
+          >
             <SkeletonTransition :loading="loadingPermissions">
               <template #skeleton>
                 <div style="padding: 16px; display: flex; flex-direction: column; gap: 16px;">
-                  <SkeletonLine width="40%" height="14px" />
-                  <SkeletonLine width="100%" height="12px" />
-                  <SkeletonLine width="100%" height="12px" />
-                  <SkeletonLine width="100%" height="12px" />
-                  <SkeletonLine width="35%" height="14px" />
-                  <SkeletonLine width="100%" height="12px" />
-                  <SkeletonLine width="100%" height="12px" />
+                  <SkeletonLine
+                    width="40%"
+                    height="14px"
+                  />
+                  <SkeletonLine
+                    width="100%"
+                    height="12px"
+                  />
+                  <SkeletonLine
+                    width="100%"
+                    height="12px"
+                  />
+                  <SkeletonLine
+                    width="100%"
+                    height="12px"
+                  />
+                  <SkeletonLine
+                    width="35%"
+                    height="14px"
+                  />
+                  <SkeletonLine
+                    width="100%"
+                    height="12px"
+                  />
+                  <SkeletonLine
+                    width="100%"
+                    height="12px"
+                  />
                 </div>
               </template>
 
-            <div v-if="permissionTree.length === 0" class="admin-users__empty">
-              <p class="admin-users__empty-text">Нет доступных разрешений</p>
-            </div>
-
-            <div v-else class="admin-users__permissions">
               <div
-                v-for="category in permissionTree"
-                :key="category.category"
-                class="admin-users__perm-group"
+                v-if="permissionTree.length === 0"
+                class="admin-users__empty"
               >
-                <h4 class="admin-users__perm-category">{{ category.category }}</h4>
-                <div class="admin-users__perm-list">
-                  <label
-                    v-for="perm in category.permissions"
-                    :key="perm.key"
-                    class="admin-users__perm-item"
-                  >
-                    <input
-                      type="checkbox"
-                      class="admin-users__checkbox"
-                      :checked="userPermissions[perm.key] === true"
-                      @change="onPermissionChange(perm.key, $event.target.checked)"
-                    />
-                    <span class="admin-users__perm-label">{{ perm.label }}</span>
-                    <span v-if="perm.description" class="admin-users__perm-desc">{{ perm.description }}</span>
-                  </label>
+                <p class="admin-users__empty-text">
+                  Нет доступных разрешений
+                </p>
+              </div>
+
+              <div
+                v-else
+                class="admin-users__permissions"
+              >
+                <div
+                  v-for="category in permissionTree"
+                  :key="category.category"
+                  class="admin-users__perm-group"
+                >
+                  <h4 class="admin-users__perm-category">
+                    {{ category.category }}
+                  </h4>
+                  <div class="admin-users__perm-list">
+                    <label
+                      v-for="perm in category.permissions"
+                      :key="perm.key"
+                      class="admin-users__perm-item"
+                    >
+                      <input
+                        type="checkbox"
+                        class="admin-users__checkbox"
+                        :checked="userPermissions[perm.key] === true"
+                        @change="onPermissionChange(perm.key, $event.target.checked)"
+                      >
+                      <span class="admin-users__perm-label">{{ perm.label }}</span>
+                      <span
+                        v-if="perm.description"
+                        class="admin-users__perm-desc"
+                      >{{ perm.description }}</span>
+                    </label>
+                  </div>
                 </div>
               </div>
-            </div>
             </SkeletonTransition>
 
             <div class="admin-users__actions">
@@ -265,7 +367,7 @@
           class="admin-users__input"
           placeholder="Введите новый пароль"
           @keydown.enter="resetPassword"
-        />
+        >
         <button
           class="admin-users__btn admin-users__btn--icon"
           type="button"
@@ -284,7 +386,10 @@
       </button>
 
       <template #actions>
-        <button class="admin-users__btn admin-users__btn--outline" @click="closePasswordModal">
+        <button
+          class="admin-users__btn admin-users__btn--outline"
+          @click="closePasswordModal"
+        >
           Отмена
         </button>
         <button
@@ -311,7 +416,10 @@
       </p>
 
       <template #actions>
-        <button class="admin-users__btn admin-users__btn--outline" @click="showDeleteModal = false">
+        <button
+          class="admin-users__btn admin-users__btn--outline"
+          @click="showDeleteModal = false"
+        >
           Отмена
         </button>
         <button

--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -1,281 +1,336 @@
 <template>
-    <section class="center">
-        <header class="center__header">
-            <div class="header-top">
-                <h2 class="center__title">Центр заявок</h2>
-                <div class="unread-badge" data-testid="center-badge-unread" v-if="unreadCount > 0" :class="{ 'shake-animation': shouldShake }">
-                    Новые: {{ unreadCount }}
-                </div>
-            </div>
-        </header>
+  <section class="center">
+    <header class="center__header">
+      <div class="header-top">
+        <h2 class="center__title">
+          Центр заявок
+        </h2>
+        <div
+          v-if="unreadCount > 0"
+          class="unread-badge"
+          data-testid="center-badge-unread"
+          :class="{ 'shake-animation': shouldShake }"
+        >
+          Новые: {{ unreadCount }}
+        </div>
+      </div>
+    </header>
         
-        <div class="center__filters">
-            <div class="center__tabs">
-                <FilterTabs
-                    :tabs="archiveTabs"
-                    v-model="archiveMode"
-                />
-            </div>
-            <div class="filters__main">
-                <div class="filters-row">
-                    <div class="field search">
-                        <input
-                            placeholder="Поиск заявок..."
-                            type="text"
-                            class="field__input search"
-                            data-testid="center-input-search"
-                            v-model="searchQuery"
-                            @input="applyFilters"
-                        />
-                        <img src="@/assets/icons/search.png" class="center__icon" />
-                    </div>
-                    
-                    <OrganizationFilter
-                        ref="organizationFilter"
-                        v-model="selectedOrganizationId"
-                        :organizations="organizations"
-                        @change="handleOrganizationChange"
-                    />
-
-                    <!-- Новый DateFilter -->
-                    <DateFilter
-                        ref="dateFilter"
-                        :mode="'range'"
-                        :selected-date="selectedDate"
-                        :date-range-start="dateRangeStart"
-                        :date-range-end="dateRangeEnd"
-                        @update:selectedDate="updateSelectedDate"
-                        @update:dateRangeStart="updateDateRangeStart"
-                        @update:dateRangeEnd="updateDateRangeEnd"
-                        @apply="applyDateFilters"
-                        @clear="clearDateRange"
-                    />
-
-                    <button 
-                        class="reset-sort-btn"
-                        @click="resetSort"
-                        :disabled="!sortField"
-                    >
-                        Сбросить сортировку
-                    </button>
-
-                    <button
-                        class="today-filter-btn"
-                        :class="{ 'today-filter-btn--active': activeToday }"
-                        data-testid="center-button-today"
-                        @click="toggleActiveToday"
-                    >
-                        Заявки на сегодня
-                    </button>
-
-                    <button
-                        class="reset-filters-btn"
-                        data-testid="center-button-reset-filters"
-                        @click="resetFilters"
-                        :disabled="!hasActiveFilters"
-                    >
-                        Сбросить фильтры
-                    </button>
-                </div>
-
-                <div class="filters-row filters-row--secondary">
-                    <div class="filter-section">
-                        <div class="filter-section__header">
-                            <span class="filter-label">Подтверждение</span>
-                        </div>
-                        <div class="status-buttons">
-                            <button
-                                v-for="confirmation in confirmations"
-                                :key="confirmation.value"
-                                class="status-btn"
-                                :class="{ 'status-btn--active': selectedConfirmations.includes(confirmation.value) }"
-                                :data-testid="`center-button-confirmation-${confirmation.value}`"
-                                @click="toggleConfirmation(confirmation.value)"
-                            >
-                                {{ confirmation.label }}
-                            </button>
-                        </div>
-                    </div>
-
-                    <div class="filter-section">
-                        <div class="filter-section__header">
-                            <span class="filter-label">Статус заявки</span>
-                        </div>
-                        <div class="status-buttons">
-                            <button
-                                v-for="status in applicationStatuses"
-                                :key="status.value"
-                                class="status-btn"
-                                :class="{ 'status-btn--active': selectedApplicationStatuses.includes(status.value) }"
-                                :data-testid="`center-button-status-${status.value}`"
-                                @click="toggleApplicationStatus(status.value)"
-                            >
-                                {{ status.label }}
-                            </button>
-                        </div>
-                    </div>
-                    
-                    <div class="filter-section filter-section--refresh">
-                        <RefreshButton @refresh="fetchApplications" />
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <div class="applications-table" :class="{ 'with-details': selectedApplication }">
-            <div class="table-header">
-                <div class="header-row">
-                    <div class="header-col confirmation-col" @click="sortBy('confirmation')">
-                        <p :class="{ 'active-sort': sortField === 'confirmation' }">Подтверждение</p>
-                        <img 
-                            src="@/assets/icons/sort.png" 
-                            class="sort-icon" 
-                            :class="{ 
-                                'sorted': sortField === 'confirmation',
-                                'desc': sortField === 'confirmation' && sortDirection === 'desc'
-                            }" 
-                        />
-                    </div>
-                    <div class="header-col number-col" @click="sortBy('number')">
-                        <p :class="{ 'active-sort': sortField === 'number' }">Номер заявки</p>
-                        <img 
-                            src="@/assets/icons/sort.png" 
-                            class="sort-icon" 
-                            :class="{ 
-                                'sorted': sortField === 'number',
-                                'desc': sortField === 'number' && sortDirection === 'desc'
-                            }" 
-                        />
-                    </div>
-                    <div class="header-col date-col" @click="sortBy('date')">
-                        <p :class="{ 'active-sort': sortField === 'date' }">Дата и время</p>
-                        <img 
-                            src="@/assets/icons/sort.png" 
-                            class="sort-icon" 
-                            :class="{ 
-                                'sorted': sortField === 'date',
-                                'desc': sortField === 'date' && sortDirection === 'desc'
-                            }" 
-                        />
-                    </div>
-                    <div class="header-col organization-col" @click="sortBy('organization')">
-                        <p :class="{ 'active-sort': sortField === 'organization' }">Организация</p>
-                        <img 
-                            src="@/assets/icons/sort.png" 
-                            class="sort-icon" 
-                            :class="{ 
-                                'sorted': sortField === 'organization',
-                                'desc': sortField === 'organization' && sortDirection === 'desc'
-                            }" 
-                        />
-                    </div>
-                    <div class="header-col sender-col" @click="sortBy('sender')">
-                        <p :class="{ 'active-sort': sortField === 'sender' }">Отправитель</p>
-                        <img 
-                            src="@/assets/icons/sort.png" 
-                            class="sort-icon" 
-                            :class="{ 
-                                'sorted': sortField === 'sender',
-                                'desc': sortField === 'sender' && sortDirection === 'desc'
-                            }" 
-                        />
-                    </div>
-                    <div class="header-col status-col" @click="sortBy('status')">
-                        <p :class="{ 'active-sort': sortField === 'status' }">Статус заявки</p>
-                        <img 
-                            src="@/assets/icons/sort.png" 
-                            class="sort-icon" 
-                            :class="{ 
-                                'sorted': sortField === 'status',
-                                'desc': sortField === 'status' && sortDirection === 'desc'
-                            }" 
-                        />
-                    </div>
-                    <div class="header-col actions-col"></div>
-                </div>
-            </div>
-            
-            <div class="table-body">
-                <SkeletonTransition :loading="loading">
-                    <template #skeleton>
-                        <SkeletonTable :rows="10" :columns="6" />
-                    </template>
-                <div v-if="filteredApplications.length > 0" class="applications-list">
-                    <div
-                        v-for="(application, index) in sortedApplications"
-                        :key="application.id"
-                        class="application-item"
-                        :class="{
-                            'unread': application.status === 'Непрочитано',
-                            'initial-load': isInitialLoad,
-                            'filtered': !isInitialLoad
-                        }"
-                        :data-testid="`center-row-${application.id}`"
-                        @click="openApplication(application)"
-                        :style="isInitialLoad ? { 'animation-delay': `${index * 0.05}s` } : {}"
-                    >
-                        <div class="application-row">
-                            <div class="application-col confirmation-col">
-                                <span 
-                                    class="confirmation-badge"
-                                    :class="getConfirmationClass(application.confirmation)"
-                                >
-                                    {{ application.confirmation }}
-                                </span>
-                            </div>
-                            <div class="application-col number-col">
-                                <span class="application-number">{{ application.application_number }}</span>
-                            </div>
-                            <div class="application-col date-col">
-                                {{ formatDateTime(application.sending_datetime) }}
-                            </div>
-                            <div class="application-col organization-col">
-                                {{ getOrganizationName(application) }}
-                            </div>
-                            <div class="application-col sender-col" :title="getFullNameTooltip(application.sender_name)">
-                                {{ getSenderName(application.sender_name) }}
-                            </div>
-                            <div class="application-col status-col">
-                                <span 
-                                    class="status-badge"
-                                    :class="getStatusClass(application.status)"
-                                >
-                                    {{ application.status }}
-                                </span>
-                            </div>
-                            <div class="application-col actions-col">
-                                <button 
-                                    @click.stop="downloadApplication(application)" 
-                                    class="download-btn"
-                                    title="Скачать"
-                                >
-                                    Скачать
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <p v-else class="no-data-message">
-                    {{ hasActiveFilters ? 'Нет данных по выбранным фильтрам' : 'Заявок нет' }}
-                </p>
-                </SkeletonTransition>
-            </div>
-        </div>
-
-        <!-- Исправлено: используем selectedApplication вместо showDetail -->
-        <ApplicationDetail
-            v-if="selectedApplication"
-            :application="selectedApplication"
-            :current-user-id="currentUserId"
-            :current-user-name="currentUserName"
-            :mode="'center'"
-            @close="closeDetail"
-            @confirmation-updated="handleConfirmationUpdate"
-            @application-updated="handleApplicationUpdate"
-            @duplicate="handleDuplicate"
-            @application-changed="handleApplicationChanged"
+    <div class="center__filters">
+      <div class="center__tabs">
+        <FilterTabs
+          v-model="archiveMode"
+          :tabs="archiveTabs"
         />
-    </section>
+      </div>
+      <div class="filters__main">
+        <div class="filters-row">
+          <div class="field search">
+            <input
+              v-model="searchQuery"
+              placeholder="Поиск заявок..."
+              type="text"
+              class="field__input search"
+              data-testid="center-input-search"
+              @input="applyFilters"
+            >
+            <img
+              src="@/assets/icons/search.png"
+              class="center__icon"
+            >
+          </div>
+                    
+          <OrganizationFilter
+            ref="organizationFilter"
+            v-model="selectedOrganizationId"
+            :organizations="organizations"
+            @change="handleOrganizationChange"
+          />
+
+          <!-- Новый DateFilter -->
+          <DateFilter
+            ref="dateFilter"
+            :mode="'range'"
+            :selected-date="selectedDate"
+            :date-range-start="dateRangeStart"
+            :date-range-end="dateRangeEnd"
+            @update:selected-date="updateSelectedDate"
+            @update:date-range-start="updateDateRangeStart"
+            @update:date-range-end="updateDateRangeEnd"
+            @apply="applyDateFilters"
+            @clear="clearDateRange"
+          />
+
+          <button 
+            class="reset-sort-btn"
+            :disabled="!sortField"
+            @click="resetSort"
+          >
+            Сбросить сортировку
+          </button>
+
+          <button
+            class="today-filter-btn"
+            :class="{ 'today-filter-btn--active': activeToday }"
+            data-testid="center-button-today"
+            @click="toggleActiveToday"
+          >
+            Заявки на сегодня
+          </button>
+
+          <button
+            class="reset-filters-btn"
+            data-testid="center-button-reset-filters"
+            :disabled="!hasActiveFilters"
+            @click="resetFilters"
+          >
+            Сбросить фильтры
+          </button>
+        </div>
+
+        <div class="filters-row filters-row--secondary">
+          <div class="filter-section">
+            <div class="filter-section__header">
+              <span class="filter-label">Подтверждение</span>
+            </div>
+            <div class="status-buttons">
+              <button
+                v-for="confirmation in confirmations"
+                :key="confirmation.value"
+                class="status-btn"
+                :class="{ 'status-btn--active': selectedConfirmations.includes(confirmation.value) }"
+                :data-testid="`center-button-confirmation-${confirmation.value}`"
+                @click="toggleConfirmation(confirmation.value)"
+              >
+                {{ confirmation.label }}
+              </button>
+            </div>
+          </div>
+
+          <div class="filter-section">
+            <div class="filter-section__header">
+              <span class="filter-label">Статус заявки</span>
+            </div>
+            <div class="status-buttons">
+              <button
+                v-for="status in applicationStatuses"
+                :key="status.value"
+                class="status-btn"
+                :class="{ 'status-btn--active': selectedApplicationStatuses.includes(status.value) }"
+                :data-testid="`center-button-status-${status.value}`"
+                @click="toggleApplicationStatus(status.value)"
+              >
+                {{ status.label }}
+              </button>
+            </div>
+          </div>
+                    
+          <div class="filter-section filter-section--refresh">
+            <RefreshButton @refresh="fetchApplications" />
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div
+      class="applications-table"
+      :class="{ 'with-details': selectedApplication }"
+    >
+      <div class="table-header">
+        <div class="header-row">
+          <div
+            class="header-col confirmation-col"
+            @click="sortBy('confirmation')"
+          >
+            <p :class="{ 'active-sort': sortField === 'confirmation' }">
+              Подтверждение
+            </p>
+            <img 
+              src="@/assets/icons/sort.png" 
+              class="sort-icon" 
+              :class="{ 
+                'sorted': sortField === 'confirmation',
+                'desc': sortField === 'confirmation' && sortDirection === 'desc'
+              }" 
+            >
+          </div>
+          <div
+            class="header-col number-col"
+            @click="sortBy('number')"
+          >
+            <p :class="{ 'active-sort': sortField === 'number' }">
+              Номер заявки
+            </p>
+            <img 
+              src="@/assets/icons/sort.png" 
+              class="sort-icon" 
+              :class="{ 
+                'sorted': sortField === 'number',
+                'desc': sortField === 'number' && sortDirection === 'desc'
+              }" 
+            >
+          </div>
+          <div
+            class="header-col date-col"
+            @click="sortBy('date')"
+          >
+            <p :class="{ 'active-sort': sortField === 'date' }">
+              Дата и время
+            </p>
+            <img 
+              src="@/assets/icons/sort.png" 
+              class="sort-icon" 
+              :class="{ 
+                'sorted': sortField === 'date',
+                'desc': sortField === 'date' && sortDirection === 'desc'
+              }" 
+            >
+          </div>
+          <div
+            class="header-col organization-col"
+            @click="sortBy('organization')"
+          >
+            <p :class="{ 'active-sort': sortField === 'organization' }">
+              Организация
+            </p>
+            <img 
+              src="@/assets/icons/sort.png" 
+              class="sort-icon" 
+              :class="{ 
+                'sorted': sortField === 'organization',
+                'desc': sortField === 'organization' && sortDirection === 'desc'
+              }" 
+            >
+          </div>
+          <div
+            class="header-col sender-col"
+            @click="sortBy('sender')"
+          >
+            <p :class="{ 'active-sort': sortField === 'sender' }">
+              Отправитель
+            </p>
+            <img 
+              src="@/assets/icons/sort.png" 
+              class="sort-icon" 
+              :class="{ 
+                'sorted': sortField === 'sender',
+                'desc': sortField === 'sender' && sortDirection === 'desc'
+              }" 
+            >
+          </div>
+          <div
+            class="header-col status-col"
+            @click="sortBy('status')"
+          >
+            <p :class="{ 'active-sort': sortField === 'status' }">
+              Статус заявки
+            </p>
+            <img 
+              src="@/assets/icons/sort.png" 
+              class="sort-icon" 
+              :class="{ 
+                'sorted': sortField === 'status',
+                'desc': sortField === 'status' && sortDirection === 'desc'
+              }" 
+            >
+          </div>
+          <div class="header-col actions-col" />
+        </div>
+      </div>
+            
+      <div class="table-body">
+        <SkeletonTransition :loading="loading">
+          <template #skeleton>
+            <SkeletonTable
+              :rows="10"
+              :columns="6"
+            />
+          </template>
+          <div
+            v-if="filteredApplications.length > 0"
+            class="applications-list"
+          >
+            <div
+              v-for="(application, index) in sortedApplications"
+              :key="application.id"
+              class="application-item"
+              :class="{
+                'unread': application.status === 'Непрочитано',
+                'initial-load': isInitialLoad,
+                'filtered': !isInitialLoad
+              }"
+              :data-testid="`center-row-${application.id}`"
+              :style="isInitialLoad ? { 'animation-delay': `${index * 0.05}s` } : {}"
+              @click="openApplication(application)"
+            >
+              <div class="application-row">
+                <div class="application-col confirmation-col">
+                  <span 
+                    class="confirmation-badge"
+                    :class="getConfirmationClass(application.confirmation)"
+                  >
+                    {{ application.confirmation }}
+                  </span>
+                </div>
+                <div class="application-col number-col">
+                  <span class="application-number">{{ application.application_number }}</span>
+                </div>
+                <div class="application-col date-col">
+                  {{ formatDateTime(application.sending_datetime) }}
+                </div>
+                <div class="application-col organization-col">
+                  {{ getOrganizationName(application) }}
+                </div>
+                <div
+                  class="application-col sender-col"
+                  :title="getFullNameTooltip(application.sender_name)"
+                >
+                  {{ getSenderName(application.sender_name) }}
+                </div>
+                <div class="application-col status-col">
+                  <span 
+                    class="status-badge"
+                    :class="getStatusClass(application.status)"
+                  >
+                    {{ application.status }}
+                  </span>
+                </div>
+                <div class="application-col actions-col">
+                  <button 
+                    class="download-btn" 
+                    title="Скачать"
+                    @click.stop="downloadApplication(application)"
+                  >
+                    Скачать
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+          <p
+            v-else
+            class="no-data-message"
+          >
+            {{ hasActiveFilters ? 'Нет данных по выбранным фильтрам' : 'Заявок нет' }}
+          </p>
+        </SkeletonTransition>
+      </div>
+    </div>
+
+    <!-- Исправлено: используем selectedApplication вместо showDetail -->
+    <ApplicationDetail
+      v-if="selectedApplication"
+      :application="selectedApplication"
+      :current-user-id="currentUserId"
+      :current-user-name="currentUserName"
+      :mode="'center'"
+      @close="closeDetail"
+      @confirmation-updated="handleConfirmationUpdate"
+      @application-updated="handleApplicationUpdate"
+      @duplicate="handleDuplicate"
+      @application-changed="handleApplicationChanged"
+    />
+  </section>
 </template>
 
 <script>
@@ -491,6 +546,46 @@ export default {
 
         unreadCount() {
             return this.applications.filter(app => app.status === 'Непрочитано').length;
+        }
+    },
+    watch: {
+        archiveMode() {
+            this.fetchApplications();
+        },
+        '$route.query.archive'(val) {
+            this.archiveMode = val === 'true' ? 'archive' : 'active';
+        },
+    },
+    mounted() {
+        this.startShakeAnimation();
+
+        if (this.$route.query.archive === 'true') {
+            this.archiveMode = 'archive';
+        }
+
+        this.fetchOrganizations();
+        this.fetchApplications();
+        this.getCurrentUser();
+
+        // Динамическое обновление списка заявок - статусы/confirmations
+        // могут меняться из других сессий (согласование, взятие в работу, завершение).
+        // Polling 30s достаточен для UX без overkill.
+        this.applicationsPollInterval = setInterval(() => {
+            if (!this.isInitialLoad) {
+                this.fetchApplications();
+            }
+        }, 30000);
+
+        setTimeout(() => {
+            this.isInitialLoad = false;
+        }, 1000);
+    },
+    beforeUnmount() {
+        if (this.shakeInterval) {
+            clearInterval(this.shakeInterval);
+        }
+        if (this.applicationsPollInterval) {
+            clearInterval(this.applicationsPollInterval);
         }
     },
     methods: {
@@ -889,46 +984,6 @@ export default {
                     }, 600);
                 }
             }, 60000);
-        }
-    },
-    watch: {
-        archiveMode() {
-            this.fetchApplications();
-        },
-        '$route.query.archive'(val) {
-            this.archiveMode = val === 'true' ? 'archive' : 'active';
-        },
-    },
-    mounted() {
-        this.startShakeAnimation();
-
-        if (this.$route.query.archive === 'true') {
-            this.archiveMode = 'archive';
-        }
-
-        this.fetchOrganizations();
-        this.fetchApplications();
-        this.getCurrentUser();
-
-        // Динамическое обновление списка заявок - статусы/confirmations
-        // могут меняться из других сессий (согласование, взятие в работу, завершение).
-        // Polling 30s достаточен для UX без overkill.
-        this.applicationsPollInterval = setInterval(() => {
-            if (!this.isInitialLoad) {
-                this.fetchApplications();
-            }
-        }, 30000);
-
-        setTimeout(() => {
-            this.isInitialLoad = false;
-        }, 1000);
-    },
-    beforeUnmount() {
-        if (this.shakeInterval) {
-            clearInterval(this.shakeInterval);
-        }
-        if (this.applicationsPollInterval) {
-            clearInterval(this.applicationsPollInterval);
         }
     }
 }

--- a/frontend/src/views/CarsView.vue
+++ b/frontend/src/views/CarsView.vue
@@ -1,417 +1,530 @@
 <template>
-    <section class="carsview" data-testid="cars-page">
-        <header class="carsview__header">
-            <h2 class="carsview__title">
-                Список <span class="blue">автомобилей</span>
-            </h2>
-            <p class="carsview__subtitle">
-                Вкладка для просмотра автомобилей, которые вы или ваша организация/компания когда-либо привязывали к заявкам.
-            </p>
-        </header>
+  <section
+    class="carsview"
+    data-testid="cars-page"
+  >
+    <header class="carsview__header">
+      <h2 class="carsview__title">
+        Список <span class="blue">автомобилей</span>
+      </h2>
+      <p class="carsview__subtitle">
+        Вкладка для просмотра автомобилей, которые вы или ваша организация/компания когда-либо привязывали к заявкам.
+      </p>
+    </header>
 
-        <div class="carsview__filters">
-            <div class="filters-container">
-                <SearchComponent
-                    :title="'Поиск машин...'"
-                    v-model="searchQuery"
-                />
-                <div class="filter-tabs" v-if="ownershipInfo">
-                    <button
-                        v-if="ownershipInfo.has_organization"
-                        class="filter-tab"
-                        data-testid="filter-tab-organization"
-                        :class="{ 'filter-tab--active': currentFilter === 'organization' }"
-                        title="Автомобили, которых привязывали пользователи вашей организации"
-                        @click="switchFilter('organization')"
-                    >
-                        Машины организации
-                    </button>
-                    <button
-                        v-if="ownershipInfo.has_company"
-                        class="filter-tab"
-                        data-testid="filter-tab-company"
-                        :class="{ 'filter-tab--active': currentFilter === 'company' }"
-                        title="Автомобили, которых привязывали пользователи вашей компании"
-                        @click="switchFilter('company')"
-                    >
-                        Машины компании
-                    </button>
-                    <button
-                        class="filter-tab"
-                        data-testid="filter-tab-user"
-                        :class="{ 'filter-tab--active': currentFilter === 'user' }"
-                        title="Только те автомобили, которых привязывали лично вы"
-                        @click="switchFilter('user')"
-                    >
-                        Мои машины
-                    </button>
-                    <button
-                        class="filter-tab"
-                        data-testid="filter-tab-all-system"
-                        :class="{ 'filter-tab--active': currentFilter === 'all_system' }"
-                        title="Все автомобили, когда-либо зарегистрированные в системе"
-                        @click="switchFilter('all_system')"
-                    >
-                        Все машины системы
-                    </button>
-                </div>
-            </div>
-        </div>
-
-        <div class="carsview__container">
-            <!-- Таблица автомобилей -->
-            <div class="cars-card">
-                <div class="card-header">
-                    <div class="card-header__title">
-                        <h3 class="card-title">
-                            <span v-if="currentFilter === 'organization'" class="highlight-text">Машины <span class="blue">организации</span></span>
-                            <span v-else-if="currentFilter === 'company'" class="highlight-text">Машины <span class="blue">компании</span></span>
-                            <span v-else-if="currentFilter === 'all_system'" class="highlight-text">Все <span class="blue">машины системы</span></span>
-                            <span v-else class="highlight-text">Мои <span class="blue">автомобили</span></span>
-                        </h3>
-                    </div>
-                    <div class="card-header__settings">
-                        <button
-                            class="add-button"
-                            data-testid="cars-view-add-button"
-                            @click="showAddCarModal"
-                            v-if="currentFilter !== 'all_system'"
-                        >
-                            Добавить
-                        </button>
-                        <RefreshButton @refresh="fetchCars" />
-                    </div>
-                </div>
-                
-                <div class="card-content">
-                    <!-- Заголовок таблицы всегда отображается -->
-                    <div class="cars-header">
-                        <div class="header-row">
-                            <div class="header-col number-col" @click="sortBy('id')">
-                                <p :class="{ 'active-sort': sortField === 'id' }">№</p>
-                                <img 
-                                    src="@/assets/icons/sort.png" 
-                                    class="sort-icon" 
-                                    :class="{ 
-                                        'sorted': sortField === 'id',
-                                        'desc': sortField === 'id' && sortDirection === 'desc'
-                                    }" 
-                                />
-                            </div>
-                            <div class="header-col car-number-col" @click="sortBy('number')">
-                                <p :class="{ 'active-sort': sortField === 'number' }">Номер</p>
-                                <img 
-                                    src="@/assets/icons/sort.png" 
-                                    class="sort-icon" 
-                                    :class="{ 
-                                        'sorted': sortField === 'number',
-                                        'desc': sortField === 'number' && sortDirection === 'desc'
-                                    }" 
-                                />
-                            </div>
-                            <div class="header-col brand-col" @click="sortBy('mark')">
-                                <p :class="{ 'active-sort': sortField === 'mark' }">Марка</p>
-                                <img 
-                                    src="@/assets/icons/sort.png" 
-                                    class="sort-icon" 
-                                    :class="{ 
-                                        'sorted': sortField === 'mark',
-                                        'desc': sortField === 'mark' && sortDirection === 'desc'
-                                    }" 
-                                />
-                            </div>
-                            <div class="header-col format-col" @click="sortBy('format_name')">
-                                <p :class="{ 'active-sort': sortField === 'format_name' }">Формат номера</p>
-                                <img 
-                                    src="@/assets/icons/sort.png" 
-                                    class="sort-icon" 
-                                    :class="{ 
-                                        'sorted': sortField === 'format_name',
-                                        'desc': sortField === 'format_name' && sortDirection === 'desc'
-                                    }" 
-                                />
-                            </div>
-                            <div class="header-col status-col" @click="sortBy('status')">
-                                <p :class="{ 'active-sort': sortField === 'status' }">Статус</p>
-                                <img 
-                                    src="@/assets/icons/sort.png" 
-                                    class="sort-icon" 
-                                    :class="{ 
-                                        'sorted': sortField === 'status',
-                                        'desc': sortField === 'status' && sortDirection === 'desc'
-                                    }" 
-                                />
-                            </div>
-                            <div class="header-col actions-col">
-                                Действия
-                            </div>
-                        </div>
-                    </div>
-                    
-                    <!-- Тело таблицы -->
-                    <div class="cars-container">
-                        <SkeletonTransition :loading="loading">
-                            <template #skeleton>
-                                <SkeletonTable :rows="6" :columns="5" />
-                            </template>
-                        <div v-if="filteredCars.length > 0" class="cars-body">
-                            <div 
-                                v-for="(car) in sortedCars" 
-                                :key="car.id" 
-                                class="car-item"
-                            >
-                                <div class="car-row">
-                                    <div class="car-col number-col">
-                                        {{ car.id }}
-                                    </div>
-                                    <div class="car-col car-number-col">
-                                        {{ car.number }}
-                                    </div>
-                                    <div class="car-col brand-col">
-                                        {{ car.mark }}
-                                    </div>
-                                    <div class="car-col format-col">
-                                        {{ car.format_name || 'Не указан' }}
-                                    </div>
-                                    <div class="car-col status-col">
-                                        <span 
-                                            class="status-badge"
-                                            :class="{
-                                                'status-active': car.status,
-                                                'status-inactive': !car.status
-                                            }"
-                                        >
-                                            {{ car.status ? 'Активна' : 'Неактивна' }}
-                                        </span>
-                                    </div>
-                                    <div class="car-col actions-col">
-                                        <button 
-                                            v-if="currentFilter !== 'all_system'"
-                                            @click="editCar(car)" 
-                                            class="edit-btn"
-                                            title="Редактировать"
-                                        >
-                                            <img 
-                                                src="@/assets/icons/edit.png" 
-                                                alt="Редактировать" 
-                                                class="edit-icon"
-                                            />
-                                        </button>
-                                        <button
-                                            v-if="currentFilter !== 'all_system'"
-                                            @click="openDeleteCarConfirmation(car)"
-                                            class="delete-btn"
-                                            title="Удалить"
-                                        >
-                                            <img 
-                                                src="@/assets/icons/trashcan.png" 
-                                                alt="Удалить" 
-                                                class="delete-icon"
-                                            />
-                                        </button>
-                                        <span v-if="currentFilter === 'all_system'" class="read-only-text">
-                                            Только просмотр
-                                        </span>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <p v-else class="no-data-message">
-                            {{ hasActiveFilters ? 'Нет данных по выбранным фильтрам' : 'Автомобилей нет' }}
-                        </p>
-                        </SkeletonTransition>
-                    </div>
-                </div>
-            </div>
-            
-            <div class="carsview__right-side">
-                <div class="carsview__help">
-                    <template v-if="currentFilter === 'organization'">
-                        <p class="help__text">
-                            Здесь находятся автомобили, привязанные к вашей <strong class="blue">организации</strong>. Вы можете использовать эти автомобили при подаче автозаявок.
-                        </p>
-                        <p class="help__text">
-                            Новые номера машин попадают в этот список <strong class="blue">автоматически</strong>, при подаче заявки.
-                        </p>
-                    </template>
-                    <template v-else-if="currentFilter === 'company'">
-                        <p class="help__text">
-                            Здесь находятся автомобили, привязанные к вашей <strong class="blue">компании</strong>. Вы можете использовать эти автомобили при подаче автозаявок.
-                        </p>
-                        <p class="help__text">
-                            Новые номера машин попадают в этот список <strong class="blue">автоматически</strong>, при подаче заявки.
-                        </p>
-                    </template>
-                    <template v-else-if="currentFilter === 'user'">
-                        <p class="help__text">
-                            Здесь находятся <strong class="blue">ваши автомобили</strong>, добавленные лично. Вы можете использовать их при подаче автозаявок.
-                        </p>
-                        <p class="help__text">
-                            Новые номера машин попадают в этот список <strong class="blue">автоматически</strong>, при подаче заявки.
-                        </p>
-                    </template>
-                    <template v-else-if="currentFilter === 'all_system'">
-                        <p class="help__text">
-                            Здесь отображаются <strong class="blue">все автомобили</strong>, которые есть в системе. В этой вкладке доступен только просмотр, добавление, редактирование и удаление машин недоступно.
-                        </p>
-                    </template>
-                </div>
-            </div>
-        </div>
-
-        <!-- Модальное окно добавления машины -->
-        <div v-if="showModal && currentFilter !== 'all_system'" class="modal-overlay" data-testid="cars-view-modal" @click="closeModal">
-            <div class="modal-content" @click.stop>
-                <div class="modal-header">
-                    <div class="modal-header__top">
-                        <h3>{{ editingCar ? 'Редактирование' : 'Добавление Т/С' }}</h3>
-                        <div v-if="notification.show" class="notification-badge" :class="notification.type">
-                            {{ notification.message }}
-                        </div>
-                    </div>
-                    <button class="modal-close" data-testid="cars-view-modal-close" @click="closeModal">×</button>
-                </div>
-                <div class="modal-body">
-                    <div class="data__completion">
-                        <div class="completion__format">
-                            <div class="format__header">
-                                <label class="format__label">Формат номеров</label>
-                                <button class="add-button" @click="saveCar" :disabled="!canSaveCar">
-                                    {{ editingCar ? 'Сохранить' : 'Добавить' }}
-                                </button>
-                            </div>
-                            <div class="format__dropdown">
-                                <button class="dropdown__button" data-testid="cars-view-format-dropdown" @click="toggleFormatDropdown">
-                                    <div class="button__content">
-                                        <span class="button__text">{{ selectedFormatText }}</span>
-                                        <img src="@/assets/icons/arrow.png" class="button__arrow" :class="{ 'button__arrow--open': isFormatDropdownOpen }" />
-                                    </div>
-                                </button>
-                                <transition name="dropdown">
-                                    <div v-if="isFormatDropdownOpen" class="dropdown__menu">
-                                        <div 
-                                            v-for="format in availableFormats" 
-                                            :key="format.format.id"
-                                            class="dropdown__item" 
-                                            @click="selectFormat(format)"
-                                        >
-                                            <span class="item__text">{{ format.format.name }}</span>
-                                        </div>
-                                    </div>
-                                </transition>
-                            </div>
-                        </div>
-                        
-                        <div class="completion__fields">
-                            <div class="completion__number">
-                                <div class="completion__number-header">
-                                    <label class="input__label">Номер Т/C <span class="required">*</span></label>
-                                </div>
-                                
-                                <!-- Динамический формат из базы данных -->
-                                <div class="number__field" v-if="selectedFormat">
-                                    <input 
-                                        v-for="(cell, index) in selectedFormat.cells" 
-                                        :key="index"
-                                        class="number__input" 
-                                        :placeholder="getPlaceholder(cell)"
-                                        v-model="numberParts[index]"
-                                        @input="validatePart(index, $event, cell)"
-                                        @blur="formatPart(index, cell)"
-                                        :maxlength="cell.max_length"
-                                        :style="{ width: getInputWidth(cell) }"
-                                    />
-                                </div>
-                                <div v-else class="no-format-message">
-                                    Выберите формат номера
-                                </div>
-                            </div>
-                            
-                            <div class="completion__mark">
-                                <div class="completion__mark-header">
-                                    <label class="input__label">Марка Т/С <span class="required">*</span></label>
-                                </div>
-                                <div class="mark__field">
-                                    <div class="mark__dropdown">
-                                        <button class="mark__dropdown-button" @click="toggleMarkDropdown">
-                                            <div class="mark__button-content">
-                                                <span class="mark__button-text">{{ selectedMark || 'Выберите марку' }}</span>
-                                                <img src="@/assets/icons/arrow.png" class="mark__button-arrow" :class="{ 'mark__button-arrow--open': isMarkDropdownOpen }" />
-                                            </div>
-                                        </button>
-                                        <transition name="dropdown">
-                                            <div v-if="isMarkDropdownOpen" class="mark__dropdown-menu">
-                                                <div class="mark__search">
-                                                    <input 
-                                                        class="mark__search-input" 
-                                                        placeholder="Поиск марки..."
-                                                        v-model="markSearch"
-                                                        @input="filterMarks"
-                                                    />
-                                                </div>
-                                                <div class="mark__dropdown-list">
-                                                    <div 
-                                                        v-for="mark in filteredMarks" 
-                                                        :key="mark"
-                                                        class="mark__dropdown-item"
-                                                        @click="selectMark(mark)"
-                                                    >
-                                                        <span class="mark__item-text">{{ mark }}</span>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </transition>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-
-                        <!-- Привязка -->
-                        <div class="completion__binding" v-if="currentFilter !== 'all_system'">
-                            <label class="input__label">Привязка</label>
-                            <div class="binding-info">
-                                <p class="binding-note">
-                                    <strong>Добавляемый автомобиль автоматически привязывается к аккаунту пользователя.</strong>
-                                    Автомобиль можно привязать к организации или компании, для использования <strong>другими сотрудниками</strong>:
-                                </p>
-                            </div>
-                            <div class="binding-options">
-                                <label class="binding-option" v-if="ownershipInfo && ownershipInfo.has_organization">
-                                    <input 
-                                        type="checkbox" 
-                                        v-model="bindToOrganization"
-                                        :disabled="bindToCompany"
-                                    />
-                                    <span>Привязать к организации</span>
-                                </label>
-                                <label class="binding-option" v-if="ownershipInfo && ownershipInfo.has_company">
-                                    <input 
-                                        type="checkbox" 
-                                        v-model="bindToCompany"
-                                        :disabled="bindToOrganization"
-                                    />
-                                    <span>Привязать к компании</span>
-                                </label>
-                                <div class="user-binding">
-                                    <span class="user-binding-text"><strong class="red">Внимание!</strong> При привязке автомобиля к организации или компании, он будет доступен для отображения и использования для всех сотрудников, привязанных к организации/компании. </span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <ConfirmationModal
-            :show="showDeleteCarModal"
-            title="Подтверждение удаления"
-            :message="`Вы уверены, что хотите удалить автомобиль ${carToDelete?.number || ''}?`"
-            confirm-text="Удалить"
-            cancel-text="Отмена"
-            :confirm-button-style="{ background: '#ff4444', borderColor: '#ff4444' }"
-            @confirm="confirmDeleteCar"
-            @cancel="cancelDeleteCar"
+    <div class="carsview__filters">
+      <div class="filters-container">
+        <SearchComponent
+          v-model="searchQuery"
+          :title="'Поиск машин...'"
         />
-    </section>
+        <div
+          v-if="ownershipInfo"
+          class="filter-tabs"
+        >
+          <button
+            v-if="ownershipInfo.has_organization"
+            class="filter-tab"
+            data-testid="filter-tab-organization"
+            :class="{ 'filter-tab--active': currentFilter === 'organization' }"
+            title="Автомобили, которых привязывали пользователи вашей организации"
+            @click="switchFilter('organization')"
+          >
+            Машины организации
+          </button>
+          <button
+            v-if="ownershipInfo.has_company"
+            class="filter-tab"
+            data-testid="filter-tab-company"
+            :class="{ 'filter-tab--active': currentFilter === 'company' }"
+            title="Автомобили, которых привязывали пользователи вашей компании"
+            @click="switchFilter('company')"
+          >
+            Машины компании
+          </button>
+          <button
+            class="filter-tab"
+            data-testid="filter-tab-user"
+            :class="{ 'filter-tab--active': currentFilter === 'user' }"
+            title="Только те автомобили, которых привязывали лично вы"
+            @click="switchFilter('user')"
+          >
+            Мои машины
+          </button>
+          <button
+            class="filter-tab"
+            data-testid="filter-tab-all-system"
+            :class="{ 'filter-tab--active': currentFilter === 'all_system' }"
+            title="Все автомобили, когда-либо зарегистрированные в системе"
+            @click="switchFilter('all_system')"
+          >
+            Все машины системы
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div class="carsview__container">
+      <!-- Таблица автомобилей -->
+      <div class="cars-card">
+        <div class="card-header">
+          <div class="card-header__title">
+            <h3 class="card-title">
+              <span
+                v-if="currentFilter === 'organization'"
+                class="highlight-text"
+              >Машины <span class="blue">организации</span></span>
+              <span
+                v-else-if="currentFilter === 'company'"
+                class="highlight-text"
+              >Машины <span class="blue">компании</span></span>
+              <span
+                v-else-if="currentFilter === 'all_system'"
+                class="highlight-text"
+              >Все <span class="blue">машины системы</span></span>
+              <span
+                v-else
+                class="highlight-text"
+              >Мои <span class="blue">автомобили</span></span>
+            </h3>
+          </div>
+          <div class="card-header__settings">
+            <button
+              v-if="currentFilter !== 'all_system'"
+              class="add-button"
+              data-testid="cars-view-add-button"
+              @click="showAddCarModal"
+            >
+              Добавить
+            </button>
+            <RefreshButton @refresh="fetchCars" />
+          </div>
+        </div>
+                
+        <div class="card-content">
+          <!-- Заголовок таблицы всегда отображается -->
+          <div class="cars-header">
+            <div class="header-row">
+              <div
+                class="header-col number-col"
+                @click="sortBy('id')"
+              >
+                <p :class="{ 'active-sort': sortField === 'id' }">
+                  №
+                </p>
+                <img 
+                  src="@/assets/icons/sort.png" 
+                  class="sort-icon" 
+                  :class="{ 
+                    'sorted': sortField === 'id',
+                    'desc': sortField === 'id' && sortDirection === 'desc'
+                  }" 
+                >
+              </div>
+              <div
+                class="header-col car-number-col"
+                @click="sortBy('number')"
+              >
+                <p :class="{ 'active-sort': sortField === 'number' }">
+                  Номер
+                </p>
+                <img 
+                  src="@/assets/icons/sort.png" 
+                  class="sort-icon" 
+                  :class="{ 
+                    'sorted': sortField === 'number',
+                    'desc': sortField === 'number' && sortDirection === 'desc'
+                  }" 
+                >
+              </div>
+              <div
+                class="header-col brand-col"
+                @click="sortBy('mark')"
+              >
+                <p :class="{ 'active-sort': sortField === 'mark' }">
+                  Марка
+                </p>
+                <img 
+                  src="@/assets/icons/sort.png" 
+                  class="sort-icon" 
+                  :class="{ 
+                    'sorted': sortField === 'mark',
+                    'desc': sortField === 'mark' && sortDirection === 'desc'
+                  }" 
+                >
+              </div>
+              <div
+                class="header-col format-col"
+                @click="sortBy('format_name')"
+              >
+                <p :class="{ 'active-sort': sortField === 'format_name' }">
+                  Формат номера
+                </p>
+                <img 
+                  src="@/assets/icons/sort.png" 
+                  class="sort-icon" 
+                  :class="{ 
+                    'sorted': sortField === 'format_name',
+                    'desc': sortField === 'format_name' && sortDirection === 'desc'
+                  }" 
+                >
+              </div>
+              <div
+                class="header-col status-col"
+                @click="sortBy('status')"
+              >
+                <p :class="{ 'active-sort': sortField === 'status' }">
+                  Статус
+                </p>
+                <img 
+                  src="@/assets/icons/sort.png" 
+                  class="sort-icon" 
+                  :class="{ 
+                    'sorted': sortField === 'status',
+                    'desc': sortField === 'status' && sortDirection === 'desc'
+                  }" 
+                >
+              </div>
+              <div class="header-col actions-col">
+                Действия
+              </div>
+            </div>
+          </div>
+                    
+          <!-- Тело таблицы -->
+          <div class="cars-container">
+            <SkeletonTransition :loading="loading">
+              <template #skeleton>
+                <SkeletonTable
+                  :rows="6"
+                  :columns="5"
+                />
+              </template>
+              <div
+                v-if="filteredCars.length > 0"
+                class="cars-body"
+              >
+                <div 
+                  v-for="(car) in sortedCars" 
+                  :key="car.id" 
+                  class="car-item"
+                >
+                  <div class="car-row">
+                    <div class="car-col number-col">
+                      {{ car.id }}
+                    </div>
+                    <div class="car-col car-number-col">
+                      {{ car.number }}
+                    </div>
+                    <div class="car-col brand-col">
+                      {{ car.mark }}
+                    </div>
+                    <div class="car-col format-col">
+                      {{ car.format_name || 'Не указан' }}
+                    </div>
+                    <div class="car-col status-col">
+                      <span 
+                        class="status-badge"
+                        :class="{
+                          'status-active': car.status,
+                          'status-inactive': !car.status
+                        }"
+                      >
+                        {{ car.status ? 'Активна' : 'Неактивна' }}
+                      </span>
+                    </div>
+                    <div class="car-col actions-col">
+                      <button 
+                        v-if="currentFilter !== 'all_system'"
+                        class="edit-btn" 
+                        title="Редактировать"
+                        @click="editCar(car)"
+                      >
+                        <img 
+                          src="@/assets/icons/edit.png" 
+                          alt="Редактировать" 
+                          class="edit-icon"
+                        >
+                      </button>
+                      <button
+                        v-if="currentFilter !== 'all_system'"
+                        class="delete-btn"
+                        title="Удалить"
+                        @click="openDeleteCarConfirmation(car)"
+                      >
+                        <img 
+                          src="@/assets/icons/trashcan.png" 
+                          alt="Удалить" 
+                          class="delete-icon"
+                        >
+                      </button>
+                      <span
+                        v-if="currentFilter === 'all_system'"
+                        class="read-only-text"
+                      >
+                        Только просмотр
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <p
+                v-else
+                class="no-data-message"
+              >
+                {{ hasActiveFilters ? 'Нет данных по выбранным фильтрам' : 'Автомобилей нет' }}
+              </p>
+            </SkeletonTransition>
+          </div>
+        </div>
+      </div>
+            
+      <div class="carsview__right-side">
+        <div class="carsview__help">
+          <template v-if="currentFilter === 'organization'">
+            <p class="help__text">
+              Здесь находятся автомобили, привязанные к вашей <strong class="blue">организации</strong>. Вы можете использовать эти автомобили при подаче автозаявок.
+            </p>
+            <p class="help__text">
+              Новые номера машин попадают в этот список <strong class="blue">автоматически</strong>, при подаче заявки.
+            </p>
+          </template>
+          <template v-else-if="currentFilter === 'company'">
+            <p class="help__text">
+              Здесь находятся автомобили, привязанные к вашей <strong class="blue">компании</strong>. Вы можете использовать эти автомобили при подаче автозаявок.
+            </p>
+            <p class="help__text">
+              Новые номера машин попадают в этот список <strong class="blue">автоматически</strong>, при подаче заявки.
+            </p>
+          </template>
+          <template v-else-if="currentFilter === 'user'">
+            <p class="help__text">
+              Здесь находятся <strong class="blue">ваши автомобили</strong>, добавленные лично. Вы можете использовать их при подаче автозаявок.
+            </p>
+            <p class="help__text">
+              Новые номера машин попадают в этот список <strong class="blue">автоматически</strong>, при подаче заявки.
+            </p>
+          </template>
+          <template v-else-if="currentFilter === 'all_system'">
+            <p class="help__text">
+              Здесь отображаются <strong class="blue">все автомобили</strong>, которые есть в системе. В этой вкладке доступен только просмотр, добавление, редактирование и удаление машин недоступно.
+            </p>
+          </template>
+        </div>
+      </div>
+    </div>
+
+    <!-- Модальное окно добавления машины -->
+    <div
+      v-if="showModal && currentFilter !== 'all_system'"
+      class="modal-overlay"
+      data-testid="cars-view-modal"
+      @click="closeModal"
+    >
+      <div
+        class="modal-content"
+        @click.stop
+      >
+        <div class="modal-header">
+          <div class="modal-header__top">
+            <h3>{{ editingCar ? 'Редактирование' : 'Добавление Т/С' }}</h3>
+            <div
+              v-if="notification.show"
+              class="notification-badge"
+              :class="notification.type"
+            >
+              {{ notification.message }}
+            </div>
+          </div>
+          <button
+            class="modal-close"
+            data-testid="cars-view-modal-close"
+            @click="closeModal"
+          >
+            ×
+          </button>
+        </div>
+        <div class="modal-body">
+          <div class="data__completion">
+            <div class="completion__format">
+              <div class="format__header">
+                <label class="format__label">Формат номеров</label>
+                <button
+                  class="add-button"
+                  :disabled="!canSaveCar"
+                  @click="saveCar"
+                >
+                  {{ editingCar ? 'Сохранить' : 'Добавить' }}
+                </button>
+              </div>
+              <div class="format__dropdown">
+                <button
+                  class="dropdown__button"
+                  data-testid="cars-view-format-dropdown"
+                  @click="toggleFormatDropdown"
+                >
+                  <div class="button__content">
+                    <span class="button__text">{{ selectedFormatText }}</span>
+                    <img
+                      src="@/assets/icons/arrow.png"
+                      class="button__arrow"
+                      :class="{ 'button__arrow--open': isFormatDropdownOpen }"
+                    >
+                  </div>
+                </button>
+                <transition name="dropdown">
+                  <div
+                    v-if="isFormatDropdownOpen"
+                    class="dropdown__menu"
+                  >
+                    <div 
+                      v-for="format in availableFormats" 
+                      :key="format.format.id"
+                      class="dropdown__item" 
+                      @click="selectFormat(format)"
+                    >
+                      <span class="item__text">{{ format.format.name }}</span>
+                    </div>
+                  </div>
+                </transition>
+              </div>
+            </div>
+                        
+            <div class="completion__fields">
+              <div class="completion__number">
+                <div class="completion__number-header">
+                  <label class="input__label">Номер Т/C <span class="required">*</span></label>
+                </div>
+                                
+                <!-- Динамический формат из базы данных -->
+                <div
+                  v-if="selectedFormat"
+                  class="number__field"
+                >
+                  <input 
+                    v-for="(cell, index) in selectedFormat.cells" 
+                    :key="index"
+                    v-model="numberParts[index]" 
+                    class="number__input"
+                    :placeholder="getPlaceholder(cell)"
+                    :maxlength="cell.max_length"
+                    :style="{ width: getInputWidth(cell) }"
+                    @input="validatePart(index, $event, cell)"
+                    @blur="formatPart(index, cell)"
+                  >
+                </div>
+                <div
+                  v-else
+                  class="no-format-message"
+                >
+                  Выберите формат номера
+                </div>
+              </div>
+                            
+              <div class="completion__mark">
+                <div class="completion__mark-header">
+                  <label class="input__label">Марка Т/С <span class="required">*</span></label>
+                </div>
+                <div class="mark__field">
+                  <div class="mark__dropdown">
+                    <button
+                      class="mark__dropdown-button"
+                      @click="toggleMarkDropdown"
+                    >
+                      <div class="mark__button-content">
+                        <span class="mark__button-text">{{ selectedMark || 'Выберите марку' }}</span>
+                        <img
+                          src="@/assets/icons/arrow.png"
+                          class="mark__button-arrow"
+                          :class="{ 'mark__button-arrow--open': isMarkDropdownOpen }"
+                        >
+                      </div>
+                    </button>
+                    <transition name="dropdown">
+                      <div
+                        v-if="isMarkDropdownOpen"
+                        class="mark__dropdown-menu"
+                      >
+                        <div class="mark__search">
+                          <input 
+                            v-model="markSearch" 
+                            class="mark__search-input"
+                            placeholder="Поиск марки..."
+                            @input="filterMarks"
+                          >
+                        </div>
+                        <div class="mark__dropdown-list">
+                          <div 
+                            v-for="mark in filteredMarks" 
+                            :key="mark"
+                            class="mark__dropdown-item"
+                            @click="selectMark(mark)"
+                          >
+                            <span class="mark__item-text">{{ mark }}</span>
+                          </div>
+                        </div>
+                      </div>
+                    </transition>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Привязка -->
+            <div
+              v-if="currentFilter !== 'all_system'"
+              class="completion__binding"
+            >
+              <label class="input__label">Привязка</label>
+              <div class="binding-info">
+                <p class="binding-note">
+                  <strong>Добавляемый автомобиль автоматически привязывается к аккаунту пользователя.</strong>
+                  Автомобиль можно привязать к организации или компании, для использования <strong>другими сотрудниками</strong>:
+                </p>
+              </div>
+              <div class="binding-options">
+                <label
+                  v-if="ownershipInfo && ownershipInfo.has_organization"
+                  class="binding-option"
+                >
+                  <input 
+                    v-model="bindToOrganization" 
+                    type="checkbox"
+                    :disabled="bindToCompany"
+                  >
+                  <span>Привязать к организации</span>
+                </label>
+                <label
+                  v-if="ownershipInfo && ownershipInfo.has_company"
+                  class="binding-option"
+                >
+                  <input 
+                    v-model="bindToCompany" 
+                    type="checkbox"
+                    :disabled="bindToOrganization"
+                  >
+                  <span>Привязать к компании</span>
+                </label>
+                <div class="user-binding">
+                  <span class="user-binding-text"><strong class="red">Внимание!</strong> При привязке автомобиля к организации или компании, он будет доступен для отображения и использования для всех сотрудников, привязанных к организации/компании. </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <ConfirmationModal
+      :show="showDeleteCarModal"
+      title="Подтверждение удаления"
+      :message="`Вы уверены, что хотите удалить автомобиль ${carToDelete?.number || ''}?`"
+      confirm-text="Удалить"
+      cancel-text="Отмена"
+      :confirm-button-style="{ background: '#ff4444', borderColor: '#ff4444' }"
+      @confirm="confirmDeleteCar"
+      @cancel="cancelDeleteCar"
+    />
+  </section>
 </template>
 
 <script>
@@ -594,6 +707,24 @@ export default {
                 this.bindToOrganization = false;
             }
         }
+    },
+    async mounted() {
+        await Promise.all([
+            this.fetchOwnershipInfo(),
+            this.fetchFormats()
+        ]);
+        await this.fetchCars();
+        
+        // Закрытие dropdown при клике вне
+        document.addEventListener('click', (e) => {
+            if (!e.target.closest('.format__dropdown')) {
+                this.isFormatDropdownOpen = false;
+            }
+            
+            if (!e.target.closest('.mark__dropdown')) {
+                this.isMarkDropdownOpen = false;
+            }
+        });
     },
     methods: {
         async fetchCars() {
@@ -1062,24 +1193,6 @@ export default {
                 this.showNotification("Ошибка при сохранении автомобиля", 'error');
             }
         }
-    },
-    async mounted() {
-        await Promise.all([
-            this.fetchOwnershipInfo(),
-            this.fetchFormats()
-        ]);
-        await this.fetchCars();
-        
-        // Закрытие dropdown при клике вне
-        document.addEventListener('click', (e) => {
-            if (!e.target.closest('.format__dropdown')) {
-                this.isFormatDropdownOpen = false;
-            }
-            
-            if (!e.target.closest('.mark__dropdown')) {
-                this.isMarkDropdownOpen = false;
-            }
-        });
     }
 }
 </script>

--- a/frontend/src/views/EmployeeView.vue
+++ b/frontend/src/views/EmployeeView.vue
@@ -1,253 +1,306 @@
 <template>
-    <section class="employeesview" data-testid="employees-page">
-        <header class="employeesview__header">
-            <h2 class="employeesview__title">
-                Список <span class="blue">сотрудников</span>
-            </h2>
-            <p class="employeesview__subtitle">
-                Вкладка для просмотра сотрудников, которых вы или ваша организация/компания когда-либо привязывали к заявкам.
-            </p>
-        </header>
+  <section
+    class="employeesview"
+    data-testid="employees-page"
+  >
+    <header class="employeesview__header">
+      <h2 class="employeesview__title">
+        Список <span class="blue">сотрудников</span>
+      </h2>
+      <p class="employeesview__subtitle">
+        Вкладка для просмотра сотрудников, которых вы или ваша организация/компания когда-либо привязывали к заявкам.
+      </p>
+    </header>
 
-        <div class="employeesview__filters">
-            <div class="filters-container">
-                <SearchComponent
-                    :title="'Поиск сотрудников...'"
-                    v-model="searchQuery"
-                />
-                <div class="filter-tabs" v-if="ownershipInfo">
-                    <button
-                        v-if="ownershipInfo.has_organization"
-                        class="filter-tab"
-                        data-testid="filter-tab-organization"
-                        :class="{ 'filter-tab--active': currentFilter === 'organization' }"
-                        title="Сотрудники, которых привязывали пользователи вашей организации"
-                        @click="switchFilter('organization')"
-                    >
-                        Сотрудники организации
-                    </button>
-                    <button
-                        v-if="ownershipInfo.has_company"
-                        class="filter-tab"
-                        data-testid="filter-tab-company"
-                        :class="{ 'filter-tab--active': currentFilter === 'company' }"
-                        title="Сотрудники, которых привязывали пользователи вашей компании"
-                        @click="switchFilter('company')"
-                    >
-                        Сотрудники компании
-                    </button>
-                    <button
-                        class="filter-tab"
-                        data-testid="filter-tab-user"
-                        :class="{ 'filter-tab--active': currentFilter === 'user' }"
-                        title="Только те сотрудники, которых привязывали лично вы"
-                        @click="switchFilter('user')"
-                    >
-                        Мои сотрудники
-                    </button>
-                    <button
-                        class="filter-tab"
-                        data-testid="filter-tab-all-system"
-                        :class="{ 'filter-tab--active': currentFilter === 'all_system' }"
-                        title="Все сотрудники, когда-либо зарегистрированные в системе"
-                        @click="switchFilter('all_system')"
-                    >
-                        Все сотрудники системы
-                    </button>
-                </div>
-            </div>
-        </div>
-
-        <div class="employeesview__container">
-            <!-- Таблица сотрудников -->
-            <div class="employees-card">
-                <div class="card-header">
-                    <div class="card-header__title">
-                        <h3 class="card-title">
-                            <span v-if="currentFilter === 'organization'" class="highlight-text">Сотрудники <span class="blue">организации</span></span>
-                            <span v-else-if="currentFilter === 'company'" class="highlight-text">Сотрудники <span class="blue">компании</span></span>
-                            <span v-else-if="currentFilter === 'all_system'" class="highlight-text">Все <span class="blue">сотрудники системы</span></span>
-                            <span v-else class="highlight-text">Мои <span class="blue">сотрудники</span></span>
-                        </h3>
-                    </div>
-                    <div class="card-header__settings">
-                        <button
-                            class="add-button"
-                            v-if="currentFilter !== 'all_system'"
-                            @click="showAddEmployeeModal"
-                        >
-                            Добавить
-                        </button>
-                        <RefreshButton @refresh="fetchEmployees" />
-                    </div>
-                </div>
-                
-                <div class="card-content">
-                    <!-- Заголовок таблицы всегда отображается -->
-                    <div class="employees-header">
-                        <div class="header-row">
-                            <div class="header-col number-col" @click="sortBy('id')">
-                                <p :class="{ 'active-sort': sortField === 'id' }">№</p>
-                                <img 
-                                    src="@/assets/icons/sort.png" 
-                                    class="sort-icon" 
-                                    :class="{ 
-                                        'sorted': sortField === 'id',
-                                        'desc': sortField === 'id' && sortDirection === 'desc'
-                                    }" 
-                                />
-                            </div>
-                            <div class="header-col name-col" @click="sortBy('last_name')">
-                                <p :class="{ 'active-sort': sortField === 'last_name' }">ФИО</p>
-                                <img 
-                                    src="@/assets/icons/sort.png" 
-                                    class="sort-icon" 
-                                    :class="{ 
-                                        'sorted': sortField === 'last_name',
-                                        'desc': sortField === 'last_name' && sortDirection === 'desc'
-                                    }" 
-                                />
-                            </div>
-                            <div class="header-col position-col" @click="sortBy('position')">
-                                <p :class="{ 'active-sort': sortField === 'position' }">Должность</p>
-                                <img 
-                                    src="@/assets/icons/sort.png" 
-                                    class="sort-icon" 
-                                    :class="{ 
-                                        'sorted': sortField === 'position',
-                                        'desc': sortField === 'position' && sortDirection === 'desc'
-                                    }" 
-                                />
-                            </div>
-                            <div class="header-col status-col" @click="sortBy('status')">
-                                <p :class="{ 'active-sort': sortField === 'status' }">Статус</p>
-                                <img 
-                                    src="@/assets/icons/sort.png" 
-                                    class="sort-icon" 
-                                    :class="{ 
-                                        'sorted': sortField === 'status',
-                                        'desc': sortField === 'status' && sortDirection === 'desc'
-                                    }" 
-                                />
-                            </div>
-                            <div class="header-col actions-col">
-                                Действия
-                            </div>
-                        </div>
-                    </div>
-                    
-                    <!-- Тело таблицы -->
-                    <div class="employees-container">
-                        <SkeletonTransition :loading="loading">
-                            <template #skeleton>
-                                <SkeletonTable :rows="6" :columns="5" />
-                            </template>
-                        <div v-if="filteredEmployees.length > 0" class="employees-body">
-                            <div 
-                                v-for="(employee) in sortedEmployees" 
-                                :key="employee.id" 
-                                class="employee-item"
-                            >
-                                <div class="employee-row">
-                                    <div class="employee-col number-col">
-                                        {{ employee.id }}
-                                    </div>
-                                    <div class="employee-col name-col" :title="formatFullName(employee)">
-                                        {{ truncateText(formatFullName(employee), 20) }}
-                                    </div>
-                                    <div class="employee-col position-col" :title="employee.position || 'Не указана'">
-                                        {{ truncateText(employee.position || 'Не указана', 20) }}
-                                    </div>
-                                    <div class="employee-col status-col">
-                                        <span 
-                                            class="status-badge"
-                                            :class="{
-                                                'status-active': employee.status,
-                                                'status-inactive': !employee.status
-                                            }"
-                                        >
-                                            {{ employee.status ? 'Активен' : 'Неактивен' }}
-                                        </span>
-                                    </div>
-                                    <div class="employee-col actions-col">
-                                        <button 
-                                            @click="editEmployee(employee)" 
-                                            class="edit-btn"
-                                            title="Редактировать"
-                                        >
-                                            <img 
-                                                src="@/assets/icons/edit.png" 
-                                                alt="Редактировать" 
-                                                class="edit-icon"
-                                            />
-                                        </button>
-                                        <button 
-                                            @click="deleteEmployee(employee)" 
-                                            class="delete-btn"
-                                            title="Удалить"
-                                        >
-                                            <img 
-                                                src="@/assets/icons/trashcan.png" 
-                                                alt="Удалить" 
-                                                class="delete-icon"
-                                            />
-                                        </button>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <p v-else class="no-data-message">
-                            {{ hasActiveFilters ? 'Нет данных по выбранным фильтрам' : 'Сотрудников нет' }}
-                        </p>
-                        </SkeletonTransition>
-                    </div>
-                </div>
-            </div>
-            
-            <div class="employeesview__right-side">
-                <div class="employeesview__help">
-                    <template v-if="currentFilter === 'organization'">
-                        <p class="help__text">
-                            Здесь находятся сотрудники, привязанные к вашей <strong class="blue">организации</strong>. Вы можете использовать этих сотрудников при подаче заявок на пропуск.
-                        </p>
-                        <p class="help__text">
-                            Новые сотрудники попадают в этот список <strong class="blue">автоматически</strong>, при подаче заявки.
-                        </p>
-                    </template>
-                    <template v-else-if="currentFilter === 'company'">
-                        <p class="help__text">
-                            Здесь находятся сотрудники, привязанные к вашей <strong class="blue">компании</strong>. Вы можете использовать этих сотрудников при подаче заявок на пропуск.
-                        </p>
-                        <p class="help__text">
-                            Новые сотрудники попадают в этот список <strong class="blue">автоматически</strong>, при подаче заявки.
-                        </p>
-                    </template>
-                    <template v-else-if="currentFilter === 'user'">
-                        <p class="help__text">
-                            Здесь находятся <strong class="blue">ваши сотрудники</strong>, добавленные лично. Вы можете использовать их при подаче заявок на пропуск.
-                        </p>
-                        <p class="help__text">
-                            Новые сотрудники попадают в этот список <strong class="blue">автоматически</strong>, при подаче заявки.
-                        </p>
-                    </template>
-                    <template v-else-if="currentFilter === 'all_system'">
-                        <p class="help__text">
-                            Здесь отображаются <strong class="blue">все сотрудники</strong>, которые есть в системе. В этой вкладке доступен только просмотр, добавление, редактирование и удаление сотрудников недоступно.
-                        </p>
-                    </template>
-                </div>
-            </div>
-        </div>
-
-        <EmployeeEditModal
-            :visible="showModal"
-            :editingEmployee="editingEmployee"
-            :citizenships="availableCitizenships"
-            :ownershipInfo="ownershipInfo"
-            @saved="onEmployeeSaved"
-            @close="closeModal"
+    <div class="employeesview__filters">
+      <div class="filters-container">
+        <SearchComponent
+          v-model="searchQuery"
+          :title="'Поиск сотрудников...'"
         />
-    </section>
+        <div
+          v-if="ownershipInfo"
+          class="filter-tabs"
+        >
+          <button
+            v-if="ownershipInfo.has_organization"
+            class="filter-tab"
+            data-testid="filter-tab-organization"
+            :class="{ 'filter-tab--active': currentFilter === 'organization' }"
+            title="Сотрудники, которых привязывали пользователи вашей организации"
+            @click="switchFilter('organization')"
+          >
+            Сотрудники организации
+          </button>
+          <button
+            v-if="ownershipInfo.has_company"
+            class="filter-tab"
+            data-testid="filter-tab-company"
+            :class="{ 'filter-tab--active': currentFilter === 'company' }"
+            title="Сотрудники, которых привязывали пользователи вашей компании"
+            @click="switchFilter('company')"
+          >
+            Сотрудники компании
+          </button>
+          <button
+            class="filter-tab"
+            data-testid="filter-tab-user"
+            :class="{ 'filter-tab--active': currentFilter === 'user' }"
+            title="Только те сотрудники, которых привязывали лично вы"
+            @click="switchFilter('user')"
+          >
+            Мои сотрудники
+          </button>
+          <button
+            class="filter-tab"
+            data-testid="filter-tab-all-system"
+            :class="{ 'filter-tab--active': currentFilter === 'all_system' }"
+            title="Все сотрудники, когда-либо зарегистрированные в системе"
+            @click="switchFilter('all_system')"
+          >
+            Все сотрудники системы
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div class="employeesview__container">
+      <!-- Таблица сотрудников -->
+      <div class="employees-card">
+        <div class="card-header">
+          <div class="card-header__title">
+            <h3 class="card-title">
+              <span
+                v-if="currentFilter === 'organization'"
+                class="highlight-text"
+              >Сотрудники <span class="blue">организации</span></span>
+              <span
+                v-else-if="currentFilter === 'company'"
+                class="highlight-text"
+              >Сотрудники <span class="blue">компании</span></span>
+              <span
+                v-else-if="currentFilter === 'all_system'"
+                class="highlight-text"
+              >Все <span class="blue">сотрудники системы</span></span>
+              <span
+                v-else
+                class="highlight-text"
+              >Мои <span class="blue">сотрудники</span></span>
+            </h3>
+          </div>
+          <div class="card-header__settings">
+            <button
+              v-if="currentFilter !== 'all_system'"
+              class="add-button"
+              @click="showAddEmployeeModal"
+            >
+              Добавить
+            </button>
+            <RefreshButton @refresh="fetchEmployees" />
+          </div>
+        </div>
+                
+        <div class="card-content">
+          <!-- Заголовок таблицы всегда отображается -->
+          <div class="employees-header">
+            <div class="header-row">
+              <div
+                class="header-col number-col"
+                @click="sortBy('id')"
+              >
+                <p :class="{ 'active-sort': sortField === 'id' }">
+                  №
+                </p>
+                <img 
+                  src="@/assets/icons/sort.png" 
+                  class="sort-icon" 
+                  :class="{ 
+                    'sorted': sortField === 'id',
+                    'desc': sortField === 'id' && sortDirection === 'desc'
+                  }" 
+                >
+              </div>
+              <div
+                class="header-col name-col"
+                @click="sortBy('last_name')"
+              >
+                <p :class="{ 'active-sort': sortField === 'last_name' }">
+                  ФИО
+                </p>
+                <img 
+                  src="@/assets/icons/sort.png" 
+                  class="sort-icon" 
+                  :class="{ 
+                    'sorted': sortField === 'last_name',
+                    'desc': sortField === 'last_name' && sortDirection === 'desc'
+                  }" 
+                >
+              </div>
+              <div
+                class="header-col position-col"
+                @click="sortBy('position')"
+              >
+                <p :class="{ 'active-sort': sortField === 'position' }">
+                  Должность
+                </p>
+                <img 
+                  src="@/assets/icons/sort.png" 
+                  class="sort-icon" 
+                  :class="{ 
+                    'sorted': sortField === 'position',
+                    'desc': sortField === 'position' && sortDirection === 'desc'
+                  }" 
+                >
+              </div>
+              <div
+                class="header-col status-col"
+                @click="sortBy('status')"
+              >
+                <p :class="{ 'active-sort': sortField === 'status' }">
+                  Статус
+                </p>
+                <img 
+                  src="@/assets/icons/sort.png" 
+                  class="sort-icon" 
+                  :class="{ 
+                    'sorted': sortField === 'status',
+                    'desc': sortField === 'status' && sortDirection === 'desc'
+                  }" 
+                >
+              </div>
+              <div class="header-col actions-col">
+                Действия
+              </div>
+            </div>
+          </div>
+                    
+          <!-- Тело таблицы -->
+          <div class="employees-container">
+            <SkeletonTransition :loading="loading">
+              <template #skeleton>
+                <SkeletonTable
+                  :rows="6"
+                  :columns="5"
+                />
+              </template>
+              <div
+                v-if="filteredEmployees.length > 0"
+                class="employees-body"
+              >
+                <div 
+                  v-for="(employee) in sortedEmployees" 
+                  :key="employee.id" 
+                  class="employee-item"
+                >
+                  <div class="employee-row">
+                    <div class="employee-col number-col">
+                      {{ employee.id }}
+                    </div>
+                    <div
+                      class="employee-col name-col"
+                      :title="formatFullName(employee)"
+                    >
+                      {{ truncateText(formatFullName(employee), 20) }}
+                    </div>
+                    <div
+                      class="employee-col position-col"
+                      :title="employee.position || 'Не указана'"
+                    >
+                      {{ truncateText(employee.position || 'Не указана', 20) }}
+                    </div>
+                    <div class="employee-col status-col">
+                      <span 
+                        class="status-badge"
+                        :class="{
+                          'status-active': employee.status,
+                          'status-inactive': !employee.status
+                        }"
+                      >
+                        {{ employee.status ? 'Активен' : 'Неактивен' }}
+                      </span>
+                    </div>
+                    <div class="employee-col actions-col">
+                      <button 
+                        class="edit-btn" 
+                        title="Редактировать"
+                        @click="editEmployee(employee)"
+                      >
+                        <img 
+                          src="@/assets/icons/edit.png" 
+                          alt="Редактировать" 
+                          class="edit-icon"
+                        >
+                      </button>
+                      <button 
+                        class="delete-btn" 
+                        title="Удалить"
+                        @click="deleteEmployee(employee)"
+                      >
+                        <img 
+                          src="@/assets/icons/trashcan.png" 
+                          alt="Удалить" 
+                          class="delete-icon"
+                        >
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <p
+                v-else
+                class="no-data-message"
+              >
+                {{ hasActiveFilters ? 'Нет данных по выбранным фильтрам' : 'Сотрудников нет' }}
+              </p>
+            </SkeletonTransition>
+          </div>
+        </div>
+      </div>
+            
+      <div class="employeesview__right-side">
+        <div class="employeesview__help">
+          <template v-if="currentFilter === 'organization'">
+            <p class="help__text">
+              Здесь находятся сотрудники, привязанные к вашей <strong class="blue">организации</strong>. Вы можете использовать этих сотрудников при подаче заявок на пропуск.
+            </p>
+            <p class="help__text">
+              Новые сотрудники попадают в этот список <strong class="blue">автоматически</strong>, при подаче заявки.
+            </p>
+          </template>
+          <template v-else-if="currentFilter === 'company'">
+            <p class="help__text">
+              Здесь находятся сотрудники, привязанные к вашей <strong class="blue">компании</strong>. Вы можете использовать этих сотрудников при подаче заявок на пропуск.
+            </p>
+            <p class="help__text">
+              Новые сотрудники попадают в этот список <strong class="blue">автоматически</strong>, при подаче заявки.
+            </p>
+          </template>
+          <template v-else-if="currentFilter === 'user'">
+            <p class="help__text">
+              Здесь находятся <strong class="blue">ваши сотрудники</strong>, добавленные лично. Вы можете использовать их при подаче заявок на пропуск.
+            </p>
+            <p class="help__text">
+              Новые сотрудники попадают в этот список <strong class="blue">автоматически</strong>, при подаче заявки.
+            </p>
+          </template>
+          <template v-else-if="currentFilter === 'all_system'">
+            <p class="help__text">
+              Здесь отображаются <strong class="blue">все сотрудники</strong>, которые есть в системе. В этой вкладке доступен только просмотр, добавление, редактирование и удаление сотрудников недоступно.
+            </p>
+          </template>
+        </div>
+      </div>
+    </div>
+
+    <EmployeeEditModal
+      :visible="showModal"
+      :editing-employee="editingEmployee"
+      :citizenships="availableCitizenships"
+      :ownership-info="ownershipInfo"
+      @saved="onEmployeeSaved"
+      @close="closeModal"
+    />
+  </section>
 </template>
 
 <script>
@@ -352,6 +405,13 @@ export default {
                 this.$forceUpdate();
             }, 50);
         }
+    },
+    async mounted() {
+        await Promise.all([
+            this.fetchOwnershipInfo(),
+            this.fetchCitizenships()
+        ]);
+        await this.fetchEmployees();
     },
     methods: {
         async fetchEmployees() {
@@ -474,13 +534,6 @@ export default {
             return text.substring(0, maxLength) + '...';
         },
 
-    },
-    async mounted() {
-        await Promise.all([
-            this.fetchOwnershipInfo(),
-            this.fetchCitizenships()
-        ]);
-        await this.fetchEmployees();
     }
 }
 </script>

--- a/frontend/src/views/FeedbackPage.vue
+++ b/frontend/src/views/FeedbackPage.vue
@@ -2,27 +2,32 @@
   <section class="feedback">
     <header class="feedback__header">
       <div class="header-top">
-        <h2 class="feedback__title">Обратная связь</h2>
+        <h2 class="feedback__title">
+          Обратная связь
+        </h2>
         <div class="header-stats">
           <div class="stat-item">
             <span class="stat-label">Всего:</span>
             <span class="stat-value">{{ feedbacks.length }}</span>
           </div>
-          <div class="stat-item" v-if="unreadCount > 0">
+          <div
+            v-if="unreadCount > 0"
+            class="stat-item"
+          >
             <span class="stat-label">Новые:</span>
             <span class="stat-value stat-new">{{ unreadCount }}</span>
           </div>
         </div>
         <SearchComponent
-          title="Поиск по имени или сообщению..."
           v-model="searchQuery"
-          @search="handleSearch"
+          title="Поиск по имени или сообщению..."
           class="search-component"
+          @search="handleSearch"
         />
         <button 
           class="refresh-btn-header"
-          @click="fetchFeedbacks"
           :disabled="loading"
+          @click="fetchFeedbacks"
         >
           Обновить
         </button>
@@ -73,7 +78,10 @@
       </div>
     </div>
 
-    <div class="feedback__list" :class="{ loading }">
+    <div
+      class="feedback__list"
+      :class="{ loading }"
+    >
       <SkeletonTransition :loading="loading">
         <template #skeleton>
           <div style="display: flex; flex-direction: column; gap: 12px; padding: 12px;">
@@ -84,11 +92,19 @@
           </div>
         </template>
 
-        <div v-if="filteredFeedbacks.length === 0" class="empty-state">
-          <p class="no-data-message">{{ getEmptyMessage() }}</p>
+        <div
+          v-if="filteredFeedbacks.length === 0"
+          class="empty-state"
+        >
+          <p class="no-data-message">
+            {{ getEmptyMessage() }}
+          </p>
         </div>
 
-        <div v-else class="feedbacks-container">
+        <div
+          v-else
+          class="feedbacks-container"
+        >
           <div
             v-for="feedback in filteredFeedbacks"
             :key="feedback.id"
@@ -103,24 +119,38 @@
                 <div class="user-name-container">
                   <span class="user-name">{{ feedback.user_name || 'Неизвестный пользователь' }}</span>
                   <span class="ticket-number">#{{ feedback.id }}</span>
-                  <span class="unread-dot" v-if="!feedback.is_read"></span>
+                  <span
+                    v-if="!feedback.is_read"
+                    class="unread-dot"
+                  />
                 </div>
                 <div class="user-meta">
                   <span class="timestamp">Создано: {{ formatDateTime(feedback.created_at) }}</span>
-                  <span v-if="feedback.resolved_at" class="timestamp resolved-time">Выполнено: {{ formatDateTime(feedback.resolved_at) }}</span>
+                  <span
+                    v-if="feedback.resolved_at"
+                    class="timestamp resolved-time"
+                  >Выполнено: {{ formatDateTime(feedback.resolved_at) }}</span>
                 </div>
               </div>
 
               <div class="status-indicators">
-                <span class="status-badge" :class="getStatusClass(feedback.status)">
+                <span
+                  class="status-badge"
+                  :class="getStatusClass(feedback.status)"
+                >
                   {{ feedback.status }}
                 </span>
               </div>
             </div>
 
             <div class="feedback-content">
-              <p class="message">{{ feedback.message }}</p>
-              <div v-if="feedback.resolution_comment" class="resolution-comment">
+              <p class="message">
+                {{ feedback.message }}
+              </p>
+              <div
+                v-if="feedback.resolution_comment"
+                class="resolution-comment"
+              >
                 <strong>Ответ заявителю:</strong> {{ feedback.resolution_comment }}
               </div>
             </div>
@@ -129,18 +159,21 @@
               <div class="action-buttons">
                 <button
                   v-if="!feedback.is_read"
-                  @click="markAsRead(feedback.id)"
                   class="action-btn mark-read-btn"
                   :disabled="updating === feedback.id"
+                  @click="markAsRead(feedback.id)"
                 >
                   Прочитано
                 </button>
 
-                <div v-if="feedback.status === 'Не решено'" class="resolve-section">
+                <div
+                  v-if="feedback.status === 'Не решено'"
+                  class="resolve-section"
+                >
                   <button
-                    @click="markAsResolved(feedback.id)"
                     class="action-btn resolve-btn"
                     :disabled="updating === feedback.id"
+                    @click="markAsResolved(feedback.id)"
                   >
                     Выполнить
                   </button>
@@ -150,14 +183,14 @@
                     class="resolve-comment-input"
                     rows="2"
                     :disabled="updating === feedback.id"
-                  ></textarea>
+                  />
                 </div>
 
                 <button
                   v-if="feedback.status === 'Решено'"
-                  @click="markAsPending(feedback.id)"
                   class="action-btn return-btn"
                   :disabled="updating === feedback.id"
+                  @click="markAsPending(feedback.id)"
                 >
                   Вернуть в обращение
                 </button>
@@ -236,6 +269,9 @@ export default {
     unreadCount() {
       return this.feedbacks.filter(f => !f.is_read).length;
     }
+  },
+  mounted() {
+    this.fetchFeedbacks();
   },
   methods: {
     handleSearch(variants) {
@@ -394,9 +430,6 @@ export default {
       }
       return 'Обращений пока нет';
     }
-  },
-  mounted() {
-    this.fetchFeedbacks();
   }
 }
 </script>

--- a/frontend/src/views/NewsAndReview.vue
+++ b/frontend/src/views/NewsAndReview.vue
@@ -5,20 +5,33 @@
       <div class="left-column">
         <div class="news-container">
           <div class="news-header">
-            <h2 class="news-title">Последние новости</h2>
+            <h2 class="news-title">
+              Последние новости
+            </h2>
             <div class="header-actions">
-              <button class="manage-btn" @click="openManageModal">Управление</button>
+              <button
+                class="manage-btn"
+                @click="openManageModal"
+              >
+                Управление
+              </button>
               <RefreshButton @refresh="fetchAllData" />
             </div>
           </div>
-          <div class="divider"></div>
+          <div class="divider" />
           <div class="news-list">
             <!-- Лоадер -->
-            <div v-if="loadingNews" class="loading-message">
+            <div
+              v-if="loadingNews"
+              class="loading-message"
+            >
               <LoaderSpinner label="Загрузка новостей…" />
             </div>
             <!-- Новости -->
-            <div v-else-if="newsItems.length > 0" class="news-items">
+            <div
+              v-else-if="newsItems.length > 0"
+              class="news-items"
+            >
               <article
                 v-for="(item, index) in newsItems"
                 :key="item.id"
@@ -29,30 +42,72 @@
                   <time class="news-date">{{ formatDate(item.created_at) }}</time>
                   <span class="item-type">Новость</span>
                 </div>
-                <h3 class="news-item-title">{{ item.title }}</h3>
-                <p class="news-item-description">{{ item.description }}</p>
-                <button class="news-details-button" @click="openNewsModal(item)">Читать далее</button>
+                <h3 class="news-item-title">
+                  {{ item.title }}
+                </h3>
+                <p class="news-item-description">
+                  {{ item.description }}
+                </p>
+                <button
+                  class="news-details-button"
+                  @click="openNewsModal(item)"
+                >
+                  Читать далее
+                </button>
               </article>
             </div>
-            <div v-else class="empty-state"><p>Нет новостей</p></div>
+            <div
+              v-else
+              class="empty-state"
+            >
+              <p>Нет новостей</p>
+            </div>
           </div>
         </div>
       </div>
 
       <!-- Правая колонка -->
       <div class="right-column">
-        <div class="guide-card" :style="{ animationDelay: '0.2s' }" @click="openGuide">
+        <div
+          class="guide-card"
+          :style="{ animationDelay: '0.2s' }"
+          @click="openGuide"
+        >
           <div class="guide-content">
             <div class="guide-text">
               <h3 class="guide-title">
                 <div class="guide-icon">
-                  <svg width="35" height="35" viewBox="0 0 35 35" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <rect width="35" height="35" fill="url(#pattern0)" />
+                  <svg
+                    width="35"
+                    height="35"
+                    viewBox="0 0 35 35"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <rect
+                      width="35"
+                      height="35"
+                      fill="url(#pattern0)"
+                    />
                     <defs>
-                      <pattern id="pattern0" patternContentUnits="objectBoundingBox" width="1" height="1">
-                        <use xlink:href="#image0" transform="scale(0.015625)" />
+                      <pattern
+                        id="pattern0"
+                        patternContentUnits="objectBoundingBox"
+                        width="1"
+                        height="1"
+                      >
+                        <use
+                          xlink:href="#image0"
+                          transform="scale(0.015625)"
+                        />
                       </pattern>
-                      <image id="image0" width="64" height="64" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAACXBIWXMAAAHYAAAB2AH6XKZyAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAwxJREFUeJzt209oHkUcxvGPMQlqBAk9WCoBJZdoDuLJQyMtlBZSKv4Be6m3QpRcKmoN9RQPpVCCUA+e9FRPCqWlHixeVGwPUpFCrNhi0ItQJH+MQpU2TQ+7L+8SeHl3N7OZTbJfWN7Z3fnNPPMw876zs/PSsL15oGRcP17AM3gknJyg/IwvQxfajynMY3UTHM+HbPwgvqtBo4ocr3drVG/OxvfiC0m3bzGHS1jOWcZaxrA7TV/G94FiDmG0pKaOvKHt6grexYPrLHM6U+Z0wJizKugBxzPpDzCTM6729OTI8zSG0/QiTlcnZ+PJY8BwJn0F/1WkJQp5DHgsk16qSkgs8hiQnSytViUkFnkM2NI0BsQWEJvGgNgCOjCDf2zAhKuOBkzhHTyafr5XZWV1M+AgTq65dgovV1VhnQx4Dp9rP2TdTT978Fl6Pzh1MWAnLmAgPf8dz+K39HxAsrrzROiK62LABIbS9DJexHVJ12+tN+zC0dAV18WA1nR7RfIMP5uez+Kw9nAou4bZkboY0OJtXFxz7ZJkAaYS6mTAp/iow70z+LiKSmMakH20/hpvdsl/LM3XYjGEiLxLYlXwCZ5EH97XHueduIvXJPOC/9P4dRPTgH/xVsGYvzEZUkSdvgOi0BgQW0BsGgNiC4hNY0BsAbFpDIgtIDaNAbEFxKYxILaA2DQGxBYQm8aA2AJis+0NKLskNoZXJRsSd4STE4SnimQuasAQvsGegnGxWOmWoagBm6XhJMvuV7plKjsE/pK8qLiMhZJlVM2cHO8OyhjwE8Zxq0Rs7Sj6K3Abr9gijad4DziHP9L0wziBkaCKwnAPV/Fhml4XR7S3n2f360yq5k8OIY8D3RqXZwhkX2I+lEn/mSM2JityDNU8Gw5G8Eua/hZ7M/d2S3Zu1JEbuBaqsJva3Wo8VKGbiQltA5bwUlw54ci756YXX2Ff5tqPkn+RLeBOYF0h+BXnQxY4KHkOiP3NXuQY69aoIhOhReyX/BTOF4irNWW3nfVJ3B3F4+l5nbiHHwQeAg1bkfsR5B+/y7yHCAAAAABJRU5ErkJggg=="/>
+                      <image
+                        id="image0"
+                        width="64"
+                        height="64"
+                        preserveAspectRatio="none"
+                        xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAACXBIWXMAAAHYAAAB2AH6XKZyAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAwxJREFUeJzt209oHkUcxvGPMQlqBAk9WCoBJZdoDuLJQyMtlBZSKv4Be6m3QpRcKmoN9RQPpVCCUA+e9FRPCqWlHixeVGwPUpFCrNhi0ItQJH+MQpU2TQ+7L+8SeHl3N7OZTbJfWN7Z3fnNPPMw876zs/PSsL15oGRcP17AM3gknJyg/IwvQxfajynMY3UTHM+HbPwgvqtBo4ocr3drVG/OxvfiC0m3bzGHS1jOWcZaxrA7TV/G94FiDmG0pKaOvKHt6grexYPrLHM6U+Z0wJizKugBxzPpDzCTM6729OTI8zSG0/QiTlcnZ+PJY8BwJn0F/1WkJQp5DHgsk16qSkgs8hiQnSytViUkFnkM2NI0BsQWEJvGgNgCOjCDf2zAhKuOBkzhHTyafr5XZWV1M+AgTq65dgovV1VhnQx4Dp9rP2TdTT978Fl6Pzh1MWAnLmAgPf8dz+K39HxAsrrzROiK62LABIbS9DJexHVJ12+tN+zC0dAV18WA1nR7RfIMP5uez+Kw9nAou4bZkboY0OJtXFxz7ZJkAaYS6mTAp/iow70z+LiKSmMakH20/hpvdsl/LM3XYjGEiLxLYlXwCZ5EH97XHueduIvXJPOC/9P4dRPTgH/xVsGYvzEZUkSdvgOi0BgQW0BsGgNiC4hNY0BsAbFpDIgtIDaNAbEFxKYxILaA2DQGxBYQm8aA2AJis+0NKLskNoZXJRsSd4STE4SnimQuasAQvsGegnGxWOmWoagBm6XhJMvuV7plKjsE/pK8qLiMhZJlVM2cHO8OyhjwE8Zxq0Rs7Sj6K3Abr9gijad4DziHP9L0wziBkaCKwnAPV/Fhml4XR7S3n2f360yq5k8OIY8D3RqXZwhkX2I+lEn/mSM2JityDNU8Gw5G8Eua/hZ7M/d2S3Zu1JEbuBaqsJva3Wo8VKGbiQltA5bwUlw54ci756YXX2Ff5tqPkn+RLeBOYF0h+BXnQxY4KHkOiP3NXuQY69aoIhOhReyX/BTOF4irNWW3nfVJ3B3F4+l5nbiHHwQeAg1bkfsR5B+/y7yHCAAAAABJRU5ErkJggg=="
+                      />
                     </defs>
                   </svg>
                 </div>
@@ -75,45 +130,101 @@
           @click="openAnnouncementModal(activeAnnouncement)"
         >
           <div class="card-header">
-            <span class="card-type" :class="{ important: activeAnnouncement.is_important }">
+            <span
+              class="card-type"
+              :class="{ important: activeAnnouncement.is_important }"
+            >
               {{ activeAnnouncement.is_important ? 'Важное объявление' : 'Объявление' }}
             </span>
             <time class="card-date">{{ formatDate(activeAnnouncement.created_at) }}</time>
           </div>
-          <h3 class="card-title">{{ activeAnnouncement.title }}</h3>
-          <p class="card-description">{{ activeAnnouncement.description }}</p>
-          <button class="card-button">Читать далее</button>
+          <h3 class="card-title">
+            {{ activeAnnouncement.title }}
+          </h3>
+          <p class="card-description">
+            {{ activeAnnouncement.description }}
+          </p>
+          <button class="card-button">
+            Читать далее
+          </button>
         </div>
       </div>
     </div>
 
     <!-- Модальное окно управления -->
     <transition name="modal-fade">
-      <div v-if="showManageModal" class="modal-overlay" @click.self="closeManageModal">
+      <div
+        v-if="showManageModal"
+        class="modal-overlay"
+        @click.self="closeManageModal"
+      >
         <div class="modal-content manage-modal">
           <div class="modal-header">
-            <h3 class="modal-title">Управление контентом</h3>
-            <button class="modal-close" @click="closeManageModal">
-              <svg width="10" height="10" viewBox="0 0 14 14" fill="none"><path d="M13 1L1 13M1 1L13 13" stroke="#666" stroke-width="2" stroke-linecap="round"/></svg>
+            <h3 class="modal-title">
+              Управление контентом
+            </h3>
+            <button
+              class="modal-close"
+              @click="closeManageModal"
+            >
+              <svg
+                width="10"
+                height="10"
+                viewBox="0 0 14 14"
+                fill="none"
+              ><path
+                d="M13 1L1 13M1 1L13 13"
+                stroke="#666"
+                stroke-width="2"
+                stroke-linecap="round"
+              /></svg>
             </button>
           </div>
 
           <div class="modal-body">
             <div class="manage-tabs">
-              <button class="tab-btn" :class="{ active: activeTab === 'news' }" @click="activeTab = 'news'">Новости</button>
-              <button class="tab-btn" :class="{ active: activeTab === 'announcements' }" @click="activeTab = 'announcements'">Объявления</button>
+              <button
+                class="tab-btn"
+                :class="{ active: activeTab === 'news' }"
+                @click="activeTab = 'news'"
+              >
+                Новости
+              </button>
+              <button
+                class="tab-btn"
+                :class="{ active: activeTab === 'announcements' }"
+                @click="activeTab = 'announcements'"
+              >
+                Объявления
+              </button>
             </div>
 
             <!-- Новости -->
-            <div v-if="activeTab === 'news'" class="manage-section">
+            <div
+              v-if="activeTab === 'news'"
+              class="manage-section"
+            >
               <div class="section-header">
-                <div class="section-title">Список новостей</div>
-                <button class="add-btn" @click="openCreateNewsModal">+ Добавить новость</button>
+                <div class="section-title">
+                  Список новостей
+                </div>
+                <button
+                  class="add-btn"
+                  @click="openCreateNewsModal"
+                >
+                  + Добавить новость
+                </button>
               </div>
               <div class="items-list">
-                <div v-for="item in allNewsItems" :key="item.id" class="manage-item">
+                <div
+                  v-for="item in allNewsItems"
+                  :key="item.id"
+                  class="manage-item"
+                >
                   <div class="item-main">
-                    <div class="item-title">{{ item.title }}</div>
+                    <div class="item-title">
+                      {{ item.title }}
+                    </div>
                     <div class="item-meta">
                       <span>{{ formatDate(item.created_at) }}</span>
                       <span>{{ item.created_by_name || 'Система' }}</span>
@@ -121,31 +232,71 @@
                     </div>
                   </div>
                   <div class="item-actions">
-                    <button class="action-btn edit-btn" @click="editNewsItem(item)">Редактировать</button>
-                    <button class="action-btn toggle-btn" @click="toggleNewsActive(item)">{{ item.is_active ? 'Скрыть' : 'Показать' }}</button>
-                    <button class="action-btn delete-btn" @click="deleteNewsItem(item.id)">Удалить</button>
+                    <button
+                      class="action-btn edit-btn"
+                      @click="editNewsItem(item)"
+                    >
+                      Редактировать
+                    </button>
+                    <button
+                      class="action-btn toggle-btn"
+                      @click="toggleNewsActive(item)"
+                    >
+                      {{ item.is_active ? 'Скрыть' : 'Показать' }}
+                    </button>
+                    <button
+                      class="action-btn delete-btn"
+                      @click="deleteNewsItem(item.id)"
+                    >
+                      Удалить
+                    </button>
                   </div>
                 </div>
-                <div v-if="allNewsItems.length === 0" class="empty-manage">Нет новостей</div>
+                <div
+                  v-if="allNewsItems.length === 0"
+                  class="empty-manage"
+                >
+                  Нет новостей
+                </div>
               </div>
             </div>
 
             <!-- Объявления -->
-            <div v-if="activeTab === 'announcements'" class="manage-section">
+            <div
+              v-if="activeTab === 'announcements'"
+              class="manage-section"
+            >
               <div class="section-header">
-                <div class="section-title">Список объявлений</div>
-                <button class="add-btn" @click="openCreateAnnouncementModal">+ Добавить объявление</button>
+                <div class="section-title">
+                  Список объявлений
+                </div>
+                <button
+                  class="add-btn"
+                  @click="openCreateAnnouncementModal"
+                >
+                  + Добавить объявление
+                </button>
               </div>
               <div class="info-message">
                 <span>Активно может быть только одно объявление</span>
               </div>
               <div class="items-list">
-                <div v-for="item in allAnnouncements" :key="item.id" class="manage-item">
+                <div
+                  v-for="item in allAnnouncements"
+                  :key="item.id"
+                  class="manage-item"
+                >
                   <div class="item-main">
                     <div class="item-title">
                       {{ item.title }}
-                      <span v-if="item.is_important" class="important-badge">Важное</span>
-                      <span v-if="item.is_active" class="active-badge">Активно</span>
+                      <span
+                        v-if="item.is_important"
+                        class="important-badge"
+                      >Важное</span>
+                      <span
+                        v-if="item.is_active"
+                        class="active-badge"
+                      >Активно</span>
                     </div>
                     <div class="item-meta">
                       <span>{{ formatDate(item.created_at) }}</span>
@@ -154,19 +305,51 @@
                     </div>
                   </div>
                   <div class="item-actions">
-                    <button class="action-btn edit-btn" @click="editAnnouncement(item)">Редактировать</button>
-                    <button v-if="!item.is_active" class="action-btn activate-btn" @click="setActiveAnnouncement(item.id)">Активировать</button>
-                    <button v-if="item.is_active" class="action-btn deactivate-btn" @click="deactivateAnnouncement(item.id)">Деактивировать</button>
-                    <button class="action-btn delete-btn" @click="deleteAnnouncement(item.id)">Удалить</button>
+                    <button
+                      class="action-btn edit-btn"
+                      @click="editAnnouncement(item)"
+                    >
+                      Редактировать
+                    </button>
+                    <button
+                      v-if="!item.is_active"
+                      class="action-btn activate-btn"
+                      @click="setActiveAnnouncement(item.id)"
+                    >
+                      Активировать
+                    </button>
+                    <button
+                      v-if="item.is_active"
+                      class="action-btn deactivate-btn"
+                      @click="deactivateAnnouncement(item.id)"
+                    >
+                      Деактивировать
+                    </button>
+                    <button
+                      class="action-btn delete-btn"
+                      @click="deleteAnnouncement(item.id)"
+                    >
+                      Удалить
+                    </button>
                   </div>
                 </div>
-                <div v-if="allAnnouncements.length === 0" class="empty-manage">Нет объявлений</div>
+                <div
+                  v-if="allAnnouncements.length === 0"
+                  class="empty-manage"
+                >
+                  Нет объявлений
+                </div>
               </div>
             </div>
           </div>
 
           <div class="modal-footer">
-            <button class="btn close-btn" @click="closeManageModal">Закрыть</button>
+            <button
+              class="btn close-btn"
+              @click="closeManageModal"
+            >
+              Закрыть
+            </button>
           </div>
         </div>
       </div>
@@ -174,20 +357,72 @@
 
     <!-- Модальное окно создания/редактирования новости -->
     <transition name="modal-fade">
-      <div v-if="showNewsModal" class="modal-overlay" @click.self="closeNewsModal">
+      <div
+        v-if="showNewsModal"
+        class="modal-overlay"
+        @click.self="closeNewsModal"
+      >
         <div class="modal-content">
           <div class="modal-header">
-            <h3 class="modal-title">{{ editingNews ? 'Редактировать новость' : 'Создать новость' }}</h3>
-            <button class="modal-close" @click="closeNewsModal"><svg width="10" height="10" viewBox="0 0 14 14" fill="none"><path d="M13 1L1 13M1 1L13 13" stroke="#666" stroke-width="2" stroke-linecap="round"/></svg></button>
+            <h3 class="modal-title">
+              {{ editingNews ? 'Редактировать новость' : 'Создать новость' }}
+            </h3>
+            <button
+              class="modal-close"
+              @click="closeNewsModal"
+            >
+              <svg
+                width="10"
+                height="10"
+                viewBox="0 0 14 14"
+                fill="none"
+              ><path
+                d="M13 1L1 13M1 1L13 13"
+                stroke="#666"
+                stroke-width="2"
+                stroke-linecap="round"
+              /></svg>
+            </button>
           </div>
           <div class="modal-body">
-            <div class="form-group"><label class="form-label">Заголовок</label><input type="text" class="form-input" v-model="newsForm.title" placeholder="Введите заголовок" /></div>
-            <div class="form-group"><label class="form-label">Краткое описание</label><textarea class="form-textarea" v-model="newsForm.description" placeholder="Введите краткое описание" rows="3"></textarea></div>
-            <div class="form-group"><label class="form-label">Полный текст</label><textarea class="form-textarea" v-model="newsForm.fullText" placeholder="Введите полный текст" rows="5"></textarea></div>
+            <div class="form-group">
+              <label class="form-label">Заголовок</label><input
+                v-model="newsForm.title"
+                type="text"
+                class="form-input"
+                placeholder="Введите заголовок"
+              >
+            </div>
+            <div class="form-group">
+              <label class="form-label">Краткое описание</label><textarea
+                v-model="newsForm.description"
+                class="form-textarea"
+                placeholder="Введите краткое описание"
+                rows="3"
+              />
+            </div>
+            <div class="form-group">
+              <label class="form-label">Полный текст</label><textarea
+                v-model="newsForm.fullText"
+                class="form-textarea"
+                placeholder="Введите полный текст"
+                rows="5"
+              />
+            </div>
           </div>
           <div class="modal-footer">
-            <button class="btn cancel-btn" @click="closeNewsModal">Отмена</button>
-            <button class="btn save-btn" @click="submitNews">Сохранить</button>
+            <button
+              class="btn cancel-btn"
+              @click="closeNewsModal"
+            >
+              Отмена
+            </button>
+            <button
+              class="btn save-btn"
+              @click="submitNews"
+            >
+              Сохранить
+            </button>
           </div>
         </div>
       </div>
@@ -195,21 +430,78 @@
 
     <!-- Модальное окно создания/редактирования объявления -->
     <transition name="modal-fade">
-      <div v-if="showAnnouncementModal" class="modal-overlay" @click.self="closeAnnouncementModal">
+      <div
+        v-if="showAnnouncementModal"
+        class="modal-overlay"
+        @click.self="closeAnnouncementModal"
+      >
         <div class="modal-content">
           <div class="modal-header">
-            <h3 class="modal-title">{{ editingAnnouncement ? 'Редактировать объявление' : 'Создать объявление' }}</h3>
-            <button class="modal-close" @click="closeAnnouncementModal"><svg width="10" height="10" viewBox="0 0 14 14" fill="none"><path d="M13 1L1 13M1 1L13 13" stroke="#666" stroke-width="2" stroke-linecap="round"/></svg></button>
+            <h3 class="modal-title">
+              {{ editingAnnouncement ? 'Редактировать объявление' : 'Создать объявление' }}
+            </h3>
+            <button
+              class="modal-close"
+              @click="closeAnnouncementModal"
+            >
+              <svg
+                width="10"
+                height="10"
+                viewBox="0 0 14 14"
+                fill="none"
+              ><path
+                d="M13 1L1 13M1 1L13 13"
+                stroke="#666"
+                stroke-width="2"
+                stroke-linecap="round"
+              /></svg>
+            </button>
           </div>
           <div class="modal-body">
-            <div class="form-group"><label class="form-label">Заголовок</label><input type="text" class="form-input" v-model="announcementForm.title" placeholder="Введите заголовок" /></div>
-            <div class="form-group"><label class="form-label">Краткое описание</label><textarea class="form-textarea" v-model="announcementForm.description" placeholder="Введите краткое описание" rows="3"></textarea></div>
-            <div class="form-group"><label class="form-label">Полный текст</label><textarea class="form-textarea" v-model="announcementForm.fullText" placeholder="Введите полный текст" rows="5"></textarea></div>
-            <div class="form-group"><label class="checkbox-label"><input type="checkbox" v-model="announcementForm.isImportant" /><span>Важное объявление</span></label></div>
+            <div class="form-group">
+              <label class="form-label">Заголовок</label><input
+                v-model="announcementForm.title"
+                type="text"
+                class="form-input"
+                placeholder="Введите заголовок"
+              >
+            </div>
+            <div class="form-group">
+              <label class="form-label">Краткое описание</label><textarea
+                v-model="announcementForm.description"
+                class="form-textarea"
+                placeholder="Введите краткое описание"
+                rows="3"
+              />
+            </div>
+            <div class="form-group">
+              <label class="form-label">Полный текст</label><textarea
+                v-model="announcementForm.fullText"
+                class="form-textarea"
+                placeholder="Введите полный текст"
+                rows="5"
+              />
+            </div>
+            <div class="form-group">
+              <label class="checkbox-label"><input
+                v-model="announcementForm.isImportant"
+                type="checkbox"
+              ><span>Важное объявление</span></label>
+            </div>
           </div>
           <div class="modal-footer">
-            <button class="btn cancel-btn" @click="closeAnnouncementModal">Отмена</button>
-            <button class="btn save-btn" @click="submitAnnouncement">Сохранить</button>
+            <button
+              class="btn cancel-btn"
+              @click="closeAnnouncementModal"
+            >
+              Отмена
+            </button>
+            <button
+              class="btn save-btn"
+              @click="submitAnnouncement"
+            >
+              Сохранить
+            </button>
           </div>
         </div>
       </div>
@@ -217,15 +509,37 @@
 
     <!-- Модальное окно просмотра новости -->
     <transition name="modal-fade">
-      <div v-if="showNewsDetailsModal" class="modal-overlay" @click.self="closeNewsDetailsModal">
+      <div
+        v-if="showNewsDetailsModal"
+        class="modal-overlay"
+        @click.self="closeNewsDetailsModal"
+      >
         <div class="modal-content">
           <div class="modal-body">
-            <div class="modal-info"><time class="modal-date">{{ formatDate(selectedNews?.created_at) }}</time><span class="modal-type">Новость</span></div>
-            <h3 class="modal-title">{{ selectedNews?.title }}</h3>
-            <p class="modal-description">{{ selectedNews?.description }}</p>
-            <div v-if="selectedNews?.full_text" class="modal-full-text">{{ selectedNews.full_text }}</div>
+            <div class="modal-info">
+              <time class="modal-date">{{ formatDate(selectedNews?.created_at) }}</time><span class="modal-type">Новость</span>
+            </div>
+            <h3 class="modal-title">
+              {{ selectedNews?.title }}
+            </h3>
+            <p class="modal-description">
+              {{ selectedNews?.description }}
+            </p>
+            <div
+              v-if="selectedNews?.full_text"
+              class="modal-full-text"
+            >
+              {{ selectedNews.full_text }}
+            </div>
           </div>
-          <div class="modal-footer"><button class="btn close-btn" @click="closeNewsDetailsModal">Закрыть</button></div>
+          <div class="modal-footer">
+            <button
+              class="btn close-btn"
+              @click="closeNewsDetailsModal"
+            >
+              Закрыть
+            </button>
+          </div>
         </div>
       </div>
     </transition>
@@ -272,6 +586,9 @@ export default {
       activeAnnouncement: null,
       allAnnouncements: []
     }
+  },
+  mounted() {
+    this.fetchAllData()
   },
   methods: {
     formatDate(dateString) {
@@ -470,9 +787,6 @@ export default {
     closeAnnouncementModal() { this.showAnnouncementModal = false; this.editingAnnouncement = null },
     submitAnnouncement() { if (!this.announcementForm.title || !this.announcementForm.description) { alert('Заполните заголовок и описание'); return } this.editingAnnouncement ? this.updateAnnouncement() : this.createAnnouncement() },
     openGuide() { console.log('Открыть инструкцию') }
-  },
-  mounted() {
-    this.fetchAllData()
   }
 }
 </script>

--- a/frontend/src/views/RequestsView.vue
+++ b/frontend/src/views/RequestsView.vue
@@ -1,7 +1,9 @@
 <template>
   <div class="requests-view dashboard-card">
     <div class="management-header">
-      <h3 class="management-title">Мониторинг запросов</h3>
+      <h3 class="management-title">
+        Мониторинг запросов
+      </h3>
       <div class="header-controls">
         <div class="stats-summary">
           <span class="stat-item">
@@ -18,7 +20,10 @@
           </span>
           <span class="stat-item">
             <span class="stat-label">Ошибки:</span>
-            <span class="stat-value" :class="{ 'stat-error': stats.error_rate > 5 }">
+            <span
+              class="stat-value"
+              :class="{ 'stat-error': stats.error_rate > 5 }"
+            >
               {{ (stats.error_rate || 0).toFixed(1) }}%
             </span>
           </span>
@@ -26,7 +31,10 @@
             <span class="stat-label">RPM:</span>
             <span class="stat-value">{{ (stats.requests_per_minute || 0).toFixed(1) }}</span>
           </span>
-          <span class="stat-item realtime-stat" v-if="realtime.last_minute_count != null">
+          <span
+            v-if="realtime.last_minute_count != null"
+            class="stat-item realtime-stat"
+          >
             <span class="stat-label">Сейчас:</span>
             <span class="stat-value live-value">
               {{ realtime.last_second_count || 0 }}/с
@@ -39,12 +47,24 @@
 
     <div class="chart-section">
       <div class="chart-header">
-        <h4 class="chart-title">Запросы {{ selectedPeriod.title }}</h4>
+        <h4 class="chart-title">
+          Запросы {{ selectedPeriod.title }}
+        </h4>
         <div class="chart-header-actions">
           <span class="chart-interval">интервал: {{ selectedPeriod.intervalHuman }}</span>
           <div class="chart-period-dropdown">
-            <select v-model="chartPeriod" @change="onChartPeriodChange" class="chart-period-select">
-              <option v-for="p in chartPeriods" :key="p.key" :value="p.key">{{ p.label }}</option>
+            <select
+              v-model="chartPeriod"
+              class="chart-period-select"
+              @change="onChartPeriodChange"
+            >
+              <option
+                v-for="p in chartPeriods"
+                :key="p.key"
+                :value="p.key"
+              >
+                {{ p.label }}
+              </option>
             </select>
           </div>
         </div>
@@ -53,60 +73,117 @@
         :data="timelineData"
         :height="180"
         color="#4F5BDF"
-        :intervalLabel="selectedPeriod.xAxisLabel"
+        :interval-label="selectedPeriod.xAxisLabel"
       />
     </div>
 
     <div class="filters-bar">
       <SearchComponent
-        :title="'Поиск по логам...'"
         v-model="searchQuery"
+        :title="'Поиск по логам...'"
         @keyup.enter="refreshLogs"
       />
       <div class="filter-controls">
-        <select v-model="filterMethod" @change="refreshLogs" class="filter-select">
-          <option value="">Все методы</option>
-          <option value="GET">GET</option>
-          <option value="POST">POST</option>
-          <option value="PUT">PUT</option>
-          <option value="DELETE">DELETE</option>
-          <option value="PATCH">PATCH</option>
+        <select
+          v-model="filterMethod"
+          class="filter-select"
+          @change="refreshLogs"
+        >
+          <option value="">
+            Все методы
+          </option>
+          <option value="GET">
+            GET
+          </option>
+          <option value="POST">
+            POST
+          </option>
+          <option value="PUT">
+            PUT
+          </option>
+          <option value="DELETE">
+            DELETE
+          </option>
+          <option value="PATCH">
+            PATCH
+          </option>
         </select>
-        <select v-model="filterStatus" @change="refreshLogs" class="filter-select">
-          <option value="">Все статусы</option>
-          <option value="200">200 OK</option>
-          <option value="400">400 Bad Request</option>
-          <option value="401">401 Unauthorized</option>
-          <option value="403">403 Forbidden</option>
-          <option value="404">404 Not Found</option>
-          <option value="500">500 Server Error</option>
+        <select
+          v-model="filterStatus"
+          class="filter-select"
+          @change="refreshLogs"
+        >
+          <option value="">
+            Все статусы
+          </option>
+          <option value="200">
+            200 OK
+          </option>
+          <option value="400">
+            400 Bad Request
+          </option>
+          <option value="401">
+            401 Unauthorized
+          </option>
+          <option value="403">
+            403 Forbidden
+          </option>
+          <option value="404">
+            404 Not Found
+          </option>
+          <option value="500">
+            500 Server Error
+          </option>
         </select>
-        <select v-model="filterUser" @change="refreshLogs" class="filter-select">
-          <option value="">Все пользователи</option>
-          <option v-for="u in users" :key="u.id" :value="u.id">
+        <select
+          v-model="filterUser"
+          class="filter-select"
+          @change="refreshLogs"
+        >
+          <option value="">
+            Все пользователи
+          </option>
+          <option
+            v-for="u in users"
+            :key="u.id"
+            :value="u.id"
+          >
             {{ u.username }}
           </option>
         </select>
         <input
-          type="date"
           v-model="filterStartDate"
-          @change="refreshLogs"
-          class="date-input"
-        />
-        <input
           type="date"
-          v-model="filterEndDate"
-          @change="refreshLogs"
           class="date-input"
-        />
+          @change="refreshLogs"
+        >
+        <input
+          v-model="filterEndDate"
+          type="date"
+          class="date-input"
+          @change="refreshLogs"
+        >
       </div>
-      <button @click="refreshLogs" class="refresh-button">
-        <img src="@/assets/icons/refresh.png" class="refresh-icon" />
+      <button
+        class="refresh-button"
+        @click="refreshLogs"
+      >
+        <img
+          src="@/assets/icons/refresh.png"
+          class="refresh-icon"
+        >
       </button>
-      <button @click="clearFilters" class="clear-filters-btn">
+      <button
+        class="clear-filters-btn"
+        @click="clearFilters"
+      >
         Сбросить
       </button>
-      <button @click="exportLogs" class="export-btn" :disabled="isExporting">
+      <button
+        class="export-btn"
+        :disabled="isExporting"
+        @click="exportLogs"
+      >
         {{ isExporting ? 'Экспорт...' : 'Экспорт' }}
       </button>
     </div>
@@ -115,8 +192,13 @@
       <div class="logs-table-section">
         <div class="table-container">
           <div class="table-header">
-            <div class="header-col time-col" @click="sortBy('created_at')">
-              <p :class="{ 'active-sort': sortField === 'created_at' }">Время</p>
+            <div
+              class="header-col time-col"
+              @click="sortBy('created_at')"
+            >
+              <p :class="{ 'active-sort': sortField === 'created_at' }">
+                Время
+              </p>
               <img
                 src="@/assets/icons/sort.png"
                 class="sort-icon"
@@ -124,10 +206,15 @@
                   'sorted': sortField === 'created_at',
                   'desc': sortField === 'created_at' && sortDirection === 'desc'
                 }"
-              />
+              >
             </div>
-            <div class="header-col method-col" @click="sortBy('method')">
-              <p :class="{ 'active-sort': sortField === 'method' }">Метод</p>
+            <div
+              class="header-col method-col"
+              @click="sortBy('method')"
+            >
+              <p :class="{ 'active-sort': sortField === 'method' }">
+                Метод
+              </p>
               <img
                 src="@/assets/icons/sort.png"
                 class="sort-icon"
@@ -135,10 +222,15 @@
                   'sorted': sortField === 'method',
                   'desc': sortField === 'method' && sortDirection === 'desc'
                 }"
-              />
+              >
             </div>
-            <div class="header-col path-col" @click="sortBy('url')">
-              <p :class="{ 'active-sort': sortField === 'url' }">URL</p>
+            <div
+              class="header-col path-col"
+              @click="sortBy('url')"
+            >
+              <p :class="{ 'active-sort': sortField === 'url' }">
+                URL
+              </p>
               <img
                 src="@/assets/icons/sort.png"
                 class="sort-icon"
@@ -146,10 +238,15 @@
                   'sorted': sortField === 'url',
                   'desc': sortField === 'url' && sortDirection === 'desc'
                 }"
-              />
+              >
             </div>
-            <div class="header-col status-col" @click="sortBy('response_status')">
-              <p :class="{ 'active-sort': sortField === 'response_status' }">Статус</p>
+            <div
+              class="header-col status-col"
+              @click="sortBy('response_status')"
+            >
+              <p :class="{ 'active-sort': sortField === 'response_status' }">
+                Статус
+              </p>
               <img
                 src="@/assets/icons/sort.png"
                 class="sort-icon"
@@ -157,10 +254,15 @@
                   'sorted': sortField === 'response_status',
                   'desc': sortField === 'response_status' && sortDirection === 'desc'
                 }"
-              />
+              >
             </div>
-            <div class="header-col user-col" @click="sortBy('username')">
-              <p :class="{ 'active-sort': sortField === 'username' }">Пользователь</p>
+            <div
+              class="header-col user-col"
+              @click="sortBy('username')"
+            >
+              <p :class="{ 'active-sort': sortField === 'username' }">
+                Пользователь
+              </p>
               <img
                 src="@/assets/icons/sort.png"
                 class="sort-icon"
@@ -168,10 +270,15 @@
                   'sorted': sortField === 'username',
                   'desc': sortField === 'username' && sortDirection === 'desc'
                 }"
-              />
+              >
             </div>
-            <div class="header-col duration-col" @click="sortBy('duration_ms')">
-              <p :class="{ 'active-sort': sortField === 'duration_ms' }">Время</p>
+            <div
+              class="header-col duration-col"
+              @click="sortBy('duration_ms')"
+            >
+              <p :class="{ 'active-sort': sortField === 'duration_ms' }">
+                Время
+              </p>
               <img
                 src="@/assets/icons/sort.png"
                 class="sort-icon"
@@ -179,11 +286,14 @@
                   'sorted': sortField === 'duration_ms',
                   'desc': sortField === 'duration_ms' && sortDirection === 'desc'
                 }"
-              />
+              >
             </div>
           </div>
 
-          <div class="table-body" ref="logsBody">
+          <div
+            ref="logsBody"
+            class="table-body"
+          >
             <div
               v-for="log in logs"
               :key="log.id"
@@ -196,29 +306,44 @@
               @click="selectLog(log)"
             >
               <div class="table-col time-col">
-                <span class="cell-content" :title="formatFullDate(log.created_at)">
+                <span
+                  class="cell-content"
+                  :title="formatFullDate(log.created_at)"
+                >
                   {{ formatTime(log.created_at) }}
                 </span>
               </div>
               <div class="table-col method-col">
-                <span class="method-badge" :class="getMethodClass(log.method)">
+                <span
+                  class="method-badge"
+                  :class="getMethodClass(log.method)"
+                >
                   {{ log.method }}
                 </span>
               </div>
               <div class="table-col path-col">
-                <span class="truncate-text" :title="log.url">
+                <span
+                  class="truncate-text"
+                  :title="log.url"
+                >
                   {{ truncatePath(log.url) }}
                 </span>
               </div>
               <div class="table-col status-col">
-                <span class="status-badge" :class="getStatusClass(log.response_status)">
+                <span
+                  class="status-badge"
+                  :class="getStatusClass(log.response_status)"
+                >
                   {{ log.response_status || 'N/A' }}
                 </span>
               </div>
               <div class="table-col user-col">
                 <span class="cell-content">
                   {{ log.username || 'Аноним' }}
-                  <span v-if="log.user_id" class="user-id">(ID: {{ log.user_id }})</span>
+                  <span
+                    v-if="log.user_id"
+                    class="user-id"
+                  >(ID: {{ log.user_id }})</span>
                 </span>
               </div>
               <div class="table-col duration-col">
@@ -232,9 +357,9 @@
           <div class="table-footer">
             <div class="pagination-controls">
               <button
-                @click="prevPage"
                 :disabled="pagination.page <= 1"
                 class="pagination-btn"
+                @click="prevPage"
               >
                 &larr;
               </button>
@@ -242,16 +367,26 @@
                 Страница {{ pagination.page }} из {{ totalPages }}
               </span>
               <button
-                @click="nextPage"
                 :disabled="pagination.page >= totalPages"
                 class="pagination-btn"
+                @click="nextPage"
               >
                 &rarr;
               </button>
-              <select v-model="perPage" @change="changePageSize" class="page-size-select">
-                <option value="20">20</option>
-                <option value="50">50</option>
-                <option value="100">100</option>
+              <select
+                v-model="perPage"
+                class="page-size-select"
+                @change="changePageSize"
+              >
+                <option value="20">
+                  20
+                </option>
+                <option value="50">
+                  50
+                </option>
+                <option value="100">
+                  100
+                </option>
               </select>
             </div>
             <span class="items-count">
@@ -261,11 +396,22 @@
         </div>
       </div>
 
-      <div class="log-details-section" :class="{'with-details': selectedLog}">
-        <div v-if="selectedLog" class="log-details-content">
+      <div
+        class="log-details-section"
+        :class="{'with-details': selectedLog}"
+      >
+        <div
+          v-if="selectedLog"
+          class="log-details-content"
+        >
           <div class="details-header">
-            <h3 class="details-title">Детали запроса</h3>
-            <button @click="selectedLog = null" class="close-details-btn">
+            <h3 class="details-title">
+              Детали запроса
+            </h3>
+            <button
+              class="close-details-btn"
+              @click="selectedLog = null"
+            >
               &times;
             </button>
           </div>
@@ -284,7 +430,10 @@
 
               <div class="detail-group">
                 <label class="detail-label">Метод:</label>
-                <span class="detail-value method-value" :class="getMethodClass(selectedLog.method)">
+                <span
+                  class="detail-value method-value"
+                  :class="getMethodClass(selectedLog.method)"
+                >
                   {{ selectedLog.method }}
                 </span>
               </div>
@@ -298,7 +447,10 @@
 
               <div class="detail-group">
                 <label class="detail-label">Статус ответа:</label>
-                <span class="detail-value status-value" :class="getStatusClass(selectedLog.response_status)">
+                <span
+                  class="detail-value status-value"
+                  :class="getStatusClass(selectedLog.response_status)"
+                >
                   {{ selectedLog.response_status || 'N/A' }}
                 </span>
               </div>
@@ -312,35 +464,56 @@
                 <label class="detail-label">Пользователь:</label>
                 <span class="detail-value">
                   {{ selectedLog.username || 'Аноним' }}
-                  <span v-if="selectedLog.user_id" class="user-id">(ID: {{ selectedLog.user_id }})</span>
+                  <span
+                    v-if="selectedLog.user_id"
+                    class="user-id"
+                  >(ID: {{ selectedLog.user_id }})</span>
                 </span>
               </div>
 
-              <div class="detail-group" v-if="selectedLog.headers">
+              <div
+                v-if="selectedLog.headers"
+                class="detail-group"
+              >
                 <label class="detail-label">Заголовки:</label>
                 <pre class="detail-value code-block">{{ formatJson(selectedLog.headers) }}</pre>
               </div>
 
-              <div class="detail-group" v-if="selectedLog.request_body">
+              <div
+                v-if="selectedLog.request_body"
+                class="detail-group"
+              >
                 <label class="detail-label">Тело запроса:</label>
                 <pre class="detail-value code-block request-body">{{ formatJson(selectedLog.request_body) }}</pre>
               </div>
 
-              <div class="detail-group" v-if="selectedLog.response_body">
+              <div
+                v-if="selectedLog.response_body"
+                class="detail-group"
+              >
                 <label class="detail-label">Тело ответа:</label>
                 <pre class="detail-value code-block response-body">{{ formatJson(selectedLog.response_body) }}</pre>
               </div>
             </div>
           </div>
         </div>
-        <div v-else class="no-selection-message">
+        <div
+          v-else
+          class="no-selection-message"
+        >
           <p>Выберите запрос для просмотра деталей</p>
         </div>
       </div>
     </div>
 
-    <div v-if="isLoading" class="loading-overlay">
-      <LoaderSpinner size="large" :label="''" />
+    <div
+      v-if="isLoading"
+      class="loading-overlay"
+    >
+      <LoaderSpinner
+        size="large"
+        :label="''"
+      />
     </div>
   </div>
 </template>
@@ -414,6 +587,19 @@ export default {
     selectedPeriod() {
       return this.chartPeriods.find(p => p.key === this.chartPeriod) || this.chartPeriods[4];
     }
+  },
+  async mounted() {
+    await Promise.all([
+      this.fetchLogs(),
+      this.fetchStats(),
+      this.fetchTimeline(),
+      this.fetchUsers(),
+      this.fetchRealtime()
+    ]);
+    this.startPolling();
+  },
+  beforeUnmount() {
+    this.stopPolling();
   },
   methods: {
     buildFilterParams() {
@@ -709,19 +895,6 @@ export default {
         notification.remove();
       }, 3000);
     }
-  },
-  async mounted() {
-    await Promise.all([
-      this.fetchLogs(),
-      this.fetchStats(),
-      this.fetchTimeline(),
-      this.fetchUsers(),
-      this.fetchRealtime()
-    ]);
-    this.startPolling();
-  },
-  beforeUnmount() {
-    this.stopPolling();
   }
 };
 </script>


### PR DESCRIPTION
## Summary

Поднимаем уровень с `flat/essential` → `flat/recommended`. Это **baseline + style + best-practices** в одном пресете.

## Цифры

```
Перед --fix: 10204 warnings
После --fix: 128 warnings (10076 auto-fixed)
Errors: 0 → 0
Tests: 214/214 ✅
Build: ✅ 2s
```

**Нулевых runtime-изменений** — ESLint правила меняют форматирование/naming/structure, логика та же.

## Что auto-fix сделал (95%)

- `vue/html-indent` (5650) — привёл отступы к единому стандарту
- `vue/max-attributes-per-line` (1935) — перенёс длинные строки атрибутов
- `vue/singleline-html-element-content-newline` (1034)
- `vue/attributes-order` (836) — reorder атрибутов (`v-if` перед `class`)
- `vue/html-self-closing` (442) — `<br/>` вместо `<br></br>`
- `vue/order-in-components` (107) — упорядочил `name`/`components`/`props`/`data`/`methods`
- `vue/html-closing-bracket-spacing` (40)
- `vue/v-on-event-hyphenation` (8), `vue/attribute-hyphenation` (6)
- и ещё по мелочи

## Что осталось (128 warnings, не блокируют CI)

- **88** `vue/require-explicit-emits` — компоненты зовут `$emit('x')` без декларации `emits: ['x']`. Не баг, но good practice для readability
- **34** `vue/require-default-prop` — non-required props без дефолтов
- **3** `vue/no-v-html` — у нас 3 места v-html (через DOMPurify sanitize). Info, не actionable
- **1** `vue/require-prop-types`, **1** `vue/no-required-prop-with-default`, **1** `vue/attributes-order`

Это best-practice debt. Фиксим постепенно в бэклоге — не блокирует merge (severity=warn).

## Test plan

- [x] `npm run lint` — 128 warnings, 0 errors
- [x] `npm run test:run` — 214/214 passed
- [x] `npm run build` — собрался
- [ ] CI зелёный
- [ ] Визуальный smoke на staging — UI не поломался (auto-fix трогал только whitespace/order)

## Размер diff

103 файла, +13699/-7816 строк. Почти вся разница — reformatting ESLint'ом (многие `<div attr1 attr2 attr3>` превратились в multi-line).