### PR TITLE
feat: PUT /employees/:id/territory-status + employees_history (#116 bug 5)

### DIFF
--- a/internal/handlers/employees.go
+++ b/internal/handlers/employees.go
@@ -40,6 +40,31 @@ func (h *EmployeeHandler) CreateEmployee(c echo.Context) error {
 	return RespondSuccess(c, resp)
 }
 
+// UpdateEmployeeTerritoryStatus обрабатывает PUT /employees/:id/territory-status.
+// @Summary Обновление статуса нахождения сотрудника на территории
+// @Tags employees
+// @Security BearerAuth
+// @Accept json
+// @Produce json
+// @Param id path int true "ID сотрудника"
+// @Param body body services.UpdateTerritoryStatusRequest true "Новый территориальный статус"
+// @Success 200 {object} map[string]interface{}
+// @Router /employees/{id}/territory-status [put]
+func (h *EmployeeHandler) UpdateEmployeeTerritoryStatus(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid employee ID")
+	}
+	var req services.UpdateTerritoryStatusRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	if err := h.service.UpdateEmployeeTerritoryStatus(c.Request().Context(), id, req); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Employee territory status updated successfully")
+}
+
 // GetActiveEmployeesForTable обрабатывает GET /employees/active-for-table/:table_id.
 // @Summary Получение активных сотрудников для таблицы
 // @Tags employees

--- a/internal/handlers/employees_test.go
+++ b/internal/handlers/employees_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
 
 // --- 401 Unauthorized tests ---
