### PR TITLE
fix: блок 1 quick-wins (#184)

### DIFF
--- a/frontend/src/components/BlankSelector.vue
+++ b/frontend/src/components/BlankSelector.vue
@@ -501,7 +501,7 @@ export default {
 }
 
 .attachment {
-    width: 139px;
+    max-width: 130px;
     min-height: 25px;
     border: 1px solid #e6e6e6;
     border-radius: 10px;

--- a/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
@@ -516,7 +516,7 @@ export default {
             const date = new Date(dateTimeString);
             return date.toLocaleString('ru-RU', {
                 day: '2-digit', month: '2-digit', year: 'numeric',
-                hour: '2-digit', minute: '2-digit', second: '2-digit'
+                hour: '2-digit', minute: '2-digit'
             }).replace(',', '');
         },
 

--- a/frontend/src/components/CreateApplication/VehicleForm.vue
+++ b/frontend/src/components/CreateApplication/VehicleForm.vue
@@ -1004,8 +1004,9 @@ export default {
     padding: 10px 12px;
     border-radius: 8px;
     font-size: 12px;
-    max-width: 500px;
-    white-space: nowrap;
+    max-width: 419px;
+    white-space: normal;
+    word-break: break-word;
     box-shadow: 0 2px 8px rgba(0,0,0,0.2);
 }
 

--- a/frontend/src/components/TheHeader/TheHeader.vue
+++ b/frontend/src/components/TheHeader/TheHeader.vue
@@ -26,7 +26,7 @@
         />
       </template>
       <template v-else>
-        <h3>Добрый день, {{ displayName }}!</h3>
+        <h3>{{ greeting }}</h3>
         <p class="header__subtitle">
           Мы рады, что вы здесь!
         </p>
@@ -62,9 +62,9 @@
         @click="showNotifications = !showNotifications"
       >
         <img
-          src="@/assets/icons/messages.png"
+          src="@/assets/icons/notifications.png"
           class="notifications__icon"
-          alt="Сообщения"
+          alt="Уведомления"
         >
         <span
           v-if="unreadCount > 0"
@@ -130,13 +130,25 @@ export default {
       showAnnouncement: false,
       activeAnnouncement: null,
       showNotifications: false,
-      unreadCount: 0
+      unreadCount: 0,
+      currentHour: new Date().getHours(),
     };
   },
   computed: {
     displayName() {
       return this.userFirstName || this.userLastName || '';
-    }
+    },
+    greetingPrefix() {
+      const h = this.currentHour;
+      if (h >= 6 && h < 12) return 'Доброе утро';
+      if (h >= 12 && h < 18) return 'Добрый день';
+      if (h >= 18 && h < 23) return 'Добрый вечер';
+      return 'Доброй ночи';
+    },
+    greeting() {
+      const name = this.displayName;
+      return name ? `${this.greetingPrefix}, ${name}!` : `${this.greetingPrefix}!`;
+    },
   },
   watch: {
     '$route'() {
@@ -221,6 +233,10 @@ export default {
       const minutes = String(now.getMinutes()).padStart(2, '0');
       const seconds = String(now.getSeconds()).padStart(2, '0');
       this.currentDateTime = `${day}.${month}.${year} ${hours}:${minutes}:${seconds}`;
+      const h = now.getHours();
+      if (h !== this.currentHour) {
+        this.currentHour = h;
+      }
     },
     startDateTimeTimer() {
       this.updateDateTime();
@@ -352,12 +368,11 @@ h3 {
 }
 
 .user__notifications {
-  width: fit-content;
+  width: 35px;
   height: 35px;
-  border-radius: 50px;
-  padding: 0 15px;
+  border-radius: 50%;
+  padding: 0;
   display: flex;
-  gap:20px;
   align-items: center;
   justify-content: center;
   border: 1px solid #e6e6e6;
@@ -517,8 +532,7 @@ h3 {
   }
 
   .user__notifications {
-    padding: 0 8px;
-    gap: 8px;
+    padding: 0;
   }
 
   .appl-btn {

--- a/frontend/src/components/UserNotificationsInline.vue
+++ b/frontend/src/components/UserNotificationsInline.vue
@@ -340,6 +340,7 @@ export default {
   flex: 1;
   overflow-y: auto;
   padding: 8px 0;
+  max-height: 200px;
 }
 
 .notifications__list.empty-list {
@@ -359,6 +360,7 @@ export default {
 .notifications__items {
   display: flex;
   flex-direction: column;
+  gap: 10px;
 }
 
 .notification-item {
@@ -384,6 +386,10 @@ export default {
   justify-content: center;
   padding-top: 6px;
   flex-shrink: 0;
+}
+
+.notification-item:not(.unread) .notification-dot-wrapper {
+  display: none;
 }
 
 .notification-dot {

--- a/frontend/src/components/UserProfileHeader.vue
+++ b/frontend/src/components/UserProfileHeader.vue
@@ -480,6 +480,8 @@ export default {
   background: linear-gradient(135deg, #f0f4ff 0%, #d9e2ff 100%);
   color: #3a4a6e;
   border: 1px solid #d0d9f0;
+  cursor: default;
+  gap: 6px;
 }
 
 .email-badge {

--- a/frontend/src/composables/useRussianPhoneMask.js
+++ b/frontend/src/composables/useRussianPhoneMask.js
@@ -15,10 +15,11 @@
 export function formatRussianPhone(raw) {
   if (raw == null) return ''
   let digits = String(raw).replace(/\D/g, '')
+  if (!digits) return ''
   // Ведущая 8 или 7 - заменяем на 7 (префикс страны один и тот же).
-  if (digits.length && (digits[0] === '8' || digits[0] === '7')) {
+  if (digits[0] === '8' || digits[0] === '7') {
     digits = '7' + digits.slice(1)
-  } else if (digits.length) {
+  } else {
     // Если юзер начал с другой цифры (например, 9), считаем что забыл код страны.
     digits = '7' + digits
   }


### PR DESCRIPTION
## Что сделано (Issue #184, Блок 1: quick wins)

### Шапка (TheHeader.vue)
- Динамическое приветствие по времени суток (06-12 утро / 12-18 день / 18-23 вечер / 23-06 ночи)
- Корректное приветствие при отсутствии имени или фамилии (без "Добрый день, !")
- Иконка `notifications.png` вместо `messages.png`
- Блок `user__notifications` 35x35 (вместо 52x35)

### Создание учётки
- Убрал автоподставление "+7" при пустом вводе (formatRussianPhone теперь возвращает "" для пустого ввода)

### Личный кабинет
- `position-badge`: cursor default + gap 6px
- `notification-dot-wrapper` полностью скрывается для прочитанных уведомлений
- gap 10px между уведомлениями
- max-height 200px на блок notifications

### Прочее
- EmployeeDetailsModal: убрал секунды в дате/времени
- VehicleForm tooltip: max-width 419px, перенос текста
- BlankSelector .attachment: max-width 130px

## План тестирования
- [ ] Шапка: проверить смену приветствия по часам, корректное отображение при пустых имени/фамилии
- [ ] Создание пользователя: при пустом телефоне поле остаётся пустым (нет "+7")
- [ ] ЛК: position-badge не подсвечивается как кликабельный
- [ ] ЛК: прочитанные уведомления выровнены по левому краю
- [ ] Карточка сотрудника: отсутствие секунд в датах
- [ ] VehicleForm: tooltip переносится по строкам, не превышает 419px