### PR TITLE
feat: страница 500 + bug-report в Telegram (#158)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,5 +52,13 @@ PGADMIN_PASSWORD=admin
 BASIC_AUTH_USER=admin
 BASIC_AUTH_PASS=changeme
 
+# === Telegram bug-report ===
+# Бот и чат, куда улетают 500-репорты со страницы Error500.
+# Если пустые - репорты пишутся только в БД без отправки в TG.
+# Создать бота: @BotFather -> /newbot
+# Получить chat_id: добавить бота в канал/группу и отправить "curl https://api.telegram.org/bot<TOKEN>/getUpdates"
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_CHAT_ID=
+
 # === Frontend ===
 VITE_API_BASE_URL=http://localhost:8080

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -154,6 +154,8 @@ func main() {
 	approverService := services.NewApproverService(db)
 	consentService := services.NewConsentService(db)
 	settingsService := services.NewSettingsService(db, cfg)
+	telegramService := services.NewTelegramService(cfg.TelegramBotToken, cfg.TelegramChatID)
+	bugReportService := services.NewBugReportService(db, telegramService)
 
 	// Handlers
 	authHandler := handlers.NewAuthHandler(authService, cfg.CookieSecure, cfg.JWTRefreshTTL)
@@ -180,6 +182,7 @@ func main() {
 	permissionHandler := handlers.NewPermissionHandler(permissionService)
 	consentHandler := handlers.NewConsentHandler(consentService, db)
 	settingsHandler := handlers.NewSettingsHandler(settingsService)
+	bugReportHandler := handlers.NewBugReportHandler(bugReportService)
 
 	// Swagger UI: http://localhost:8090/swagger/index.html
 	if cfg.SwaggerEnabled {
@@ -194,7 +197,7 @@ func main() {
 	loginLimiter := mw.LoginRateLimit(5, 15*time.Minute)
 
 	// Routes
-	router.Setup(e, authHandler, userTypesHandler, attachmentHandler, lpfHandler, citizenshipHandler, organizationHandler, companyHandler, usersHandler, unloadPlaceHandler, carHandler, employeeHandler, systemTableHandler, uniqueCarHandler, uniqueEmployeeHandler, feedbackHandler, applicationHandler, approverHandler, permissionHandler, consentHandler, settingsHandler, newsHandler, notificationHandler, requestLogsHandler, employeesHistoryHandler, []byte(cfg.JWTSecret), loginLimiter)
+	router.Setup(e, authHandler, userTypesHandler, attachmentHandler, lpfHandler, citizenshipHandler, organizationHandler, companyHandler, usersHandler, unloadPlaceHandler, carHandler, employeeHandler, systemTableHandler, uniqueCarHandler, uniqueEmployeeHandler, feedbackHandler, applicationHandler, approverHandler, permissionHandler, consentHandler, settingsHandler, newsHandler, notificationHandler, requestLogsHandler, employeesHistoryHandler, bugReportHandler, []byte(cfg.JWTSecret), loginLimiter)
 
 	// Общий ctx для фоновых задач и graceful shutdown. Отменяется по SIGINT/SIGTERM.
 	ctxSig, stopSig := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -63,13 +63,14 @@ export default {
     },
     /**
      * Показывать шапку, навигацию и связанный chrome только когда юзер
-     * аутентифицирован и находится не на странице логина. Иначе после
+     * аутентифицирован и находится не на странице логина/ошибки. Иначе после
      * setTokens() в LoginComponent до router.push('/news')
      * (задержан на 1.5с из-за success-анимации) шапка и меню моргают
-     * поверх формы логина.
+     * поверх формы логина. На /500 chrome тоже скрываем - это full-page view.
      */
     showChrome() {
-      return this.isAuthenticated && this.$route.path !== '/';
+      const hidePaths = ['/', '/500']
+      return this.isAuthenticated && !hidePaths.includes(this.$route.path);
     }
   },
   created() {

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,5 +1,6 @@
 import { useAuthStore } from '@/stores/auth'
 import router from '@/router'
+import { buildBugContext, saveBugContext } from '@/composables/useBugReport'
 
 // API_BASE_URL оставляем настраиваемым для локальной разработки с отдельным backend-портом,
 // но на staging/prod он пуст и префикс /api обеспечивает маршрутизацию через nginx:
@@ -92,9 +93,34 @@ async function doFetch(path, options, token) {
   }
 }
 
+// Эндпоинты, на которых 5xx НЕ редиректим на /500 - это внутренние
+// механизмы (refresh, отправка самого bug-report), их ответы должны
+// обрабатываться локально, иначе получим infinite redirect loop.
+const SKIP_500_REDIRECT = ['/bug-report', '/refresh-token', '/login', '/logout']
+
+function shouldHandleAsServerError(path, status) {
+  if (status < 500 || status > 599) return false
+  if (SKIP_500_REDIRECT.some((p) => path === p || path.startsWith(p + '?'))) return false
+  if (router.currentRoute.value.path === '/500') return false
+  return true
+}
+
 async function baseRequest(path, options = {}) {
   const authStore = useAuthStore()
   let response = await doFetch(path, options, authStore.token)
+
+  // 5xx -> сохраняем безопасный контекст и редиректим на /500.
+  // Ответ не читаем: тело может содержать детали ошибки, которые нам
+  // показывать юзеру нельзя (leak архитектуры). Используем только status и path.
+  if (shouldHandleAsServerError(path, response.status)) {
+    saveBugContext(buildBugContext({
+      route: `${options.method || 'GET'} ${path}`,
+      httpStatus: response.status,
+      message: response.statusText || `HTTP ${response.status}`,
+    }))
+    router.push('/500')
+    return response
+  }
 
   if (response.status !== 401 || isAuthEndpoint(path) || options._retried) {
     return response

--- a/frontend/src/composables/useBugReport.js
+++ b/frontend/src/composables/useBugReport.js
@@ -1,0 +1,85 @@
+// useBugReport - утилиты страницы Error500.
+// buildBugContext собирает безопасный контекст (без response body), buildBugHash
+// хеширует его для дедупликации, sendBugReport отправляет POST на бэк.
+
+const LS_PREFIX = 'bug_reported:'
+const SS_CTX_KEY = 'last_bug_ctx'
+
+/**
+ * Собрать безопасный контекст ошибки.
+ * На страницу 500 отправляются ТОЛЬКО эти поля - без response body,
+ * заголовков или чего-либо что может содержать внутренние данные.
+ *
+ * @param {Object} params
+ * @param {string} params.route - путь запроса (pathname, без query)
+ * @param {number} params.httpStatus - HTTP-код (500-599)
+ * @param {string} [params.message] - generic HTTP status text ("Internal Server Error")
+ * @returns {Object} контекст
+ */
+export function buildBugContext({ route, httpStatus, message = '' }) {
+  return {
+    route: String(route || '').slice(0, 255),
+    httpStatus: Number(httpStatus) || 500,
+    message: String(message || '').slice(0, 500),
+    timestamp: new Date().toISOString(),
+  }
+}
+
+/**
+ * Хеш для дедупликации: sha256(route + "|" + status + "|" + message).slice(0, 16).
+ * Один юзер не сможет отправить два репорта на одинаковую комбинацию (uniq в БД).
+ * Используется Web Crypto - доступен в любом современном браузере (SubtleCrypto).
+ *
+ * @param {Object} ctx
+ * @returns {Promise<string>} 16-символьный hex
+ */
+export async function buildBugHash(ctx) {
+  const input = `${ctx.route}|${ctx.httpStatus}|${ctx.message}`
+  const bytes = new TextEncoder().encode(input)
+  const hashBuf = await crypto.subtle.digest('SHA-256', bytes)
+  const hex = Array.from(new Uint8Array(hashBuf))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+  return hex.slice(0, 16)
+}
+
+/**
+ * Сохранить контекст в sessionStorage, чтобы компонент Error500.vue мог
+ * его прочитать после router.push('/500'). Истекает при закрытии вкладки.
+ */
+export function saveBugContext(ctx) {
+  try {
+    sessionStorage.setItem(SS_CTX_KEY, JSON.stringify(ctx))
+  } catch {
+    // sessionStorage недоступен (Safari private mode) - не критично.
+  }
+}
+
+export function loadBugContext() {
+  try {
+    const raw = sessionStorage.getItem(SS_CTX_KEY)
+    return raw ? JSON.parse(raw) : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * true если юзер уже отправлял репорт на этот bug_hash в этом браузере.
+ * localStorage, чтобы флаг переживал F5.
+ */
+export function isReported(bugHash) {
+  try {
+    return localStorage.getItem(LS_PREFIX + bugHash) === '1'
+  } catch {
+    return false
+  }
+}
+
+export function markReported(bugHash) {
+  try {
+    localStorage.setItem(LS_PREFIX + bugHash, '1')
+  } catch {
+    // private mode - silent fail
+  }
+}

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -107,6 +107,12 @@ const routes = [
     name: 'AdminUsers',
     component: () => import('./views/AdminUsers.vue'),
     meta: { requiresAuth: true, requiresBuro: true }
+  },
+  {
+    path: '/500',
+    name: 'Error500',
+    component: () => import('./views/Error500.vue'),
+    meta: { requiresAuth: false }
   }
 ];
 

--- a/frontend/src/views/Error500.vue
+++ b/frontend/src/views/Error500.vue
@@ -1,0 +1,529 @@
+<template>
+  <div
+    class="err500"
+    data-testid="error-500-page"
+  >
+    <div class="err500__grid" />
+    <div
+      class="err500__bg-number"
+      aria-hidden="true"
+    >
+      <span>500</span>
+    </div>
+
+    <header class="err500__topbar">
+      <span class="err500__brand">Systemburo</span>
+      <div class="err500__chip">
+        Ошибка сервера
+      </div>
+    </header>
+
+    <main class="err500__main">
+      <section class="err500__hero">
+        <div class="err500__kicker">
+          Ошибка 500
+        </div>
+        <h1 class="err500__title">
+          Что-то <em>сломалось</em> на нашей стороне.
+        </h1>
+        <p class="err500__lede">
+          Мы уже знаем о проблеме и разбираемся. Помогите быстрее её починить — отправьте один клик с деталями этого инцидента напрямую в чат разработки.
+        </p>
+
+        <div class="err500__actions">
+          <button
+            class="err500__btn err500__btn--primary"
+            :disabled="reportSending || reportSent"
+            data-testid="send-bug-report-btn"
+            @click="handleReport"
+          >
+            <span v-if="reportSent">
+              <svg
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+              ><polyline points="20 6 9 17 4 12" /></svg>
+              Отчёт отправлен
+            </span>
+            <span v-else-if="reportSending">
+              Отправляется...
+            </span>
+            <span v-else>
+              <svg
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+              >
+                <path d="M22 2L11 13" />
+                <path d="M22 2l-7 20-4-9-9-4z" />
+              </svg>
+              Отправить отчёт разработчикам
+            </span>
+          </button>
+
+          <p
+            class="err500__hint"
+            :class="{ 'err500__hint--success': reportSent, 'err500__hint--error': reportError }"
+          >
+            <template v-if="reportSent">
+              Спасибо — команда получила отчёт и уже смотрит.
+            </template>
+            <template v-else-if="reportError">
+              {{ reportError }}
+            </template>
+            <template v-else>
+              Отправим: маршрут, код ошибки, ID инцидента и время. Без содержимого ответа сервера. Кнопка сработает один раз для одного и того же бага.
+            </template>
+          </p>
+
+          <div class="err500__actions-row">
+            <button
+              class="err500__btn err500__btn--outlined"
+              @click="goHome"
+            >
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+              ><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" /></svg>
+              На главную
+            </button>
+            <button
+              class="err500__btn err500__btn--outlined"
+              @click="reload"
+            >
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+              >
+                <polyline points="23 4 23 10 17 10" />
+                <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
+              </svg>
+              Обновить
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <aside class="err500__evidence">
+        <div class="err500__evidence-inner">
+          <div class="err500__evidence-label">
+            <span>Системный инцидент</span>
+            <span>зафиксирован</span>
+          </div>
+          <pre class="err500__code"># server response
+<span class="c500-k">STATUS</span>   <span class="c500-s">{{ ctx.httpStatus }}</span> {{ statusText }}
+<span class="c500-k">REQUEST</span>  {{ ctx.route }}
+<span class="c500-k">ID</span>       {{ bugHash || '...' }}
+<span class="c500-k">TIME</span>     {{ formattedTime }}
+
+# stack trace и детали исключения
+# остаются только в защищённом
+# серверном логе</pre>
+          <dl class="err500__meta">
+            <div>
+              <dt>ID инцидента</dt>
+              <dd>{{ bugHash || '...' }}</dd>
+            </div>
+            <div>
+              <dt>Время</dt>
+              <dd>{{ formattedTime }}</dd>
+            </div>
+            <div>
+              <dt>HTTP-код</dt>
+              <dd>{{ ctx.httpStatus }} {{ statusText }}</dd>
+            </div>
+            <div>
+              <dt>Маршрут</dt>
+              <dd>{{ ctx.route }}</dd>
+            </div>
+          </dl>
+        </div>
+      </aside>
+    </main>
+  </div>
+</template>
+
+<script>
+import { apiRequest } from '@/api/client'
+import {
+  loadBugContext,
+  buildBugHash,
+  isReported,
+  markReported,
+} from '@/composables/useBugReport'
+
+const DEFAULT_STATUS_TEXT = {
+  500: 'Internal Server Error',
+  502: 'Bad Gateway',
+  503: 'Service Unavailable',
+  504: 'Gateway Timeout',
+}
+
+export default {
+  name: 'ErrorFive00',
+  data() {
+    return {
+      ctx: {
+        route: '—',
+        httpStatus: 500,
+        message: 'Internal Server Error',
+        timestamp: new Date().toISOString(),
+      },
+      bugHash: '',
+      reportSending: false,
+      reportSent: false,
+      reportError: '',
+    }
+  },
+  computed: {
+    statusText() {
+      return DEFAULT_STATUS_TEXT[this.ctx.httpStatus] || this.ctx.message || 'Server Error'
+    },
+    formattedTime() {
+      const d = new Date(this.ctx.timestamp)
+      return d.toLocaleTimeString('ru-RU', { hour: '2-digit', minute: '2-digit', second: '2-digit' }) + ' МСК'
+    },
+  },
+  async mounted() {
+    const saved = loadBugContext()
+    if (saved) {
+      this.ctx = { ...this.ctx, ...saved }
+    }
+    this.bugHash = await buildBugHash(this.ctx)
+    if (isReported(this.bugHash)) {
+      this.reportSent = true
+    }
+  },
+  methods: {
+    async handleReport() {
+      if (!this.bugHash || this.reportSending || this.reportSent) return
+      this.reportSending = true
+      this.reportError = ''
+      try {
+        const response = await apiRequest('/bug-report', {
+          method: 'POST',
+          body: JSON.stringify({
+            bug_hash: this.bugHash,
+            route: this.ctx.route,
+            http_status: this.ctx.httpStatus,
+            message: this.ctx.message,
+          }),
+        })
+        if (response.ok || response.status === 409) {
+          // 409 = уже отправляли - для юзера считаем отправленным.
+          markReported(this.bugHash)
+          this.reportSent = true
+        } else if (response.status === 429) {
+          this.reportError = 'Слишком много репортов подряд, попробуйте через пару минут.'
+        } else {
+          this.reportError = 'Не удалось отправить отчёт. Попробуйте ещё раз позже.'
+        }
+      } catch {
+        this.reportError = 'Нет связи с сервером. Попробуйте ещё раз через минуту.'
+      } finally {
+        this.reportSending = false
+      }
+    },
+    goHome() {
+      this.$router.push('/')
+    },
+    reload() {
+      window.location.reload()
+    },
+  },
+}
+</script>
+
+<style scoped>
+.err500 {
+  min-height: 100vh;
+  background:
+    radial-gradient(1200px 700px at 15% 0%, #eef0ff 0%, transparent 55%),
+    radial-gradient(900px 600px at 100% 100%, #ffe4e6 0%, transparent 50%),
+    #f5f6fa;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  color: #1a1a1a;
+}
+.err500__grid {
+  position: fixed;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(79, 91, 223, 0.06) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(79, 91, 223, 0.06) 1px, transparent 1px);
+  background-size: 60px 60px;
+  pointer-events: none;
+  z-index: 0;
+}
+.err500__bg-number {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  z-index: 0;
+  pointer-events: none;
+  user-select: none;
+  overflow: hidden;
+}
+.err500__bg-number span {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 900;
+  font-size: clamp(400px, 82vh, 900px);
+  line-height: 0.78;
+  color: #4F5BDF;
+  opacity: 0.08;
+  letter-spacing: -0.08em;
+  white-space: nowrap;
+  transform: translateY(-4%);
+}
+.err500__topbar {
+  position: relative;
+  z-index: 3;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 28px 48px;
+}
+.err500__brand {
+  font-weight: 700;
+  font-size: 15px;
+  letter-spacing: 0.5px;
+}
+.err500__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 16px;
+  border-radius: 999px;
+  background: #fee2e2;
+  color: #dc2626;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+}
+.err500__chip::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #dc2626;
+  animation: err500_pulse 1.5s ease-in-out infinite;
+}
+@keyframes err500_pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%      { opacity: 0.4; transform: scale(1.5); }
+}
+.err500__main {
+  position: relative;
+  z-index: 2;
+  flex: 1;
+  display: grid;
+  grid-template-columns: 1.1fr 1fr;
+  align-items: center;
+  gap: 80px;
+  padding: 20px 96px 60px;
+}
+.err500__kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 4px;
+  color: #dc2626;
+  text-transform: uppercase;
+  margin-bottom: 24px;
+}
+.err500__kicker::before {
+  content: '';
+  width: 36px;
+  height: 2px;
+  background: #dc2626;
+}
+.err500__title {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 800;
+  font-size: clamp(48px, 6vw, 80px);
+  line-height: 1.02;
+  letter-spacing: -0.025em;
+  margin: 0 0 28px;
+  max-width: 820px;
+}
+.err500__title em {
+  font-style: normal;
+  color: #4F5BDF;
+  font-weight: 800;
+}
+.err500__lede {
+  font-size: 17px;
+  line-height: 1.6;
+  color: #6b7280;
+  margin: 0 0 36px;
+  max-width: 540px;
+}
+.err500__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  max-width: 540px;
+}
+.err500__btn {
+  font-family: inherit;
+  font-size: 15px;
+  font-weight: 500;
+  padding: 14px 28px;
+  border-radius: 30px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+}
+.err500__btn--primary {
+  background: #4F5BDF;
+  color: #fff;
+  border-color: #4F5BDF;
+}
+.err500__btn--primary:hover:not(:disabled) {
+  background: #3d49c7;
+  border-color: #3d49c7;
+}
+.err500__btn--primary:disabled {
+  background: #e5e7eb;
+  color: #9ca3af;
+  border-color: #e5e7eb;
+  cursor: not-allowed;
+}
+.err500__btn--outlined {
+  background: transparent;
+  color: #4F5BDF;
+  border-color: #4F5BDF;
+}
+.err500__btn--outlined:hover {
+  background: #eef0ff;
+}
+.err500__actions-row {
+  display: flex;
+  gap: 12px;
+}
+.err500__actions-row .err500__btn {
+  flex: 1;
+}
+.err500__hint {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.55;
+  color: #6b7280;
+}
+.err500__hint--success {
+  color: #047857;
+  font-weight: 500;
+}
+.err500__hint--error {
+  color: #dc2626;
+}
+.err500__evidence {
+  position: relative;
+}
+.err500__evidence-inner {
+  background: #fff;
+  border: 1px solid #e6e6e6;
+  border-radius: 30px;
+  padding: 36px;
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.08);
+}
+.err500__evidence-label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 3px;
+  text-transform: uppercase;
+  color: #6b7280;
+  margin-bottom: 14px;
+  display: flex;
+  justify-content: space-between;
+}
+.err500__code {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 14.5px;
+  background: #0f1129;
+  color: #a5b4fc;
+  padding: 22px 26px;
+  border-radius: 20px;
+  line-height: 1.7;
+  overflow-x: auto;
+  margin: 0;
+}
+.err500__code .c500-k { color: #fbbf24; }
+.err500__code .c500-s { color: #fca5a5; }
+.err500__meta {
+  margin: 24px 0 0;
+  padding-top: 20px;
+  border-top: 1px dashed #e6e6e6;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 18px 24px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 14px;
+}
+.err500__meta dt {
+  font-family: 'Montserrat', sans-serif;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: #9ca0b0;
+  margin-bottom: 6px;
+}
+.err500__meta dd {
+  margin: 0 0 4px;
+  color: #1a1a1a;
+  font-weight: 500;
+}
+
+@media (max-width: 1100px) {
+  .err500__main {
+    grid-template-columns: 1fr;
+    padding: 10px 40px 40px;
+    gap: 40px;
+  }
+  .err500__title {
+    font-size: clamp(40px, 9vw, 64px);
+  }
+}
+@media (max-width: 640px) {
+  .err500__topbar {
+    padding: 20px 24px;
+  }
+  .err500__main {
+    padding: 10px 24px 30px;
+  }
+  .err500__actions-row {
+    flex-direction: column;
+  }
+  .err500__evidence-inner {
+    padding: 24px 20px;
+  }
+  .err500__bg-number span {
+    font-size: 440px;
+  }
+}
+</style>

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,11 @@ type Config struct {
 	// всегда true (HTTPS). На локальной разработке (http://localhost) - false,
 	// иначе браузер не отправит cookie.
 	CookieSecure bool `env:"COOKIE_SECURE" envDefault:"true"`
+
+	// Telegram bot для bug-report-ов со страницы Error500. Оба поля опциональные:
+	// если пустые - репорты пишутся только в БД, TG-отправка пропускается (warn-лог).
+	TelegramBotToken string `env:"TELEGRAM_BOT_TOKEN" envDefault:""`
+	TelegramChatID   string `env:"TELEGRAM_CHAT_ID" envDefault:""`
 }
 
 func Load() (*Config, error) {

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -81,6 +81,7 @@ func AllModels() []interface{} {
 		// Feedback & notifications
 		&models.Feedback{},
 		&models.Notification{},
+		&models.BugReport{},
 
 		// News
 		&models.News{},

--- a/internal/handlers/bug_report.go
+++ b/internal/handlers/bug_report.go
@@ -1,0 +1,62 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+
+	"github.com/labstack/echo/v4"
+)
+
+type BugReportHandler struct {
+	service services.BugReportService
+}
+
+// NewBugReportHandler создаёт хендлер для POST /api/bug-report.
+func NewBugReportHandler(service services.BugReportService) *BugReportHandler {
+	return &BugReportHandler{service: service}
+}
+
+// Submit godoc
+// @Summary      Отправить отчёт о баге
+// @Description  Принимает с фронта bug_hash и контекст 500-ошибки, записывает
+// @Description  в bug_reports и асинхронно отправляет в Telegram. Один юзер -
+// @Description  один репорт на конкретный bug_hash (409 при повторе).
+// @Tags         bug-report
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        request body models.BugReportRequest true "Контекст ошибки"
+// @Success      200 {object} models.BugReport
+// @Failure      400 {object} models.HTTPError "Invalid request"
+// @Failure      401 {object} models.HTTPError
+// @Failure      409 {object} models.HTTPError "Already reported"
+// @Failure      429 {object} models.HTTPError "Rate limit exceeded"
+// @Router       /bug-report [post]
+func (h *BugReportHandler) Submit(c echo.Context) error {
+	var req models.BugReportRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+
+	userID := c.Get("user_id").(int)
+	username, _ := c.Get("username").(string)
+
+	// UserAgent обрезаем на границе базы (size:255) на стороне модели,
+	// но лучше обрежем тут явно, чтобы не полагаться на silent truncate БД.
+	ua := c.Request().UserAgent()
+	if len(ua) > 255 {
+		ua = ua[:255]
+	}
+
+	report, err := h.service.Submit(c.Request().Context(), userID, username, req, ua)
+	if err != nil {
+		if errors.Is(err, services.ErrBugAlreadyReported) {
+			return echo.NewHTTPError(http.StatusConflict, "Вы уже отправляли отчёт об этом баге")
+		}
+		return err
+	}
+	return RespondSuccess(c, report)
+}

--- a/internal/handlers/bug_report_test.go
+++ b/internal/handlers/bug_report_test.go
@@ -1,0 +1,95 @@
+package handlers_test
+
+import (
+	"net/http"
+	"testing"
+
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBugReport_Unauthorized(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	body := `{"bug_hash":"abc12345","route":"POST /applications","http_status":500,"message":"Internal Server Error"}`
+	rec := testutil.POST(t, e, "/bug-report", body, nil)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestBugReport_Submit_Ok(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "buguser", "password123", 1, td.OrgID, td.CompanyID)
+	body := `{"bug_hash":"abc12345","route":"POST /applications","http_status":500,"message":"Internal Server Error"}`
+
+	rec := testutil.POST(t, e, "/bug-report", body, testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	data := testutil.ParseMap(t, rec)
+	assert.Equal(t, "abc12345", data["bug_hash"])
+	assert.Equal(t, float64(500), data["http_status"])
+}
+
+func TestBugReport_Submit_Duplicate_409(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "duper", "password123", 1, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+	body := `{"bug_hash":"dup123ab","route":"GET /news","http_status":500,"message":"boom"}`
+
+	rec := testutil.POST(t, e, "/bug-report", body, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Второй раз тот же bug_hash - 409
+	rec2 := testutil.POST(t, e, "/bug-report", body, h)
+	assert.Equal(t, http.StatusConflict, rec2.Code)
+}
+
+func TestBugReport_Submit_RateLimit_429(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "rateuser", "password123", 1, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	// Лимит - 3 репорта за 5 минут. Четвёртый уходит в 429.
+	hashes := []string{"h1234567", "h2345678", "h3456789"}
+	for _, hx := range hashes {
+		body := `{"bug_hash":"` + hx + `","route":"/x","http_status":500,"message":"x"}`
+		rec := testutil.POST(t, e, "/bug-report", body, h)
+		require.Equal(t, http.StatusOK, rec.Code, "hash %s", hx)
+	}
+	body4 := `{"bug_hash":"h4567890","route":"/x","http_status":500,"message":"x"}`
+	rec := testutil.POST(t, e, "/bug-report", body4, h)
+	assert.Equal(t, http.StatusTooManyRequests, rec.Code)
+}
+
+func TestBugReport_Submit_InvalidPayload_400(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "badpayload", "password123", 1, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	// слишком короткий bug_hash (меньше 8)
+	rec := testutil.POST(t, e, "/bug-report", `{"bug_hash":"ab","route":"/x","http_status":500}`, h)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	// невалидный http_status (не в 4xx/5xx)
+	rec = testutil.POST(t, e, "/bug-report", `{"bug_hash":"validhash","route":"/x","http_status":200}`, h)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}

--- a/internal/models/bug_report.go
+++ b/internal/models/bug_report.go
@@ -1,0 +1,29 @@
+package models
+
+import "time"
+
+// BugReport - репорт о клиентской 500-ошибке, отправленный пользователем со страницы Error500.
+// Один юзер может отправить только один репорт на конкретный bug_hash (uniq index),
+// при повторе handler возвращает 409. Stack trace не храним - только route, status
+// и generic HTTP-message (без содержимого ответа сервера) для защиты от leak архитектуры.
+type BugReport struct {
+	ID         int       `json:"id"`
+	UserID     int       `gorm:"index:idx_bug_user_hash,unique" json:"user_id"`
+	BugHash    string    `gorm:"size:16;index:idx_bug_user_hash,unique" json:"bug_hash"`
+	Route      string    `gorm:"size:255" json:"route"`
+	HTTPStatus int       `json:"http_status"`
+	Message    string    `gorm:"size:500" json:"message"`
+	UserAgent  string    `gorm:"size:255" json:"user_agent"`
+	CreatedAt  time.Time `gorm:"index" json:"created_at"`
+}
+
+// BugReportRequest - входной payload POST /api/bug-report.
+// user_id не из body, а из JWT-context. Все поля, которые принимаем от клиента,
+// имеют ограниченный размер и валидацию по максимальной длине - чтобы не принять
+// огромный stack trace если фронт случайно его пришлёт.
+type BugReportRequest struct {
+	BugHash    string `json:"bug_hash" validate:"required,min=8,max=16"`
+	Route      string `json:"route" validate:"required,max=255"`
+	HTTPStatus int    `json:"http_status" validate:"required,gte=400,lte=599"`
+	Message    string `json:"message" validate:"max=500"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -10,7 +10,7 @@ import (
 // Setup регистрирует все маршруты.
 // loginLimiter опционален (nil в тестах) - отдельный per-IP rate limit на /login.
 // В production передаётся mw.LoginRateLimit из cmd/server/main.go.
-func Setup(e *echo.Echo, auth *handlers.AuthHandler, userTypes *handlers.UserTypesHandler, attachments *handlers.AttachmentHandler, lpf *handlers.LicensePlateFormatHandler, cs *handlers.CitizenshipHandler, org *handlers.OrganizationHandler, comp *handlers.CompanyHandler, users *handlers.UsersHandler, up *handlers.UnloadPlaceHandler, cars *handlers.CarHandler, employees *handlers.EmployeeHandler, st *handlers.SystemTableHandler, uc *handlers.UniqueCarHandler, ue *handlers.UniqueEmployeeHandler, fb *handlers.FeedbackHandler, app *handlers.ApplicationHandler, approvers *handlers.ApproverHandler, permissions *handlers.PermissionHandler, consent *handlers.ConsentHandler, settings *handlers.SettingsHandler, news *handlers.NewsHandler, notifications *handlers.NotificationHandler, requestLogs *handlers.RequestLogsHandler, employeesHistory *handlers.EmployeesHistoryHandler, jwtSecret []byte, loginLimiter echo.MiddlewareFunc) {
+func Setup(e *echo.Echo, auth *handlers.AuthHandler, userTypes *handlers.UserTypesHandler, attachments *handlers.AttachmentHandler, lpf *handlers.LicensePlateFormatHandler, cs *handlers.CitizenshipHandler, org *handlers.OrganizationHandler, comp *handlers.CompanyHandler, users *handlers.UsersHandler, up *handlers.UnloadPlaceHandler, cars *handlers.CarHandler, employees *handlers.EmployeeHandler, st *handlers.SystemTableHandler, uc *handlers.UniqueCarHandler, ue *handlers.UniqueEmployeeHandler, fb *handlers.FeedbackHandler, app *handlers.ApplicationHandler, approvers *handlers.ApproverHandler, permissions *handlers.PermissionHandler, consent *handlers.ConsentHandler, settings *handlers.SettingsHandler, news *handlers.NewsHandler, notifications *handlers.NotificationHandler, requestLogs *handlers.RequestLogsHandler, employeesHistory *handlers.EmployeesHistoryHandler, bugReport *handlers.BugReportHandler, jwtSecret []byte, loginLimiter echo.MiddlewareFunc) {
 	// Health check — вне /api, для мониторинга и readiness-проб.
 	e.GET("/health", func(c echo.Context) error {
 		return c.JSON(200, map[string]string{"status": "ok"})
@@ -289,4 +289,7 @@ func Setup(e *echo.Echo, auth *handlers.AuthHandler, userTypes *handlers.UserTyp
 	rlg.GET("/realtime", requestLogs.GetRealtime)
 	rlg.GET("/timeline", requestLogs.GetTimeline)
 	rlg.GET("/export", requestLogs.Export)
+
+	// Bug-report - юзер отправляет со страницы Error500 (POST /api/bug-report)
+	protected.POST("/bug-report", bugReport.Submit)
 }

--- a/internal/services/bug_report_service.go
+++ b/internal/services/bug_report_service.go
@@ -1,0 +1,111 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"systemburo/internal/models"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+// ErrBugAlreadyReported возвращается когда юзер уже отправил репорт на этот bug_hash.
+// Маппится в handler'е в 409 Conflict.
+var ErrBugAlreadyReported = errors.New("bug already reported by this user")
+
+// BugReportService принимает репорт со страницы Error500 и:
+//  1. Проверяет per-user rate limit (3 репорта за 5 минут).
+//  2. INSERT .. ON CONFLICT DO NOTHING (uniq на user_id+bug_hash).
+//  3. Если вставка прошла - асинхронно отправляет в Telegram (fire-and-forget).
+type BugReportService interface {
+	Submit(ctx context.Context, userID int, username string, req models.BugReportRequest, userAgent string) (*models.BugReport, error)
+}
+
+type bugReportService struct {
+	db    *gorm.DB
+	tg    TelegramService
+	limit int           // сколько репортов разрешено за окно
+	win   time.Duration // окно rate limit
+}
+
+// NewBugReportService конструирует сервис. Rate limit: 3 репорта за 5 минут на юзера.
+// Значения фиксированы - тут нет смысла выносить в env.
+func NewBugReportService(db *gorm.DB, tg TelegramService) BugReportService {
+	return &bugReportService{
+		db:    db,
+		tg:    tg,
+		limit: 3,
+		win:   5 * time.Minute,
+	}
+}
+
+func (s *bugReportService) Submit(ctx context.Context, userID int, username string, req models.BugReportRequest, userAgent string) (*models.BugReport, error) {
+	// Rate limit: считаем последние N запросов за окно.
+	since := time.Now().Add(-s.win)
+	var count int64
+	if err := s.db.WithContext(ctx).
+		Model(&models.BugReport{}).
+		Where("user_id = ? AND created_at > ?", userID, since).
+		Count(&count).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "не удалось проверить частоту репортов")
+	}
+	if count >= int64(s.limit) {
+		return nil, echo.NewHTTPError(http.StatusTooManyRequests,
+			fmt.Sprintf("лимит: %d репортов за %s", s.limit, s.win))
+	}
+
+	report := &models.BugReport{
+		UserID:     userID,
+		BugHash:    req.BugHash,
+		Route:      req.Route,
+		HTTPStatus: req.HTTPStatus,
+		Message:    req.Message,
+		UserAgent:  userAgent,
+		CreatedAt:  time.Now(),
+	}
+
+	// INSERT .. ON CONFLICT DO NOTHING эквивалент: Create с ошибкой по uniq index.
+	// GORM возвращает ошибку Duplicate key - проверяем по RowsAffected=0 после
+	// Clauses(OnConflict{DoNothing}).
+	res := s.db.WithContext(ctx).
+		Exec(`INSERT INTO bug_reports (user_id, bug_hash, route, http_status, message, user_agent, created_at)
+		      VALUES (?, ?, ?, ?, ?, ?, ?) ON CONFLICT (user_id, bug_hash) DO NOTHING`,
+			report.UserID, report.BugHash, report.Route, report.HTTPStatus,
+			report.Message, report.UserAgent, report.CreatedAt)
+	if res.Error != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "не удалось сохранить репорт")
+	}
+	if res.RowsAffected == 0 {
+		return nil, ErrBugAlreadyReported
+	}
+
+	// Подгрузим ID свежесозданной записи (нужно для ответа и TG).
+	if err := s.db.WithContext(ctx).
+		Where("user_id = ? AND bug_hash = ?", report.UserID, report.BugHash).
+		First(report).Error; err != nil {
+		// Запись точно есть (мы только что вставили) - если тут ошибка,
+		// это серьёзно, но TG уже смысла слать нет.
+		slog.Error("bug_report saved but readback failed", "error", err)
+		return report, nil
+	}
+
+	// Fire-and-forget: TG-отправка не должна блокировать API.
+	go func() {
+		// Свежий context - родительский мог завершиться.
+		sendCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := s.tg.SendBugReport(sendCtx, report, username); err != nil {
+			slog.Error("telegram delivery failed",
+				"bug_hash", report.BugHash,
+				"user_id", report.UserID,
+				"error", err)
+		}
+	}()
+
+	return report, nil
+}

--- a/internal/services/telegram_service.go
+++ b/internal/services/telegram_service.go
@@ -1,0 +1,157 @@
+package services
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"systemburo/internal/models"
+)
+
+// TelegramService отправляет сообщения в канал/чат через Telegram Bot API.
+// Используется best-effort: при неудаче логируем slog.Error, но не блокируем
+// основной флоу (bug_report уже записан в БД).
+type TelegramService interface {
+	SendBugReport(ctx context.Context, report *models.BugReport, username string) error
+}
+
+type telegramService struct {
+	botToken   string
+	chatID     string
+	apiBaseURL string
+	httpClient *http.Client
+	// backoffBase - стартовый интервал retry. В проде 1с, в тестах выставляется
+	// через newTelegramServiceForTest для ускорения.
+	backoffBase time.Duration
+}
+
+const telegramAPIBaseURL = "https://api.telegram.org"
+
+// NewTelegramService создаёт TG-клиент. Если botToken или chatID пустые -
+// возвращает nil-подобный сервис, который в SendBugReport логирует предупреждение
+// и возвращает nil. Это позволяет запускаться без TG в dev-окружении.
+func NewTelegramService(botToken, chatID string) TelegramService {
+	return &telegramService{
+		botToken:    botToken,
+		chatID:      chatID,
+		apiBaseURL:  telegramAPIBaseURL,
+		backoffBase: time.Second,
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+type telegramSendRequest struct {
+	ChatID    string `json:"chat_id"`
+	Text      string `json:"text"`
+	ParseMode string `json:"parse_mode"`
+}
+
+// SendBugReport форматирует отчёт и отправляет в TG. Retry до 3 попыток с exp backoff.
+// Если botToken/chatID не настроены - только warn и return nil (не error), чтобы
+// bug_report сохранялся в БД даже без TG-интеграции.
+func (s *telegramService) SendBugReport(ctx context.Context, report *models.BugReport, username string) error {
+	if s.botToken == "" || s.chatID == "" {
+		slog.Warn("telegram not configured, bug_report stored only in db",
+			"bug_hash", report.BugHash)
+		return nil
+	}
+
+	text := formatBugReport(report, username)
+	payload := telegramSendRequest{
+		ChatID:    s.chatID,
+		Text:      text,
+		ParseMode: "Markdown",
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal telegram payload: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/bot%s/sendMessage", s.apiBaseURL, s.botToken)
+	backoff := s.backoffBase
+	var lastErr error
+	for attempt := 1; attempt <= 3; attempt++ {
+		err := s.sendOnce(ctx, url, body)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		slog.Warn("telegram send failed, will retry",
+			"attempt", attempt,
+			"error", err,
+			"bug_hash", report.BugHash)
+		if attempt < 3 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(backoff):
+			}
+			backoff *= 2
+		}
+	}
+	return fmt.Errorf("telegram send failed after 3 attempts: %w", lastErr)
+}
+
+func (s *telegramService) sendOnce(ctx context.Context, url string, body []byte) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("new request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("do request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	return fmt.Errorf("unexpected status: %d", resp.StatusCode)
+}
+
+// formatBugReport - Markdown-форматирование для TG.
+// Экранирование Markdown в Telegram упрощено: сообщения от клиентов
+// не содержат пользовательского ввода (кроме UserAgent), поэтому
+// достаточно базовой проверки на backticks в message.
+func formatBugReport(r *models.BugReport, username string) string {
+	return fmt.Sprintf(
+		"*Bug report* `%s`\n\n"+
+			"*Пользователь:* %s (id=%d)\n"+
+			"*Маршрут:* `%s`\n"+
+			"*Статус:* %d\n"+
+			"*Сообщение:* %s\n"+
+			"*User-Agent:* %s\n"+
+			"*Время:* %s",
+		r.BugHash,
+		sanitizeForMarkdown(username),
+		r.UserID,
+		sanitizeForMarkdown(r.Route),
+		r.HTTPStatus,
+		sanitizeForMarkdown(r.Message),
+		sanitizeForMarkdown(r.UserAgent),
+		r.CreatedAt.Format("2006-01-02 15:04:05 MST"),
+	)
+}
+
+// sanitizeForMarkdown удаляет символы, ломающие TG Markdown.
+func sanitizeForMarkdown(s string) string {
+	// Убираем backticks и звёздочки - достаточно для целостности форматирования
+	replacer := map[rune]rune{'`': '\'', '*': '·'}
+	out := make([]rune, 0, len(s))
+	for _, r := range s {
+		if repl, ok := replacer[r]; ok {
+			out = append(out, repl)
+		} else {
+			out = append(out, r)
+		}
+	}
+	return string(out)
+}

--- a/internal/services/telegram_service_test.go
+++ b/internal/services/telegram_service_test.go
@@ -1,0 +1,123 @@
+package services
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"systemburo/internal/models"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testReport() *models.BugReport {
+	return &models.BugReport{
+		BugHash:    "abc123de",
+		UserID:     42,
+		Route:      "POST /applications",
+		HTTPStatus: 500,
+		Message:    "Internal Server Error",
+		UserAgent:  "Mozilla/5.0",
+		CreatedAt:  time.Now(),
+	}
+}
+
+// newTestTelegramService - сервис с подменённым API URL и ускоренным backoff
+// для тестов. Воспроизводит NewTelegramService, но не делает реальных запросов
+// к api.telegram.org.
+func newTestTelegramService(apiURL, token, chatID string) *telegramService {
+	return &telegramService{
+		botToken:    token,
+		chatID:      chatID,
+		apiBaseURL:  apiURL,
+		backoffBase: 5 * time.Millisecond,
+		httpClient:  &http.Client{Timeout: 2 * time.Second},
+	}
+}
+
+// Пустой bot token - сервис не должен делать сетевой запрос и возвращать nil.
+func TestTelegramService_EmptyConfig_NoRequest(t *testing.T) {
+	calls := int32(0)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	s := NewTelegramService("", "")
+	err := s.SendBugReport(context.Background(), testReport(), "alice")
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&calls))
+}
+
+// Happy path - успешно отправляется с первого раза.
+func TestTelegramService_Success(t *testing.T) {
+	calls := int32(0)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		assert.Equal(t, "/bottest-token/sendMessage", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	s := newTestTelegramService(srv.URL, "test-token", "test-chat")
+	err := s.SendBugReport(context.Background(), testReport(), "alice")
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls))
+}
+
+// 5xx ответы: 2 попытки 500, третья 200 - считаем успехом, три вызова.
+func TestTelegramService_RetryOn5xx_ThenSucceeds(t *testing.T) {
+	calls := int32(0)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	s := newTestTelegramService(srv.URL, "t", "c")
+	err := s.SendBugReport(context.Background(), testReport(), "alice")
+	require.NoError(t, err)
+	assert.Equal(t, int32(3), atomic.LoadInt32(&calls))
+}
+
+// Все 3 попытки 500 - возвращаем ошибку.
+func TestTelegramService_AllRetriesFail(t *testing.T) {
+	calls := int32(0)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	s := newTestTelegramService(srv.URL, "t", "c")
+	err := s.SendBugReport(context.Background(), testReport(), "alice")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "after 3 attempts")
+	assert.Equal(t, int32(3), atomic.LoadInt32(&calls))
+}
+
+// Проверка, что format содержит критичные поля.
+func TestFormatBugReport_ContainsFields(t *testing.T) {
+	r := testReport()
+	text := formatBugReport(r, "alice")
+	assert.Contains(t, text, r.BugHash)
+	assert.Contains(t, text, r.Route)
+	assert.Contains(t, text, "500")
+	assert.Contains(t, text, "alice")
+}
+
+// Sanitize: backtick и звёздочки замещаются.
+func TestSanitizeForMarkdown(t *testing.T) {
+	out := sanitizeForMarkdown("hello `backtick` *star*")
+	assert.NotContains(t, out, "`")
+	assert.NotContains(t, out, "*")
+}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -138,6 +138,9 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	permissionHandler := handlers.NewPermissionHandler(permissionService)
 	consentHandler := handlers.NewConsentHandler(consentService, db)
 	settingsHandler := handlers.NewSettingsHandler(settingsService)
+	telegramService := services.NewTelegramService("", "")
+	bugReportService := services.NewBugReportService(db, telegramService)
+	bugReportHandler := handlers.NewBugReportHandler(bugReportService)
 
 	// Setup Echo with routes (no rate limiter, no logger — clean for tests)
 	e := echo.New()
@@ -150,7 +153,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 		citizenshipHandler, organizationHandler, companyHandler, usersHandler,
 		unloadPlaceHandler, carHandler, employeeHandler, systemTableHandler,
 		uniqueCarHandler, uniqueEmployeeHandler, feedbackHandler,
-		applicationHandler, approverHandler, permissionHandler, consentHandler, settingsHandler, newsHandler, notificationHandler, requestLogsHandler, employeesHistoryHandler, []byte(TestJWTSecret), nil)
+		applicationHandler, approverHandler, permissionHandler, consentHandler, settingsHandler, newsHandler, notificationHandler, requestLogsHandler, employeesHistoryHandler, bugReportHandler, []byte(TestJWTSecret), nil)
 
 	// No-op cleanup: shared DB stays open for the test binary lifetime.
 	cleanup := func() {}


### PR DESCRIPTION
Closes #158

## Summary
- Стилизованная страница 500 ошибки (`/500`) с кнопкой «Отправить отчёт разработчикам»
- Бэк принимает POST `/api/bug-report` и асинхронно форвардит в Telegram-канал через бота (env-конфиг)
- Дедуп: `sha256(route+status+message)[:16]` + uniq `(user_id, bug_hash)` → второй репорт на тот же баг возвращает 409

## Безопасность
- Фронт **не** показывает stack trace / response body / имена функций - только `STATUS`, `REQUEST` (маршрут который у юзера и так в URL), `ID` инцидента и `TIME`
- Бэк сохраняет в `bug_reports` только те же безопасные поля (без server log)
- Per-user rate limit 3 репорта за 5 минут (защита от спама)
- TG-клиент: 3 retry с exp backoff; без конфига warn + skip (репорт остаётся в БД)
- Interceptor редиректит на `/500` только для 5xx; `/refresh-token`, `/login`, `/bug-report` не перехватываются (иначе loop)

## Тесты
- `go test ./internal/services/... -run TestTelegram -v` — 4 зелёных (empty config, happy, retry→success, all fail)
- `go test ./internal/handlers/... -run TestBugReport -v` — 5 зелёных (401, 200, 409 duplicate, 429 rate limit, 400 invalid)
- `npm run lint` — чистый
- `npm run build` — успешный, Error500 бандлится отдельным chunk'ом (6 kB)

## Test plan
- [ ] После деплоя: на staging искусственно вызвать 500 (например временный `panic`) → фронт редиректит на `/500`
- [ ] Нажать «Отправить отчёт» → в TG-канал прилетает сообщение с bug_hash, user, route, status
- [ ] Повторный клик → кнопка отключается, 409 на бэке
- [ ] После F5 на `/500` кнопка остаётся disabled (localStorage запомнил)
- [ ] `curl -I https://stagingburo.washka17.site/api/bug-report` без Bearer → 401