### PR TITLE
fix: AccountComponent gap 15px + notifications max-width (#116 bug 2)

### DIFF
--- a/frontend/src/components/AccountComponent.vue
+++ b/frontend/src/components/AccountComponent.vue
@@ -34,7 +34,7 @@
           class="dashboard-card-animated"
         />
 
-        <UserNotificationsInline class="dashboard-card-animated" />
+        <UserNotificationsInline class="dashboard-card-animated notifications" />
       </SkeletonTransition>
     </div>
     
@@ -301,8 +301,12 @@ export default {
 /* Стили для строк */
 .first-row {
   display: flex;
-  gap: 30px;
+  gap: 15px;
   margin-bottom: 15px;
+}
+
+.first-row :deep(.notifications) {
+  max-width: 38%;
 }
 
 /* SkeletonTransition оборачивает детей в div — раскладываем его в flex row
@@ -310,7 +314,7 @@ export default {
 .first-row > div {
   display: flex;
   flex-direction: row;
-  gap: 30px;
+  gap: 15px;
   flex: 1;
   min-width: 0;
   width: 100%;


### PR DESCRIPTION
Bug 2 из #116 - на /personal-cabinet first-row gap должен быть 15px (в dev стояло 30px). Также блок notifications должен занимать max 38% ширины.

Минимальные изменения:
- `.first-row { gap: 30px }` -> `15px` (и в nested `.first-row > div`)
- Добавил класс `notifications` на UserNotificationsInline + селектор `.first-row :deep(.notifications) { max-width: 38% }`