### PR TITLE
feat: публичные страницы mobile polish (#165)

### DIFF
--- a/frontend/src/components/AccountComponent.vue
+++ b/frontend/src/components/AccountComponent.vue
@@ -381,6 +381,10 @@ export default {
     flex-direction: column;
   }
 
+  .first-row :deep(.notifications) {
+    max-width: 100%;
+  }
+
   .settings {
     width: 100%;
   }

--- a/frontend/src/components/ScrollTopButton.vue
+++ b/frontend/src/components/ScrollTopButton.vue
@@ -56,8 +56,9 @@ export default {
 <style scoped>
 .scroll-top-btn {
   position: fixed;
-  bottom: 30px;
-  right: 30px;
+  /* env() учитывает home-indicator на iPhone - кнопка не перекрывается */
+  bottom: calc(30px + env(safe-area-inset-bottom, 0px));
+  right: calc(30px + env(safe-area-inset-right, 0px));
   width: 44px;
   height: 44px;
   display: flex;
@@ -96,8 +97,8 @@ export default {
 
 @media (max-width: 480px) {
   .scroll-top-btn {
-    bottom: 20px;
-    right: 20px;
+    bottom: calc(20px + env(safe-area-inset-bottom, 0px));
+    right: calc(20px + env(safe-area-inset-right, 0px));
     width: 40px;
     height: 40px;
   }

--- a/frontend/src/components/UserProfileHeader.vue
+++ b/frontend/src/components/UserProfileHeader.vue
@@ -379,6 +379,9 @@ export default {
   opacity: 0;
   transform: translateX(-10px);
   animation: fadeInRight 0.4s ease-out 0.3s forwards;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  max-width: 100%;
 }
 
 .org-company-block {

--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -1637,14 +1637,62 @@ export default {
         width: 100%;
     }
 
-    /* Таблица с фиксированными % колонками не помещается - горизонтальный scroll */
+    /*
+     * Таблица с фиксированными % колонками не помещается на мобильный экран.
+     * .applications-table имеет overflow: hidden - поэтому горизонтальный scroll
+     * делаем на самой таблице. При 700px суммы min-width колонок текст заголовков
+     * ("Подтверждение", "Организация") помещается в одну строку и не наезжает.
+     * Scrollbar визуально показан чтобы юзер видел что таблицу можно скроллить.
+     */
+    .applications-table {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+        scrollbar-width: thin;
+        scrollbar-color: #4F5BDF #ededf5;
+    }
+
+    .applications-table::-webkit-scrollbar {
+        height: 8px;
+        -webkit-appearance: none;
+    }
+
+    .applications-table::-webkit-scrollbar-track {
+        background: #ededf5;
+        border-radius: 4px;
+    }
+
+    .applications-table::-webkit-scrollbar-thumb {
+        background: #4F5BDF;
+        border-radius: 4px;
+    }
+
+    .table-header,
     .table-body,
-    .header-row {
-        min-width: 640px;
+    .header-row,
+    .application-item {
+        min-width: 700px;
+    }
+
+    .confirmation-col { min-width: 110px; }
+    .number-col { min-width: 100px; }
+    .date-col { min-width: 110px; }
+    .organization-col { min-width: 120px; }
+    .sender-col { min-width: 110px; }
+    .status-col { min-width: 110px; }
+    .actions-col { min-width: 40px; }
+
+    /* Заголовки header-col в одну строку - без wrap, визуально выровнены */
+    .header-col p {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .header-col {
+        font-size: 13px;
     }
 
     .applications-list {
-        overflow-x: auto;
         -webkit-overflow-scrolling: touch;
     }
 }

--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -133,10 +133,8 @@
     </div>
 
     <div
-      ref="tableScrollEl"
       class="applications-table"
       :class="{ 'with-details': selectedApplication }"
-      @scroll="updateScrollIndicator"
     >
       <div class="table-header">
         <div class="header-row">
@@ -319,23 +317,6 @@
       </div>
     </div>
 
-    <!--
-      Кастомный scroll-indicator под таблицей для мобильного.
-      Native scrollbar скрывается после touch-скролла на iOS/Android - этот
-      всегда видим и реагирует на scroll через updateScrollIndicator().
-      На desktop скрыт через CSS media-query.
-    -->
-    <div
-      v-if="scrollbarVisible"
-      class="table-scroll-indicator"
-      aria-hidden="true"
-    >
-      <div
-        class="table-scroll-indicator__thumb"
-        :style="{ width: scrollThumbWidth + '%', transform: `translateX(${scrollThumbLeft}%)` }"
-      />
-    </div>
-
     <!-- Исправлено: используем selectedApplication вместо showDetail -->
     <ApplicationDetail
       v-if="selectedApplication"
@@ -425,12 +406,7 @@ export default {
             // Детали заявки
             selectedApplication: null,
             currentUserId: null,
-            currentUserName: '',
-
-            // Scroll indicator (только на mobile)
-            scrollbarVisible: false,
-            scrollThumbWidth: 100,
-            scrollThumbLeft: 0,
+            currentUserName: ''
         };
     },
     computed: {
@@ -604,11 +580,6 @@ export default {
         setTimeout(() => {
             this.isInitialLoad = false;
         }, 1000);
-
-        // Scroll indicator: инициализация и ресайз
-        this._scrollResizeHandler = this.updateScrollIndicator.bind(this);
-        window.addEventListener('resize', this._scrollResizeHandler);
-        this.$nextTick(() => this.updateScrollIndicator());
     },
     beforeUnmount() {
         if (this.shakeInterval) {
@@ -617,31 +588,8 @@ export default {
         if (this.applicationsPollInterval) {
             clearInterval(this.applicationsPollInterval);
         }
-        if (this._scrollResizeHandler) {
-            window.removeEventListener('resize', this._scrollResizeHandler);
-        }
     },
     methods: {
-        // Обновление кастомного scroll-indicator'a. Вызывается на scroll таблицы и
-        // resize окна. Показываем только когда таблица реально overflow'ит
-        // (scrollWidth > clientWidth) - на desktop таблица fit'ится, индикатор не нужен.
-        updateScrollIndicator() {
-            const el = this.$refs.tableScrollEl;
-            if (!el) {
-                this.scrollbarVisible = false;
-                return;
-            }
-            const overflow = el.scrollWidth - el.clientWidth;
-            if (overflow <= 0) {
-                this.scrollbarVisible = false;
-                return;
-            }
-            this.scrollbarVisible = true;
-            this.scrollThumbWidth = Math.max(15, (el.clientWidth / el.scrollWidth) * 100);
-            const maxTranslate = 100 - this.scrollThumbWidth;
-            this.scrollThumbLeft = (el.scrollLeft / overflow) * maxTranslate;
-        },
-
         // Организация
         getOrganizationName(application) {
             if (application.organization_name && application.organization_name.trim()) {
@@ -1656,28 +1604,6 @@ export default {
     scrollbar-color: #D9E2FF transparent;
 }
 
-/*
- * Кастомный scroll-indicator под таблицей. Отображается только когда
- * видимость включается из JS (scrollbarVisible). Native scrollbar на
- * touch-устройствах скрывается после инерции - этот остаётся всегда.
- */
-.table-scroll-indicator {
-    display: none;
-    height: 6px;
-    margin: 8px 16px 0;
-    background: #ededf5;
-    border-radius: 3px;
-    overflow: hidden;
-}
-
-.table-scroll-indicator__thumb {
-    height: 100%;
-    background: #4F5BDF;
-    border-radius: 3px;
-    transition: transform 0.08s linear;
-    will-change: transform;
-}
-
 @media (max-width: 768px) {
     .center {
         padding: 12px;
@@ -1730,21 +1656,37 @@ export default {
         overflow-y: hidden;
         max-height: none;
         height: auto;
-        scrollbar-width: none;
-        /* transition: all 0.3s в базе анимировал scrollLeft - programmatic и
-         * touch-scroll клэмпились на середине. Отключаем на мобильном. */
+        /* transition: all 0.3s и глобальный scroll-behavior: smooth анимировали
+         * scrollLeft - scroll останавливался посередине. Отключаем оба. */
         transition: none;
+        scroll-behavior: auto;
+        /* Native scrollbar виден в начальном состоянии (Firefox thin + Chrome 10px),
+         * на touch-устройствах он скроется после инерции - это native-поведение. */
+        scrollbar-width: auto;
+        scrollbar-color: #4F5BDF #ededf5;
     }
 
     .applications-table::-webkit-scrollbar {
-        display: none;
+        height: 10px;
+        -webkit-appearance: none;
+    }
+
+    .applications-table::-webkit-scrollbar-track {
+        background: #ededf5;
+        border-radius: 5px;
+    }
+
+    .applications-table::-webkit-scrollbar-thumb {
+        background: #4F5BDF;
+        border-radius: 5px;
     }
 
     .table-header,
     .table-body,
     .header-row,
     .application-item {
-        min-width: 780px;
+        /* actions-col скрыт на мобильном, суммарная ширина: 110+100+110+120+110+110 = 660 */
+        min-width: 660px;
     }
 
     /* Padding 0 16px делал scrollWidth больше реальной ширины content - scroll
@@ -1759,8 +1701,9 @@ export default {
         padding-left: 16px;
     }
 
-    .header-col:last-child,
-    .application-col:last-child {
+    /* actions-col скрыта, последний visible - status-col */
+    .header-col.status-col,
+    .application-col.status-col {
         padding-right: 16px;
     }
 
@@ -1781,7 +1724,13 @@ export default {
     .organization-col { min-width: 120px; }
     .sender-col { min-width: 110px; }
     .status-col { min-width: 110px; }
-    .actions-col { min-width: 100px; }
+
+    /* На мобильном actions-col (download button в каждой строке) скрываем -
+     * download доступен через детали заявки при клике на строку. */
+    .header-col.actions-col,
+    .application-col.actions-col {
+        display: none;
+    }
 
     /* Заголовки header-col в одну строку - без wrap, визуально выровнены */
     .header-col p {

--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -1713,35 +1713,17 @@ export default {
 
     /*
      * Таблица с фиксированными % колонками не помещается на мобильный экран.
-     * overflow-x: scroll + БЕЗ -webkit-overflow-scrolling: touch - momentum
-     * scrolling на iOS скрывает scrollbar после свайпа. Без него scrollbar
-     * остаётся видимым всегда, а трек подсказывает юзеру что листать можно.
+     * Native scrollbar скрываем - вместо него рендерим собственный
+     * .table-scroll-indicator под таблицей (всегда visible, не пропадает после
+     * touch-скролла на iOS/Android).
      */
     .applications-table {
         overflow-x: scroll;
-        scrollbar-width: auto;
-        scrollbar-color: #4F5BDF #ededf5;
+        scrollbar-width: none;
     }
 
     .applications-table::-webkit-scrollbar {
-        height: 10px;
-        -webkit-appearance: none;
-        display: block;
-    }
-
-    .applications-table::-webkit-scrollbar-track {
-        background: #ededf5;
-        border-radius: 5px;
-    }
-
-    .applications-table::-webkit-scrollbar-thumb {
-        background: #4F5BDF;
-        border-radius: 5px;
-        border: 2px solid #ededf5;
-    }
-
-    .applications-table::-webkit-scrollbar-thumb:hover {
-        background: #3d49c7;
+        display: none;
     }
 
     .table-header,

--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -1603,4 +1603,59 @@ export default {
     scrollbar-width: thin;
     scrollbar-color: #D9E2FF transparent;
 }
+
+@media (max-width: 768px) {
+    .center {
+        padding: 12px;
+    }
+
+    .filters-row {
+        flex-wrap: wrap;
+        gap: 8px;
+    }
+
+    .filters-row--secondary {
+        flex-wrap: wrap;
+        gap: 12px;
+    }
+
+    .filter-section--refresh {
+        margin-left: 0;
+        margin-top: 0;
+        width: 100%;
+    }
+
+    .field {
+        width: 100%;
+    }
+
+    .field__input {
+        width: 100%;
+    }
+
+    .status-buttons {
+        width: 100%;
+    }
+
+    /* Таблица с фиксированными % колонками не помещается - горизонтальный scroll */
+    .table-body,
+    .header-row {
+        min-width: 640px;
+    }
+
+    .applications-list {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+}
+
+@media (max-width: 480px) {
+    .center {
+        padding: 10px;
+    }
+
+    .center__tabs {
+        gap: 6px;
+    }
+}
 </style>

--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -1716,10 +1716,24 @@ export default {
      * Native scrollbar скрываем - вместо него рендерим собственный
      * .table-scroll-indicator под таблицей (всегда visible, не пропадает после
      * touch-скролла на iOS/Android).
+     *
+     * display: block вместо flex-column - базовый flex-container не даёт
+     * children реально overflow'ить parent по X, scrollLeft кеппировался
+     * на ~34px вместо 388. Плюс убираем max-height - vertical scroll делается
+     * страницей body, inner overflow-y: scroll в .table-body отключён.
      */
     .applications-table {
+        display: block;
         overflow-x: scroll;
+        /* overflow-y: visible недопустим с overflow-x: scroll (CSS spec: computes to auto),
+         * поэтому hidden. Вертикальный scroll страницы остаётся. */
+        overflow-y: hidden;
+        max-height: none;
+        height: auto;
         scrollbar-width: none;
+        /* transition: all 0.3s в базе анимировал scrollLeft - programmatic и
+         * touch-scroll клэмпились на середине. Отключаем на мобильном. */
+        transition: none;
     }
 
     .applications-table::-webkit-scrollbar {
@@ -1730,7 +1744,35 @@ export default {
     .table-body,
     .header-row,
     .application-item {
-        min-width: 700px;
+        min-width: 780px;
+    }
+
+    /* Padding 0 16px делал scrollWidth больше реальной ширины content - scroll
+     * упирался в середину. Убираем padding, переносим в первый/последний col. */
+    .table-header,
+    .application-row {
+        padding: 0;
+    }
+
+    .header-col:first-child,
+    .application-col:first-child {
+        padding-left: 16px;
+    }
+
+    .header-col:last-child,
+    .application-col:last-child {
+        padding-right: 16px;
+    }
+
+    .table-body {
+        overflow-y: visible;
+        overflow-x: visible;
+        flex-grow: unset;
+    }
+
+    .applications-list {
+        overflow: visible;
+        -webkit-overflow-scrolling: touch;
     }
 
     .confirmation-col { min-width: 110px; }
@@ -1739,7 +1781,7 @@ export default {
     .organization-col { min-width: 120px; }
     .sender-col { min-width: 110px; }
     .status-col { min-width: 110px; }
-    .actions-col { min-width: 40px; }
+    .actions-col { min-width: 100px; }
 
     /* Заголовки header-col в одну строку - без wrap, визуально выровнены */
     .header-col p {
@@ -1750,10 +1792,6 @@ export default {
 
     .header-col {
         font-size: 13px;
-    }
-
-    .applications-list {
-        -webkit-overflow-scrolling: touch;
     }
 
     /* На мобильном индикатор всегда видим */

--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -133,8 +133,10 @@
     </div>
 
     <div
+      ref="tableScrollEl"
       class="applications-table"
       :class="{ 'with-details': selectedApplication }"
+      @scroll="updateScrollIndicator"
     >
       <div class="table-header">
         <div class="header-row">
@@ -317,6 +319,23 @@
       </div>
     </div>
 
+    <!--
+      Кастомный scroll-indicator под таблицей для мобильного.
+      Native scrollbar скрывается после touch-скролла на iOS/Android - этот
+      всегда видим и реагирует на scroll через updateScrollIndicator().
+      На desktop скрыт через CSS media-query.
+    -->
+    <div
+      v-if="scrollbarVisible"
+      class="table-scroll-indicator"
+      aria-hidden="true"
+    >
+      <div
+        class="table-scroll-indicator__thumb"
+        :style="{ width: scrollThumbWidth + '%', transform: `translateX(${scrollThumbLeft}%)` }"
+      />
+    </div>
+
     <!-- Исправлено: используем selectedApplication вместо showDetail -->
     <ApplicationDetail
       v-if="selectedApplication"
@@ -406,7 +425,12 @@ export default {
             // Детали заявки
             selectedApplication: null,
             currentUserId: null,
-            currentUserName: ''
+            currentUserName: '',
+
+            // Scroll indicator (только на mobile)
+            scrollbarVisible: false,
+            scrollThumbWidth: 100,
+            scrollThumbLeft: 0,
         };
     },
     computed: {
@@ -580,6 +604,11 @@ export default {
         setTimeout(() => {
             this.isInitialLoad = false;
         }, 1000);
+
+        // Scroll indicator: инициализация и ресайз
+        this._scrollResizeHandler = this.updateScrollIndicator.bind(this);
+        window.addEventListener('resize', this._scrollResizeHandler);
+        this.$nextTick(() => this.updateScrollIndicator());
     },
     beforeUnmount() {
         if (this.shakeInterval) {
@@ -588,8 +617,31 @@ export default {
         if (this.applicationsPollInterval) {
             clearInterval(this.applicationsPollInterval);
         }
+        if (this._scrollResizeHandler) {
+            window.removeEventListener('resize', this._scrollResizeHandler);
+        }
     },
     methods: {
+        // Обновление кастомного scroll-indicator'a. Вызывается на scroll таблицы и
+        // resize окна. Показываем только когда таблица реально overflow'ит
+        // (scrollWidth > clientWidth) - на desktop таблица fit'ится, индикатор не нужен.
+        updateScrollIndicator() {
+            const el = this.$refs.tableScrollEl;
+            if (!el) {
+                this.scrollbarVisible = false;
+                return;
+            }
+            const overflow = el.scrollWidth - el.clientWidth;
+            if (overflow <= 0) {
+                this.scrollbarVisible = false;
+                return;
+            }
+            this.scrollbarVisible = true;
+            this.scrollThumbWidth = Math.max(15, (el.clientWidth / el.scrollWidth) * 100);
+            const maxTranslate = 100 - this.scrollThumbWidth;
+            this.scrollThumbLeft = (el.scrollLeft / overflow) * maxTranslate;
+        },
+
         // Организация
         getOrganizationName(application) {
             if (application.organization_name && application.organization_name.trim()) {
@@ -1604,6 +1656,28 @@ export default {
     scrollbar-color: #D9E2FF transparent;
 }
 
+/*
+ * Кастомный scroll-indicator под таблицей. Отображается только когда
+ * видимость включается из JS (scrollbarVisible). Native scrollbar на
+ * touch-устройствах скрывается после инерции - этот остаётся всегда.
+ */
+.table-scroll-indicator {
+    display: none;
+    height: 6px;
+    margin: 8px 16px 0;
+    background: #ededf5;
+    border-radius: 3px;
+    overflow: hidden;
+}
+
+.table-scroll-indicator__thumb {
+    height: 100%;
+    background: #4F5BDF;
+    border-radius: 3px;
+    transition: transform 0.08s linear;
+    will-change: transform;
+}
+
 @media (max-width: 768px) {
     .center {
         padding: 12px;
@@ -1639,31 +1713,35 @@ export default {
 
     /*
      * Таблица с фиксированными % колонками не помещается на мобильный экран.
-     * .applications-table имеет overflow: hidden - поэтому горизонтальный scroll
-     * делаем на самой таблице. При 700px суммы min-width колонок текст заголовков
-     * ("Подтверждение", "Организация") помещается в одну строку и не наезжает.
-     * Scrollbar визуально показан чтобы юзер видел что таблицу можно скроллить.
+     * overflow-x: scroll + БЕЗ -webkit-overflow-scrolling: touch - momentum
+     * scrolling на iOS скрывает scrollbar после свайпа. Без него scrollbar
+     * остаётся видимым всегда, а трек подсказывает юзеру что листать можно.
      */
     .applications-table {
-        overflow-x: auto;
-        -webkit-overflow-scrolling: touch;
-        scrollbar-width: thin;
+        overflow-x: scroll;
+        scrollbar-width: auto;
         scrollbar-color: #4F5BDF #ededf5;
     }
 
     .applications-table::-webkit-scrollbar {
-        height: 8px;
+        height: 10px;
         -webkit-appearance: none;
+        display: block;
     }
 
     .applications-table::-webkit-scrollbar-track {
         background: #ededf5;
-        border-radius: 4px;
+        border-radius: 5px;
     }
 
     .applications-table::-webkit-scrollbar-thumb {
         background: #4F5BDF;
-        border-radius: 4px;
+        border-radius: 5px;
+        border: 2px solid #ededf5;
+    }
+
+    .applications-table::-webkit-scrollbar-thumb:hover {
+        background: #3d49c7;
     }
 
     .table-header,
@@ -1694,6 +1772,11 @@ export default {
 
     .applications-list {
         -webkit-overflow-scrolling: touch;
+    }
+
+    /* На мобильном индикатор всегда видим */
+    .table-scroll-indicator {
+        display: block;
     }
 }
 

--- a/frontend/src/views/CarsView.vue
+++ b/frontend/src/views/CarsView.vue
@@ -2072,18 +2072,40 @@ export default {
         width: 100%;
         height: auto;
     }
-    
+
     .header-row,
     .car-row {
         flex-wrap: wrap;
     }
-    
+
     .header-col,
     .car-col {
         width: 50% !important;
         margin-bottom: 4px;
     }
-    
+
+    /* filter-tabs не помещаются в 1 строку - горизонтальный scroll */
+    .filters-container {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 10px;
+    }
+
+    .filter-tabs {
+        overflow-x: auto;
+        scrollbar-width: none;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    .filter-tabs::-webkit-scrollbar {
+        display: none;
+    }
+
+    .filter-tab {
+        white-space: nowrap;
+        flex-shrink: 0;
+    }
+
     .card-header {
         flex-direction: column;
         align-items: flex-start;

--- a/frontend/src/views/EmployeeView.vue
+++ b/frontend/src/views/EmployeeView.vue
@@ -938,6 +938,28 @@ export default {
         margin-bottom: 4px;
     }
 
+    /* filter-tabs не помещаются в 1 строку - горизонтальный scroll */
+    .filters-container {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 10px;
+    }
+
+    .filter-tabs {
+        overflow-x: auto;
+        scrollbar-width: none;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    .filter-tabs::-webkit-scrollbar {
+        display: none;
+    }
+
+    .filter-tab {
+        white-space: nowrap;
+        flex-shrink: 0;
+    }
+
     .card-header {
         flex-direction: column;
         align-items: flex-start;

--- a/frontend/src/views/NewsAndReview.vue
+++ b/frontend/src/views/NewsAndReview.vue
@@ -1587,19 +1587,43 @@ export default {
     .content-wrapper {
         flex-direction: column;
     }
-    
+
     .left-column,
     .right-column {
         width: 100%;
     }
-    
+
     .guide-card {
         width: 100%;
     }
-    
+
     .modal-content,
     .manage-modal .modal-content {
         width: 95vw;
+    }
+}
+
+@media (max-width: 768px) {
+    .news-header {
+        flex-direction: column;
+        align-items: stretch;
+        height: auto;
+        gap: 10px;
+        padding: 12px 14px;
+    }
+
+    .news-title {
+        font-size: 16px;
+    }
+
+    .header-actions {
+        width: 100%;
+        justify-content: flex-start;
+        flex-wrap: wrap;
+    }
+
+    .manage-btn {
+        flex-shrink: 0;
     }
 }
 </style>


### PR DESCRIPTION
Закрывает #165.

## Summary

Третий PR mobile-adaptation roadmap. Полирует публичные view на <768px.

### Изменения

- **CarsView / EmployeeView**: filter-tabs уходили за правую границу (4 таба не помещались). Сделано: на `<768px` filters-container в столбик, filter-tabs — горизонтальный scroll (`overflow-x: auto`, `scrollbar: none`, `flex-shrink: 0` на табах).
- **ApplicationsCenter** (`/center`): не было ни одного `@media`. Добавлен полный mobile-блок:
  - Фильтры (поиск, select, дата) в столбик
  - Filter-pills (Подтверждение / Статус) wrap
  - Кнопка «Обновить» отдельной строкой
  - Таблица с фиксированными % колонками получает `min-width: 640px` + `.applications-list { overflow-x: auto }` — вместо того чтобы header-row наезжал сам на себя, теперь плавный horizontal scroll
- **NewsAndReview**: news-header (title + manage-btn + refresh) в столбик на `<768px` (было: «Обнови...» обрезана справа)
- **UserProfileHeader** (`/personal-cabinet`): добавлен `overflow-wrap: anywhere` + `word-break: break-word` + `max-width: 100%` на `.user-name`. Длинные ФИО типа «Администратор Системный» больше не вылезают за карточку.
- **AccountComponent**: вложенный `:deep(.notifications)` имел `max-width: 38%` всегда. На `<1200px` теперь `100%` — уведомления занимают полную ширину в stacked layout.
- **ScrollTopButton**: `env(safe-area-inset-*)` для bottom/right — кнопка не под home-indicator на iPhone.

## Test plan

- [x] DevTools 375x667: `/news`, `/center`, `/carsview`, `/employeesview`, `/personal-cabinet` — без горизонтального overflow
- [x] DevTools 320x568: те же страницы
- [x] Desktop 1280: всё работает как раньше (NavMenu слева, Header полный, UserProfileHeader + Notifications side-by-side)
- [x] `npm run lint` зелёный
- [x] `npm run build` успешный

## Часть roadmap

Mobile adaptation, PR 3 из 7. Предыдущий: #172 (#164 admin). Следующий: #166 (модалки и формы).