@@ -274,4 +275,97 @@ func TestGetActiveEmployeesForTable_NonexistentTable(t *testing.T) {
 
 	employees := testutil.ParseSlice(t, rec)
 	assert.Empty(t, employees)
+}
+
+// --- PUT /employees/:id/territory-status ---
+
+// seedEmployeeDirect вставляет сотрудника напрямую в БД для тестов territory-status.
+// Создание через POST /employees требует заявку с attachment_id - тут нам нужен
+// минимальный employee row, без привязок.
+func seedEmployeeDirect(t *testing.T, db *gorm.DB, lastName, firstName string) int {
+	t.Helper()
+	zero := 0
+	emp := models.Employee{
+		LastName:  &lastName,
+		FirstName: &firstName,
+		Status:    &zero,
+	}
+	if err := db.Create(&emp).Error; err != nil {
+		t.Fatalf("seed employee: %v", err)
+	}
+	return emp.ID
+}
+
+func TestUpdateEmployeeTerritoryStatus_Entry(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	empID := seedEmployeeDirect(t, db, "Ivanov", "Ivan")
+	token := testutil.RegisterAndLogin(t, e, "territory_u1", "pass123", 1, td.OrgID, td.CompanyID)
+	userID := getUserID(t, db, "territory_u1")
+
+	body := fmt.Sprintf(`{"territory_status": 1, "user_id": %d}`, userID)
+	rec := testutil.PUT(t, e, fmt.Sprintf("/employees/%d/territory-status", empID), body, testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	var updated models.Employee
+	require.NoError(t, db.First(&updated, empID).Error)
+	require.NotNil(t, updated.TerritoryStatus)
+	assert.Equal(t, 1, *updated.TerritoryStatus)
+	require.NotNil(t, updated.TerritoryEntryTime, "entry_time должен быть установлен при въезде")
+
+	var historyCount int64
+	db.Model(&models.EmployeeHistory{}).
+		Where("employee_id = ? AND action_type = ?", empID, "entry").Count(&historyCount)
+	assert.Equal(t, int64(1), historyCount, "в history должна быть запись action_type=entry")
+}
+
+func TestUpdateEmployeeTerritoryStatus_Exit(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	empID := seedEmployeeDirect(t, db, "Petrov", "Petr")
+	token := testutil.RegisterAndLogin(t, e, "territory_u2", "pass123", 1, td.OrgID, td.CompanyID)
+
+	body := `{"territory_status": 2}`
+	rec := testutil.PUT(t, e, fmt.Sprintf("/employees/%d/territory-status", empID), body, testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var updated models.Employee
+	require.NoError(t, db.First(&updated, empID).Error)
+	require.NotNil(t, updated.TerritoryStatus)
+	assert.Equal(t, 2, *updated.TerritoryStatus)
+
+	var historyCount int64
+	db.Model(&models.EmployeeHistory{}).
+		Where("employee_id = ? AND action_type = ?", empID, "exit").Count(&historyCount)
+	assert.Equal(t, int64(1), historyCount)
+}
+
+func TestUpdateEmployeeTerritoryStatus_NotFound(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "territory_u3", "pass123", 1, td.OrgID, td.CompanyID)
+
+	rec := testutil.PUT(t, e, "/employees/999999/territory-status", `{"territory_status": 1}`, testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestUpdateEmployeeTerritoryStatus_InvalidID(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "territory_u4", "pass123", 1, td.OrgID, td.CompanyID)
+
+	rec := testutil.PUT(t, e, "/employees/abc/territory-status", `{"territory_status": 1}`, testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -148,6 +148,7 @@ func Setup(e *echo.Echo, auth *handlers.AuthHandler, userTypes *handlers.UserTyp
 	empGroup := protected.Group("/employees")
 	empGroup.POST("", employees.CreateEmployee)
 	empGroup.GET("/active-for-table/:table_id", employees.GetActiveEmployeesForTable)
+	empGroup.PUT("/:id/territory-status", employees.UpdateEmployeeTerritoryStatus)
 	empGroup.GET("/:id/history", employeesHistory.GetByEmployee)
 	empGroup.GET("/history/unified", employeesHistory.GetUnified)
 	empGroup.GET("/history/all", employeesHistory.GetAll)

--- a/internal/services/employee_service.go
+++ b/internal/services/employee_service.go
@@ -2,8 +2,10 @@ package services
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"systemburo/internal/models"
 
@@ -17,6 +19,10 @@ type EmployeeService interface {
 	CreateEmployee(ctx context.Context, req CreateEmployeeRequest) (*CreateEmployeeResponse, error)
 	// GetActiveEmployeesForTable возвращает активных сотрудников для конкретной таблицы.
 	GetActiveEmployeesForTable(ctx context.Context, tableID int) ([]TableEmployeeResponse, error)
+	// UpdateEmployeeTerritoryStatus обновляет статус нахождения сотрудника на территории (въезд/выезд).
+	// Аналогично UpdateCarTerritoryStatus: пишет в employees_history запись
+	// с action_type=entry/exit, обновляет territory_status + territory_entry_time.
+	UpdateEmployeeTerritoryStatus(ctx context.Context, employeeID int, req UpdateTerritoryStatusRequest) error
 }
 
 // --- DTO запросов ---
@@ -178,4 +184,68 @@ func (s *employeeService) GetActiveEmployeesForTable(ctx context.Context, tableI
 		})
 	}
 	return employees, nil
+}
+
+// UpdateEmployeeTerritoryStatus обновляет территориальный статус сотрудника
+// (въезд=1 / выезд=2) и пишет в employees_history запись с action_type. Полный
+// аналог UpdateCarTerritoryStatus из car_status_service.go.
+func (s *employeeService) UpdateEmployeeTerritoryStatus(ctx context.Context, employeeID int, req UpdateTerritoryStatusRequest) error {
+	now := time.Now().UTC()
+	actionType := "unknown"
+	if req.TerritoryStatus == 1 {
+		actionType = "entry"
+	} else if req.TerritoryStatus == 2 {
+		actionType = "exit"
+	}
+
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var employee models.Employee
+		if err := tx.Select("id", "last_name", "first_name", "middle_name", "territory_status").
+			First(&employee, employeeID).Error; err != nil {
+			if err == gorm.ErrRecordNotFound {
+				return echo.NewHTTPError(http.StatusNotFound, "Employee not found")
+			}
+			return echo.NewHTTPError(http.StatusInternalServerError, "Database error")
+		}
+
+		updates := map[string]interface{}{
+			"territory_status": req.TerritoryStatus,
+			"updated_at":       now,
+		}
+		if req.TerritoryStatus == 1 {
+			updates["territory_entry_time"] = now
+		}
+		if err := tx.Model(&models.Employee{}).Where("id = ?", employeeID).Updates(updates).Error; err != nil {
+			slog.Error("не удалось обновить территориальный статус сотрудника", "employee_id", employeeID, "status", req.TerritoryStatus, "error", err)
+			return echo.NewHTTPError(http.StatusInternalServerError, "Error updating employee territory status")
+		}
+
+		fullName := ""
+		if employee.LastName != nil {
+			fullName += *employee.LastName
+		}
+		if employee.FirstName != nil {
+			fullName += " " + *employee.FirstName
+		}
+		var comment string
+		if req.TerritoryStatus == 1 {
+			comment = fmt.Sprintf("Сотрудник %s прошёл на территорию", fullName)
+		} else if req.TerritoryStatus == 2 {
+			comment = fmt.Sprintf("Сотрудник %s вышел с территории", fullName)
+		}
+
+		history := models.EmployeeHistory{
+			EmployeeID: employeeID,
+			UserID:     req.UserID,
+			ActionType: actionType,
+			Comment:    &comment,
+			CreatedAt:  now,
+		}
+		if err := tx.Create(&history).Error; err != nil {
+			slog.Error("не удалось добавить запись в историю сотрудника", "employee_id", employeeID, "action_type", actionType, "error", err)
+			return echo.NewHTTPError(http.StatusInternalServerError, "Error adding employee history entry")
+		}
+		slog.Info("территориальный статус сотрудника обновлён", "employee_id", employeeID, "action_type", actionType, "status", req.TerritoryStatus)
+		return nil
+	})
 }


