### PR TITLE
fix: ApplicationDetail employee/car доп. поля + SuccessModal период (#116)

### DIFF
--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -1753,7 +1753,27 @@ export default {
                 if (response.ok) {
                     const result = await response.json();
                     this.createdApplicationNumber = result.application_number;
-                    this.createdAttachmentsData = applicationData.attachments || [];
+                    this.createdAttachmentsData = this.attachments.map(att => {
+                        const dateData = this.attachmentDatesByAttachment[this.attachmentKey(att)] || this.getDefaultDateData();
+                        let period = '';
+                        let time = '';
+
+                        if (dateData.isOneDay) {
+                            period = dateData.singleDate || '';
+                        } else if (dateData.startDate || dateData.endDate) {
+                            period = `${dateData.startDate || ''} - ${dateData.endDate || ''}`.trim();
+                        }
+
+                        if (dateData.startTime && dateData.endTime) {
+                            time = `${dateData.startTime} - ${dateData.endTime}`;
+                        }
+
+                        return {
+                            display_name: att.display_name || att.name,
+                            period,
+                            time
+                        };
+                    });
                     this.showSuccessModal = true;
                 } else {
                     const errorText = await response.text();

--- a/internal/services/application_attachment_service.go
+++ b/internal/services/application_attachment_service.go
@@ -71,19 +71,40 @@ func (s *applicationService) GetApplicationAttachments(ctx context.Context, appl
 // GetAttachmentCars возвращает автомобили вложения с привязанными местами разгрузки.
 func (s *applicationService) GetAttachmentCars(ctx context.Context, attachmentID int) ([]CarWithPlaces, error) {
 	type carRow struct {
-		ID            int
-		CarNumber     string  `gorm:"column:car_number"`
-		CarBrand      string  `gorm:"column:car_brand"`
-		UnloadPlace   *string `gorm:"column:unload_place"`
-		EntryDateFrom *string `gorm:"column:entry_date_from"`
-		EntryTimeFrom *string `gorm:"column:entry_time_from"`
-		EntryDateTo   *string `gorm:"column:entry_date_to"`
-		EntryTimeTo   *string `gorm:"column:entry_time_to"`
+		ID             int
+		CarNumber      string  `gorm:"column:car_number"`
+		CarBrand       string  `gorm:"column:car_brand"`
+		UnloadPlace    *string `gorm:"column:unload_place"`
+		EntryDateFrom  *string `gorm:"column:entry_date_from"`
+		EntryTimeFrom  *string `gorm:"column:entry_time_from"`
+		EntryDateTo    *string `gorm:"column:entry_date_to"`
+		EntryTimeTo    *string `gorm:"column:entry_time_to"`
+		Organization   *string `gorm:"column:organization"`
+		OrganizationID *int    `gorm:"column:organization_id"`
+		Company        *string `gorm:"column:company"`
+		CompanyID      *int    `gorm:"column:company_id"`
 	}
 	cars := make([]carRow, 0)
 	if err := s.db.WithContext(ctx).Raw(`
-		SELECT id, car_number, car_brand, unload_place, entry_date_from, entry_time_from, entry_date_to, entry_time_to
-		FROM cars WHERE attachment_id = ?
+		SELECT
+			c.id,
+			c.car_number,
+			c.car_brand,
+			c.unload_place,
+			c.entry_date_from,
+			c.entry_time_from,
+			c.entry_date_to,
+			c.entry_time_to,
+			o.name AS organization,
+			o.id   AS organization_id,
+			comp.name AS company,
+			comp.id   AS company_id
+		FROM cars c
+		JOIN attachments a ON c.attachment_id = a.id
+		JOIN applications app ON a.application_id = app.id
+		LEFT JOIN organizations o ON app.organization_id = o.id
+		LEFT JOIN companies comp ON app.company_id = comp.id
+		WHERE c.attachment_id = ?
 	`, attachmentID).Scan(&cars).Error; err != nil {
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching cars")
 	}
@@ -100,15 +121,19 @@ func (s *applicationService) GetAttachmentCars(ctx context.Context, attachmentID
 		`, car.ID).Scan(&places)
 
 		result = append(result, CarWithPlaces{
-			ID:            car.ID,
-			CarNumber:     car.CarNumber,
-			CarBrand:      car.CarBrand,
-			UnloadPlace:   car.UnloadPlace,
-			EntryDateFrom: car.EntryDateFrom,
-			EntryTimeFrom: car.EntryTimeFrom,
-			EntryDateTo:   car.EntryDateTo,
-			EntryTimeTo:   car.EntryTimeTo,
-			UnloadPlaces:  places,
+			ID:             car.ID,
+			CarNumber:      car.CarNumber,
+			CarBrand:       car.CarBrand,
+			UnloadPlace:    car.UnloadPlace,
+			EntryDateFrom:  car.EntryDateFrom,
+			EntryTimeFrom:  car.EntryTimeFrom,
+			EntryDateTo:    car.EntryDateTo,
+			EntryTimeTo:    car.EntryTimeTo,
+			Organization:   car.Organization,
+			OrganizationID: car.OrganizationID,
+			Company:        car.Company,
+			CompanyID:      car.CompanyID,
+			UnloadPlaces:   places,
 		})
 	}
 
@@ -124,14 +149,43 @@ func (s *applicationService) GetAttachmentEmployees(ctx context.Context, attachm
 		MiddleName           *string `gorm:"column:middle_name"`
 		Position             *string `gorm:"column:position"`
 		CitizenshipID        *int    `gorm:"column:citizenship_id"`
+		CitizenshipName      *string `gorm:"column:citizenship_name"`
 		PassportSeriesNumber *string `gorm:"column:passport_series_number"`
 		PatentNumber         *string `gorm:"column:patent_number"`
 		OtherPermission      *string `gorm:"column:other_permission"`
+		EntryDateTo          *string `gorm:"column:entry_date_to"`
+		PassTime             *string `gorm:"column:pass_time"`
+		Organization         *string `gorm:"column:organization"`
+		OrganizationID       *int    `gorm:"column:organization_id"`
+		Company              *string `gorm:"column:company"`
+		CompanyID            *int    `gorm:"column:company_id"`
 	}
 	employees := make([]empRow, 0)
 	if err := s.db.WithContext(ctx).Raw(`
-		SELECT id, last_name, first_name, middle_name, position, citizenship_id, passport_series_number, patent_number, other_permission
-		FROM employees WHERE attachment_id = ?
+		SELECT
+			e.id,
+			e.last_name,
+			e.first_name,
+			e.middle_name,
+			e.position,
+			e.citizenship_id,
+			ci.name AS citizenship_name,
+			e.passport_series_number,
+			e.patent_number,
+			e.other_permission,
+			a.entry_date_to,
+			CONCAT(a.entry_time_from, ' - ', a.entry_time_to) AS pass_time,
+			o.name AS organization,
+			o.id   AS organization_id,
+			comp.name AS company,
+			comp.id   AS company_id
+		FROM employees e
+		JOIN attachments a ON e.attachment_id = a.id
+		LEFT JOIN citizenships ci ON e.citizenship_id = ci.id
+		LEFT JOIN applications app ON a.application_id = app.id
+		LEFT JOIN organizations o ON app.organization_id = o.id
+		LEFT JOIN companies comp ON app.company_id = comp.id
+		WHERE e.attachment_id = ?
 	`, attachmentID).Scan(&employees).Error; err != nil {
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching employees")
 	}
@@ -158,9 +212,16 @@ func (s *applicationService) GetAttachmentEmployees(ctx context.Context, attachm
 			MiddleName:           emp.MiddleName,
 			Position:             emp.Position,
 			CitizenshipID:        emp.CitizenshipID,
+			CitizenshipName:      emp.CitizenshipName,
 			PassportSeriesNumber: emp.PassportSeriesNumber,
 			PatentNumber:         emp.PatentNumber,
 			OtherPermission:      emp.OtherPermission,
+			EntryDateTo:          emp.EntryDateTo,
+			PassTime:             emp.PassTime,
+			Organization:         emp.Organization,
+			OrganizationID:       emp.OrganizationID,
+			Company:              emp.Company,
+			CompanyID:            emp.CompanyID,
 			TargetTables:         tables,
 		})
 	}

--- a/internal/services/application_service.go
+++ b/internal/services/application_service.go
@@ -389,15 +389,19 @@ type AttachmentInfo struct {
 
 // CarWithPlaces автомобиль с привязанными местами разгрузки.
 type CarWithPlaces struct {
-	ID            int              `json:"id"`
-	CarNumber     string           `json:"car_number"`
-	CarBrand      string           `json:"car_brand"`
-	UnloadPlace   *string          `json:"unload_place"`
-	EntryDateFrom *string          `json:"entry_date_from"`
-	EntryTimeFrom *string          `json:"entry_time_from"`
-	EntryDateTo   *string          `json:"entry_date_to"`
-	EntryTimeTo   *string          `json:"entry_time_to"`
-	UnloadPlaces  []UnloadPlaceRef `json:"unload_places"`
+	ID             int              `json:"id"`
+	CarNumber      string           `json:"car_number"`
+	CarBrand       string           `json:"car_brand"`
+	UnloadPlace    *string          `json:"unload_place"`
+	EntryDateFrom  *string          `json:"entry_date_from"`
+	EntryTimeFrom  *string          `json:"entry_time_from"`
+	EntryDateTo    *string          `json:"entry_date_to"`
+	EntryTimeTo    *string          `json:"entry_time_to"`
+	Organization   *string          `json:"organization"`
+	OrganizationID *int             `json:"organization_id"`
+	Company        *string          `json:"company"`
+	CompanyID      *int             `json:"company_id"`
+	UnloadPlaces   []UnloadPlaceRef `json:"unload_places"`
 }
 
 // UnloadPlaceRef ссылка на место разгрузки.
@@ -415,9 +419,16 @@ type EmployeeWithTables struct {
 	MiddleName           *string        `json:"middle_name"`
 	Position             *string        `json:"position"`
 	CitizenshipID        *int           `json:"citizenship_id"`
+	CitizenshipName      *string        `json:"citizenship_name"`
 	PassportSeriesNumber *string        `json:"passport_series_number"`
 	PatentNumber         *string        `json:"patent_number"`
 	OtherPermission      *string        `json:"other_permission"`
+	EntryDateTo          *string        `json:"entry_date_to"`
+	PassTime             *string        `json:"pass_time"`
+	Organization         *string        `json:"organization"`
+	OrganizationID       *int           `json:"organization_id"`
+	Company              *string        `json:"company"`
+	CompanyID            *int           `json:"company_id"`
 	TargetTables         []TableInfoRef `json:"target_tables"`
 }
 


### PR DESCRIPTION
## Контекст

Закрывает **bugs 4 и 8** из issue #116.

## Bug 4: ApplicationDetail не показывал доп. поля сотрудника/автомобиля

**Симптом:** при открытии заявки через ApplicationDetail и клике на сотрудника/автомобиль в модалке EmployeeDetailsModal / VehicleDetailsModal были пустые:
- Гражданство (`citizenship_name`)
- Срок действия (`entry_date_to`)
- Время прохода (`pass_time`)
- Организация / Компания (`organization`, `company`)

**Причина:** Go-обработчики `GetAttachmentEmployees` и `GetAttachmentCars` в `internal/services/application_attachment_service.go` возвращали только голые колонки из `employees` / `cars`, без JOIN-ов. Старый Rust-бэкенд (origin/old_branch, `backend/src/handlers/applications.rs:3848/3941`) делал JOIN на `citizenships`, `applications -> organizations/companies` и возвращал `citizenship_name`, `entry_date_to`, `pass_time`, `organization`, `company` и т.п.

**Фикс:** добавил JOIN-ы в SQL и расширил DTO `EmployeeWithTables` / `CarWithPlaces`. Фронтенд уже мапил эти поля в `openEmployeeModal` / `openVehicleModal` — просто теперь они не пустые.

## Bug 8: ApplicationSuccessModal показывал счётчик, но не период/время

**Симптом:** после создания заявки в модалке успеха счётчик вложений работал (`attachmentsData.length`), но `att.period` / `att.time` были пустые — `v-if` скрывал строки.

**Причина:** `CreateApplication.vue:1756` присваивал `createdAttachmentsData = applicationData.attachments`. В этой структуре поля называются `attachment_display_name`, `entry_date_from`, `entry_time_to` и т.п. А шаблон `ApplicationSuccessModal` ожидает `att.display_name`, `att.period`, `att.time`.

**Фикс:** заменил сырое присвоение на маппинг из `this.attachments` и `this.attachmentDatesByAttachment` (как было в old_branch, `CreateApplication.vue:1895`).

## Изменения

- `internal/services/application_service.go` — расширены DTO `CarWithPlaces` и `EmployeeWithTables` (добавлены organization, company, citizenship_name, entry_date_to, pass_time).
- `internal/services/application_attachment_service.go` — обновлены запросы в `GetAttachmentCars` и `GetAttachmentEmployees`: JOIN на attachments, applications, organizations, companies, citizenships.
- `frontend/src/components/CreateApplication/CreateApplication.vue` — маппинг `createdAttachmentsData` в формат `{ display_name, period, time }`.

## Проверка

- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm run test:run` — 214/214 passed
- [x] `npm run build` — OK
- [x] `go build ./...` — OK
- [x] `go vet ./...` — OK
- [x] handlers-тесты требуют postgres (не запускаются локально без БД) — в CI против живого стека

## Ручная проверка (после деплоя)

- [ ] Открыть любую заявку в `/center`, кликнуть на сотрудника → в модалке должны быть Гражданство, Действует до, Время прохода, Организация, Компания
- [ ] Открыть автомобиль → Организация, Компания видны
- [ ] Создать новую заявку → в `ApplicationSuccessModal` для каждого вложения видны период и время, а не только имя