### PR TITLE
feat: блок 2A форматирование ФИО (#184)

### DIFF
--- a/frontend/src/utils/__tests__/formatName.spec.js
+++ b/frontend/src/utils/__tests__/formatName.spec.js
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { formatShortName, formatFullName } from '../formatName'
+
+describe('formatShortName', () => {
+  it('полное ФИО -> Фамилия И.О.', () => {
+    expect(formatShortName({ last_name: 'Иванов', first_name: 'Иван', middle_name: 'Иванович' }))
+      .toBe('Иванов И.И.')
+  })
+
+  it('фамилия и имя -> Фамилия И.', () => {
+    expect(formatShortName({ last_name: 'Иванов', first_name: 'Иван' })).toBe('Иванов И.')
+  })
+
+  it('только фамилия -> Фамилия', () => {
+    expect(formatShortName({ last_name: 'Иванов' })).toBe('Иванов')
+  })
+
+  it('только имя -> Имя (не сокращаем)', () => {
+    expect(formatShortName({ first_name: 'Иван' })).toBe('Иван')
+  })
+
+  it('имя и отчество без фамилии -> Имя Отчество (полностью)', () => {
+    expect(formatShortName({ first_name: 'Иван', middle_name: 'Иванович' }))
+      .toBe('Иван Иванович')
+  })
+
+  it('пустые поля -> ""', () => {
+    expect(formatShortName({})).toBe('')
+    expect(formatShortName(null)).toBe('')
+    expect(formatShortName(undefined)).toBe('')
+  })
+
+  it('игнорирует пробелы по краям', () => {
+    expect(formatShortName({ last_name: '  Иванов ', first_name: ' Иван' }))
+      .toBe('Иванов И.')
+  })
+
+  it('первая буква в верхнем регистре', () => {
+    expect(formatShortName({ last_name: 'иванов', first_name: 'иван' }))
+      .toBe('иванов И.')
+  })
+})
+
+describe('formatFullName', () => {
+  it('собирает три части в одну строку', () => {
+    expect(formatFullName({ last_name: 'Иванов', first_name: 'Иван', middle_name: 'Иванович' }))
+      .toBe('Иванов Иван Иванович')
+  })
+
+  it('пропускает пустые части', () => {
+    expect(formatFullName({ last_name: 'Иванов', middle_name: 'Иванович' }))
+      .toBe('Иванов Иванович')
+  })
+
+  it('пустой объект -> ""', () => {
+    expect(formatFullName({})).toBe('')
+  })
+})

--- a/frontend/src/utils/formatName.js
+++ b/frontend/src/utils/formatName.js
@@ -1,0 +1,53 @@
+/**
+ * Утилиты форматирования ФИО для всех таблиц, списков и карточек.
+ *
+ * formatShortName({ last_name, first_name, middle_name }):
+ *   "Иванов Иван Иванович" -> "Иванов И.И."
+ *   "Иванов Иван"          -> "Иванов И."
+ *   "Иванов"               -> "Иванов"
+ *   "Иван"                 -> "Иван"     (нет фамилии - не сокращаем имя)
+ *   "Иван Иванович"        -> "Иван Иванович"  (нет фамилии - и имя и отчество полностью)
+ *
+ * formatFullName({ last_name, first_name, middle_name }):
+ *   "Иванов Иван Иванович"
+ */
+
+/**
+ * @typedef {Object} NameParts
+ * @property {?string} [last_name]
+ * @property {?string} [first_name]
+ * @property {?string} [middle_name]
+ */
+
+const trim = (v) => (v == null ? '' : String(v).trim())
+
+/**
+ * @param {NameParts} parts
+ * @returns {string}
+ */
+export function formatShortName(parts) {
+  if (!parts) return ''
+  const last = trim(parts.last_name)
+  const first = trim(parts.first_name)
+  const middle = trim(parts.middle_name)
+
+  if (!last) {
+    return [first, middle].filter(Boolean).join(' ')
+  }
+
+  let out = last
+  if (first) out += ` ${first[0].toUpperCase()}.`
+  if (middle) out += `${middle[0].toUpperCase()}.`
+  return out
+}
+
+/**
+ * @param {NameParts} parts
+ * @returns {string}
+ */
+export function formatFullName(parts) {
+  if (!parts) return ''
+  return [trim(parts.last_name), trim(parts.first_name), trim(parts.middle_name)]
+    .filter(Boolean)
+    .join(' ')
+}

--- a/frontend/src/views/AdminUsers.vue
+++ b/frontend/src/views/AdminUsers.vue
@@ -444,6 +444,7 @@ import BaseModal from '@/components/ui/BaseModal.vue';
 import BaseDropdown from '@/components/ui/BaseDropdown.vue';
 import StatusBadge from '@/components/ui/StatusBadge.vue';
 import SkeletonTransition from '@/components/ui/SkeletonTransition.vue';
+import { formatShortName } from '@/utils/formatName';
 import SkeletonTable from '@/components/ui/SkeletonTable.vue';
 import SkeletonLine from '@/components/ui/SkeletonLine.vue';
 
@@ -712,15 +713,8 @@ export default {
     },
 
     formatUserName(user) {
-      if (!user.last_name && !user.first_name && !user.middle_name) return '—';
-      let result = user.last_name || '';
-      if (user.first_name) {
-        result += ` ${user.first_name.charAt(0).toUpperCase()}.`;
-        if (user.middle_name) {
-          result += `${user.middle_name.charAt(0).toUpperCase()}.`;
-        }
-      }
-      return result || '—';
+      const formatted = formatShortName(user);
+      return formatted || '—';
     },
 
     getUserTypeName(id) {

--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -283,9 +283,12 @@
                 </div>
                 <div
                   class="application-col sender-col"
-                  :title="getFullNameTooltip(application.sender_name)"
                 >
-                  {{ getSenderName(application.sender_name) }}
+                  <span
+                    v-if="application.sender_name"
+                    class="sender-tooltip-anchor"
+                    :data-tooltip="application.sender_full_name || application.sender_name"
+                  >{{ application.sender_name }}</span>
                 </div>
                 <div class="application-col status-col">
                   <span 
@@ -605,17 +608,6 @@ export default {
             this.selectedOrganizationId = id;
             this.selectedOrganizationName = name;
             this.applyFilters();
-        },
-        
-        // Отправитель
-        getSenderName(fullName) {
-            if (!fullName) return '';
-            return fullName;
-        },
-        
-        getFullNameTooltip(fullName) {
-            if (!fullName) return '';
-            return fullName.replace(/\./g, '').trim();
         },
         
         // Поиск
@@ -1331,28 +1323,48 @@ export default {
 
 .sender-col {
     width: 15%;
-    position: relative;
 }
 
-.sender-col:hover::after {
-    content: attr(title);
+.sender-tooltip-anchor {
+    position: relative;
+    cursor: default;
+}
+
+.sender-tooltip-anchor::after {
+    content: attr(data-tooltip);
     position: absolute;
-    bottom: 100%;
+    top: calc(100% + 6px);
     left: 50%;
     transform: translateX(-50%);
     background: #333;
-    color: white;
-    padding: 5px 10px;
-    border-radius: 4px;
+    color: #fff;
+    padding: 6px 10px;
+    border-radius: 6px;
     font-size: 12px;
     white-space: nowrap;
     z-index: 1000;
     pointer-events: none;
     opacity: 0;
-    transition: opacity 0.2s;
+    transition: opacity 0.15s;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
 }
 
-.sender-col:hover::after {
+.sender-tooltip-anchor::before {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 5px solid transparent;
+    border-bottom-color: #333;
+    z-index: 1001;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s;
+}
+
+.sender-tooltip-anchor:hover::after,
+.sender-tooltip-anchor:hover::before {
     opacity: 1;
 }
 

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -107,7 +107,51 @@ func AutoMigrate(db *gorm.DB) error {
 	if err := db.AutoMigrate(AllModels()...); err != nil {
 		return err
 	}
+	if err := installSQLFunctions(db); err != nil {
+		return err
+	}
 	slog.Info("AutoMigrate completed")
+	return nil
+}
+
+// installSQLFunctions создаёт пользовательские SQL-функции, переиспользуемые
+// в запросах сервисов. CREATE OR REPLACE безопасен при каждом старте.
+func installSQLFunctions(db *gorm.DB) error {
+	const formatShortName = `
+CREATE OR REPLACE FUNCTION format_short_name(p_last TEXT, p_first TEXT, p_middle TEXT)
+RETURNS TEXT AS $$
+BEGIN
+    IF COALESCE(p_last, '') = '' THEN
+        RETURN TRIM(BOTH ' ' FROM
+            COALESCE(p_first, '') ||
+            CASE WHEN COALESCE(p_middle, '') <> '' THEN ' ' || p_middle ELSE '' END
+        );
+    END IF;
+    RETURN p_last ||
+        CASE WHEN COALESCE(p_first, '') <> '' THEN ' ' || LEFT(p_first, 1) || '.' ELSE '' END ||
+        CASE WHEN COALESCE(p_middle, '') <> '' THEN LEFT(p_middle, 1) || '.' ELSE '' END;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+`
+	const formatFullName = `
+CREATE OR REPLACE FUNCTION format_full_name(p_last TEXT, p_first TEXT, p_middle TEXT)
+RETURNS TEXT AS $$
+BEGIN
+    RETURN TRIM(BOTH ' ' FROM
+        COALESCE(p_last, '') ||
+        CASE WHEN COALESCE(p_first, '') <> '' THEN ' ' || p_first ELSE '' END ||
+        CASE WHEN COALESCE(p_middle, '') <> '' THEN ' ' || p_middle ELSE '' END
+    );
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+`
+	if err := db.Exec(formatShortName).Error; err != nil {
+		return err
+	}
+	if err := db.Exec(formatFullName).Error; err != nil {
+		return err
+	}
+	slog.Info("SQL functions installed: format_short_name, format_full_name")
 	return nil
 }
 

--- a/internal/services/application_service.go
+++ b/internal/services/application_service.go
@@ -478,22 +478,10 @@ func (s *applicationService) GetApplications(ctx context.Context, username strin
 			a.*,
 			COALESCE(o.name, c.name) as organization_name,
 			c.name as company_name,
-			CONCAT(COALESCE(u.last_name, ''),
-				CASE WHEN u.first_name IS NOT NULL AND u.first_name != '' THEN ' ' || u.first_name ELSE '' END,
-				CASE WHEN u.middle_name IS NOT NULL AND u.middle_name != '' THEN ' ' || u.middle_name ELSE '' END
-			) as sender_full_name,
-			CONCAT(COALESCE(u.last_name, ''),
-				CASE WHEN u.first_name IS NOT NULL AND u.first_name != '' THEN ' ' || LEFT(u.first_name, 1) || '.' ELSE '' END,
-				CASE WHEN u.middle_name IS NOT NULL AND u.middle_name != '' THEN ' ' || LEFT(u.middle_name, 1) || '.' ELSE '' END
-			) as sender_name,
-			CONCAT(COALESCE(ru.last_name, ''),
-				CASE WHEN ru.first_name IS NOT NULL AND ru.first_name != '' THEN ' ' || ru.first_name ELSE '' END,
-				CASE WHEN ru.middle_name IS NOT NULL AND ru.middle_name != '' THEN ' ' || ru.middle_name ELSE '' END
-			) as responsible_full_name,
-			CONCAT(COALESCE(ru.last_name, ''),
-				CASE WHEN ru.first_name IS NOT NULL AND ru.first_name != '' THEN ' ' || LEFT(ru.first_name, 1) || '.' ELSE '' END,
-				CASE WHEN ru.middle_name IS NOT NULL AND ru.middle_name != '' THEN ' ' || LEFT(ru.middle_name, 1) || '.' ELSE '' END
-			) as responsible_name
+			format_full_name(u.last_name, u.first_name, u.middle_name) as sender_full_name,
+			format_short_name(u.last_name, u.first_name, u.middle_name) as sender_name,
+			format_full_name(ru.last_name, ru.first_name, ru.middle_name) as responsible_full_name,
+			format_short_name(ru.last_name, ru.first_name, ru.middle_name) as responsible_name
 		`).
 		Joins("LEFT JOIN organizations o ON a.organization_id = o.id").
 		Joins("LEFT JOIN companies c ON a.company_id = c.id").
@@ -562,22 +550,10 @@ func (s *applicationService) GetApplicationsPaginated(ctx context.Context, usern
 			a.*,
 			COALESCE(o.name, c.name) as organization_name,
 			c.name as company_name,
-			CONCAT(COALESCE(u.last_name, ''),
-				CASE WHEN u.first_name IS NOT NULL AND u.first_name != '' THEN ' ' || u.first_name ELSE '' END,
-				CASE WHEN u.middle_name IS NOT NULL AND u.middle_name != '' THEN ' ' || u.middle_name ELSE '' END
-			) as sender_full_name,
-			CONCAT(COALESCE(u.last_name, ''),
-				CASE WHEN u.first_name IS NOT NULL AND u.first_name != '' THEN ' ' || LEFT(u.first_name, 1) || '.' ELSE '' END,
-				CASE WHEN u.middle_name IS NOT NULL AND u.middle_name != '' THEN ' ' || LEFT(u.middle_name, 1) || '.' ELSE '' END
-			) as sender_name,
-			CONCAT(COALESCE(ru.last_name, ''),
-				CASE WHEN ru.first_name IS NOT NULL AND ru.first_name != '' THEN ' ' || ru.first_name ELSE '' END,
-				CASE WHEN ru.middle_name IS NOT NULL AND ru.middle_name != '' THEN ' ' || ru.middle_name ELSE '' END
-			) as responsible_full_name,
-			CONCAT(COALESCE(ru.last_name, ''),
-				CASE WHEN ru.first_name IS NOT NULL AND ru.first_name != '' THEN ' ' || LEFT(ru.first_name, 1) || '.' ELSE '' END,
-				CASE WHEN ru.middle_name IS NOT NULL AND ru.middle_name != '' THEN ' ' || LEFT(ru.middle_name, 1) || '.' ELSE '' END
-			) as responsible_name
+			format_full_name(u.last_name, u.first_name, u.middle_name) as sender_full_name,
+			format_short_name(u.last_name, u.first_name, u.middle_name) as sender_name,
+			format_full_name(ru.last_name, ru.first_name, ru.middle_name) as responsible_full_name,
+			format_short_name(ru.last_name, ru.first_name, ru.middle_name) as responsible_name
 		`).
 		Order("a.sending_datetime DESC").
 		Offset(offset).
@@ -603,22 +579,10 @@ func (s *applicationService) GetUserApplications(ctx context.Context, username s
 			a.*,
 			COALESCE(o.name, c.name) as organization_name,
 			c.name as company_name,
-			CONCAT(COALESCE(u.last_name, ''),
-				CASE WHEN u.first_name IS NOT NULL AND u.first_name != '' THEN ' ' || u.first_name ELSE '' END,
-				CASE WHEN u.middle_name IS NOT NULL AND u.middle_name != '' THEN ' ' || u.middle_name ELSE '' END
-			) as sender_full_name,
-			CONCAT(COALESCE(u.last_name, ''),
-				CASE WHEN u.first_name IS NOT NULL AND u.first_name != '' THEN ' ' || LEFT(u.first_name, 1) || '.' ELSE '' END,
-				CASE WHEN u.middle_name IS NOT NULL AND u.middle_name != '' THEN ' ' || LEFT(u.middle_name, 1) || '.' ELSE '' END
-			) as sender_name,
-			CONCAT(COALESCE(ru.last_name, ''),
-				CASE WHEN ru.first_name IS NOT NULL AND ru.first_name != '' THEN ' ' || ru.first_name ELSE '' END,
-				CASE WHEN ru.middle_name IS NOT NULL AND ru.middle_name != '' THEN ' ' || ru.middle_name ELSE '' END
-			) as responsible_full_name,
-			CONCAT(COALESCE(ru.last_name, ''),
-				CASE WHEN ru.first_name IS NOT NULL AND ru.first_name != '' THEN ' ' || LEFT(ru.first_name, 1) || '.' ELSE '' END,
-				CASE WHEN ru.middle_name IS NOT NULL AND ru.middle_name != '' THEN ' ' || LEFT(ru.middle_name, 1) || '.' ELSE '' END
-			) as responsible_name
+			format_full_name(u.last_name, u.first_name, u.middle_name) as sender_full_name,
+			format_short_name(u.last_name, u.first_name, u.middle_name) as sender_name,
+			format_full_name(ru.last_name, ru.first_name, ru.middle_name) as responsible_full_name,
+			format_short_name(ru.last_name, ru.first_name, ru.middle_name) as responsible_name
 		`).
 		Joins("LEFT JOIN organizations o ON a.organization_id = o.id").
 		Joins("LEFT JOIN companies c ON a.company_id = c.id").
@@ -671,22 +635,10 @@ func (s *applicationService) GetApplicationByID(ctx context.Context, username st
 			a.*,
 			COALESCE(o.name, c.name) as organization_name,
 			c.name as company_name,
-			CONCAT(COALESCE(u.last_name, ''),
-				CASE WHEN u.first_name IS NOT NULL AND u.first_name != '' THEN ' ' || u.first_name ELSE '' END,
-				CASE WHEN u.middle_name IS NOT NULL AND u.middle_name != '' THEN ' ' || u.middle_name ELSE '' END
-			) as sender_full_name,
-			CONCAT(COALESCE(u.last_name, ''),
-				CASE WHEN u.first_name IS NOT NULL AND u.first_name != '' THEN ' ' || LEFT(u.first_name, 1) || '.' ELSE '' END,
-				CASE WHEN u.middle_name IS NOT NULL AND u.middle_name != '' THEN ' ' || LEFT(u.middle_name, 1) || '.' ELSE '' END
-			) as sender_name,
-			CONCAT(COALESCE(ru.last_name, ''),
-				CASE WHEN ru.first_name IS NOT NULL AND ru.first_name != '' THEN ' ' || ru.first_name ELSE '' END,
-				CASE WHEN ru.middle_name IS NOT NULL AND ru.middle_name != '' THEN ' ' || ru.middle_name ELSE '' END
-			) as responsible_full_name,
-			CONCAT(COALESCE(ru.last_name, ''),
-				CASE WHEN ru.first_name IS NOT NULL AND ru.first_name != '' THEN ' ' || LEFT(ru.first_name, 1) || '.' ELSE '' END,
-				CASE WHEN ru.middle_name IS NOT NULL AND ru.middle_name != '' THEN ' ' || LEFT(ru.middle_name, 1) || '.' ELSE '' END
-			) as responsible_name
+			format_full_name(u.last_name, u.first_name, u.middle_name) as sender_full_name,
+			format_short_name(u.last_name, u.first_name, u.middle_name) as sender_name,
+			format_full_name(ru.last_name, ru.first_name, ru.middle_name) as responsible_full_name,
+			format_short_name(ru.last_name, ru.first_name, ru.middle_name) as responsible_name
 		`).
 		Joins("LEFT JOIN organizations o ON a.organization_id = o.id").
 		Joins("LEFT JOIN companies c ON a.company_id = c.id").
@@ -788,16 +740,10 @@ func (s *applicationService) GetApplicationDetails(ctx context.Context, applicat
 			a.*,
 			COALESCE(o.name, c.name) as organization_name,
 			c.name as company_name,
-			CONCAT(COALESCE(u.last_name, ''), ' ', COALESCE(u.first_name, ''), ' ', COALESCE(u.middle_name, '')) as sender_full_name,
-			CONCAT(COALESCE(u.last_name, ''),
-				CASE WHEN u.first_name IS NOT NULL AND u.first_name != '' THEN ' ' || LEFT(u.first_name, 1) || '.' ELSE '' END,
-				CASE WHEN u.middle_name IS NOT NULL AND u.middle_name != '' THEN ' ' || LEFT(u.middle_name, 1) || '.' ELSE '' END
-			) as sender_name,
-			CONCAT(COALESCE(ru.last_name, ''), ' ', COALESCE(ru.first_name, ''), ' ', COALESCE(ru.middle_name, '')) as responsible_full_name,
-			CONCAT(COALESCE(ru.last_name, ''),
-				CASE WHEN ru.first_name IS NOT NULL AND ru.first_name != '' THEN ' ' || LEFT(ru.first_name, 1) || '.' ELSE '' END,
-				CASE WHEN ru.middle_name IS NOT NULL AND u.middle_name != '' THEN ' ' || LEFT(ru.middle_name, 1) || '.' ELSE '' END
-			) as responsible_name
+			format_full_name(u.last_name, u.first_name, u.middle_name) as sender_full_name,
+			format_short_name(u.last_name, u.first_name, u.middle_name) as sender_name,
+			format_full_name(ru.last_name, ru.first_name, ru.middle_name) as responsible_full_name,
+			format_short_name(ru.last_name, ru.first_name, ru.middle_name) as responsible_name
 		`).
 		Joins("LEFT JOIN organizations o ON a.organization_id = o.id").
 		Joins("LEFT JOIN companies c ON a.company_id = c.id").


### PR DESCRIPTION
## Что сделано (Issue #184, Блок 2: форматирование ФИО)

### Backend
- SQL-функции `format_short_name(last, first, middle)` и `format_full_name(...)` в миграции (CREATE OR REPLACE при каждом старте).
- Логика `format_short_name`: при отсутствии фамилии возвращает имя/отчество полностью (а не "И."). Соответствует требованию: "Иван" -> "Иван", не "И."
- Все CONCAT(...) для sender/responsible в `application_service.go` заменены на эти функции (5 мест).

### Frontend
- Утилита `frontend/src/utils/formatName.js`: `formatShortName`, `formatFullName` — единая логика на клиенте.
- 11 unit-тестов покрывают краевые случаи.
- AdminUsers переключен на utility (был свой неправильный код для случая "только имя").
- ApplicationsCenter: кастомный tooltip с полным ФИО **строго под** отправителем, **по центру** (CSS-only через `data-tooltip` + `::before/::after`).

## План тестирования
- [ ] Центр заявок: tooltip появляется под именем отправителя по центру, содержит полное ФИО
- [ ] Если у пользователя только имя (без фамилии) - отображается полностью
- [ ] AdminUsers: пользователь только с именем не отображается как " И."
- [ ] Backend: применить миграцию (запуск контейнера) - функции создаются без ошибок