### PR TITLE
fix: тестовые даты на 2099 (тесты ломались после 2026-04-30)

### DIFF
--- a/internal/handlers/api_contract_test.go
+++ b/internal/handlers/api_contract_test.go
@@ -137,7 +137,7 @@ func TestAPIContract_ApplicationsList(t *testing.T) {
 			"attachment_display_name": "Contract Template",
 			"unique_attachment_id": %d,
 			"entry_date_from": "2026-04-01",
-			"entry_date_to": "2026-04-30",
+			"entry_date_to": "2099-12-31",
 			"entry_time_from": "08:00",
 			"entry_time_to": "18:00",
 			"data": {
@@ -179,7 +179,7 @@ func TestAPIContract_ApplicationDetail(t *testing.T) {
 			"attachment_display_name": "Detail Template",
 			"unique_attachment_id": %d,
 			"entry_date_from": "2026-04-01",
-			"entry_date_to": "2026-04-30",
+			"entry_date_to": "2099-12-31",
 			"entry_time_from": "08:00",
 			"entry_time_to": "18:00",
 			"data": {

--- a/internal/handlers/applications_expiry_test.go
+++ b/internal/handlers/applications_expiry_test.go
@@ -137,7 +137,7 @@ func TestCheckExpiredAttachments(t *testing.T) {
 							"attachment_display_name": "Cars A",
 							"unique_attachment_id": %d,
 							"entry_date_from": "2026-04-01",
-							"entry_date_to": "2026-12-31",
+							"entry_date_to": "2099-12-31",
 							"entry_time_from": "08:00",
 							"entry_time_to": "18:00",
 							"data": {"vehicles": [{"car_number": "B001BB777", "car_brand": "Honda"}]}
@@ -148,7 +148,7 @@ func TestCheckExpiredAttachments(t *testing.T) {
 							"attachment_display_name": "Cars B",
 							"unique_attachment_id": %d,
 							"entry_date_from": "2026-04-01",
-							"entry_date_to": "2026-12-31",
+							"entry_date_to": "2099-12-31",
 							"entry_time_from": "08:00",
 							"entry_time_to": "18:00",
 							"data": {"vehicles": [{"car_number": "C001CC777", "car_brand": "Mazda"}]}
@@ -223,7 +223,7 @@ func TestCheckExpiredAttachments(t *testing.T) {
 				require.NotEmpty(t, attachments)
 				attID := int(attachments[0]["id"].(float64))
 
-				// entry_date_to is 2026-04-30, which is in the future — nothing should change.
+				// entry_date_to is 2099-12-31, which is in the future — nothing should change.
 				err := appSvc.CheckExpiredAttachments(context.Background())
 				require.NoError(t, err)
 

--- a/internal/handlers/applications_test.go
+++ b/internal/handlers/applications_test.go
@@ -97,7 +97,7 @@ func submitCompleteApplication(t *testing.T, e *echo.Echo, token string, orgName
 			"attachment_display_name": "Cars Template",
 			"unique_attachment_id": %d,
 			"entry_date_from": "2026-04-01",
-			"entry_date_to": "2026-04-30",
+			"entry_date_to": "2099-12-31",
 			"entry_time_from": "08:00",
 			"entry_time_to": "18:00",
 			"data": {
@@ -918,7 +918,7 @@ func TestSubmitCompleteApplication_WithEmployeesAndItems(t *testing.T) {
 				"attachment_display_name": "People Template",
 				"unique_attachment_id": %d,
 				"entry_date_from": "2026-04-01",
-				"entry_date_to": "2026-04-30",
+				"entry_date_to": "2099-12-31",
 				"data": {
 					"employees": [{
 						"last_name": "Ivanov",
@@ -937,7 +937,7 @@ func TestSubmitCompleteApplication_WithEmployeesAndItems(t *testing.T) {
 				"attachment_display_name": "Items Template",
 				"unique_attachment_id": %d,
 				"entry_date_from": "2026-04-01",
-				"entry_date_to": "2026-04-30",
+				"entry_date_to": "2099-12-31",
 				"data": {
 					"items": [{
 						"name": "Cement bags",

--- a/internal/handlers/cars_test.go
+++ b/internal/handlers/cars_test.go
@@ -36,7 +36,7 @@ func seedCarViaCompleteApp(t *testing.T, e *echo.Echo, db *gorm.DB, token string
 			"attachment_display_name": "Car Template",
 			"unique_attachment_id": %d,
 			"entry_date_from": "2026-04-01",
-			"entry_date_to": "2026-04-30",
+			"entry_date_to": "2099-12-31",
 			"entry_time_from": "08:00",
 			"entry_time_to": "18:00",
 			"data": {
@@ -563,7 +563,7 @@ func TestCarWithUnloadPlaces(t *testing.T) {
 			"attachment_display_name": "Car Template",
 			"unique_attachment_id": %d,
 			"entry_date_from": "2026-04-01",
-			"entry_date_to": "2026-04-30",
+			"entry_date_to": "2099-12-31",
 			"entry_time_from": "08:00",
 			"entry_time_to": "18:00",
 			"data": {

--- a/internal/handlers/employees_test.go
+++ b/internal/handlers/employees_test.go
@@ -212,7 +212,7 @@ func TestGetActiveEmployeesForTable_WithActiveEmployee(t *testing.T) {
 			"attachment_display_name": "People Template",
 			"unique_attachment_id": %d,
 			"entry_date_from": "2026-04-01",
-			"entry_date_to": "2026-04-30",
+			"entry_date_to": "2099-12-31",
 			"data": {
 				"employees": [{
 					"last_name": "ActiveWorker",


### PR DESCRIPTION
Хардкод 'entry_date_to: 2026-04-30' стал прошлым 2026-05-01, expiry-сервис стал автоматически закрывать тестовые заявки -> упали TestCheckExpiredAttachments и TestCheckActiveCar_Found. Заменил на 2099-12-31. Не относится напрямую к issue/184, но блокирует деплой stage.