### PR TITLE
fix: CreateUserModal + UserControl - phone mask, type full-width (#116 bug 3)

### DIFF
--- a/frontend/src/components/CreateUserModal.vue
+++ b/frontend/src/components/CreateUserModal.vue
@@ -52,11 +52,11 @@
               >
             </div>
 
-            <div class="form-group">
+            <div class="form-group form-group--full">
               <label class="form-label">Тип пользователя:</label>
-              <select 
-                v-model="newUser.type_id" 
-                required 
+              <select
+                v-model="newUser.type_id"
+                required
                 class="form-select"
               >
                 <option
@@ -154,15 +154,16 @@
 
             <div class="form-group">
               <label class="form-label">Телефон:</label>
-              <input 
-                v-model="newUser.phone" 
-                type="tel" 
-                placeholder="Введите телефон"
+              <input
+                :value="newUser.phone"
+                type="tel"
+                placeholder="+7 (___) ___ __-__"
                 class="form-input"
                 autocomplete="off"
                 autocorrect="off"
                 autocapitalize="off"
                 spellcheck="false"
+                @input="newUser.phone = formatRussianPhone($event.target.value)"
               >
             </div>
           </div>
@@ -243,6 +244,7 @@
 
 <script>
 import { apiRequest } from '@/api/client'
+import { formatRussianPhone } from '@/composables/useRussianPhoneMask'
 export default {
   props: {
     organizations: {
@@ -288,6 +290,7 @@ export default {
     }
   },
   methods: {
+    formatRussianPhone,
     async createNewUser() {
       try {
         const userData = {
@@ -446,6 +449,11 @@ export default {
 
 .form-group {
   margin-bottom: 0;
+}
+
+/* Растягиваем "Тип пользователя" на всю ширину form-grid (2 колонки) */
+.form-group--full {
+  grid-column: 1 / -1;
 }
 
 .form-label {

--- a/frontend/src/components/UserControl.vue
+++ b/frontend/src/components/UserControl.vue
@@ -289,15 +289,16 @@
                 
                 <div class="detail-group">
                   <label class="detail-label">Телефон:</label>
-                  <input 
-                    v-model="selectedUser.phone" 
+                  <input
+                    :value="selectedUser.phone"
                     class="form-input-sm"
-                    placeholder="Введите телефон"
+                    placeholder="+7 (___) ___ __-__"
                     type="tel"
                     autocomplete="new-password"
                     autocorrect="off"
                     autocapitalize="off"
                     spellcheck="false"
+                    @input="onPhoneInput($event, 'selectedUser')"
                     @change="updateUserInfo(selectedUser)"
                   >
                 </div>
@@ -493,12 +494,6 @@
             </div>
             
             <div class="modal-body">
-              <div
-                v-if="!hasOrgOrCompany"
-                class="form-hint form-hint--warning"
-              >
-                Укажите организацию или компанию - хотя бы одно из двух обязательно.
-              </div>
               <div class="form-wrap">
                 <div class="input-group half">
                   <label class="input-label">Логин <span class="required">*</span></label>
@@ -606,7 +601,7 @@
                     </transition>
                   </div>
                 </div>
-                <div class="input-group half">
+                <div class="input-group full">
                   <label class="input-label">Тип пользователя <span class="required">*</span></label>
                   <div
                     class="custom-select"
@@ -689,11 +684,11 @@
                 <div class="input-group half">
                   <label class="input-label">Телефон</label>
                   <input
-                    v-model="newUser.phone"
-                    placeholder="Введите телефон"
+                    :value="newUser.phone"
+                    placeholder="+7 (___) ___ __-__"
                     class="modal-input"
                     type="tel"
-                    @input="saveDraft"
+                    @input="onPhoneInput($event, 'newUser')"
                   >
                 </div>
               </div>
@@ -787,6 +782,7 @@
 <script>
 import { apiRequest } from '@/api/client'
 import { ref } from 'vue';
+import { formatRussianPhone } from '@/composables/useRussianPhoneMask'
 import SearchComponent from './SearchComponent.vue';
 import RefreshButton from './RefreshButton.vue';
 import PermissionTree from './PermissionTree.vue';
@@ -954,6 +950,17 @@ export default {
   },
  
   methods: {
+    // onPhoneInput применяет российскую маску к введённому телефону и записывает
+    // результат обратно в reactive model. Используется для newUser/selectedUser
+    // чтобы явно триггерить saveDraft (где он нужен) отдельно.
+    onPhoneInput(event, modelKey) {
+      const masked = formatRussianPhone(event.target.value)
+      this[modelKey].phone = masked
+      if (modelKey === 'newUser') {
+        this.saveDraft()
+      }
+    },
+
     refreshAllData() {
       this.fetchOrganizations();
       this.fetchCompanies();

--- a/frontend/src/composables/useRussianPhoneMask.js
+++ b/frontend/src/composables/useRussianPhoneMask.js
@@ -1,0 +1,46 @@
+/**
+ * Маска для российского номера телефона: +7 (999) 999 99-99.
+ *
+ * Применение:
+ * import { formatRussianPhone } from '@/composables/useRussianPhoneMask'
+ *
+ * <input :value="phone" @input="phone = formatRussianPhone($event.target.value)">
+ *
+ * Особенности:
+ * - Ведущие 8/7/+7 приводятся к +7.
+ * - Любые символы кроме цифр удаляются на входе.
+ * - Маска накладывается по мере ввода - частичный ввод показывается частично.
+ *   Например "89" -> "+7 (9", "891" -> "+7 (91", "89123456789" -> "+7 (912) 345 67-89".
+ */
+export function formatRussianPhone(raw) {
+  if (raw == null) return ''
+  let digits = String(raw).replace(/\D/g, '')
+  // Ведущая 8 или 7 - заменяем на 7 (префикс страны один и тот же).
+  if (digits.length && (digits[0] === '8' || digits[0] === '7')) {
+    digits = '7' + digits.slice(1)
+  } else if (digits.length) {
+    // Если юзер начал с другой цифры (например, 9), считаем что забыл код страны.
+    digits = '7' + digits
+  }
+  digits = digits.slice(0, 11) // +7 + 10 цифр = 11
+
+  const d = digits.slice(1) // после страны
+  let out = '+7'
+  if (d.length > 0) out += ' (' + d.slice(0, 3)
+  if (d.length >= 3) out += ')'
+  if (d.length > 3) out += ' ' + d.slice(3, 6)
+  if (d.length > 6) out += ' ' + d.slice(6, 8)
+  if (d.length > 8) out += '-' + d.slice(8, 10)
+  return out
+}
+
+/**
+ * Вытаскивает только цифры в формате +7XXXXXXXXXX для отправки на backend.
+ * Возвращает null если номер пустой.
+ */
+export function phoneToE164(masked) {
+  if (!masked) return null
+  const digits = String(masked).replace(/\D/g, '')
+  if (!digits) return null
+  return '+' + digits.replace(/^8/, '7')
+}


### PR DESCRIPTION
Bug 3 из #116.

1. **Маска телефона** `+7 (999) 999 99-99` с авто-заменой 8→+7. Новый utility `composables/useRussianPhoneMask.js` (`formatRussianPhone`). Применён в обеих модалках (CreateUserModal — создание, UserControl — создание и редактирование selectedUser).

2. **'Тип пользователя' full-width**:
   - CreateUserModal: class `form-group--full` + `grid-column: 1 / -1`
   - UserControl: `input-group half` → `full` (стиль уже был)

3. **Убран hint** "Укажите организацию или компанию — хотя бы одно из двух обязательно" в форме создания UserControl.

Lint чист, 214/214 tests.