### PR TITLE
fix: #116 pts 10+11 - PeopleTable колонки + история сотрудника 500

### DIFF
--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -86,6 +86,32 @@
             >
           </div>
           <div
+            class="col position-col"
+            @click="sortBy('position')"
+          >
+            <p :class="{ 'active-sort': sortField === 'position' }">
+              Должность
+            </p>
+            <img
+              src="@/assets/icons/sort.png"
+              class="sort-icon"
+              :class="{ 'sorted': sortField === 'position', 'desc': sortField === 'position' && sortDirection === 'desc' }"
+            >
+          </div>
+          <div
+            class="col citizenship-col"
+            @click="sortBy('citizenship')"
+          >
+            <p :class="{ 'active-sort': sortField === 'citizenship' }">
+              Гражданство
+            </p>
+            <img
+              src="@/assets/icons/sort.png"
+              class="sort-icon"
+              :class="{ 'sorted': sortField === 'citizenship', 'desc': sortField === 'citizenship' && sortDirection === 'desc' }"
+            >
+          </div>
+          <div
             class="col organization-col"
             @click="sortBy('organization')"
           >
@@ -96,6 +122,19 @@
               src="@/assets/icons/sort.png"
               class="sort-icon"
               :class="{ 'sorted': sortField === 'organization', 'desc': sortField === 'organization' && sortDirection === 'desc' }"
+            >
+          </div>
+          <div
+            class="col pass-places-col"
+            @click="sortBy('pass_places')"
+          >
+            <p :class="{ 'active-sort': sortField === 'pass_places' }">
+              Места прохода
+            </p>
+            <img
+              src="@/assets/icons/sort.png"
+              class="sort-icon"
+              :class="{ 'sorted': sortField === 'pass_places', 'desc': sortField === 'pass_places' && sortDirection === 'desc' }"
             >
           </div>
           <div
@@ -201,8 +240,17 @@
                 <div class="col middle-name-col">
                   {{ item.middle_name || '-' }}
                 </div>
+                <div class="col position-col">
+                  {{ item.position || '-' }}
+                </div>
+                <div class="col citizenship-col">
+                  {{ item.citizenshipName || '-' }}
+                </div>
                 <div class="col organization-col">
                   {{ item.organization_name }}
+                </div>
+                <div class="col pass-places-col">
+                  {{ item.pass_places || '-' }}
                 </div>
                 <div class="col date-col">
                   {{ formatDate(item.entry_date_to) }}
