### PR TITLE
feat: maintenance mode с супер-админским bypass (#159)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -156,9 +156,10 @@ func main() {
 	settingsService := services.NewSettingsService(db, cfg)
 	telegramService := services.NewTelegramService(cfg.TelegramBotToken, cfg.TelegramChatID)
 	bugReportService := services.NewBugReportService(db, telegramService)
+	maintenanceService := services.NewMaintenanceService(db)
 
 	// Handlers
-	authHandler := handlers.NewAuthHandler(authService, cfg.CookieSecure, cfg.JWTRefreshTTL)
+	authHandler := handlers.NewAuthHandler(authService, maintenanceService, cfg.CookieSecure, cfg.JWTRefreshTTL)
 	userTypesHandler := handlers.NewUserTypesHandler(userTypeService)
 	lpfHandler := handlers.NewLicensePlateFormatHandler(lpfService)
 	attachmentHandler := handlers.NewAttachmentHandler(attachmentService)
@@ -183,6 +184,7 @@ func main() {
 	consentHandler := handlers.NewConsentHandler(consentService, db)
 	settingsHandler := handlers.NewSettingsHandler(settingsService)
 	bugReportHandler := handlers.NewBugReportHandler(bugReportService)
+	maintenanceHandler := handlers.NewMaintenanceHandler(maintenanceService)
 
 	// Swagger UI: http://localhost:8090/swagger/index.html
 	if cfg.SwaggerEnabled {
@@ -195,9 +197,10 @@ func main() {
 	// Защита от онлайн brute-force до попадания в Argon2id (который замедляет
 	// только офлайн-атаки). Дополняется per-user lockout в authService.Login.
 	loginLimiter := mw.LoginRateLimit(5, 15*time.Minute)
+	maintenanceBlock := mw.MaintenanceBlock(maintenanceService)
 
 	// Routes
-	router.Setup(e, authHandler, userTypesHandler, attachmentHandler, lpfHandler, citizenshipHandler, organizationHandler, companyHandler, usersHandler, unloadPlaceHandler, carHandler, employeeHandler, systemTableHandler, uniqueCarHandler, uniqueEmployeeHandler, feedbackHandler, applicationHandler, approverHandler, permissionHandler, consentHandler, settingsHandler, newsHandler, notificationHandler, requestLogsHandler, employeesHistoryHandler, bugReportHandler, []byte(cfg.JWTSecret), loginLimiter)
+	router.Setup(e, authHandler, userTypesHandler, attachmentHandler, lpfHandler, citizenshipHandler, organizationHandler, companyHandler, usersHandler, unloadPlaceHandler, carHandler, employeeHandler, systemTableHandler, uniqueCarHandler, uniqueEmployeeHandler, feedbackHandler, applicationHandler, approverHandler, permissionHandler, consentHandler, settingsHandler, newsHandler, notificationHandler, requestLogsHandler, employeesHistoryHandler, bugReportHandler, maintenanceHandler, maintenanceBlock, []byte(cfg.JWTSecret), loginLimiter)
 
 	// Общий ctx для фоновых задач и graceful shutdown. Отменяется по SIGINT/SIGTERM.
 	ctxSig, stopSig := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -69,7 +69,7 @@ export default {
      * поверх формы логина. На /500 chrome тоже скрываем - это full-page view.
      */
     showChrome() {
-      const hidePaths = ['/', '/500']
+      const hidePaths = ['/', '/500', '/maintenance']
       return this.isAuthenticated && !hidePaths.includes(this.$route.path);
     }
   },

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,4 +1,5 @@
 import { useAuthStore } from '@/stores/auth'
+import { useMaintenanceStore } from '@/stores/maintenance'
 import router from '@/router'
 import { buildBugContext, saveBugContext } from '@/composables/useBugReport'
 
@@ -108,6 +109,20 @@ function shouldHandleAsServerError(path, status) {
 async function baseRequest(path, options = {}) {
   const authStore = useAuthStore()
   let response = await doFetch(path, options, authStore.token)
+
+  // 503 Service Unavailable = maintenance. Только что узнали об этом на лету -
+  // обновляем стор (чтобы guard начал редиректить сразу) и шлём юзера на
+  // /maintenance. Не путаем с 500 - у maintenance отдельная страница и нет
+  // bug-report'а.
+  if (response.status === 503 && router.currentRoute.value.path !== '/maintenance') {
+    try {
+      await useMaintenanceStore().fetchStatus()
+    } catch {
+      // не критично
+    }
+    router.push('/maintenance')
+    return response
+  }
 
   // 5xx -> сохраняем безопасный контекст и редиректим на /500.
   // Ответ не читаем: тело может содержать детали ошибки, которые нам

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -5,6 +5,7 @@ import router from './router'
 import { vPermission } from './directives/permission'
 import bus from './eventBus'
 import { tryRestoreSession } from '@/api/client'
+import { useMaintenanceStore } from '@/stores/maintenance'
 import './assets/tokens.css'
 
 const app = createApp(App)
@@ -18,6 +19,9 @@ app.directive('permission', vPermission)
 // на /, а наш await tryRestoreSession() применится уже ПОСЛЕ редиректа.
 // Silent fail OK: если cookie мёртв, guard штатно отправит на /.
 await tryRestoreSession()
+// Загружаем maintenance-статус до mount - чтобы router.beforeEach guard мог
+// сразу решать, пускать ли юзера на любую страницу или отправлять на /maintenance.
+await useMaintenanceStore().fetchStatus()
 
 app.use(router)
 await router.isReady()

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router';
 import { useAuthStore } from '@/stores/auth';
+import { useMaintenanceStore } from '@/stores/maintenance';
 import LoginComponent from './components/LoginComponent.vue';
 import TablesComponent from './components/TablesComponent.vue';
 import AccountComponent from './components/AccountComponent.vue';
@@ -113,6 +114,18 @@ const routes = [
     name: 'Error500',
     component: () => import('./views/Error500.vue'),
     meta: { requiresAuth: false }
+  },
+  {
+    path: '/maintenance',
+    name: 'Maintenance',
+    component: () => import('./views/Maintenance.vue'),
+    meta: { requiresAuth: false }
+  },
+  {
+    path: '/admin/system-control',
+    name: 'SystemControl',
+    component: () => import('./views/admin/SystemControl.vue'),
+    meta: { requiresAuth: true, requiresBuro: true }
   }
 ];
 
@@ -127,8 +140,21 @@ const router = createRouter({
 // состояние без async гонок.
 router.beforeEach((to, from, next) => {
   const authStore = useAuthStore();
+  const maintenanceStore = useMaintenanceStore();
   const isAuthenticated = authStore.isAuthenticated;
   const isBuroPropuskov = authStore.isAdmin;
+
+  // Maintenance: если режим включён и юзер не супер-админ - на /maintenance.
+  // Сам /maintenance + /500 доступны всегда чтобы не зациклить.
+  if (
+    maintenanceStore.enabled
+    && !isBuroPropuskov
+    && to.name !== 'Maintenance'
+    && to.name !== 'Error500'
+  ) {
+    next({ name: 'Maintenance' });
+    return;
+  }
 
   if (to.meta.requiresAuth && !isAuthenticated) {
     next('/');

--- a/frontend/src/stores/maintenance.js
+++ b/frontend/src/stores/maintenance.js
@@ -1,0 +1,56 @@
+import { defineStore } from 'pinia'
+
+const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || '') + '/api'
+
+/**
+ * Глобальный стор статуса технических работ.
+ * Заполняется в bootstrap (main.js) через fetchStatus(), потом
+ * перечитывается:
+ *   - на странице /maintenance каждые 30 секунд (auto-refresh)
+ *   - после PUT /admin/maintenance (моментально)
+ */
+export const useMaintenanceStore = defineStore('maintenance', {
+  state: () => ({
+    enabled: false,
+    message: '',
+    startedAt: '',
+    supportEmail: '',
+    loaded: false,
+  }),
+  actions: {
+    /**
+     * Публичный GET без auth - доступен и неавторизованному юзеру на /login.
+     */
+    async fetchStatus() {
+      try {
+        const r = await fetch(`${API_BASE_URL}/settings/maintenance`, {
+          method: 'GET',
+          credentials: 'include',
+          headers: { 'Accept': 'application/json' },
+        })
+        if (!r.ok) {
+          this.loaded = true
+          return
+        }
+        const body = await r.json()
+        const data = body && typeof body === 'object' && 'success' in body ? body.data : body
+        this.enabled = !!data?.enabled
+        this.message = data?.message || ''
+        this.startedAt = data?.started_at || ''
+        this.supportEmail = data?.support_email || ''
+      } catch {
+        // Сетевая ошибка - считаем, что режим не включён, иначе положим сайт
+        // неверным результатом.
+      } finally {
+        this.loaded = true
+      }
+    },
+    setFromPayload(payload) {
+      this.enabled = !!payload?.enabled
+      this.message = payload?.message || ''
+      this.startedAt = payload?.started_at || ''
+      this.supportEmail = payload?.support_email || ''
+      this.loaded = true
+    },
+  },
+})

--- a/frontend/src/views/Maintenance.vue
+++ b/frontend/src/views/Maintenance.vue
@@ -1,0 +1,586 @@
+<template>
+  <div
+    class="mt"
+    data-testid="maintenance-page"
+  >
+    <div class="mt__grid" />
+    <div
+      class="mt__bg-number"
+      aria-hidden="true"
+    >
+      <span>OFF</span>
+    </div>
+
+    <header class="mt__topbar">
+      <span class="mt__brand">Systemburo</span>
+      <div class="mt__chip">
+        Плановое обслуживание
+      </div>
+    </header>
+
+    <main class="mt__main">
+      <section class="mt__hero">
+        <div class="mt__kicker">
+          Статус сервиса
+        </div>
+        <h1 class="mt__title">
+          Технические <em>работы</em>.
+        </h1>
+        <p class="mt__lede">
+          {{ messageText }}
+        </p>
+
+        <div class="mt__actions">
+          <button
+            class="mt__btn mt__btn--primary"
+            data-testid="reload-btn"
+            @click="reload"
+          >
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+            >
+              <polyline points="23 4 23 10 17 10" />
+              <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
+            </svg>
+            Обновить страницу
+          </button>
+          <p class="mt__hint">
+            <span class="mt__tick" />
+            <span class="mt__hint-text">
+              Авто-проверка статуса каждые <b>{{ secondsLeft }}</b> с. Когда сервис вернётся — вас перебросит на главную автоматически.
+            </span>
+          </p>
+        </div>
+      </section>
+
+      <aside class="mt__evidence">
+        <div class="mt__evidence-shape">
+          <svg viewBox="0 0 200 200">
+            <defs>
+              <linearGradient
+                id="mtgg"
+                x1="0%"
+                y1="0%"
+                x2="100%"
+                y2="100%"
+              >
+                <stop
+                  offset="0%"
+                  stop-color="#818cf8"
+                />
+                <stop
+                  offset="100%"
+                  stop-color="#4F5BDF"
+                />
+              </linearGradient>
+            </defs>
+            <g transform="translate(100, 100)">
+              <g fill="url(#mtgg)">
+                <rect
+                  x="-12"
+                  y="-92"
+                  width="24"
+                  height="36"
+                  rx="6"
+                />
+                <rect
+                  x="-12"
+                  y="-92"
+                  width="24"
+                  height="36"
+                  rx="6"
+                  transform="rotate(45)"
+                />
+                <rect
+                  x="-12"
+                  y="-92"
+                  width="24"
+                  height="36"
+                  rx="6"
+                  transform="rotate(90)"
+                />
+                <rect
+                  x="-12"
+                  y="-92"
+                  width="24"
+                  height="36"
+                  rx="6"
+                  transform="rotate(135)"
+                />
+                <rect
+                  x="-12"
+                  y="-92"
+                  width="24"
+                  height="36"
+                  rx="6"
+                  transform="rotate(180)"
+                />
+                <rect
+                  x="-12"
+                  y="-92"
+                  width="24"
+                  height="36"
+                  rx="6"
+                  transform="rotate(225)"
+                />
+                <rect
+                  x="-12"
+                  y="-92"
+                  width="24"
+                  height="36"
+                  rx="6"
+                  transform="rotate(270)"
+                />
+                <rect
+                  x="-12"
+                  y="-92"
+                  width="24"
+                  height="36"
+                  rx="6"
+                  transform="rotate(315)"
+                />
+              </g>
+              <circle
+                r="70"
+                fill="url(#mtgg)"
+                stroke="#3d49c7"
+                stroke-width="3"
+              />
+              <circle
+                r="28"
+                fill="#fff"
+              />
+              <circle
+                r="10"
+                fill="#4F5BDF"
+              />
+            </g>
+          </svg>
+        </div>
+        <div class="mt__evidence-inner">
+          <div class="mt__evidence-label">
+            <span>Deploy log</span>
+          </div>
+          <pre class="mt__code"># deployment pipeline
+<span class="mt-t">[14:02]</span> <span class="mt-step">BACKUP</span>   <span class="mt-ok">ok</span>
+<span class="mt-t">[14:08]</span> <span class="mt-step">SERVICES</span> stopped
+<span class="mt-t">[14:12]</span> <span class="mt-step">MIGRATE</span>  <span class="mt-run">running...</span>
+        schema applied 3/5
+<span class="mt-t">[--:--]</span> <span class="mt-step">SMOKE</span>    <span class="mt-wait">pending</span>
+<span class="mt-t">[--:--]</span> <span class="mt-step">RESTART</span>  <span class="mt-wait">pending</span></pre>
+          <div class="mt__progress">
+            <div class="mt__progress-top">
+              <span class="mt__progress-label">Общий прогресс обновления</span>
+              <span class="mt__progress-pct">60% · 3 из 5</span>
+            </div>
+            <div class="mt__progress-bar">
+              <div class="mt__progress-fill" />
+            </div>
+          </div>
+          <dl class="mt__meta">
+            <div>
+              <dt>Начало</dt>
+              <dd>{{ startedAtText }}</dd>
+            </div>
+            <div>
+              <dt>Ожидаемое окончание</dt>
+              <dd>{{ expectedEndText }}</dd>
+            </div>
+            <div style="grid-column: 1 / -1;">
+              <dt>Контакт</dt>
+              <dd>
+                <a :href="`mailto:${supportEmailText}`">{{ supportEmailText }}</a>
+              </dd>
+            </div>
+          </dl>
+        </div>
+      </aside>
+    </main>
+  </div>
+</template>
+
+<script>
+import { useMaintenanceStore } from '@/stores/maintenance'
+
+const POLL_MS = 30_000
+
+export default {
+  name: 'MaintenancePage',
+  data() {
+    return {
+      secondsLeft: 30,
+      tickInterval: null,
+      pollInterval: null,
+    }
+  },
+  computed: {
+    store() {
+      return useMaintenanceStore()
+    },
+    messageText() {
+      return this.store.message
+        || 'Обновляем систему пропусков. Сервис временно недоступен — мы вернёмся, как только закончим проверки. Страница автоматически обновится, когда работы завершатся.'
+    },
+    startedAtText() {
+      if (!this.store.startedAt) return '—'
+      const d = new Date(this.store.startedAt)
+      return d.toLocaleString('ru-RU', {
+        day: '2-digit', month: 'short', year: 'numeric',
+        hour: '2-digit', minute: '2-digit',
+      }) + ' МСК'
+    },
+    expectedEndText() {
+      return '—'
+    },
+    supportEmailText() {
+      return this.store.supportEmail || 'support@buropropuskov.ru'
+    },
+  },
+  mounted() {
+    this.tickInterval = setInterval(() => {
+      this.secondsLeft -= 1
+      if (this.secondsLeft <= 0) this.secondsLeft = 30
+    }, 1000)
+    this.pollInterval = setInterval(async () => {
+      await this.store.fetchStatus()
+      if (!this.store.enabled) {
+        // Режим выключен - редиректим на главную (бутстрап распределит дальше).
+        window.location.href = '/'
+      }
+    }, POLL_MS)
+  },
+  beforeUnmount() {
+    if (this.tickInterval) clearInterval(this.tickInterval)
+    if (this.pollInterval) clearInterval(this.pollInterval)
+  },
+  methods: {
+    reload() {
+      window.location.reload()
+    },
+  },
+}
+</script>
+
+<style scoped>
+.mt {
+  min-height: 100vh;
+  background:
+    radial-gradient(1200px 700px at 15% 0%, #eef0ff 0%, transparent 55%),
+    radial-gradient(900px 600px at 100% 100%, #ccfbf1 0%, transparent 50%),
+    #f5f6fa;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  color: #1a1a1a;
+}
+.mt__grid {
+  position: fixed;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(79, 91, 223, 0.06) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(79, 91, 223, 0.06) 1px, transparent 1px);
+  background-size: 60px 60px;
+  pointer-events: none;
+  z-index: 0;
+}
+.mt__bg-number {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  z-index: 0;
+  pointer-events: none;
+  user-select: none;
+  overflow: hidden;
+}
+.mt__bg-number span {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 900;
+  font-size: clamp(400px, 82vh, 900px);
+  line-height: 0.78;
+  color: #4F5BDF;
+  opacity: 0.08;
+  letter-spacing: -0.08em;
+  white-space: nowrap;
+  transform: translateY(-4%);
+}
+.mt__topbar {
+  position: relative;
+  z-index: 3;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 28px 48px;
+}
+.mt__brand {
+  font-weight: 700;
+  font-size: 15px;
+  letter-spacing: 0.5px;
+}
+.mt__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 16px;
+  border-radius: 999px;
+  background: #eef0ff;
+  color: #4F5BDF;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+}
+.mt__chip::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #4F5BDF;
+  animation: mt_pulse 1.5s ease-in-out infinite;
+}
+@keyframes mt_pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%      { opacity: 0.4; transform: scale(1.5); }
+}
+.mt__main {
+  position: relative;
+  z-index: 2;
+  flex: 1;
+  display: grid;
+  grid-template-columns: 1.1fr 1fr;
+  align-items: center;
+  gap: 80px;
+  padding: 20px 96px 60px;
+}
+.mt__kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 4px;
+  color: #4F5BDF;
+  text-transform: uppercase;
+  margin-bottom: 24px;
+}
+.mt__kicker::before {
+  content: '';
+  width: 36px;
+  height: 2px;
+  background: #4F5BDF;
+}
+.mt__title {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 800;
+  font-size: clamp(48px, 6vw, 80px);
+  line-height: 1.02;
+  letter-spacing: -0.025em;
+  margin: 0 0 28px;
+}
+.mt__title em {
+  font-style: normal;
+  color: #4F5BDF;
+  font-weight: 800;
+}
+.mt__lede {
+  font-size: 17px;
+  line-height: 1.6;
+  color: #6b7280;
+  margin: 0 0 36px;
+  max-width: 540px;
+}
+.mt__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  max-width: 540px;
+}
+.mt__btn {
+  font-family: inherit;
+  font-size: 15px;
+  font-weight: 500;
+  padding: 14px 28px;
+  border-radius: 30px;
+  border: 1px solid #4F5BDF;
+  background: #4F5BDF;
+  color: #fff;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+}
+.mt__btn:hover { background: #3d49c7; border-color: #3d49c7; }
+.mt__hint {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.55;
+  color: #6b7280;
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+.mt__hint-text { flex: 1; }
+.mt__tick {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 2px solid #4F5BDF;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: mt_rotate 1s linear infinite;
+  flex-shrink: 0;
+  margin-top: 3px;
+}
+@keyframes mt_rotate {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+.mt__evidence { position: relative; }
+.mt__evidence-inner {
+  background: #fff;
+  border: 1px solid #e6e6e6;
+  border-radius: 30px;
+  padding: 36px;
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.08);
+}
+.mt__evidence-shape {
+  position: absolute;
+  top: -34px;
+  left: -24px;
+  width: 110px;
+  height: 110px;
+  filter: drop-shadow(0 10px 20px rgba(79, 91, 223, 0.3));
+  z-index: 1;
+}
+.mt__evidence-shape svg {
+  width: 100%;
+  height: 100%;
+  animation: mt_spin 8s linear infinite;
+  transform-origin: 50% 50%;
+}
+@keyframes mt_spin {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+.mt__evidence-label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 3px;
+  text-transform: uppercase;
+  color: #6b7280;
+  margin-bottom: 14px;
+  padding-left: 80px;
+}
+.mt__code {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 14.5px;
+  background: #0f1129;
+  color: #a5b4fc;
+  padding: 22px 26px;
+  border-radius: 20px;
+  line-height: 1.75;
+  overflow-x: auto;
+  margin: 0;
+}
+.mt__code .mt-t { color: #64748b; }
+.mt__code .mt-ok { color: #34d399; }
+.mt__code .mt-run { color: #a5b4fc; font-weight: 600; }
+.mt__code .mt-wait { color: #64748b; }
+.mt__code .mt-step { color: #fff; }
+.mt__progress {
+  margin-top: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.mt__progress-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 13px;
+}
+.mt__progress-label { font-weight: 500; }
+.mt__progress-pct {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 12px;
+  color: #4F5BDF;
+  font-weight: 600;
+}
+.mt__progress-bar {
+  height: 8px;
+  background: #eef0ff;
+  border-radius: 999px;
+  overflow: hidden;
+  position: relative;
+}
+.mt__progress-fill {
+  height: 100%;
+  width: 60%;
+  background: linear-gradient(90deg, #4F5BDF 0%, #818cf8 100%);
+  border-radius: 999px;
+  position: relative;
+  overflow: hidden;
+}
+.mt__progress-fill::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.4), transparent);
+  animation: mt_shimmer 2s linear infinite;
+}
+@keyframes mt_shimmer {
+  from { transform: translateX(-100%); }
+  to   { transform: translateX(100%); }
+}
+.mt__meta {
+  margin: 24px 0 0;
+  padding-top: 20px;
+  border-top: 1px dashed #e6e6e6;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 18px 24px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 14px;
+}
+.mt__meta dt {
+  font-family: 'Montserrat', sans-serif;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: #9ca0b0;
+  margin-bottom: 6px;
+}
+.mt__meta dd {
+  margin: 0 0 4px;
+  color: #1a1a1a;
+  font-weight: 500;
+}
+.mt__meta a { color: #4F5BDF; text-decoration: none; }
+
+@media (max-width: 1100px) {
+  .mt__main {
+    grid-template-columns: 1fr;
+    padding: 10px 40px 40px;
+    gap: 40px;
+  }
+  .mt__evidence-shape { display: none; }
+  .mt__evidence-label { padding-left: 0; }
+  .mt__title { font-size: clamp(40px, 9vw, 64px); }
+}
+@media (max-width: 640px) {
+  .mt__topbar { padding: 20px 24px; }
+  .mt__main { padding: 10px 24px 30px; }
+  .mt__evidence-inner { padding: 24px 20px; }
+  .mt__bg-number span { font-size: 440px; }
+  .mt__meta { grid-template-columns: 1fr; }
+}
+</style>

--- a/frontend/src/views/admin/SystemControl.vue
+++ b/frontend/src/views/admin/SystemControl.vue
@@ -1,0 +1,437 @@
+<template>
+  <div class="sc">
+    <div class="sc__card">
+      <header class="sc__header">
+        <h1>Системное управление</h1>
+        <p class="sc__lede">
+          Скрытая страница управления режимом технических работ. Доступна только
+          супер-админу (<code>type_id = 6</code>) по прямой ссылке, в меню не
+          показывается.
+        </p>
+      </header>
+
+      <section class="sc__status">
+        <div class="sc__status-row">
+          <span class="sc__status-label">Текущий статус</span>
+          <span
+            class="sc__status-pill"
+            :class="{ 'sc__status-pill--on': enabled }"
+          >
+            {{ enabled ? 'ТЕХНИЧЕСКИЕ РАБОТЫ ВКЛЮЧЕНЫ' : 'Сервис работает нормально' }}
+          </span>
+        </div>
+        <p
+          v-if="enabled && startedAt"
+          class="sc__status-meta"
+        >
+          Начало: {{ formatStart(startedAt) }}
+        </p>
+      </section>
+
+      <section class="sc__form">
+        <label class="sc__field">
+          <span class="sc__field-label">Сообщение для пользователей</span>
+          <textarea
+            v-model="draftMessage"
+            class="sc__textarea"
+            rows="3"
+            placeholder="Например: Обновляем систему до v1.5.0, вернёмся к 17:00 МСК"
+            :disabled="busy"
+          />
+        </label>
+        <label class="sc__field">
+          <span class="sc__field-label">Контакт поддержки (email)</span>
+          <input
+            v-model="draftSupportEmail"
+            type="email"
+            class="sc__input"
+            placeholder="support@buropropuskov.ru"
+            :disabled="busy"
+          >
+        </label>
+      </section>
+
+      <section class="sc__actions">
+        <button
+          v-if="!enabled"
+          class="sc__btn sc__btn--primary"
+          :disabled="busy"
+          @click="confirmEnable"
+        >
+          Включить технические работы
+        </button>
+        <button
+          v-else
+          class="sc__btn sc__btn--danger"
+          :disabled="busy"
+          @click="disable"
+        >
+          Выключить технические работы
+        </button>
+        <p class="sc__hint">
+          При включении <strong>отзываются все refresh-токены не-админов</strong> —
+          через ≤15 минут обычных юзеров выбросит на страницу «Технические работы»
+          и они не смогут залогиниться, пока режим активен. Супер-админ
+          (<code>type_id = 6</code>) продолжает работать без ограничений.
+        </p>
+      </section>
+
+      <div
+        v-if="errorText"
+        class="sc__error"
+      >
+        {{ errorText }}
+      </div>
+    </div>
+
+    <!-- Подтверждение включения -->
+    <teleport to="body">
+      <transition name="sc-fade">
+        <div
+          v-if="confirmOpen"
+          class="sc__modal-overlay"
+          @click.self="confirmOpen = false"
+        >
+          <div class="sc__modal">
+            <h2>Включить режим технических работ?</h2>
+            <p>
+              Все активные сессии не-админов будут отозваны. Это действие нужно
+              только если вы делаете обновление системы или миграцию БД.
+            </p>
+            <div class="sc__modal-actions">
+              <button
+                class="sc__btn"
+                @click="confirmOpen = false"
+              >
+                Отмена
+              </button>
+              <button
+                class="sc__btn sc__btn--primary"
+                :disabled="busy"
+                @click="enable"
+              >
+                Да, включить
+              </button>
+            </div>
+          </div>
+        </div>
+      </transition>
+    </teleport>
+  </div>
+</template>
+
+<script>
+import { apiRequest } from '@/api/client'
+import { useMaintenanceStore } from '@/stores/maintenance'
+
+export default {
+  name: 'SystemControl',
+  data() {
+    return {
+      enabled: false,
+      message: '',
+      startedAt: '',
+      supportEmail: '',
+      draftMessage: '',
+      draftSupportEmail: 'support@buropropuskov.ru',
+      busy: false,
+      errorText: '',
+      confirmOpen: false,
+    }
+  },
+  async mounted() {
+    await this.load()
+  },
+  methods: {
+    async load() {
+      this.errorText = ''
+      try {
+        const r = await apiRequest('/admin/maintenance', { method: 'GET' })
+        if (!r.ok) {
+          this.errorText = 'Не удалось загрузить текущий статус.'
+          return
+        }
+        const data = await r.json()
+        this.apply(data)
+      } catch {
+        this.errorText = 'Сеть недоступна.'
+      }
+    },
+    apply(data) {
+      this.enabled = !!data?.enabled
+      this.message = data?.message || ''
+      this.startedAt = data?.started_at || ''
+      this.supportEmail = data?.support_email || ''
+      this.draftMessage = this.message
+      if (data?.support_email) this.draftSupportEmail = data.support_email
+      useMaintenanceStore().setFromPayload(data)
+    },
+    confirmEnable() {
+      this.confirmOpen = true
+    },
+    async enable() {
+      this.busy = true
+      this.errorText = ''
+      try {
+        const r = await apiRequest('/admin/maintenance', {
+          method: 'PUT',
+          body: JSON.stringify({
+            enabled: true,
+            message: this.draftMessage,
+            support_email: this.draftSupportEmail,
+          }),
+        })
+        if (!r.ok) {
+          this.errorText = 'Не удалось включить режим.'
+          return
+        }
+        const data = await r.json()
+        this.apply(data)
+        this.confirmOpen = false
+      } catch {
+        this.errorText = 'Сеть недоступна.'
+      } finally {
+        this.busy = false
+      }
+    },
+    async disable() {
+      this.busy = true
+      this.errorText = ''
+      try {
+        const r = await apiRequest('/admin/maintenance', {
+          method: 'PUT',
+          body: JSON.stringify({ enabled: false }),
+        })
+        if (!r.ok) {
+          this.errorText = 'Не удалось выключить режим.'
+          return
+        }
+        const data = await r.json()
+        this.apply(data)
+      } catch {
+        this.errorText = 'Сеть недоступна.'
+      } finally {
+        this.busy = false
+      }
+    },
+    formatStart(iso) {
+      if (!iso) return '—'
+      const d = new Date(iso)
+      return d.toLocaleString('ru-RU', {
+        day: '2-digit', month: 'short', year: 'numeric',
+        hour: '2-digit', minute: '2-digit',
+      }) + ' МСК'
+    },
+  },
+}
+</script>
+
+<style scoped>
+.sc {
+  min-height: calc(100vh - 80px);
+  background: #f5f6fa;
+  padding: 40px 24px;
+  display: flex;
+  justify-content: center;
+}
+.sc__card {
+  width: 100%;
+  max-width: 720px;
+  background: #fff;
+  border: 1px solid #e6e6e6;
+  border-radius: 30px;
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.08);
+  padding: 36px 40px 32px;
+}
+.sc__header h1 {
+  margin: 0 0 10px;
+  font-weight: 700;
+  font-size: 24px;
+  color: #1a1a1a;
+}
+.sc__lede {
+  margin: 0 0 28px;
+  font-size: 14px;
+  line-height: 1.55;
+  color: #6b7280;
+}
+.sc__lede code {
+  background: #f3f4f9;
+  padding: 1px 6px;
+  border-radius: 6px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 12px;
+}
+.sc__status {
+  padding: 16px 20px;
+  background: #f7f7fb;
+  border: 1px solid #e6e6e6;
+  border-radius: 20px;
+  margin-bottom: 28px;
+}
+.sc__status-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+.sc__status-label {
+  font-size: 13px;
+  color: #6b7280;
+  font-weight: 500;
+}
+.sc__status-pill {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: #d1fae5;
+  color: #047857;
+}
+.sc__status-pill--on {
+  background: #ffb3b3;
+  color: #c62828;
+}
+.sc__status-meta {
+  margin: 10px 0 0;
+  font-size: 12px;
+  color: #6b7280;
+}
+.sc__form {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  margin-bottom: 28px;
+}
+.sc__field { display: block; }
+.sc__field-label {
+  display: block;
+  font-size: 13px;
+  font-weight: 500;
+  color: #1a1a1a;
+  margin-bottom: 8px;
+}
+.sc__textarea,
+.sc__input {
+  width: 100%;
+  padding: 12px 16px;
+  border: 1px solid #e6e6e6;
+  border-radius: 16px;
+  font-family: 'Montserrat', sans-serif;
+  font-size: 14px;
+  color: #1a1a1a;
+  background: #fff;
+  resize: vertical;
+}
+.sc__textarea:focus,
+.sc__input:focus {
+  outline: none;
+  border-color: #4F5BDF;
+}
+.sc__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.sc__btn {
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 500;
+  padding: 12px 28px;
+  border-radius: 30px;
+  border: 1px solid #e6e6e6;
+  background: #fff;
+  color: #1a1a1a;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+.sc__btn:hover:not(:disabled) { background: #f3f4f9; }
+.sc__btn:disabled { opacity: 0.6; cursor: not-allowed; }
+.sc__btn--primary {
+  background: #4F5BDF;
+  color: #fff;
+  border-color: #4F5BDF;
+}
+.sc__btn--primary:hover:not(:disabled) {
+  background: #3d49c7;
+  border-color: #3d49c7;
+}
+.sc__btn--danger {
+  background: #c62828;
+  color: #fff;
+  border-color: #c62828;
+}
+.sc__btn--danger:hover:not(:disabled) {
+  background: #a02020;
+  border-color: #a02020;
+}
+.sc__hint {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.55;
+  color: #6b7280;
+}
+.sc__hint code {
+  background: #f3f4f9;
+  padding: 1px 4px;
+  border-radius: 4px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px;
+}
+.sc__error {
+  margin-top: 20px;
+  padding: 12px 16px;
+  border-radius: 12px;
+  background: #fee2e2;
+  color: #c62828;
+  font-size: 13px;
+}
+
+.sc__modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 17, 41, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+  padding: 20px;
+}
+.sc__modal {
+  background: #fff;
+  border-radius: 30px;
+  padding: 32px 36px 28px;
+  max-width: 480px;
+  width: 100%;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
+}
+.sc__modal h2 {
+  margin: 0 0 14px;
+  font-size: 20px;
+  font-weight: 700;
+}
+.sc__modal p {
+  margin: 0 0 24px;
+  font-size: 14px;
+  line-height: 1.55;
+  color: #6b7280;
+}
+.sc__modal-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+.sc-fade-enter-active,
+.sc-fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+.sc-fade-enter-from,
+.sc-fade-leave-to { opacity: 0; }
+
+@media (max-width: 640px) {
+  .sc__card { padding: 28px 24px; }
+  .sc__status-row { flex-direction: column; align-items: flex-start; gap: 8px; }
+}
+</style>

--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -14,6 +14,7 @@ const refreshCookieName = "refresh_token"
 
 type AuthHandler struct {
 	service       services.AuthService
+	maintenance   services.MaintenanceService
 	cookieSecure  bool
 	refreshMaxAge int
 }
@@ -22,9 +23,12 @@ type AuthHandler struct {
 // cookieSecure должен быть true в prod/staging (HTTPS), false только для
 // локальной разработки на http://localhost.
 // refreshTTL задаёт MaxAge для refresh cookie в секундах.
-func NewAuthHandler(service services.AuthService, cookieSecure bool, refreshTTL time.Duration) *AuthHandler {
+// maintenance используется для 503-bypass не-админам на /login при
+// включённом режиме техработ.
+func NewAuthHandler(service services.AuthService, maintenance services.MaintenanceService, cookieSecure bool, refreshTTL time.Duration) *AuthHandler {
 	return &AuthHandler{
 		service:       service,
+		maintenance:   maintenance,
 		cookieSecure:  cookieSecure,
 		refreshMaxAge: int(refreshTTL.Seconds()),
 	}
@@ -74,6 +78,18 @@ func (h *AuthHandler) Login(c echo.Context) error {
 	resp, err := h.service.Login(c.Request().Context(), req, requestMeta(c))
 	if err != nil {
 		return err
+	}
+	// Maintenance-bypass: super-admin (type_id=6) всегда проходит, иначе -
+	// отзываем только что выданный refresh и возвращаем 503. Проверку
+	// делаем после пароля чтобы не выдавать 503 как oracle для подбора
+	// учёток (одинаковая задержка на верный и неверный пароль).
+	if h.maintenance != nil && resp.TypeID != 6 {
+		if st := h.maintenance.GetStatusCached(c.Request().Context()); st != nil && st.Enabled {
+			_ = h.service.Logout(c.Request().Context(), req.Username,
+				models.LogoutRequest{RefreshToken: resp.RefreshToken}, requestMeta(c))
+			return echo.NewHTTPError(http.StatusServiceUnavailable,
+				"Сервис временно недоступен: технические работы")
+		}
 	}
 	// refresh_token уходит в HttpOnly cookie, в JSON его не отдаём.
 	h.setRefreshCookie(c, resp.RefreshToken)

--- a/internal/handlers/maintenance.go
+++ b/internal/handlers/maintenance.go
@@ -1,0 +1,86 @@
+package handlers
+
+import (
+	"net/http"
+
+	"systemburo/internal/services"
+
+	"github.com/labstack/echo/v4"
+)
+
+// MaintenanceHandler обслуживает три endpoint'а:
+//   - GET  /api/settings/maintenance  (public, без JWT) - статус для /maintenance и /login
+//   - GET  /api/admin/maintenance     (admin) - полный статус + message
+//   - PUT  /api/admin/maintenance     (admin) - переключение режима
+type MaintenanceHandler struct {
+	service services.MaintenanceService
+}
+
+func NewMaintenanceHandler(service services.MaintenanceService) *MaintenanceHandler {
+	return &MaintenanceHandler{service: service}
+}
+
+// GetPublicStatus возвращает публичный статус режима техработ (без auth).
+// Используется страницей /maintenance для авто-рефреша и формой /login для
+// проверки, стоит ли давать возможность логиниться.
+func (h *MaintenanceHandler) GetPublicStatus(c echo.Context) error {
+	st, err := h.service.GetStatus(c.Request().Context())
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, st)
+}
+
+// GetAdminStatus возвращает тот же статус для админского экрана SystemControl.
+// Оставлен как отдельный метод - если позже понадобятся доп. поля только для
+// админа (например, кто включил и когда), их можно добавить только сюда.
+func (h *MaintenanceHandler) GetAdminStatus(c echo.Context) error {
+	typeID, _ := c.Get("type_id").(int)
+	if typeID != 6 {
+		return echo.NewHTTPError(http.StatusForbidden, "Доступ только для бюро пропусков")
+	}
+	st, err := h.service.GetStatus(c.Request().Context())
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, st)
+}
+
+// MaintenanceToggleRequest — тело PUT /api/admin/maintenance.
+type MaintenanceToggleRequest struct {
+	Enabled      bool   `json:"enabled"`
+	Message      string `json:"message" validate:"max=500"`
+	SupportEmail string `json:"support_email" validate:"max=255"`
+}
+
+// ToggleMaintenance включает или выключает режим обслуживания.
+// При Enable=true дополнительно revoke non-admin refresh_tokens
+// (см. MaintenanceService.Enable).
+func (h *MaintenanceHandler) ToggleMaintenance(c echo.Context) error {
+	typeID, _ := c.Get("type_id").(int)
+	if typeID != 6 {
+		return echo.NewHTTPError(http.StatusForbidden, "Доступ только для бюро пропусков")
+	}
+	userID, _ := c.Get("user_id").(int)
+	username, _ := c.Get("username").(string)
+
+	var req MaintenanceToggleRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+
+	if req.Enabled {
+		if err := h.service.Enable(c.Request().Context(), userID, username, req.Message, req.SupportEmail); err != nil {
+			return err
+		}
+	} else {
+		if err := h.service.Disable(c.Request().Context(), userID, username); err != nil {
+			return err
+		}
+	}
+	st, err := h.service.GetStatus(c.Request().Context())
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, st)
+}

--- a/internal/handlers/maintenance_test.go
+++ b/internal/handlers/maintenance_test.go
@@ -1,0 +1,132 @@
+package handlers_test
+
+import (
+	"net/http"
+	"testing"
+
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaintenance_PublicStatus_Default(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	// Публичный endpoint без auth.
+	rec := testutil.GET(t, e, "/settings/maintenance", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	m := testutil.ParseMap(t, rec)
+	assert.Equal(t, false, m["enabled"])
+}
+
+func TestMaintenance_AdminGet_Forbidden_ForRegularUser(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "mt_regular", "pass12345", 1, td.OrgID, td.CompanyID)
+	rec := testutil.GET(t, e, "/admin/maintenance", testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestMaintenance_Toggle_AdminOnly(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	adminToken := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(adminToken)
+
+	// Enable
+	body := `{"enabled":true,"message":"БД-миграция 1.5.0","support_email":"support@buropropuskov.ru"}`
+	rec := testutil.PUT(t, e, "/admin/maintenance", body, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	m := testutil.ParseMap(t, rec)
+	assert.Equal(t, true, m["enabled"])
+	assert.Equal(t, "БД-миграция 1.5.0", m["message"])
+
+	// Публичный endpoint тоже должен увидеть enabled=true
+	rec = testutil.GET(t, e, "/settings/maintenance", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	m = testutil.ParseMap(t, rec)
+	assert.Equal(t, true, m["enabled"])
+	assert.Equal(t, "support@buropropuskov.ru", m["support_email"])
+
+	// Disable
+	body = `{"enabled":false}`
+	rec = testutil.PUT(t, e, "/admin/maintenance", body, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	m = testutil.ParseMap(t, rec)
+	assert.Equal(t, false, m["enabled"])
+}
+
+// Enable maintenance должен revoke refresh_tokens всех не-админов. После этого
+// их /refresh-token будет 401, они попадут на /login -> 503.
+func TestMaintenance_Enable_RevokesNonAdminRefreshTokens(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	// Обычный юзер - логинимся, получаем refresh.
+	testutil.RegisterAndLogin(t, e, "mt_regular2", "pass12345", 1, td.OrgID, td.CompanyID)
+	// Супер-админ - включает maintenance.
+	adminToken := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	body := `{"enabled":true,"message":"test"}`
+	rec := testutil.PUT(t, e, "/admin/maintenance", body, testutil.AuthHeader(adminToken))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Проверяем что refresh_tokens обычного юзера помечены revoked.
+	var nonAdminRevoked int64
+	db.Raw(`
+		SELECT COUNT(*) FROM refresh_tokens rt
+		JOIN users u ON rt.user_id = u.id
+		WHERE u.type_id != 6 AND rt.is_revoked = true
+	`).Scan(&nonAdminRevoked)
+	assert.Greater(t, nonAdminRevoked, int64(0), "не-админские refresh_tokens должны быть revoked")
+
+	// Админские refresh_tokens должны остаться активными.
+	var adminActive int64
+	db.Raw(`
+		SELECT COUNT(*) FROM refresh_tokens rt
+		JOIN users u ON rt.user_id = u.id
+		WHERE u.type_id = 6 AND rt.is_revoked = false
+	`).Scan(&adminActive)
+	assert.Greater(t, adminActive, int64(0), "админские refresh_tokens не должны быть revoked")
+}
+
+// При включённом maintenance обычный юзер получает 503 на /login даже с
+// правильными credentials. Super-admin (type_id=6) проходит.
+func TestMaintenance_Login_BlockedForRegular_AllowedForAdmin(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	// Создаём обычного юзера и супер-админа, но не логинимся сразу -
+	// делаем это после включения режима.
+	testutil.RegisterUser(t, e, "mt_user", "pass12345", 1, td.OrgID, td.CompanyID)
+	testutil.RegisterUser(t, e, "mt_admin", "pass12345", 6, td.OrgID, td.CompanyID)
+
+	// Ещё один админ для включения maintenance (текущему mt_admin тоже пойдёт).
+	initialAdminToken := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	body := `{"enabled":true,"message":"work"}`
+	rec := testutil.PUT(t, e, "/admin/maintenance", body, testutil.AuthHeader(initialAdminToken))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Обычный юзер пытается залогиниться - 503
+	loginReq := `{"username":"mt_user","password":"pass12345"}`
+	rec = testutil.POST(t, e, "/login", loginReq, nil)
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code,
+		"обычный юзер должен получать 503 на /login во время maintenance")
+
+	// Super-admin логинится успешно
+	loginReq = `{"username":"mt_admin","password":"pass12345"}`
+	rec = testutil.POST(t, e, "/login", loginReq, nil)
+	assert.Equal(t, http.StatusOK, rec.Code, "super-admin должен логиниться даже во время maintenance")
+}

--- a/internal/middleware/maintenance.go
+++ b/internal/middleware/maintenance.go
@@ -1,0 +1,31 @@
+package middleware
+
+import (
+	"net/http"
+
+	"systemburo/internal/services"
+
+	"github.com/labstack/echo/v4"
+)
+
+// MaintenanceBlock - после JWTAuth блокирует 503-м любой protected-запрос
+// если включён режим техработ. Super-admin (type_id=6) проходит всегда.
+// Для производительности использует GetStatusCached (10-сек in-memory).
+func MaintenanceBlock(svc services.MaintenanceService) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			typeID, _ := c.Get("type_id").(int)
+			// Super-admin проходит всегда - иначе как включать/выключать
+			// maintenance и тестировать систему.
+			if typeID == 6 {
+				return next(c)
+			}
+			st := svc.GetStatusCached(c.Request().Context())
+			if st != nil && st.Enabled {
+				return echo.NewHTTPError(http.StatusServiceUnavailable,
+					"Сервис временно недоступен: технические работы")
+			}
+			return next(c)
+		}
+	}
+}

--- a/internal/middleware/maintenance_test.go
+++ b/internal/middleware/maintenance_test.go
@@ -1,0 +1,67 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"systemburo/internal/services"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+// stubMaintenanceService позволяет тестировать middleware без БД.
+type stubMaintenanceService struct {
+	enabled bool
+}
+
+func (s *stubMaintenanceService) GetStatus(ctx context.Context) (*services.MaintenanceStatus, error) {
+	return &services.MaintenanceStatus{Enabled: s.enabled}, nil
+}
+func (s *stubMaintenanceService) GetStatusCached(ctx context.Context) *services.MaintenanceStatus {
+	return &services.MaintenanceStatus{Enabled: s.enabled}
+}
+func (s *stubMaintenanceService) Enable(ctx context.Context, _ int, _, _, _ string) error {
+	s.enabled = true
+	return nil
+}
+func (s *stubMaintenanceService) Disable(ctx context.Context, _ int, _ string) error {
+	s.enabled = false
+	return nil
+}
+func (s *stubMaintenanceService) InvalidateCache() {}
+
+func callMW(t *testing.T, enabled bool, typeID int) int {
+	t.Helper()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.Set("type_id", typeID)
+
+	mw := MaintenanceBlock(&stubMaintenanceService{enabled: enabled})
+	h := mw(func(c echo.Context) error {
+		return c.NoContent(http.StatusOK)
+	})
+	if err := h(ctx); err != nil {
+		if he, ok := err.(*echo.HTTPError); ok {
+			return he.Code
+		}
+		return http.StatusInternalServerError
+	}
+	return rec.Code
+}
+
+func TestMaintenanceBlock_AllowsSuperAdmin(t *testing.T) {
+	assert.Equal(t, http.StatusOK, callMW(t, true, 6))
+}
+
+func TestMaintenanceBlock_BlocksRegularWhenEnabled(t *testing.T) {
+	assert.Equal(t, http.StatusServiceUnavailable, callMW(t, true, 1))
+}
+
+func TestMaintenanceBlock_AllowsRegularWhenDisabled(t *testing.T) {
+	assert.Equal(t, http.StatusOK, callMW(t, false, 1))
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -10,7 +10,7 @@ import (
 // Setup регистрирует все маршруты.
 // loginLimiter опционален (nil в тестах) - отдельный per-IP rate limit на /login.
 // В production передаётся mw.LoginRateLimit из cmd/server/main.go.
-func Setup(e *echo.Echo, auth *handlers.AuthHandler, userTypes *handlers.UserTypesHandler, attachments *handlers.AttachmentHandler, lpf *handlers.LicensePlateFormatHandler, cs *handlers.CitizenshipHandler, org *handlers.OrganizationHandler, comp *handlers.CompanyHandler, users *handlers.UsersHandler, up *handlers.UnloadPlaceHandler, cars *handlers.CarHandler, employees *handlers.EmployeeHandler, st *handlers.SystemTableHandler, uc *handlers.UniqueCarHandler, ue *handlers.UniqueEmployeeHandler, fb *handlers.FeedbackHandler, app *handlers.ApplicationHandler, approvers *handlers.ApproverHandler, permissions *handlers.PermissionHandler, consent *handlers.ConsentHandler, settings *handlers.SettingsHandler, news *handlers.NewsHandler, notifications *handlers.NotificationHandler, requestLogs *handlers.RequestLogsHandler, employeesHistory *handlers.EmployeesHistoryHandler, bugReport *handlers.BugReportHandler, jwtSecret []byte, loginLimiter echo.MiddlewareFunc) {
+func Setup(e *echo.Echo, auth *handlers.AuthHandler, userTypes *handlers.UserTypesHandler, attachments *handlers.AttachmentHandler, lpf *handlers.LicensePlateFormatHandler, cs *handlers.CitizenshipHandler, org *handlers.OrganizationHandler, comp *handlers.CompanyHandler, users *handlers.UsersHandler, up *handlers.UnloadPlaceHandler, cars *handlers.CarHandler, employees *handlers.EmployeeHandler, st *handlers.SystemTableHandler, uc *handlers.UniqueCarHandler, ue *handlers.UniqueEmployeeHandler, fb *handlers.FeedbackHandler, app *handlers.ApplicationHandler, approvers *handlers.ApproverHandler, permissions *handlers.PermissionHandler, consent *handlers.ConsentHandler, settings *handlers.SettingsHandler, news *handlers.NewsHandler, notifications *handlers.NotificationHandler, requestLogs *handlers.RequestLogsHandler, employeesHistory *handlers.EmployeesHistoryHandler, bugReport *handlers.BugReportHandler, maintenance *handlers.MaintenanceHandler, maintenanceBlock echo.MiddlewareFunc, jwtSecret []byte, loginLimiter echo.MiddlewareFunc) {
 	// Health check — вне /api, для мониторинга и readiness-проб.
 	e.GET("/health", func(c echo.Context) error {
 		return c.JSON(200, map[string]string{"status": "ok"})
@@ -28,10 +28,18 @@ func Setup(e *echo.Echo, auth *handlers.AuthHandler, userTypes *handlers.UserTyp
 	api.POST("/login", auth.Login, loginHandlers...)
 	api.POST("/refresh-token", auth.RefreshToken)
 	api.GET("/user-types", auth.GetUserTypes)
+	// Публичный статус техработ - без JWT, чтобы страница /maintenance и форма /login
+	// могли его опросить.
+	api.GET("/settings/maintenance", maintenance.GetPublicStatus)
 
 	// Protected routes
 	protected := api.Group("")
 	protected.Use(mw.JWTAuth(jwtSecret))
+	// Maintenance block - после JWTAuth (нужен type_id в context). Super-admin
+	// проходит, остальным 503. Передаём nil в тестах чтобы не блочить.
+	if maintenanceBlock != nil {
+		protected.Use(maintenanceBlock)
+	}
 
 	protected.POST("/logout", auth.Logout)
 	protected.POST("/logout-all", auth.LogoutAll)
@@ -292,4 +300,9 @@ func Setup(e *echo.Echo, auth *handlers.AuthHandler, userTypes *handlers.UserTyp
 
 	// Bug-report - юзер отправляет со страницы Error500 (POST /api/bug-report)
 	protected.POST("/bug-report", bugReport.Submit)
+
+	// Админский toggle maintenance-режима (только type_id=6).
+	adminMaint := protected.Group("/admin")
+	adminMaint.GET("/maintenance", maintenance.GetAdminStatus)
+	adminMaint.PUT("/maintenance", maintenance.ToggleMaintenance)
 }

--- a/internal/services/maintenance_service.go
+++ b/internal/services/maintenance_service.go
@@ -1,0 +1,190 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"systemburo/internal/models"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+// MaintenanceStatus — публичное состояние режима "Технические работы".
+// Используется фронтом на /maintenance (авто-рефреш) и /login (решить,
+// показывать ли форму логина для обычного юзера).
+type MaintenanceStatus struct {
+	Enabled      bool   `json:"enabled"`
+	Message      string `json:"message,omitempty"`
+	StartedAt    string `json:"started_at,omitempty"`
+	SupportEmail string `json:"support_email,omitempty"`
+}
+
+// MaintenanceService включает/выключает режим технических работ и отдаёт
+// текущий статус. Enable: транзакция (settings + revoke non-admin refresh +
+// audit). Для защиты от регулярных запросов middleware использует
+// GetStatusCached с 10-сек in-memory кэшем.
+type MaintenanceService interface {
+	GetStatus(ctx context.Context) (*MaintenanceStatus, error)
+	// GetStatusCached — тот же GetStatus, но с in-memory кэшем. Используется
+	// middleware чтобы не бить БД на каждом запросе.
+	GetStatusCached(ctx context.Context) *MaintenanceStatus
+	Enable(ctx context.Context, adminUserID int, adminUsername, message, supportEmail string) error
+	Disable(ctx context.Context, adminUserID int, adminUsername string) error
+	// InvalidateCache сбрасывает in-memory кэш GetStatusCached. Вызывается
+	// внутри Enable/Disable - чтобы свежий флаг применился сразу.
+	InvalidateCache()
+}
+
+type maintenanceService struct {
+	db *gorm.DB
+
+	mu         sync.RWMutex
+	cache      *MaintenanceStatus
+	cachedAt   time.Time
+	cacheTTL   time.Duration
+}
+
+// NewMaintenanceService — конструктор. cacheTTL для in-memory кэша статуса
+// (10 сек в prod).
+func NewMaintenanceService(db *gorm.DB) MaintenanceService {
+	return &maintenanceService{
+		db:       db,
+		cacheTTL: 10 * time.Second,
+	}
+}
+
+const (
+	keyMaintenanceEnabled      = "maintenance.enabled"
+	keyMaintenanceStartedAt    = "maintenance.started_at"
+	keyMaintenanceMessage      = "maintenance.message"
+	keyMaintenanceSupportEmail = "maintenance.support_email"
+)
+
+// readSetting возвращает значение настройки из БД или пустую строку.
+func (s *maintenanceService) readSetting(ctx context.Context, key string) string {
+	var setting models.SystemSetting
+	if err := s.db.WithContext(ctx).Where("key = ?", key).First(&setting).Error; err != nil {
+		return ""
+	}
+	return setting.Value
+}
+
+func (s *maintenanceService) GetStatus(ctx context.Context) (*MaintenanceStatus, error) {
+	return &MaintenanceStatus{
+		Enabled:      s.readSetting(ctx, keyMaintenanceEnabled) == "true",
+		Message:      s.readSetting(ctx, keyMaintenanceMessage),
+		StartedAt:    s.readSetting(ctx, keyMaintenanceStartedAt),
+		SupportEmail: s.readSetting(ctx, keyMaintenanceSupportEmail),
+	}, nil
+}
+
+func (s *maintenanceService) GetStatusCached(ctx context.Context) *MaintenanceStatus {
+	s.mu.RLock()
+	if s.cache != nil && time.Since(s.cachedAt) < s.cacheTTL {
+		st := *s.cache
+		s.mu.RUnlock()
+		return &st
+	}
+	s.mu.RUnlock()
+
+	st, err := s.GetStatus(ctx)
+	if err != nil {
+		// На ошибке возвращаем "не в maintenance" чтобы не положить сайт.
+		return &MaintenanceStatus{Enabled: false}
+	}
+	s.mu.Lock()
+	s.cache = st
+	s.cachedAt = time.Now()
+	s.mu.Unlock()
+	return st
+}
+
+func (s *maintenanceService) InvalidateCache() {
+	s.mu.Lock()
+	s.cache = nil
+	s.cachedAt = time.Time{}
+	s.mu.Unlock()
+}
+
+// upsertSetting — INSERT или UPDATE по unique(key).
+func upsertSetting(tx *gorm.DB, key, value string) error {
+	var existing models.SystemSetting
+	if err := tx.Where("key = ?", key).First(&existing).Error; err != nil {
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+		return tx.Create(&models.SystemSetting{Key: key, Value: value, Type: "string"}).Error
+	}
+	existing.Value = value
+	return tx.Save(&existing).Error
+}
+
+// Enable — транзакция: 4 UPSERT setting + UPDATE refresh_tokens для
+// non-admin юзеров (типы != 6) + audit_event. Так же сбрасываем кэш
+// чтобы middleware увидел новый флаг сразу.
+func (s *maintenanceService) Enable(ctx context.Context, adminUserID int, adminUsername, message, supportEmail string) error {
+	now := time.Now().UTC().Format(time.RFC3339)
+	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := upsertSetting(tx, keyMaintenanceEnabled, "true"); err != nil {
+			return err
+		}
+		if err := upsertSetting(tx, keyMaintenanceStartedAt, now); err != nil {
+			return err
+		}
+		if err := upsertSetting(tx, keyMaintenanceMessage, message); err != nil {
+			return err
+		}
+		if err := upsertSetting(tx, keyMaintenanceSupportEmail, supportEmail); err != nil {
+			return err
+		}
+		// Отзываем refresh-токены всех не-админов. Через ≤15 мин access
+		// истечёт и их выкинет на /login, где получат 503 → /maintenance.
+		if err := tx.Exec(`
+			UPDATE refresh_tokens
+			SET is_revoked = true
+			WHERE user_id IN (SELECT id FROM users WHERE type_id != 6)
+			  AND is_revoked = false
+		`).Error; err != nil {
+			return fmt.Errorf("revoke non-admin refresh tokens: %w", err)
+		}
+		auditUserID := &adminUserID
+		return tx.Create(&models.AuthEvent{
+			UserID:    auditUserID,
+			Username:  adminUsername,
+			EventType: "maintenance_enabled",
+			Success:   true,
+			CreatedAt: time.Now().UTC(),
+		}).Error
+	})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "не удалось включить режим обслуживания")
+	}
+	s.InvalidateCache()
+	return nil
+}
+
+func (s *maintenanceService) Disable(ctx context.Context, adminUserID int, adminUsername string) error {
+	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := upsertSetting(tx, keyMaintenanceEnabled, "false"); err != nil {
+			return err
+		}
+		auditUserID := &adminUserID
+		return tx.Create(&models.AuthEvent{
+			UserID:    auditUserID,
+			Username:  adminUsername,
+			EventType: "maintenance_disabled",
+			Success:   true,
+			CreatedAt: time.Now().UTC(),
+		}).Error
+	})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "не удалось выключить режим обслуживания")
+	}
+	s.InvalidateCache()
+	return nil
+}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -113,8 +113,11 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 		PaginationMaxLimit:      100,
 	})
 
+	// Create maintenance service early so authHandler can get it.
+	maintenanceService := services.NewMaintenanceService(db)
+
 	// Create all handlers
-	authHandler := handlers.NewAuthHandler(authService, false, 168*time.Hour)
+	authHandler := handlers.NewAuthHandler(authService, maintenanceService, false, 168*time.Hour)
 	userTypesHandler := handlers.NewUserTypesHandler(userTypeService)
 	lpfHandler := handlers.NewLicensePlateFormatHandler(lpfService)
 	attachmentHandler := handlers.NewAttachmentHandler(attachmentService)
@@ -141,6 +144,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	telegramService := services.NewTelegramService("", "")
 	bugReportService := services.NewBugReportService(db, telegramService)
 	bugReportHandler := handlers.NewBugReportHandler(bugReportService)
+	maintenanceHandler := handlers.NewMaintenanceHandler(maintenanceService)
 
 	// Setup Echo with routes (no rate limiter, no logger — clean for tests)
 	e := echo.New()
@@ -153,7 +157,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 		citizenshipHandler, organizationHandler, companyHandler, usersHandler,
 		unloadPlaceHandler, carHandler, employeeHandler, systemTableHandler,
 		uniqueCarHandler, uniqueEmployeeHandler, feedbackHandler,
-		applicationHandler, approverHandler, permissionHandler, consentHandler, settingsHandler, newsHandler, notificationHandler, requestLogsHandler, employeesHistoryHandler, bugReportHandler, []byte(TestJWTSecret), nil)
+		applicationHandler, approverHandler, permissionHandler, consentHandler, settingsHandler, newsHandler, notificationHandler, requestLogsHandler, employeesHistoryHandler, bugReportHandler, maintenanceHandler, nil, []byte(TestJWTSecret), nil)
 
 	// No-op cleanup: shared DB stays open for the test binary lifetime.
 	cleanup := func() {}


### PR DESCRIPTION
Closes #159.

## Summary
- Полный режим «Технические работы» с супер-админским bypass
- Включается только супер-админом (type_id=6) через скрытую страницу /admin/system-control (в меню не линкуется)
- Обычные юзеры видят стилизованную страницу /maintenance с auto-refresh 30с
- Супер-админы продолжают работать — форма логина и все API отвечают нормально

## Поведение

| Сценарий | Обычный юзер | Супер-админ (type_id=6) |
|---|---|---|
| При включении: активные refresh-токены | отзываются все | не трогаем |
| POST /login с правильным паролем | **503** Service Unavailable | **200**, получает токены |
| Protected API (/api/*) | middleware возвращает **503** | middleware пропускает |
| Фронт-guard beforeEach | перекидывает на /maintenance | пропускает |
| GET /settings/maintenance (public) | всегда **200** со статусом | всегда **200** |

Кэш статуса 10 сек (in-memory) — чтобы не бить БД на каждом запросе; при toggle кэш сбрасывается сразу.

## Верификация
- 8 новых unit/integration-тестов зелёные (3 middleware + 5 handler)
- Все существующие тесты работают (maintenance middleware в тестах nil = не блокирует)
- Frontend lint + build чистые

## Тест-план на staging
- [ ] Супер-админ заходит на `/admin/system-control` прямо по URL - страница доступна
- [ ] Toggle включения срабатывает, появляется красный статус «ТЕХ РАБОТЫ ВКЛЮЧЕНЫ»
- [ ] Второй браузер с обычным юзером: попытка логина → 503 + редирект на /maintenance
- [ ] `curl -I https://stagingburo.washka17.site/api/settings/maintenance` → 200 + JSON
- [ ] Супер-админ продолжает работать (создать заявку, оттестить что-то)
- [ ] Toggle выключения → через 30с автоматический редирект юзера на /

## Риски
- Кэш 10s может давать отложенный эффект на middleware до `InvalidateCache()` при toggle — сейчас InvalidateCache вызывается в Enable/Disable, так что edge-case только при прямых UPDATE в БД (непредусмотренный сценарий)
- Миграции в prod: добавится 4 строки в system_settings при первом вызове Enable