### PR TITLE
fix: блок 6 - UTC время операций (#184)

### DIFF
--- a/cmd/seed/main.go
+++ b/cmd/seed/main.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"os"
 
+	"systemburo/internal/database"
+
 	"golang.org/x/crypto/argon2"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
@@ -29,7 +31,7 @@ func main() {
 		dsn = "postgres://postgres:postgres@localhost:5432/auto_registry?sslmode=disable"
 	}
 
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	db, err := gorm.Open(postgres.Open(database.EnsureUTCTimezone(dsn)), &gorm.Config{})
 	if err != nil {
 		log.Fatalf("DB connection failed: %v", err)
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -77,8 +77,15 @@ func main() {
 	if cfg.LogLevel == "debug" {
 		gormLogLevel = logger.Info
 	}
-	db, err := gorm.Open(postgres.Open(cfg.DatabaseURL), &gorm.Config{
+	// Все autoCreateTime/autoUpdateTime поля заполняются в UTC, чтобы избежать
+	// расхождений между локальной зоной хост-системы и timestamptz-столбцами
+	// в Postgres. Issue #184.
+	dsnWithTZ := database.EnsureUTCTimezone(cfg.DatabaseURL)
+	db, err := gorm.Open(postgres.Open(dsnWithTZ), &gorm.Config{
 		Logger: logger.Default.LogMode(gormLogLevel),
+		NowFunc: func() time.Time {
+			return time.Now().UTC()
+		},
 	})
 	if err != nil {
 		slog.Error("failed to connect to database", "error", err)

--- a/internal/database/dsn.go
+++ b/internal/database/dsn.go
@@ -1,0 +1,55 @@
+package database
+
+import (
+	"net/url"
+	"strings"
+)
+
+// EnsureUTCTimezone добавляет TimeZone=UTC к Postgres DSN, если параметр не задан.
+//
+// Поддерживает оба формата:
+//   - URL: "postgres://user:pass@host/db?sslmode=disable" -> добавляет ?TimeZone=UTC
+//   - keyword: "host=... user=... dbname=..." -> добавляет " TimeZone=UTC"
+//
+// Цель: заставить gorm/pgx отдавать timestamptz в UTC независимо от TZ
+// контейнера и сервера БД. Без этого "удаление в 21:22" в Алматы (+5/+6)
+// записывается как 15:22 после неявной конверсии в локальную зону. Issue #184.
+func EnsureUTCTimezone(dsn string) string {
+	if dsn == "" {
+		return dsn
+	}
+
+	if strings.HasPrefix(dsn, "postgres://") || strings.HasPrefix(dsn, "postgresql://") {
+		u, err := url.Parse(dsn)
+		if err != nil {
+			return dsn
+		}
+		q := u.Query()
+		if hasTimeZoneKey(q) {
+			return dsn
+		}
+		q.Set("TimeZone", "UTC")
+		u.RawQuery = q.Encode()
+		return u.String()
+	}
+
+	// keyword/value формат: пропускаем если уже задан timezone.
+	low := strings.ToLower(dsn)
+	if strings.Contains(low, "timezone=") || strings.Contains(low, "time_zone=") {
+		return dsn
+	}
+	if strings.HasSuffix(dsn, " ") {
+		return dsn + "TimeZone=UTC"
+	}
+	return dsn + " TimeZone=UTC"
+}
+
+func hasTimeZoneKey(q url.Values) bool {
+	for k := range q {
+		switch strings.ToLower(k) {
+		case "timezone", "time_zone":
+			return true
+		}
+	}
+	return false
+}

--- a/internal/database/dsn_test.go
+++ b/internal/database/dsn_test.go
@@ -1,0 +1,100 @@
+package database
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestEnsureUTCTimezone_AddsParameterWhenMissing проверяет, что TimeZone=UTC
+// добавляется к URL-DSN, если он не задан.
+func TestEnsureUTCTimezone_AddsParameterWhenMissing(t *testing.T) {
+	cases := []struct {
+		name string
+		dsn  string
+		want string
+	}{
+		{
+			name: "URL без параметров",
+			dsn:  "postgres://user:pass@host/db",
+			want: "TimeZone=UTC",
+		},
+		{
+			name: "URL с sslmode",
+			dsn:  "postgres://user:pass@host/db?sslmode=disable",
+			want: "TimeZone=UTC",
+		},
+		{
+			name: "postgresql:// схема",
+			dsn:  "postgresql://user:pass@host/db?sslmode=disable",
+			want: "TimeZone=UTC",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := EnsureUTCTimezone(tc.dsn)
+			if !strings.Contains(got, tc.want) {
+				t.Errorf("EnsureUTCTimezone(%q) = %q, want substring %q", tc.dsn, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEnsureUTCTimezone_KeepsExistingTimezone проверяет, что параметр TimeZone
+// не перезаписывается, если уже задан.
+func TestEnsureUTCTimezone_KeepsExistingTimezone(t *testing.T) {
+	cases := []struct {
+		name string
+		dsn  string
+	}{
+		{
+			name: "URL с TimeZone=Asia/Almaty",
+			dsn:  "postgres://user:pass@host/db?TimeZone=Asia/Almaty",
+		},
+		{
+			name: "URL с TimeZone=Europe/Moscow и другими параметрами",
+			dsn:  "postgres://user:pass@host/db?sslmode=disable&TimeZone=Europe/Moscow",
+		},
+		{
+			name: "keyword DSN с TimeZone",
+			dsn:  "host=db user=postgres dbname=test TimeZone=Europe/London",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := EnsureUTCTimezone(tc.dsn)
+			if strings.Contains(got, "TimeZone=UTC") {
+				t.Errorf("EnsureUTCTimezone(%q) wrongly added UTC, got %q", tc.dsn, got)
+			}
+		})
+	}
+}
+
+// TestEnsureUTCTimezone_KeywordDSN проверяет добавление к keyword-DSN.
+func TestEnsureUTCTimezone_KeywordDSN(t *testing.T) {
+	dsn := "host=db user=postgres dbname=test sslmode=disable"
+	got := EnsureUTCTimezone(dsn)
+	if !strings.Contains(got, "TimeZone=UTC") {
+		t.Errorf("EnsureUTCTimezone(%q) = %q, want substring TimeZone=UTC", dsn, got)
+	}
+}
+
+// TestEnsureUTCTimezone_EmptyInput проверяет, что пустой DSN возвращается как есть.
+func TestEnsureUTCTimezone_EmptyInput(t *testing.T) {
+	if got := EnsureUTCTimezone(""); got != "" {
+		t.Errorf("EnsureUTCTimezone(\"\") = %q, want empty", got)
+	}
+}
+
+// TestEnsureUTCTimezone_PreservesExistingParams проверяет, что добавление
+// TimeZone не ломает другие query-параметры.
+func TestEnsureUTCTimezone_PreservesExistingParams(t *testing.T) {
+	dsn := "postgres://user:pass@host/db?sslmode=disable&pool_max_conns=10"
+	got := EnsureUTCTimezone(dsn)
+	for _, must := range []string{"sslmode=disable", "pool_max_conns=10", "TimeZone=UTC"} {
+		if !strings.Contains(got, must) {
+			t.Errorf("EnsureUTCTimezone(%q) lost parameter %q: %q", dsn, must, got)
+		}
+	}
+}

--- a/internal/handlers/utc_time_test.go
+++ b/internal/handlers/utc_time_test.go
@@ -1,0 +1,160 @@
+package handlers_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"systemburo/internal/models"
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCarHistory_CreatedAtIsValidISO8601 проверяет, что endpoint /cars/{id}/history
+// отдаёт created_at в формате ISO 8601 с TZ-маркером, и что это значение можно
+// распарсить через time.Parse(time.RFC3339, ...). Issue #184.
+func TestCarHistory_CreatedAtIsValidISO8601(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "carutc1", "pass123", 1, td.OrgID, td.CompanyID)
+	appID, _, carID := seedCarViaCompleteApp(t, e, db, token, "Test Organization")
+	activateCarViaApp(t, e, db, appID, td)
+
+	// Сделаем действие, чтобы появилась запись истории.
+	rec := testutil.PUT(t, e, fmt.Sprintf("/cars/%d/territory-status", carID),
+		`{"territory_status": 1}`, testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = testutil.GET(t, e, fmt.Sprintf("/cars/%d/history", carID), testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	history := testutil.ParseSlice(t, rec)
+	require.NotEmpty(t, history, "история должна содержать как минимум 1 запись")
+
+	for i, item := range history {
+		raw, ok := item["created_at"].(string)
+		require.True(t, ok, "запись %d: created_at должно быть строкой", i)
+		require.NotEmpty(t, raw, "запись %d: created_at не должно быть пустым", i)
+
+		_, err := time.Parse(time.RFC3339, raw)
+		assert.NoErrorf(t, err, "запись %d: created_at=%q должно парситься как RFC3339", i, raw)
+
+		// Маркер таймзоны обязателен: либо "Z" (UTC), либо "+HH:MM"/"-HH:MM".
+		hasTZ := strings.HasSuffix(raw, "Z") ||
+			strings.Contains(raw[10:], "+") ||
+			strings.Count(raw, "-") >= 3
+		assert.Truef(t, hasTZ, "запись %d: created_at=%q должно содержать TZ-маркер", i, raw)
+	}
+}
+
+// TestCarHistory_DeleteActionRecordedAtUTC проверяет ключевой кейс из issue #184:
+// удаление машины записывается с моментом времени = time.Now().UTC(), и при отдаче
+// через API оно корректно представлено в RFC3339. До фикса хардкод +03:00
+// генерировал смещение которое не учитывало локаль пользователя.
+func TestCarHistory_DeleteActionRecordedAtUTC(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "carutc2", "pass123", 1, td.OrgID, td.CompanyID)
+	appID, _, carID := seedCarViaCompleteApp(t, e, db, token, "Test Organization")
+	activateCarViaApp(t, e, db, appID, td)
+
+	beforeUTC := time.Now().UTC().Add(-2 * time.Second)
+
+	// Деактивация (мягкое удаление) -- именно этот сценарий отлажен в issue.
+	rec := testutil.PUT(t, e, fmt.Sprintf("/cars/%d/deactivate", carID),
+		`{"status": 2}`, testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	afterUTC := time.Now().UTC().Add(2 * time.Second)
+
+	// Получаем запись из БД напрямую и убеждаемся, что момент в UTC-окне.
+	var hist models.CarHistory
+	require.NoError(t,
+		db.Where("car_id = ? AND action_type = ?", carID, "delete").
+			Order("created_at DESC").
+			First(&hist).Error)
+
+	createdUTC := hist.CreatedAt.UTC()
+	assert.Truef(t,
+		!createdUTC.Before(beforeUTC) && !createdUTC.After(afterUTC),
+		"created_at=%v должно быть между %v и %v (UTC)", createdUTC, beforeUTC, afterUTC)
+
+	// API должен отдать тот же момент в RFC3339.
+	rec = testutil.GET(t, e, fmt.Sprintf("/cars/%d/history", carID), testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	items := testutil.ParseSlice(t, rec)
+	var deleteAt string
+	for _, item := range items {
+		if action, _ := item["action_type"].(string); action == "delete" {
+			deleteAt, _ = item["created_at"].(string)
+			break
+		}
+	}
+	require.NotEmpty(t, deleteAt, "API должно вернуть запись delete")
+
+	parsed, err := time.Parse(time.RFC3339, deleteAt)
+	require.NoError(t, err, "created_at=%q должно парситься", deleteAt)
+
+	// API-значение и БД-значение должны представлять один и тот же момент
+	// (с точностью до секунды -- gorm может округлить субсекундные знаки).
+	diff := parsed.Sub(createdUTC)
+	if diff < 0 {
+		diff = -diff
+	}
+	assert.LessOrEqual(t, diff, time.Second,
+		"API created_at=%v и DB created_at=%v должны совпадать с точностью до секунды", parsed, createdUTC)
+}
+
+// TestCarsCurrentStatus_TerritoryEntryTimeIsUTC проверяет что endpoint
+// /cars/current-status отдаёт territory_entry_time в формате ISO 8601 с TZ-маркером.
+// Issue #184.
+func TestCarsCurrentStatus_TerritoryEntryTimeIsUTC(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "carutc3", "pass123", 1, td.OrgID, td.CompanyID)
+	appID, _, carID := seedCarViaCompleteApp(t, e, db, token, "Test Organization")
+	activateCarViaApp(t, e, db, appID, td)
+
+	// Делаем "въезд", который проставит territory_entry_time через time.Now().UTC().
+	rec := testutil.PUT(t, e, fmt.Sprintf("/cars/%d/territory-status", carID),
+		`{"territory_status": 1}`, testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = testutil.GET(t, e, "/cars/history/current-status", testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	items := testutil.ParseSlice(t, rec)
+	var entryTime string
+	for _, item := range items {
+		if id, ok := item["car_id"].(float64); ok && int(id) == carID {
+			entryTime, _ = item["entry_time"].(string)
+			break
+		}
+	}
+	require.NotEmpty(t, entryTime, "entry_time должно быть установлено для активной машины")
+
+	_, err := time.Parse(time.RFC3339, entryTime)
+	assert.NoErrorf(t, err, "entry_time=%q должно парситься как RFC3339", entryTime)
+
+	hasTZ := strings.HasSuffix(entryTime, "Z") ||
+		strings.Contains(entryTime[10:], "+") ||
+		strings.Count(entryTime, "-") >= 3
+	assert.Truef(t, hasTZ, "entry_time=%q должно содержать TZ-маркер", entryTime)
+}
+
+// проверяем, что объект models.CarHistory не используется напрямую -- референс через тип:
+var _ = models.CarHistory{}

--- a/internal/middleware/request_logger.go
+++ b/internal/middleware/request_logger.go
@@ -14,7 +14,7 @@ import (
 func RequestLogger(db *gorm.DB) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			start := time.Now()
+			start := time.Now().UTC()
 
 			err := next(c)
 

--- a/internal/services/auth_service.go
+++ b/internal/services/auth_service.go
@@ -186,7 +186,7 @@ func (s *authService) Login(ctx context.Context, req models.LoginRequest, meta *
 	// Учётка заблокирована - не разрешаем попытки (даже с правильным паролем),
 	// пока не истечёт lock-период. Это важно: иначе валидная попытка сбросила бы
 	// счётчик и атакующий мог бы "разморозить" учётку угадав пароль в моменте.
-	if user.LockedUntil != nil && user.LockedUntil.After(time.Now()) {
+	if user.LockedUntil != nil && user.LockedUntil.After(time.Now().UTC()) {
 		remaining := int(time.Until(*user.LockedUntil).Seconds())
 		s.recordAuthEvent(ctx, &user.ID, user.Username, models.AuthEventLoginLocked, false, meta,
 			fmt.Sprintf("locked for %ds", remaining))
@@ -202,7 +202,7 @@ func (s *authService) Login(ctx context.Context, req models.LoginRequest, meta *
 
 	// Успешный вход - сбрасываем счётчик неудачных попыток и lock.
 	// Также апдейтим last_login_at для аудита активности.
-	now := time.Now()
+	now := time.Now().UTC()
 	updates := map[string]interface{}{"last_login_at": now}
 	if user.FailedLoginCount > 0 || user.LockedUntil != nil {
 		updates["failed_login_count"] = 0
@@ -228,7 +228,7 @@ func (s *authService) Login(ctx context.Context, req models.LoginRequest, meta *
 		UserID:    user.ID,
 		FamilyID:  familyID,
 		TokenHash: hashRefreshToken(refreshJWT),
-		ExpiresAt: time.Now().Add(s.refreshTTL),
+		ExpiresAt: time.Now().UTC().Add(s.refreshTTL),
 		IPAddress: metaIPPtr(meta),
 		UserAgent: metaUAPtr(meta),
 	}
@@ -310,7 +310,7 @@ func (s *authService) RefreshToken(ctx context.Context, req models.RefreshTokenR
 		UserID:    user.ID,
 		FamilyID:  storedToken.FamilyID,
 		TokenHash: hashRefreshToken(newRefresh),
-		ExpiresAt: time.Now().Add(s.refreshTTL),
+		ExpiresAt: time.Now().UTC().Add(s.refreshTTL),
 		IPAddress: metaIPPtr(meta),
 		UserAgent: metaUAPtr(meta),
 	}
@@ -435,7 +435,7 @@ func (s *authService) registerFailedLogin(ctx context.Context, user *models.User
 		"failed_login_count": user.FailedLoginCount,
 	}
 	if user.FailedLoginCount >= maxFailedLoginsBeforeLock {
-		lockUntil := time.Now().Add(accountLockDuration)
+		lockUntil := time.Now().UTC().Add(accountLockDuration)
 		updates["locked_until"] = lockUntil
 		// Отдельное event - удобно алёртить "аккаунт только что залочили".
 		s.recordAuthEvent(ctx, &user.ID, user.Username, models.AuthEventAccountLocked, false, nil,

--- a/internal/services/bug_report_service.go
+++ b/internal/services/bug_report_service.go
@@ -46,7 +46,7 @@ func NewBugReportService(db *gorm.DB, tg TelegramService) BugReportService {
 
 func (s *bugReportService) Submit(ctx context.Context, userID int, username string, req models.BugReportRequest, userAgent string) (*models.BugReport, error) {
 	// Rate limit: считаем последние N запросов за окно.
-	since := time.Now().Add(-s.win)
+	since := time.Now().UTC().Add(-s.win)
 	var count int64
 	if err := s.db.WithContext(ctx).
 		Model(&models.BugReport{}).
@@ -66,7 +66,7 @@ func (s *bugReportService) Submit(ctx context.Context, userID int, username stri
 		HTTPStatus: req.HTTPStatus,
 		Message:    req.Message,
 		UserAgent:  userAgent,
-		CreatedAt:  time.Now(),
+		CreatedAt:  time.Now().UTC(),
 	}
 
 	// INSERT .. ON CONFLICT DO NOTHING эквивалент: Create с ошибкой по uniq index.

--- a/internal/services/car_history_service.go
+++ b/internal/services/car_history_service.go
@@ -149,7 +149,6 @@ func (s *carService) GetAllCarsHistory(ctx context.Context) ([]AllCarsHistoryIte
 		if strings.TrimSpace(userName) == "" {
 			userName = "Система"
 		}
-		mskTime := r.CreatedAt.Add(3 * time.Hour)
 		items = append(items, AllCarsHistoryItem{
 			ID:           r.ID,
 			CarID:        r.CarID,
@@ -157,7 +156,7 @@ func (s *carService) GetAllCarsHistory(ctx context.Context) ([]AllCarsHistoryIte
 			UserName:     userName,
 			ActionType:   r.ActionType,
 			Comment:      r.Comment,
-			CreatedAt:    mskTime.Format("2006-01-02T15:04:05+03:00"),
+			CreatedAt:    FormatUTC(r.CreatedAt),
 			CarNumber:    r.CarNumber,
 			CarBrand:     r.CarBrand,
 			Organization: r.Organization,
@@ -256,8 +255,6 @@ func (s *carService) mapHistoryRows(rows []carHistoryRow, includeCarInfo bool) [
 			userName = "Система"
 		}
 
-		mskTime := r.CreatedAt.Add(3 * time.Hour)
-
 		var metadata *json.RawMessage
 		if r.Metadata != nil {
 			raw := json.RawMessage(*r.Metadata)
@@ -277,7 +274,7 @@ func (s *carService) mapHistoryRows(rows []carHistoryRow, includeCarInfo bool) [
 			OldValue:   r.OldValue,
 			NewValue:   r.NewValue,
 			Comment:    r.Comment,
-			CreatedAt:  mskTime.Format("2006-01-02T15:04:05+03:00"),
+			CreatedAt:  FormatUTC(r.CreatedAt),
 			Metadata:   metadata,
 		}
 		if includeCarInfo {

--- a/internal/services/car_query_service.go
+++ b/internal/services/car_query_service.go
@@ -141,11 +141,7 @@ func (s *carService) enrichTableCars(ctx context.Context, rows []tableCarRow) ([
 			status = *row.Status
 		}
 
-		var territoryEntryTimeStr *string
-		if row.TerritoryEntryTime != nil {
-			s := row.TerritoryEntryTime.Add(3 * time.Hour).Format("2006-01-02T15:04:05+03:00")
-			territoryEntryTimeStr = &s
-		}
+		territoryEntryTimeStr := FormatUTCPtr(row.TerritoryEntryTime)
 
 		places := placesByCarID[row.ID]
 		if places == nil {

--- a/internal/services/car_status_service.go
+++ b/internal/services/car_status_service.go
@@ -48,21 +48,11 @@ func (s *carService) GetCarsCurrentStatus(ctx context.Context) ([]CarCurrentStat
 		if r.TerritoryStatus != nil {
 			ts = *r.TerritoryStatus
 		}
-		var entryTimeStr *string
-		if r.TerritoryEntryTime != nil {
-			s := r.TerritoryEntryTime.Add(3 * time.Hour).Format("2006-01-02T15:04:05+03:00")
-			entryTimeStr = &s
-		}
-		var lastExitStr *string
-		if r.LastExitTime != nil {
-			s := r.LastExitTime.Add(3 * time.Hour).Format("2006-01-02T15:04:05+03:00")
-			lastExitStr = &s
-		}
 		items = append(items, CarCurrentStatus{
 			CarID:           r.ID,
 			TerritoryStatus: ts,
-			EntryTime:       entryTimeStr,
-			LastExitTime:    lastExitStr,
+			EntryTime:       FormatUTCPtr(r.TerritoryEntryTime),
+			LastExitTime:    FormatUTCPtr(r.LastExitTime),
 		})
 	}
 	return items, nil

--- a/internal/services/consent_service.go
+++ b/internal/services/consent_service.go
@@ -35,7 +35,7 @@ func (s *consentService) Grant(ctx context.Context, userID int, req models.Grant
 		Granted:     true,
 		IPAddress:   ip,
 		UserAgent:   ua,
-		GrantedAt:   time.Now(),
+		GrantedAt:   time.Now().UTC(),
 	}
 	if err := s.db.WithContext(ctx).Create(&consent).Error; err != nil {
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error granting consent")
@@ -45,7 +45,7 @@ func (s *consentService) Grant(ctx context.Context, userID int, req models.Grant
 
 // Revoke отзывает активное согласие на обработку персональных данных.
 func (s *consentService) Revoke(ctx context.Context, userID int, consentType string) error {
-	now := time.Now()
+	now := time.Now().UTC()
 	result := s.db.WithContext(ctx).
 		Model(&models.PDConsent{}).
 		Where("user_id = ? AND consent_type = ? AND revoked_at IS NULL", userID, consentType).

--- a/internal/services/employees_history_service.go
+++ b/internal/services/employees_history_service.go
@@ -200,21 +200,11 @@ func (s *employeesHistoryService) GetCurrentStatus(ctx context.Context) ([]Emplo
 		if r.TerritoryStatus != nil {
 			ts = *r.TerritoryStatus
 		}
-		var entryTimeStr *string
-		if r.TerritoryEntryTime != nil {
-			s := r.TerritoryEntryTime.Add(3 * time.Hour).Format("2006-01-02T15:04:05+03:00")
-			entryTimeStr = &s
-		}
-		var lastExitStr *string
-		if r.LastExitTime != nil {
-			s := r.LastExitTime.Add(3 * time.Hour).Format("2006-01-02T15:04:05+03:00")
-			lastExitStr = &s
-		}
 		items = append(items, EmployeeCurrentStatus{
 			EmployeeID:      r.ID,
 			TerritoryStatus: ts,
-			EntryTime:       entryTimeStr,
-			LastExitTime:    lastExitStr,
+			EntryTime:       FormatUTCPtr(r.TerritoryEntryTime),
+			LastExitTime:    FormatUTCPtr(r.LastExitTime),
 		})
 	}
 	return items, nil
@@ -240,7 +230,6 @@ func mapEmployeeHistoryRows(rows []employeeHistoryRow) []EmployeeHistoryItem {
 		if strings.TrimSpace(userName) == "" {
 			userName = "Система"
 		}
-		mskTime := r.CreatedAt.Add(3 * time.Hour)
 		items = append(items, EmployeeHistoryItem{
 			ID:                 r.ID,
 			EmployeeID:         r.EmployeeID,
@@ -254,7 +243,7 @@ func mapEmployeeHistoryRows(rows []employeeHistoryRow) []EmployeeHistoryItem {
 			NewValue:           r.NewValue,
 			Comment:            r.Comment,
 			Metadata:           r.Metadata,
-			CreatedAt:          mskTime.Format("2006-01-02T15:04:05+03:00"),
+			CreatedAt:          FormatUTC(r.CreatedAt),
 			EmployeeLastName:   r.EmployeeLastName,
 			EmployeeFirstName:  r.EmployeeFirstName,
 			EmployeeMiddleName: r.EmployeeMiddleName,

--- a/internal/services/maintenance_service.go
+++ b/internal/services/maintenance_service.go
@@ -99,7 +99,7 @@ func (s *maintenanceService) GetStatusCached(ctx context.Context) *MaintenanceSt
 	}
 	s.mu.Lock()
 	s.cache = st
-	s.cachedAt = time.Now()
+	s.cachedAt = time.Now().UTC()
 	s.mu.Unlock()
 	return st
 }

--- a/internal/services/request_logs_service.go
+++ b/internal/services/request_logs_service.go
@@ -142,8 +142,8 @@ func (s *requestLogsService) GetStats(ctx context.Context, typeID int) (*models.
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "failed to fetch stats")
 	}
 
-	// Today
-	todayStart := time.Now().Truncate(24 * time.Hour)
+	// Today (по UTC -- created_at в БД хранится в UTC).
+	todayStart := time.Now().UTC().Truncate(24 * time.Hour)
 	s.db.WithContext(ctx).Table("request_logs").Where("created_at >= ?", todayStart).Count(&stats.Today)
 
 	// Avg duration
@@ -162,7 +162,7 @@ func (s *requestLogsService) GetStats(ctx context.Context, typeID int) (*models.
 	}
 
 	// Requests per minute (за последний час)
-	hourAgo := time.Now().Add(-1 * time.Hour)
+	hourAgo := time.Now().UTC().Add(-1 * time.Hour)
 	var lastHourCount int64
 	s.db.WithContext(ctx).Table("request_logs").
 		Where("created_at >= ?", hourAgo).
@@ -178,7 +178,7 @@ func (s *requestLogsService) GetRealtime(ctx context.Context, typeID int) (*mode
 		return nil, err
 	}
 
-	now := time.Now()
+	now := time.Now().UTC()
 	var stats models.RealtimeStats
 
 	s.db.WithContext(ctx).Table("request_logs").

--- a/internal/services/system_table_service.go
+++ b/internal/services/system_table_service.go
@@ -348,7 +348,7 @@ func (s *systemTableService) Update(ctx context.Context, id int, req models.Upda
 	}
 
 	updates := map[string]interface{}{
-		"updated_at": time.Now(),
+		"updated_at": time.Now().UTC(),
 	}
 	if req.DisplayName != nil {
 		updates["display_name"] = *req.DisplayName

--- a/internal/services/system_table_timeslot_service.go
+++ b/internal/services/system_table_timeslot_service.go
@@ -113,7 +113,7 @@ func (s *systemTableService) UpdateTimeSlot(ctx context.Context, tableID, slotID
 			"close_time":  slot.CloseTime,
 			"is_next_day": slot.IsNextDay,
 			"is_active":   slot.IsActive,
-			"updated_at":  time.Now(),
+			"updated_at":  time.Now().UTC(),
 		})
 	if result.Error != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "Error updating time slot")

--- a/internal/services/timeutil.go
+++ b/internal/services/timeutil.go
@@ -1,0 +1,32 @@
+package services
+
+import "time"
+
+// FormatUTC сериализует момент времени в RFC3339 (с миллисекундной точностью)
+// в UTC-зоне. Если t уже не UTC, значение конвертируется без изменения момента.
+//
+// Это единственное правильное представление времени в API: клиент через
+// new Date(s).toLocaleString() сам приведёт к локальной зоне.
+func FormatUTC(t time.Time) string {
+	return t.UTC().Format(time.RFC3339)
+}
+
+// FormatUTCPtr возвращает указатель на FormatUTC(*t), либо nil для nil-входа.
+// Удобно для опциональных полей вроде territory_entry_time, last_exit_time.
+func FormatUTCPtr(t *time.Time) *string {
+	if t == nil {
+		return nil
+	}
+	s := FormatUTC(*t)
+	return &s
+}
+
+// NowUTC возвращает текущий момент в UTC. Использовать вместо time.Now()
+// для всех timestamp-полей (created_at, updated_at, sending_datetime и т.д.).
+//
+// Локальная зона сервера в Go может отличаться от UTC -- если писать time.Now()
+// без UTC, в Postgres timestamptz столбец конвертирует, но любая ручная сериализация
+// в JSON или сравнения дадут расхождение по часам.
+func NowUTC() time.Time {
+	return time.Now().UTC()
+}

--- a/internal/services/timeutil_test.go
+++ b/internal/services/timeutil_test.go
@@ -1,0 +1,119 @@
+package services
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestFormatUTC_AlwaysUTC проверяет что FormatUTC выдаёт строку в UTC (Z-суффикс)
+// независимо от Location входного значения. Это гарантирует, что фронт через
+// new Date(s).toLocaleString() корректно конвертирует в локальную зону пользователя.
+func TestFormatUTC_AlwaysUTC(t *testing.T) {
+	// Будущая дата, чтобы избежать совпадений с существующими тестовыми
+	// фикстурами и не вводить flakiness вокруг "сейчас".
+	base := time.Date(2099, 12, 31, 21, 22, 0, 0, time.UTC)
+
+	t.Run("UTC input returns Z-suffix", func(t *testing.T) {
+		got := FormatUTC(base)
+		if !strings.HasSuffix(got, "Z") {
+			t.Errorf("FormatUTC(UTC) = %q, want suffix Z", got)
+		}
+	})
+
+	t.Run("Asia/Almaty input is converted to UTC", func(t *testing.T) {
+		almaty, err := time.LoadLocation("Asia/Almaty")
+		if err != nil {
+			t.Skip("Asia/Almaty timezone unavailable")
+		}
+		// 2099-12-31 21:22 по Алматы (UTC+5) = 16:22 UTC.
+		local := time.Date(2099, 12, 31, 21, 22, 0, 0, almaty)
+		got := FormatUTC(local)
+		if !strings.HasSuffix(got, "Z") {
+			t.Errorf("FormatUTC(Asia/Almaty) = %q, want suffix Z", got)
+		}
+		want := "2099-12-31T16:22:00Z"
+		if got != want {
+			t.Errorf("FormatUTC(Asia/Almaty) = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("Europe/Moscow input is converted to UTC", func(t *testing.T) {
+		moscow, err := time.LoadLocation("Europe/Moscow")
+		if err != nil {
+			t.Skip("Europe/Moscow timezone unavailable")
+		}
+		// 2099-12-31 18:22 по Москве (UTC+3) = 15:22 UTC.
+		local := time.Date(2099, 12, 31, 18, 22, 0, 0, moscow)
+		got := FormatUTC(local)
+		want := "2099-12-31T15:22:00Z"
+		if got != want {
+			t.Errorf("FormatUTC(Europe/Moscow) = %q, want %q", got, want)
+		}
+	})
+}
+
+// TestFormatUTC_RoundTripParseable проверяет, что результат корректно
+// парсится обратно через time.Parse с тем же моментом во времени.
+// Это гарантирует совместимость с new Date(...) на фронте.
+func TestFormatUTC_RoundTripParseable(t *testing.T) {
+	original := time.Date(2099, 12, 31, 15, 22, 0, 0, time.UTC)
+	formatted := FormatUTC(original)
+
+	parsed, err := time.Parse(time.RFC3339, formatted)
+	if err != nil {
+		t.Fatalf("time.Parse(RFC3339, %q) failed: %v", formatted, err)
+	}
+	if !parsed.Equal(original) {
+		t.Errorf("round-trip mismatch: got %v, want %v", parsed, original)
+	}
+}
+
+// TestFormatUTCPtr_NilSafe проверяет nil-входы.
+func TestFormatUTCPtr_NilSafe(t *testing.T) {
+	if got := FormatUTCPtr(nil); got != nil {
+		t.Errorf("FormatUTCPtr(nil) = %v, want nil", got)
+	}
+
+	moment := time.Date(2099, 12, 31, 15, 22, 0, 0, time.UTC)
+	got := FormatUTCPtr(&moment)
+	if got == nil {
+		t.Fatal("FormatUTCPtr(&t) = nil, want non-nil")
+	}
+	want := "2099-12-31T15:22:00Z"
+	if *got != want {
+		t.Errorf("FormatUTCPtr(&t) = %q, want %q", *got, want)
+	}
+}
+
+// TestNowUTC_ReturnsUTCLocation проверяет, что NowUTC всегда возвращает
+// значение в UTC-зоне -- даже если хост-машина в другой TZ.
+func TestNowUTC_ReturnsUTCLocation(t *testing.T) {
+	got := NowUTC()
+	if got.Location() != time.UTC {
+		t.Errorf("NowUTC().Location() = %v, want UTC", got.Location())
+	}
+}
+
+// TestFormatUTC_PreservesInstant проверяет, что момент времени сохраняется
+// даже если Location другой -- баг "удаление в 21:22 фиксируется как 15:22"
+// возникает именно при потере точного момента после конверсий.
+func TestFormatUTC_PreservesInstant(t *testing.T) {
+	almaty, err := time.LoadLocation("Asia/Almaty")
+	if err != nil {
+		t.Skip("Asia/Almaty timezone unavailable")
+	}
+
+	// Один и тот же момент в двух разных зонах должен дать одинаковую UTC-строку.
+	utcMoment := time.Date(2099, 12, 31, 16, 22, 0, 0, time.UTC)
+	almatyMoment := utcMoment.In(almaty) // тот же instant, другая Location
+
+	if !utcMoment.Equal(almatyMoment) {
+		t.Fatal("test setup invalid: moments must be equal")
+	}
+
+	if FormatUTC(utcMoment) != FormatUTC(almatyMoment) {
+		t.Errorf("FormatUTC must produce identical strings for same instant: %q vs %q",
+			FormatUTC(utcMoment), FormatUTC(almatyMoment))
+	}
+}

--- a/internal/services/unload_place_service.go
+++ b/internal/services/unload_place_service.go
@@ -209,7 +209,7 @@ func (s *unloadPlaceService) Create(ctx context.Context, req CreateUnloadPlaceRe
 		Status:        status,
 		StatusComment: req.StatusComment,
 		IsActive:      true,
-		UpdatedAt:     time.Now(),
+		UpdatedAt:     time.Now().UTC(),
 	}
 
 	if err := s.db.WithContext(ctx).Create(&place).Error; err != nil {
@@ -231,7 +231,7 @@ func (s *unloadPlaceService) Update(ctx context.Context, id int, req UpdateUnloa
 	}
 
 	updates := map[string]interface{}{
-		"updated_at": time.Now(),
+		"updated_at": time.Now().UTC(),
 	}
 	if req.Name != nil {
 		updates["name"] = *req.Name

--- a/internal/services/unload_place_timeslot_service.go
+++ b/internal/services/unload_place_timeslot_service.go
@@ -57,7 +57,7 @@ func (s *unloadPlaceService) AddTimeSlot(ctx context.Context, placeID int, req C
 		CloseTime:     req.CloseTime,
 		IsNextDay:     isNextDay,
 		IsActive:      isActive,
-		UpdatedAt:     time.Now(),
+		UpdatedAt:     time.Now().UTC(),
 	}
 
 	if err := s.db.WithContext(ctx).Create(&slot).Error; err != nil {
@@ -124,7 +124,7 @@ func (s *unloadPlaceService) UpdateTimeSlot(ctx context.Context, placeID, slotID
 			"close_time":  closeTime,
 			"is_next_day": isNextDay,
 			"is_active":   isActive,
-			"updated_at":  time.Now(),
+			"updated_at":  time.Now().UTC(),
 		})
 	if result.Error != nil {
 		slog.Error("не удалось обновить временной слот", "slot_id", slotID, "place_id", placeID, "error", result.Error)

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -189,8 +189,11 @@ func CleanDB(t *testing.T, db *gorm.DB) {
 func initTestDB() *gorm.DB {
 	dsn := getTestDSN()
 	ensureTestDatabase(dsn)
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
+	db, err := gorm.Open(postgres.Open(database.EnsureUTCTimezone(dsn)), &gorm.Config{
 		Logger: logger.Default.LogMode(logger.Silent),
+		NowFunc: func() time.Time {
+			return time.Now().UTC()
+		},
 	})
 	if err != nil {
 		log.Fatalf("failed to connect to test database: %v", err)


### PR DESCRIPTION
## Корень проблемы
Хардкод `+03:00` и `time.Now()` без `.UTC()` вызывали смещение 6 часов (21:22 -> 15:22) для пользователей вне MSK.

## Что сделано
- Утилита `internal/services/timeutil.go` — `FormatUTC`/`FormatUTCPtr`/`NowUTC`
- `internal/database/dsn.go` — `EnsureUTCTimezone` добавляет `TimeZone=UTC` в DSN
- Удалены хардкоды `Add(3*time.Hour)` и `+03:00` в car_history/car_status/car_query/employees_history сервисах
- Все `time.Now()` для записи timestamps -> `time.Now().UTC()` (auth, bug_report, consent, request_logs, unload_place, system_table, maintenance, request_logger)
- `gorm.Config.NowFunc` возвращает UTC в server, seed, testutil

## Тесты
- timeutil_test.go — round-trip RFC3339 + конверсия из Asia/Almaty/Europe/Moscow
- dsn_test.go — 4 кейса (URL/keyword DSN, с TimeZone и без)
- utc_time_test.go — 3 интеграционных теста (включая ключевой baseline-кейс)

## Замечание ревьюера (не блокер)
- В auth_service `time.Now().Add(...)` для JWT NumericDate — техникально OK (unix timestamp location-independent), но для консистентности можно тоже UTC

Code review статус: ✅ готово к merge