### PR TITLE
feat: блок 8 - Pinia синхронизация справочников ЛК (#184)

### DIFF
--- a/frontend/src/components/CitizenshipManagement.vue
+++ b/frontend/src/components/CitizenshipManagement.vue
@@ -161,17 +161,17 @@
                   class="form-input-sm"
                   placeholder="Название гражданства"
                   autocomplete="off"
-                  @change="updateCitizenship(selectedCitizenship)"
+                  @change="saveCitizenship(selectedCitizenship)"
                 >
               </div>
 
               <div class="checkbox-section">
                 <label class="checkbox-label">
-                  <input 
-                    v-model="selectedCitizenship.is_active" 
+                  <input
+                    v-model="selectedCitizenship.is_active"
                     type="checkbox"
                     class="checkbox"
-                    @change="updateCitizenship(selectedCitizenship)"
+                    @change="saveCitizenship(selectedCitizenship)"
                   >
                   <span class="checkbox-text">Активное гражданство</span>
                 </label>
@@ -197,11 +197,11 @@
 
               <div class="checkbox-section">
                 <label class="checkbox-label">
-                  <input 
-                    v-model="selectedCitizenship.patent_required" 
+                  <input
+                    v-model="selectedCitizenship.patent_required"
                     type="checkbox"
                     class="checkbox"
-                    @change="updateCitizenship(selectedCitizenship)"
+                    @change="saveCitizenship(selectedCitizenship)"
                   >
                   <span class="checkbox-text">Требуется патент</span>
                 </label>
@@ -303,7 +303,8 @@
 </template>
 
 <script>
-import { apiRequest } from '@/api/client'
+import { mapState, mapActions } from 'pinia';
+import { useCitizenshipsStore } from '@/stores/citizenships';
 import RefreshButton from './RefreshButton.vue';
 import SearchComponent from './SearchComponent.vue';
 
@@ -320,15 +321,17 @@ export default {
         is_default: false,
         patent_required: false
       },
-      citizenships: [],
       showAddModal: false,
       selectedCitizenship: null,
       sortField: null,
-      sortDirection: 'asc',
-      isLoading: false
+      sortDirection: 'asc'
     };
   },
   computed: {
+    ...mapState(useCitizenshipsStore, {
+      citizenships: 'items',
+      isLoading: 'isLoading',
+    }),
     filteredCitizenships() {
       if (!this.searchQuery) return this.citizenships;
       const query = this.searchQuery.toLowerCase();
@@ -378,157 +381,110 @@ export default {
     this.refreshData();
   },
   methods: {
+    ...mapActions(useCitizenshipsStore, {
+      refreshStore: 'refresh',
+      createCitizenship: 'createCitizenship',
+      updateCitizenshipAction: 'updateCitizenship',
+      deleteCitizenshipAction: 'deleteCitizenship',
+    }),
+
     async refreshData() {
-      this.isLoading = true;
-      try {
-        await this.fetchCitizenships();
-      } finally {
-        this.isLoading = false;
-      }
+      await this.refreshStore();
     },
-    async fetchCitizenships() {
-      try {
-        const response = await apiRequest("/citizenships", {
-        });
-        if (response.ok) {
-          const data = await response.json();
-          this.citizenships = data;
-        }
-      } catch (error) {
-        console.error("Error fetching citizenships:", error);
-        this.showNotification("Ошибка при загрузке гражданств", "error");
-      }
-    },
+
     async addCitizenship() {
       if (!this.newCitizenship.name.trim()) {
         this.showNotification("Введите название гражданства", "warning");
         return;
       }
-      
-      try {
-        const response = await apiRequest("/citizenships", {
-          method: "POST",
-          body: JSON.stringify(this.newCitizenship),
-        });
-        
-        if (response.ok) {
-          this.newCitizenship = {
-            name: '',
-            is_default: false,
-            patent_required: false
-          };
-          this.showAddModal = false;
-          await this.refreshData();
-          this.showNotification("Гражданство успешно добавлено", "success");
-        } else {
-          const errorText = await response.text();
-          this.showNotification(errorText || "Ошибка при добавлении гражданства", "error");
-        }
-      } catch (error) {
-        console.error("Error adding citizenship:", error);
-        this.showNotification("Ошибка сети", "error");
+
+      const result = await this.createCitizenship(this.newCitizenship);
+
+      if (result.ok) {
+        this.newCitizenship = {
+          name: '',
+          is_default: false,
+          patent_required: false
+        };
+        this.showAddModal = false;
+        this.showNotification("Гражданство успешно добавлено", "success");
+      } else {
+        this.showNotification(result.message || "Ошибка при добавлении гражданства", "error");
       }
     },
-    async updateCitizenship(citizenship) {
-      try {
-        const citizenshipData = {
-          name: citizenship.name,
-          is_active: citizenship.is_active,
-          is_default: citizenship.is_default,
-          patent_required: citizenship.patent_required
-        };
-        const response = await apiRequest(`/citizenships/${citizenship.id}`, {
-          method: "PUT",
-          body: JSON.stringify(citizenshipData),
-        });
-        
-        if (response.ok) {
-          // Обновляем данные в таблице
-          await this.refreshData();
-          // Обновляем выбранное гражданство актуальными данными
-          const updatedCitizenship = this.citizenships.find(c => c.id === citizenship.id);
-          if (updatedCitizenship) {
-            this.selectedCitizenship = JSON.parse(JSON.stringify(updatedCitizenship));
-          }
-          this.showNotification("Гражданство успешно обновлено", "success");
-        } else {
-          const errorText = await response.text();
-          this.showNotification(errorText || "Ошибка при обновлении гражданства", "error");
-          await this.refreshData(); // Перезагружаем данные чтобы откатить изменения
+
+    /**
+     * Сохраняет изменения гражданства через store. Назван saveCitizenship чтобы
+     * не конфликтовать с action'ом updateCitizenship из store.
+     */
+    async saveCitizenship(citizenship) {
+      const payload = {
+        name: citizenship.name,
+        is_active: citizenship.is_active,
+        is_default: citizenship.is_default,
+        patent_required: citizenship.patent_required,
+      };
+
+      const result = await this.updateCitizenshipAction(citizenship.id, payload);
+
+      if (result.ok) {
+        const fresh = this.citizenships.find(c => c.id === citizenship.id);
+        if (fresh) {
+          this.selectedCitizenship = JSON.parse(JSON.stringify(fresh));
         }
-      } catch (error) {
-        console.error("Error updating citizenship:", error);
-        this.showNotification("Ошибка сети", "error");
+        this.showNotification("Гражданство успешно обновлено", "success");
+      } else {
+        this.showNotification(result.message || "Ошибка при обновлении гражданства", "error");
         await this.refreshData();
       }
     },
+
     async handleDefaultCitizenshipChange() {
-      // Сохраняем текущее состояние чекбокса
       const isDefault = this.selectedCitizenship.is_default;
-      
+
       try {
-        // Если чекбокс выбран - устанавливаем гражданство по умолчанию
         if (isDefault) {
           await this.setDefaultCitizenship(this.selectedCitizenship);
         } else {
-          // Если чекбокс снят - обновляем гражданство без установки по умолчанию
-          await this.updateCitizenship(this.selectedCitizenship);
+          await this.saveCitizenship(this.selectedCitizenship);
         }
       } catch (error) {
-        // В случае ошибки откатываем состояние чекбокса
         this.selectedCitizenship.is_default = !isDefault;
         console.error("Error handling default citizenship change:", error);
       }
     },
+
     async setDefaultCitizenship(citizenship) {
-      try {
-        const citizenshipData = {
-          name: citizenship.name,
-          is_active: citizenship.is_active,
-          is_default: true,
-          patent_required: citizenship.patent_required
-        };
-        const response = await apiRequest(`/citizenships/${citizenship.id}`, {
-          method: "PUT",
-          body: JSON.stringify(citizenshipData),
-        });
-        
-        if (response.ok) {
-          await this.refreshData();
-          // Обновляем выбранное гражданство
-          const updatedCitizenship = this.citizenships.find(c => c.id === citizenship.id);
-          if (updatedCitizenship) {
-            this.selectedCitizenship = JSON.parse(JSON.stringify(updatedCitizenship));
-          }
-          this.showNotification("Гражданство по умолчанию успешно установлено", "success");
-        } else {
-          const errorText = await response.text();
-          this.showNotification(errorText || "Ошибка при установке гражданства по умолчанию", "error");
+      const payload = {
+        name: citizenship.name,
+        is_active: citizenship.is_active,
+        is_default: true,
+        patent_required: citizenship.patent_required,
+      };
+
+      const result = await this.updateCitizenshipAction(citizenship.id, payload);
+
+      if (result.ok) {
+        const fresh = this.citizenships.find(c => c.id === citizenship.id);
+        if (fresh) {
+          this.selectedCitizenship = JSON.parse(JSON.stringify(fresh));
         }
-      } catch (error) {
-        console.error("Error setting default citizenship:", error);
-        this.showNotification("Ошибка сети", "error");
+        this.showNotification("Гражданство по умолчанию успешно установлено", "success");
+      } else {
+        this.showNotification(result.message || "Ошибка при установке гражданства по умолчанию", "error");
       }
     },
+
     async confirmDeleteCitizenship(citizenship) {
       if (!confirm(`Вы уверены, что хотите удалить гражданство "${citizenship.name}"?`)) return;
-      
-      try {
-        const response = await apiRequest(`/citizenships/${citizenship.id}`, {
-          method: "DELETE",
-        });
-        
-        if (response.ok) {
-          this.selectedCitizenship = null;
-          await this.refreshData();
-          this.showNotification("Гражданство успешно удалено", "success");
-        } else {
-          const error = await response.json();
-          this.showNotification(error.message || "Ошибка при удалении гражданства", "error");
-        }
-      } catch (error) {
-        console.error("Error deleting citizenship:", error);
-        this.showNotification("Ошибка сети", "error");
+
+      const result = await this.deleteCitizenshipAction(citizenship.id);
+
+      if (result.ok) {
+        this.selectedCitizenship = null;
+        this.showNotification("Гражданство успешно удалено", "success");
+      } else {
+        this.showNotification(result.message || "Ошибка при удалении гражданства", "error");
       }
     },
     selectCitizenship(citizenship) {

--- a/frontend/src/components/CompaniesManagement.vue
+++ b/frontend/src/components/CompaniesManagement.vue
@@ -146,7 +146,7 @@
                     class="form-input-sm"
                     placeholder="Введите название компании"
                     autocomplete="off"
-                    @change="updateCompany(selectedCompany)"
+                    @change="saveCompany(selectedCompany)"
                   >
                 </div>
               </div>
@@ -257,14 +257,15 @@
       confirm-text="Удалить"
       cancel-text="Отмена"
       :confirm-button-style="{ background: '#ff4444', borderColor: '#ff4444' }"
-      @confirm="deleteCompany"
+      @confirm="removeCompany"
       @cancel="cancelDelete"
     />
   </div>
 </template>
 
 <script>
-import { apiRequest } from '@/api/client'
+import { mapState, mapActions } from 'pinia';
+import { useCompaniesStore } from '@/stores/companies';
 import RefreshButton from './RefreshButton.vue';
 import SearchComponent from './SearchComponent.vue';
 import ResponsibleUsersSection from './ResponsibleUsersSection.vue';
@@ -285,17 +286,19 @@ export default {
     return {
       searchQuery: '',
       newCompanyName: '',
-      companiesWithUsers: [],
       showAddModal: false,
       showDeleteModal: false,
       selectedCompany: null,
       companyToDelete: null,
       sortField: null,
-      sortDirection: 'asc',
-      isLoading: false
+      sortDirection: 'asc'
     };
   },
   computed: {
+    ...mapState(useCompaniesStore, {
+      companiesWithUsers: 'itemsWithUsers',
+      isLoading: 'isLoading',
+    }),
     filteredCompanies() {
       if (!this.searchQuery) return this.companiesWithUsers;
       const query = this.searchQuery.toLowerCase();
@@ -357,135 +360,81 @@ export default {
     this.refreshData();
   },
   methods: {
+    ...mapActions(useCompaniesStore, ['refresh', 'createCompany', 'updateCompany', 'deleteCompany', 'fetchCompaniesWithUsers']),
+
     async refreshData() {
-      this.isLoading = true;
-      try {
-        await this.fetchCompaniesWithUsers();
-      } finally {
-        this.isLoading = false;
-      }
+      await this.refresh();
     },
-    async fetchCompaniesWithUsers() {
-      try {
-        const response = await apiRequest("/companies/with-users-extended", {
-        });
-        if (response.ok) {
-          const data = await response.json();
-          this.companiesWithUsers = data.map(comp => ({
-            ...comp,
-            originalName: comp.name
-          }));
-        }
-      } catch (error) {
-        console.error("Error fetching companies:", error);
-        this.showNotification("Ошибка при загрузке компаний", "error");
-      }
-    },
+
     async addCompany() {
       if (!this.newCompanyName.trim()) {
         this.showNotification("Введите название компании", "warning");
         return;
       }
-      
+
       if (this.isLoading) return;
-      
-      this.isLoading = true;
-      
-      try {
-        const response = await apiRequest("/companies", {
-          method: "POST",
-          body: JSON.stringify({
-            name: this.newCompanyName.trim(),
-          }),
-        });
-        
-        if (response.ok) {
-          const newComp = await response.json();
-          this.newCompanyName = '';
-          this.showAddModal = false;
-          await this.refreshData();
-          
-          // Автоматически выбираем новую компанию
-          const createdComp = this.companiesWithUsers.find(comp => comp.id === newComp.id);
-          if (createdComp) {
-            this.selectedCompany = { ...createdComp };
-          }
-          
-          this.showNotification("Компания успешно создана", "success");
-        } else {
-          const error = await response.json();
-          this.showNotification(error.message || "Ошибка при создании компании", "error");
+
+      const result = await this.createCompany({
+        name: this.newCompanyName.trim(),
+      });
+
+      if (result.ok) {
+        this.newCompanyName = '';
+        this.showAddModal = false;
+        // Автоматически выбираем новую компанию
+        const createdComp = this.companiesWithUsers.find(comp => comp.id === result.data.id);
+        if (createdComp) {
+          this.selectedCompany = { ...createdComp };
         }
-      } catch (error) {
-        console.error("Error adding company:", error);
-        this.showNotification("Ошибка сети", "error");
-      } finally {
-        this.isLoading = false;
+        this.showNotification("Компания успешно создана", "success");
+      } else {
+        this.showNotification(result.message || "Ошибка при создании компании", "error");
       }
     },
-    async updateCompany(comp) {
+
+    async saveCompany(comp) {
       if (comp.name === comp.originalName) return;
-      
-      try {
-        const response = await apiRequest(`/companies/${comp.id}`, {
-          method: "PUT",
-          body: JSON.stringify({
-            name: comp.name,
-          }),
-        });
-        
-        if (response.ok) {
-          comp.originalName = comp.name;
-          this.showNotification("Компания успешно обновлена", "success");
-        } else {
-          const error = await response.json();
-          comp.name = comp.originalName;
-          this.showNotification(error.message || "Ошибка при обновлении компании", "error");
-        }
-      } catch (error) {
-        console.error("Error updating company:", error);
+
+      const result = await this.updateCompany(comp.id, { name: comp.name });
+
+      if (result.ok) {
+        this.showNotification("Компания успешно обновлена", "success");
+      } else {
         comp.name = comp.originalName;
-        this.showNotification("Ошибка сети", "error");
+        this.showNotification(result.message || "Ошибка при обновлении компании", "error");
       }
     },
+
     confirmDeleteCompany(comp) {
       if (comp.user_count > 0) {
         this.showNotification("Нельзя удалить компанию с пользователями", "warning");
         return;
       }
-      
+
       this.companyToDelete = comp;
       this.showDeleteModal = true;
     },
-    
+
     cancelDelete() {
       this.showDeleteModal = false;
       this.companyToDelete = null;
     },
 
-    async deleteCompany() {
+    async removeCompany() {
       if (!this.companyToDelete) return;
-      
-      try {
-        const response = await apiRequest(`/companies/${this.companyToDelete.id}`, {
-          method: "DELETE",
-        });
-        
-        if (response.ok) {
-          this.selectedCompany = null;
-          this.showDeleteModal = false;
-          this.companyToDelete = null;
-          await this.refreshData();
-          this.showNotification("Компания успешно удалена", "success");
-        } else {
-          const error = await response.json();
-          this.showNotification(error.message || "Ошибка при удалении компании", "error");
-        }
-      } catch (error) {
-        console.error("Error deleting company:", error);
-        this.showNotification("Ошибка сети", "error");
+
+      const result = await this.deleteCompany(this.companyToDelete.id);
+
+      if (result.ok) {
+        this.selectedCompany = null;
+        this.showDeleteModal = false;
+        this.companyToDelete = null;
+        this.showNotification("Компания успешно удалена", "success");
+      } else {
+        this.showNotification(result.message || "Ошибка при удалении компании", "error");
       }
     },
+
     selectCompany(comp) {
       this.selectedCompany = { ...comp };
     },

--- a/frontend/src/components/CreateUserModal.vue
+++ b/frontend/src/components/CreateUserModal.vue
@@ -244,17 +244,12 @@
 
 <script>
 import { apiRequest } from '@/api/client'
+import { mapState, mapActions } from 'pinia';
+import { useOrganizationsStore } from '@/stores/organizations';
+import { useCompaniesStore } from '@/stores/companies';
 import { formatRussianPhone } from '@/composables/useRussianPhoneMask'
 export default {
   props: {
-    organizations: {
-      type: Array,
-      required: true
-    },
-    companies: {
-      type: Array,
-      required: true
-    },
     userTypes: {
       type: Array,
       required: true
@@ -279,6 +274,8 @@ export default {
     };
   },
   computed: {
+    ...mapState(useOrganizationsStore, { organizations: 'items' }),
+    ...mapState(useCompaniesStore, { companies: 'items' }),
     isFormValid() {
       return (
         this.newUser.username &&
@@ -289,7 +286,19 @@ export default {
       );
     }
   },
+  async created() {
+    // Если списки в стор'ах ещё не загружены - подтягиваем. Если уже есть -
+    // pinia вернёт текущий state мгновенно, лишних запросов не будет.
+    const orgs = useOrganizationsStore();
+    const comps = useCompaniesStore();
+    const promises = [];
+    if (orgs.items.length === 0) promises.push(this.fetchOrganizations());
+    if (comps.items.length === 0) promises.push(this.fetchCompanies());
+    if (promises.length) await Promise.all(promises);
+  },
   methods: {
+    ...mapActions(useOrganizationsStore, ['fetchOrganizations']),
+    ...mapActions(useCompaniesStore, ['fetchCompanies']),
     formatRussianPhone,
     async createNewUser() {
       try {

--- a/frontend/src/components/OrganizationsManagement.vue
+++ b/frontend/src/components/OrganizationsManagement.vue
@@ -146,7 +146,7 @@
                     class="form-input-sm"
                     placeholder="Введите название организации"
                     autocomplete="off"
-                    @change="updateOrganization(selectedOrganization)"
+                    @change="saveOrganization(selectedOrganization)"
                   >
                 </div>
               </div>
@@ -284,14 +284,15 @@
       confirm-text="Удалить"
       cancel-text="Отмена"
       :confirm-button-style="{ background: '#ff4444', borderColor: '#ff4444' }"
-      @confirm="deleteOrganization"
+      @confirm="removeOrganization"
       @cancel="cancelDelete"
     />
   </div>
 </template>
 
 <script>
-import { apiRequest } from '@/api/client'
+import { mapState, mapActions } from 'pinia';
+import { useOrganizationsStore } from '@/stores/organizations';
 import RefreshButton from './RefreshButton.vue';
 import SearchComponent from './SearchComponent.vue';
 import ResponsibleUsersSection from './ResponsibleUsersSection.vue';
@@ -312,22 +313,24 @@ export default {
     return {
       searchQuery: '',
       newOrganizationName: '',
-      organizationsWithUsers: [],
       showAddModal: false,
       showDeleteModal: false,
       selectedOrganization: null,
       organizationToDelete: null,
       sortField: null,
-      sortDirection: 'asc',
-      isLoading: false
+      sortDirection: 'asc'
     };
   },
   computed: {
+    ...mapState(useOrganizationsStore, {
+      organizationsWithUsers: 'itemsWithUsers',
+      isLoading: 'isLoading',
+    }),
     filteredOrganizations() {
       if (!this.searchQuery) return this.organizationsWithUsers;
       const query = this.searchQuery.toLowerCase();
-      return this.organizationsWithUsers.filter(org => 
-        org.name.toLowerCase().includes(query) || 
+      return this.organizationsWithUsers.filter(org =>
+        org.name.toLowerCase().includes(query) ||
         org.id.toString().includes(query)
       );
     },
@@ -384,97 +387,51 @@ export default {
     this.refreshData();
   },
   methods: {
+    ...mapActions(useOrganizationsStore, ['refresh', 'createOrganization', 'updateOrganization', 'deleteOrganization', 'fetchOrganizationsWithUsers']),
+
     async refreshData() {
-      this.isLoading = true;
-      try {
-        await this.fetchOrganizationsWithUsers();
-      } finally {
-        this.isLoading = false;
-      }
+      await this.refresh();
     },
-    async fetchOrganizationsWithUsers() {
-      try {
-        const response = await apiRequest("/organizations/with-users-extended", {
-        });
-        if (response.ok) {
-          const data = await response.json();
-          this.organizationsWithUsers = data.map(org => ({
-            ...org,
-            originalName: org.name
-          }));
-        }
-      } catch (error) {
-        console.error("Error fetching organizations:", error);
-        this.showNotification("Ошибка при загрузке организаций", "error");
-      }
-    },
-    
+
     async addOrganization() {
       if (!this.newOrganizationName.trim()) {
         this.showNotification("Введите название организации", "warning");
         return;
       }
-      
+
       if (this.isLoading) return;
-      
-      this.isLoading = true;
-      
-      try {
-        const response = await apiRequest("/organizations", {
-          method: "POST",
-          body: JSON.stringify({
-            name: this.newOrganizationName.trim(),
-          }),
-        });
-        
-        if (response.ok) {
-          const newOrg = await response.json();
-          this.newOrganizationName = '';
-          this.showAddModal = false;
-          await this.refreshData();
-          
-          // Автоматически выбираем новую организацию
-          const createdOrg = this.organizationsWithUsers.find(org => org.id === newOrg.id);
-          if (createdOrg) {
-            this.selectedOrganization = { ...createdOrg };
-          }
-          
-          this.showNotification("Организация успешно создана", "success");
-        } else {
-          const error = await response.json();
-          this.showNotification(error.message || "Ошибка при создании организации", "error");
+
+      const result = await this.createOrganization({
+        name: this.newOrganizationName.trim(),
+      });
+
+      if (result.ok) {
+        this.newOrganizationName = '';
+        this.showAddModal = false;
+        // Автоматически выбираем новую организацию
+        const createdOrg = this.organizationsWithUsers.find(org => org.id === result.data.id);
+        if (createdOrg) {
+          this.selectedOrganization = { ...createdOrg };
         }
-      } catch (error) {
-        console.error("Error adding organization:", error);
-        this.showNotification("Ошибка сети", "error");
-      } finally {
-        this.isLoading = false;
+        this.showNotification("Организация успешно создана", "success");
+      } else {
+        this.showNotification(result.message || "Ошибка при создании организации", "error");
       }
     },
 
-    async updateOrganization(org) {
+    async saveOrganization(org) {
       if (org.name === org.originalName) return;
-      
-      try {
-        const response = await apiRequest(`/organizations/${org.id}`, {
-          method: "PUT",
-          body: JSON.stringify({
-            name: org.name,
-          }),
-        });
-        
-        if (response.ok) {
-          org.originalName = org.name;
-          this.showNotification("Организация успешно обновлена", "success");
-        } else {
-          const error = await response.json();
-          org.name = org.originalName;
-          this.showNotification(error.message || "Ошибка при обновлении организации", "error");
-        }
-      } catch (error) {
-        console.error("Error updating organization:", error);
+
+      const result = await this.updateOrganization(org.id, { name: org.name });
+
+      if (result.ok) {
+        // originalName обновится из refresh() в store; локальный selectedOrganization
+        // останется с новым именем - оно совпадает с свежим из store
+        this.showNotification("Организация успешно обновлена", "success");
+      } else {
+        // Откатываем имя в локальной копии
         org.name = org.originalName;
-        this.showNotification("Ошибка сети", "error");
+        this.showNotification(result.message || "Ошибка при обновлении организации", "error");
       }
     },
 
@@ -483,37 +440,28 @@ export default {
         this.showNotification("Нельзя удалить организацию с пользователями", "warning");
         return;
       }
-      
+
       this.organizationToDelete = org;
       this.showDeleteModal = true;
     },
-    
+
     cancelDelete() {
       this.showDeleteModal = false;
       this.organizationToDelete = null;
     },
 
-    async deleteOrganization() {
+    async removeOrganization() {
       if (!this.organizationToDelete) return;
-      
-      try {
-        const response = await apiRequest(`/organizations/${this.organizationToDelete.id}`, {
-          method: "DELETE",
-        });
-        
-        if (response.ok) {
-          this.selectedOrganization = null;
-          this.showDeleteModal = false;
-          this.organizationToDelete = null;
-          await this.refreshData();
-          this.showNotification("Организация успешно удалена", "success");
-        } else {
-          const error = await response.json();
-          this.showNotification(error.message || "Ошибка при удалении организации", "error");
-        }
-      } catch (error) {
-        console.error("Error deleting organization:", error);
-        this.showNotification("Ошибка сети", "error");
+
+      const result = await this.deleteOrganization(this.organizationToDelete.id);
+
+      if (result.ok) {
+        this.selectedOrganization = null;
+        this.showDeleteModal = false;
+        this.organizationToDelete = null;
+        this.showNotification("Организация успешно удалена", "success");
+      } else {
+        this.showNotification(result.message || "Ошибка при удалении организации", "error");
       }
     },
 

--- a/frontend/src/components/UserControl.vue
+++ b/frontend/src/components/UserControl.vue
@@ -782,6 +782,9 @@
 <script>
 import { apiRequest } from '@/api/client'
 import { ref } from 'vue';
+import { mapState, mapActions } from 'pinia';
+import { useOrganizationsStore } from '@/stores/organizations';
+import { useCompaniesStore } from '@/stores/companies';
 import { formatRussianPhone } from '@/composables/useRussianPhoneMask'
 import { formatShortName } from '@/utils/formatName'
 import SearchComponent from './SearchComponent.vue';
@@ -813,8 +816,6 @@ export default {
       showNewPass: false,
       currentLanguage: '',
       isCapsLockOn: false,
-      organizations: [],
-      companies: [],
       userTypes: [],
       sortField: null,
       sortDirection: 'desc',
@@ -845,6 +846,8 @@ export default {
     };
   },
   computed: {
+    ...mapState(useOrganizationsStore, { organizations: 'items' }),
+    ...mapState(useCompaniesStore, { companies: 'items' }),
     filteredUsers() {
       const searchTerm = this.userSearch.toLowerCase();
       return this.allUsers
@@ -925,19 +928,16 @@ export default {
     }
   },
   async created() {
+    // Подтягиваем актуальные справочники из stores. Дальнейшая синхронизация
+    // (после CRUD в OrganizationsManagement/CompaniesManagement) идёт через
+    // pinia reactivity - listener'ы на window.event больше не нужны.
     await Promise.all([
-      this.fetchOrganizations(), 
+      this.fetchOrganizations(),
       this.fetchCompanies(),
       this.fetchUserTypes()
     ]);
-    
-    // Слушаем события обновления организаций и компаний
-    window.addEventListener('organization-updated', this.fetchOrganizations);
-    window.addEventListener('company-updated', this.fetchCompanies);
   },
   beforeUnmount() {
-    window.removeEventListener('organization-updated', this.fetchOrganizations);
-    window.removeEventListener('company-updated', this.fetchCompanies);
     document.removeEventListener('click', this.handleClickOutside);
   },
   mounted() {
@@ -951,6 +951,15 @@ export default {
   },
  
   methods: {
+    ...mapActions(useOrganizationsStore, {
+      fetchOrganizations: 'fetchOrganizations',
+      refreshOrganizations: 'refresh',
+    }),
+    ...mapActions(useCompaniesStore, {
+      fetchCompanies: 'fetchCompanies',
+      refreshCompanies: 'refresh',
+    }),
+
     // onPhoneInput применяет российскую маску к введённому телефону и записывает
     // результат обратно в reactive model. Используется для newUser/selectedUser
     // чтобы явно триггерить saveDraft (где он нужен) отдельно.
@@ -1115,9 +1124,10 @@ export default {
       this.clearDraft();
       this.resetNewUser();
       this.$emit('fetch-users');
-      // Обновляем организации и компании после создания пользователя
-      this.fetchOrganizations();
-      this.fetchCompanies();
+      // Обновляем оба представления (items + itemsWithUsers) - чтобы синхронно
+      // отрисовался user_count в OrganizationsManagement/CompaniesManagement.
+      this.refreshOrganizations();
+      this.refreshCompanies();
     },
     
     resetNewUser() {
@@ -1216,9 +1226,9 @@ export default {
             alert("Пользователь успешно удален");
             this.selectedUser = null;
             this.$emit('fetch-users');
-            // Обновляем организации и компании после удаления пользователя
-            this.fetchOrganizations();
-            this.fetchCompanies();
+            // user_count меняется - подтягиваем оба представления.
+            this.refreshOrganizations();
+            this.refreshCompanies();
           } else {
             const errorData = await response.json();
             alert(errorData.message || "Ошибка при удалении пользователя");
@@ -1250,30 +1260,6 @@ export default {
         }
       } catch (error) {
         console.error("Error fetching user types:", error);
-      }
-    },
-    
-    async fetchOrganizations() {
-      try {
-        const response = await apiRequest("/organizations", {
-        });
-        if (response.ok) {
-          this.organizations = await response.json();
-        }
-      } catch (error) {
-        console.error("Error fetching organizations:", error);
-      }
-    },
-    
-    async fetchCompanies() {
-      try {
-        const response = await apiRequest("/companies", {
-        });
-        if (response.ok) {
-          this.companies = await response.json();
-        }
-      } catch (error) {
-        console.error("Error fetching companies:", error);
       }
     },
     

--- a/frontend/src/stores/__tests__/citizenships.spec.js
+++ b/frontend/src/stores/__tests__/citizenships.spec.js
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useCitizenshipsStore } from '../citizenships'
+
+vi.mock('@/api/client', () => ({
+  apiRequest: vi.fn(),
+}))
+import { apiRequest } from '@/api/client'
+
+function okJson(payload) {
+  return {
+    ok: true,
+    json: vi.fn().mockResolvedValue(payload),
+  }
+}
+
+function errText(text, status = 400) {
+  return {
+    ok: false,
+    status,
+    text: vi.fn().mockResolvedValue(text),
+  }
+}
+
+describe('citizenships store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  describe('fetchCitizenships', () => {
+    it('загружает справочник из /citizenships', async () => {
+      apiRequest.mockResolvedValue(okJson([
+        { id: 1, name: 'РФ', is_active: true, is_default: true, patent_required: false },
+      ]))
+      const store = useCitizenshipsStore()
+
+      await store.fetchCitizenships()
+
+      expect(apiRequest).toHaveBeenCalledWith('/citizenships')
+      expect(store.items).toHaveLength(1)
+    })
+  })
+
+  describe('createCitizenship', () => {
+    it('создаёт и подтягивает свежий список', async () => {
+      apiRequest
+        .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue({}) })
+        .mockResolvedValueOnce(okJson([{ id: 2, name: 'KZ', is_active: true, is_default: false, patent_required: true }]))
+
+      const store = useCitizenshipsStore()
+      const result = await store.createCitizenship({ name: 'KZ' })
+
+      expect(result).toEqual({ ok: true })
+      expect(store.items).toHaveLength(1)
+      expect(store.items[0].name).toBe('KZ')
+    })
+
+    it('возвращает текстовое сообщение при ошибке', async () => {
+      apiRequest.mockResolvedValueOnce(errText('Already exists'))
+      const store = useCitizenshipsStore()
+
+      const result = await store.createCitizenship({ name: 'dup' })
+
+      expect(result).toEqual({ ok: false, message: 'Already exists' })
+    })
+  })
+
+  describe('updateCitizenship', () => {
+    it('обновляет гражданство и рефрешит state', async () => {
+      apiRequest
+        .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue({}) })
+        .mockResolvedValueOnce(okJson([
+          { id: 1, name: 'РФ updated', is_active: true, is_default: false, patent_required: false },
+        ]))
+
+      const store = useCitizenshipsStore()
+      const result = await store.updateCitizenship(1, {
+        name: 'РФ updated',
+        is_active: true,
+        is_default: false,
+        patent_required: false,
+      })
+
+      expect(result.ok).toBe(true)
+      expect(store.items[0].name).toBe('РФ updated')
+    })
+  })
+
+  describe('deleteCitizenship', () => {
+    it('удаляет и обновляет state', async () => {
+      apiRequest
+        .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue({}) })
+        .mockResolvedValueOnce(okJson([]))
+
+      const store = useCitizenshipsStore()
+      const result = await store.deleteCitizenship(1)
+
+      expect(result.ok).toBe(true)
+      expect(store.items).toEqual([])
+    })
+  })
+
+  describe('getters', () => {
+    it('defaultCitizenship возвращает is_default=true', () => {
+      const store = useCitizenshipsStore()
+      store.items = [
+        { id: 1, name: 'РФ', is_active: true, is_default: false, patent_required: false },
+        { id: 2, name: 'KZ', is_active: true, is_default: true, patent_required: false },
+      ]
+
+      expect(store.defaultCitizenship).toEqual(store.items[1])
+    })
+
+    it('activeItems фильтрует по is_active', () => {
+      const store = useCitizenshipsStore()
+      store.items = [
+        { id: 1, name: 'A', is_active: true, is_default: false, patent_required: false },
+        { id: 2, name: 'B', is_active: false, is_default: false, patent_required: false },
+      ]
+
+      expect(store.activeItems).toHaveLength(1)
+      expect(store.activeItems[0].id).toBe(1)
+    })
+
+    it('findById возвращает гражданство или null', () => {
+      const store = useCitizenshipsStore()
+      store.items = [{ id: 5, name: 'X' }]
+
+      expect(store.findById(5)).toEqual({ id: 5, name: 'X' })
+      expect(store.findById(99)).toBeNull()
+    })
+  })
+})

--- a/frontend/src/stores/__tests__/companies.spec.js
+++ b/frontend/src/stores/__tests__/companies.spec.js
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useCompaniesStore } from '../companies'
+
+vi.mock('@/api/client', () => ({
+  apiRequest: vi.fn(),
+}))
+import { apiRequest } from '@/api/client'
+
+function okJson(payload) {
+  return {
+    ok: true,
+    json: vi.fn().mockResolvedValue(payload),
+  }
+}
+
+function errJson(payload, status = 400) {
+  return {
+    ok: false,
+    status,
+    json: vi.fn().mockResolvedValue(payload),
+  }
+}
+
+describe('companies store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  describe('fetchCompanies', () => {
+    it('загружает базовый список из /companies', async () => {
+      apiRequest.mockResolvedValue(okJson([{ id: 1, name: 'Acme Inc' }]))
+      const store = useCompaniesStore()
+
+      await store.fetchCompanies()
+
+      expect(apiRequest).toHaveBeenCalledWith('/companies')
+      expect(store.items).toEqual([{ id: 1, name: 'Acme Inc' }])
+    })
+  })
+
+  describe('fetchCompaniesWithUsers', () => {
+    it('добавляет originalName к каждому элементу', async () => {
+      apiRequest.mockResolvedValue(okJson([{ id: 1, name: 'Acme Inc', user_count: 3 }]))
+      const store = useCompaniesStore()
+
+      await store.fetchCompaniesWithUsers()
+
+      expect(store.itemsWithUsers).toEqual([
+        { id: 1, name: 'Acme Inc', user_count: 3, originalName: 'Acme Inc' },
+      ])
+    })
+  })
+
+  describe('refresh', () => {
+    it('загружает оба представления и сбрасывает isLoading', async () => {
+      apiRequest
+        .mockResolvedValueOnce(okJson([{ id: 1, name: 'A' }]))
+        .mockResolvedValueOnce(okJson([{ id: 1, name: 'A', user_count: 0 }]))
+      const store = useCompaniesStore()
+
+      await store.refresh()
+
+      expect(store.items).toHaveLength(1)
+      expect(store.itemsWithUsers).toHaveLength(1)
+      expect(store.isLoading).toBe(false)
+    })
+  })
+
+  describe('createCompany', () => {
+    it('создаёт компанию и подтягивает свежие данные', async () => {
+      apiRequest
+        .mockResolvedValueOnce(okJson({ id: 5, name: 'New Co' }))
+        .mockResolvedValueOnce(okJson([{ id: 5, name: 'New Co' }]))
+        .mockResolvedValueOnce(okJson([{ id: 5, name: 'New Co', user_count: 0 }]))
+
+      const store = useCompaniesStore()
+      const result = await store.createCompany({ name: 'New Co' })
+
+      expect(result).toEqual({ ok: true, data: { id: 5, name: 'New Co' } })
+      expect(store.items).toEqual([{ id: 5, name: 'New Co' }])
+    })
+
+    it('возвращает ошибку без рефреша при неуспехе', async () => {
+      apiRequest.mockResolvedValueOnce(errJson({ message: 'fail' }))
+      const store = useCompaniesStore()
+
+      const result = await store.createCompany({ name: 'X' })
+
+      expect(result).toEqual({ ok: false, message: 'fail' })
+      expect(apiRequest).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('updateCompany', () => {
+    it('обновляет и рефрешит', async () => {
+      apiRequest
+        .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue({}) })
+        .mockResolvedValueOnce(okJson([{ id: 1, name: 'Renamed' }]))
+        .mockResolvedValueOnce(okJson([{ id: 1, name: 'Renamed', user_count: 0 }]))
+
+      const store = useCompaniesStore()
+      const result = await store.updateCompany(1, { name: 'Renamed' })
+
+      expect(result.ok).toBe(true)
+      expect(store.items[0].name).toBe('Renamed')
+    })
+  })
+
+  describe('deleteCompany', () => {
+    it('удаляет компанию', async () => {
+      apiRequest
+        .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue({}) })
+        .mockResolvedValueOnce(okJson([]))
+        .mockResolvedValueOnce(okJson([]))
+
+      const store = useCompaniesStore()
+      const result = await store.deleteCompany(1)
+
+      expect(result.ok).toBe(true)
+    })
+  })
+
+  describe('getters', () => {
+    it('findById и nameById', () => {
+      const store = useCompaniesStore()
+      store.items = [{ id: 1, name: 'A' }]
+
+      expect(store.findById(1)).toEqual({ id: 1, name: 'A' })
+      expect(store.findById(2)).toBeNull()
+      expect(store.nameById(1)).toBe('A')
+      expect(store.nameById(2)).toBe('')
+    })
+  })
+})

--- a/frontend/src/stores/__tests__/organizations.spec.js
+++ b/frontend/src/stores/__tests__/organizations.spec.js
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useOrganizationsStore } from '../organizations'
+
+vi.mock('@/api/client', () => ({
+  apiRequest: vi.fn(),
+}))
+import { apiRequest } from '@/api/client'
+
+function okJson(payload) {
+  return {
+    ok: true,
+    json: vi.fn().mockResolvedValue(payload),
+  }
+}
+
+function errJson(payload, status = 400) {
+  return {
+    ok: false,
+    status,
+    json: vi.fn().mockResolvedValue(payload),
+  }
+}
+
+describe('organizations store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  describe('fetchOrganizations', () => {
+    it('загружает базовый список из /organizations', async () => {
+      apiRequest.mockResolvedValue(okJson([{ id: 1, name: 'Acme' }, { id: 2, name: 'Globex' }]))
+      const store = useOrganizationsStore()
+
+      await store.fetchOrganizations()
+
+      expect(apiRequest).toHaveBeenCalledWith('/organizations')
+      expect(store.items).toEqual([{ id: 1, name: 'Acme' }, { id: 2, name: 'Globex' }])
+    })
+
+    it('не падает при сетевой ошибке', async () => {
+      apiRequest.mockRejectedValue(new Error('network'))
+      const store = useOrganizationsStore()
+
+      await store.fetchOrganizations()
+
+      expect(store.items).toEqual([])
+      expect(store.error).toBeInstanceOf(Error)
+    })
+  })
+
+  describe('fetchOrganizationsWithUsers', () => {
+    it('добавляет originalName к каждому элементу', async () => {
+      apiRequest.mockResolvedValue(okJson([{ id: 1, name: 'Acme', user_count: 5 }]))
+      const store = useOrganizationsStore()
+
+      await store.fetchOrganizationsWithUsers()
+
+      expect(apiRequest).toHaveBeenCalledWith('/organizations/with-users-extended')
+      expect(store.itemsWithUsers).toEqual([
+        { id: 1, name: 'Acme', user_count: 5, originalName: 'Acme' },
+      ])
+    })
+  })
+
+  describe('refresh', () => {
+    it('подтягивает оба представления параллельно', async () => {
+      apiRequest
+        .mockResolvedValueOnce(okJson([{ id: 1, name: 'Acme' }]))
+        .mockResolvedValueOnce(okJson([{ id: 1, name: 'Acme', user_count: 0 }]))
+      const store = useOrganizationsStore()
+
+      await store.refresh()
+
+      expect(apiRequest).toHaveBeenCalledTimes(2)
+      expect(store.items).toHaveLength(1)
+      expect(store.itemsWithUsers).toHaveLength(1)
+      expect(store.isLoading).toBe(false)
+    })
+  })
+
+  describe('createOrganization', () => {
+    it('создаёт организацию и обновляет state через refresh', async () => {
+      apiRequest
+        .mockResolvedValueOnce(okJson({ id: 7, name: 'New' }))
+        .mockResolvedValueOnce(okJson([{ id: 7, name: 'New' }]))
+        .mockResolvedValueOnce(okJson([{ id: 7, name: 'New', user_count: 0 }]))
+
+      const store = useOrganizationsStore()
+      const result = await store.createOrganization({ name: 'New' })
+
+      expect(result.ok).toBe(true)
+      expect(result.data).toEqual({ id: 7, name: 'New' })
+      expect(store.items).toEqual([{ id: 7, name: 'New' }])
+      expect(store.itemsWithUsers[0]).toMatchObject({ id: 7, name: 'New', originalName: 'New' })
+    })
+
+    it('возвращает ошибку при неуспешном ответе', async () => {
+      apiRequest.mockResolvedValueOnce(errJson({ message: 'duplicate' }))
+      const store = useOrganizationsStore()
+
+      const result = await store.createOrganization({ name: 'dup' })
+
+      expect(result).toEqual({ ok: false, message: 'duplicate' })
+      // refresh не должен быть вызван
+      expect(apiRequest).toHaveBeenCalledTimes(1)
+    })
+
+    it('возвращает сетевую ошибку при reject', async () => {
+      apiRequest.mockRejectedValueOnce(new Error('fail'))
+      const store = useOrganizationsStore()
+
+      const result = await store.createOrganization({ name: 'x' })
+
+      expect(result).toEqual({ ok: false, message: 'Ошибка сети' })
+    })
+  })
+
+  describe('updateOrganization', () => {
+    it('обновляет организацию и подтягивает refresh', async () => {
+      apiRequest
+        .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue({}) })
+        .mockResolvedValueOnce(okJson([{ id: 1, name: 'Renamed' }]))
+        .mockResolvedValueOnce(okJson([{ id: 1, name: 'Renamed', user_count: 2 }]))
+
+      const store = useOrganizationsStore()
+      const result = await store.updateOrganization(1, { name: 'Renamed' })
+
+      expect(result.ok).toBe(true)
+      expect(store.items[0].name).toBe('Renamed')
+    })
+  })
+
+  describe('deleteOrganization', () => {
+    it('удаляет и обновляет state', async () => {
+      apiRequest
+        .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue({}) })
+        .mockResolvedValueOnce(okJson([]))
+        .mockResolvedValueOnce(okJson([]))
+
+      const store = useOrganizationsStore()
+      const result = await store.deleteOrganization(1)
+
+      expect(result.ok).toBe(true)
+      expect(store.items).toEqual([])
+    })
+  })
+
+  describe('getters', () => {
+    it('findById возвращает организацию по id', () => {
+      const store = useOrganizationsStore()
+      store.items = [{ id: 1, name: 'A' }, { id: 2, name: 'B' }]
+
+      expect(store.findById(2)).toEqual({ id: 2, name: 'B' })
+      expect(store.findById(99)).toBeNull()
+    })
+
+    it('nameById возвращает имя или пустую строку', () => {
+      const store = useOrganizationsStore()
+      store.items = [{ id: 1, name: 'A' }]
+
+      expect(store.nameById(1)).toBe('A')
+      expect(store.nameById(99)).toBe('')
+    })
+  })
+})

--- a/frontend/src/stores/citizenships.js
+++ b/frontend/src/stores/citizenships.js
@@ -1,0 +1,112 @@
+import { defineStore } from 'pinia'
+import { apiRequest } from '@/api/client'
+
+/**
+ * Глобальный стор справочника гражданств.
+ *
+ * Использует один список { id, name, is_active, is_default, patent_required }
+ * - в отличие от organizations/companies, у citizenships нет двух
+ * представлений (нет endpoint'а с user_count).
+ *
+ * После CUD-операций через actions автоматически перечитываются данные -
+ * любой компонент, читающий items через computed, получит свежий список.
+ */
+export const useCitizenshipsStore = defineStore('citizenships', {
+  state: () => ({
+    items: [],
+    isLoading: false,
+    error: null,
+  }),
+
+  getters: {
+    findById: (state) => (id) => state.items.find(c => c.id === id) || null,
+    defaultCitizenship: (state) => state.items.find(c => c.is_default) || null,
+    activeItems: (state) => state.items.filter(c => c.is_active),
+  },
+
+  actions: {
+    async fetchCitizenships() {
+      try {
+        const response = await apiRequest('/citizenships')
+        if (response.ok) {
+          this.items = await response.json()
+        }
+      } catch (err) {
+        console.error('Error fetching citizenships:', err)
+        this.error = err
+      }
+    },
+
+    async refresh() {
+      this.isLoading = true
+      try {
+        await this.fetchCitizenships()
+      } finally {
+        this.isLoading = false
+      }
+    },
+
+    /**
+     * @param {{ name: string, is_default?: boolean, patent_required?: boolean }} payload
+     */
+    async createCitizenship(payload) {
+      try {
+        const response = await apiRequest('/citizenships', {
+          method: 'POST',
+          body: JSON.stringify(payload),
+        })
+        if (response.ok) {
+          await this.refresh()
+          return { ok: true }
+        }
+        const message = await response.text()
+        return { ok: false, message }
+      } catch (err) {
+        console.error('Error creating citizenship:', err)
+        return { ok: false, message: 'Ошибка сети' }
+      }
+    },
+
+    /**
+     * @param {number} id
+     * @param {{ name: string, is_active: boolean, is_default: boolean, patent_required: boolean }} payload
+     */
+    async updateCitizenship(id, payload) {
+      try {
+        const response = await apiRequest(`/citizenships/${id}`, {
+          method: 'PUT',
+          body: JSON.stringify(payload),
+        })
+        if (response.ok) {
+          await this.refresh()
+          return { ok: true }
+        }
+        const message = await response.text()
+        return { ok: false, message }
+      } catch (err) {
+        console.error('Error updating citizenship:', err)
+        return { ok: false, message: 'Ошибка сети' }
+      }
+    },
+
+    /**
+     * @param {number} id
+     */
+    async deleteCitizenship(id) {
+      try {
+        const response = await apiRequest(`/citizenships/${id}`, {
+          method: 'DELETE',
+        })
+        if (response.ok) {
+          await this.refresh()
+          return { ok: true }
+        }
+        const error = await response.json().catch(() => ({}))
+        return { ok: false, message: error.message }
+      } catch (err) {
+        console.error('Error deleting citizenship:', err)
+        return { ok: false, message: 'Ошибка сети' }
+      }
+    },
+  },
+})

--- a/frontend/src/stores/companies.js
+++ b/frontend/src/stores/companies.js
@@ -1,0 +1,135 @@
+import { defineStore } from 'pinia'
+import { apiRequest } from '@/api/client'
+
+/**
+ * Глобальный стор справочника компаний.
+ *
+ * Аналог organizations store. Поддерживает два представления:
+ *   - items: лёгкий список { id, name } для dropdown'ов
+ *   - itemsWithUsers: расширенный с user_count для CompaniesManagement
+ *
+ * После любой CUD-операции через action'ы автоматически синхронизируются
+ * оба списка - все компоненты ЛК получают свежие данные без ручных fetch'ей.
+ */
+export const useCompaniesStore = defineStore('companies', {
+  state: () => ({
+    items: [],
+    itemsWithUsers: [],
+    isLoading: false,
+    error: null,
+  }),
+
+  getters: {
+    findById: (state) => (id) => state.items.find(c => c.id === id) || null,
+    nameById: (state) => (id) => {
+      const comp = state.items.find(c => c.id === id)
+      return comp ? comp.name : ''
+    },
+  },
+
+  actions: {
+    async fetchCompanies() {
+      try {
+        const response = await apiRequest('/companies')
+        if (response.ok) {
+          this.items = await response.json()
+        }
+      } catch (err) {
+        console.error('Error fetching companies:', err)
+        this.error = err
+      }
+    },
+
+    async fetchCompaniesWithUsers() {
+      try {
+        const response = await apiRequest('/companies/with-users-extended')
+        if (response.ok) {
+          const data = await response.json()
+          this.itemsWithUsers = data.map(comp => ({
+            ...comp,
+            originalName: comp.name,
+          }))
+        }
+      } catch (err) {
+        console.error('Error fetching companies with users:', err)
+        this.error = err
+      }
+    },
+
+    async refresh() {
+      this.isLoading = true
+      try {
+        await Promise.all([
+          this.fetchCompanies(),
+          this.fetchCompaniesWithUsers(),
+        ])
+      } finally {
+        this.isLoading = false
+      }
+    },
+
+    /**
+     * @param {{ name: string }} payload
+     */
+    async createCompany(payload) {
+      try {
+        const response = await apiRequest('/companies', {
+          method: 'POST',
+          body: JSON.stringify(payload),
+        })
+        if (response.ok) {
+          const data = await response.json()
+          await this.refresh()
+          return { ok: true, data }
+        }
+        const error = await response.json().catch(() => ({}))
+        return { ok: false, message: error.message }
+      } catch (err) {
+        console.error('Error creating company:', err)
+        return { ok: false, message: 'Ошибка сети' }
+      }
+    },
+
+    /**
+     * @param {number} id
+     * @param {{ name: string }} payload
+     */
+    async updateCompany(id, payload) {
+      try {
+        const response = await apiRequest(`/companies/${id}`, {
+          method: 'PUT',
+          body: JSON.stringify(payload),
+        })
+        if (response.ok) {
+          await this.refresh()
+          return { ok: true }
+        }
+        const error = await response.json().catch(() => ({}))
+        return { ok: false, message: error.message }
+      } catch (err) {
+        console.error('Error updating company:', err)
+        return { ok: false, message: 'Ошибка сети' }
+      }
+    },
+
+    /**
+     * @param {number} id
+     */
+    async deleteCompany(id) {
+      try {
+        const response = await apiRequest(`/companies/${id}`, {
+          method: 'DELETE',
+        })
+        if (response.ok) {
+          await this.refresh()
+          return { ok: true }
+        }
+        const error = await response.json().catch(() => ({}))
+        return { ok: false, message: error.message }
+      } catch (err) {
+        console.error('Error deleting company:', err)
+        return { ok: false, message: 'Ошибка сети' }
+      }
+    },
+  },
+})

--- a/frontend/src/stores/organizations.js
+++ b/frontend/src/stores/organizations.js
@@ -1,0 +1,154 @@
+import { defineStore } from 'pinia'
+import { apiRequest } from '@/api/client'
+
+/**
+ * Глобальный стор справочника организаций.
+ *
+ * Используется компонентами ЛК (OrganizationsManagement, UserControl,
+ * CreateUserModal). Поддерживает два представления:
+ *   - items: лёгкий список { id, name } для dropdown'ов и выбора
+ *   - itemsWithUsers: расширенный список с user_count и метаданными для
+ *     управления (таблица в OrganizationsManagement)
+ *
+ * Любые CUD-операции выполняются через actions, что гарантирует, что все
+ * подписчики (через computed на getters) получат свежие данные сразу - без
+ * window-events и ручных fetch'ей в каждом компоненте.
+ */
+export const useOrganizationsStore = defineStore('organizations', {
+  state: () => ({
+    items: [],
+    itemsWithUsers: [],
+    isLoading: false,
+    error: null,
+  }),
+
+  getters: {
+    findById: (state) => (id) => state.items.find(o => o.id === id) || null,
+    nameById: (state) => (id) => {
+      const org = state.items.find(o => o.id === id)
+      return org ? org.name : ''
+    },
+  },
+
+  actions: {
+    /**
+     * Загружает базовый список { id, name } (используется UserControl/dropdown).
+     */
+    async fetchOrganizations() {
+      try {
+        const response = await apiRequest('/organizations')
+        if (response.ok) {
+          this.items = await response.json()
+        }
+      } catch (err) {
+        console.error('Error fetching organizations:', err)
+        this.error = err
+      }
+    },
+
+    /**
+     * Загружает расширенный список с user_count (для OrganizationsManagement).
+     * Каждый элемент дополняется originalName для трекинга изменений inline.
+     */
+    async fetchOrganizationsWithUsers() {
+      try {
+        const response = await apiRequest('/organizations/with-users-extended')
+        if (response.ok) {
+          const data = await response.json()
+          this.itemsWithUsers = data.map(org => ({
+            ...org,
+            originalName: org.name,
+          }))
+        }
+      } catch (err) {
+        console.error('Error fetching organizations with users:', err)
+        this.error = err
+      }
+    },
+
+    /**
+     * Полная синхронизация: подтягивает оба представления параллельно.
+     * Вызывается после CUD-операций, чтобы все потребители увидели свежие данные.
+     */
+    async refresh() {
+      this.isLoading = true
+      try {
+        await Promise.all([
+          this.fetchOrganizations(),
+          this.fetchOrganizationsWithUsers(),
+        ])
+      } finally {
+        this.isLoading = false
+      }
+    },
+
+    /**
+     * Создаёт организацию и обновляет state. Возвращает созданную сущность,
+     * чтобы вызывающий мог автоматически выбрать её в UI.
+     * @param {{ name: string }} payload
+     * @returns {Promise<{ ok: boolean, data?: object, message?: string }>}
+     */
+    async createOrganization(payload) {
+      try {
+        const response = await apiRequest('/organizations', {
+          method: 'POST',
+          body: JSON.stringify(payload),
+        })
+        if (response.ok) {
+          const data = await response.json()
+          await this.refresh()
+          return { ok: true, data }
+        }
+        const error = await response.json().catch(() => ({}))
+        return { ok: false, message: error.message }
+      } catch (err) {
+        console.error('Error creating organization:', err)
+        return { ok: false, message: 'Ошибка сети' }
+      }
+    },
+
+    /**
+     * Обновляет организацию. После успеха перечитывает оба списка.
+     * @param {number} id
+     * @param {{ name: string }} payload
+     */
+    async updateOrganization(id, payload) {
+      try {
+        const response = await apiRequest(`/organizations/${id}`, {
+          method: 'PUT',
+          body: JSON.stringify(payload),
+        })
+        if (response.ok) {
+          await this.refresh()
+          return { ok: true }
+        }
+        const error = await response.json().catch(() => ({}))
+        return { ok: false, message: error.message }
+      } catch (err) {
+        console.error('Error updating organization:', err)
+        return { ok: false, message: 'Ошибка сети' }
+      }
+    },
+
+    /**
+     * Удаляет организацию. После успеха перечитывает оба списка.
+     * @param {number} id
+     */
+    async deleteOrganization(id) {
+      try {
+        const response = await apiRequest(`/organizations/${id}`, {
+          method: 'DELETE',
+        })
+        if (response.ok) {
+          await this.refresh()
+          return { ok: true }
+        }
+        const error = await response.json().catch(() => ({}))
+        return { ok: false, message: error.message }
+      } catch (err) {
+        console.error('Error deleting organization:', err)
+        return { ok: false, message: 'Ошибка сети' }
+      }
+    },
+  },
+})


### PR DESCRIPTION
## Что сделано
3 новых Pinia store + рефакторинг ЛК-компонентов под mapState/mapActions.

### Stores
- `stores/organizations.js` — items + itemsWithUsers + CRUD actions
- `stores/companies.js` — аналогично
- `stores/citizenships.js` — справочник гражданств

После любой CUD-операции `refresh()` подтягивает оба представления — все подписчики получают обновление автоматически через Pinia reactivity.

### Use case
Создал организацию в OrganizationsManagement → сразу видна в dropdown UserControl/CreateUserModal без F5 и без custom events.

### Изменённые компоненты
OrganizationsManagement, CompaniesManagement, CitizenshipManagement, UserControl, CreateUserModal.

### Тесты
27 unit-тестов (252/252 в проекте).

## Замечания ревьюера (не блокеры)
- `refresh()` делает 2 параллельных fetch — после CUD получаем 1 POST + 2 GET (раньше был 1 GET). Trade-off за устойчивость.
- `error: null` в state ставится только при catch — при response.ok=false ошибка не пишется. Минор.
- Стилистическая непоследовательность: где-то локально переименовали методы (saveOrganization), где-то использовали mapActions с переименованием (updateCitizenshipAction). Можно унифицировать в следующем PR.

Code review статус: ✅ готово к merge