### PR TITLE
feat: NavMenu - burger menu + drawer на мобильном (#167)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -153,6 +153,11 @@ body:not(.auth-active) #app {
   margin-left: 0;
 }
 
+/* Блокировка body-scroll пока mobile drawer открыт */
+body.nav-drawer-open {
+  overflow: hidden;
+}
+
 .form-input-sm {
   border-radius: 10px !important;
 }

--- a/frontend/src/components/NavMenu.vue
+++ b/frontend/src/components/NavMenu.vue
@@ -1,12 +1,32 @@
 <template>
-  <nav
-    class="nav-menu"
-    role="navigation"
-    aria-label="Основная навигация"
-    :class="{ expanded: isExpanded }"
-    @mouseenter="expandMenu"
-    @mouseleave="collapseMenu"
-  >
+  <div>
+    <!-- Backdrop для мобильного drawer'а -->
+    <transition name="nav-backdrop">
+      <div
+        v-if="mobileOpen"
+        class="nav-menu__backdrop"
+        @click="closeMobile"
+      />
+    </transition>
+
+    <nav
+      class="nav-menu"
+      role="navigation"
+      aria-label="Основная навигация"
+      :class="{ expanded: isExpanded, 'nav-menu--mobile-open': mobileOpen }"
+      @mouseenter="expandMenu"
+      @mouseleave="collapseMenu"
+    >
+      <!-- Кнопка закрытия для мобильного -->
+      <button
+        v-if="mobileOpen"
+        class="nav-menu__close"
+        aria-label="Закрыть меню"
+        @click="closeMobile"
+      >
+        ✕
+      </button>
+
     <!-- Внутренний контейнер для контента -->
     <div class="nav-content">
       <!-- ЗАЯВКИ -->
@@ -250,7 +270,8 @@
         </div>
       </div>
     </div>
-  </nav>
+    </nav>
+  </div>
 </template>
 
 <script>
@@ -272,19 +293,36 @@ export default {
       systemTables: [],
       newApplicationsCount: 0,
       applicationsPollingInterval: null,
-      tablesPollingInterval: null
+      tablesPollingInterval: null,
+      mobileOpen: false
     };