### PR DESCRIPTION
Bug 5 из issue #116 — frontend `PeopleTable.vue` делает `PUT /employees/:id/territory-status` и получает **404** (endpoint не существовал). Для машин аналогичный endpoint был давно.

## Что добавил

### Service
```go
EmployeeService.UpdateEmployeeTerritoryStatus(ctx, employeeID, req)
```
- Транзакция: обновляет `territory_status` + `territory_entry_time` в `employees`, создаёт запись в `employees_history` (action_type=entry/exit, comment с ФИО).
- 404 если employee не найден.
- Полный клон паттерна `UpdateCarTerritoryStatus` из `car_status_service.go`.

### Handler
```go
PUT /api/employees/:id/territory-status
Body: { territory_status: 1|2, user_id?: int }
→ 200 { message: "Employee territory status updated successfully" }
```

### Route
`empGroup.PUT("/:id/territory-status", employees.UpdateEmployeeTerritoryStatus)`

## Тесты (4/4 passed, race-safe)

| Test | Проверяет |
|---|---|
| `TestUpdateEmployeeTerritoryStatus_Entry` | status=1 → employee.territory_status=1 + territory_entry_time set + history.action_type=entry |
| `TestUpdateEmployeeTerritoryStatus_Exit` | status=2 → history.action_type=exit |
| `TestUpdateEmployeeTerritoryStatus_NotFound` | несуществующий id → 404 |
| `TestUpdateEmployeeTerritoryStatus_InvalidID` | нечисловой id → 400 |

## Test plan

- [x] `go test -race ./internal/handlers/ -run TestUpdateEmployeeTerritoryStatus` → 4/4
- [x] `go build ./...` → чисто
- [ ] После deploy на staging — PeopleTable.vue кнопка "проход/выход" должна работать (no more 404)
- [ ] История сотрудника (`employees_history`) пополняется