@@ -382,8 +430,14 @@ export default {
             case 'middle_name':
             case 'organization':
             case 'status':
+            case 'position':
+            case 'pass_places':
               valueA = (a[this.sortField] || '').toString().toLowerCase();
               valueB = (b[this.sortField] || '').toString().toLowerCase();
+              break;
+            case 'citizenship':
+              valueA = (a.citizenshipName || '').toString().toLowerCase();
+              valueB = (b.citizenshipName || '').toString().toLowerCase();
               break;
             case 'entry_date_to':
               valueA = a.entry_date_to ? new Date(a.entry_date_to) : new Date(0);
@@ -518,6 +572,7 @@ export default {
             organization_name: orgName || 'Не указана',
             entry_date_to: emp.entry_date_to || '',
             pass_time: emp.pass_time || '',
+          pass_places: emp.pass_places || '',
             status: 'Активен',
             applicationId: emp.application_id,
             target_tables: emp.target_tables || [],
@@ -844,14 +899,17 @@ export default {
   white-space: nowrap;
 }
 
-.entry-col { width: 6.5%; }
-.exit-col { width: 8%; }
-.last-name-col { width: 12%; }
-.first-name-col { width: 12%; }
-.middle-name-col { width: 12%; }
-.organization-col { width: 18%; }
-.date-col { width: 11.5%; }
-.time-col { width: 10%; }
+.entry-col { width: 6%; }
+.exit-col { width: 6%; }
+.last-name-col { width: 9%; }
+.first-name-col { width: 8%; }
+.middle-name-col { width: 8%; }
+.position-col { width: 9%; }
+.citizenship-col { width: 8%; }
+.organization-col { width: 11%; }
+.pass-places-col { width: 10%; }
+.date-col { width: 8%; }
+.time-col { width: 8%; }
 .status-col { width: 7%; }
 .actions-col { width: 2%; }
 

--- a/internal/handlers/employees_test.go
+++ b/internal/handlers/employees_test.go
@@ -250,6 +250,71 @@ func TestGetActiveEmployeesForTable_WithActiveEmployee(t *testing.T) {
 	testutil.ParseSlice(t, rec)
 }
 
+// TestEmployeeHistory_ReadEndpoints проверяет что после PUT /territory-status
+// запись в employees_history читается через GET /:id/history и /history/unified
+// без 500. Ранее ломалось из-за обращения к несуществующим полям org.short_name.
+func TestEmployeeHistory_ReadEndpoints(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	// Создать сотрудника напрямую в БД (без полной заявки для простоты).
+	lastName, firstName := "TestLast", "TestFirst"
+	pos := "TestPos"
+	status := 1
+	employee := models.Employee{
+		LastName:  &lastName,
+		FirstName: &firstName,
+		Position:  &pos,
+		Status:    &status,
+	}
+	require.NoError(t, db.Create(&employee).Error)
+
+	token := testutil.RegisterAndLogin(t, e, "emphist1", "pass123", 1, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	// Регистрируем entry - должен создать запись в employees_history.
+	putBody := `{"territory_status":1,"user_id":null}`
+	rec := testutil.PUT(t, e, fmt.Sprintf("/employees/%d/territory-status", employee.ID), putBody, h)
+	require.Equal(t, http.StatusOK, rec.Code, "PUT territory-status должен пройти")
+
+	// GET /employees/:id/history - раньше возвращал 500, сейчас должен 200 и вернуть запись.
+	rec = testutil.GET(t, e, fmt.Sprintf("/employees/%d/history", employee.ID), h)
+	require.Equal(t, http.StatusOK, rec.Code, "GET /employees/:id/history должен вернуть 200")
+	items := testutil.ParseSlice(t, rec)
+	require.Len(t, items, 1, "должна быть 1 запись entry")
+	assert.Equal(t, "entry", items[0]["action_type"])
+
+	// GET /employees/history/unified - тоже был 500.
+	rec = testutil.GET(t, e,
+		fmt.Sprintf("/employees/history/unified?last_name=%s&first_name=%s", lastName, firstName), h)
+	require.Equal(t, http.StatusOK, rec.Code, "GET /employees/history/unified должен вернуть 200")
+	items = testutil.ParseSlice(t, rec)
+	require.Len(t, items, 1)
+}
+
+// TestGetActiveEmployeesForTable_IncludesExtendedFields проверяет что
+// endpoint возвращает citizenship_name / position / company / pass_places -
+// эти поля нужны PeopleTable.vue для отображения соответствующих колонок.
+func TestGetActiveEmployeesForTable_IncludesExtendedFields(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "empfields1", "pass123", 1, td.OrgID, td.CompanyID)
+	tableID := seedSystemTable(t, db)
+
+	rec := testutil.GET(t, e, fmt.Sprintf("/employees/active-for-table/%d", tableID), testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Даже при пустом списке проверяем что поля декларированы в JSON (через smoke-check:
+	// endpoint не падает с 500 на SQL с новыми JOIN к citizenships). Сами значения
+	// покрываются integration-сценарием с полной заявкой в _WithActiveEmployee.
+	testutil.ParseSlice(t, rec)
+}
+
 func TestGetActiveEmployeesForTable_InvalidID(t *testing.T) {
 	e, db, cleanup := testutil.SetupTestApp(t)
 	defer cleanup()

--- a/internal/services/employee_service.go
+++ b/internal/services/employee_service.go
@@ -50,15 +50,21 @@ type CreateEmployeeResponse struct {
 // --- DTO ответов ---
 
 // TableEmployeeResponse -- сотрудник для отображения в таблице.
+// CitizenshipName / Position / Company / PassPlaces добавлены для отображения
+// соответствующих колонок в PeopleTable.vue (#116 пункт 10).
 type TableEmployeeResponse struct {
-	ID           int     `json:"id"`
-	LastName     string  `json:"last_name"`
-	FirstName    string  `json:"first_name"`
-	MiddleName   *string `json:"middle_name"`
-	Organization *string `json:"organization"`
-	EntryDateTo  *string `json:"entry_date_to"`
-	PassTime     *string `json:"pass_time"`
-	Status       int     `json:"status"`
+	ID              int     `json:"id"`
+	LastName        string  `json:"last_name"`
+	FirstName       string  `json:"first_name"`
+	MiddleName      *string `json:"middle_name"`
+	Organization    *string `json:"organization"`
+	Company         *string `json:"company"`
+	CitizenshipName *string `json:"citizenship_name"`
+	Position        *string `json:"position"`
+	PassPlaces      *string `json:"pass_places"`
+	EntryDateTo     *string `json:"entry_date_to"`
+	PassTime        *string `json:"pass_time"`
+	Status          int     `json:"status"`
 }
 
 // --- Реализация ---
@@ -123,16 +129,22 @@ func (s *employeeService) CreateEmployee(ctx context.Context, req CreateEmployee
 }
 
 // GetActiveEmployeesForTable возвращает активных сотрудников для указанной таблицы.
+// Включает citizenship / position / company / pass_places (#116 пункт 10) чтобы
+// PeopleTable.vue мог отрисовать соответствующие колонки.
 func (s *employeeService) GetActiveEmployeesForTable(ctx context.Context, tableID int) ([]TableEmployeeResponse, error) {
 	type employeeRow struct {
-		ID           int
-		LastName     string
-		FirstName    string
-		MiddleName   *string
-		Organization *string
-		EntryDateTo  *string
-		PassTime     *string
-		Status       *int
+		ID              int
+		LastName        string
+		FirstName       string
+		MiddleName      *string
+		Organization    *string
+		Company         *string
+		CitizenshipName *string
+		Position        *string
+		PassPlaces      *string
+		EntryDateTo     *string
+		PassTime        *string
+		Status          *int
 	}
 
 	rows := make([]employeeRow, 0)
@@ -143,6 +155,15 @@ func (s *employeeService) GetActiveEmployeesForTable(ctx context.Context, tableI
 			e.first_name,
 			e.middle_name,
 			COALESCE(o.name, co.name) AS organization,
+			COALESCE(co.name, '') AS company,
+			c.name AS citizenship_name,
+			e.position,
+			(
+				SELECT STRING_AGG(DISTINCT st.display_name, ', ' ORDER BY st.display_name)
+				FROM employee_target_tables ett2
+				JOIN system_tables st ON ett2.table_id = st.id
+				WHERE ett2.employee_id = e.id
+			) AS pass_places,
 			a.entry_date_to,
 			CONCAT(a.entry_time_from, ' - ', a.entry_time_to) AS pass_time,
 			e.status
@@ -152,13 +173,15 @@ func (s *employeeService) GetActiveEmployeesForTable(ctx context.Context, tableI
 		JOIN applications app ON a.application_id = app.id
 		LEFT JOIN organizations o ON app.organization_id = o.id
 		LEFT JOIN companies co ON app.company_id = co.id
+		LEFT JOIN citizenships c ON e.citizenship_id = c.id
 		WHERE ett.table_id = ?
 		AND e.status = 1
 		AND app.confirmation = ?
 		AND app.status IN (?, ?)
 		AND CURRENT_DATE BETWEEN a.entry_date_from::date AND a.entry_date_to::date
 		GROUP BY e.id, e.last_name, e.first_name, e.middle_name,
-				 o.name, co.name, a.entry_date_to, a.entry_time_from,
+				 o.name, co.name, c.name, e.position,
+				 a.entry_date_to, a.entry_time_from,
 				 a.entry_time_to, e.status
 		ORDER BY e.last_name, e.first_name
 	`, tableID, models.ConfirmationApproved, models.StatusInWork, models.StatusCompleted).Scan(&rows).Error
@@ -173,14 +196,18 @@ func (s *employeeService) GetActiveEmployeesForTable(ctx context.Context, tableI
 			status = *r.Status
 		}
 		employees = append(employees, TableEmployeeResponse{
-			ID:           r.ID,
-			LastName:     r.LastName,
-			FirstName:    r.FirstName,
-			MiddleName:   r.MiddleName,
-			Organization: r.Organization,
-			EntryDateTo:  r.EntryDateTo,
-			PassTime:     r.PassTime,
-			Status:       status,
+			ID:              r.ID,
+			LastName:        r.LastName,
+			FirstName:       r.FirstName,
+			MiddleName:      r.MiddleName,
+			Organization:    r.Organization,
+			Company:         r.Company,
+			CitizenshipName: r.CitizenshipName,
+			Position:        r.Position,
+			PassPlaces:      r.PassPlaces,
+			EntryDateTo:     r.EntryDateTo,
+			PassTime:        r.PassTime,
+			Status:          status,
 		})
 	}
 	return employees, nil

--- a/internal/services/employees_history_service.go
+++ b/internal/services/employees_history_service.go
@@ -106,8 +106,8 @@ const baseSelectSQL = `
 		e.last_name AS employee_last_name,
 		e.first_name AS employee_first_name,
 		e.middle_name AS employee_middle_name,
-		COALESCE(org.short_name, '') AS organization,
-		COALESCE(comp.short_name, '') AS company
+		COALESCE(org.name, '') AS organization,
+		COALESCE(comp.name, '') AS company
 	FROM employees_history eh
 	LEFT JOIN users u ON eh.user_id = u.id
 	LEFT JOIN system_tables st ON eh.table_id = st.id


### PR DESCRIPTION
Закрывает оставшиеся пункты из [issue #116](https://github.com/buropropuskov/systemburo/issues/116) после верификации на staging.

## Пункт 10: PeopleTable не показывал гражданство/должность/места прохода
Бэк DTO \`TableEmployeeResponse\` расширен: \`citizenship_name\`, \`position\`, \`company\`, \`pass_places\` (STRING_AGG по \`employee_target_tables\` -> \`system_tables\`). SQL в \`GetActiveEmployeesForTable\` сгруппирован соответственно.

Фронт \`PeopleTable.vue\`: добавлены 3 новые колонки (Должность, Гражданство, Места прохода), перераспределены ширины чтобы уложились в 100%, добавлена сортировка.

## Пункт 11: GET /employees/:id/history 500 Error
Причина: \`baseSelectSQL\` в \`employees_history_service.go\` обращался к \`org.short_name\`/\`comp.short_name\`, а в \`models.Organization\`/\`Company\` нет поля \`short_name\` - только \`name\`. SQL падал с \"column does not exist\".

Исправлено: \`org.name\`/\`comp.name\`.

## Тесты
- \`TestEmployeeHistory_ReadEndpoints\` - создаёт запись в истории через PUT, потом GET /:id/history и /history/unified возвращают 200 с entry
- \`TestGetActiveEmployeesForTable_IncludesExtendedFields\` - smoke-check что endpoint не падает на расширенном SQL с JOIN \`citizenships\`

Все \`TestEmployees*\` и \`TestGetActive*\` проходят локально.

## Test plan
- [ ] Staging: на /table/post_27 открыть PeopleTable - видны колонки Должность, Гражданство, Места прохода
- [ ] В EmployeeDetailsModal (клик по строке) - Полная история открывается, не 500
- [ ] DevTools: \`GET /api/employees/{id}/history\` -> 200 с массивом записей