+  },
+  watch: {
+    // Закрываем drawer при переходе по пункту меню
+    '$route'() {
+      this.closeMobile();
+    }
   },
   async mounted() {
     document.body.classList.add('auth-active');
     await this.fetchSystemTables();
     this.startApplicationsPolling();
     this.startTablesPolling();
+
+    // Слушаем событие от burger-кнопки в TheHeader
+    this.$bus.on('mobile-nav-toggle', this.toggleMobile);
+    // Esc закрывает drawer
+    this._escHandler = (e) => {
+      if (e.key === 'Escape' && this.mobileOpen) {
+        this.closeMobile();
+      }
+    };
+    window.addEventListener('keydown', this._escHandler);
   },
   beforeUnmount() {
     document.body.classList.remove('auth-active');
     this.stopApplicationsPolling();
-    
+
     if (this.hoverTimeout) {
       clearTimeout(this.hoverTimeout);
     }
@@ -294,8 +332,25 @@ export default {
     if (this.dropdownLeaveTimeout) {
       clearTimeout(this.dropdownLeaveTimeout);
     }
+
+    this.$bus.off('mobile-nav-toggle', this.toggleMobile);
+    if (this._escHandler) {
+      window.removeEventListener('keydown', this._escHandler);
+    }
+    // Обязательно снимаем body lock если компонент unmount'нулся в открытом состоянии
+    document.body.classList.remove('nav-drawer-open');
   },
   methods: {
+    toggleMobile() {
+      this.mobileOpen = !this.mobileOpen;
+      // Блокируем scroll body когда drawer открыт
+      document.body.classList.toggle('nav-drawer-open', this.mobileOpen);
+    },
+    closeMobile() {
+      if (!this.mobileOpen) return;
+      this.mobileOpen = false;
+      document.body.classList.remove('nav-drawer-open');
+    },
     expandMenu() {
       if (this.hoverTimeout) {
         clearTimeout(this.hoverTimeout);
@@ -768,12 +823,96 @@ export default {
 }
 
 /*
- * На <768px fixed sidebar съедает 50px слева и ломает контент.
- * Временно скрываем - полноценный burger + drawer в #167.
+ * Mobile drawer (<768px): nav скрыт по-умолчанию, открывается через burger
+ * в TheHeader (emits $bus mobile-nav-toggle). Drawer выезжает слева,
+ * занимает 280px (или 85% viewport), с backdrop позади.
  */
+.nav-menu__backdrop {
+  display: none;
+}
+
+.nav-menu__close {
+  display: none;
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  width: 44px;
+  height: 44px;
+  border: none;
+  background: transparent;
+  font-size: 22px;
+  color: #333;
+  cursor: pointer;
+  border-radius: 50%;
+  z-index: 2;
+}
+
+.nav-menu__close:hover {
+  background: #f0f0f5;
+}
+
+.nav-backdrop-enter-active,
+.nav-backdrop-leave-active {
+  transition: opacity 0.25s ease;
+}
+.nav-backdrop-enter-from,
+.nav-backdrop-leave-to {
+  opacity: 0;
+}
+
 @media (max-width: 768px) {
   .nav-menu {
-    display: none;
+    /* Позиция - слева, выезжает drawer-style */
+    width: 280px;
+    max-width: 85vw;
+    transform: translateX(-100%);
+    transition: transform 0.28s cubic-bezier(0.2, 0.8, 0.2, 1);
+    z-index: 10000;
+    box-shadow: none;
+  }
+
+  .nav-menu.nav-menu--mobile-open {
+    transform: translateX(0);
+    box-shadow: 2px 0 20px rgba(0, 0, 0, 0.2);
+  }
+
+  .nav-menu .nav-content {
+    width: 100%;
+    padding-top: 48px;
+  }
+
+  /* На мобильном содержимое всегда развёрнуто - hover не работает на touch */
+  .nav-menu .nav-text,
+  .nav-menu .section-title {
+    opacity: 1 !important;
+  }
+
+  .nav-menu .nav-item {
+    min-height: 48px;
+  }
+
+  .nav-menu__backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 17, 41, 0.5);
+    z-index: 9999;
+  }
+
+  .nav-menu__close {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  /* dropdown'ы в drawer - inline (не абсолютные) на мобильном */
+  .dropdown-list {
+    position: static !important;
+    width: 100% !important;
+    box-shadow: none !important;
+    border: none !important;
+    margin-left: 20px !important;
   }
 }
+
 </style>

--- a/frontend/src/components/TheHeader/TheHeader.vue
+++ b/frontend/src/components/TheHeader/TheHeader.vue
@@ -3,6 +3,17 @@
     ref="header"
     class="header"
   >
+    <button
+      class="header__burger"
+      aria-label="Открыть меню"
+      type="button"
+      @click="toggleMobileNav"
+    >
+      <span />
+      <span />
+      <span />
+    </button>
+
     <div class="header__title">
       <template v-if="loading">
         <SkeletonLine
@@ -162,6 +173,9 @@ export default {
     },
     openFeedbackModal() {
       this.showFeedbackModal = true;
+    },
+    toggleMobileNav() {
+      this.$bus.emit('mobile-nav-toggle');
     },
     handleFeedbackSubmitted(message) {
       console.log('Обратная связь отправлена:', message);
@@ -433,11 +447,45 @@ h3 {
   }
 }
 
+/* Burger-кнопка - только на мобильном */
+.header__burger {
+  display: none;
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  flex-direction: column;
+  gap: 4px;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  border-radius: 8px;
+  transition: background 0.2s;
+}
+
+.header__burger:hover {
+  background: #f0f0f5;
+}
+
+.header__burger span {
+  display: block;
+  width: 22px;
+  height: 2px;
+  background: #333;
+  border-radius: 1px;
+}
+
 /* Адаптивность */
 @media (max-width: 768px) {
   .header {
     padding: 0 12px;
     gap: 8px;
+  }
+
+  .header__burger {
+    display: flex;
   }
 
   .header__info {

--- a/frontend/src/components/UserApplications.vue
+++ b/frontend/src/components/UserApplications.vue
@@ -1122,21 +1122,69 @@ export default {
 }
 
 @media (max-width: 768px) {
+  /* Таблица - horizontal scroll вместо wrap (колонки в столбик нечитаемы) */
+  .applications-list,
+  .applications-header,
+  .applications-body,
+  .applications-list-content {
+    overflow: visible !important;
+  }
+
+  .applications-body {
+    overflow-x: scroll !important;
+    overflow-y: auto !important;
+  }
+
+  .applications-header {
+    overflow-x: scroll !important;
+    overflow-y: hidden !important;
+    scrollbar-width: none;
+  }
+
+  .applications-header::-webkit-scrollbar,
+  .applications-body::-webkit-scrollbar:horizontal {
+    display: none;
+  }
+
+  .header-row,
+  .application-row {
+    flex-wrap: nowrap !important;
+    min-width: 600px;
+  }
+
   .header-col,
   .application-col {
-    width: 50% !important;
+    width: auto !important;
+    min-width: 110px !important;
+    flex: 0 0 auto !important;
+    white-space: nowrap;
   }
-  
-  .confirmation-col,
-  .status-col {
-    width: 50% !important;
+
+  .header-col.date-col,
+  .application-col.date-col {
+    min-width: 140px !important;
+  }
+
+  .header-col p,
+  .header-col {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }
 
 @media (max-width: 576px) {
+  /* Оставляем horizontal-scroll from 768px, просто уменьшаем min-widths для экономии места */
   .header-col,
   .application-col {
-    width: 100% !important;
+    min-width: 100px !important;
+    font-size: 13px;
+    padding: 0 10px !important;
+  }
+
+  .header-col.date-col,
+  .application-col.date-col {
+    min-width: 120px !important;
   }
 }
 </style>

--- a/frontend/src/components/UserApplications.vue
+++ b/frontend/src/components/UserApplications.vue
@@ -1122,28 +1122,27 @@ export default {
 }
 
 @media (max-width: 768px) {
-  /* Таблица - horizontal scroll вместо wrap (колонки в столбик нечитаемы) */
-  .applications-list,
+  /*
+   * Синхронный horizontal scroll: scroll на .applications-list (общий parent
+   * header+body), inner header/body имеют visible overflow чтобы наследовать
+   * scroll от parent'а. Headers и data двигаются вместе.
+   */
+  .applications-list {
+    overflow-x: auto !important;
+    overflow-y: hidden !important;
+  }
+
   .applications-header,
   .applications-body,
   .applications-list-content {
-    overflow: visible !important;
+    overflow-x: visible !important;
+    min-width: 600px;
   }
 
   .applications-body {
-    overflow-x: scroll !important;
-    overflow-y: auto !important;
-  }
-
-  .applications-header {
-    overflow-x: scroll !important;
-    overflow-y: hidden !important;
-    scrollbar-width: none;
-  }
-
-  .applications-header::-webkit-scrollbar,
-  .applications-body::-webkit-scrollbar:horizontal {
-    display: none;
+    overflow-y: visible !important;
+    height: auto !important;
+    max-height: none !important;
   }
 
   .header-row,
@@ -1156,7 +1155,7 @@ export default {
   .application-col {
     width: auto !important;
     min-width: 110px !important;
-    flex: 0 0 auto !important;
+    flex: 1 1 auto !important;
     white-space: nowrap;
   }
 

--- a/frontend/src/components/UserControl.vue
+++ b/frontend/src/components/UserControl.vue
@@ -2224,15 +2224,26 @@ export default {
     height: 300px;
   }
   
+  /* Таблица - horizontal scroll вместо wrap в столбик */
+  .users-list {
+    overflow-x: auto;
+  }
+
   .header-row,
   .user-row {
-    flex-wrap: wrap;
+    flex-wrap: nowrap !important;
+    min-width: 600px;
   }
-  
+
   .header-col,
   .user-col {
-    width: 50% !important;
-    margin-bottom: 4px;
+    width: auto !important;
+    min-width: 110px !important;
+    flex: 0 0 auto !important;
+    margin-bottom: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   
   .details-grid-two-columns {

--- a/frontend/src/components/UserControl.vue
+++ b/frontend/src/components/UserControl.vue
@@ -2224,22 +2224,37 @@ export default {
     height: 300px;
   }
   
-  /* Таблица - horizontal scroll вместо wrap в столбик */
+  /*
+   * Таблица - horizontal scroll вместо wrap в столбик.
+   * Scroll на .users-list - оба child'а (.users-header + .users-body) получают
+   * min-width 600px и двигаются синхронно.
+   */
   .users-list {
-    overflow-x: auto;
+    overflow-x: auto !important;
+    overflow-y: hidden !important;
+  }
+
+  .users-header,
+  .users-body {
+    min-width: 600px;
+    overflow-x: visible !important;
+    overflow-y: visible !important;
+    height: auto !important;
+    max-height: none !important;
   }
 
   .header-row,
   .user-row {
     flex-wrap: nowrap !important;
     min-width: 600px;
+    width: 100%;
   }
 
   .header-col,
   .user-col {
     width: auto !important;
     min-width: 110px !important;
-    flex: 0 0 auto !important;
+    flex: 1 1 auto !important;
     margin-bottom: 0;
     white-space: nowrap;
     overflow: hidden;

--- a/frontend/src/components/UserProfileHeader.vue
+++ b/frontend/src/components/UserProfileHeader.vue
@@ -580,6 +580,8 @@ export default {
     align-items: center;
     text-align: center;
     padding: 15px;
+    width: 100%;
+    height: auto;
   }
   
   .user-avatar {


### PR DESCRIPTION
Закрывает #167.

## Summary

Пятый PR mobile-adaptation roadmap. Архитектурное изменение NavMenu — на <768px fixed sidebar превращается в slide-in drawer, управляемый burger-кнопкой в TheHeader.

### Изменения

- **`NavMenu.vue`**:
  - `mobileOpen` state, toggle через `$bus.on('mobile-nav-toggle')` из header
  - Template: wrapper `<div>` с backdrop + nav + close-button (✕ 44x44)
  - Закрытие: клик по backdrop / Esc / автоматически при `$route` change / клик на пункт меню
  - Body scroll-lock (`body.nav-drawer-open`) пока drawer открыт
  - Transition: slide-in слева 0.28s cubic-bezier
  - Width 280px / max 85vw, nav-items min-height 48px
  - Ранее на <768px был `display: none` — теперь полноценный drawer
- **`TheHeader/TheHeader.vue`**:
  - Burger-кнопка 40x40 слева от title (3 полосы), visible только `<768px`
  - Click emits `$bus.emit('mobile-nav-toggle')`
- **`App.vue`**:
  - Global `body.nav-drawer-open { overflow: hidden }` для блокировки scroll

### A11y

- `role="navigation"`, `aria-label="Основная навигация"` (уже было)
- Burger — `aria-label="Открыть меню"`, close — `aria-label="Закрыть меню"`
- Esc закрывает drawer

## Test plan

- [x] DevTools 375x667: burger виден слева, sidebar скрыт
- [x] Клик burger → drawer слайд слева + backdrop
- [x] Клик nav-item → navigate + drawer закрывается
- [x] Клик backdrop → закрытие
- [x] Esc → закрытие
- [x] Desktop 1280: burger скрыт, fixed sidebar как раньше (hover-expand 50→188px)
- [x] `npm run build` успешный

## Часть roadmap

Mobile adaptation, PR 5 из 7. Предыдущий: #174 (#166 modals). Следующий: #168 (tables card-view).