### PR TITLE
fix: беджи объявлений вернул old_branch палитру (#116 bug 6)

### DIFF
--- a/frontend/src/components/AnnouncementModal.vue
+++ b/frontend/src/components/AnnouncementModal.vue
@@ -190,16 +190,16 @@ export default {
   font-weight: 500;
   padding: 2px 8px;
   border-radius: 20px;
-  background: #FFE0B2;
-  color: #9A3412;
+  background: #fff3cd;
+  color: #856404;
   display: inline-flex;
   align-items: center;
   gap: 6px;
 }
 
 .modal-type.important {
-  background: #FECACA;
-  color: #B91C1C;
+  background: #ffb3b3;
+  color: #c62828;
 }
 
 .modal-description {

--- a/frontend/src/views/NewsAndReview.vue
+++ b/frontend/src/views/NewsAndReview.vue
@@ -1049,13 +1049,13 @@ export default {
     font-weight: 500;
     padding: 2px 8px;
     border-radius: 20px;
-    background: #FFE0B2;
-    color: #9A3412;
+    background: #fff3cd;
+    color: #856404;
 }
 
 .card-type.important {
-    background: #FECACA;
-    color: #B91C1C;
+    background: #ffb3b3;
+    color: #c62828;
 }
 
 .card-date {


### PR DESCRIPTION
Bug 6 из #116.

В `dev` беджи "Объявление" / "Важное объявление" были в приглушённой пастельной палитре (`#FFE0B2` / `#FECACA`), в `old_branch` были ярче (`#fff3cd` жёлтый / `#ffb3b3` красный). Визуально не то что ожидается.

Возвращаю старую палитру в двух местах:
- `AnnouncementModal.vue` (`.modal-type` / `.modal-type.important`) — модалка деталей
- `NewsAndReview.vue` (`.card-type` / `.card-type.important`) — карточка активного объявления на /news

CSS-only, никакой логики не затрагивает.