### PR TITLE
fix(dev): vite proxy для /api и /uploads

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,12 +38,17 @@ services:
       context: ./frontend
       target: dev
     env_file: .env
+    environment:
+      # Vite dev-proxy цель: в docker backend доступен по имени сервиса.
+      # При локальном npm run dev без docker сработает фолбэк http://localhost:8090.
+      VITE_API_TARGET: http://go-backend:${BIND_PORT:-8090}
     ports:
       - "8081:8081"
     volumes:
       - ./frontend/src:/app/src
       - ./frontend/public:/app/public
       - ./frontend/index.html:/app/index.html
+      - ./frontend/vite.config.js:/app/vite.config.js
     depends_on:
       - go-backend
     restart: unless-stopped

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -11,9 +11,20 @@ export default defineConfig({
   },
   server: {
     port: 8081,
+    /*
+     * Dev-proxy: в dev нет nginx, фронт и бэкенд - отдельные контейнеры/процессы.
+     * Фронт видит бэкенд по имени сервиса docker (go-backend) либо на localhost
+     * при `npm run dev` без docker. VITE_API_TARGET позволяет подменить target
+     * из окружения (docker-compose ставит go-backend:8090, локально - default).
+     * В prod nginx проксирует /api сам - этот блок не активируется.
+     */
     proxy: {
+      '/api': {
+        target: process.env.VITE_API_TARGET || 'http://localhost:8090',
+        changeOrigin: true,
+      },
       '/uploads': {
-        target: process.env.VITE_API_BASE_URL || 'http://localhost:8080',
+        target: process.env.VITE_API_TARGET || 'http://localhost:8090',
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary

В dev нет nginx, frontend и backend — разные контейнеры/процессы. Без proxy запросы `/api/*` от браузера на `localhost:8081` получали 404 от vite dev-server, который не знал куда их проксировать. Prod работает через nginx, dev был сломан.

## Что сделано

- `frontend/vite.config.js`: добавлен proxy на `/api` и `/uploads` → `VITE_API_TARGET` (default `http://localhost:8090`)
- `docker-compose.yml`: для frontend-сервиса задан `VITE_API_TARGET=http://go-backend:${BIND_PORT:-8090}` — в docker бэкенд резолвится по имени сервиса
- Примонтирован `vite.config.js` в контейнер, чтобы правки подхватывались без ребилда

## Prod impact

Нулевой. `docker-compose.prod.yml` не затронут, nginx роутит `/api` сам.

## Test plan

- [x] `curl -X POST http://localhost:8081/api/login ...` → 200
- [x] UI-логин на http://localhost:8081/ работает в docker-compose (dev-up)
- [x] Заход на `/admin/system-control` после логина — страница открывается