### PR TITLE
fix(ci): deploy SSH command_timeout 30m

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,9 @@ jobs:
           username: ${{ secrets.VPS_USER }}
           password: ${{ secrets.VPS_PASSWORD }}
           key: ${{ secrets.VPS_SSH_KEY }}
+          # Default command_timeout=10m - не хватает на полный npm ci + Docker rebuild
+          # с npmmirror (медленнее чем прежний Cloudflare-кеш). Ставим 30m.
+          command_timeout: 30m
           script: |
             set -e
             test -d /opt/systemburo/.git || git clone git@github.com:${{ github.repository }}.git /opt/systemburo


### PR DESCRIPTION
Deploy to Staging падал с 'Run Command Timeout' через 10m дефолта appleboy/ssh-action. npm ci с npmmirror работает, но полный Docker rebuild frontend+backend+nginx не помещается.

`command_timeout: 30m` даёт запас.

После merge финально проверим: build должен успеть, staging обновится.