### PR TITLE
feat: админ-панели mobile polish (#164)

### DIFF
--- a/frontend/src/components/NavMenu.vue
+++ b/frontend/src/components/NavMenu.vue
@@ -766,4 +766,14 @@ export default {
   background-color: var(--color-border);
   margin: 4px 0;
 }
+
+/*
+ * На <768px fixed sidebar съедает 50px слева и ломает контент.
+ * Временно скрываем - полноценный burger + drawer в #167.
+ */
+@media (max-width: 768px) {
+  .nav-menu {
+    display: none;
+  }
+}
 </style>

--- a/frontend/src/components/TheHeader/TheHeader.vue
+++ b/frontend/src/components/TheHeader/TheHeader.vue
@@ -435,52 +435,64 @@ h3 {
 
 /* Адаптивность */
 @media (max-width: 768px) {
+  .header {
+    padding: 0 12px;
+    gap: 8px;
+  }
+
   .header__info {
     gap: 10px;
   }
-  
-  .feedback-btn {
-    padding: 0 10px;
-    font-size: 13px;
+
+  .header__title {
+    min-width: 0;
+    flex: 1 1 auto;
   }
-  
-  .broadcast {
-    padding: 0 12px;
-    font-size: 13px;
-  }
-  
-  .time {
-    min-width: 140px;
+
+  .header__title h3 {
     font-size: 14px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
-  
+
+  .header__subtitle {
+    display: none;
+  }
+
+  /* Вторичная информация не помещается на мобильном - скрываем */
+  .feedback-btn,
+  .broadcast,
+  .time,
+  .language-selector {
+    display: none;
+  }
+
+  .user__notifications {
+    padding: 0 8px;
+    gap: 8px;
+  }
+
+  .appl-btn {
+    padding: 0 14px;
+    font-size: 13px;
+    white-space: nowrap;
+  }
+
   .appl-btn--fixed {
     right: 10px;
     top: 10px;
   }
 }
 
-@media (max-width: 576px) {
+@media (max-width: 480px) {
   .header {
     padding: 0 10px;
   }
-  
-  .header__title h3 {
-    font-size: 14px;
-  }
-  
-  .header__subtitle {
-    font-size: 11px;
-  }
-  
-  .user__notifications {
-    padding: 0 10px;
-    gap: 10px;
-  }
-  
-  .feedback-btn {
+
+  .appl-btn {
+    padding: 0 12px;
     font-size: 12px;
-    padding: 0 8px;
   }
 }
 </style>

--- a/frontend/src/views/AdminSettings.vue
+++ b/frontend/src/views/AdminSettings.vue
@@ -836,5 +836,27 @@ export default {
   .range-labels {
     max-width: 100%;
   }
+
+  /* Длинные MIME-типы (application/vnd.openxmlformats...) переполняли flex-row */
+  .checkbox-label {
+    max-width: 100%;
+  }
+
+  .checkbox-text {
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+}
+
+@media (max-width: 480px) {
+  .admin-settings__content {
+    padding: 16px;
+  }
+
+  .sidebar-item {
+    font-size: 11px;
+    padding: 8px 6px;
+  }
 }
 </style>


### PR DESCRIPTION
Закрывает #164.

## Summary

Второй PR mobile-adaptation roadmap. Делает админские страницы usable на <768px.

### Изменения

- **`NavMenu.vue`**: скрыт на `<768px` (`display: none`). Fixed sidebar `width: 50px` съедал место и контент обрезался. Полноценный burger + drawer — в #167.
- **`TheHeader/TheHeader.vue`**: на `<768px` скрыты вторичные элементы:
  - `subtitle` («Мы рады, что вы здесь!»)
  - `feedback-btn` («Сообщить о проблеме»)
  - `broadcast` (объявление)
  - `time` (дата/время)
  - `language-selector` (RU)
  - Title — single-line + `text-overflow: ellipsis`
  - `appl-btn` — компактный padding/font-size
  - На `<480px` ещё компактнее.
- **`AdminSettings.vue`**: длинные MIME-типы (`application/vnd.openxmlformats-officedocument.wordprocessingml.document`) переполняли flex-row. Добавил `max-width: 100%` на `.checkbox-label` + `overflow-wrap: anywhere` и `word-break: break-word` на `.checkbox-text`. На `<480px` уменьшил padding/font-size sidebar-item.

### Остальные админские view (SystemControl, AdminUsers, FeedbackPage, RequestsView)

В рамках ручной проверки через Playwright на 320/375/1280px уже имеют адекватные media-queries и не требуют правок. Скриншоты в коммит-артефактах.

## Test plan

- [x] DevTools 320x568: SystemControl / AdminUsers / AdminSettings / FeedbackPage / RequestsView — без горизонтального scroll
- [x] DevTools 375x667: то же + header компактный, title с `...`
- [x] Desktop 1280x800: NavMenu виден, TheHeader полный — regression не сломан
- [x] `npm run lint` зелёный
- [x] `npm run build` успешный

## Часть roadmap

Mobile adaptation, PR 2 из 7. Предыдущий: #170 (#163 infrastructure). Следующий: #165 (public pages polish).