### PR TITLE
feat: блок 7 - унификация статусов через StatusBadge (#184)

### DIFF
--- a/frontend/src/components/CreateApplication/ExistingCarsModal.vue
+++ b/frontend/src/components/CreateApplication/ExistingCarsModal.vue
@@ -121,15 +121,7 @@
                 {{ car.mark }}
               </div>
               <div class="table-cell status-cell">
-                <span
-                  class="status-badge"
-                  :class="{
-                    'status-active': car.status,
-                    'status-inactive': !car.status
-                  }"
-                >
-                  {{ car.status ? 'Активна' : 'Неактивна' }}
-                </span>
+                <StatusBadge :status="car.status ? 'Активна' : 'Неактивна'" />
               </div>
             </div>
 
@@ -174,12 +166,14 @@
 import { apiRequest } from '@/api/client'
 import SearchComponent from '@/components/SearchComponent.vue'
 import LoaderSpinner from '@/components/ui/LoaderSpinner.vue'
+import StatusBadge from '@/components/ui/StatusBadge.vue'
 
 export default {
     name: 'ExistingCarsModal',
     components: {
         SearchComponent,
-        LoaderSpinner
+        LoaderSpinner,
+        StatusBadge
     },
     props: {
         visible: {
@@ -609,29 +603,7 @@ export default {
     opacity: 0.6;
 }
 
-.status-badge {
-    padding: 4px 10px;
-    border-radius: 12px;
-    font-size: 11px;
-    font-weight: 500;
-    display: inline-block;
-    min-width: 70px;
-    text-align: center;
-}
-
-.status-active {
-    background-color: #f0f9ff;
-    color: #0369a1;
-    border: 1px solid #bae6fd;
-}
-
-.status-inactive {
-    background-color: #fef2f2;
-    color: #991b1b;
-    border: 1px solid #fecaca;
-}
-
-.table-row--disabled .status-badge {
+.table-row--disabled :deep(.status-badge) {
     opacity: 0.7;
 }
 

--- a/frontend/src/components/CreateApplication/ExistingEmployeesModal.vue
+++ b/frontend/src/components/CreateApplication/ExistingEmployeesModal.vue
@@ -114,15 +114,7 @@
                 {{ employee.citizenship_name || 'Не указано' }}
               </div>
               <div class="table-cell status-cell">
-                <span
-                  class="status-badge"
-                  :class="{
-                    'status-active': employee.status,
-                    'status-inactive': !employee.status
-                  }"
-                >
-                  {{ employee.status ? 'Активен' : 'Неактивен' }}
-                </span>
+                <StatusBadge :status="employee.status ? 'Активен' : 'Неактивен'" />
               </div>
             </div>
 
@@ -165,12 +157,14 @@
 import { apiRequest } from '@/api/client'
 import SearchComponent from '@/components/SearchComponent.vue'
 import LoaderSpinner from '@/components/ui/LoaderSpinner.vue'
+import StatusBadge from '@/components/ui/StatusBadge.vue'
 
 export default {
     name: 'ExistingEmployeesModal',
     components: {
         SearchComponent,
-        LoaderSpinner
+        LoaderSpinner,
+        StatusBadge
     },
     props: {
         visible: {
@@ -574,29 +568,7 @@ export default {
     opacity: 0.6;
 }
 
-.status-badge {
-    padding: 4px 10px;
-    border-radius: 12px;
-    font-size: 11px;
-    font-weight: 500;
-    display: inline-block;
-    min-width: 70px;
-    text-align: center;
-}
-
-.status-active {
-    background-color: #f0f9ff;
-    color: #0369a1;
-    border: 1px solid #bae6fd;
-}
-
-.status-inactive {
-    background-color: #fef2f2;
-    color: #991b1b;
-    border: 1px solid #fecaca;
-}
-
-.table-row--disabled .status-badge {
+.table-row--disabled :deep(.status-badge) {
     opacity: 0.7;
 }
 

--- a/frontend/src/views/CarsView.vue
+++ b/frontend/src/views/CarsView.vue
@@ -226,15 +226,7 @@
                       {{ car.format_name || 'Не указан' }}
                     </div>
                     <div class="car-col status-col">
-                      <span 
-                        class="status-badge"
-                        :class="{
-                          'status-active': car.status,
-                          'status-inactive': !car.status
-                        }"
-                      >
-                        {{ car.status ? 'Активна' : 'Неактивна' }}
-                      </span>
+                      <StatusBadge :status="car.status ? 'Активна' : 'Неактивна'" />
                     </div>
                     <div class="car-col actions-col">
                       <button 
@@ -536,6 +528,7 @@ import SearchComponent from '@/components/SearchComponent.vue';
 import RefreshButton from '@/components/RefreshButton.vue';
 import SkeletonTransition from '@/components/ui/SkeletonTransition.vue';
 import SkeletonTable from '@/components/ui/SkeletonTable.vue';
+import StatusBadge from '@/components/ui/StatusBadge.vue';
 import ConfirmationModal from '@/components/ConfirmationModal.vue';
 
 export default {
@@ -544,6 +537,7 @@ export default {
         RefreshButton,
         SkeletonTransition,
         SkeletonTable,
+        StatusBadge,
         ConfirmationModal
     },
     data() {
@@ -1516,27 +1510,6 @@ export default {
     scrollbar-color: #D9E2FF transparent;
     scroll-behavior: smooth;
     overscroll-behavior: contain;
-}
-
-/* Стили для бейджей статуса */
-.status-badge {
-    padding: 4px 12px;
-    border-radius: 12px;
-    font-size: 12px;
-    font-weight: 500;
-    display: inline-block;
-}
-
-.status-active {
-    background-color: #f0f9ff;
-    color: #0369a1;
-    border: 1px solid #bae6fd
-}
-
-.status-inactive {
-    background-color: #fef2f2;
-    color: #991b1b;
-    border: 1px solid #fecaca;
 }
 
 /* Кнопки действий */

--- a/frontend/src/views/EmployeeView.vue
+++ b/frontend/src/views/EmployeeView.vue
@@ -212,15 +212,7 @@
                       {{ truncateText(employee.position || 'Не указана', 20) }}
                     </div>
                     <div class="employee-col status-col">
-                      <span 
-                        class="status-badge"
-                        :class="{
-                          'status-active': employee.status,
-                          'status-inactive': !employee.status
-                        }"
-                      >
-                        {{ employee.status ? 'Активен' : 'Неактивен' }}
-                      </span>
+                      <StatusBadge :status="employee.status ? 'Активен' : 'Неактивен'" />
                     </div>
                     <div class="employee-col actions-col">
                       <button 
@@ -312,6 +304,7 @@ import SearchComponent from '@/components/SearchComponent.vue';
 import RefreshButton from '@/components/RefreshButton.vue';
 import SkeletonTransition from '@/components/ui/SkeletonTransition.vue';
 import SkeletonTable from '@/components/ui/SkeletonTable.vue';
+import StatusBadge from '@/components/ui/StatusBadge.vue';
 import EmployeeEditModal from '@/components/EmployeeEditModal.vue';
 
 export default {
@@ -320,6 +313,7 @@ export default {
         RefreshButton,
         SkeletonTransition,
         SkeletonTable,
+        StatusBadge,
         EmployeeEditModal
     },
     data() {
@@ -852,27 +846,6 @@ export default {
     scrollbar-color: #D9E2FF transparent;
     scroll-behavior: smooth;
     overscroll-behavior: contain;
-}
-
-/* Стили для бейджей статуса */
-.status-badge {
-    padding: 4px 12px;
-    border-radius: 12px;
-    font-size: 12px;
-    font-weight: 500;
-    display: inline-block;
-}
-
-.status-active {
-    background-color: #f0f9ff;
-    color: #0369a1;
-    border: 1px solid #bae6fd
-}
-
-.status-inactive {
-    background-color: #fef2f2;
-    color: #991b1b;
-    border: 1px solid #fecaca;
 }
 
 /* Кнопки действий */


### PR DESCRIPTION
## Что сделано

Унификация отображения статуса машин/сотрудников через существующий компонент `ui/StatusBadge.vue`. Поле `status` (0/1) уже отдаётся API `/unique-cars` и `/unique-employees`.

### Покрыто StatusBadge
1. **CarsView** (`/carsview`) — таблица 'Мои/организации/компании/все машины'. Удалены локальные `.status-badge`/`.status-active`/`.status-inactive`.
2. **EmployeeView** (`/employeesview`) — таблица сотрудников.
3. **ExistingCarsModal** — модалка 'Существующие машины' при создании заявки.
4. **ExistingEmployeesModal** — модалка 'Существующие сотрудники'.

### Намеренно не тронуто (другой смысл status)
- `CarsTable`/`PeopleTable` — там `item.status` это статус **заявки** (хардкод 'В работе'/'Активен'/'Удален'), не сущности. По ТЗ в этих таблицах все строки по определению активны (в активной заявке).
- `*DetailsModal` — `getStatusText` показывает **территориальный** статус (на территории/выехал), не активность сущности.
- `FactTable` — статусная колонка закомментирована.
- `CarsFact` — статус заявки на КПП.

### TODO (вне scope)
- `VehiclesList.vue`, `EmployeesList.vue` (CreateApplication) — в форме создания заявки status не пробрасывается из API. Если в будущем нужно показывать активность сущности прямо в форме — нужно править `CreateApplication.vue` (~1999, спред props).

## Проверка
- eslint: 0 ошибок
- vitest: 225/225 тестов прошли

## План тестирования
- [ ] /carsview - бейджи 'Активна'/'Неактивна' выглядят как остальные StatusBadge
- [ ] /employeesview - аналогично
- [ ] Модалки 'Существующие машины/сотрудники' - бейджи единого стиля