### PR TITLE
fix: EmployeesList передача camelCase→snake_case в details (#116 bugs 1+7)

### DIFF
--- a/frontend/src/components/CreateApplication/EmployeesList.vue
+++ b/frontend/src/components/CreateApplication/EmployeesList.vue
@@ -137,6 +137,7 @@
       :show="showDetailsModal"
       :employee="selectedEmployee"
       :all-tables="allTables"
+      source="employeeslist"
       @close="closeDetailsModal"
     />
   </div>
@@ -169,7 +170,28 @@ export default {
     },
     methods: {
         showEmployeeDetails(employee) {
-            this.selectedEmployee = employee;
+            // EmployeeForm кладёт в employeesByAttachment объекты в camelCase
+            // (lastName, firstName, citizenshipName, targetTables, ...), а
+            // EmployeeDetailsModal читает snake_case (last_name, ..., target_tables).
+            // Трансформируем перед передачей — иначе ФИО, места прохода, паспорт
+            // не отображаются в модалке details (баг из issue #116).
+            this.selectedEmployee = {
+                id: employee.id,
+                last_name: employee.lastName,
+                first_name: employee.firstName,
+                middle_name: employee.middleName,
+                position: employee.position,
+                citizenshipName: employee.citizenshipName,
+                passport_series_number: employee.passportSeriesNumber,
+                patent_number: employee.patentNumber,
+                other_permission: employee.otherPermission,
+                target_tables: employee.targetTables || [],
+                entry_date_to: employee.entryDateTo,
+                pass_time: employee.passTime,
+                organization: employee.organization,
+                company: employee.company,
+                applicationId: employee.applicationId
+            };
             this.showDetailsModal = true;
         },
         closeDetailsModal() {


### PR DESCRIPTION
Bugs 1 и 7 из #116 - при клике details-icon на сотрудника в списке создания заявки, модалка показывает только гражданство+должность, а ФИО/паспорт/места прохода не отображаются.

**Причина:** `EmployeeForm` emit-ит объект в camelCase (`lastName`, `firstName`, `targetTables`, ...), `EmployeeDetailsModal` читает snake_case (`employee.last_name`, `employee.target_tables`, ...).

**Fix:** в `EmployeesList.vue:showEmployeeDetails()` трансформируем camelCase → snake_case перед передачей. Также проставлен `source="employeeslist"` - модалка сама скроет секцию Статус/История для этого контекста (готовая логика в computed `showStatusSection` / `showHistorySection`).

## Test plan
- [x] lint чисто, 214/214 tests
- [ ] После merge+deploy: кликнуть details на сотрудника в создании заявки → все поля видны