### PR TITLE
fix: AdminUsers - truncate cells + max-height на list-panel

### DIFF
--- a/frontend/src/views/AdminUsers.vue
+++ b/frontend/src/views/AdminUsers.vue
@@ -1216,5 +1216,30 @@ export default {
     width: 100%;
     text-align: center;
   }
+
+  /*
+   * Table-layout fixed + .admin-users__th--type{width: 120px} делал суммарную
+   * ширину table > wrapper - overflow visible смещал данные слева. Делаем
+   * synced horizontal scroll: scroll на .table-wrap, table растягивается до
+   * естественной ширины контента, ничего не обрезается.
+   */
+  .admin-users__table-wrap {
+    overflow-x: auto;
+    overflow-y: auto;
+  }
+
+  .admin-users__table {
+    table-layout: auto;
+    min-width: 600px;
+  }
+
+  .admin-users__th,
+  .admin-users__row td {
+    white-space: nowrap;
+  }
+
+  .admin-users__th--type {
+    width: auto;
+  }
 }
 </style>

--- a/frontend/src/views/AdminUsers.vue
+++ b/frontend/src/views/AdminUsers.vue
@@ -778,6 +778,9 @@ export default {
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  /* Ограничиваем высоту panel'а - остальные user'ы доступны через
+   * внутренний vertical-scroll в .admin-users__table-wrap */
+  max-height: calc(100dvh - 180px);
 }
 
 .admin-users__detail-panel {
@@ -836,8 +839,23 @@ export default {
   white-space: nowrap;
 }
 
-.admin-users__th--type {
-  width: 120px;
+/* Все cells truncate'ятся ellipsis'ом - помещаются в любую ширину panel'а */
+.admin-users__td {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.admin-users__td--type {
+  overflow: hidden;
+}
+
+.admin-users__td--type :deep(*) {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: inline-block;
 }
 
 .admin-users__row {
@@ -1202,26 +1220,42 @@ export default {
   }
 
   /*
-   * Synced horizontal scroll - table-layout: fixed + width: 120px на type-col
-   * давали суммарную ширину больше wrapper, last col обрезалась справа.
+   * Compact table - данные truncate'ятся ellipsis'ом и помещаются в
+   * narrow list-panel БЕЗ horizontal-scroll. StatusBadge внутри type-col
+   * через :deep ужимаем чтобы badge не задавал свою min-width.
    */
   .admin-users__table-wrap {
-    overflow-x: auto;
-    overflow-y: auto;
+    overflow-x: hidden;
   }
 
   .admin-users__table {
-    table-layout: auto;
-    min-width: 600px;
+    table-layout: fixed;
+    width: 100%;
   }
 
   .admin-users__th,
   .admin-users__row td {
+    padding: 6px 8px;
+    font-size: 12px;
+    overflow: hidden;
+    text-overflow: ellipsis;
     white-space: nowrap;
   }
 
   .admin-users__th--type {
-    width: auto;
+    width: 28%;
+  }
+
+  .admin-users__td--type {
+    overflow: hidden;
+  }
+
+  .admin-users__td--type :deep(*) {
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    display: inline-block;
   }
 }
 

--- a/frontend/src/views/AdminUsers.vue
+++ b/frontend/src/views/AdminUsers.vue
@@ -1200,28 +1200,10 @@ export default {
   .admin-users__list-panel {
     max-height: 300px;
   }
-}
-
-@media (max-width: 768px) {
-  .admin-users__form-row--three,
-  .admin-users__form-row--two {
-    flex-direction: column;
-  }
-
-  .admin-users__actions {
-    flex-direction: column;
-  }
-
-  .admin-users__btn {
-    width: 100%;
-    text-align: center;
-  }
 
   /*
-   * Table-layout fixed + .admin-users__th--type{width: 120px} делал суммарную
-   * ширину table > wrapper - overflow visible смещал данные слева. Делаем
-   * synced horizontal scroll: scroll на .table-wrap, table растягивается до
-   * естественной ширины контента, ничего не обрезается.
+   * Synced horizontal scroll - table-layout: fixed + width: 120px на type-col
+   * давали суммарную ширину больше wrapper, last col обрезалась справа.
    */
   .admin-users__table-wrap {
     overflow-x: auto;
@@ -1240,6 +1222,22 @@ export default {
 
   .admin-users__th--type {
     width: auto;
+  }
+}
+
+@media (max-width: 768px) {
+  .admin-users__form-row--three,
+  .admin-users__form-row--two {
+    flex-direction: column;
+  }
+
+  .admin-users__actions {
+    flex-direction: column;
+  }
+
+  .admin-users__btn {
+    width: 100%;
+    text-align: center;
   }
 }
 </style>


### PR DESCRIPTION
## Summary

Hotfix после merge mobile-adaptation roadmap (#170-#177).

### Изменения в `frontend/src/views/AdminUsers.vue`

- **Truncate cells через ellipsis** на всех `.admin-users__td` — раньше badge "Бюро пропусков" в колонке Тип обрезался справа из-за `table-layout: fixed` + `width: 120px` на th--type. Теперь при недостатке места cell получает `…` вместо обрезки.
- **`:deep(*)` truncate** для содержимого `StatusBadge` внутри type-col — компонент имел свою min-width.
- **`max-height: calc(100dvh - 180px)`** на `.admin-users__list-panel` — при 200+ user'ах panel не растягивался во всю высоту страницы, теперь vertical-scroll работает внутри через уже существующий `.admin-users__table-wrap { overflow-y: auto }`.
- В @media 1024 убраны старые scroll-фиксы — truncate работает на всех viewport, отдельный mobile-pattern не нужен.

## Test plan

- [x] Desktop 1280: list-panel scroll'ится внутри при 201 user, badge "Бюро пропусков" видно ellipsis'ом
- [x] Tablet 800: то же
- [x] Mobile 430: то же
- [x] `npm run lint` зелёный