### PR TITLE
fix: блок 9 - модалки overlay уровня + унификация backdrop (#184)

### DIFF
--- a/frontend/src/components/AnnouncementModal.vue
+++ b/frontend/src/components/AnnouncementModal.vue
@@ -93,6 +93,8 @@ export default {
   align-items: center;
   justify-content: center;
   z-index: 10000;
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
 }
 
 .modal-fade-enter-active,

--- a/frontend/src/components/ApplicationApprovers.vue
+++ b/frontend/src/components/ApplicationApprovers.vue
@@ -170,124 +170,126 @@
     </div>
 
     <!-- Модальное окно добавления принимающего -->
-    <div
-      v-if="showAddModal"
-      class="modal-overlay"
-      @click.self="closeAddModal"
-    >
-      <div class="modal modal-compact">
-        <div class="modal-header">
-          <h3>Добавить принимающего</h3>
-          <button
-            class="modal-close"
-            @click="closeAddModal"
-          >
-            ×
-          </button>
-        </div>
+    <Teleport to="body">
+      <div
+        v-if="showAddModal"
+        class="modal-overlay"
+        @click.self="closeAddModal"
+      >
+        <div class="modal modal-compact">
+          <div class="modal-header">
+            <h3>Добавить принимающего</h3>
+            <button
+              class="modal-close"
+              @click="closeAddModal"
+            >
+              ×
+            </button>
+          </div>
         
-        <div class="modal-content">
-          <div class="user-search-section">
-            <input
-              ref="searchInput"
-              v-model="userSearchQuery"
-              class="search-input"
-              placeholder="Поиск пользователей..."
-              type="text"
-              autocomplete="off"
-              @input="searchUsers"
-              @focus="showUserDropdown = true"
-              @blur="onSearchBlur"
-            >
-            <div
-              v-if="showUserDropdown && filteredAvailableUsers.length > 0"
-              class="user-dropdown"
-            >
-              <div class="user-dropdown-content">
-                <div 
-                  v-for="user in filteredAvailableUsers" 
-                  :key="user.id"
-                  class="user-item"
-                  @mousedown.prevent="addUser(user)"
-                >
-                  <div class="user-info">
-                    <div class="user-name">
-                      {{ getFullName(user) }}
+          <div class="modal-content">
+            <div class="user-search-section">
+              <input
+                ref="searchInput"
+                v-model="userSearchQuery"
+                class="search-input"
+                placeholder="Поиск пользователей..."
+                type="text"
+                autocomplete="off"
+                @input="searchUsers"
+                @focus="showUserDropdown = true"
+                @blur="onSearchBlur"
+              >
+              <div
+                v-if="showUserDropdown && filteredAvailableUsers.length > 0"
+                class="user-dropdown"
+              >
+                <div class="user-dropdown-content">
+                  <div 
+                    v-for="user in filteredAvailableUsers" 
+                    :key="user.id"
+                    class="user-item"
+                    @mousedown.prevent="addUser(user)"
+                  >
+                    <div class="user-info">
+                      <div class="user-name">
+                        {{ getFullName(user) }}
+                      </div>
+                      <div class="user-details">
+                        <span class="user-username">@{{ user.username }}</span>
+                        <span
+                          v-if="user.position"
+                          class="user-position"
+                        >{{ user.position }}</span>
+                      </div>
                     </div>
-                    <div class="user-details">
-                      <span class="user-username">@{{ user.username }}</span>
+                  </div>
+                </div>
+              </div>
+              <div
+                v-else-if="showUserDropdown && filteredAvailableUsers.length === 0"
+                class="user-dropdown no-results-dropdown"
+              >
+                <div class="user-dropdown-content">
+                  <div class="no-results-message">
+                    Нет доступных пользователей
+                  </div>
+                </div>
+              </div>
+            </div>
+          
+            <div class="selected-users">
+              <div class="selected-users-header">
+                <span>Выбрано пользователей:</span>
+                <span class="selected-count">{{ selectedUsers.length }}</span>
+              </div>
+            
+              <div class="users-list-container">
+                <div class="users-list">
+                  <div 
+                    v-for="user in selectedUsers" 
+                    :key="user.id"
+                    class="selected-user"
+                  >
+                    <div class="selected-user-info">
+                      <span class="selected-user-name">{{ getFullName(user) }}</span>
+                      <span class="selected-user-username">@{{ user.username }}</span>
                       <span
                         v-if="user.position"
-                        class="user-position"
+                        class="selected-user-position"
                       >{{ user.position }}</span>
                     </div>
+                    <button 
+                      class="remove-user-btn"
+                      title="Удалить из списка"
+                      @click="removeUser(user)"
+                    >
+                      ×
+                    </button>
                   </div>
                 </div>
               </div>
             </div>
-            <div
-              v-else-if="showUserDropdown && filteredAvailableUsers.length === 0"
-              class="user-dropdown no-results-dropdown"
-            >
-              <div class="user-dropdown-content">
-                <div class="no-results-message">
-                  Нет доступных пользователей
-                </div>
-              </div>
-            </div>
           </div>
-          
-          <div class="selected-users">
-            <div class="selected-users-header">
-              <span>Выбрано пользователей:</span>
-              <span class="selected-count">{{ selectedUsers.length }}</span>
-            </div>
-            
-            <div class="users-list-container">
-              <div class="users-list">
-                <div 
-                  v-for="user in selectedUsers" 
-                  :key="user.id"
-                  class="selected-user"
-                >
-                  <div class="selected-user-info">
-                    <span class="selected-user-name">{{ getFullName(user) }}</span>
-                    <span class="selected-user-username">@{{ user.username }}</span>
-                    <span
-                      v-if="user.position"
-                      class="selected-user-position"
-                    >{{ user.position }}</span>
-                  </div>
-                  <button 
-                    class="remove-user-btn"
-                    title="Удалить из списка"
-                    @click="removeUser(user)"
-                  >
-                    ×
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
         
-        <div class="modal-footer">
-          <button
-            class="modal-cancel-btn"
-            @click="closeAddModal"
-          >
-            Отмена
-          </button>
-          <button 
-            class="modal-add-btn"
-            :disabled="selectedUsers.length === 0 || loading"
-            @click="addApprovers"
-          >
-            {{ loading ? 'Добавление...' : `Добавить (${selectedUsers.length})` }}
-          </button>
+          <div class="modal-footer">
+            <button
+              class="modal-cancel-btn"
+              @click="closeAddModal"
+            >
+              Отмена
+            </button>
+            <button 
+              class="modal-add-btn"
+              :disabled="selectedUsers.length === 0 || loading"
+              @click="addApprovers"
+            >
+              {{ loading ? 'Добавление...' : `Добавить (${selectedUsers.length})` }}
+            </button>
+          </div>
         </div>
       </div>
-    </div>
+    </Teleport>
 
     <!-- Уведомления -->
     <div
@@ -879,6 +881,8 @@ export default {
   justify-content: center;
   align-items: center;
   z-index: 20000;
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
   animation: fadeIn 0.2s ease-out;
 }
 

--- a/frontend/src/components/ApplicationDetail/ApplicationDetail.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationDetail.vue
@@ -969,6 +969,8 @@ export default {
     justify-content: center;
     align-items: center;
     z-index: 10000;
+    backdrop-filter: blur(0.1px);
+    -webkit-backdrop-filter: blur(0.1px);
     animation: fadeIn 0.2s ease-out;
 }
 

--- a/frontend/src/components/ApplicationDetail/ApplicationHistory.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationHistory.vue
@@ -8,203 +8,205 @@
     </button>
 
     <!-- Модальное окно истории -->
-    <div
-      v-if="showModal"
-      class="history-modal-overlay"
-      @click.self="closeModal"
-    >
-      <div class="history-modal">
-        <div class="modal-header">
-          <h3>История заявки {{ applicationNumber }}</h3>
-          <div class="header-actions">
-            <button
-              class="export-btn"
-              :disabled="filteredHistory.length === 0 || isExporting"
-              @click="exportToExcel"
-            >
-              <img
-                v-if="!isExporting"
-                src="@/assets/icons/export.png"
-                class="export-icon"
-              >
-              <span v-if="!isExporting">Экспорт</span>
-              <div
-                v-else
-                class="export-loader"
-              />
-            </button>
-            <button
-              class="close-btn"
-              @click="closeModal"
-            >
-              ×
-            </button>
-          </div>
-        </div>
-
-        <!-- Фильтры -->
-        <div class="history-filters">
-          <div class="filter-row">
-            <div class="user-filter">
-              <span class="filter-label">Пользователь:</span>
-              <div
-                class="custom-select"
-                @click="toggleUserDropdown"
-              >
-                <div class="select-trigger">
-                  <span class="selected-value">{{ selectedUserName }}</span>
-                  <img 
-                    src="@/assets/icons/arrow.png" 
-                    class="select-arrow" 
-                    :class="{ 'arrow-open': userDropdownOpen }"
-                  >
-                </div>
-                <transition name="fade">
-                  <div
-                    v-if="userDropdownOpen"
-                    class="select-dropdown"
-                  >
-                    <div 
-                      class="select-option"
-                      :class="{ 'selected': selectedUserId === null }"
-                      @click="selectUser(null)"
-                    >
-                      Все пользователи
-                    </div>
-                    <div 
-                      v-for="user in uniqueUsers" 
-                      :key="user.id"
-                      class="select-option"
-                      :class="{ 'selected': selectedUserId === user.id }"
-                      @click="selectUser(user.id)"
-                    >
-                      {{ user.name }}
-                    </div>
-                  </div>
-                </transition>
-              </div>
-            </div>
-                        
-            <div class="sort-filter">
-              <span class="filter-label">Сортировка:</span>
+    <Teleport to="body">
+      <div
+        v-if="showModal"
+        class="history-modal-overlay"
+        @click.self="closeModal"
+      >
+        <div class="history-modal">
+          <div class="modal-header">
+            <h3>История заявки {{ applicationNumber }}</h3>
+            <div class="header-actions">
               <button
-                class="sort-btn"
-                @click="toggleSortOrder"
+                class="export-btn"
+                :disabled="filteredHistory.length === 0 || isExporting"
+                @click="exportToExcel"
               >
                 <img
-                  src="@/assets/icons/sort.png"
-                  class="sort-icon"
-                  :class="{ 'sort-asc': sortOrder === 'asc' }"
+                  v-if="!isExporting"
+                  src="@/assets/icons/export.png"
+                  class="export-icon"
                 >
-                <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
+                <span v-if="!isExporting">Экспорт</span>
+                <div
+                  v-else
+                  class="export-loader"
+                />
+              </button>
+              <button
+                class="close-btn"
+                @click="closeModal"
+              >
+                ×
               </button>
             </div>
           </div>
-        </div>
 
-        <div
-          ref="scrollContainer"
-          class="modal-content"
-        >
-          <div
-            v-if="loading"
-            class="history-loading"
-          >
-            <LoaderSpinner label="Загрузка истории…" />
-          </div>
-                    
-          <div
-            v-else-if="filteredHistory.length === 0"
-            class="history-empty"
-          >
-            История пуста
-          </div>
-                    
-          <div
-            v-else
-            class="history-timeline"
-          >
-            <div 
-              v-for="(item, index) in filteredHistory" 
-              :key="item.id" 
-              class="history-item"
-            >
-              <div
-                class="timeline-dot"
-                :class="getActionClass(item.action_type)"
-              />
-              <div
-                v-if="index < filteredHistory.length - 1"
-                class="timeline-line"
-              />
-                            
-              <div class="history-content">
-                <div class="history-header">
-                  <!-- Для системных действий показываем "Система" -->
-                  <span
-                    v-if="item.action_type === 'confirmation_change' || item.action_type === 'status_change' || !item.user_id"
-                    class="user-name system-name"
+          <!-- Фильтры -->
+          <div class="history-filters">
+            <div class="filter-row">
+              <div class="user-filter">
+                <span class="filter-label">Пользователь:</span>
+                <div
+                  class="custom-select"
+                  @click="toggleUserDropdown"
+                >
+                  <div class="select-trigger">
+                    <span class="selected-value">{{ selectedUserName }}</span>
+                    <img 
+                      src="@/assets/icons/arrow.png" 
+                      class="select-arrow" 
+                      :class="{ 'arrow-open': userDropdownOpen }"
+                    >
+                  </div>
+                  <transition name="fade">
+                    <div
+                      v-if="userDropdownOpen"
+                      class="select-dropdown"
+                    >
+                      <div 
+                        class="select-option"
+                        :class="{ 'selected': selectedUserId === null }"
+                        @click="selectUser(null)"
+                      >
+                        Все пользователи
+                      </div>
+                      <div 
+                        v-for="user in uniqueUsers" 
+                        :key="user.id"
+                        class="select-option"
+                        :class="{ 'selected': selectedUserId === user.id }"
+                        @click="selectUser(user.id)"
+                      >
+                        {{ user.name }}
+                      </div>
+                    </div>
+                  </transition>
+                </div>
+              </div>
+                        
+              <div class="sort-filter">
+                <span class="filter-label">Сортировка:</span>
+                <button
+                  class="sort-btn"
+                  @click="toggleSortOrder"
+                >
+                  <img
+                    src="@/assets/icons/sort.png"
+                    class="sort-icon"
+                    :class="{ 'sort-asc': sortOrder === 'asc' }"
                   >
-                    Система
-                  </span>
-                  <span
-                    v-else
-                    class="user-name"
-                  >{{ item.user_name }}</span>
-                  <span class="action-time">{{ formatTime(item.created_at) }}</span>
-                </div>
-                                
-                <div class="action-text">
-                  {{ getActionText(item) }}
-                </div>
-                                
-                <!-- Для пересылки показываем дополнительную информацию -->
+                  <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <div
+            ref="scrollContainer"
+            class="modal-content"
+          >
+            <div
+              v-if="loading"
+              class="history-loading"
+            >
+              <LoaderSpinner label="Загрузка истории…" />
+            </div>
+                    
+            <div
+              v-else-if="filteredHistory.length === 0"
+              class="history-empty"
+            >
+              История пуста
+            </div>
+                    
+            <div
+              v-else
+              class="history-timeline"
+            >
+              <div 
+                v-for="(item, index) in filteredHistory" 
+                :key="item.id" 
+                class="history-item"
+              >
                 <div
-                  v-if="item.action_type === 'assigned_responsible' && item.metadata?.forwarded_by"
-                  class="forward-info"
-                >
-                  Переслано пользователем {{ item.metadata.forwarded_by }}
-                </div>
-                                
-                <!-- Для просмотра показываем дополнительную информацию -->
+                  class="timeline-dot"
+                  :class="getActionClass(item.action_type)"
+                />
                 <div
-                  v-if="item.action_type === 'assigned_viewer' && item.metadata?.forwarded_by"
-                  class="forward-info"
-                >
-                  Переслано пользователем {{ item.metadata.forwarded_by }}
-                </div>
+                  v-if="index < filteredHistory.length - 1"
+                  class="timeline-line"
+                />
+                            
+                <div class="history-content">
+                  <div class="history-header">
+                    <!-- Для системных действий показываем "Система" -->
+                    <span
+                      v-if="item.action_type === 'confirmation_change' || item.action_type === 'status_change' || !item.user_id"
+                      class="user-name system-name"
+                    >
+                      Система
+                    </span>
+                    <span
+                      v-else
+                      class="user-name"
+                    >{{ item.user_name }}</span>
+                    <span class="action-time">{{ formatTime(item.created_at) }}</span>
+                  </div>
                                 
-                <!-- Бейдж обязательного согласования -->
-                <div
-                  v-if="item.metadata?.required_approval"
-                  class="required-badge"
-                >
-                  Обязательно
-                </div>
+                  <div class="action-text">
+                    {{ getActionText(item) }}
+                  </div>
                                 
-                <!-- Статус изменения -->
-                <div
-                  v-if="item.old_value && item.new_value && item.old_value !== item.new_value"
-                  class="status-change"
-                >
-                  <span class="old-status">{{ item.old_value }}</span>
-                  <span class="arrow">→</span>
-                  <span class="new-status">{{ item.new_value }}</span>
-                </div>
+                  <!-- Для пересылки показываем дополнительную информацию -->
+                  <div
+                    v-if="item.action_type === 'assigned_responsible' && item.metadata?.forwarded_by"
+                    class="forward-info"
+                  >
+                    Переслано пользователем {{ item.metadata.forwarded_by }}
+                  </div>
                                 
-                <!-- Комментарий (если есть) -->
-                <div
-                  v-if="item.comment && item.action_type !== 'revoke_approval'"
-                  class="action-comment"
-                >
-                  {{ item.comment }}
+                  <!-- Для просмотра показываем дополнительную информацию -->
+                  <div
+                    v-if="item.action_type === 'assigned_viewer' && item.metadata?.forwarded_by"
+                    class="forward-info"
+                  >
+                    Переслано пользователем {{ item.metadata.forwarded_by }}
+                  </div>
+                                
+                  <!-- Бейдж обязательного согласования -->
+                  <div
+                    v-if="item.metadata?.required_approval"
+                    class="required-badge"
+                  >
+                    Обязательно
+                  </div>
+                                
+                  <!-- Статус изменения -->
+                  <div
+                    v-if="item.old_value && item.new_value && item.old_value !== item.new_value"
+                    class="status-change"
+                  >
+                    <span class="old-status">{{ item.old_value }}</span>
+                    <span class="arrow">→</span>
+                    <span class="new-status">{{ item.new_value }}</span>
+                  </div>
+                                
+                  <!-- Комментарий (если есть) -->
+                  <div
+                    v-if="item.comment && item.action_type !== 'revoke_approval'"
+                    class="action-comment"
+                  >
+                    {{ item.comment }}
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    </Teleport>
   </div>
 </template>
 
@@ -715,6 +717,8 @@ export default {
     justify-content: center;
     align-items: center;
     z-index: 20000;
+    backdrop-filter: blur(0.1px);
+    -webkit-backdrop-filter: blur(0.1px);
     animation: fadeIn 0.2s ease-out;
 }
 

--- a/frontend/src/components/ApplicationDetail/ForwardModal.vue
+++ b/frontend/src/components/ApplicationDetail/ForwardModal.vue
@@ -1,167 +1,169 @@
 <!-- ForwardModal.vue -->
 <template>
-  <div
-    class="modal-overlay"
-    @click.self="close"
-  >
-    <div class="modal">
-      <div class="modal-header">
-        <h3>Переслать заявку</h3>
-        <button
-          class="modal-close"
-          @click="close"
-        >
-          ×
-        </button>
-      </div>
-      <div class="modal-content">
-        <div class="user-search-section">
-          <input
-            ref="searchInput"
-            v-model="searchQuery"
-            class="forward-search-input"
-            placeholder="Поиск пользователей..."
-            type="text"
-            @input="searchUsers"
-            @focus="onSearchFocus"
-            @blur="onSearchBlur"
+  <Teleport to="body">
+    <div
+      class="modal-overlay"
+      @click.self="close"
+    >
+      <div class="modal">
+        <div class="modal-header">
+          <h3>Переслать заявку</h3>
+          <button
+            class="modal-close"
+            @click="close"
           >
-          <div
-            v-if="showDropdown && filteredUsers.length > 0"
-            class="forward-user-dropdown"
-          >
-            <div class="forward-user-dropdown-content">
-              <div 
-                v-for="user in filteredUsers" 
-                :key="user.username"
-                class="forward-user-item"
-                @mousedown.prevent="addUser(user)"
-              >
-                <div class="forward-user-info">
-                  <div class="forward-user-main">
-                    <span class="forward-user-name">{{ getUserDisplayName(user) }}</span>
-                    <span class="forward-user-username">@{{ user.username }}</span>
-                  </div>
-                  <div class="forward-user-details">
-                    <span
-                      v-if="user.position"
-                      class="forward-user-position"
-                    >{{ user.position }}</span>
-                    <span
-                      v-if="user.organization"
-                      class="forward-user-organization"
-                    >{{ user.organization }}</span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            v-else-if="showDropdown && filteredUsers.length === 0"
-            class="forward-user-dropdown no-results"
-          >
-            <div class="forward-user-dropdown-content">
-              <div class="no-results-message">
-                Пользователи не найдены
-              </div>
-            </div>
-          </div>
+            ×
+          </button>
         </div>
-                
-        <div
-          v-if="selectedUsers.length > 0"
-          class="selected-forward-users"
-        >
-          <h4>Выбранные пользователи ({{ selectedUsers.length }})</h4>
-          <div class="forward-users-list-container">
-            <div class="forward-users-list">
-              <div 
-                v-for="user in selectedUsers" 
-                :key="user.username"
-                class="forward-selected-user"
-              >
-                <div class="forward-selected-user-info">
-                  <div class="forward-selected-user-main">
-                    <span class="forward-selected-user-name">{{ getUserDisplayName(user) }}</span>
-                    <span class="forward-selected-user-username">@{{ user.username }}</span>
-                  </div>
-                  <div class="forward-selected-user-details">
-                    <span
-                      v-if="user.position"
-                      class="forward-selected-user-position"
-                    >{{ user.position }}</span>
-                    <span
-                      v-if="user.organization"
-                      class="forward-selected-user-organization"
-                    >{{ user.organization }}</span>
-                  </div>
-                                    
-                  <!-- Настройки доступа -->
-                  <div class="forward-selected-user-settings">
-                    <!-- Тумблер "Требуется согласование" -->
-                    <label class="setting-toggle">
-                      <input 
-                        v-model="user.requires_approval" 
-                        type="checkbox"
-                        class="setting-checkbox"
-                        @change="onApprovalToggle(user)"
-                      >
-                      <span class="toggle-slider" />
-                      <span class="toggle-text">Требуется согласование</span>
-                    </label>
-
-                    <!-- Тумблер "Согласование обязательно" (активен только если requires_approval = true) -->
-                    <label
-                      class="setting-toggle"
-                      :class="{ 'toggle-disabled': !user.requires_approval }"
-                    >
-                      <input 
-                        v-model="user.required_approval" 
-                        type="checkbox"
-                        :disabled="!user.requires_approval"
-                        class="setting-checkbox"
-                      >
-                      <span class="toggle-slider" />
-                      <span class="toggle-text">Согласование обязательно</span>
-                    </label>
-                  </div>
-                </div>
-                <button 
-                  class="remove-forward-user-btn"
-                  title="Удалить"
-                  @click="removeUser(user)"
+        <div class="modal-content">
+          <div class="user-search-section">
+            <input
+              ref="searchInput"
+              v-model="searchQuery"
+              class="forward-search-input"
+              placeholder="Поиск пользователей..."
+              type="text"
+              @input="searchUsers"
+              @focus="onSearchFocus"
+              @blur="onSearchBlur"
+            >
+            <div
+              v-if="showDropdown && filteredUsers.length > 0"
+              class="forward-user-dropdown"
+            >
+              <div class="forward-user-dropdown-content">
+                <div 
+                  v-for="user in filteredUsers" 
+                  :key="user.username"
+                  class="forward-user-item"
+                  @mousedown.prevent="addUser(user)"
                 >
-                  ×
-                </button>
+                  <div class="forward-user-info">
+                    <div class="forward-user-main">
+                      <span class="forward-user-name">{{ getUserDisplayName(user) }}</span>
+                      <span class="forward-user-username">@{{ user.username }}</span>
+                    </div>
+                    <div class="forward-user-details">
+                      <span
+                        v-if="user.position"
+                        class="forward-user-position"
+                      >{{ user.position }}</span>
+                      <span
+                        v-if="user.organization"
+                        class="forward-user-organization"
+                      >{{ user.organization }}</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              v-else-if="showDropdown && filteredUsers.length === 0"
+              class="forward-user-dropdown no-results"
+            >
+              <div class="forward-user-dropdown-content">
+                <div class="no-results-message">
+                  Пользователи не найдены
+                </div>
               </div>
             </div>
           </div>
-        </div>
                 
-        <div
-          v-else
-          class="no-forward-users"
-        >
-          <p>Выберите пользователей для пересылки заявки</p>
+          <div
+            v-if="selectedUsers.length > 0"
+            class="selected-forward-users"
+          >
+            <h4>Выбранные пользователи ({{ selectedUsers.length }})</h4>
+            <div class="forward-users-list-container">
+              <div class="forward-users-list">
+                <div 
+                  v-for="user in selectedUsers" 
+                  :key="user.username"
+                  class="forward-selected-user"
+                >
+                  <div class="forward-selected-user-info">
+                    <div class="forward-selected-user-main">
+                      <span class="forward-selected-user-name">{{ getUserDisplayName(user) }}</span>
+                      <span class="forward-selected-user-username">@{{ user.username }}</span>
+                    </div>
+                    <div class="forward-selected-user-details">
+                      <span
+                        v-if="user.position"
+                        class="forward-selected-user-position"
+                      >{{ user.position }}</span>
+                      <span
+                        v-if="user.organization"
+                        class="forward-selected-user-organization"
+                      >{{ user.organization }}</span>
+                    </div>
+                                    
+                    <!-- Настройки доступа -->
+                    <div class="forward-selected-user-settings">
+                      <!-- Тумблер "Требуется согласование" -->
+                      <label class="setting-toggle">
+                        <input 
+                          v-model="user.requires_approval" 
+                          type="checkbox"
+                          class="setting-checkbox"
+                          @change="onApprovalToggle(user)"
+                        >
+                        <span class="toggle-slider" />
+                        <span class="toggle-text">Требуется согласование</span>
+                      </label>
+
+                      <!-- Тумблер "Согласование обязательно" (активен только если requires_approval = true) -->
+                      <label
+                        class="setting-toggle"
+                        :class="{ 'toggle-disabled': !user.requires_approval }"
+                      >
+                        <input 
+                          v-model="user.required_approval" 
+                          type="checkbox"
+                          :disabled="!user.requires_approval"
+                          class="setting-checkbox"
+                        >
+                        <span class="toggle-slider" />
+                        <span class="toggle-text">Согласование обязательно</span>
+                      </label>
+                    </div>
+                  </div>
+                  <button 
+                    class="remove-forward-user-btn"
+                    title="Удалить"
+                    @click="removeUser(user)"
+                  >
+                    ×
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+                
+          <div
+            v-else
+            class="no-forward-users"
+          >
+            <p>Выберите пользователей для пересылки заявки</p>
+          </div>
         </div>
-      </div>
-      <div class="modal-footer">
-        <button 
-          class="modal-cancel-btn"
-          @click="close"
-        >
-          Отмена
-        </button>
-        <button 
-          class="modal-send-btn"
-          :disabled="selectedUsers.length === 0 || isSending"
-          @click="send"
-        >
-          {{ isSending ? 'Отправка...' : 'Отправить' }}
-        </button>
+        <div class="modal-footer">
+          <button 
+            class="modal-cancel-btn"
+            @click="close"
+          >
+            Отмена
+          </button>
+          <button 
+            class="modal-send-btn"
+            :disabled="selectedUsers.length === 0 || isSending"
+            @click="send"
+          >
+            {{ isSending ? 'Отправка...' : 'Отправить' }}
+          </button>
+        </div>
       </div>
     </div>
-  </div>
+  </Teleport>
 </template>
 
 <script>
@@ -363,11 +365,13 @@ export default {
     left: 0;
     right: 0;
     bottom: 0;
-    background: rgba(0, 0, 0, 0.7);
+    background: rgba(0, 0, 0, 0.5);
     display: flex;
     justify-content: center;
     align-items: center;
     z-index: 20000;
+    backdrop-filter: blur(0.1px);
+    -webkit-backdrop-filter: blur(0.1px);
     animation: fadeIn 0.3s ease-out;
 }
 

--- a/frontend/src/components/AttachmentsManagement.vue
+++ b/frontend/src/components/AttachmentsManagement.vue
@@ -321,214 +321,216 @@
     </div>
 
     <!-- Модальное окно создания вложения -->
-    <div
-      v-if="showAddModal"
-      class="modal-overlay"
-      @click.self="closeAddModal"
-    >
-      <div class="modal-content horizontal-modal">
-        <div class="modal-header">
-          <h3>Создать новое вложение</h3>
-          <button
-            class="modal-close"
-            @click="closeAddModal"
-          >
-            ×
-          </button>
-        </div>
+    <Teleport to="body">
+      <div
+        v-if="showAddModal"
+        class="modal-overlay"
+        @click.self="closeAddModal"
+      >
+        <div class="modal-content horizontal-modal">
+          <div class="modal-header">
+            <h3>Создать новое вложение</h3>
+            <button
+              class="modal-close"
+              @click="closeAddModal"
+            >
+              ×
+            </button>
+          </div>
         
-        <div class="modal-body-horizontal">
-          <!-- Левая часть - основная информация -->
-          <div class="modal-main-info">
-            <div class="main-fields">
-              <div class="form-group-compact">
-                <label class="form-label-compact">Наименование вложения *</label>
-                <input
-                  v-model="newAttachment.display_name"
-                  placeholder="Автозаявка"
-                  class="input-compact"
-                  :class="{ 'has-duplicate': duplicateCheck.display_name }"
-                  @input="checkExistingAttachments"
-                >
-                <div
-                  v-if="duplicateCheck.display_name"
-                  class="duplicate-alert"
-                >
-                  <p>Найдено похожее вложение:</p>
-                  <div
-                    class="duplicate-item"
-                    @click="restoreDuplicate(duplicateCheck.display_name)"
+          <div class="modal-body-horizontal">
+            <!-- Левая часть - основная информация -->
+            <div class="modal-main-info">
+              <div class="main-fields">
+                <div class="form-group-compact">
+                  <label class="form-label-compact">Наименование вложения *</label>
+                  <input
+                    v-model="newAttachment.display_name"
+                    placeholder="Автозаявка"
+                    class="input-compact"
+                    :class="{ 'has-duplicate': duplicateCheck.display_name }"
+                    @input="checkExistingAttachments"
                   >
-                    <span>{{ duplicateCheck.display_name.display_name }}</span>
-                    <span class="duplicate-status">(в архиве)</span>
-                  </div>
-                </div>
-              </div>
-
-              <div class="form-group-compact">
-                <label class="form-label-compact">Тип вложения *</label>
-                <div class="custom-select">
                   <div
-                    class="select-header"
-                    @click="toggleNewAttachmentTypeDropdown"
+                    v-if="duplicateCheck.display_name"
+                    class="duplicate-alert"
                   >
-                    <span class="select-value">{{ getAttachmentTypeLabel(newAttachment.attachment_type) }}</span>
-                    <img
-                      src="@/assets/icons/arrow.png"
-                      class="select-arrow"
-                      :class="{ rotated: newAttachmentTypeDropdownOpen }"
-                    >
-                  </div>
-                  <transition name="dropdown-fade">
+                    <p>Найдено похожее вложение:</p>
                     <div
-                      v-if="newAttachmentTypeDropdownOpen"
-                      class="select-dropdown"
+                      class="duplicate-item"
+                      @click="restoreDuplicate(duplicateCheck.display_name)"
                     >
-                      <div 
-                        class="select-option"
-                        :class="{ active: newAttachment.attachment_type === 'cars' }"
-                        @click="selectNewAttachmentType('cars')"
-                      >
-                        Машины
-                      </div>
-                      <div 
-                        class="select-option"
-                        :class="{ active: newAttachment.attachment_type === 'people' }"
-                        @click="selectNewAttachmentType('people')"
-                      >
-                        Люди
-                      </div>
-                      <div 
-                        class="select-option"
-                        :class="{ active: newAttachment.attachment_type === 'items' }"
-                        @click="selectNewAttachmentType('items')"
-                      >
-                        ТМЦ
-                      </div>
+                      <span>{{ duplicateCheck.display_name.display_name }}</span>
+                      <span class="duplicate-status">(в архиве)</span>
                     </div>
-                  </transition>
+                  </div>
                 </div>
-              </div>
+
+                <div class="form-group-compact">
+                  <label class="form-label-compact">Тип вложения *</label>
+                  <div class="custom-select">
+                    <div
+                      class="select-header"
+                      @click="toggleNewAttachmentTypeDropdown"
+                    >
+                      <span class="select-value">{{ getAttachmentTypeLabel(newAttachment.attachment_type) }}</span>
+                      <img
+                        src="@/assets/icons/arrow.png"
+                        class="select-arrow"
+                        :class="{ rotated: newAttachmentTypeDropdownOpen }"
+                      >
+                    </div>
+                    <transition name="dropdown-fade">
+                      <div
+                        v-if="newAttachmentTypeDropdownOpen"
+                        class="select-dropdown"
+                      >
+                        <div 
+                          class="select-option"
+                          :class="{ active: newAttachment.attachment_type === 'cars' }"
+                          @click="selectNewAttachmentType('cars')"
+                        >
+                          Машины
+                        </div>
+                        <div 
+                          class="select-option"
+                          :class="{ active: newAttachment.attachment_type === 'people' }"
+                          @click="selectNewAttachmentType('people')"
+                        >
+                          Люди
+                        </div>
+                        <div 
+                          class="select-option"
+                          :class="{ active: newAttachment.attachment_type === 'items' }"
+                          @click="selectNewAttachmentType('items')"
+                        >
+                          ТМЦ
+                        </div>
+                      </div>
+                    </transition>
+                  </div>
+                </div>
               
-              <div class="form-group-compact">
-                <label class="form-label-compact">Системное имя *</label>
-                <input
-                  v-model="newAttachment.name"
-                  placeholder="avtozayavka"
-                  class="input-compact"
-                  :class="{ 'has-duplicate': duplicateCheck.name, 'has-error': nameError }"
-                  @input="validateSystemName"
-                  @blur="checkExistingAttachments"
-                >
-                <span class="form-hint">Латинские буквы, цифры и подчеркивания</span>
-                <span
-                  v-if="nameError"
-                  class="form-error"
-                >{{ nameError }}</span>
-                <div
-                  v-if="duplicateCheck.name"
-                  class="duplicate-alert"
-                >
-                  <p>Найдено вложение с таким системным именем:</p>
-                  <div
-                    class="duplicate-item"
-                    @click="restoreDuplicate(duplicateCheck.name)"
+                <div class="form-group-compact">
+                  <label class="form-label-compact">Системное имя *</label>
+                  <input
+                    v-model="newAttachment.name"
+                    placeholder="avtozayavka"
+                    class="input-compact"
+                    :class="{ 'has-duplicate': duplicateCheck.name, 'has-error': nameError }"
+                    @input="validateSystemName"
+                    @blur="checkExistingAttachments"
                   >
-                    <span>{{ duplicateCheck.name.display_name }}</span>
-                    <span class="duplicate-status">(в архиве)</span>
+                  <span class="form-hint">Латинские буквы, цифры и подчеркивания</span>
+                  <span
+                    v-if="nameError"
+                    class="form-error"
+                  >{{ nameError }}</span>
+                  <div
+                    v-if="duplicateCheck.name"
+                    class="duplicate-alert"
+                  >
+                    <p>Найдено вложение с таким системным именем:</p>
+                    <div
+                      class="duplicate-item"
+                      @click="restoreDuplicate(duplicateCheck.name)"
+                    >
+                      <span>{{ duplicateCheck.name.display_name }}</span>
+                      <span class="duplicate-status">(в архиве)</span>
+                    </div>
                   </div>
                 </div>
-              </div>
 
-              <div class="form-group-compact">
-                <label class="form-label-compact">Заголовок *</label>
-                <input
-                  v-model="newAttachment.title"
-                  placeholder="АВТОЗАЯВКИ"
-                  class="input-compact"
-                  :class="{ 'has-duplicate': duplicateCheck.title }"
-                  @input="checkExistingAttachments"
-                >
-                <span class="form-hint">Отображается в заголовке категории</span>
-                <div
-                  v-if="duplicateCheck.title"
-                  class="duplicate-alert"
-                >
-                  <p>Найдено вложение с таким заголовком:</p>
-                  <div
-                    class="duplicate-item"
-                    @click="restoreDuplicate(duplicateCheck.title)"
+                <div class="form-group-compact">
+                  <label class="form-label-compact">Заголовок *</label>
+                  <input
+                    v-model="newAttachment.title"
+                    placeholder="АВТОЗАЯВКИ"
+                    class="input-compact"
+                    :class="{ 'has-duplicate': duplicateCheck.title }"
+                    @input="checkExistingAttachments"
                   >
-                    <span>{{ duplicateCheck.title.display_name }}</span>
-                    <span class="duplicate-status">(в архиве)</span>
+                  <span class="form-hint">Отображается в заголовке категории</span>
+                  <div
+                    v-if="duplicateCheck.title"
+                    class="duplicate-alert"
+                  >
+                    <p>Найдено вложение с таким заголовком:</p>
+                    <div
+                      class="duplicate-item"
+                      @click="restoreDuplicate(duplicateCheck.title)"
+                    >
+                      <span>{{ duplicateCheck.title.display_name }}</span>
+                      <span class="duplicate-status">(в архиве)</span>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
-          </div>
 
-          <!-- Правая часть - инструкция -->
-          <div class="modal-cells-section">
-            <div class="cells-header-compact">
-              <h4 class="cells-title-compact">
-                Инструкция к вложению
-              </h4>
-            </div>
+            <!-- Правая часть - инструкция -->
+            <div class="modal-cells-section">
+              <div class="cells-header-compact">
+                <h4 class="cells-title-compact">
+                  Инструкция к вложению
+                </h4>
+              </div>
             
-            <div class="cells-scroll-container">
-              <div class="settings-grid">
-                <div class="setting-item">
-                  <TextConstructor
-                    v-model="newAttachment.instruction"
-                    placeholder="Введите инструкцию для вложения..."
-                    rows="12"
-                  />
-                  <span class="setting-hint">
-                    Инструкция будет отображаться при выборе данного вложения
-                  </span>
-                </div>
+              <div class="cells-scroll-container">
+                <div class="settings-grid">
+                  <div class="setting-item">
+                    <TextConstructor
+                      v-model="newAttachment.instruction"
+                      placeholder="Введите инструкцию для вложения..."
+                      rows="12"
+                    />
+                    <span class="setting-hint">
+                      Инструкция будет отображаться при выборе данного вложения
+                    </span>
+                  </div>
 
-                <div class="setting-item">
-                  <h5 class="fields-preview-title">
-                    Предварительный просмотр:
-                  </h5>
-                  <div class="preview-card">
-                    <div class="preview-header">
-                      <div class="preview-title">
-                        {{ newAttachment.title || 'ЗАГОЛОВОК' }}
+                  <div class="setting-item">
+                    <h5 class="fields-preview-title">
+                      Предварительный просмотр:
+                    </h5>
+                    <div class="preview-card">
+                      <div class="preview-header">
+                        <div class="preview-title">
+                          {{ newAttachment.title || 'ЗАГОЛОВОК' }}
+                        </div>
                       </div>
+                      <div class="preview-attachment">
+                        <span class="preview-attachment-name">
+                          {{ newAttachment.display_name || 'Название вложения' }}
+                        </span>
+                      </div>
+                      <button class="preview-add-btn">
+                        Добавить
+                      </button>
                     </div>
-                    <div class="preview-attachment">
-                      <span class="preview-attachment-name">
-                        {{ newAttachment.display_name || 'Название вложения' }}
-                      </span>
-                    </div>
-                    <button class="preview-add-btn">
-                      Добавить
-                    </button>
                   </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
         
-        <div class="modal-footer">
-          <button
-            class="modal-cancel"
-            @click="closeAddModal"
-          >
-            Отмена
-          </button>
-          <button
-            class="modal-confirm"
-            @click="createAttachment"
-          >
-            Создать
-          </button>
+          <div class="modal-footer">
+            <button
+              class="modal-cancel"
+              @click="closeAddModal"
+            >
+              Отмена
+            </button>
+            <button
+              class="modal-confirm"
+              @click="createAttachment"
+            >
+              Создать
+            </button>
+          </div>
         </div>
       </div>
-    </div>
+    </Teleport>
 
     <!-- Уведомления -->
     <div
@@ -1730,19 +1732,19 @@ export default {
 
 /* Модальные окна */
 .modal-overlay {
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.1);
+  background: rgba(0, 0, 0, 0.5);
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 100;
+  z-index: 1000;
   padding: 20px;
-  border-radius: 16px;
-  border: 1px solid #e6e6e6;
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
 }
 
 .horizontal-modal {

--- a/frontend/src/components/CarDetailsModal.vue
+++ b/frontend/src/components/CarDetailsModal.vue
@@ -1,391 +1,393 @@
 <template>
-  <div
-    class="modal-overlay"
-    @mousedown="onOverlayMousedown"
-    @mouseup="onOverlayMouseup"
-  >
-    <div class="modal-wrapper">
-      <!-- Основное модальное окно с деталями автомобиля -->
-      <div
-        class="car-details-modal main-modal"
-        :class="{ 'shifted': isMainShifted }"
-        @mousedown.stop
-      >
-        <div class="modal-header">
-          <h3>Детали автомобиля</h3>
-          <div class="header-actions">
-            <button
-              class="history-btn"
-              @click="openCarHistory"
-            >
-              <span>История автомобиля</span>
-            </button>
-            <button
-              class="application-btn"
-              @click="openApplication"
-            >
-              <span>Открыть заявку</span>
-            </button>
-            <button
-              class="close-btn"
-              @click="close"
-            >
-              ×
-            </button>
-          </div>
-        </div>
-
-        <div class="modal-content">
-          <div class="car-info-section">
-            <h4>Информация об автомобиле</h4>
-            <div class="info-grid two-columns">
-              <div class="info-item">
-                <span class="info-label">Номер машины:</span>
-                <span class="info-value">{{ car.car_number || 'Не указан' }}</span>
-              </div>
-              <div class="info-item">
-                <span class="info-label">Марка:</span>
-                <span class="info-value">{{ car.car_brand || 'Не указана' }}</span>
-              </div>
-              <div class="info-item">
-                <span class="info-label">Организация:</span>
-                <span class="info-value">{{ car.organization_name || car.organization || 'Не указана' }}</span>
-              </div>
-              <div class="info-item">
-                <span class="info-label">Компания:</span>
-                <span class="info-value">{{ car.company || 'Не указана' }}</span>
-              </div>
-              <div class="info-item">
-                <span class="info-label">Действует до:</span>
-                <span class="info-value">{{ formatDate(car.entry_date_to) }}</span>
-              </div>
-              <div class="info-item">
-                <span class="info-label">Время пребывания:</span>
-                <span class="info-value">{{ formatTimeRange(car.entry_time_from, car.entry_time_to) }}</span>
-              </div>
-            </div>
-            
-            <div class="places-section">
-              <h5>Места разгрузки</h5>
-              <div class="places-list">
-                <div 
-                  v-for="placeId in car.unload_place_ids" 
-                  :key="placeId"
-                  class="place-item"
-                  @click="showUnloadPlaceDetails(placeId)"
-                >
-                  {{ getPlaceName(placeId) }}
-                </div>
-                <div
-                  v-if="!car.unload_place_ids || car.unload_place_ids.length === 0"
-                  class="no-places"
-                >
-                  Места разгрузки не указаны
-                </div>
-              </div>
-            </div>
-
-            <div class="status-section">
-              <h5>Статус</h5>
-              <div
-                class="status-badge"
-                :class="getStatusClass"
-              >
-                {{ getStatusText }}
-              </div>
-            </div>
-          </div>
-
-          <div class="history-section">
-            <div class="section-header">
-              <h4>История въездов и выездов</h4>
-              <button
-                class="export-btn"
-                :disabled="history.length === 0 || isExporting"
-                @click="exportHistory"
-              >
-                <img
-                  v-if="!isExporting"
-                  src="@/assets/icons/export.png"
-                  class="export-icon"
-                >
-                <span v-if="!isExporting">Экспорт</span>
-                <div
-                  v-else
-                  class="export-loader"
-                />
-              </button>
-            </div>
-            
-            <div
-              v-if="loadingHistory"
-              class="loading-container"
-            >
-              <LoaderSpinner label="Загрузка истории…" />
-            </div>
-            
-            <div
-              v-else-if="history.length === 0"
-              class="no-history"
-            >
-              История отсутствует
-            </div>
-            
-            <div
-              v-else
-              class="history-timeline"
-            >
-              <div 
-                v-for="(item, index) in history" 
-                :key="item.id" 
-                class="history-item"
-              >
-                <div
-                  class="timeline-dot"
-                  :class="getActionClass(item.action_type)"
-                />
-                <div
-                  v-if="index < history.length - 1"
-                  class="timeline-line"
-                />
-                
-                <div class="history-content">
-                  <div class="history-header">
-                    <span class="user-name">{{ item.user_name || 'Система' }}</span>
-                    <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
-                  </div>
-                  
-                  <div class="action-text">
-                    {{ getActionText(item) }}
-                  </div>
-                  
-                  <div
-                    v-if="item.comment"
-                    class="action-comment"
-                  >
-                    {{ item.comment }}
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <!-- Дополнительное модальное окно с деталями места разгрузки -->
-      <transition 
-        name="place-slide"
-        @after-leave="onPlaceLeave"
-      >
+  <Teleport to="body">
+    <div
+      class="modal-overlay"
+      @mousedown="onOverlayMousedown"
+      @mouseup="onOverlayMouseup"
+    >
+      <div class="modal-wrapper">
+        <!-- Основное модальное окно с деталями автомобиля -->
         <div
-          v-if="showPlaceModal"
-          class="modal-content place-modal"
+          class="car-details-modal main-modal"
+          :class="{ 'shifted': isMainShifted }"
+          @mousedown.stop
         >
           <div class="modal-header">
-            <div class="header-with-status">
-              <h3 class="modal-title">
-                Информация о месте разгрузки
-              </h3>
-              <span
-                class="status-badge"
-                :class="getPlaceStatusClass(selectedPlace)"
+            <h3>Детали автомобиля</h3>
+            <div class="header-actions">
+              <button
+                class="history-btn"
+                @click="openCarHistory"
               >
-                {{ getPlaceStatusText(selectedPlace) }}
-              </span>
-              <div
-                v-if="selectedPlace && selectedPlace.status === 'active'"
-                class="time-info"
+                <span>История автомобиля</span>
+              </button>
+              <button
+                class="application-btn"
+                @click="openApplication"
               >
-                {{ getTimeInfoText() }}
-              </div>
+                <span>Открыть заявку</span>
+              </button>
+              <button
+                class="close-btn"
+                @click="close"
+              >
+                ×
+              </button>
             </div>
-            <button
-              class="modal-close"
-              @click="closeUnloadPlaceDetails"
-            >
-              <svg
-                width="10"
-                height="10"
-                viewBox="0 0 14 14"
-                fill="none"
-              >
-                <path
-                  d="M13 1L1 13M1 1L13 13"
-                  stroke="#666"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                />
-              </svg>
-            </button>
           </div>
 
-          <div class="modal-body">
-            <div
-              v-if="selectedPlace"
-              class="place-details"
-            >
-              <div class="details-section">
-                <div class="section-header">
-                  <h4 class="section-title">
-                    Основная информация
-                  </h4>
+          <div class="modal-content">
+            <div class="car-info-section">
+              <h4>Информация об автомобиле</h4>
+              <div class="info-grid two-columns">
+                <div class="info-item">
+                  <span class="info-label">Номер машины:</span>
+                  <span class="info-value">{{ car.car_number || 'Не указан' }}</span>
                 </div>
-                <div class="section-body">
-                  <div class="info-grid">
-                    <div class="info-row">
-                      <span class="info-label">Наименование:</span>
-                      <span class="info-value">{{ selectedPlace.name }}</span>
-                    </div>
+                <div class="info-item">
+                  <span class="info-label">Марка:</span>
+                  <span class="info-value">{{ car.car_brand || 'Не указана' }}</span>
+                </div>
+                <div class="info-item">
+                  <span class="info-label">Организация:</span>
+                  <span class="info-value">{{ car.organization_name || car.organization || 'Не указана' }}</span>
+                </div>
+                <div class="info-item">
+                  <span class="info-label">Компания:</span>
+                  <span class="info-value">{{ car.company || 'Не указана' }}</span>
+                </div>
+                <div class="info-item">
+                  <span class="info-label">Действует до:</span>
+                  <span class="info-value">{{ formatDate(car.entry_date_to) }}</span>
+                </div>
+                <div class="info-item">
+                  <span class="info-label">Время пребывания:</span>
+                  <span class="info-value">{{ formatTimeRange(car.entry_time_from, car.entry_time_to) }}</span>
+                </div>
+              </div>
+            
+              <div class="places-section">
+                <h5>Места разгрузки</h5>
+                <div class="places-list">
+                  <div 
+                    v-for="placeId in car.unload_place_ids" 
+                    :key="placeId"
+                    class="place-item"
+                    @click="showUnloadPlaceDetails(placeId)"
+                  >
+                    {{ getPlaceName(placeId) }}
                   </div>
                   <div
-                    v-if="selectedPlace.status !== 'active' && selectedPlace.status_comment"
-                    class="comment-text"
+                    v-if="!car.unload_place_ids || car.unload_place_ids.length === 0"
+                    class="no-places"
                   >
-                    {{ selectedPlace.status_comment }}
+                    Места разгрузки не указаны
                   </div>
                 </div>
               </div>
 
-              <div class="details-section">
-                <div class="section-header">
-                  <h4 class="section-title">
-                    Режим работы
-                  </h4>
+              <div class="status-section">
+                <h5>Статус</h5>
+                <div
+                  class="status-badge"
+                  :class="getStatusClass"
+                >
+                  {{ getStatusText }}
                 </div>
-                <div class="section-body">
-                  <div
-                    v-if="hasTimeSlots(selectedPlace)"
-                    class="schedule-grid"
+              </div>
+            </div>
+
+            <div class="history-section">
+              <div class="section-header">
+                <h4>История въездов и выездов</h4>
+                <button
+                  class="export-btn"
+                  :disabled="history.length === 0 || isExporting"
+                  @click="exportHistory"
+                >
+                  <img
+                    v-if="!isExporting"
+                    src="@/assets/icons/export.png"
+                    class="export-icon"
                   >
-                    <div 
-                      v-for="day in daysWithSlots(selectedPlace)" 
-                      :key="day" 
-                      class="schedule-day-card"
-                      :class="{ 'current-day': isCurrentDay(day) }"
+                  <span v-if="!isExporting">Экспорт</span>
+                  <div
+                    v-else
+                    class="export-loader"
+                  />
+                </button>
+              </div>
+            
+              <div
+                v-if="loadingHistory"
+                class="loading-container"
+              >
+                <LoaderSpinner label="Загрузка истории…" />
+              </div>
+            
+              <div
+                v-else-if="history.length === 0"
+                class="no-history"
+              >
+                История отсутствует
+              </div>
+            
+              <div
+                v-else
+                class="history-timeline"
+              >
+                <div 
+                  v-for="(item, index) in history" 
+                  :key="item.id" 
+                  class="history-item"
+                >
+                  <div
+                    class="timeline-dot"
+                    :class="getActionClass(item.action_type)"
+                  />
+                  <div
+                    v-if="index < history.length - 1"
+                    class="timeline-line"
+                  />
+                
+                  <div class="history-content">
+                    <div class="history-header">
+                      <span class="user-name">{{ item.user_name || 'Система' }}</span>
+                      <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                    </div>
+                  
+                    <div class="action-text">
+                      {{ getActionText(item) }}
+                    </div>
+                  
+                    <div
+                      v-if="item.comment"
+                      class="action-comment"
                     >
-                      <div class="day-name">
-                        {{ getFullDayName(day) }}
+                      {{ item.comment }}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Дополнительное модальное окно с деталями места разгрузки -->
+        <transition 
+          name="place-slide"
+          @after-leave="onPlaceLeave"
+        >
+          <div
+            v-if="showPlaceModal"
+            class="modal-content place-modal"
+          >
+            <div class="modal-header">
+              <div class="header-with-status">
+                <h3 class="modal-title">
+                  Информация о месте разгрузки
+                </h3>
+                <span
+                  class="status-badge"
+                  :class="getPlaceStatusClass(selectedPlace)"
+                >
+                  {{ getPlaceStatusText(selectedPlace) }}
+                </span>
+                <div
+                  v-if="selectedPlace && selectedPlace.status === 'active'"
+                  class="time-info"
+                >
+                  {{ getTimeInfoText() }}
+                </div>
+              </div>
+              <button
+                class="modal-close"
+                @click="closeUnloadPlaceDetails"
+              >
+                <svg
+                  width="10"
+                  height="10"
+                  viewBox="0 0 14 14"
+                  fill="none"
+                >
+                  <path
+                    d="M13 1L1 13M1 1L13 13"
+                    stroke="#666"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                  />
+                </svg>
+              </button>
+            </div>
+
+            <div class="modal-body">
+              <div
+                v-if="selectedPlace"
+                class="place-details"
+              >
+                <div class="details-section">
+                  <div class="section-header">
+                    <h4 class="section-title">
+                      Основная информация
+                    </h4>
+                  </div>
+                  <div class="section-body">
+                    <div class="info-grid">
+                      <div class="info-row">
+                        <span class="info-label">Наименование:</span>
+                        <span class="info-value">{{ selectedPlace.name }}</span>
                       </div>
-                      <div class="day-slots">
-                        <div 
-                          v-for="slot in getSlotsForDay(selectedPlace.time_slots, day)" 
-                          :key="slot.id" 
-                          class="slot-badge"
-                          :class="{ 'active-slot': isCurrentDay(day) && isActiveSlot(slot) }"
-                        >
-                          <span
-                            v-if="isRoundTheClockSlot(slot)"
-                            class="round-clock-text"
-                          >круглосуточно</span>
-                          <template v-else>
-                            <span class="slot-time">
-                              {{ formatTime(slot.open_time) }} – {{ formatTime(slot.close_time) }}
-                            </span>
-                            <div class="slot-badges">
-                              <span
-                                v-if="slot.is_next_day"
-                                class="next-day-badge"
-                              >+1</span>
-                              <span
-                                v-if="!slot.is_active"
-                                class="inactive-badge"
-                              >неакт</span>
-                            </div>
-                          </template>
+                    </div>
+                    <div
+                      v-if="selectedPlace.status !== 'active' && selectedPlace.status_comment"
+                      class="comment-text"
+                    >
+                      {{ selectedPlace.status_comment }}
+                    </div>
+                  </div>
+                </div>
+
+                <div class="details-section">
+                  <div class="section-header">
+                    <h4 class="section-title">
+                      Режим работы
+                    </h4>
+                  </div>
+                  <div class="section-body">
+                    <div
+                      v-if="hasTimeSlots(selectedPlace)"
+                      class="schedule-grid"
+                    >
+                      <div 
+                        v-for="day in daysWithSlots(selectedPlace)" 
+                        :key="day" 
+                        class="schedule-day-card"
+                        :class="{ 'current-day': isCurrentDay(day) }"
+                      >
+                        <div class="day-name">
+                          {{ getFullDayName(day) }}
+                        </div>
+                        <div class="day-slots">
+                          <div 
+                            v-for="slot in getSlotsForDay(selectedPlace.time_slots, day)" 
+                            :key="slot.id" 
+                            class="slot-badge"
+                            :class="{ 'active-slot': isCurrentDay(day) && isActiveSlot(slot) }"
+                          >
+                            <span
+                              v-if="isRoundTheClockSlot(slot)"
+                              class="round-clock-text"
+                            >круглосуточно</span>
+                            <template v-else>
+                              <span class="slot-time">
+                                {{ formatTime(slot.open_time) }} – {{ formatTime(slot.close_time) }}
+                              </span>
+                              <div class="slot-badges">
+                                <span
+                                  v-if="slot.is_next_day"
+                                  class="next-day-badge"
+                                >+1</span>
+                                <span
+                                  v-if="!slot.is_active"
+                                  class="inactive-badge"
+                                >неакт</span>
+                              </div>
+                            </template>
+                          </div>
                         </div>
                       </div>
                     </div>
-                  </div>
-                  <div
-                    v-else
-                    class="no-schedule"
-                  >
-                    Режим работы не указан
-                  </div>
-                </div>
-              </div>
-
-              <div class="details-section">
-                <div class="section-header location-header">
-                  <h4 class="section-title">
-                    Местоположение
-                  </h4>
-                  <a 
-                    v-if="selectedPlace.map_link" 
-                    :href="selectedPlace.map_link" 
-                    target="_blank" 
-                    class="map-link-btn"
-                  >
-                    Как добраться?
-                  </a>
-                </div>
-                <div class="section-body photo-body">
-                  <div
-                    v-if="selectedPlace.photos && selectedPlace.photos.length > 0"
-                    class="photo-container"
-                  >
-                    <div 
-                      ref="photoWrapper" 
-                      class="photo-wrapper"
-                      @mousedown="startDrag"
-                      @mousemove="onDrag"
-                      @mouseup="stopDrag"
-                      @mouseleave="stopDrag"
-                      @wheel="onZoom"
+                    <div
+                      v-else
+                      class="no-schedule"
                     >
-                      <img 
-                        :src="getMainPhotoUrl(selectedPlace.photos)" 
-                        alt="Место разгрузки"
-                        class="place-photo"
-                        :style="photoStyle"
-                        draggable="false"
-                        @load="updateImageDimensions"
-                      >
-                    </div>
-                    <div class="photo-controls">
-                      <button
-                        class="photo-control-btn"
-                        @click="zoomIn"
-                      >
-                        +
-                      </button>
-                      <button
-                        class="photo-control-btn"
-                        @click="zoomOut"
-                      >
-                        −
-                      </button>
-                      <button
-                        class="photo-control-btn"
-                        @click="resetPhoto"
-                      >
-                        ↺
-                      </button>
+                      Режим работы не указан
                     </div>
                   </div>
-                  <div
-                    v-else
-                    class="no-photo-placeholder"
-                  >
-                    Нет фотографии
+                </div>
+
+                <div class="details-section">
+                  <div class="section-header location-header">
+                    <h4 class="section-title">
+                      Местоположение
+                    </h4>
+                    <a 
+                      v-if="selectedPlace.map_link" 
+                      :href="selectedPlace.map_link" 
+                      target="_blank" 
+                      class="map-link-btn"
+                    >
+                      Как добраться?
+                    </a>
+                  </div>
+                  <div class="section-body photo-body">
+                    <div
+                      v-if="selectedPlace.photos && selectedPlace.photos.length > 0"
+                      class="photo-container"
+                    >
+                      <div 
+                        ref="photoWrapper" 
+                        class="photo-wrapper"
+                        @mousedown="startDrag"
+                        @mousemove="onDrag"
+                        @mouseup="stopDrag"
+                        @mouseleave="stopDrag"
+                        @wheel="onZoom"
+                      >
+                        <img 
+                          :src="getMainPhotoUrl(selectedPlace.photos)" 
+                          alt="Место разгрузки"
+                          class="place-photo"
+                          :style="photoStyle"
+                          draggable="false"
+                          @load="updateImageDimensions"
+                        >
+                      </div>
+                      <div class="photo-controls">
+                        <button
+                          class="photo-control-btn"
+                          @click="zoomIn"
+                        >
+                          +
+                        </button>
+                        <button
+                          class="photo-control-btn"
+                          @click="zoomOut"
+                        >
+                          −
+                        </button>
+                        <button
+                          class="photo-control-btn"
+                          @click="resetPhoto"
+                        >
+                          ↺
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      v-else
+                      class="no-photo-placeholder"
+                    >
+                      Нет фотографии
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-      </transition>
-    </div>
+        </transition>
+      </div>
 
-    <CarHistoryModal
-      v-if="showCarHistory"
-      :car-id="car.id"
-      :car-number="car.car_number || 'по факту'"
-      :current-user-id="currentUserId"
-      :current-user-name="currentUserName"
-      @close="showCarHistory = false"
-    />
-  </div>
+      <CarHistoryModal
+        v-if="showCarHistory"
+        :car-id="car.id"
+        :car-number="car.car_number || 'по факту'"
+        :current-user-id="currentUserId"
+        :current-user-name="currentUserName"
+        @close="showCarHistory = false"
+      />
+    </div>
+  </Teleport>
 </template>
 
 <script>
@@ -1052,6 +1054,8 @@ export default {
   justify-content: center;
   align-items: center;
   z-index: 11000;
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
   animation: fadeIn 0.2s ease-out;
 }
 

--- a/frontend/src/components/CarHistoryModal.vue
+++ b/frontend/src/components/CarHistoryModal.vue
@@ -1,215 +1,217 @@
 <template>
-  <div
-    class="modal-overlay"
-    @mousedown="onOverlayMousedown"
-    @mouseup="onOverlayMouseup"
-  >
+  <Teleport to="body">
     <div
-      class="car-history-modal"
-      @mousedown.stop
+      class="modal-overlay"
+      @mousedown="onOverlayMousedown"
+      @mouseup="onOverlayMouseup"
     >
-      <div class="modal-header">
-        <h3>История автомобиля {{ carNumber }}</h3>
-        <div class="header-actions">
-          <button
-            class="export-btn"
-            :disabled="filteredHistory.length === 0 || isExporting"
-            @click="exportToExcel"
-          >
-            <img
-              v-if="!isExporting"
-              src="@/assets/icons/export.png"
-              class="export-icon"
-            >
-            <span v-if="!isExporting">Экспорт</span>
-            <div
-              v-else
-              class="export-loader"
-            />
-          </button>
-          <button
-            class="close-btn"
-            @click="close"
-          >
-            ×
-          </button>
-        </div>
-      </div>
-
-      <div class="history-filters">
-        <div class="filter-row">
-          <div class="search-filter">
-            <span class="filter-label">Поиск:</span>
-            <input 
-              v-model="searchQuery" 
-              type="text" 
-              class="search-input" 
-              placeholder="Поиск по пользователю, действию..."
-              @input="applyFilters"
-            >
-          </div>
-          <div class="user-filter">
-            <span class="filter-label">Пользователь:</span>
-            <div
-              class="custom-select"
-              @click="toggleUserDropdown"
-            >
-              <div class="select-trigger">
-                <span class="selected-value">{{ selectedUserName }}</span>
-                <img 
-                  src="@/assets/icons/arrow.png" 
-                  class="select-arrow" 
-                  :class="{ 'arrow-open': userDropdownOpen }"
-                >
-              </div>
-              <transition name="fade">
-                <div
-                  v-if="userDropdownOpen"
-                  class="select-dropdown"
-                >
-                  <div 
-                    class="select-option"
-                    :class="{ 'selected': selectedUserId === null }"
-                    @click="selectUser(null)"
-                  >
-                    Все пользователи
-                  </div>
-                  <div 
-                    v-for="user in uniqueUsers" 
-                    :key="user.id"
-                    class="select-option"
-                    :class="{ 'selected': selectedUserId === user.id }"
-                    @click="selectUser(user.id)"
-                  >
-                    {{ user.name }}
-                  </div>
-                </div>
-              </transition>
-            </div>
-          </div>
-          
-          <div class="date-filter">
-            <span class="filter-label">Период:</span>
-            <input 
-              v-model="dateFrom" 
-              type="date" 
-              class="date-input"
-              @change="applyFilters"
-            >
-            <span class="date-separator">—</span>
-            <input 
-              v-model="dateTo" 
-              type="date" 
-              class="date-input"
-              @change="applyFilters"
-            >
-          </div>
-          
-          <div class="sort-filter">
-            <span class="filter-label">Сортировка:</span>
+      <div
+        class="car-history-modal"
+        @mousedown.stop
+      >
+        <div class="modal-header">
+          <h3>История автомобиля {{ carNumber }}</h3>
+          <div class="header-actions">
             <button
-              class="sort-btn"
-              @click="toggleSortOrder"
+              class="export-btn"
+              :disabled="filteredHistory.length === 0 || isExporting"
+              @click="exportToExcel"
             >
               <img
-                src="@/assets/icons/sort.png"
-                class="sort-icon"
-                :class="{ 'sort-asc': sortOrder === 'asc' }"
+                v-if="!isExporting"
+                src="@/assets/icons/export.png"
+                class="export-icon"
               >
-              <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
+              <span v-if="!isExporting">Экспорт</span>
+              <div
+                v-else
+                class="export-loader"
+              />
+            </button>
+            <button
+              class="close-btn"
+              @click="close"
+            >
+              ×
             </button>
           </div>
         </div>
-      </div>
 
-      <div
-        ref="scrollContainer"
-        class="modal-content"
-      >
-        <div
-          v-if="loading"
-          class="history-loading"
-        >
-          <LoaderSpinner label="Загрузка истории…" />
+        <div class="history-filters">
+          <div class="filter-row">
+            <div class="search-filter">
+              <span class="filter-label">Поиск:</span>
+              <input 
+                v-model="searchQuery" 
+                type="text" 
+                class="search-input" 
+                placeholder="Поиск по пользователю, действию..."
+                @input="applyFilters"
+              >
+            </div>
+            <div class="user-filter">
+              <span class="filter-label">Пользователь:</span>
+              <div
+                class="custom-select"
+                @click="toggleUserDropdown"
+              >
+                <div class="select-trigger">
+                  <span class="selected-value">{{ selectedUserName }}</span>
+                  <img 
+                    src="@/assets/icons/arrow.png" 
+                    class="select-arrow" 
+                    :class="{ 'arrow-open': userDropdownOpen }"
+                  >
+                </div>
+                <transition name="fade">
+                  <div
+                    v-if="userDropdownOpen"
+                    class="select-dropdown"
+                  >
+                    <div 
+                      class="select-option"
+                      :class="{ 'selected': selectedUserId === null }"
+                      @click="selectUser(null)"
+                    >
+                      Все пользователи
+                    </div>
+                    <div 
+                      v-for="user in uniqueUsers" 
+                      :key="user.id"
+                      class="select-option"
+                      :class="{ 'selected': selectedUserId === user.id }"
+                      @click="selectUser(user.id)"
+                    >
+                      {{ user.name }}
+                    </div>
+                  </div>
+                </transition>
+              </div>
+            </div>
+          
+            <div class="date-filter">
+              <span class="filter-label">Период:</span>
+              <input 
+                v-model="dateFrom" 
+                type="date" 
+                class="date-input"
+                @change="applyFilters"
+              >
+              <span class="date-separator">—</span>
+              <input 
+                v-model="dateTo" 
+                type="date" 
+                class="date-input"
+                @change="applyFilters"
+              >
+            </div>
+          
+            <div class="sort-filter">
+              <span class="filter-label">Сортировка:</span>
+              <button
+                class="sort-btn"
+                @click="toggleSortOrder"
+              >
+                <img
+                  src="@/assets/icons/sort.png"
+                  class="sort-icon"
+                  :class="{ 'sort-asc': sortOrder === 'asc' }"
+                >
+                <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
+              </button>
+            </div>
+          </div>
         </div>
-        
+
         <div
-          v-else-if="filteredHistory.length === 0"
-          class="history-empty"
+          ref="scrollContainer"
+          class="modal-content"
         >
-          История пуста
-        </div>
-        
-        <div
-          v-else
-          class="history-timeline"
-        >
-          <div 
-            v-for="(item, index) in filteredHistory" 
-            :key="item.id" 
-            class="history-item"
+          <div
+            v-if="loading"
+            class="history-loading"
           >
-            <div
-              class="timeline-dot"
-              :class="getActionClass(item.action_type)"
-            />
-            <div
-              v-if="index < filteredHistory.length - 1"
-              class="timeline-line"
-            />
+            <LoaderSpinner label="Загрузка истории…" />
+          </div>
+        
+          <div
+            v-else-if="filteredHistory.length === 0"
+            class="history-empty"
+          >
+            История пуста
+          </div>
+        
+          <div
+            v-else
+            class="history-timeline"
+          >
+            <div 
+              v-for="(item, index) in filteredHistory" 
+              :key="item.id" 
+              class="history-item"
+            >
+              <div
+                class="timeline-dot"
+                :class="getActionClass(item.action_type)"
+              />
+              <div
+                v-if="index < filteredHistory.length - 1"
+                class="timeline-line"
+              />
             
-            <div class="history-content">
-              <div class="history-header">
-                <span class="user-name">{{ item.user_name || 'Система' }}</span>
-                <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
-              </div>
+              <div class="history-content">
+                <div class="history-header">
+                  <span class="user-name">{{ item.user_name || 'Система' }}</span>
+                  <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                </div>
               
-              <div class="action-text">
-                {{ getActionText(item) }}
-              </div>
+                <div class="action-text">
+                  {{ getActionText(item) }}
+                </div>
               
-              <div
-                v-if="item.action_type === 'entry' || item.action_type === 'exit'"
-                class="action-comment"
-              >
-                {{ getActionComment(item) }}
-              </div>
+                <div
+                  v-if="item.action_type === 'entry' || item.action_type === 'exit'"
+                  class="action-comment"
+                >
+                  {{ getActionComment(item) }}
+                </div>
               
-              <div
-                v-if="item.comment && item.action_type !== 'entry' && item.action_type !== 'exit'"
-                class="action-comment"
-              >
-                {{ item.comment }}
-              </div>
+                <div
+                  v-if="item.comment && item.action_type !== 'entry' && item.action_type !== 'exit'"
+                  class="action-comment"
+                >
+                  {{ item.comment }}
+                </div>
               
-              <div
-                v-if="item.old_value && item.new_value && item.old_value !== item.new_value"
-                class="value-change"
-              >
-                <span class="old-value">{{ item.old_value }}</span>
-                <span class="arrow">→</span>
-                <span class="new-value">{{ item.new_value }}</span>
-              </div>
+                <div
+                  v-if="item.old_value && item.new_value && item.old_value !== item.new_value"
+                  class="value-change"
+                >
+                  <span class="old-value">{{ item.old_value }}</span>
+                  <span class="arrow">→</span>
+                  <span class="new-value">{{ item.new_value }}</span>
+                </div>
               
-              <div
-                v-if="item.field_name"
-                class="field-name"
-              >
-                Поле: {{ item.field_name }}
-              </div>
+                <div
+                  v-if="item.field_name"
+                  class="field-name"
+                >
+                  Поле: {{ item.field_name }}
+                </div>
               
-              <div
-                v-if="item.table_name"
-                class="place-name"
-              >
-                {{ item.table_name }}
+                <div
+                  v-if="item.table_name"
+                  class="place-name"
+                >
+                  {{ item.table_name }}
+                </div>
               </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
+  </Teleport>
 </template>
 
 <script>
@@ -750,6 +752,8 @@ export default {
   justify-content: center;
   align-items: center;
   z-index: 12000;
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
   animation: fadeIn 0.2s ease-out;
 }
 

--- a/frontend/src/components/CarsTableHistoryModal.vue
+++ b/frontend/src/components/CarsTableHistoryModal.vue
@@ -1,236 +1,238 @@
 <template>
-  <div
-    class="modal-overlay"
-    @click.self="close"
-  >
-    <div class="cars-history-modal">
-      <div class="modal-header">
-        <h3>История въездов и выездов всех автомобилей</h3>
-        <div class="header-actions">
-          <button
-            class="export-btn"
-            :disabled="filteredHistory.length === 0 || isExporting"
-            @click="exportToExcel"
-          >
-            <img
-              v-if="!isExporting"
-              src="@/assets/icons/export.png"
-              class="export-icon"
-            >
-            <span v-if="!isExporting">Экспорт</span>
-            <div
-              v-else
-              class="export-loader"
-            />
-          </button>
-          <button
-            class="close-btn"
-            @click="close"
-          >
-            ×
-          </button>
-        </div>
-      </div>
-
-      <div class="history-filters">
-        <div class="filter-row">
-          <div class="search-filter">
-            <span class="filter-label">Поиск:</span>
-            <input 
-              v-model="searchQuery" 
-              type="text" 
-              class="search-input" 
-              placeholder="Поиск по автомобилю, номеру, организации..."
-              @input="applyFilters"
-            >
-          </div>
-          <div class="user-filter">
-            <span class="filter-label">Пользователь:</span>
-            <div
-              class="custom-select"
-              @click="toggleUserDropdown"
-            >
-              <div class="select-trigger">
-                <span class="selected-value">{{ selectedUserName }}</span>
-                <img 
-                  src="@/assets/icons/arrow.png" 
-                  class="select-arrow" 
-                  :class="{ 'arrow-open': userDropdownOpen }"
-                >
-              </div>
-              <transition name="fade">
-                <div
-                  v-if="userDropdownOpen"
-                  class="select-dropdown"
-                >
-                  <div 
-                    class="select-option"
-                    :class="{ 'selected': selectedUserId === null }"
-                    @click="selectUser(null)"
-                  >
-                    Все пользователи
-                  </div>
-                  <div 
-                    v-for="user in uniqueUsers" 
-                    :key="user.id"
-                    class="select-option"
-                    :class="{ 'selected': selectedUserId === user.id }"
-                    @click="selectUser(user.id)"
-                  >
-                    {{ user.name }}
-                  </div>
-                </div>
-              </transition>
-            </div>
-          </div>
-          
-          <div class="car-filter">
-            <span class="filter-label">Автомобиль:</span>
-            <div
-              class="custom-select"
-              @click="toggleCarDropdown"
-            >
-              <div class="select-trigger">
-                <span class="selected-value">{{ selectedCarName }}</span>
-                <img 
-                  src="@/assets/icons/arrow.png" 
-                  class="select-arrow" 
-                  :class="{ 'arrow-open': carDropdownOpen }"
-                >
-              </div>
-              <transition name="fade">
-                <div
-                  v-if="carDropdownOpen"
-                  class="select-dropdown"
-                >
-                  <div 
-                    class="select-option"
-                    :class="{ 'selected': selectedCarId === null }"
-                    @click="selectCar(null)"
-                  >
-                    Все автомобили
-                  </div>
-                  <div 
-                    v-for="car in cars" 
-                    :key="car.id"
-                    class="select-option"
-                    :class="{ 'selected': selectedCarId === car.id }"
-                    @click="selectCar(car.id)"
-                  >
-                    {{ formatCarName(car) }}
-                  </div>
-                </div>
-              </transition>
-            </div>
-          </div>
-          
-          <div class="date-filter">
-            <span class="filter-label">Период:</span>
-            <input 
-              v-model="dateFrom" 
-              type="date" 
-              class="date-input"
-              @change="applyFilters"
-            >
-            <span class="date-separator">—</span>
-            <input 
-              v-model="dateTo" 
-              type="date" 
-              class="date-input"
-              @change="applyFilters"
-            >
-          </div>
-          
-          <div class="sort-filter">
-            <span class="filter-label">Сортировка:</span>
+  <Teleport to="body">
+    <div
+      class="modal-overlay"
+      @click.self="close"
+    >
+      <div class="cars-history-modal">
+        <div class="modal-header">
+          <h3>История въездов и выездов всех автомобилей</h3>
+          <div class="header-actions">
             <button
-              class="sort-btn"
-              @click="toggleSortOrder"
+              class="export-btn"
+              :disabled="filteredHistory.length === 0 || isExporting"
+              @click="exportToExcel"
             >
               <img
-                src="@/assets/icons/sort.png"
-                class="sort-icon"
-                :class="{ 'sort-asc': sortOrder === 'asc' }"
+                v-if="!isExporting"
+                src="@/assets/icons/export.png"
+                class="export-icon"
               >
-              <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
+              <span v-if="!isExporting">Экспорт</span>
+              <div
+                v-else
+                class="export-loader"
+              />
+            </button>
+            <button
+              class="close-btn"
+              @click="close"
+            >
+              ×
             </button>
           </div>
         </div>
-      </div>
 
-      <div
-        ref="scrollContainer"
-        class="modal-content"
-      >
-        <div
-          v-if="loading"
-          class="history-loading"
-        >
-          <LoaderSpinner label="Загрузка истории…" />
+        <div class="history-filters">
+          <div class="filter-row">
+            <div class="search-filter">
+              <span class="filter-label">Поиск:</span>
+              <input 
+                v-model="searchQuery" 
+                type="text" 
+                class="search-input" 
+                placeholder="Поиск по автомобилю, номеру, организации..."
+                @input="applyFilters"
+              >
+            </div>
+            <div class="user-filter">
+              <span class="filter-label">Пользователь:</span>
+              <div
+                class="custom-select"
+                @click="toggleUserDropdown"
+              >
+                <div class="select-trigger">
+                  <span class="selected-value">{{ selectedUserName }}</span>
+                  <img 
+                    src="@/assets/icons/arrow.png" 
+                    class="select-arrow" 
+                    :class="{ 'arrow-open': userDropdownOpen }"
+                  >
+                </div>
+                <transition name="fade">
+                  <div
+                    v-if="userDropdownOpen"
+                    class="select-dropdown"
+                  >
+                    <div 
+                      class="select-option"
+                      :class="{ 'selected': selectedUserId === null }"
+                      @click="selectUser(null)"
+                    >
+                      Все пользователи
+                    </div>
+                    <div 
+                      v-for="user in uniqueUsers" 
+                      :key="user.id"
+                      class="select-option"
+                      :class="{ 'selected': selectedUserId === user.id }"
+                      @click="selectUser(user.id)"
+                    >
+                      {{ user.name }}
+                    </div>
+                  </div>
+                </transition>
+              </div>
+            </div>
+          
+            <div class="car-filter">
+              <span class="filter-label">Автомобиль:</span>
+              <div
+                class="custom-select"
+                @click="toggleCarDropdown"
+              >
+                <div class="select-trigger">
+                  <span class="selected-value">{{ selectedCarName }}</span>
+                  <img 
+                    src="@/assets/icons/arrow.png" 
+                    class="select-arrow" 
+                    :class="{ 'arrow-open': carDropdownOpen }"
+                  >
+                </div>
+                <transition name="fade">
+                  <div
+                    v-if="carDropdownOpen"
+                    class="select-dropdown"
+                  >
+                    <div 
+                      class="select-option"
+                      :class="{ 'selected': selectedCarId === null }"
+                      @click="selectCar(null)"
+                    >
+                      Все автомобили
+                    </div>
+                    <div 
+                      v-for="car in cars" 
+                      :key="car.id"
+                      class="select-option"
+                      :class="{ 'selected': selectedCarId === car.id }"
+                      @click="selectCar(car.id)"
+                    >
+                      {{ formatCarName(car) }}
+                    </div>
+                  </div>
+                </transition>
+              </div>
+            </div>
+          
+            <div class="date-filter">
+              <span class="filter-label">Период:</span>
+              <input 
+                v-model="dateFrom" 
+                type="date" 
+                class="date-input"
+                @change="applyFilters"
+              >
+              <span class="date-separator">—</span>
+              <input 
+                v-model="dateTo" 
+                type="date" 
+                class="date-input"
+                @change="applyFilters"
+              >
+            </div>
+          
+            <div class="sort-filter">
+              <span class="filter-label">Сортировка:</span>
+              <button
+                class="sort-btn"
+                @click="toggleSortOrder"
+              >
+                <img
+                  src="@/assets/icons/sort.png"
+                  class="sort-icon"
+                  :class="{ 'sort-asc': sortOrder === 'asc' }"
+                >
+                <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
+              </button>
+            </div>
+          </div>
         </div>
-        
+
         <div
-          v-else-if="filteredHistory.length === 0"
-          class="history-empty"
+          ref="scrollContainer"
+          class="modal-content"
         >
-          История пуста
-        </div>
-        
-        <div
-          v-else
-          class="history-timeline"
-        >
-          <div 
-            v-for="(item, index) in filteredHistory" 
-            :key="item.id" 
-            class="history-item"
+          <div
+            v-if="loading"
+            class="history-loading"
           >
-            <div
-              class="timeline-dot"
-              :class="getActionClass(item.action_type)"
-            />
-            <div
-              v-if="index < filteredHistory.length - 1"
-              class="timeline-line"
-            />
+            <LoaderSpinner label="Загрузка истории…" />
+          </div>
+        
+          <div
+            v-else-if="filteredHistory.length === 0"
+            class="history-empty"
+          >
+            История пуста
+          </div>
+        
+          <div
+            v-else
+            class="history-timeline"
+          >
+            <div 
+              v-for="(item, index) in filteredHistory" 
+              :key="item.id" 
+              class="history-item"
+            >
+              <div
+                class="timeline-dot"
+                :class="getActionClass(item.action_type)"
+              />
+              <div
+                v-if="index < filteredHistory.length - 1"
+                class="timeline-line"
+              />
             
-            <div class="history-content">
-              <div class="history-header">
-                <span class="car-info">{{ getCarInfo(item) }}</span>
-                <span class="user-name">{{ item.user_name || 'Система' }}</span>
-                <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
-              </div>
+              <div class="history-content">
+                <div class="history-header">
+                  <span class="car-info">{{ getCarInfo(item) }}</span>
+                  <span class="user-name">{{ item.user_name || 'Система' }}</span>
+                  <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                </div>
               
-              <div class="action-text">
-                {{ getActionText(item) }}
-              </div>
+                <div class="action-text">
+                  {{ getActionText(item) }}
+                </div>
               
-              <div
-                v-if="item.action_type === 'entry' || item.action_type === 'exit'"
-                class="action-comment"
-              >
-                {{ getActionComment(item) }}
-              </div>
+                <div
+                  v-if="item.action_type === 'entry' || item.action_type === 'exit'"
+                  class="action-comment"
+                >
+                  {{ getActionComment(item) }}
+                </div>
               
-              <div
-                v-if="item.comment && item.action_type !== 'entry' && item.action_type !== 'exit'"
-                class="action-comment"
-              >
-                {{ item.comment }}
-              </div>
+                <div
+                  v-if="item.comment && item.action_type !== 'entry' && item.action_type !== 'exit'"
+                  class="action-comment"
+                >
+                  {{ item.comment }}
+                </div>
 
-              <div
-                v-if="item.table_name"
-                class="place-name"
-              >
-                {{ item.table_name }}
+                <div
+                  v-if="item.table_name"
+                  class="place-name"
+                >
+                  {{ item.table_name }}
+                </div>
               </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
+  </Teleport>
 </template>
 
 <script>
@@ -674,6 +676,8 @@ export default {
   justify-content: center;
   align-items: center;
   z-index: 13000;
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
   animation: fadeIn 0.2s ease-out;
 }
 

--- a/frontend/src/components/CitizenshipManagement.vue
+++ b/frontend/src/components/CitizenshipManagement.vue
@@ -233,72 +233,74 @@
     </div>
 
     <!-- Модальное окно добавления гражданства -->
-    <div
-      v-if="showAddModal"
-      class="modal-overlay"
-      @click.self="showAddModal = false"
-    >
-      <div class="modal-content small-modal">
-        <div class="modal-header">
-          <h3>Добавить гражданство</h3>
-          <button
-            class="modal-close"
-            @click="showAddModal = false"
-          >
-            ×
-          </button>
-        </div>
-        
-        <div class="modal-body">
-          <div class="form-group">
-            <label class="form-label">Название гражданства</label>
-            <input
-              v-model="newCitizenship.name"
-              placeholder="Российская Федерация"
-              class="form-input"
-              @keyup.enter="addCitizenship"
+    <Teleport to="body">
+      <div
+        v-if="showAddModal"
+        class="modal-overlay"
+        @click.self="showAddModal = false"
+      >
+        <div class="modal-content small-modal">
+          <div class="modal-header">
+            <h3>Добавить гражданство</h3>
+            <button
+              class="modal-close"
+              @click="showAddModal = false"
             >
+              ×
+            </button>
           </div>
-          
-          <div class="checkbox-group">
-            <label class="checkbox-label">
-              <input 
-                v-model="newCitizenship.is_default" 
-                type="checkbox"
-                class="checkbox"
-              >
-              <span class="checkbox-text">Гражданство по умолчанию</span>
-            </label>
-          </div>
-
-          <div class="checkbox-group">
-            <label class="checkbox-label">
-              <input 
-                v-model="newCitizenship.patent_required" 
-                type="checkbox"
-                class="checkbox"
-              >
-              <span class="checkbox-text">Требуется патент</span>
-            </label>
-          </div>
-        </div>
         
-        <div class="modal-footer">
-          <button
-            class="modal-cancel"
-            @click="showAddModal = false"
-          >
-            Отмена
-          </button>
-          <button
-            class="modal-confirm"
-            @click="addCitizenship"
-          >
-            Добавить
-          </button>
+          <div class="modal-body">
+            <div class="form-group">
+              <label class="form-label">Название гражданства</label>
+              <input
+                v-model="newCitizenship.name"
+                placeholder="Российская Федерация"
+                class="form-input"
+                @keyup.enter="addCitizenship"
+              >
+            </div>
+          
+            <div class="checkbox-group">
+              <label class="checkbox-label">
+                <input 
+                  v-model="newCitizenship.is_default" 
+                  type="checkbox"
+                  class="checkbox"
+                >
+                <span class="checkbox-text">Гражданство по умолчанию</span>
+              </label>
+            </div>
+
+            <div class="checkbox-group">
+              <label class="checkbox-label">
+                <input 
+                  v-model="newCitizenship.patent_required" 
+                  type="checkbox"
+                  class="checkbox"
+                >
+                <span class="checkbox-text">Требуется патент</span>
+              </label>
+            </div>
+          </div>
+        
+          <div class="modal-footer">
+            <button
+              class="modal-cancel"
+              @click="showAddModal = false"
+            >
+              Отмена
+            </button>
+            <button
+              class="modal-confirm"
+              @click="addCitizenship"
+            >
+              Добавить
+            </button>
+          </div>
         </div>
       </div>
-    </div>
+    </Teleport>
   </div>
 </template>
 
@@ -995,12 +997,14 @@ export default {
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.05);
+  background: rgba(0, 0, 0, 0.5);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 1000;
   padding: 20px;
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
 }
 
 .small-modal {

--- a/frontend/src/components/CompaniesManagement.vue
+++ b/frontend/src/components/CompaniesManagement.vue
@@ -209,45 +209,47 @@
     </div>
 
     <!-- Модальное окно добавления -->
-    <div
-      v-if="showAddModal"
-      class="modal-overlay"
-      @click.self="showAddModal = false"
-    >
-      <div class="modal-content">
-        <div class="modal-header">
-          <h3>Добавить компанию</h3>
-          <button
-            class="modal-close"
-            @click="showAddModal = false"
-          >
-            ×
-          </button>
-        </div>
-        <div class="modal-body">
-          <input
-            v-model="newCompanyName"
-            placeholder="Введите название компании"
-            class="modal-input"
-            @keyup.enter="addCompany"
-          >
-        </div>
-        <div class="modal-footer">
-          <button
-            class="modal-cancel"
-            @click="showAddModal = false"
-          >
-            Отмена
-          </button>
-          <button
-            class="modal-confirm"
-            @click="addCompany"
-          >
-            Добавить
-          </button>
+    <Teleport to="body">
+      <div
+        v-if="showAddModal"
+        class="modal-overlay"
+        @click.self="showAddModal = false"
+      >
+        <div class="modal-content">
+          <div class="modal-header">
+            <h3>Добавить компанию</h3>
+            <button
+              class="modal-close"
+              @click="showAddModal = false"
+            >
+              ×
+            </button>
+          </div>
+          <div class="modal-body">
+            <input
+              v-model="newCompanyName"
+              placeholder="Введите название компании"
+              class="modal-input"
+              @keyup.enter="addCompany"
+            >
+          </div>
+          <div class="modal-footer">
+            <button
+              class="modal-cancel"
+              @click="showAddModal = false"
+            >
+              Отмена
+            </button>
+            <button
+              class="modal-confirm"
+              @click="addCompany"
+            >
+              Добавить
+            </button>
+          </div>
         </div>
       </div>
-    </div>
+    </Teleport>
 
     <!-- Модальное окно подтверждения удаления -->
     <ConfirmationModal
@@ -901,11 +903,13 @@ export default {
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.3);
+  background: rgba(0, 0, 0, 0.5);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 1000;
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
 }
 
 .modal-content {

--- a/frontend/src/components/ConfirmationModal.vue
+++ b/frontend/src/components/ConfirmationModal.vue
@@ -1,36 +1,38 @@
 <template>
-  <transition name="modal-fade">
-    <div
-      v-if="show"
-      class="modal-overlay"
-      @click.self="handleCancel"
-    >
-      <div class="modal">
-        <div class="modal-header">
-          {{ title }}
-        </div>
-        <div class="modal-content">
-          {{ message }}
-        </div>
-        <div class="modal-actions">
-          <button 
-            class="cancel-btn" 
-            :style="cancelButtonStyle"
-            @click="handleCancel"
-          >
-            {{ cancelText }}
-          </button>
-          <button 
-            class="confirm-btn" 
-            :style="confirmButtonStyle"
-            @click="handleConfirm"
-          >
-            {{ confirmText }}
-          </button>
+  <Teleport to="body">
+    <transition name="modal-fade">
+      <div
+        v-if="show"
+        class="modal-overlay"
+        @click.self="handleCancel"
+      >
+        <div class="modal">
+          <div class="modal-header">
+            {{ title }}
+          </div>
+          <div class="modal-content">
+            {{ message }}
+          </div>
+          <div class="modal-actions">
+            <button 
+              class="cancel-btn" 
+              :style="cancelButtonStyle"
+              @click="handleCancel"
+            >
+              {{ cancelText }}
+            </button>
+            <button 
+              class="confirm-btn" 
+              :style="confirmButtonStyle"
+              @click="handleConfirm"
+            >
+              {{ confirmText }}
+            </button>
+          </div>
         </div>
       </div>
-    </div>
-  </transition>
+    </transition>
+  </Teleport>
 </template>
 
 <script>
@@ -91,6 +93,8 @@ export default {
   align-items: center;
   justify-content: center;
   z-index: 1000;
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
   animation: overlayAppear 0.3s ease-out;
 }
 

--- a/frontend/src/components/CreateApplication/CarsBindingModal.vue
+++ b/frontend/src/components/CreateApplication/CarsBindingModal.vue
@@ -1,126 +1,128 @@
 <template>
-  <div
-    class="modal-overlay"
-    @click="$emit('close')"
-  >
+  <Teleport to="body">
     <div
-      class="modal-content"
-      @click.stop
+      class="modal-overlay"
+      @click="$emit('close')"
     >
-      <div class="modal-header">
-        <div class="modal-header__top">
-          <h3>Привязка новых автомобилей</h3>
+      <div
+        class="modal-content"
+        @click.stop
+      >
+        <div class="modal-header">
+          <div class="modal-header__top">
+            <h3>Привязка новых автомобилей</h3>
+          </div>
+          <button
+            class="modal-close"
+            @click="$emit('close')"
+          >
+            ×
+          </button>
         </div>
-        <button
-          class="modal-close"
-          @click="$emit('close')"
-        >
-          ×
-        </button>
-      </div>
-      <div class="modal-body">
-        <div class="binding-info">
-          <p class="binding-description">
-            Все добавленные автомобили ниже <strong>автоматически привязываются</strong> к вашему аккаунту.
-            Вы можете выбрать и привязать автомобили к организации и/или компании для использования <strong>другими сотрудниками</strong>:
-          </p>
-                    
-          <div class="cars-list-section">
-            <p class="section-title">
-              Список новых автомобилей:
+        <div class="modal-body">
+          <div class="binding-info">
+            <p class="binding-description">
+              Все добавленные автомобили ниже <strong>автоматически привязываются</strong> к вашему аккаунту.
+              Вы можете выбрать и привязать автомобили к организации и/или компании для использования <strong>другими сотрудниками</strong>:
             </p>
-            <div class="cars-list">
-              <div 
-                v-for="car in newCarsToBind" 
-                :key="car.plateNumber"
-                class="car-item"
-                :class="{ 'car-item--shared': car.bindToEntity }"
-                @click="$emit('toggle-car-binding', car)"
-              >
-                <div class="car-selector">
-                  <div class="selector-checkbox">
-                    <div
-                      class="checkbox"
-                      :class="{ 'checkbox--checked': car.bindToEntity }"
-                    />
+                    
+            <div class="cars-list-section">
+              <p class="section-title">
+                Список новых автомобилей:
+              </p>
+              <div class="cars-list">
+                <div 
+                  v-for="car in newCarsToBind" 
+                  :key="car.plateNumber"
+                  class="car-item"
+                  :class="{ 'car-item--shared': car.bindToEntity }"
+                  @click="$emit('toggle-car-binding', car)"
+                >
+                  <div class="car-selector">
+                    <div class="selector-checkbox">
+                      <div
+                        class="checkbox"
+                        :class="{ 'checkbox--checked': car.bindToEntity }"
+                      />
+                    </div>
+                    <div class="car-info">
+                      <span class="car-number">{{ car.plateNumber }}</span>
+                      <span class="car-mark">{{ car.mark }}</span>
+                    </div>
                   </div>
-                  <div class="car-info">
-                    <span class="car-number">{{ car.plateNumber }}</span>
-                    <span class="car-mark">{{ car.mark }}</span>
+                  <div class="car-binding-status">
+                    <span
+                      v-if="car.bindToEntity"
+                      class="status-shared"
+                    >
+                      Будет доступна
+                    </span>
+                    <span
+                      v-else
+                      class="status-private"
+                    >
+                      Привязка только к вам
+                    </span>
                   </div>
-                </div>
-                <div class="car-binding-status">
-                  <span
-                    v-if="car.bindToEntity"
-                    class="status-shared"
-                  >
-                    Будет доступна
-                  </span>
-                  <span
-                    v-else
-                    class="status-private"
-                  >
-                    Привязка только к вам
-                  </span>
                 </div>
               </div>
             </div>
-          </div>
 
-          <div class="binding-options-section">
-            <p class="section-title">
-              Привязать выбранные автомобили к:
-            </p>
-            <div class="binding-options">
-              <label
-                v-if="hasOrganization"
-                class="binding-option"
-              >
-                <input 
-                  v-model="bindToOrganization" 
-                  type="checkbox"
-                  :disabled="bindToCompany"
+            <div class="binding-options-section">
+              <p class="section-title">
+                Привязать выбранные автомобили к:
+              </p>
+              <div class="binding-options">
+                <label
+                  v-if="hasOrganization"
+                  class="binding-option"
                 >
-                <span class="option-text">К организации "{{ organization }}"</span>
-              </label>
-              <label
-                v-if="hasCompany"
-                class="binding-option"
-              >
-                <input 
-                  v-model="bindToCompany" 
-                  type="checkbox"
-                  :disabled="bindToOrganization"
+                  <input 
+                    v-model="bindToOrganization" 
+                    type="checkbox"
+                    :disabled="bindToCompany"
+                  >
+                  <span class="option-text">К организации "{{ organization }}"</span>
+                </label>
+                <label
+                  v-if="hasCompany"
+                  class="binding-option"
                 >
-                <span class="option-text">К компании "{{ company }}"</span>
-              </label>
+                  <input 
+                    v-model="bindToCompany" 
+                    type="checkbox"
+                    :disabled="bindToOrganization"
+                  >
+                  <span class="option-text">К компании "{{ company }}"</span>
+                </label>
+              </div>
+            </div>
+
+            <div class="warning-section">
+              <p class="warning-text">
+                <strong class="red">Внимание!</strong> При привязке автомобиля к организации или компании, он будет доступен для отображения и использования для всех сотрудников, привязанных к организации/компании.
+              </p>
             </div>
           </div>
-
-          <div class="warning-section">
-            <p class="warning-text">
-              <strong class="red">Внимание!</strong> При привязке автомобиля к организации или компании, он будет доступен для отображения и использования для всех сотрудников, привязанных к организации/компании.
-            </p>
-          </div>
-        </div>
                 
-        <div class="modal-actions">
-          <button
-            class="cancel-btn"
-            @click="$emit('skip-binding')"
-          >
-            Пропустить
-          </button>
-          <button
-            class="confirm-btn"
-            @click="$emit('confirm-binding')"
-          >
-            Привязать и отправить
-          </button>
+          <div class="modal-actions">
+            <button
+              class="cancel-btn"
+              @click="$emit('skip-binding')"
+            >
+              Пропустить
+            </button>
+            <button
+              class="confirm-btn"
+              @click="$emit('confirm-binding')"
+            >
+              Привязать и отправить
+            </button>
+          </div>
         </div>
       </div>
     </div>
-  </div>
+  </Teleport>
 </template>
 
 <script>
@@ -169,6 +171,8 @@ export default {
     align-items: center;
     justify-content: center;
     z-index: 1000;
+    backdrop-filter: blur(0.1px);
+    -webkit-backdrop-filter: blur(0.1px);
 }
 
 .modal-content {

--- a/frontend/src/components/CreateApplication/EmployeeBindingModal.vue
+++ b/frontend/src/components/CreateApplication/EmployeeBindingModal.vue
@@ -1,94 +1,96 @@
 <template>
-  <div
-    class="modal-overlay"
-    @click="$emit('close')"
-  >
+  <Teleport to="body">
     <div
-      class="modal-content"
-      @click.stop
+      class="modal-overlay"
+      @click="$emit('close')"
     >
-      <div class="modal-header">
-        <div class="modal-header__top">
-          <h3>Привязка новых сотрудников</h3>
+      <div
+        class="modal-content"
+        @click.stop
+      >
+        <div class="modal-header">
+          <div class="modal-header__top">
+            <h3>Привязка новых сотрудников</h3>
+          </div>
+          <button
+            class="modal-close"
+            @click="$emit('close')"
+          >
+            ×
+          </button>
         </div>
-        <button
-          class="modal-close"
-          @click="$emit('close')"
-        >
-          ×
-        </button>
-      </div>
-      <div class="modal-body">
-        <div class="binding-info">
-          <p class="binding-description">
-            Все добавленные сотрудники будут <strong>автоматически привязаны</strong> к вашему аккаунту.
-            Вы можете дополнительно привязать их к организации и/или компании для использования <strong>другими сотрудниками</strong>:
-          </p>
-                    
-          <div class="employees-list-section">
-            <p class="section-title">
-              Новые сотрудники ({{ newEmployeesToBind.length }}):
+        <div class="modal-body">
+          <div class="binding-info">
+            <p class="binding-description">
+              Все добавленные сотрудники будут <strong>автоматически привязаны</strong> к вашему аккаунту.
+              Вы можете дополнительно привязать их к организации и/или компании для использования <strong>другими сотрудниками</strong>:
             </p>
-            <div class="employees-list">
-              <div 
-                v-for="employee in newEmployeesToBind" 
-                :key="employee.passportSeriesNumber"
-                class="employee-item"
-              >
-                <div class="employee-info">
-                  <span class="employee-name">{{ formatFullName(employee) }}</span>
-                  <span class="employee-position">{{ employee.position }}</span>
+                    
+            <div class="employees-list-section">
+              <p class="section-title">
+                Новые сотрудники ({{ newEmployeesToBind.length }}):
+              </p>
+              <div class="employees-list">
+                <div 
+                  v-for="employee in newEmployeesToBind" 
+                  :key="employee.passportSeriesNumber"
+                  class="employee-item"
+                >
+                  <div class="employee-info">
+                    <span class="employee-name">{{ formatFullName(employee) }}</span>
+                    <span class="employee-position">{{ employee.position }}</span>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
 
-          <div class="binding-options-section">
-            <p class="section-title">
-              Привязать всех сотрудников к:
-            </p>
-            <div class="binding-options">
-              <label
-                v-if="hasOrganization"
-                class="binding-option"
-              >
-                <input 
-                  v-model="bindToOrganization" 
-                  type="checkbox"
+            <div class="binding-options-section">
+              <p class="section-title">
+                Привязать всех сотрудников к:
+              </p>
+              <div class="binding-options">
+                <label
+                  v-if="hasOrganization"
+                  class="binding-option"
                 >
-                <span class="option-text">Организации "{{ organization }}"</span>
-              </label>
-              <label
-                v-if="hasCompany"
-                class="binding-option"
-              >
-                <input 
-                  v-model="bindToCompany" 
-                  type="checkbox"
+                  <input 
+                    v-model="bindToOrganization" 
+                    type="checkbox"
+                  >
+                  <span class="option-text">Организации "{{ organization }}"</span>
+                </label>
+                <label
+                  v-if="hasCompany"
+                  class="binding-option"
                 >
-                <span class="option-text">Компании "{{ company }}"</span>
-              </label>
+                  <input 
+                    v-model="bindToCompany" 
+                    type="checkbox"
+                  >
+                  <span class="option-text">Компании "{{ company }}"</span>
+                </label>
+              </div>
+            </div>
+
+            <div class="warning-section">
+              <p class="warning-text">
+                <strong class="red">Внимание!</strong> При привязке сотрудника к организации или компании, он будет доступен для отображения и использования для всех сотрудников, привязанных к организации/компании.
+              </p>
             </div>
           </div>
-
-          <div class="warning-section">
-            <p class="warning-text">
-              <strong class="red">Внимание!</strong> При привязке сотрудника к организации или компании, он будет доступен для отображения и использования для всех сотрудников, привязанных к организации/компании.
-            </p>
-          </div>
-        </div>
                 
-        <div class="modal-actions">
-          <button
-            class="confirm-btn"
-            @click="handleConfirm"
-          >
-            {{ buttonText }}
-          </button>
+          <div class="modal-actions">
+            <button
+              class="confirm-btn"
+              @click="handleConfirm"
+            >
+              {{ buttonText }}
+            </button>
+          </div>
         </div>
       </div>
     </div>
-  </div>
+  </Teleport>
 </template>
 
 <script>
@@ -150,6 +152,8 @@ export default {
     align-items: center;
     justify-content: center;
     z-index: 1000;
+    backdrop-filter: blur(0.1px);
+    -webkit-backdrop-filter: blur(0.1px);
 }
 
 .modal-content {

--- a/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
@@ -1,299 +1,301 @@
 <template>
-  <transition name="modal-fade">
-    <div
-      v-if="show"
-      class="modal-overlay"
-      @click.self="close"
-    >
-      <div class="modal-wrapper">
-        <!-- Основное модальное окно с деталями сотрудника -->
-        <div 
-          class="modal-content compact-modal main-modal"
-          :class="{ 'shifted': isMainShifted }"
-        >
-          <div class="modal-header">
-            <h3 class="modal-title">
-              {{ modalTitle }}
-            </h3>
-            <div class="header-actions">
+  <Teleport to="body">
+    <transition name="modal-fade">
+      <div
+        v-if="show"
+        class="modal-overlay"
+        @click.self="close"
+      >
+        <div class="modal-wrapper">
+          <!-- Основное модальное окно с деталями сотрудника -->
+          <div 
+            class="modal-content compact-modal main-modal"
+            :class="{ 'shifted': isMainShifted }"
+          >
+            <div class="modal-header">
+              <h3 class="modal-title">
+                {{ modalTitle }}
+              </h3>
+              <div class="header-actions">
+                <button
+                  class="history-btn"
+                  @click="openFullHistory"
+                >
+                  <span>Полная история</span>
+                </button>
+                <button 
+                  v-if="source !== 'application' && employee?.applicationId" 
+                  class="application-btn" 
+                  @click="openApplication"
+                >
+                  <span>Открыть заявку</span>
+                </button>
+              </div>
               <button
-                class="history-btn"
-                @click="openFullHistory"
+                class="modal-close"
+                @click="close"
               >
-                <span>Полная история</span>
-              </button>
-              <button 
-                v-if="source !== 'application' && employee?.applicationId" 
-                class="application-btn" 
-                @click="openApplication"
-              >
-                <span>Открыть заявку</span>
+                <svg
+                  width="10"
+                  height="10"
+                  viewBox="0 0 14 14"
+                  fill="none"
+                >
+                  <path
+                    d="M13 1L1 13M1 1L13 13"
+                    stroke="#666"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                  />
+                </svg>
               </button>
             </div>
-            <button
-              class="modal-close"
-              @click="close"
-            >
-              <svg
-                width="10"
-                height="10"
-                viewBox="0 0 14 14"
-                fill="none"
-              >
-                <path
-                  d="M13 1L1 13M1 1L13 13"
-                  stroke="#666"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                />
-              </svg>
-            </button>
-          </div>
                     
-          <div class="modal-body">
-            <div
-              v-if="employee"
-              class="employee-details"
-            >
-              <!-- Основная информация -->
-              <div class="details-section">
-                <div class="section-header">
-                  <h4 class="section-title">
-                    Основная информация
-                  </h4>
-                </div>
-                <div class="section-body">
-                  <div class="details-grid two-columns">
-                    <div class="detail-item">
-                      <span class="detail-label">Фамилия:</span>
-                      <span class="detail-value">{{ employee.last_name || 'Не указано' }}</span>
-                    </div>
-                    <div class="detail-item">
-                      <span class="detail-label">Имя:</span>
-                      <span class="detail-value">{{ employee.first_name || 'Не указано' }}</span>
-                    </div>
-                    <div class="detail-item">
-                      <span class="detail-label">Отчество:</span>
-                      <span class="detail-value">{{ employee.middle_name || '-' }}</span>
-                    </div>
-                    <div class="detail-item">
-                      <span class="detail-label">Должность:</span>
-                      <span class="detail-value">{{ employee.position || 'Не указана' }}</span>
-                    </div>
-                    <div class="detail-item">
-                      <span class="detail-label">Гражданство:</span>
-                      <span class="detail-value">{{ employee.citizenshipName || 'Не указано' }}</span>
-                    </div>
-                    <div
-                      v-if="employee.organization"
-                      class="detail-item"
-                    >
-                      <span class="detail-label">Организация:</span>
-                      <span class="detail-value">{{ employee.organization }}</span>
-                    </div>
-                    <div
-                      v-if="employee.company"
-                      class="detail-item"
-                    >
-                      <span class="detail-label">Компания:</span>
-                      <span class="detail-value">{{ employee.company }}</span>
-                    </div>
-                    <div class="detail-item">
-                      <span class="detail-label">Действует до:</span>
-                      <span class="detail-value">{{ formatDate(employee.entry_date_to) || '-' }}</span>
-                    </div>
-                    <div class="detail-item">
-                      <span class="detail-label">Время прохода:</span>
-                      <span class="detail-value">{{ employee.pass_time || '-' }}</span>
-                    </div>
+            <div class="modal-body">
+              <div
+                v-if="employee"
+                class="employee-details"
+              >
+                <!-- Основная информация -->
+                <div class="details-section">
+                  <div class="section-header">
+                    <h4 class="section-title">
+                      Основная информация
+                    </h4>
                   </div>
-                </div>
-              </div>
-
-              <!-- Документы (чувствительные данные) -->
-              <div class="details-section">
-                <div class="section-header">
-                  <h4 class="section-title">
-                    Документы
-                  </h4>
-                </div>
-                <div class="section-body">
-                  <div class="details-grid two-columns">
-                    <div class="detail-item">
-                      <span class="detail-label">Серия и номер паспорта:</span>
-                      <div class="sensitive-data">
-                        <span 
-                          class="data-text"
-                          :class="{ 'hidden-data': !showFullPassport }"
-                        >
-                          {{ employee.passport_series_number || 'Не указан' }}
-                        </span>
-                        <button 
-                          v-if="employee.passport_series_number"
-                          class="show-more-btn"
-                          @click="togglePassport"
-                        >
-                          {{ showFullPassport ? 'Скрыть' : 'Показать' }}
-                        </button>
+                  <div class="section-body">
+                    <div class="details-grid two-columns">
+                      <div class="detail-item">
+                        <span class="detail-label">Фамилия:</span>
+                        <span class="detail-value">{{ employee.last_name || 'Не указано' }}</span>
+                      </div>
+                      <div class="detail-item">
+                        <span class="detail-label">Имя:</span>
+                        <span class="detail-value">{{ employee.first_name || 'Не указано' }}</span>
+                      </div>
+                      <div class="detail-item">
+                        <span class="detail-label">Отчество:</span>
+                        <span class="detail-value">{{ employee.middle_name || '-' }}</span>
+                      </div>
+                      <div class="detail-item">
+                        <span class="detail-label">Должность:</span>
+                        <span class="detail-value">{{ employee.position || 'Не указана' }}</span>
+                      </div>
+                      <div class="detail-item">
+                        <span class="detail-label">Гражданство:</span>
+                        <span class="detail-value">{{ employee.citizenshipName || 'Не указано' }}</span>
+                      </div>
+                      <div
+                        v-if="employee.organization"
+                        class="detail-item"
+                      >
+                        <span class="detail-label">Организация:</span>
+                        <span class="detail-value">{{ employee.organization }}</span>
+                      </div>
+                      <div
+                        v-if="employee.company"
+                        class="detail-item"
+                      >
+                        <span class="detail-label">Компания:</span>
+                        <span class="detail-value">{{ employee.company }}</span>
+                      </div>
+                      <div class="detail-item">
+                        <span class="detail-label">Действует до:</span>
+                        <span class="detail-value">{{ formatDate(employee.entry_date_to) || '-' }}</span>
+                      </div>
+                      <div class="detail-item">
+                        <span class="detail-label">Время прохода:</span>
+                        <span class="detail-value">{{ employee.pass_time || '-' }}</span>
                       </div>
                     </div>
-                    <div
-                      v-if="employee.patent_number"
-                      class="detail-item"
-                    >
-                      <span class="detail-label">Номер патента:</span>
-                      <div class="sensitive-data">
-                        <span 
-                          class="data-text"
-                          :class="{ 'hidden-data': !showFullPatent }"
-                        >
-                          {{ employee.patent_number }}
-                        </span>
-                        <button 
-                          class="show-more-btn"
-                          @click="togglePatent"
-                        >
-                          {{ showFullPatent ? 'Скрыть' : 'Показать' }}
-                        </button>
+                  </div>
+                </div>
+
+                <!-- Документы (чувствительные данные) -->
+                <div class="details-section">
+                  <div class="section-header">
+                    <h4 class="section-title">
+                      Документы
+                    </h4>
+                  </div>
+                  <div class="section-body">
+                    <div class="details-grid two-columns">
+                      <div class="detail-item">
+                        <span class="detail-label">Серия и номер паспорта:</span>
+                        <div class="sensitive-data">
+                          <span 
+                            class="data-text"
+                            :class="{ 'hidden-data': !showFullPassport }"
+                          >
+                            {{ employee.passport_series_number || 'Не указан' }}
+                          </span>
+                          <button 
+                            v-if="employee.passport_series_number"
+                            class="show-more-btn"
+                            @click="togglePassport"
+                          >
+                            {{ showFullPassport ? 'Скрыть' : 'Показать' }}
+                          </button>
+                        </div>
+                      </div>
+                      <div
+                        v-if="employee.patent_number"
+                        class="detail-item"
+                      >
+                        <span class="detail-label">Номер патента:</span>
+                        <div class="sensitive-data">
+                          <span 
+                            class="data-text"
+                            :class="{ 'hidden-data': !showFullPatent }"
+                          >
+                            {{ employee.patent_number }}
+                          </span>
+                          <button 
+                            class="show-more-btn"
+                            @click="togglePatent"
+                          >
+                            {{ showFullPatent ? 'Скрыть' : 'Показать' }}
+                          </button>
+                        </div>
+                      </div>
+                      <div
+                        v-if="employee.other_permission"
+                        class="detail-item full-width"
+                      >
+                        <span class="detail-label">Иное разрешение:</span>
+                        <span class="detail-value">{{ employee.other_permission }}</span>
                       </div>
                     </div>
+                  </div>
+                </div>
+
+                <!-- Места прохода (таблицы) -->
+                <div class="details-section">
+                  <div class="section-header">
+                    <h4 class="section-title">
+                      Места прохода
+                    </h4>
+                  </div>
+                  <div class="section-body">
+                    <div class="places-list">
+                      <div 
+                        v-for="tableId in employee.target_tables" 
+                        :key="tableId"
+                        class="place-item"
+                        :class="{ 'active': showPlaceModal && selectedTable && selectedTable.id === tableId }"
+                        @click="showTableDetails(tableId)"
+                      >
+                        {{ getTableName(tableId) }}
+                      </div>
+                      <div
+                        v-if="!employee.target_tables || employee.target_tables.length === 0"
+                        class="no-places"
+                      >
+                        Места прохода не указаны
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- Статус территории (скрыт только для employeeslist) -->
+                <div
+                  v-if="showStatusSection"
+                  class="details-section"
+                >
+                  <div class="section-header">
+                    <h4 class="section-title">
+                      Статус
+                    </h4>
+                  </div>
+                  <div class="section-body">
                     <div
-                      v-if="employee.other_permission"
-                      class="detail-item full-width"
+                      class="status-badge"
+                      :class="getStatusClass"
                     >
-                      <span class="detail-label">Иное разрешение:</span>
-                      <span class="detail-value">{{ employee.other_permission }}</span>
+                      {{ getStatusText }}
                     </div>
                   </div>
                 </div>
-              </div>
 
-              <!-- Места прохода (таблицы) -->
-              <div class="details-section">
-                <div class="section-header">
-                  <h4 class="section-title">
-                    Места прохода
-                  </h4>
-                </div>
-                <div class="section-body">
-                  <div class="places-list">
-                    <div 
-                      v-for="tableId in employee.target_tables" 
-                      :key="tableId"
-                      class="place-item"
-                      :class="{ 'active': showPlaceModal && selectedTable && selectedTable.id === tableId }"
-                      @click="showTableDetails(tableId)"
+                <!-- История проходов (скрыта только для employeeslist) -->
+                <div
+                  v-if="showHistorySection"
+                  class="details-section"
+                >
+                  <div class="section-header">
+                    <h4 class="section-title">
+                      История проходов
+                    </h4>
+                    <button
+                      class="export-btn"
+                      :disabled="entryExitHistory.length === 0 || isExporting"
+                      @click="exportHistory"
                     >
-                      {{ getTableName(tableId) }}
-                    </div>
+                      <img
+                        v-if="!isExporting"
+                        src="@/assets/icons/export.png"
+                        class="export-icon"
+                      >
+                      <span v-if="!isExporting">Экспорт</span>
+                      <div
+                        v-else
+                        class="export-loader"
+                      />
+                    </button>
+                  </div>
+                  <div class="section-body">
                     <div
-                      v-if="!employee.target_tables || employee.target_tables.length === 0"
-                      class="no-places"
+                      v-if="loadingHistory"
+                      class="loading-container"
                     >
-                      Места прохода не указаны
+                      <div class="loader" />
+                      <span>Загрузка истории...</span>
                     </div>
-                  </div>
-                </div>
-              </div>
-
-              <!-- Статус территории (скрыт только для employeeslist) -->
-              <div
-                v-if="showStatusSection"
-                class="details-section"
-              >
-                <div class="section-header">
-                  <h4 class="section-title">
-                    Статус
-                  </h4>
-                </div>
-                <div class="section-body">
-                  <div
-                    class="status-badge"
-                    :class="getStatusClass"
-                  >
-                    {{ getStatusText }}
-                  </div>
-                </div>
-              </div>
-
-              <!-- История проходов (скрыта только для employeeslist) -->
-              <div
-                v-if="showHistorySection"
-                class="details-section"
-              >
-                <div class="section-header">
-                  <h4 class="section-title">
-                    История проходов
-                  </h4>
-                  <button
-                    class="export-btn"
-                    :disabled="entryExitHistory.length === 0 || isExporting"
-                    @click="exportHistory"
-                  >
-                    <img
-                      v-if="!isExporting"
-                      src="@/assets/icons/export.png"
-                      class="export-icon"
+                                    
+                    <div
+                      v-else-if="entryExitHistory.length === 0"
+                      class="no-history"
                     >
-                    <span v-if="!isExporting">Экспорт</span>
+                      История проходов отсутствует
+                    </div>
+                                    
                     <div
                       v-else
-                      class="export-loader"
-                    />
-                  </button>
-                </div>
-                <div class="section-body">
-                  <div
-                    v-if="loadingHistory"
-                    class="loading-container"
-                  >
-                    <div class="loader" />
-                    <span>Загрузка истории...</span>
-                  </div>
-                                    
-                  <div
-                    v-else-if="entryExitHistory.length === 0"
-                    class="no-history"
-                  >
-                    История проходов отсутствует
-                  </div>
-                                    
-                  <div
-                    v-else
-                    class="history-timeline"
-                  >
-                    <div 
-                      v-for="(item, index) in entryExitHistory" 
-                      :key="item.id" 
-                      class="history-item"
+                      class="history-timeline"
                     >
-                      <div
-                        class="timeline-dot"
-                        :class="getActionClass(item)"
-                      />
-                      <div
-                        v-if="index < entryExitHistory.length - 1"
-                        class="timeline-line"
-                      />
-                                            
-                      <div class="history-content">
-                        <div class="history-header">
-                          <span class="user-name">{{ item.user_name || 'Система' }}</span>
-                          <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
-                        </div>
-                                                
-                        <div class="action-text">
-                          {{ getActionText(item) }}
-                        </div>
-                                                
-                        <div class="action-comment">
-                          {{ item.comment || getActionComment(item) }}
-                        </div>
+                      <div 
+                        v-for="(item, index) in entryExitHistory" 
+                        :key="item.id" 
+                        class="history-item"
+                      >
                         <div
-                          v-if="item.table_name"
-                          class="place-name"
-                        >
-                          {{ item.table_name }}
+                          class="timeline-dot"
+                          :class="getActionClass(item)"
+                        />
+                        <div
+                          v-if="index < entryExitHistory.length - 1"
+                          class="timeline-line"
+                        />
+                                            
+                        <div class="history-content">
+                          <div class="history-header">
+                            <span class="user-name">{{ item.user_name || 'Система' }}</span>
+                            <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                          </div>
+                                                
+                          <div class="action-text">
+                            {{ getActionText(item) }}
+                          </div>
+                                                
+                          <div class="action-comment">
+                            {{ item.comment || getActionComment(item) }}
+                          </div>
+                          <div
+                            v-if="item.table_name"
+                            class="place-name"
+                          >
+                            {{ item.table_name }}
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -302,27 +304,27 @@
               </div>
             </div>
           </div>
-        </div>
 
-        <!-- Дополнительное модальное окно с деталями места прохода -->
-        <transition 
-          name="place-slide"
-          @after-leave="onPlaceLeave"
-        >
-          <div
-            v-if="showPlaceModal"
-            class="place-modal-container"
+          <!-- Дополнительное модальное окно с деталями места прохода -->
+          <transition 
+            name="place-slide"
+            @after-leave="onPlaceLeave"
           >
-            <TableInfoModal
-              :table="selectedTable"
-              :all-tables="allTables"
-              @close="closeTableDetails"
-            />
-          </div>
-        </transition>
+            <div
+              v-if="showPlaceModal"
+              class="place-modal-container"
+            >
+              <TableInfoModal
+                :table="selectedTable"
+                :all-tables="allTables"
+                @close="closeTableDetails"
+              />
+            </div>
+          </transition>
+        </div>
       </div>
-    </div>
-  </transition>
+    </transition>
+  </Teleport>
 
   <!-- Модальное окно полной истории сотрудника -->
   <EmployeeHistoryModal
@@ -716,6 +718,8 @@ export default {
     align-items: center;
     justify-content: center;
     z-index: 1000;
+    backdrop-filter: blur(0.1px);
+    -webkit-backdrop-filter: blur(0.1px);
     animation: overlayAppear 0.4s ease-out;
 }
 

--- a/frontend/src/components/CreateApplication/EmployeeHistoryModal.vue
+++ b/frontend/src/components/CreateApplication/EmployeeHistoryModal.vue
@@ -1,250 +1,252 @@
 <template>
-  <div
-    class="modal-overlay"
-    @click.self="close"
-  >
-    <div class="employee-history-modal">
-      <div class="modal-header">
-        <h3>История сотрудника {{ fullName }}</h3>
-        <div class="header-actions">
-          <button
-            class="export-btn"
-            :disabled="filteredHistory.length === 0 || isExporting"
-            @click="exportToExcel"
-          >
-            <img
-              v-if="!isExporting"
-              src="@/assets/icons/export.png"
-              class="export-icon"
-            >
-            <span v-if="!isExporting">Экспорт</span>
-            <div
-              v-else
-              class="export-loader"
-            />
-          </button>
-          <button
-            class="close-btn"
-            @click="close"
-          >
-            ×
-          </button>
-        </div>
-      </div>
-
-      <div class="history-filters">
-        <div class="filter-row">
-          <div class="search-filter">
-            <span class="filter-label">Поиск:</span>
-            <input 
-              v-model="searchQuery" 
-              type="text" 
-              class="search-input" 
-              placeholder="Поиск по пользователю, действию..."
-              @input="applyFilters"
-            >
-          </div>
-          <div class="user-filter">
-            <span class="filter-label">Пользователь:</span>
-            <div
-              class="custom-select"
-              @click="toggleUserDropdown"
-            >
-              <div class="select-trigger">
-                <span class="selected-value">{{ selectedUserName }}</span>
-                <img 
-                  src="@/assets/icons/arrow.png" 
-                  class="select-arrow" 
-                  :class="{ 'arrow-open': userDropdownOpen }"
-                >
-              </div>
-              <transition name="fade">
-                <div
-                  v-if="userDropdownOpen"
-                  class="select-dropdown"
-                >
-                  <div 
-                    class="select-option"
-                    :class="{ 'selected': selectedUserId === null }"
-                    @click="selectUser(null)"
-                  >
-                    Все пользователи
-                  </div>
-                  <div 
-                    v-for="user in uniqueUsers" 
-                    :key="user.id"
-                    class="select-option"
-                    :class="{ 'selected': selectedUserId === user.id }"
-                    @click="selectUser(user.id)"
-                  >
-                    {{ user.name }}
-                  </div>
-                </div>
-              </transition>
-            </div>
-          </div>
-          
-          <div class="place-filter">
-            <span class="filter-label">Место прохода:</span>
-            <div
-              class="custom-select"
-              @click="togglePlaceDropdown"
-            >
-              <div class="select-trigger">
-                <span class="selected-value">{{ selectedPlaceName }}</span>
-                <img 
-                  src="@/assets/icons/arrow.png" 
-                  class="select-arrow" 
-                  :class="{ 'arrow-open': placeDropdownOpen }"
-                >
-              </div>
-              <transition name="fade">
-                <div
-                  v-if="placeDropdownOpen"
-                  class="select-dropdown"
-                >
-                  <div 
-                    class="select-option"
-                    :class="{ 'selected': selectedPlaceId === null }"
-                    @click="selectPlace(null)"
-                  >
-                    Все места
-                  </div>
-                  <div 
-                    v-for="place in uniquePlaces" 
-                    :key="place.id"
-                    class="select-option"
-                    :class="{ 'selected': selectedPlaceId === place.id }"
-                    @click="selectPlace(place.id)"
-                  >
-                    {{ place.name }}
-                  </div>
-                </div>
-              </transition>
-            </div>
-          </div>
-          
-          <div class="date-filter">
-            <span class="filter-label">Период:</span>
-            <input 
-              v-model="dateFrom" 
-              type="date" 
-              class="date-input"
-              @change="applyFilters"
-            >
-            <span class="date-separator">—</span>
-            <input 
-              v-model="dateTo" 
-              type="date" 
-              class="date-input"
-              @change="applyFilters"
-            >
-          </div>
-          
-          <div class="sort-filter">
-            <span class="filter-label">Сортировка:</span>
+  <Teleport to="body">
+    <div
+      class="modal-overlay"
+      @click.self="close"
+    >
+      <div class="employee-history-modal">
+        <div class="modal-header">
+          <h3>История сотрудника {{ fullName }}</h3>
+          <div class="header-actions">
             <button
-              class="sort-btn"
-              @click="toggleSortOrder"
+              class="export-btn"
+              :disabled="filteredHistory.length === 0 || isExporting"
+              @click="exportToExcel"
             >
               <img
-                src="@/assets/icons/sort.png"
-                class="sort-icon"
-                :class="{ 'sort-asc': sortOrder === 'asc' }"
+                v-if="!isExporting"
+                src="@/assets/icons/export.png"
+                class="export-icon"
               >
-              <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
+              <span v-if="!isExporting">Экспорт</span>
+              <div
+                v-else
+                class="export-loader"
+              />
+            </button>
+            <button
+              class="close-btn"
+              @click="close"
+            >
+              ×
             </button>
           </div>
         </div>
-      </div>
 
-      <div
-        ref="scrollContainer"
-        class="modal-content"
-      >
-        <div
-          v-if="loading"
-          class="history-loading"
-        >
-          <div class="loader" />
+        <div class="history-filters">
+          <div class="filter-row">
+            <div class="search-filter">
+              <span class="filter-label">Поиск:</span>
+              <input 
+                v-model="searchQuery" 
+                type="text" 
+                class="search-input" 
+                placeholder="Поиск по пользователю, действию..."
+                @input="applyFilters"
+              >
+            </div>
+            <div class="user-filter">
+              <span class="filter-label">Пользователь:</span>
+              <div
+                class="custom-select"
+                @click="toggleUserDropdown"
+              >
+                <div class="select-trigger">
+                  <span class="selected-value">{{ selectedUserName }}</span>
+                  <img 
+                    src="@/assets/icons/arrow.png" 
+                    class="select-arrow" 
+                    :class="{ 'arrow-open': userDropdownOpen }"
+                  >
+                </div>
+                <transition name="fade">
+                  <div
+                    v-if="userDropdownOpen"
+                    class="select-dropdown"
+                  >
+                    <div 
+                      class="select-option"
+                      :class="{ 'selected': selectedUserId === null }"
+                      @click="selectUser(null)"
+                    >
+                      Все пользователи
+                    </div>
+                    <div 
+                      v-for="user in uniqueUsers" 
+                      :key="user.id"
+                      class="select-option"
+                      :class="{ 'selected': selectedUserId === user.id }"
+                      @click="selectUser(user.id)"
+                    >
+                      {{ user.name }}
+                    </div>
+                  </div>
+                </transition>
+              </div>
+            </div>
+          
+            <div class="place-filter">
+              <span class="filter-label">Место прохода:</span>
+              <div
+                class="custom-select"
+                @click="togglePlaceDropdown"
+              >
+                <div class="select-trigger">
+                  <span class="selected-value">{{ selectedPlaceName }}</span>
+                  <img 
+                    src="@/assets/icons/arrow.png" 
+                    class="select-arrow" 
+                    :class="{ 'arrow-open': placeDropdownOpen }"
+                  >
+                </div>
+                <transition name="fade">
+                  <div
+                    v-if="placeDropdownOpen"
+                    class="select-dropdown"
+                  >
+                    <div 
+                      class="select-option"
+                      :class="{ 'selected': selectedPlaceId === null }"
+                      @click="selectPlace(null)"
+                    >
+                      Все места
+                    </div>
+                    <div 
+                      v-for="place in uniquePlaces" 
+                      :key="place.id"
+                      class="select-option"
+                      :class="{ 'selected': selectedPlaceId === place.id }"
+                      @click="selectPlace(place.id)"
+                    >
+                      {{ place.name }}
+                    </div>
+                  </div>
+                </transition>
+              </div>
+            </div>
+          
+            <div class="date-filter">
+              <span class="filter-label">Период:</span>
+              <input 
+                v-model="dateFrom" 
+                type="date" 
+                class="date-input"
+                @change="applyFilters"
+              >
+              <span class="date-separator">—</span>
+              <input 
+                v-model="dateTo" 
+                type="date" 
+                class="date-input"
+                @change="applyFilters"
+              >
+            </div>
+          
+            <div class="sort-filter">
+              <span class="filter-label">Сортировка:</span>
+              <button
+                class="sort-btn"
+                @click="toggleSortOrder"
+              >
+                <img
+                  src="@/assets/icons/sort.png"
+                  class="sort-icon"
+                  :class="{ 'sort-asc': sortOrder === 'asc' }"
+                >
+                <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
+              </button>
+            </div>
+          </div>
         </div>
-        
+
         <div
-          v-else-if="filteredHistory.length === 0"
-          class="history-empty"
+          ref="scrollContainer"
+          class="modal-content"
         >
-          История пуста
-        </div>
-        
-        <div
-          v-else
-          class="history-timeline"
-        >
-          <div 
-            v-for="(item, index) in filteredHistory" 
-            :key="item.id" 
-            class="history-item"
+          <div
+            v-if="loading"
+            class="history-loading"
           >
-            <div
-              class="timeline-dot"
-              :class="getActionClass(item.action_type)"
-            />
-            <div
-              v-if="index < filteredHistory.length - 1"
-              class="timeline-line"
-            />
+            <div class="loader" />
+          </div>
+        
+          <div
+            v-else-if="filteredHistory.length === 0"
+            class="history-empty"
+          >
+            История пуста
+          </div>
+        
+          <div
+            v-else
+            class="history-timeline"
+          >
+            <div 
+              v-for="(item, index) in filteredHistory" 
+              :key="item.id" 
+              class="history-item"
+            >
+              <div
+                class="timeline-dot"
+                :class="getActionClass(item.action_type)"
+              />
+              <div
+                v-if="index < filteredHistory.length - 1"
+                class="timeline-line"
+              />
             
-            <div class="history-content">
-              <div class="history-header">
-                <span class="user-name">{{ item.user_name || 'Система' }}</span>
-                <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
-              </div>
+              <div class="history-content">
+                <div class="history-header">
+                  <span class="user-name">{{ item.user_name || 'Система' }}</span>
+                  <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                </div>
               
-              <div class="action-text">
-                {{ getActionText(item) }}
-              </div>
+                <div class="action-text">
+                  {{ getActionText(item) }}
+                </div>
               
-              <div
-                v-if="item.action_type === 'entry' || item.action_type === 'exit'"
-                class="action-comment"
-              >
-                {{ getActionComment(item) }}
-              </div>
+                <div
+                  v-if="item.action_type === 'entry' || item.action_type === 'exit'"
+                  class="action-comment"
+                >
+                  {{ getActionComment(item) }}
+                </div>
               
-              <div
-                v-if="item.comment && item.action_type !== 'entry' && item.action_type !== 'exit'"
-                class="action-comment"
-              >
-                {{ item.comment }}
-              </div>
+                <div
+                  v-if="item.comment && item.action_type !== 'entry' && item.action_type !== 'exit'"
+                  class="action-comment"
+                >
+                  {{ item.comment }}
+                </div>
               
-              <div
-                v-if="item.old_value && item.new_value && item.old_value !== item.new_value"
-                class="value-change"
-              >
-                <span class="old-value">{{ item.old_value }}</span>
-                <span class="arrow">→</span>
-                <span class="new-value">{{ item.new_value }}</span>
-              </div>
+                <div
+                  v-if="item.old_value && item.new_value && item.old_value !== item.new_value"
+                  class="value-change"
+                >
+                  <span class="old-value">{{ item.old_value }}</span>
+                  <span class="arrow">→</span>
+                  <span class="new-value">{{ item.new_value }}</span>
+                </div>
               
-              <div
-                v-if="item.field_name"
-                class="field-name"
-              >
-                Поле: {{ item.field_name }}
-              </div>
-              <div
-                v-if="item.table_name"
-                class="place-name"
-              >
-                {{ item.table_name }}
+                <div
+                  v-if="item.field_name"
+                  class="field-name"
+                >
+                  Поле: {{ item.field_name }}
+                </div>
+                <div
+                  v-if="item.table_name"
+                  class="place-name"
+                >
+                  {{ item.table_name }}
+                </div>
               </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
+  </Teleport>
 </template>
 
 <script>
@@ -737,6 +739,8 @@ export default {
   justify-content: center;
   align-items: center;
   z-index: 12000;
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
   animation: fadeIn 0.2s ease-out;
 }
 

--- a/frontend/src/components/CreateApplication/EmployeesTableHistoryModal.vue
+++ b/frontend/src/components/CreateApplication/EmployeesTableHistoryModal.vue
@@ -1,223 +1,225 @@
 <template>
-  <div
-    class="modal-overlay"
-    @click.self="close"
-  >
-    <div class="employees-history-modal">
-      <div class="modal-header">
-        <h3>История проходов сотрудников (таблица)</h3>
-        <div class="header-actions">
-          <button
-            class="export-btn"
-            :disabled="filteredHistory.length === 0 || isExporting"
-            @click="exportToExcel"
-          >
-            <img
-              v-if="!isExporting"
-              src="@/assets/icons/export.png"
-              class="export-icon"
-            >
-            <span v-if="!isExporting">Экспорт</span>
-            <div
-              v-else
-              class="export-loader"
-            />
-          </button>
-          <button
-            class="close-btn"
-            @click="close"
-          >
-            ×
-          </button>
-        </div>
-      </div>
-
-      <div class="history-filters">
-        <div class="filter-row">
-          <div class="search-filter">
-            <span class="filter-label">Поиск:</span>
-            <input 
-              v-model="searchQuery" 
-              type="text" 
-              class="search-input" 
-              placeholder="Поиск по сотруднику, пользователю..."
-              @input="applyFilters"
-            >
-          </div>
-          <div class="user-filter">
-            <span class="filter-label">Пользователь:</span>
-            <div
-              class="custom-select"
-              @click="toggleUserDropdown"
-            >
-              <div class="select-trigger">
-                <span class="selected-value">{{ selectedUserName }}</span>
-                <img 
-                  src="@/assets/icons/arrow.png" 
-                  class="select-arrow" 
-                  :class="{ 'arrow-open': userDropdownOpen }"
-                >
-              </div>
-              <transition name="fade">
-                <div
-                  v-if="userDropdownOpen"
-                  class="select-dropdown"
-                >
-                  <div 
-                    class="select-option"
-                    :class="{ 'selected': selectedUserId === null }"
-                    @click="selectUser(null)"
-                  >
-                    Все пользователи
-                  </div>
-                  <div 
-                    v-for="user in uniqueUsers" 
-                    :key="user.id"
-                    class="select-option"
-                    :class="{ 'selected': selectedUserId === user.id }"
-                    @click="selectUser(user.id)"
-                  >
-                    {{ user.name }}
-                  </div>
-                </div>
-              </transition>
-            </div>
-          </div>
-          
-          <div class="employee-filter">
-            <span class="filter-label">Сотрудник:</span>
-            <div
-              class="custom-select"
-              @click="toggleEmployeeDropdown"
-            >
-              <div class="select-trigger">
-                <span class="selected-value">{{ selectedEmployeeName }}</span>
-                <img 
-                  src="@/assets/icons/arrow.png" 
-                  class="select-arrow" 
-                  :class="{ 'arrow-open': employeeDropdownOpen }"
-                >
-              </div>
-              <transition name="fade">
-                <div
-                  v-if="employeeDropdownOpen"
-                  class="select-dropdown"
-                >
-                  <div 
-                    class="select-option"
-                    :class="{ 'selected': selectedEmployeeId === null }"
-                    @click="selectEmployee(null)"
-                  >
-                    Все сотрудники
-                  </div>
-                  <div 
-                    v-for="emp in uniqueEmployees" 
-                    :key="emp.id"
-                    class="select-option"
-                    :class="{ 'selected': selectedEmployeeId === emp.id }"
-                    @click="selectEmployee(emp.id)"
-                  >
-                    {{ emp.name }}
-                  </div>
-                </div>
-              </transition>
-            </div>
-          </div>
-          
-          <div class="date-filter">
-            <span class="filter-label">Период:</span>
-            <input 
-              v-model="dateFrom" 
-              type="date" 
-              class="date-input"
-              @change="applyFilters"
-            >
-            <span class="date-separator">—</span>
-            <input 
-              v-model="dateTo" 
-              type="date" 
-              class="date-input"
-              @change="applyFilters"
-            >
-          </div>
-          
-          <div class="sort-filter">
-            <span class="filter-label">Сортировка:</span>
+  <Teleport to="body">
+    <div
+      class="modal-overlay"
+      @click.self="close"
+    >
+      <div class="employees-history-modal">
+        <div class="modal-header">
+          <h3>История проходов сотрудников (таблица)</h3>
+          <div class="header-actions">
             <button
-              class="sort-btn"
-              @click="toggleSortOrder"
+              class="export-btn"
+              :disabled="filteredHistory.length === 0 || isExporting"
+              @click="exportToExcel"
             >
               <img
-                src="@/assets/icons/sort.png"
-                class="sort-icon"
-                :class="{ 'sort-asc': sortOrder === 'asc' }"
+                v-if="!isExporting"
+                src="@/assets/icons/export.png"
+                class="export-icon"
               >
-              <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
+              <span v-if="!isExporting">Экспорт</span>
+              <div
+                v-else
+                class="export-loader"
+              />
+            </button>
+            <button
+              class="close-btn"
+              @click="close"
+            >
+              ×
             </button>
           </div>
         </div>
-      </div>
 
-      <div
-        ref="scrollContainer"
-        class="modal-content"
-      >
-        <div
-          v-if="loading"
-          class="history-loading"
-        >
-          <div class="loader" />
+        <div class="history-filters">
+          <div class="filter-row">
+            <div class="search-filter">
+              <span class="filter-label">Поиск:</span>
+              <input 
+                v-model="searchQuery" 
+                type="text" 
+                class="search-input" 
+                placeholder="Поиск по сотруднику, пользователю..."
+                @input="applyFilters"
+              >
+            </div>
+            <div class="user-filter">
+              <span class="filter-label">Пользователь:</span>
+              <div
+                class="custom-select"
+                @click="toggleUserDropdown"
+              >
+                <div class="select-trigger">
+                  <span class="selected-value">{{ selectedUserName }}</span>
+                  <img 
+                    src="@/assets/icons/arrow.png" 
+                    class="select-arrow" 
+                    :class="{ 'arrow-open': userDropdownOpen }"
+                  >
+                </div>
+                <transition name="fade">
+                  <div
+                    v-if="userDropdownOpen"
+                    class="select-dropdown"
+                  >
+                    <div 
+                      class="select-option"
+                      :class="{ 'selected': selectedUserId === null }"
+                      @click="selectUser(null)"
+                    >
+                      Все пользователи
+                    </div>
+                    <div 
+                      v-for="user in uniqueUsers" 
+                      :key="user.id"
+                      class="select-option"
+                      :class="{ 'selected': selectedUserId === user.id }"
+                      @click="selectUser(user.id)"
+                    >
+                      {{ user.name }}
+                    </div>
+                  </div>
+                </transition>
+              </div>
+            </div>
+          
+            <div class="employee-filter">
+              <span class="filter-label">Сотрудник:</span>
+              <div
+                class="custom-select"
+                @click="toggleEmployeeDropdown"
+              >
+                <div class="select-trigger">
+                  <span class="selected-value">{{ selectedEmployeeName }}</span>
+                  <img 
+                    src="@/assets/icons/arrow.png" 
+                    class="select-arrow" 
+                    :class="{ 'arrow-open': employeeDropdownOpen }"
+                  >
+                </div>
+                <transition name="fade">
+                  <div
+                    v-if="employeeDropdownOpen"
+                    class="select-dropdown"
+                  >
+                    <div 
+                      class="select-option"
+                      :class="{ 'selected': selectedEmployeeId === null }"
+                      @click="selectEmployee(null)"
+                    >
+                      Все сотрудники
+                    </div>
+                    <div 
+                      v-for="emp in uniqueEmployees" 
+                      :key="emp.id"
+                      class="select-option"
+                      :class="{ 'selected': selectedEmployeeId === emp.id }"
+                      @click="selectEmployee(emp.id)"
+                    >
+                      {{ emp.name }}
+                    </div>
+                  </div>
+                </transition>
+              </div>
+            </div>
+          
+            <div class="date-filter">
+              <span class="filter-label">Период:</span>
+              <input 
+                v-model="dateFrom" 
+                type="date" 
+                class="date-input"
+                @change="applyFilters"
+              >
+              <span class="date-separator">—</span>
+              <input 
+                v-model="dateTo" 
+                type="date" 
+                class="date-input"
+                @change="applyFilters"
+              >
+            </div>
+          
+            <div class="sort-filter">
+              <span class="filter-label">Сортировка:</span>
+              <button
+                class="sort-btn"
+                @click="toggleSortOrder"
+              >
+                <img
+                  src="@/assets/icons/sort.png"
+                  class="sort-icon"
+                  :class="{ 'sort-asc': sortOrder === 'asc' }"
+                >
+                <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
+              </button>
+            </div>
+          </div>
         </div>
-        
+
         <div
-          v-else-if="filteredHistory.length === 0"
-          class="history-empty"
+          ref="scrollContainer"
+          class="modal-content"
         >
-          История пуста
-        </div>
-        
-        <div
-          v-else
-          class="history-timeline"
-        >
-          <div 
-            v-for="(item, index) in filteredHistory" 
-            :key="item.id" 
-            class="history-item"
+          <div
+            v-if="loading"
+            class="history-loading"
           >
-            <div
-              class="timeline-dot"
-              :class="getActionClass(item.action_type)"
-            />
-            <div
-              v-if="index < filteredHistory.length - 1"
-              class="timeline-line"
-            />
+            <div class="loader" />
+          </div>
+        
+          <div
+            v-else-if="filteredHistory.length === 0"
+            class="history-empty"
+          >
+            История пуста
+          </div>
+        
+          <div
+            v-else
+            class="history-timeline"
+          >
+            <div 
+              v-for="(item, index) in filteredHistory" 
+              :key="item.id" 
+              class="history-item"
+            >
+              <div
+                class="timeline-dot"
+                :class="getActionClass(item.action_type)"
+              />
+              <div
+                v-if="index < filteredHistory.length - 1"
+                class="timeline-line"
+              />
             
-            <div class="history-content">
-              <div class="history-header">
-                <span class="employee-info">{{ getEmployeeName(item) }}</span>
-                <span
-                  v-if="item.table_name"
-                  class="table-name"
-                >{{ item.table_name }}</span>
-                <span class="user-name">{{ item.user_name || 'Система' }}</span>
-                <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
-              </div>
+              <div class="history-content">
+                <div class="history-header">
+                  <span class="employee-info">{{ getEmployeeName(item) }}</span>
+                  <span
+                    v-if="item.table_name"
+                    class="table-name"
+                  >{{ item.table_name }}</span>
+                  <span class="user-name">{{ item.user_name || 'Система' }}</span>
+                  <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                </div>
               
-              <div class="action-text">
-                {{ getActionText(item) }}
-              </div>
+                <div class="action-text">
+                  {{ getActionText(item) }}
+                </div>
               
-              <div class="action-comment">
-                {{ item.comment || getActionComment(item) }}
+                <div class="action-comment">
+                  {{ item.comment || getActionComment(item) }}
+                </div>
               </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
+  </Teleport>
 </template>
 
 <script>
@@ -634,6 +636,8 @@ export default {
   justify-content: center;
   align-items: center;
   z-index: 13000;
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
   animation: fadeIn 0.2s ease-out;
 }
 

--- a/frontend/src/components/CreateApplication/ExistingCarsModal.vue
+++ b/frontend/src/components/CreateApplication/ExistingCarsModal.vue
@@ -1,179 +1,187 @@
 <template>
-  <div
-    v-if="visible"
-    class="modal-overlay"
-    @click="$emit('close')"
-  >
+  <Teleport to="body">
     <div
-      class="modal-content"
-      @click.stop
+      v-if="visible"
+      class="modal-overlay"
+      @click="$emit('close')"
     >
-      <!-- Заголовок модалки -->
-      <div class="modal-header">
-        <h3>Выбор существующих автомобилей</h3>
-        <div class="header-right">
-          <SearchComponent
-            v-model="searchQuery"
-            title="Поиск автомобилей..."
-            @update:model-value="handleSearch"
-          />
-        </div>
-        <button
-          class="modal-close"
-          @click="$emit('close')"
-        >
-          ×
-        </button>
-      </div>
-
-      <!-- Фильтры -->
-      <div class="filter-section">
-        <div class="filter-tabs">
-          <button
-            class="filter-tab"
-            :class="{ 'filter-tab--active': currentFilter === 'all' }"
-            @click="switchFilter('all')"
-          >
-            Все машины
-          </button>
-          <button
-            v-if="userOrganizationId"
-            class="filter-tab"
-            :class="{ 'filter-tab--active': currentFilter === 'organization' }"
-            @click="switchFilter('organization')"
-          >
-            Организация
-          </button>
-          <button
-            v-if="userCompanyId"
-            class="filter-tab"
-            :class="{ 'filter-tab--active': currentFilter === 'company' }"
-            @click="switchFilter('company')"
-          >
-            Компания
-          </button>
-          <button
-            class="filter-tab"
-            :class="{ 'filter-tab--active': currentFilter === 'user' }"
-            @click="switchFilter('user')"
-          >
-            Мои
-          </button>
-        </div>
-        <div
-          v-if="tempSelectedCars.length > 0"
-          class="selected-counter"
-        >
-          Выбрано: <span class="selected-count">{{ tempSelectedCars.length }}</span>
-        </div>
-      </div>
-
-      <!-- Список машин -->
-      <div class="cars-table-container">
-        <div class="cars-table">
-          <!-- Заголовки таблицы -->
-          <div class="table-header">
-            <div class="header-cell select-cell" />
-            <div class="header-cell number-cell">
-              №
-            </div>
-            <div class="header-cell plate-cell">
-              Номер
-            </div>
-            <div class="header-cell mark-cell">
-              Марка
-            </div>
-            <div class="header-cell status-cell">
-              Статус
-            </div>
+      <div
+        class="modal-content"
+        @click.stop
+      >
+        <!-- Заголовок модалки -->
+        <div class="modal-header">
+          <h3>Выбор существующих автомобилей</h3>
+          <div class="header-right">
+            <SearchComponent
+              v-model="searchQuery"
+              title="Поиск автомобилей..."
+              @update:model-value="handleSearch"
+            />
           </div>
+          <button
+            class="modal-close"
+            @click="$emit('close')"
+          >
+            ×
+          </button>
+        </div>
 
-          <!-- Тело таблицы -->
-          <div class="table-body">
-            <div
-              v-for="car in displayedCars"
-              :key="car.id"
-              class="table-row"
-              :class="{
-                'table-row--disabled': isCarDisabled(car),
-                'table-row--selected': isCarSelected(car)
-              }"
-              @click="handleRowClick(car)"
+        <!-- Фильтры -->
+        <div class="filter-section">
+          <div class="filter-tabs">
+            <button
+              class="filter-tab"
+              :class="{ 'filter-tab--active': currentFilter === 'all' }"
+              @click="switchFilter('all')"
             >
+              Все машины
+            </button>
+            <button
+              v-if="userOrganizationId"
+              class="filter-tab"
+              :class="{ 'filter-tab--active': currentFilter === 'organization' }"
+              @click="switchFilter('organization')"
+            >
+              Организация
+            </button>
+            <button
+              v-if="userCompanyId"
+              class="filter-tab"
+              :class="{ 'filter-tab--active': currentFilter === 'company' }"
+              @click="switchFilter('company')"
+            >
+              Компания
+            </button>
+            <button
+              class="filter-tab"
+              :class="{ 'filter-tab--active': currentFilter === 'user' }"
+              @click="switchFilter('user')"
+            >
+              Мои
+            </button>
+          </div>
+          <div
+            v-if="tempSelectedCars.length > 0"
+            class="selected-counter"
+          >
+            Выбрано: <span class="selected-count">{{ tempSelectedCars.length }}</span>
+          </div>
+        </div>
+
+        <!-- Список машин -->
+        <div class="cars-table-container">
+          <div class="cars-table">
+            <!-- Заголовки таблицы -->
+            <div class="table-header">
+              <div class="header-cell select-cell" />
+              <div class="header-cell number-cell">
+                №
+              </div>
+              <div class="header-cell plate-cell">
+                Номер
+              </div>
+              <div class="header-cell mark-cell">
+                Марка
+              </div>
+              <div class="header-cell status-cell">
+                Статус
+              </div>
+            </div>
+
+            <!-- Тело таблицы -->
+            <div class="table-body">
               <div
-                class="table-cell select-cell"
-                @click.stop
+                v-for="car in displayedCars"
+                :key="car.id"
+                class="table-row"
+                :class="{
+                  'table-row--disabled': isCarDisabled(car),
+                  'table-row--selected': isCarSelected(car)
+                }"
+                @click="handleRowClick(car)"
               >
-                <input
-                  type="checkbox"
-                  :checked="isCarSelected(car)"
-                  :disabled="isCarDisabled(car)"
-                  @change="toggleCarSelection(car)"
+                <div
+                  class="table-cell select-cell"
+                  @click.stop
                 >
+                  <input
+                    type="checkbox"
+                    :checked="isCarSelected(car)"
+                    :disabled="isCarDisabled(car)"
+                    @change="toggleCarSelection(car)"
+                  >
+                </div>
+                <div class="table-cell number-cell">
+                  {{ car.id }}
+                </div>
+                <div class="table-cell plate-cell">
+                  {{ car.number }}
+                </div>
+                <div class="table-cell mark-cell">
+                  {{ car.mark }}
+                </div>
+                <div class="table-cell status-cell">
+                  <span
+                    class="status-badge"
+                    :class="{
+                      'status-active': car.status,
+                      'status-inactive': !car.status
+                    }"
+                  >
+                    {{ car.status ? 'Активна' : 'Неактивна' }}
+                  </span>
+                </div>
               </div>
-              <div class="table-cell number-cell">
-                {{ car.id }}
-              </div>
-              <div class="table-cell plate-cell">
-                {{ car.number }}
-              </div>
-              <div class="table-cell mark-cell">
-                {{ car.mark }}
-              </div>
-              <div class="table-cell status-cell">
-                <StatusBadge :status="car.status ? 'Активна' : 'Неактивна'" />
-              </div>
-            </div>
 
-            <!-- Состояния загрузки/пусто -->
-            <div
-              v-if="loadingCars"
-              class="loading-state"
-            >
-              <LoaderSpinner label="Загрузка машин…" />
-            </div>
-            <div
-              v-else-if="displayedCars.length === 0"
-              class="empty-state"
-            >
-              {{ searchQuery ? 'Ничего не найдено' : 'Нет доступных автомобилей' }}
+              <!-- Состояния загрузки/пусто -->
+              <div
+                v-if="loadingCars"
+                class="loading-state"
+              >
+                <LoaderSpinner label="Загрузка машин…" />
+              </div>
+              <div
+                v-else-if="displayedCars.length === 0"
+                class="empty-state"
+              >
+                {{ searchQuery ? 'Ничего не найдено' : 'Нет доступных автомобилей' }}
+              </div>
             </div>
           </div>
         </div>
-      </div>
 
-      <!-- Кнопки действий -->
-      <div class="modal-actions">
-        <button
-          class="btn btn-secondary"
-          @click="$emit('close')"
-        >
-          Отмена
-        </button>
-        <button
-          class="btn btn-primary"
-          :disabled="tempSelectedCars.length === 0"
-          @click="confirmSelection"
-        >
-          {{ tempSelectedCars.length > 0 ? `Выбрать (${tempSelectedCars.length})` : 'Выбрать' }}
-        </button>
+        <!-- Кнопки действий -->
+        <div class="modal-actions">
+          <button
+            class="btn btn-secondary"
+            @click="$emit('close')"
+          >
+            Отмена
+          </button>
+          <button
+            class="btn btn-primary"
+            :disabled="tempSelectedCars.length === 0"
+            @click="confirmSelection"
+          >
+            {{ tempSelectedCars.length > 0 ? `Выбрать (${tempSelectedCars.length})` : 'Выбрать' }}
+          </button>
+        </div>
       </div>
     </div>
-  </div>
+  </Teleport>
 </template>
 
 <script>
 import { apiRequest } from '@/api/client'
 import SearchComponent from '@/components/SearchComponent.vue'
 import LoaderSpinner from '@/components/ui/LoaderSpinner.vue'
-import StatusBadge from '@/components/ui/StatusBadge.vue'
 
 export default {
     name: 'ExistingCarsModal',
     components: {
         SearchComponent,
-        LoaderSpinner,
-        StatusBadge
+        LoaderSpinner
     },
     props: {
         visible: {
@@ -356,6 +364,8 @@ export default {
     justify-content: center;
     z-index: 1000;
     padding: 20px;
+    backdrop-filter: blur(0.1px);
+    -webkit-backdrop-filter: blur(0.1px);
 }
 
 .modal-content {
@@ -603,7 +613,29 @@ export default {
     opacity: 0.6;
 }
 
-.table-row--disabled :deep(.status-badge) {
+.status-badge {
+    padding: 4px 10px;
+    border-radius: 12px;
+    font-size: 11px;
+    font-weight: 500;
+    display: inline-block;
+    min-width: 70px;
+    text-align: center;
+}
+
+.status-active {
+    background-color: #f0f9ff;
+    color: #0369a1;
+    border: 1px solid #bae6fd;
+}
+
+.status-inactive {
+    background-color: #fef2f2;
+    color: #991b1b;
+    border: 1px solid #fecaca;
+}
+
+.table-row--disabled .status-badge {
     opacity: 0.7;
 }
 

--- a/frontend/src/components/CreateApplication/ExistingEmployeesModal.vue
+++ b/frontend/src/components/CreateApplication/ExistingEmployeesModal.vue
@@ -1,170 +1,178 @@
 <template>
-  <div
-    v-if="visible"
-    class="modal-overlay"
-    @click="$emit('close')"
-  >
+  <Teleport to="body">
     <div
-      class="modal-content"
-      @click.stop
+      v-if="visible"
+      class="modal-overlay"
+      @click="$emit('close')"
     >
-      <div class="modal-header">
-        <h3>Выбор существующих сотрудников</h3>
-        <div class="header-right">
-          <SearchComponent
-            v-model="searchQuery"
-            title="Поиск сотрудников..."
-            @update:model-value="handleSearch"
-          />
-        </div>
-        <button
-          class="modal-close"
-          @click="$emit('close')"
-        >
-          ×
-        </button>
-      </div>
-
-      <div class="filter-section">
-        <div class="filter-tabs">
-          <button
-            class="filter-tab"
-            :class="{ 'filter-tab--active': currentFilter === 'all' }"
-            @click="switchFilter('all')"
-          >
-            Все сотрудники
-          </button>
-          <button
-            v-if="userOrganizationId"
-            class="filter-tab"
-            :class="{ 'filter-tab--active': currentFilter === 'organization' }"
-            @click="switchFilter('organization')"
-          >
-            Организация
-          </button>
-          <button
-            class="filter-tab"
-            :class="{ 'filter-tab--active': currentFilter === 'user' }"
-            @click="switchFilter('user')"
-          >
-            Мои
-          </button>
-        </div>
-        <div
-          v-if="tempSelectedEmployees.length > 0"
-          class="selected-counter"
-        >
-          Выбрано: <span class="selected-count">{{ tempSelectedEmployees.length }}</span>
-        </div>
-      </div>
-
-      <div class="employees-table-container">
-        <div class="employees-table">
-          <div class="table-header">
-            <div class="header-cell select-cell" />
-            <div class="header-cell number-cell">
-              №
-            </div>
-            <div class="header-cell name-col">
-              ФИО
-            </div>
-            <div class="header-cell position-col">
-              Должность
-            </div>
-            <div class="header-cell citizenship-col">
-              Гражданство
-            </div>
-            <div class="header-cell status-cell">
-              Статус
-            </div>
+      <div
+        class="modal-content"
+        @click.stop
+      >
+        <div class="modal-header">
+          <h3>Выбор существующих сотрудников</h3>
+          <div class="header-right">
+            <SearchComponent
+              v-model="searchQuery"
+              title="Поиск сотрудников..."
+              @update:model-value="handleSearch"
+            />
           </div>
+          <button
+            class="modal-close"
+            @click="$emit('close')"
+          >
+            ×
+          </button>
+        </div>
 
-          <div class="table-body">
-            <div
-              v-for="employee in displayedEmployees"
-              :key="employee.id"
-              class="table-row"
-              :class="{
-                'table-row--disabled': isEmployeeDisabled(employee),
-                'table-row--selected': isEmployeeSelected(employee)
-              }"
-              @click="handleRowClick(employee)"
+        <div class="filter-section">
+          <div class="filter-tabs">
+            <button
+              class="filter-tab"
+              :class="{ 'filter-tab--active': currentFilter === 'all' }"
+              @click="switchFilter('all')"
             >
+              Все сотрудники
+            </button>
+            <button
+              v-if="userOrganizationId"
+              class="filter-tab"
+              :class="{ 'filter-tab--active': currentFilter === 'organization' }"
+              @click="switchFilter('organization')"
+            >
+              Организация
+            </button>
+            <button
+              class="filter-tab"
+              :class="{ 'filter-tab--active': currentFilter === 'user' }"
+              @click="switchFilter('user')"
+            >
+              Мои
+            </button>
+          </div>
+          <div
+            v-if="tempSelectedEmployees.length > 0"
+            class="selected-counter"
+          >
+            Выбрано: <span class="selected-count">{{ tempSelectedEmployees.length }}</span>
+          </div>
+        </div>
+
+        <div class="employees-table-container">
+          <div class="employees-table">
+            <div class="table-header">
+              <div class="header-cell select-cell" />
+              <div class="header-cell number-cell">
+                №
+              </div>
+              <div class="header-cell name-col">
+                ФИО
+              </div>
+              <div class="header-cell position-col">
+                Должность
+              </div>
+              <div class="header-cell citizenship-col">
+                Гражданство
+              </div>
+              <div class="header-cell status-cell">
+                Статус
+              </div>
+            </div>
+
+            <div class="table-body">
               <div
-                class="table-cell select-cell"
-                @click.stop
+                v-for="employee in displayedEmployees"
+                :key="employee.id"
+                class="table-row"
+                :class="{
+                  'table-row--disabled': isEmployeeDisabled(employee),
+                  'table-row--selected': isEmployeeSelected(employee)
+                }"
+                @click="handleRowClick(employee)"
               >
-                <input
-                  type="checkbox"
-                  :checked="isEmployeeSelected(employee)"
-                  :disabled="isEmployeeDisabled(employee)"
-                  @change="toggleEmployeeSelection(employee)"
+                <div
+                  class="table-cell select-cell"
+                  @click.stop
                 >
+                  <input
+                    type="checkbox"
+                    :checked="isEmployeeSelected(employee)"
+                    :disabled="isEmployeeDisabled(employee)"
+                    @change="toggleEmployeeSelection(employee)"
+                  >
+                </div>
+                <div class="table-cell number-cell">
+                  {{ employee.id }}
+                </div>
+                <div class="table-cell name-col">
+                  {{ formatFullName(employee) }}
+                </div>
+                <div class="table-cell position-col">
+                  {{ employee.position || 'Не указана' }}
+                </div>
+                <div class="table-cell citizenship-col">
+                  {{ employee.citizenship_name || 'Не указано' }}
+                </div>
+                <div class="table-cell status-cell">
+                  <span
+                    class="status-badge"
+                    :class="{
+                      'status-active': employee.status,
+                      'status-inactive': !employee.status
+                    }"
+                  >
+                    {{ employee.status ? 'Активен' : 'Неактивен' }}
+                  </span>
+                </div>
               </div>
-              <div class="table-cell number-cell">
-                {{ employee.id }}
-              </div>
-              <div class="table-cell name-col">
-                {{ formatFullName(employee) }}
-              </div>
-              <div class="table-cell position-col">
-                {{ employee.position || 'Не указана' }}
-              </div>
-              <div class="table-cell citizenship-col">
-                {{ employee.citizenship_name || 'Не указано' }}
-              </div>
-              <div class="table-cell status-cell">
-                <StatusBadge :status="employee.status ? 'Активен' : 'Неактивен'" />
-              </div>
-            </div>
 
-            <div
-              v-if="loadingEmployees"
-              class="loading-state"
-            >
-              <LoaderSpinner label="Загрузка сотрудников…" />
-            </div>
-            <div
-              v-else-if="displayedEmployees.length === 0"
-              class="empty-state"
-            >
-              {{ searchQuery ? 'Ничего не найдено' : 'Нет доступных сотрудников' }}
+              <div
+                v-if="loadingEmployees"
+                class="loading-state"
+              >
+                <LoaderSpinner label="Загрузка сотрудников…" />
+              </div>
+              <div
+                v-else-if="displayedEmployees.length === 0"
+                class="empty-state"
+              >
+                {{ searchQuery ? 'Ничего не найдено' : 'Нет доступных сотрудников' }}
+              </div>
             </div>
           </div>
         </div>
-      </div>
 
-      <div class="modal-actions">
-        <button
-          class="btn btn-secondary"
-          @click="$emit('close')"
-        >
-          Отмена
-        </button>
-        <button
-          class="btn btn-primary"
-          :disabled="tempSelectedEmployees.length === 0"
-          @click="confirmSelection"
-        >
-          {{ tempSelectedEmployees.length > 0 ? `Добавить (${tempSelectedEmployees.length})` : 'Добавить' }}
-        </button>
+        <div class="modal-actions">
+          <button
+            class="btn btn-secondary"
+            @click="$emit('close')"
+          >
+            Отмена
+          </button>
+          <button
+            class="btn btn-primary"
+            :disabled="tempSelectedEmployees.length === 0"
+            @click="confirmSelection"
+          >
+            {{ tempSelectedEmployees.length > 0 ? `Добавить (${tempSelectedEmployees.length})` : 'Добавить' }}
+          </button>
+        </div>
       </div>
     </div>
-  </div>
+  </Teleport>
 </template>
 
 <script>
 import { apiRequest } from '@/api/client'
 import SearchComponent from '@/components/SearchComponent.vue'
 import LoaderSpinner from '@/components/ui/LoaderSpinner.vue'
-import StatusBadge from '@/components/ui/StatusBadge.vue'
 
 export default {
     name: 'ExistingEmployeesModal',
     components: {
         SearchComponent,
-        LoaderSpinner,
-        StatusBadge
+        LoaderSpinner
     },
     props: {
         visible: {
@@ -568,7 +576,29 @@ export default {
     opacity: 0.6;
 }
 
-.table-row--disabled :deep(.status-badge) {
+.status-badge {
+    padding: 4px 10px;
+    border-radius: 12px;
+    font-size: 11px;
+    font-weight: 500;
+    display: inline-block;
+    min-width: 70px;
+    text-align: center;
+}
+
+.status-active {
+    background-color: #f0f9ff;
+    color: #0369a1;
+    border: 1px solid #bae6fd;
+}
+
+.status-inactive {
+    background-color: #fef2f2;
+    color: #991b1b;
+    border: 1px solid #fecaca;
+}
+
+.table-row--disabled .status-badge {
     opacity: 0.7;
 }
 

--- a/frontend/src/components/CreateApplication/UniversalBindingModal.vue
+++ b/frontend/src/components/CreateApplication/UniversalBindingModal.vue
@@ -1,207 +1,209 @@
 <template>
-  <div
-    class="modal-overlay"
-    @click.self="closeModal"
-  >
-    <div class="modal-content">
-      <div class="modal-header">
-        <h3 class="modal-title">
-          Привязка новых данных
-        </h3>
-        <button
-          class="modal-close"
-          @click="closeModal"
-        >
-          <svg
-            width="10"
-            height="10"
-            viewBox="0 0 14 14"
-            fill="none"
+  <Teleport to="body">
+    <div
+      class="modal-overlay"
+      @click.self="closeModal"
+    >
+      <div class="modal-content">
+        <div class="modal-header">
+          <h3 class="modal-title">
+            Привязка новых данных
+          </h3>
+          <button
+            class="modal-close"
+            @click="closeModal"
           >
-            <path
-              d="M13 1L1 13M1 1L13 13"
-              stroke="#666"
-              stroke-width="2"
-              stroke-linecap="round"
-            />
-          </svg>
-        </button>
-      </div>
-
-      <div class="modal-body">
-        <div class="binding-description">
-          Все добавленные данные будут <strong>автоматически привязаны</strong> к вашему аккаунту.
-          Вы можете дополнительно привязать их к организации и/или компании для использования <strong>другими сотрудниками</strong>:
+            <svg
+              width="10"
+              height="10"
+              viewBox="0 0 14 14"
+              fill="none"
+            >
+              <path
+                d="M13 1L1 13M1 1L13 13"
+                stroke="#666"
+                stroke-width="2"
+                stroke-linecap="round"
+              />
+            </svg>
+          </button>
         </div>
 
-        <div
-          v-if="newVehiclesToBind.length > 0"
-          class="data-section"
-        >
-          <div class="section-header">
-            <h4 class="section-title">
-              Новые автомобили
-            </h4>
-            <span class="count-badge">{{ newVehiclesToBind.length }}</span>
+        <div class="modal-body">
+          <div class="binding-description">
+            Все добавленные данные будут <strong>автоматически привязаны</strong> к вашему аккаунту.
+            Вы можете дополнительно привязать их к организации и/или компании для использования <strong>другими сотрудниками</strong>:
           </div>
-          <div class="section-body">
-            <div class="items-list">
-              <div
-                v-for="vehicle in newVehiclesToBind"
-                :key="vehicle.id"
-                class="item"
-                :class="{ 'item-fact': isVehicleByFact(vehicle) }"
-              >
-                <div class="item-info">
-                  <span class="item-number">{{ vehicle.plateNumber }}</span>
-                  <span class="item-detail">{{ vehicle.mark }}</span>
-                  <span
-                    v-if="isVehicleByFact(vehicle)"
-                    class="fact-badge"
-                  >По факту</span>
+
+          <div
+            v-if="newVehiclesToBind.length > 0"
+            class="data-section"
+          >
+            <div class="section-header">
+              <h4 class="section-title">
+                Новые автомобили
+              </h4>
+              <span class="count-badge">{{ newVehiclesToBind.length }}</span>
+            </div>
+            <div class="section-body">
+              <div class="items-list">
+                <div
+                  v-for="vehicle in newVehiclesToBind"
+                  :key="vehicle.id"
+                  class="item"
+                  :class="{ 'item-fact': isVehicleByFact(vehicle) }"
+                >
+                  <div class="item-info">
+                    <span class="item-number">{{ vehicle.plateNumber }}</span>
+                    <span class="item-detail">{{ vehicle.mark }}</span>
+                    <span
+                      v-if="isVehicleByFact(vehicle)"
+                      class="fact-badge"
+                    >По факту</span>
+                  </div>
                 </div>
               </div>
-            </div>
 
-            <div
-              v-if="hasVehiclesForBinding"
-              class="binding-options"
-            >
-              <p class="options-title">
-                Привязать автомобили к:
-              </p>
-              <div class="options-group">
-                <label
-                  v-if="hasOrganization"
-                  class="binding-option"
-                >
-                  <input
-                    v-model="vehiclesBindToOrganization"
-                    type="checkbox"
-                  >
-                  <span>Организации "{{ organization }}"</span>
-                </label>
-                <label
-                  v-if="hasCompany"
-                  class="binding-option"
-                >
-                  <input
-                    v-model="vehiclesBindToCompany"
-                    type="checkbox"
-                  >
-                  <span>Компании "{{ company }}"</span>
-                </label>
-              </div>
-            </div>
-            <div
-              v-else
-              class="no-binding-message"
-            >
-              Автомобили "По факту" не требуют привязки к организации/компании
-            </div>
-          </div>
-        </div>
-
-        <div
-          v-if="newEmployeesToBind.length > 0"
-          class="data-section"
-        >
-          <div class="section-header">
-            <h4 class="section-title">
-              Новые сотрудники
-            </h4>
-            <span class="count-badge">{{ newEmployeesToBind.length }}</span>
-          </div>
-          <div class="section-body">
-            <div class="items-list">
               <div
-                v-for="employee in newEmployeesToBind"
-                :key="employee.id"
-                class="item"
-                :class="{ 'item-fact': isEmployeeByFact(employee) }"
+                v-if="hasVehiclesForBinding"
+                class="binding-options"
               >
-                <div class="item-info">
-                  <span class="item-name">{{ formatFullName(employee) }}</span>
-                  <span class="item-detail">{{ employee.position }}</span>
-                  <span
-                    v-if="isEmployeeByFact(employee)"
-                    class="fact-badge"
-                  >По факту</span>
+                <p class="options-title">
+                  Привязать автомобили к:
+                </p>
+                <div class="options-group">
+                  <label
+                    v-if="hasOrganization"
+                    class="binding-option"
+                  >
+                    <input
+                      v-model="vehiclesBindToOrganization"
+                      type="checkbox"
+                    >
+                    <span>Организации "{{ organization }}"</span>
+                  </label>
+                  <label
+                    v-if="hasCompany"
+                    class="binding-option"
+                  >
+                    <input
+                      v-model="vehiclesBindToCompany"
+                      type="checkbox"
+                    >
+                    <span>Компании "{{ company }}"</span>
+                  </label>
                 </div>
               </div>
-            </div>
-
-            <div
-              v-if="hasEmployeesForBinding"
-              class="binding-options"
-            >
-              <p class="options-title">
-                Привязать сотрудников к:
-              </p>
-              <div class="options-group">
-                <label
-                  v-if="hasOrganization"
-                  class="binding-option"
-                >
-                  <input
-                    v-model="employeesBindToOrganization"
-                    type="checkbox"
-                  >
-                  <span>Организации "{{ organization }}"</span>
-                </label>
-                <label
-                  v-if="hasCompany"
-                  class="binding-option"
-                >
-                  <input
-                    v-model="employeesBindToCompany"
-                    type="checkbox"
-                  >
-                  <span>Компании "{{ company }}"</span>
-                </label>
+              <div
+                v-else
+                class="no-binding-message"
+              >
+                Автомобили "По факту" не требуют привязки к организации/компании
               </div>
             </div>
-            <div
-              v-else
-              class="no-binding-message"
-            >
-              Сотрудники "По факту" не требуют привязки к организации/компании
+          </div>
+
+          <div
+            v-if="newEmployeesToBind.length > 0"
+            class="data-section"
+          >
+            <div class="section-header">
+              <h4 class="section-title">
+                Новые сотрудники
+              </h4>
+              <span class="count-badge">{{ newEmployeesToBind.length }}</span>
+            </div>
+            <div class="section-body">
+              <div class="items-list">
+                <div
+                  v-for="employee in newEmployeesToBind"
+                  :key="employee.id"
+                  class="item"
+                  :class="{ 'item-fact': isEmployeeByFact(employee) }"
+                >
+                  <div class="item-info">
+                    <span class="item-name">{{ formatFullName(employee) }}</span>
+                    <span class="item-detail">{{ employee.position }}</span>
+                    <span
+                      v-if="isEmployeeByFact(employee)"
+                      class="fact-badge"
+                    >По факту</span>
+                  </div>
+                </div>
+              </div>
+
+              <div
+                v-if="hasEmployeesForBinding"
+                class="binding-options"
+              >
+                <p class="options-title">
+                  Привязать сотрудников к:
+                </p>
+                <div class="options-group">
+                  <label
+                    v-if="hasOrganization"
+                    class="binding-option"
+                  >
+                    <input
+                      v-model="employeesBindToOrganization"
+                      type="checkbox"
+                    >
+                    <span>Организации "{{ organization }}"</span>
+                  </label>
+                  <label
+                    v-if="hasCompany"
+                    class="binding-option"
+                  >
+                    <input
+                      v-model="employeesBindToCompany"
+                      type="checkbox"
+                    >
+                    <span>Компании "{{ company }}"</span>
+                  </label>
+                </div>
+              </div>
+              <div
+                v-else
+                class="no-binding-message"
+              >
+                Сотрудники "По факту" не требуют привязки к организации/компании
+              </div>
             </div>
           </div>
-        </div>
 
-        <div class="warning-section">
-          <p class="warning-text">
-            <strong class="warning-strong">Внимание!</strong> При привязке данных к организации или компании,
-            они будут доступны для отображения и использования <strong>всем</strong> сотрудникам, которые в них числятся.
-          </p>
-        </div>
+          <div class="warning-section">
+            <p class="warning-text">
+              <strong class="warning-strong">Внимание!</strong> При привязке данных к организации или компании,
+              они будут доступны для отображения и использования <strong>всем</strong> сотрудникам, которые в них числятся.
+            </p>
+          </div>
 
-        <div class="modal-actions">
-          <button
-            class="btn skip-btn"
-            @click="handleSkip"
-          >
-            Отправить без привязки
-          </button>
-          <button
-            class="btn confirm-btn"
-            @click="handleConfirm"
-          >
-            <transition
-              name="fade"
-              mode="out-in"
+          <div class="modal-actions">
+            <button
+              class="btn skip-btn"
+              @click="handleSkip"
             >
-              <span
-                :key="buttonText"
-                class="button-text"
-              >{{ buttonText }}</span>
-            </transition>
-          </button>
+              Отправить без привязки
+            </button>
+            <button
+              class="btn confirm-btn"
+              @click="handleConfirm"
+            >
+              <transition
+                name="fade"
+                mode="out-in"
+              >
+                <span
+                  :key="buttonText"
+                  class="button-text"
+                >{{ buttonText }}</span>
+              </transition>
+            </button>
+          </div>
         </div>
       </div>
     </div>
-  </div>
+  </Teleport>
 </template>
 
 <script>
@@ -323,7 +325,8 @@ export default {
     align-items: center;
     justify-content: center;
     z-index: 1000;
-    backdrop-filter: blur(1px);
+    backdrop-filter: blur(0.1px);
+    -webkit-backdrop-filter: blur(0.1px);
     animation: overlayAppear 0.4s ease-out;
 }
 
@@ -334,7 +337,7 @@ export default {
     }
     to {
         background: rgba(0, 0, 0, 0.5);
-        backdrop-filter: blur(1px);
+        backdrop-filter: blur(0.1px);
     }
 }
 

--- a/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
@@ -1,266 +1,268 @@
 <template>
-  <transition name="modal-fade">
-    <div
-      v-if="show"
-      class="modal-overlay"
-      @mousedown="onOverlayMousedown"
-      @mouseup="onOverlayMouseup"
-    >
-      <div class="modal-wrapper">
-        <!-- Основное модальное окно с деталями ТС -->
-        <div
-          class="modal-content compact-modal main-modal"
-          :class="{ 'shifted': isMainShifted }"
-          @mousedown.stop
-        >
-          <div class="modal-header">
-            <h3 class="modal-title">
-              {{ modalTitle }}
-            </h3>
-            <div
-              v-if="showCarFeatures"
-              class="header-actions"
-            >
-              <button
-                class="history-btn"
-                @click="openCarHistory"
+  <Teleport to="body">
+    <transition name="modal-fade">
+      <div
+        v-if="show"
+        class="modal-overlay"
+        @mousedown="onOverlayMousedown"
+        @mouseup="onOverlayMouseup"
+      >
+        <div class="modal-wrapper">
+          <!-- Основное модальное окно с деталями ТС -->
+          <div
+            class="modal-content compact-modal main-modal"
+            :class="{ 'shifted': isMainShifted }"
+            @mousedown.stop
+          >
+            <div class="modal-header">
+              <h3 class="modal-title">
+                {{ modalTitle }}
+              </h3>
+              <div
+                v-if="showCarFeatures"
+                class="header-actions"
               >
-                <span>Полная история</span>
-              </button>
+                <button
+                  class="history-btn"
+                  @click="openCarHistory"
+                >
+                  <span>Полная история</span>
+                </button>
+                <button
+                  v-if="source !== 'application'"
+                  class="application-btn"
+                  @click="openApplication"
+                >
+                  <span>Открыть заявку</span>
+                </button>
+              </div>
               <button
-                v-if="source !== 'application'"
-                class="application-btn"
-                @click="openApplication"
+                class="modal-close"
+                @click="close"
               >
-                <span>Открыть заявку</span>
+                <svg
+                  width="10"
+                  height="10"
+                  viewBox="0 0 14 14"
+                  fill="none"
+                >
+                  <path
+                    d="M13 1L1 13M1 1L13 13"
+                    stroke="#666"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                  />
+                </svg>
               </button>
             </div>
-            <button
-              class="modal-close"
-              @click="close"
-            >
-              <svg
-                width="10"
-                height="10"
-                viewBox="0 0 14 14"
-                fill="none"
-              >
-                <path
-                  d="M13 1L1 13M1 1L13 13"
-                  stroke="#666"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                />
-              </svg>
-            </button>
-          </div>
                     
-          <div class="modal-body">
-            <!-- Блок предупреждения об активной заявке -->
-            <div
-              v-if="activeInfo"
-              class="active-warning-section"
-            >
-              <div class="warning-content">
-                <div class="warning-text">
-                  <p class="warning-title">
-                    На это авто уже есть активная заявка!
-                  </p>
-                  <p class="warning-details">
-                    Действует до: {{ formatDate(activeInfo.entry_date_to) }} {{ formatTime(activeInfo.entry_time_to) }}<br>
-                    Заявка №{{ activeInfo.application_number }}<br>
-                    Организация: {{ activeInfo.organization_name || 'Не указана' }}<br>
-                    Компания: {{ activeInfo.company_name || 'Не указана' }}
-                  </p>
-                </div>
-              </div>
-            </div>
-
-            <div
-              v-if="vehicle"
-              class="vehicle-details"
-            >
-              <!-- Секция Основная информация -->
-              <div class="details-section">
-                <div class="section-header">
-                  <h4 class="section-title">
-                    Основная информация
-                  </h4>
-                </div>
-                <div class="section-body">
-                  <div class="details-grid two-columns">
-                    <div class="detail-item">
-                      <span class="detail-label">Номер Т/С:</span>
-                      <span class="detail-value">{{ vehicle.plateNumber || 'Не указано' }}</span>
-                    </div>
-                    <div class="detail-item">
-                      <span class="detail-label">Марка:</span>
-                      <span class="detail-value">{{ vehicle.mark || 'Не указано' }}</span>
-                    </div>
-                    <div
-                      v-if="getFormatName(vehicle.formatId)"
-                      class="detail-item full-width"
-                    >
-                      <span class="detail-label">Формат номера:</span>
-                      <span class="detail-value">{{ getFormatName(vehicle.formatId) }}</span>
-                    </div>
-                    <div
-                      v-if="vehicle.organization"
-                      class="detail-item"
-                    >
-                      <span class="detail-label">Организация:</span>
-                      <span class="detail-value">{{ vehicle.organization }}</span>
-                    </div>
-                    <div
-                      v-if="vehicle.company"
-                      class="detail-item"
-                    >
-                      <span class="detail-label">Компания:</span>
-                      <span class="detail-value">{{ vehicle.company }}</span>
-                    </div>
-                    <div
-                      v-if="vehicle.entry_date_to"
-                      class="detail-item"
-                    >
-                      <span class="detail-label">Действует до:</span>
-                      <span class="detail-value">{{ formatDate(vehicle.entry_date_to) }}</span>
-                    </div>
-                    <div
-                      v-if="vehicle.entry_time_from || vehicle.entry_time_to"
-                      class="detail-item"
-                    >
-                      <span class="detail-label">Время пребывания:</span>
-                      <span class="detail-value">{{ formatTimeRange(vehicle.entry_time_from, vehicle.entry_time_to) }}</span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <!-- Секция Места разгрузки -->
-              <div class="details-section">
-                <div class="section-header">
-                  <h4 class="section-title">
-                    Места разгрузки
-                  </h4>
-                </div>
-                <div class="section-body">
-                  <div class="places-list">
-                    <div 
-                      v-for="placeId in vehicle.unloadPlaces" 
-                      :key="placeId"
-                      class="place-item"
-                      :class="{ 'active': showPlaceModal && selectedUnloadPlace && selectedUnloadPlace.id === placeId }"
-                      @click="showUnloadPlaceDetails(placeId)"
-                    >
-                      {{ getPlaceName(placeId) }}
-                    </div>
-                    <div
-                      v-if="!vehicle.unloadPlaces || vehicle.unloadPlaces.length === 0"
-                      class="no-places"
-                    >
-                      Места разгрузки не указаны
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <!-- Секция Статус (только для автомобилей) -->
+            <div class="modal-body">
+              <!-- Блок предупреждения об активной заявке -->
               <div
-                v-if="showCarFeatures"
-                class="details-section"
+                v-if="activeInfo"
+                class="active-warning-section"
               >
-                <div class="section-header">
-                  <h4 class="section-title">
-                    Статус
-                  </h4>
-                </div>
-                <div class="section-body">
-                  <div
-                    class="status-badge"
-                    :class="getStatusClass"
-                  >
-                    {{ getStatusText }}
+                <div class="warning-content">
+                  <div class="warning-text">
+                    <p class="warning-title">
+                      На это авто уже есть активная заявка!
+                    </p>
+                    <p class="warning-details">
+                      Действует до: {{ formatDate(activeInfo.entry_date_to) }} {{ formatTime(activeInfo.entry_time_to) }}<br>
+                      Заявка №{{ activeInfo.application_number }}<br>
+                      Организация: {{ activeInfo.organization_name || 'Не указана' }}<br>
+                      Компания: {{ activeInfo.company_name || 'Не указана' }}
+                    </p>
                   </div>
                 </div>
               </div>
 
-              <!-- Секция История въездов и выездов (только entry/exit) -->
               <div
-                v-if="showCarFeatures"
-                class="details-section"
+                v-if="vehicle"
+                class="vehicle-details"
               >
-                <div class="section-header">
-                  <h4 class="section-title">
-                    История въездов и выездов
-                  </h4>
-                  <button
-                    class="export-btn"
-                    :disabled="entryExitHistory.length === 0 || isExporting"
-                    @click="exportHistory"
-                  >
-                    <img
-                      v-if="!isExporting"
-                      src="@/assets/icons/export.png"
-                      class="export-icon"
+                <!-- Секция Основная информация -->
+                <div class="details-section">
+                  <div class="section-header">
+                    <h4 class="section-title">
+                      Основная информация
+                    </h4>
+                  </div>
+                  <div class="section-body">
+                    <div class="details-grid two-columns">
+                      <div class="detail-item">
+                        <span class="detail-label">Номер Т/С:</span>
+                        <span class="detail-value">{{ vehicle.plateNumber || 'Не указано' }}</span>
+                      </div>
+                      <div class="detail-item">
+                        <span class="detail-label">Марка:</span>
+                        <span class="detail-value">{{ vehicle.mark || 'Не указано' }}</span>
+                      </div>
+                      <div
+                        v-if="getFormatName(vehicle.formatId)"
+                        class="detail-item full-width"
+                      >
+                        <span class="detail-label">Формат номера:</span>
+                        <span class="detail-value">{{ getFormatName(vehicle.formatId) }}</span>
+                      </div>
+                      <div
+                        v-if="vehicle.organization"
+                        class="detail-item"
+                      >
+                        <span class="detail-label">Организация:</span>
+                        <span class="detail-value">{{ vehicle.organization }}</span>
+                      </div>
+                      <div
+                        v-if="vehicle.company"
+                        class="detail-item"
+                      >
+                        <span class="detail-label">Компания:</span>
+                        <span class="detail-value">{{ vehicle.company }}</span>
+                      </div>
+                      <div
+                        v-if="vehicle.entry_date_to"
+                        class="detail-item"
+                      >
+                        <span class="detail-label">Действует до:</span>
+                        <span class="detail-value">{{ formatDate(vehicle.entry_date_to) }}</span>
+                      </div>
+                      <div
+                        v-if="vehicle.entry_time_from || vehicle.entry_time_to"
+                        class="detail-item"
+                      >
+                        <span class="detail-label">Время пребывания:</span>
+                        <span class="detail-value">{{ formatTimeRange(vehicle.entry_time_from, vehicle.entry_time_to) }}</span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- Секция Места разгрузки -->
+                <div class="details-section">
+                  <div class="section-header">
+                    <h4 class="section-title">
+                      Места разгрузки
+                    </h4>
+                  </div>
+                  <div class="section-body">
+                    <div class="places-list">
+                      <div 
+                        v-for="placeId in vehicle.unloadPlaces" 
+                        :key="placeId"
+                        class="place-item"
+                        :class="{ 'active': showPlaceModal && selectedUnloadPlace && selectedUnloadPlace.id === placeId }"
+                        @click="showUnloadPlaceDetails(placeId)"
+                      >
+                        {{ getPlaceName(placeId) }}
+                      </div>
+                      <div
+                        v-if="!vehicle.unloadPlaces || vehicle.unloadPlaces.length === 0"
+                        class="no-places"
+                      >
+                        Места разгрузки не указаны
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- Секция Статус (только для автомобилей) -->
+                <div
+                  v-if="showCarFeatures"
+                  class="details-section"
+                >
+                  <div class="section-header">
+                    <h4 class="section-title">
+                      Статус
+                    </h4>
+                  </div>
+                  <div class="section-body">
+                    <div
+                      class="status-badge"
+                      :class="getStatusClass"
                     >
-                    <span v-if="!isExporting">Экспорт</span>
+                      {{ getStatusText }}
+                    </div>
+                  </div>
+                </div>
+
+                <!-- Секция История въездов и выездов (только entry/exit) -->
+                <div
+                  v-if="showCarFeatures"
+                  class="details-section"
+                >
+                  <div class="section-header">
+                    <h4 class="section-title">
+                      История въездов и выездов
+                    </h4>
+                    <button
+                      class="export-btn"
+                      :disabled="entryExitHistory.length === 0 || isExporting"
+                      @click="exportHistory"
+                    >
+                      <img
+                        v-if="!isExporting"
+                        src="@/assets/icons/export.png"
+                        class="export-icon"
+                      >
+                      <span v-if="!isExporting">Экспорт</span>
+                      <div
+                        v-else
+                        class="export-loader"
+                      />
+                    </button>
+                  </div>
+                  <div class="section-body">
+                    <div
+                      v-if="loadingHistory"
+                      class="loading-container"
+                    >
+                      <LoaderSpinner label="Загрузка истории…" />
+                    </div>
+                                    
+                    <div
+                      v-else-if="entryExitHistory.length === 0"
+                      class="no-history"
+                    >
+                      История въездов и выездов отсутствует
+                    </div>
+                                    
                     <div
                       v-else
-                      class="export-loader"
-                    />
-                  </button>
-                </div>
-                <div class="section-body">
-                  <div
-                    v-if="loadingHistory"
-                    class="loading-container"
-                  >
-                    <LoaderSpinner label="Загрузка истории…" />
-                  </div>
-                                    
-                  <div
-                    v-else-if="entryExitHistory.length === 0"
-                    class="no-history"
-                  >
-                    История въездов и выездов отсутствует
-                  </div>
-                                    
-                  <div
-                    v-else
-                    class="history-timeline"
-                  >
-                    <div 
-                      v-for="(item, index) in entryExitHistory" 
-                      :key="item.id" 
-                      class="history-item"
+                      class="history-timeline"
                     >
-                      <div
-                        class="timeline-dot"
-                        :class="getActionClass(item)"
-                      />
-                      <div
-                        v-if="index < entryExitHistory.length - 1"
-                        class="timeline-line"
-                      />
-                                            
-                      <div class="history-content">
-                        <div class="history-header">
-                          <span class="user-name">{{ item.user_name || 'Система' }}</span>
-                          <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
-                        </div>
-                                                
-                        <div class="action-text">
-                          {{ getActionText(item) }}
-                        </div>
-                                                
-                        <div class="action-comment">
-                          {{ getActionComment(item) }}
-                        </div>
+                      <div 
+                        v-for="(item, index) in entryExitHistory" 
+                        :key="item.id" 
+                        class="history-item"
+                      >
                         <div
-                          v-if="item.table_name"
-                          class="place-name"
-                        >
-                          {{ item.table_name }}
+                          class="timeline-dot"
+                          :class="getActionClass(item)"
+                        />
+                        <div
+                          v-if="index < entryExitHistory.length - 1"
+                          class="timeline-line"
+                        />
+                                            
+                        <div class="history-content">
+                          <div class="history-header">
+                            <span class="user-name">{{ item.user_name || 'Система' }}</span>
+                            <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                          </div>
+                                                
+                          <div class="action-text">
+                            {{ getActionText(item) }}
+                          </div>
+                                                
+                          <div class="action-comment">
+                            {{ getActionComment(item) }}
+                          </div>
+                          <div
+                            v-if="item.table_name"
+                            class="place-name"
+                          >
+                            {{ item.table_name }}
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -269,27 +271,27 @@
               </div>
             </div>
           </div>
-        </div>
 
-        <!-- Дополнительное модальное окно с деталями места разгрузки -->
-        <transition 
-          name="place-slide"
-          @after-leave="onPlaceLeave"
-        >
-          <div
-            v-if="showPlaceModal"
-            class="place-modal-container"
+          <!-- Дополнительное модальное окно с деталями места разгрузки -->
+          <transition 
+            name="place-slide"
+            @after-leave="onPlaceLeave"
           >
-            <UnloadPlaceModal
-              :place="selectedUnloadPlace"
-              :all-unloading-places="allUnloadingPlaces"
-              @close="closeUnloadPlaceDetails"
-            />
-          </div>
-        </transition>
+            <div
+              v-if="showPlaceModal"
+              class="place-modal-container"
+            >
+              <UnloadPlaceModal
+                :place="selectedUnloadPlace"
+                :all-unloading-places="allUnloadingPlaces"
+                @close="closeUnloadPlaceDetails"
+              />
+            </div>
+          </transition>
+        </div>
       </div>
-    </div>
-  </transition>
+    </transition>
+  </Teleport>
 
   <!-- Модальное окно полной истории автомобиля -->
   <CarHistoryModal
@@ -810,12 +812,13 @@ export default {
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.3);
+  background: rgba(0, 0, 0, 0.5);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 1000;
-  backdrop-filter: blur(1px);
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
   animation: overlayAppear 0.4s ease-out;
 }
 
@@ -825,8 +828,8 @@ export default {
     backdrop-filter: blur(0px);
   }
   to {
-    background: rgba(0, 0, 0, 0.3);
-    backdrop-filter: blur(1px);
+    background: rgba(0, 0, 0, 0.5);
+    backdrop-filter: blur(0.1px);
   }
 }
 

--- a/frontend/src/components/CreateUserModal.vue
+++ b/frontend/src/components/CreateUserModal.vue
@@ -1,245 +1,247 @@
 <template>
-  <div
-    class="modal-overlay"
-    @click.self="$emit('close')"
-  >
-    <div class="modal-container">
-      <div class="modal-header">
-        <h3 class="modal-title">
-          Создать новую учётную запись
-        </h3>
-        <button
-          class="modal-close-btn"
-          @click="$emit('close')"
-        >
-          &times;
-        </button>
-      </div>
+  <Teleport to="body">
+    <div
+      class="modal-overlay"
+      @click.self="$emit('close')"
+    >
+      <div class="modal-container">
+        <div class="modal-header">
+          <h3 class="modal-title">
+            Создать новую учётную запись
+          </h3>
+          <button
+            class="modal-close-btn"
+            @click="$emit('close')"
+          >
+            &times;
+          </button>
+        </div>
       
-      <div class="modal-body">
-        <div class="form-section">
-          <h4 class="section-title">
-            Основные данные
-          </h4>
-          <div class="form-grid">
-            <div class="form-group">
-              <label class="form-label">Логин:</label>
-              <input 
-                v-model="newUser.username" 
-                type="text" 
-                placeholder="Введите логин"
-                class="form-input"
-                required
-                autocomplete="off"
-                autocorrect="off"
-                autocapitalize="off"
-                spellcheck="false"
-              >
-            </div>
-
-            <div class="form-group">
-              <label class="form-label">Пароль:</label>
-              <input 
-                v-model="newUser.password" 
-                type="password" 
-                placeholder="Введите пароль"
-                class="form-input"
-                required
-                autocomplete="new-password"
-                autocorrect="off"
-                autocapitalize="off"
-                spellcheck="false"
-              >
-            </div>
-
-            <div class="form-group form-group--full">
-              <label class="form-label">Тип пользователя:</label>
-              <select
-                v-model="newUser.type_id"
-                required
-                class="form-select"
-              >
-                <option
-                  :value="null"
-                  disabled
+        <div class="modal-body">
+          <div class="form-section">
+            <h4 class="section-title">
+              Основные данные
+            </h4>
+            <div class="form-grid">
+              <div class="form-group">
+                <label class="form-label">Логин:</label>
+                <input 
+                  v-model="newUser.username" 
+                  type="text" 
+                  placeholder="Введите логин"
+                  class="form-input"
+                  required
+                  autocomplete="off"
+                  autocorrect="off"
+                  autocapitalize="off"
+                  spellcheck="false"
                 >
-                  Выберите тип
-                </option>
-                <option
-                  v-for="type in userTypes"
-                  :key="type.id"
-                  :value="type.id"
+              </div>
+
+              <div class="form-group">
+                <label class="form-label">Пароль:</label>
+                <input 
+                  v-model="newUser.password" 
+                  type="password" 
+                  placeholder="Введите пароль"
+                  class="form-input"
+                  required
+                  autocomplete="new-password"
+                  autocorrect="off"
+                  autocapitalize="off"
+                  spellcheck="false"
                 >
-                  {{ type.name }}
-                </option>
-              </select>
+              </div>
+
+              <div class="form-group form-group--full">
+                <label class="form-label">Тип пользователя:</label>
+                <select
+                  v-model="newUser.type_id"
+                  required
+                  class="form-select"
+                >
+                  <option
+                    :value="null"
+                    disabled
+                  >
+                    Выберите тип
+                  </option>
+                  <option
+                    v-for="type in userTypes"
+                    :key="type.id"
+                    :value="type.id"
+                  >
+                    {{ type.name }}
+                  </option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <div class="form-section">
+            <h4 class="section-title">
+              Персональные данные
+            </h4>
+            <div class="form-grid">
+              <div class="form-group">
+                <label class="form-label">Фамилия:</label>
+                <input 
+                  v-model="newUser.last_name" 
+                  type="text" 
+                  placeholder="Введите фамилию"
+                  class="form-input"
+                  autocomplete="off"
+                  autocorrect="off"
+                  autocapitalize="off"
+                  spellcheck="false"
+                >
+              </div>
+
+              <div class="form-group">
+                <label class="form-label">Имя:</label>
+                <input 
+                  v-model="newUser.first_name" 
+                  type="text" 
+                  placeholder="Введите имя"
+                  class="form-input"
+                  autocomplete="off"
+                  autocorrect="off"
+                  autocapitalize="off"
+                  spellcheck="false"
+                >
+              </div>
+
+              <div class="form-group">
+                <label class="form-label">Отчество:</label>
+                <input 
+                  v-model="newUser.middle_name" 
+                  type="text" 
+                  placeholder="Введите отчество"
+                  class="form-input"
+                  autocomplete="off"
+                  autocorrect="off"
+                  autocapitalize="off"
+                  spellcheck="false"
+                >
+              </div>
+
+              <div class="form-group">
+                <label class="form-label">Должность:</label>
+                <input 
+                  v-model="newUser.position" 
+                  type="text" 
+                  placeholder="Введите должность"
+                  class="form-input"
+                  autocomplete="off"
+                  autocorrect="off"
+                  autocapitalize="off"
+                  spellcheck="false"
+                >
+              </div>
+
+              <div class="form-group">
+                <label class="form-label">Email:</label>
+                <input 
+                  v-model="newUser.email" 
+                  type="email" 
+                  placeholder="Введите email"
+                  class="form-input"
+                  autocomplete="off"
+                  autocorrect="off"
+                  autocapitalize="off"
+                  spellcheck="false"
+                >
+              </div>
+
+              <div class="form-group">
+                <label class="form-label">Телефон:</label>
+                <input
+                  :value="newUser.phone"
+                  type="tel"
+                  placeholder="+7 (___) ___ __-__"
+                  class="form-input"
+                  autocomplete="off"
+                  autocorrect="off"
+                  autocapitalize="off"
+                  spellcheck="false"
+                  @input="newUser.phone = formatRussianPhone($event.target.value)"
+                >
+              </div>
+            </div>
+          </div>
+
+          <div class="form-section">
+            <h4 class="section-title">
+              Организационные данные
+            </h4>
+            <div class="form-grid">
+              <div class="form-group">
+                <label class="form-label">Компания:</label>
+                <select 
+                  v-model="newUser.company_id" 
+                  required 
+                  class="form-select"
+                >
+                  <option
+                    :value="null"
+                    disabled
+                  >
+                    Выберите компанию
+                  </option>
+                  <option
+                    v-for="comp in companies"
+                    :key="comp.id"
+                    :value="comp.id"
+                  >
+                    {{ comp.name }}
+                  </option>
+                </select>
+              </div>
+
+              <div class="form-group">
+                <label class="form-label">Организация:</label>
+                <select 
+                  v-model="newUser.organization_id" 
+                  required 
+                  class="form-select"
+                >
+                  <option
+                    :value="null"
+                    disabled
+                  >
+                    Выберите организацию
+                  </option>
+                  <option
+                    v-for="org in organizations"
+                    :key="org.id"
+                    :value="org.id"
+                  >
+                    {{ org.name }}
+                  </option>
+                </select>
+              </div>
             </div>
           </div>
         </div>
 
-        <div class="form-section">
-          <h4 class="section-title">
-            Персональные данные
-          </h4>
-          <div class="form-grid">
-            <div class="form-group">
-              <label class="form-label">Фамилия:</label>
-              <input 
-                v-model="newUser.last_name" 
-                type="text" 
-                placeholder="Введите фамилию"
-                class="form-input"
-                autocomplete="off"
-                autocorrect="off"
-                autocapitalize="off"
-                spellcheck="false"
-              >
-            </div>
-
-            <div class="form-group">
-              <label class="form-label">Имя:</label>
-              <input 
-                v-model="newUser.first_name" 
-                type="text" 
-                placeholder="Введите имя"
-                class="form-input"
-                autocomplete="off"
-                autocorrect="off"
-                autocapitalize="off"
-                spellcheck="false"
-              >
-            </div>
-
-            <div class="form-group">
-              <label class="form-label">Отчество:</label>
-              <input 
-                v-model="newUser.middle_name" 
-                type="text" 
-                placeholder="Введите отчество"
-                class="form-input"
-                autocomplete="off"
-                autocorrect="off"
-                autocapitalize="off"
-                spellcheck="false"
-              >
-            </div>
-
-            <div class="form-group">
-              <label class="form-label">Должность:</label>
-              <input 
-                v-model="newUser.position" 
-                type="text" 
-                placeholder="Введите должность"
-                class="form-input"
-                autocomplete="off"
-                autocorrect="off"
-                autocapitalize="off"
-                spellcheck="false"
-              >
-            </div>
-
-            <div class="form-group">
-              <label class="form-label">Email:</label>
-              <input 
-                v-model="newUser.email" 
-                type="email" 
-                placeholder="Введите email"
-                class="form-input"
-                autocomplete="off"
-                autocorrect="off"
-                autocapitalize="off"
-                spellcheck="false"
-              >
-            </div>
-
-            <div class="form-group">
-              <label class="form-label">Телефон:</label>
-              <input
-                :value="newUser.phone"
-                type="tel"
-                placeholder="+7 (___) ___ __-__"
-                class="form-input"
-                autocomplete="off"
-                autocorrect="off"
-                autocapitalize="off"
-                spellcheck="false"
-                @input="newUser.phone = formatRussianPhone($event.target.value)"
-              >
-            </div>
-          </div>
+        <div class="modal-footer">
+          <button
+            class="modal-cancel-btn"
+            @click="$emit('close')"
+          >
+            Отмена
+          </button>
+          <button 
+            :disabled="!isFormValid" 
+            class="modal-confirm-btn"
+            @click="createNewUser"
+          >
+            Создать
+          </button>
         </div>
-
-        <div class="form-section">
-          <h4 class="section-title">
-            Организационные данные
-          </h4>
-          <div class="form-grid">
-            <div class="form-group">
-              <label class="form-label">Компания:</label>
-              <select 
-                v-model="newUser.company_id" 
-                required 
-                class="form-select"
-              >
-                <option
-                  :value="null"
-                  disabled
-                >
-                  Выберите компанию
-                </option>
-                <option
-                  v-for="comp in companies"
-                  :key="comp.id"
-                  :value="comp.id"
-                >
-                  {{ comp.name }}
-                </option>
-              </select>
-            </div>
-
-            <div class="form-group">
-              <label class="form-label">Организация:</label>
-              <select 
-                v-model="newUser.organization_id" 
-                required 
-                class="form-select"
-              >
-                <option
-                  :value="null"
-                  disabled
-                >
-                  Выберите организацию
-                </option>
-                <option
-                  v-for="org in organizations"
-                  :key="org.id"
-                  :value="org.id"
-                >
-                  {{ org.name }}
-                </option>
-              </select>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div class="modal-footer">
-        <button
-          class="modal-cancel-btn"
-          @click="$emit('close')"
-        >
-          Отмена
-        </button>
-        <button 
-          :disabled="!isFormValid" 
-          class="modal-confirm-btn"
-          @click="createNewUser"
-        >
-          Создать
-        </button>
       </div>
     </div>
-  </div>
+  </Teleport>
 </template>
 
 <script>
@@ -358,7 +360,8 @@ export default {
   justify-content: center;
   align-items: center;
   z-index: 1000;
-  backdrop-filter: blur(2px);
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
 }
 
 .modal-container {

--- a/frontend/src/components/EmployeeEditModal.vue
+++ b/frontend/src/components/EmployeeEditModal.vue
@@ -1,284 +1,286 @@
 <template>
-  <div
-    v-if="visible"
-    class="modal-overlay"
-    @click="$emit('close')"
-  >
+  <Teleport to="body">
     <div
-      class="modal-content"
-      @click.stop
+      v-if="visible"
+      class="modal-overlay"
+      @click="$emit('close')"
     >
-      <div class="modal-header">
-        <div class="modal-header__top">
-          <h3>{{ editingEmployee ? 'Редактирование' : 'Добавление сотрудника' }}</h3>
-          <div
-            v-if="notification.show"
-            class="notification-badge"
-            :class="notification.type"
-          >
-            {{ notification.message }}
-          </div>
-        </div>
-        <button
-          class="modal-close"
-          @click="$emit('close')"
-        >
-          ×
-        </button>
-      </div>
-      <div class="modal-body">
-        <div class="data__completion">
-          <div class="completion__citizenship">
-            <div class="citizenship__header">
-              <label class="citizenship__label">Гражданство <span class="required">*</span></label>
-              <button
-                class="add-button"
-                :disabled="!canSaveEmployee"
-                @click="saveEmployee"
-              >
-                {{ editingEmployee ? 'Сохранить' : 'Добавить' }}
-              </button>
-            </div>
-            <div class="citizenship__dropdown">
-              <button
-                class="dropdown__button"
-                @click="toggleCitizenshipDropdown"
-              >
-                <div class="button__content">
-                  <span class="button__text">{{ selectedCitizenshipText }}</span>
-                  <img
-                    src="@/assets/icons/arrow.png"
-                    class="button__arrow"
-                    :class="{ 'button__arrow--open': isCitizenshipDropdownOpen }"
-                  >
-                </div>
-              </button>
-              <transition name="dropdown">
-                <div
-                  v-if="isCitizenshipDropdownOpen"
-                  class="dropdown__menu"
-                >
-                  <div
-                    v-for="citizenship in citizenships"
-                    :key="citizenship.id"
-                    class="dropdown__item"
-                    @click="selectCitizenship(citizenship)"
-                  >
-                    <span class="item__text">{{ citizenship.name }}</span>
-                    <span
-                      v-if="citizenship.patent_required"
-                      class="patent-required-badge"
-                    >Требуется патент</span>
-                  </div>
-                </div>
-              </transition>
-            </div>
-          </div>
-
-          <div class="completion__fields">
-            <!-- Первая строка: Фамилия и Имя -->
-            <div class="completion__name-row">
-              <div class="completion__last-name">
-                <div class="completion__last-name-header">
-                  <label class="input__label">Фамилия <span class="required">*</span></label>
-                </div>
-                <input
-                  v-model="lastName"
-                  class="name__input"
-                  placeholder="Введите фамилию"
-                >
-              </div>
-              <div class="completion__first-name">
-                <div class="completion__first-name-header">
-                  <label class="input__label">Имя <span class="required">*</span></label>
-                </div>
-                <input
-                  v-model="firstName"
-                  class="name__input"
-                  placeholder="Введите имя"
-                >
-              </div>
-            </div>
-
-            <!-- Вторая строка: Отчество и Должность -->
-            <div class="completion__name-row">
-              <div class="completion__middle-name">
-                <div class="completion__middle-name-header">
-                  <label class="input__label">Отчество</label>
-                </div>
-                <input
-                  v-model="middleName"
-                  class="name__input"
-                  placeholder="Введите отчество"
-                >
-              </div>
-              <div class="completion__position">
-                <div class="completion__position-header">
-                  <label class="input__label">Должность <span class="required">*</span></label>
-                </div>
-                <input
-                  v-model="position"
-                  class="name__input"
-                  placeholder="Введите должность"
-                >
-              </div>
-            </div>
-
-            <!-- Третья строка: Паспорт и Номер патента -->
-            <div class="completion__name-row">
-              <div class="completion__passport">
-                <div class="completion__passport-header">
-                  <label class="input__label">Серия и номер паспорта <span class="required">*</span></label>
-                </div>
-                <input
-                  v-model="passportSeriesNumber"
-                  class="name__input"
-                  placeholder="XXXX XXXXXX"
-                  @input="formatPassport"
-                >
-              </div>
-              <div
-                class="completion__patent"
-                :class="{ 'disabled-field': !isPatentRequired }"
-              >
-                <div class="completion__patent-header">
-                  <label class="input__label">Номер патента</label>
-                </div>
-                <input
-                  v-model="patentNumber"
-                  class="name__input"
-                  placeholder="Введите номер патента"
-                  :disabled="!isPatentRequired || selectedPermission !== 'Не выбрано'"
-                  @input="handlePatentInput"
-                >
-              </div>
-            </div>
-
-            <!-- Четвертая строка: Иное разрешение -->
+      <div
+        class="modal-content"
+        @click.stop
+      >
+        <div class="modal-header">
+          <div class="modal-header__top">
+            <h3>{{ editingEmployee ? 'Редактирование' : 'Добавление сотрудника' }}</h3>
             <div
-              class="completion__permission"
-              :class="{ 'disabled-field': !isPatentRequired }"
+              v-if="notification.show"
+              class="notification-badge"
+              :class="notification.type"
             >
-              <div class="completion__permission-header">
-                <label class="input__label">Иное разрешение на работы</label>
-              </div>
-              <div class="permission__dropdown">
+              {{ notification.message }}
+            </div>
+          </div>
+          <button
+            class="modal-close"
+            @click="$emit('close')"
+          >
+            ×
+          </button>
+        </div>
+        <div class="modal-body">
+          <div class="data__completion">
+            <div class="completion__citizenship">
+              <div class="citizenship__header">
+                <label class="citizenship__label">Гражданство <span class="required">*</span></label>
                 <button
-                  class="permission__dropdown-button"
-                  :disabled="!isPatentRequired || patentNumber.trim() !== ''"
-                  @click="togglePermissionDropdown"
+                  class="add-button"
+                  :disabled="!canSaveEmployee"
+                  @click="saveEmployee"
                 >
-                  <div class="permission__button-content">
-                    <span class="permission__button-text">{{ selectedPermission || 'Не выбрано' }}</span>
+                  {{ editingEmployee ? 'Сохранить' : 'Добавить' }}
+                </button>
+              </div>
+              <div class="citizenship__dropdown">
+                <button
+                  class="dropdown__button"
+                  @click="toggleCitizenshipDropdown"
+                >
+                  <div class="button__content">
+                    <span class="button__text">{{ selectedCitizenshipText }}</span>
                     <img
                       src="@/assets/icons/arrow.png"
-                      class="permission__button-arrow"
-                      :class="{ 'permission__button-arrow--open': isPermissionDropdownOpen }"
+                      class="button__arrow"
+                      :class="{ 'button__arrow--open': isCitizenshipDropdownOpen }"
                     >
                   </div>
                 </button>
                 <transition name="dropdown">
                   <div
-                    v-if="isPermissionDropdownOpen"
-                    class="permission__dropdown-menu"
+                    v-if="isCitizenshipDropdownOpen"
+                    class="dropdown__menu"
                   >
                     <div
-                      v-for="permission in availablePermissions"
-                      :key="permission"
-                      class="permission__dropdown-item"
-                      @click="selectPermission(permission)"
+                      v-for="citizenship in citizenships"
+                      :key="citizenship.id"
+                      class="dropdown__item"
+                      @click="selectCitizenship(citizenship)"
                     >
-                      <span class="permission__item-text">{{ permission }}</span>
+                      <span class="item__text">{{ citizenship.name }}</span>
+                      <span
+                        v-if="citizenship.patent_required"
+                        class="patent-required-badge"
+                      >Требуется патент</span>
                     </div>
                   </div>
                 </transition>
               </div>
             </div>
 
-            <!-- Загрузка файлов -->
-            <div
-              v-if="isPatentRequired"
-              class="completion__files"
-            >
-              <div class="completion__files-header">
-                <label class="input__label">Фото, скан документа(-ов), подтверждающее иное разрешение на работы</label>
-              </div>
-              <div class="files__upload">
-                <input
-                  ref="fileInput"
-                  type="file"
-                  multiple
-                  accept="image/*,.pdf,.doc,.docx"
-                  class="file-input"
-                  @change="handleFileUpload"
-                >
-                <button
-                  class="upload-button"
-                  @click="triggerFileInput"
-                >
-                  Загрузить
-                </button>
-              </div>
-              <div
-                v-if="uploadedFiles.length > 0"
-                class="uploaded-files"
-              >
-                <div
-                  v-for="(file, index) in uploadedFiles"
-                  :key="index"
-                  class="uploaded-file"
-                >
-                  <span class="file-name">{{ truncateText(file.name, 30) }}</span>
-                  <button
-                    class="remove-file-btn"
-                    @click="removeFile(index)"
+            <div class="completion__fields">
+              <!-- Первая строка: Фамилия и Имя -->
+              <div class="completion__name-row">
+                <div class="completion__last-name">
+                  <div class="completion__last-name-header">
+                    <label class="input__label">Фамилия <span class="required">*</span></label>
+                  </div>
+                  <input
+                    v-model="lastName"
+                    class="name__input"
+                    placeholder="Введите фамилию"
                   >
-                    ×
+                </div>
+                <div class="completion__first-name">
+                  <div class="completion__first-name-header">
+                    <label class="input__label">Имя <span class="required">*</span></label>
+                  </div>
+                  <input
+                    v-model="firstName"
+                    class="name__input"
+                    placeholder="Введите имя"
+                  >
+                </div>
+              </div>
+
+              <!-- Вторая строка: Отчество и Должность -->
+              <div class="completion__name-row">
+                <div class="completion__middle-name">
+                  <div class="completion__middle-name-header">
+                    <label class="input__label">Отчество</label>
+                  </div>
+                  <input
+                    v-model="middleName"
+                    class="name__input"
+                    placeholder="Введите отчество"
+                  >
+                </div>
+                <div class="completion__position">
+                  <div class="completion__position-header">
+                    <label class="input__label">Должность <span class="required">*</span></label>
+                  </div>
+                  <input
+                    v-model="position"
+                    class="name__input"
+                    placeholder="Введите должность"
+                  >
+                </div>
+              </div>
+
+              <!-- Третья строка: Паспорт и Номер патента -->
+              <div class="completion__name-row">
+                <div class="completion__passport">
+                  <div class="completion__passport-header">
+                    <label class="input__label">Серия и номер паспорта <span class="required">*</span></label>
+                  </div>
+                  <input
+                    v-model="passportSeriesNumber"
+                    class="name__input"
+                    placeholder="XXXX XXXXXX"
+                    @input="formatPassport"
+                  >
+                </div>
+                <div
+                  class="completion__patent"
+                  :class="{ 'disabled-field': !isPatentRequired }"
+                >
+                  <div class="completion__patent-header">
+                    <label class="input__label">Номер патента</label>
+                  </div>
+                  <input
+                    v-model="patentNumber"
+                    class="name__input"
+                    placeholder="Введите номер патента"
+                    :disabled="!isPatentRequired || selectedPermission !== 'Не выбрано'"
+                    @input="handlePatentInput"
+                  >
+                </div>
+              </div>
+
+              <!-- Четвертая строка: Иное разрешение -->
+              <div
+                class="completion__permission"
+                :class="{ 'disabled-field': !isPatentRequired }"
+              >
+                <div class="completion__permission-header">
+                  <label class="input__label">Иное разрешение на работы</label>
+                </div>
+                <div class="permission__dropdown">
+                  <button
+                    class="permission__dropdown-button"
+                    :disabled="!isPatentRequired || patentNumber.trim() !== ''"
+                    @click="togglePermissionDropdown"
+                  >
+                    <div class="permission__button-content">
+                      <span class="permission__button-text">{{ selectedPermission || 'Не выбрано' }}</span>
+                      <img
+                        src="@/assets/icons/arrow.png"
+                        class="permission__button-arrow"
+                        :class="{ 'permission__button-arrow--open': isPermissionDropdownOpen }"
+                      >
+                    </div>
                   </button>
+                  <transition name="dropdown">
+                    <div
+                      v-if="isPermissionDropdownOpen"
+                      class="permission__dropdown-menu"
+                    >
+                      <div
+                        v-for="permission in availablePermissions"
+                        :key="permission"
+                        class="permission__dropdown-item"
+                        @click="selectPermission(permission)"
+                      >
+                        <span class="permission__item-text">{{ permission }}</span>
+                      </div>
+                    </div>
+                  </transition>
+                </div>
+              </div>
+
+              <!-- Загрузка файлов -->
+              <div
+                v-if="isPatentRequired"
+                class="completion__files"
+              >
+                <div class="completion__files-header">
+                  <label class="input__label">Фото, скан документа(-ов), подтверждающее иное разрешение на работы</label>
+                </div>
+                <div class="files__upload">
+                  <input
+                    ref="fileInput"
+                    type="file"
+                    multiple
+                    accept="image/*,.pdf,.doc,.docx"
+                    class="file-input"
+                    @change="handleFileUpload"
+                  >
+                  <button
+                    class="upload-button"
+                    @click="triggerFileInput"
+                  >
+                    Загрузить
+                  </button>
+                </div>
+                <div
+                  v-if="uploadedFiles.length > 0"
+                  class="uploaded-files"
+                >
+                  <div
+                    v-for="(file, index) in uploadedFiles"
+                    :key="index"
+                    class="uploaded-file"
+                  >
+                    <span class="file-name">{{ truncateText(file.name, 30) }}</span>
+                    <button
+                      class="remove-file-btn"
+                      @click="removeFile(index)"
+                    >
+                      ×
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
 
-          <!-- Привязка -->
-          <div class="completion__binding">
-            <label class="input__label">Привязка</label>
-            <div class="binding-info">
-              <p class="binding-note">
-                <strong>Добавляемый сотрудник автоматически привязывается к аккаунту пользователя.</strong>
-                Сотрудника можно привязать к организации или компании, для использования <strong>другими сотрудниками</strong>:
-              </p>
-            </div>
-            <div class="binding-options">
-              <label
-                v-if="ownershipInfo && ownershipInfo.has_organization"
-                class="binding-option"
-              >
-                <input
-                  v-model="bindToOrganization"
-                  type="checkbox"
+            <!-- Привязка -->
+            <div class="completion__binding">
+              <label class="input__label">Привязка</label>
+              <div class="binding-info">
+                <p class="binding-note">
+                  <strong>Добавляемый сотрудник автоматически привязывается к аккаунту пользователя.</strong>
+                  Сотрудника можно привязать к организации или компании, для использования <strong>другими сотрудниками</strong>:
+                </p>
+              </div>
+              <div class="binding-options">
+                <label
+                  v-if="ownershipInfo && ownershipInfo.has_organization"
+                  class="binding-option"
                 >
-                <span>Привязать к организации</span>
-              </label>
-              <label
-                v-if="ownershipInfo && ownershipInfo.has_company"
-                class="binding-option"
-              >
-                <input
-                  v-model="bindToCompany"
-                  type="checkbox"
+                  <input
+                    v-model="bindToOrganization"
+                    type="checkbox"
+                  >
+                  <span>Привязать к организации</span>
+                </label>
+                <label
+                  v-if="ownershipInfo && ownershipInfo.has_company"
+                  class="binding-option"
                 >
-                <span>Привязать к компании</span>
-              </label>
-              <div class="user-binding">
-                <span class="user-binding-text"><strong class="red">Внимание!</strong> При привязке сотрудника к организации или компании, он будет доступен для отображения и использования для всех сотрудников, привязанных к организации/компании. </span>
+                  <input
+                    v-model="bindToCompany"
+                    type="checkbox"
+                  >
+                  <span>Привязать к компании</span>
+                </label>
+                <div class="user-binding">
+                  <span class="user-binding-text"><strong class="red">Внимание!</strong> При привязке сотрудника к организации или компании, он будет доступен для отображения и использования для всех сотрудников, привязанных к организации/компании. </span>
+                </div>
               </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
+  </Teleport>
 </template>
 
 <script>
@@ -724,6 +726,8 @@ export default {
     align-items: center;
     justify-content: center;
     z-index: 1000;
+    backdrop-filter: blur(0.1px);
+    -webkit-backdrop-filter: blur(0.1px);
 }
 
 .modal-content {

--- a/frontend/src/components/FeedbackModal.vue
+++ b/frontend/src/components/FeedbackModal.vue
@@ -482,13 +482,14 @@ export default {
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: rgba(0, 0, 0, 0.75);
+  background-color: rgba(0, 0, 0, 0.5);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 9999;
   padding: 20px;
-  backdrop-filter: blur(4px);
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
 }
 
 .modal {

--- a/frontend/src/components/NumberFormat.vue
+++ b/frontend/src/components/NumberFormat.vue
@@ -216,379 +216,383 @@
     </div>
 
     <!-- Модальное окно добавления формата -->
-    <div
-      v-if="showAddModal"
-      class="modal-overlay"
-      @click.self="showAddModal = false"
-    >
-      <div class="modal-content horizontal-modal">
-        <div class="modal-header">
-          <h3>Добавить формат номеров</h3>
-          <button
-            class="modal-close"
-            @click="showAddModal = false"
-          >
-            ×
-          </button>
-        </div>
-        
-        <div class="modal-body-horizontal">
-          <!-- Левая часть - основная информация -->
-          <div class="modal-main-info">
-            <div class="main-fields">
-              <div class="form-group-compact">
-                <label class="form-label-compact">Название формата</label>
-                <input
-                  v-model="newFormat.name"
-                  placeholder="Российские номера"
-                  class="input-compact"
-                >
-              </div>
-              
-              <div class="form-group-compact">
-                <label class="form-label-compact">Код страны</label>
-                <input
-                  v-model="newFormat.country_code"
-                  placeholder="RU"
-                  class="input-compact"
-                >
-              </div>
-
-              <div class="default-checkbox-modal">
-                <label class="default-checkbox-label-modal">
-                  <input 
-                    v-model="newFormat.is_default" 
-                    type="checkbox"
-                    class="default-checkbox"
-                  >
-                  <span class="default-checkbox-text-modal">Формат по умолчанию</span>
-                </label>
-                <span class="default-checkbox-hint-modal">
-                  Этот формат будет выбран по умолчанию при создании нового Т/С
-                </span>
-              </div>
-            </div>
+    <Teleport to="body">
+      <div
+        v-if="showAddModal"
+        class="modal-overlay"
+        @click.self="showAddModal = false"
+      >
+        <div class="modal-content horizontal-modal">
+          <div class="modal-header">
+            <h3>Добавить формат номеров</h3>
+            <button
+              class="modal-close"
+              @click="showAddModal = false"
+            >
+              ×
+            </button>
           </div>
+        
+          <div class="modal-body-horizontal">
+            <!-- Левая часть - основная информация -->
+            <div class="modal-main-info">
+              <div class="main-fields">
+                <div class="form-group-compact">
+                  <label class="form-label-compact">Название формата</label>
+                  <input
+                    v-model="newFormat.name"
+                    placeholder="Российские номера"
+                    class="input-compact"
+                  >
+                </div>
+              
+                <div class="form-group-compact">
+                  <label class="form-label-compact">Код страны</label>
+                  <input
+                    v-model="newFormat.country_code"
+                    placeholder="RU"
+                    class="input-compact"
+                  >
+                </div>
 
-          <!-- Правая часть - клетки -->
-          <div class="modal-cells-section">
-            <div class="cells-header-compact">
-              <h4 class="cells-title-compact">
-                Клетки формата
-              </h4>
-              <button
-                class="add-cell-btn-header"
-                @click="addCell"
-              >
-                + Добавить клетку
-              </button>
-            </div>
-            
-            <div class="cells-scroll-container">
-              <div class="cells-grid-compact">
-                <div 
-                  v-for="(cell, index) in newFormat.cells" 
-                  :key="index"
-                  class="cell-card-compact"
-                >
-                  <div class="cell-header-mini">
-                    <span class="cell-number-mini">Клетка №{{ index + 1 }}</span>
-                    <button 
-                      v-if="newFormat.cells.length > 1"
-                      class="remove-cell-btn-mini"
-                      title="Удалить клетку"
-                      @click="removeCell(index)"
+                <div class="default-checkbox-modal">
+                  <label class="default-checkbox-label-modal">
+                    <input 
+                      v-model="newFormat.is_default" 
+                      type="checkbox"
+                      class="default-checkbox"
                     >
-                      ×
-                    </button>
-                  </div>
-                  
-                  <div class="cell-config-mini">
-                    <div class="config-group-mini">
-                      <label>Тип</label>
-                      <select
-                        v-model="cell.cell_type"
-                        class="select-mini"
+                    <span class="default-checkbox-text-modal">Формат по умолчанию</span>
+                  </label>
+                  <span class="default-checkbox-hint-modal">
+                    Этот формат будет выбран по умолчанию при создании нового Т/С
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            <!-- Правая часть - клетки -->
+            <div class="modal-cells-section">
+              <div class="cells-header-compact">
+                <h4 class="cells-title-compact">
+                  Клетки формата
+                </h4>
+                <button
+                  class="add-cell-btn-header"
+                  @click="addCell"
+                >
+                  + Добавить клетку
+                </button>
+              </div>
+            
+              <div class="cells-scroll-container">
+                <div class="cells-grid-compact">
+                  <div 
+                    v-for="(cell, index) in newFormat.cells" 
+                    :key="index"
+                    class="cell-card-compact"
+                  >
+                    <div class="cell-header-mini">
+                      <span class="cell-number-mini">Клетка №{{ index + 1 }}</span>
+                      <button 
+                        v-if="newFormat.cells.length > 1"
+                        class="remove-cell-btn-mini"
+                        title="Удалить клетку"
+                        @click="removeCell(index)"
                       >
-                        <option value="letters">
-                          Буквы
-                        </option>
-                        <option value="numbers">
-                          Цифры
-                        </option>
-                        <option value="mixed">
-                          Смешанный
-                        </option>
-                      </select>
+                        ×
+                      </button>
                     </div>
-                    
-                    <div class="config-group-mini">
-                      <label>Длина</label>
-                      <div class="length-controls-mini">
-                        <input 
-                          v-model.number="cell.min_length" 
-                          type="number" 
-                          min="1" 
-                          max="10"
-                          class="input-micro"
-                          placeholder="мин"
+                  
+                    <div class="cell-config-mini">
+                      <div class="config-group-mini">
+                        <label>Тип</label>
+                        <select
+                          v-model="cell.cell_type"
+                          class="select-mini"
                         >
-                        <span class="length-dash">-</span>
+                          <option value="letters">
+                            Буквы
+                          </option>
+                          <option value="numbers">
+                            Цифры
+                          </option>
+                          <option value="mixed">
+                            Смешанный
+                          </option>
+                        </select>
+                      </div>
+                    
+                      <div class="config-group-mini">
+                        <label>Длина</label>
+                        <div class="length-controls-mini">
+                          <input 
+                            v-model.number="cell.min_length" 
+                            type="number" 
+                            min="1" 
+                            max="10"
+                            class="input-micro"
+                            placeholder="мин"
+                          >
+                          <span class="length-dash">-</span>
+                          <input 
+                            v-model.number="cell.max_length" 
+                            type="number" 
+                            min="1" 
+                            max="10"
+                            class="input-micro"
+                            placeholder="макс"
+                          >
+                        </div>
+                      </div>
+
+                      <div
+                        v-if="cell.cell_type !== 'numbers'"
+                        class="config-group-mini"
+                      >
+                        <label>Алфавит</label>
+                        <select
+                          v-model="cell.alphabet_type"
+                          class="select-mini"
+                        >
+                          <option value="cyrillic">
+                            Кириллица
+                          </option>
+                          <option value="latin">
+                            Латиница
+                          </option>
+                          <option value="both">
+                            Оба
+                          </option>
+                        </select>
+                      </div>
+                    
+                      <div
+                        v-if="cell.cell_type === 'numbers'"
+                        class="config-group-mini"
+                      >
+                        <label>Дополнение</label>
+                        <select
+                          v-model="cell.padding_side"
+                          class="select-mini"
+                        >
+                          <option value="left">
+                            Слева
+                          </option>
+                          <option value="right">
+                            Справа
+                          </option>
+                        </select>
+                      </div>
+
+                      <div
+                        v-if="cell.cell_type !== 'numbers'"
+                        class="config-group-full-mini"
+                      >
+                        <label>Разрешенные буквы</label>
                         <input 
-                          v-model.number="cell.max_length" 
-                          type="number" 
-                          min="1" 
-                          max="10"
-                          class="input-micro"
-                          placeholder="макс"
+                          v-model="cell.allowed_letters"
+                          placeholder="АВЕКМНОРСТУХ"
+                          class="input-compact"
                         >
                       </div>
                     </div>
-
-                    <div
-                      v-if="cell.cell_type !== 'numbers'"
-                      class="config-group-mini"
-                    >
-                      <label>Алфавит</label>
-                      <select
-                        v-model="cell.alphabet_type"
-                        class="select-mini"
-                      >
-                        <option value="cyrillic">
-                          Кириллица
-                        </option>
-                        <option value="latin">
-                          Латиница
-                        </option>
-                        <option value="both">
-                          Оба
-                        </option>
-                      </select>
-                    </div>
-                    
-                    <div
-                      v-if="cell.cell_type === 'numbers'"
-                      class="config-group-mini"
-                    >
-                      <label>Дополнение</label>
-                      <select
-                        v-model="cell.padding_side"
-                        class="select-mini"
-                      >
-                        <option value="left">
-                          Слева
-                        </option>
-                        <option value="right">
-                          Справа
-                        </option>
-                      </select>
-                    </div>
-
-                    <div
-                      v-if="cell.cell_type !== 'numbers'"
-                      class="config-group-full-mini"
-                    >
-                      <label>Разрешенные буквы</label>
-                      <input 
-                        v-model="cell.allowed_letters"
-                        placeholder="АВЕКМНОРСТУХ"
-                        class="input-compact"
-                      >
-                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
         
-        <div class="modal-footer">
-          <button
-            class="modal-cancel"
-            @click="showAddModal = false"
-          >
-            Отмена
-          </button>
-          <button
-            class="modal-confirm"
-            @click="addFormat"
-          >
-            Добавить
-          </button>
+          <div class="modal-footer">
+            <button
+              class="modal-cancel"
+              @click="showAddModal = false"
+            >
+              Отмена
+            </button>
+            <button
+              class="modal-confirm"
+              @click="addFormat"
+            >
+              Добавить
+            </button>
+          </div>
         </div>
       </div>
-    </div>
+    </Teleport>
 
     <!-- Модальное окно редактирования клетки -->
-    <div
-      v-if="showCellEditModal"
-      class="modal-overlay"
-      @click.self="showCellEditModal = false"
-    >
-      <div class="modal-content horizontal-modal cell-edit-modal">
-        <div class="modal-header">
-          <h3>Редактировать клетку {{ editingCellIndex + 1 }}</h3>
-          <button
-            class="modal-close"
-            @click="showCellEditModal = false"
-          >
-            ×
-          </button>
-        </div>
-        
-        <div class="modal-body-horizontal">
-          <!-- Левая часть - основные настройки -->
-          <div class="modal-main-info">
-            <div class="main-fields">
-              <div class="form-group-compact">
-                <label class="form-label-compact">Тип клетки</label>
-                <select
-                  v-model="editingCell.cell_type"
-                  class="select-mini"
-                >
-                  <option value="letters">
-                    Буквы
-                  </option>
-                  <option value="numbers">
-                    Цифры
-                  </option>
-                  <option value="mixed">
-                    Смешанный
-                  </option>
-                </select>
-              </div>
-              
-              <div class="form-row-horizontal">
-                <div class="form-group-compact">
-                  <label class="form-label-compact">Мин. длина</label>
-                  <input 
-                    v-model.number="editingCell.min_length" 
-                    type="number" 
-                    min="1" 
-                    max="10"
-                    class="input-compact"
-                  >
-                </div>
-                <div class="form-group-compact">
-                  <label class="form-label-compact">Макс. длина</label>
-                  <input 
-                    v-model.number="editingCell.max_length" 
-                    type="number" 
-                    min="1" 
-                    max="10"
-                    class="input-compact"
-                  >
-                </div>
-              </div>
-
-              <div
-                v-if="editingCell.cell_type !== 'numbers'"
-                class="form-group-compact"
-              >
-                <label class="form-label-compact">Алфавит</label>
-                <select
-                  v-model="editingCell.alphabet_type"
-                  class="select-mini"
-                >
-                  <option value="cyrillic">
-                    Кириллица
-                  </option>
-                  <option value="latin">
-                    Латиница
-                  </option>
-                  <option value="both">
-                    Оба
-                  </option>
-                </select>
-              </div>
-              
-              <div
-                v-if="editingCell.cell_type === 'numbers'"
-                class="form-group-compact"
-              >
-                <label class="form-label-compact">Дополнение нулями</label>
-                <select
-                  v-model="editingCell.padding_side"
-                  class="select-mini"
-                >
-                  <option value="left">
-                    Слева
-                  </option>
-                  <option value="right">
-                    Справа
-                  </option>
-                </select>
-              </div>
-            </div>
+    <Teleport to="body">
+      <div
+        v-if="showCellEditModal"
+        class="modal-overlay"
+        @click.self="showCellEditModal = false"
+      >
+        <div class="modal-content horizontal-modal cell-edit-modal">
+          <div class="modal-header">
+            <h3>Редактировать клетку {{ editingCellIndex + 1 }}</h3>
+            <button
+              class="modal-close"
+              @click="showCellEditModal = false"
+            >
+              ×
+            </button>
           </div>
+        
+          <div class="modal-body-horizontal">
+            <!-- Левая часть - основные настройки -->
+            <div class="modal-main-info">
+              <div class="main-fields">
+                <div class="form-group-compact">
+                  <label class="form-label-compact">Тип клетки</label>
+                  <select
+                    v-model="editingCell.cell_type"
+                    class="select-mini"
+                  >
+                    <option value="letters">
+                      Буквы
+                    </option>
+                    <option value="numbers">
+                      Цифры
+                    </option>
+                    <option value="mixed">
+                      Смешанный
+                    </option>
+                  </select>
+                </div>
+              
+                <div class="form-row-horizontal">
+                  <div class="form-group-compact">
+                    <label class="form-label-compact">Мин. длина</label>
+                    <input 
+                      v-model.number="editingCell.min_length" 
+                      type="number" 
+                      min="1" 
+                      max="10"
+                      class="input-compact"
+                    >
+                  </div>
+                  <div class="form-group-compact">
+                    <label class="form-label-compact">Макс. длина</label>
+                    <input 
+                      v-model.number="editingCell.max_length" 
+                      type="number" 
+                      min="1" 
+                      max="10"
+                      class="input-compact"
+                    >
+                  </div>
+                </div>
 
-          <!-- Правая часть - дополнительные настройки -->
-          <div class="modal-cells-section">
-            <div class="cells-header-compact">
-              <h4 class="cells-title-compact">
-                Дополнительные настройки
-              </h4>
-            </div>
-            
-            <div class="cells-scroll-container">
-              <div class="cell-edit-details">
                 <div
                   v-if="editingCell.cell_type !== 'numbers'"
                   class="form-group-compact"
                 >
-                  <label class="form-label-compact">Разрешенные буквы</label>
-                  <input 
-                    v-model="editingCell.allowed_letters"
-                    placeholder="АВЕКМНОРСТУХ"
-                    class="input-compact"
+                  <label class="form-label-compact">Алфавит</label>
+                  <select
+                    v-model="editingCell.alphabet_type"
+                    class="select-mini"
                   >
-                  <span class="form-hint">
-                    Оставьте пустым для использования всех букв выбранного алфавита
-                  </span>
+                    <option value="cyrillic">
+                      Кириллица
+                    </option>
+                    <option value="latin">
+                      Латиница
+                    </option>
+                    <option value="both">
+                      Оба
+                    </option>
+                  </select>
                 </div>
+              
+                <div
+                  v-if="editingCell.cell_type === 'numbers'"
+                  class="form-group-compact"
+                >
+                  <label class="form-label-compact">Дополнение нулями</label>
+                  <select
+                    v-model="editingCell.padding_side"
+                    class="select-mini"
+                  >
+                    <option value="left">
+                      Слева
+                    </option>
+                    <option value="right">
+                      Справа
+                    </option>
+                  </select>
+                </div>
+              </div>
+            </div>
+
+            <!-- Правая часть - дополнительные настройки -->
+            <div class="modal-cells-section">
+              <div class="cells-header-compact">
+                <h4 class="cells-title-compact">
+                  Дополнительные настройки
+                </h4>
+              </div>
+            
+              <div class="cells-scroll-container">
+                <div class="cell-edit-details">
+                  <div
+                    v-if="editingCell.cell_type !== 'numbers'"
+                    class="form-group-compact"
+                  >
+                    <label class="form-label-compact">Разрешенные буквы</label>
+                    <input 
+                      v-model="editingCell.allowed_letters"
+                      placeholder="АВЕКМНОРСТУХ"
+                      class="input-compact"
+                    >
+                    <span class="form-hint">
+                      Оставьте пустым для использования всех букв выбранного алфавита
+                    </span>
+                  </div>
                 
-                <div class="cell-preview-section">
-                  <h5 class="preview-title">
-                    Предпросмотр клетки
-                  </h5>
-                  <div class="preview-content">
-                    <div class="preview-example">
-                      {{ getCellPreview(editingCell) }}
-                    </div>
-                    <div class="preview-info">
-                      <span class="preview-length">
-                        Длина: {{ editingCell.min_length }}-{{ editingCell.max_length }} символов
-                      </span>
-                      <span
-                        v-if="editingCell.allowed_letters"
-                        class="preview-letters"
-                      >
-                        Разрешённые символы: {{ editingCell.allowed_letters }}
-                      </span>
+                  <div class="cell-preview-section">
+                    <h5 class="preview-title">
+                      Предпросмотр клетки
+                    </h5>
+                    <div class="preview-content">
+                      <div class="preview-example">
+                        {{ getCellPreview(editingCell) }}
+                      </div>
+                      <div class="preview-info">
+                        <span class="preview-length">
+                          Длина: {{ editingCell.min_length }}-{{ editingCell.max_length }} символов
+                        </span>
+                        <span
+                          v-if="editingCell.allowed_letters"
+                          class="preview-letters"
+                        >
+                          Разрешённые символы: {{ editingCell.allowed_letters }}
+                        </span>
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
         
-        <div class="modal-footer">
-          <button
-            class="modal-cancel"
-            @click="showCellEditModal = false"
-          >
-            Отмена
-          </button>
-          <button
-            class="modal-confirm"
-            @click="saveCellEdit"
-          >
-            Сохранить
-          </button>
+          <div class="modal-footer">
+            <button
+              class="modal-cancel"
+              @click="showCellEditModal = false"
+            >
+              Отмена
+            </button>
+            <button
+              class="modal-confirm"
+              @click="saveCellEdit"
+            >
+              Сохранить
+            </button>
+          </div>
         </div>
       </div>
-    </div>
+    </Teleport>
   </div>
 </template>
 
@@ -1487,12 +1491,14 @@ export default {
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.05);
+  background: rgba(0, 0, 0, 0.5);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 1000;
   padding: 20px;
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
 }
 
 .horizontal-modal {

--- a/frontend/src/components/OrganizationsManagement.vue
+++ b/frontend/src/components/OrganizationsManagement.vue
@@ -209,72 +209,74 @@
     </div>
 
     <!-- Модальное окно добавления -->
-    <transition name="modal-fade">
-      <div
-        v-if="showAddModal"
-        class="modal-overlay"
-        @click.self="closeModal"
-      >
-        <div class="modal-content">
-          <div class="modal-header">
-            <h3 class="modal-title">
-              Добавить организацию
-            </h3>
-            <button
-              class="modal-close"
-              @click="closeModal"
-            >
-              <svg
-                width="10"
-                height="10"
-                viewBox="0 0 14 14"
-                fill="none"
+    <Teleport to="body">
+      <transition name="modal-fade">
+        <div
+          v-if="showAddModal"
+          class="modal-overlay"
+          @click.self="closeModal"
+        >
+          <div class="modal-content">
+            <div class="modal-header">
+              <h3 class="modal-title">
+                Добавить организацию
+              </h3>
+              <button
+                class="modal-close"
+                @click="closeModal"
               >
-                <path
-                  d="M13 1L1 13M1 1L13 13"
-                  stroke="#666"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                />
-              </svg>
-            </button>
-          </div>
+                <svg
+                  width="10"
+                  height="10"
+                  viewBox="0 0 14 14"
+                  fill="none"
+                >
+                  <path
+                    d="M13 1L1 13M1 1L13 13"
+                    stroke="#666"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                  />
+                </svg>
+              </button>
+            </div>
           
-          <div class="modal-body">
-            <div class="input-group">
-              <label class="input-label">Название организации</label>
-              <input
-                ref="nameInput"
-                v-model="newOrganizationName"
-                placeholder="Введите название организации"
-                class="modal-input"
-                @keyup.enter="addOrganization"
-              >
-              <div class="input-hint">
-                Обязательное поле
+            <div class="modal-body">
+              <div class="input-group">
+                <label class="input-label">Название организации</label>
+                <input
+                  ref="nameInput"
+                  v-model="newOrganizationName"
+                  placeholder="Введите название организации"
+                  class="modal-input"
+                  @keyup.enter="addOrganization"
+                >
+                <div class="input-hint">
+                  Обязательное поле
+                </div>
               </div>
             </div>
-          </div>
           
-          <div class="modal-footer">
-            <button
-              class="modal-btn modal-btn--cancel"
-              @click="closeModal"
-            >
-              Отмена
-            </button>
-            <button 
-              class="modal-btn modal-btn--confirm" 
-              :disabled="!newOrganizationName.trim()"
-              :class="{'modal-btn--disabled': !newOrganizationName.trim()}"
-              @click="addOrganization"
-            >
-              Создать
-            </button>
+            <div class="modal-footer">
+              <button
+                class="modal-btn modal-btn--cancel"
+                @click="closeModal"
+              >
+                Отмена
+              </button>
+              <button 
+                class="modal-btn modal-btn--confirm" 
+                :disabled="!newOrganizationName.trim()"
+                :class="{'modal-btn--disabled': !newOrganizationName.trim()}"
+                @click="addOrganization"
+              >
+                Создать
+              </button>
+            </div>
           </div>
         </div>
-      </div>
-    </transition>
+      </transition>
+    </Teleport>
 
     <!-- Модальное окно подтверждения удаления -->
     <ConfirmationModal
@@ -976,12 +978,13 @@ export default {
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.3);
+  background: rgba(0, 0, 0, 0.5);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 1000;
-  backdrop-filter: blur(1px);
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
   animation: overlayAppear 0.3s ease-out;
 }
 
@@ -991,8 +994,8 @@ export default {
     backdrop-filter: blur(0px);
   }
   to {
-    background: rgba(0, 0, 0, 0.3);
-    backdrop-filter: blur(1px);
+    background: rgba(0, 0, 0, 0.5);
+    backdrop-filter: blur(0.1px);
   }
 }
 

--- a/frontend/src/components/SessionExpiredModal.vue
+++ b/frontend/src/components/SessionExpiredModal.vue
@@ -1,50 +1,52 @@
 <template>
-  <div
-    class="modal-overlay"
-    @click.self="handleOverlayClick"
-  >
-    <div class="session-expired-modal">
-      <div class="modal-header">
-        <h2 class="modal-title">
-          Ваш сеанс скоро закончится
-        </h2>
-      </div>
-      
-      <div class="modal-body">
-        <div class="time-remaining">
-          {{ formattedTime }}
+  <Teleport to="body">
+    <div
+      class="modal-overlay"
+      @click.self="handleOverlayClick"
+    >
+      <div class="session-expired-modal">
+        <div class="modal-header">
+          <h2 class="modal-title">
+            Ваш сеанс скоро закончится
+          </h2>
         </div>
-        
-        <div class="countdown">
-          <div class="countdown-bar">
-            <div
-              class="countdown-progress"
-              :style="progressStyle"
-            />
+      
+        <div class="modal-body">
+          <div class="time-remaining">
+            {{ formattedTime }}
           </div>
-        </div>
         
-        <p class="modal-message">
-          Для продолжения работы необходимо продлить сеанс
-        </p>
-      </div>
+          <div class="countdown">
+            <div class="countdown-bar">
+              <div
+                class="countdown-progress"
+                :style="progressStyle"
+              />
+            </div>
+          </div>
+        
+          <p class="modal-message">
+            Для продолжения работы необходимо продлить сеанс
+          </p>
+        </div>
       
-      <div class="modal-footer">
-        <button
-          class="btn btn-secondary"
-          @click="logout"
-        >
-          Выйти
-        </button>
-        <button
-          class="btn btn-primary"
-          @click="extendSession"
-        >
-          Продлить сеанс
-        </button>
+        <div class="modal-footer">
+          <button
+            class="btn btn-secondary"
+            @click="logout"
+          >
+            Выйти
+          </button>
+          <button
+            class="btn btn-primary"
+            @click="extendSession"
+          >
+            Продлить сеанс
+          </button>
+        </div>
       </div>
     </div>
-  </div>
+  </Teleport>
 </template>
 
 <script>
@@ -109,7 +111,8 @@ export default {
   justify-content: center;
   align-items: center;
   z-index: 10000;
-  backdrop-filter: blur(3px);
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
 }
 
 .session-expired-modal {

--- a/frontend/src/components/SystemTableScheduleTab.vue
+++ b/frontend/src/components/SystemTableScheduleTab.vue
@@ -95,127 +95,129 @@
     </div>
 
     <!-- Модальное окно добавления/редактирования -->
-    <transition name="modal-fade">
-      <div
-        v-if="modalOpen"
-        class="modal-overlay"
-        @click.self="closeModal"
-      >
-        <div class="modal-content">
-          <div class="modal-header">
-            <h3 class="modal-title">
-              {{ editingSlotId ? 'Редактировать временнОе окно' : 'Добавить временнОе окно' }}
-            </h3>
-            <button
-              class="modal-close"
-              @click="closeModal"
-            >
-              <svg
-                width="10"
-                height="10"
-                viewBox="0 0 14 14"
+    <Teleport to="body">
+      <transition name="modal-fade">
+        <div
+          v-if="modalOpen"
+          class="modal-overlay"
+          @click.self="closeModal"
+        >
+          <div class="modal-content">
+            <div class="modal-header">
+              <h3 class="modal-title">
+                {{ editingSlotId ? 'Редактировать временнОе окно' : 'Добавить временнОе окно' }}
+              </h3>
+              <button
+                class="modal-close"
+                @click="closeModal"
               >
-                <path
-                  d="M13 1L1 13M1 1L13 13"
-                  stroke="#666"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                />
-              </svg>
-            </button>
-          </div>
+                <svg
+                  width="10"
+                  height="10"
+                  viewBox="0 0 14 14"
+                >
+                  <path
+                    d="M13 1L1 13M1 1L13 13"
+                    stroke="#666"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                  />
+                </svg>
+              </button>
+            </div>
 
-          <div class="modal-body">
-            <div class="field">
-              <label class="field-label">День недели *</label>
-              <div
-                ref="selectRef"
-                class="custom-select"
-                @click="toggleDayDropdown"
-              >
-                <div class="select-trigger">
-                  <span>{{ getFullDayName(modalDay) }}</span>
-                  <img
-                    src="@/assets/icons/arrow.png"
-                    class="select-arrow"
-                    :class="{ open: dayDropdownOpen }"
-                    width="9"
-                    height="9"
+            <div class="modal-body">
+              <div class="field">
+                <label class="field-label">День недели *</label>
+                <div
+                  ref="selectRef"
+                  class="custom-select"
+                  @click="toggleDayDropdown"
+                >
+                  <div class="select-trigger">
+                    <span>{{ getFullDayName(modalDay) }}</span>
+                    <img
+                      src="@/assets/icons/arrow.png"
+                      class="select-arrow"
+                      :class="{ open: dayDropdownOpen }"
+                      width="9"
+                      height="9"
+                    >
+                  </div>
+                  <transition name="dropdown">
+                    <div
+                      v-if="dayDropdownOpen"
+                      class="select-dropdown"
+                    >
+                      <div
+                        v-for="(dayName, idx) in fullDayNames"
+                        :key="idx"
+                        class="select-option"
+                        :class="{ selected: modalDay === idx }"
+                        @click="selectDay(idx)"
+                      >
+                        {{ dayName }}
+                      </div>
+                    </div>
+                  </transition>
+                </div>
+              </div>
+
+              <div class="time-fields">
+                <div class="field time-field">
+                  <label class="field-label">Открытие *</label>
+                  <input
+                    v-model="modalOpenTime"
+                    type="time"
+                    class="modal-input"
+                    @change="validateTimes"
                   >
                 </div>
-                <transition name="dropdown">
-                  <div
-                    v-if="dayDropdownOpen"
-                    class="select-dropdown"
+                <div class="field time-field">
+                  <label class="field-label">Закрытие *</label>
+                  <input
+                    v-model="modalCloseTime"
+                    type="time"
+                    class="modal-input"
+                    @change="validateTimes"
                   >
-                    <div
-                      v-for="(dayName, idx) in fullDayNames"
-                      :key="idx"
-                      class="select-option"
-                      :class="{ selected: modalDay === idx }"
-                      @click="selectDay(idx)"
-                    >
-                      {{ dayName }}
-                    </div>
-                  </div>
-                </transition>
+                </div>
+              </div>
+
+              <div
+                v-if="timeConflictError"
+                class="error-hint"
+              >
+                ⚠️ {{ timeConflictError }}
+              </div>
+
+              <div
+                v-if="modalNextDay && !timeConflictError"
+                class="next-day-hint"
+              >
+                ⏰ Закрытие на следующий день
               </div>
             </div>
 
-            <div class="time-fields">
-              <div class="field time-field">
-                <label class="field-label">Открытие *</label>
-                <input
-                  v-model="modalOpenTime"
-                  type="time"
-                  class="modal-input"
-                  @change="validateTimes"
-                >
-              </div>
-              <div class="field time-field">
-                <label class="field-label">Закрытие *</label>
-                <input
-                  v-model="modalCloseTime"
-                  type="time"
-                  class="modal-input"
-                  @change="validateTimes"
-                >
-              </div>
+            <div class="modal-footer">
+              <button
+                class="modal-btn cancel"
+                @click="closeModal"
+              >
+                Отмена
+              </button>
+              <button
+                class="modal-btn confirm"
+                :disabled="!modalOpenTime || !modalCloseTime || isLoading || !!timeConflictError"
+                @click="saveSlot"
+              >
+                {{ editingSlotId ? 'Сохранить' : 'Добавить' }}
+              </button>
             </div>
-
-            <div
-              v-if="timeConflictError"
-              class="error-hint"
-            >
-              ⚠️ {{ timeConflictError }}
-            </div>
-
-            <div
-              v-if="modalNextDay && !timeConflictError"
-              class="next-day-hint"
-            >
-              ⏰ Закрытие на следующий день
-            </div>
-          </div>
-
-          <div class="modal-footer">
-            <button
-              class="modal-btn cancel"
-              @click="closeModal"
-            >
-              Отмена
-            </button>
-            <button
-              class="modal-btn confirm"
-              :disabled="!modalOpenTime || !modalCloseTime || isLoading || !!timeConflictError"
-              @click="saveSlot"
-            >
-              {{ editingSlotId ? 'Сохранить' : 'Добавить' }}
-            </button>
           </div>
         </div>
-      </div>
-    </transition>
+      </transition>
+    </Teleport>
   </div>
 </template>
 
@@ -770,8 +772,9 @@ input:checked + .switch-slider:before {
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0,0,0,0.3);
-  backdrop-filter: blur(1px);
+  background: rgba(0,0,0,0.5);
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -780,7 +783,7 @@ input:checked + .switch-slider:before {
 }
 @keyframes overlayAppear {
   from { background: rgba(0,0,0,0); backdrop-filter: blur(0); }
-  to { background: rgba(0,0,0,0.3); backdrop-filter: blur(1px); }
+  to { background: rgba(0,0,0,0.5); backdrop-filter: blur(0.1px); }
 }
 
 .modal-content {

--- a/frontend/src/components/TableConstructor.vue
+++ b/frontend/src/components/TableConstructor.vue
@@ -1764,12 +1764,13 @@ export default {
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.3);
+  background: rgba(0, 0, 0, 0.5);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 10000;
-  backdrop-filter: blur(1px);
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
   animation: overlayAppear 0.3s ease-out;
 }
 
@@ -1779,8 +1780,8 @@ export default {
     backdrop-filter: blur(0px);
   }
   to {
-    background: rgba(0, 0, 0, 0.3);
-    backdrop-filter: blur(1px);
+    background: rgba(0, 0, 0, 0.5);
+    backdrop-filter: blur(0.1px);
   }
 }
 

--- a/frontend/src/components/TableConstructorCreateModal.vue
+++ b/frontend/src/components/TableConstructorCreateModal.vue
@@ -1,180 +1,182 @@
 <template>
-  <div
-    class="modal-overlay"
-    @click.self="handleClose"
-  >
-    <div class="modal-content horizontal-modal">
-      <div class="modal-header">
-        <h3>Создать новую таблицу</h3>
-        <button
-          class="modal-close"
-          @click="handleClose"
-        >
-          <svg
-            width="10"
-            height="10"
-            viewBox="0 0 14 14"
-            fill="none"
+  <Teleport to="body">
+    <div
+      class="modal-overlay"
+      @click.self="handleClose"
+    >
+      <div class="modal-content horizontal-modal">
+        <div class="modal-header">
+          <h3>Создать новую таблицу</h3>
+          <button
+            class="modal-close"
+            @click="handleClose"
           >
-            <path
-              d="M13 1L1 13M1 1L13 13"
-              stroke="#666"
-              stroke-width="2"
-              stroke-linecap="round"
-            />
-          </svg>
-        </button>
-      </div>
+            <svg
+              width="10"
+              height="10"
+              viewBox="0 0 14 14"
+              fill="none"
+            >
+              <path
+                d="M13 1L1 13M1 1L13 13"
+                stroke="#666"
+                stroke-width="2"
+                stroke-linecap="round"
+              />
+            </svg>
+          </button>
+        </div>
 
-      <div class="modal-body-horizontal">
-        <!-- Левая часть - основная информация -->
-        <div class="modal-main-info">
-          <div class="main-fields">
-            <div class="form-group-compact">
-              <label class="form-label-compact">Наименование таблицы *</label>
-              <input
-                v-model="newTable.display_name"
-                placeholder="ПОСТ №27"
-                class="input-compact"
-              >
-            </div>
-
-            <div class="form-group-compact">
-              <label class="form-label-compact">Системное имя *</label>
-              <input
-                v-model="newTable.name"
-                placeholder="post_27"
-                class="input-compact"
-                @input="validateSystemName"
-              >
-              <span class="form-hint">Латинские буквы, цифры и подчеркивания</span>
-              <span
-                v-if="nameError"
-                class="form-error"
-              >{{ nameError }}</span>
-            </div>
-
-            <div class="form-group-compact">
-              <label class="form-label-compact">Тип таблицы *</label>
-              <div class="custom-select">
-                <div
-                  class="select-header"
-                  @click="toggleTypeDropdown"
+        <div class="modal-body-horizontal">
+          <!-- Левая часть - основная информация -->
+          <div class="modal-main-info">
+            <div class="main-fields">
+              <div class="form-group-compact">
+                <label class="form-label-compact">Наименование таблицы *</label>
+                <input
+                  v-model="newTable.display_name"
+                  placeholder="ПОСТ №27"
+                  class="input-compact"
                 >
-                  <span class="select-value">{{ getTableTypeLabel(newTable.table_type) }}</span>
-                  <img
-                    src="@/assets/icons/arrow.png"
-                    class="select-arrow"
-                    :class="{ rotated: typeDropdownOpen }"
-                  >
-                </div>
-                <transition name="dropdown-fade">
+              </div>
+
+              <div class="form-group-compact">
+                <label class="form-label-compact">Системное имя *</label>
+                <input
+                  v-model="newTable.name"
+                  placeholder="post_27"
+                  class="input-compact"
+                  @input="validateSystemName"
+                >
+                <span class="form-hint">Латинские буквы, цифры и подчеркивания</span>
+                <span
+                  v-if="nameError"
+                  class="form-error"
+                >{{ nameError }}</span>
+              </div>
+
+              <div class="form-group-compact">
+                <label class="form-label-compact">Тип таблицы *</label>
+                <div class="custom-select">
                   <div
-                    v-if="typeDropdownOpen"
-                    class="select-dropdown"
+                    class="select-header"
+                    @click="toggleTypeDropdown"
                   >
-                    <div
-                      class="select-option"
-                      :class="{ active: newTable.table_type === 'cars' }"
-                      @click="selectType('cars')"
+                    <span class="select-value">{{ getTableTypeLabel(newTable.table_type) }}</span>
+                    <img
+                      src="@/assets/icons/arrow.png"
+                      class="select-arrow"
+                      :class="{ rotated: typeDropdownOpen }"
                     >
-                      Машины
+                  </div>
+                  <transition name="dropdown-fade">
+                    <div
+                      v-if="typeDropdownOpen"
+                      class="select-dropdown"
+                    >
+                      <div
+                        class="select-option"
+                        :class="{ active: newTable.table_type === 'cars' }"
+                        @click="selectType('cars')"
+                      >
+                        Машины
+                      </div>
+                      <div
+                        class="select-option"
+                        :class="{ active: newTable.table_type === 'people' }"
+                        @click="selectType('people')"
+                      >
+                        Люди
+                      </div>
                     </div>
-                    <div
-                      class="select-option"
-                      :class="{ active: newTable.table_type === 'people' }"
-                      @click="selectType('people')"
+                  </transition>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Правая часть - настройки -->
+          <div class="modal-cells-section">
+            <div class="cells-header-compact">
+              <h4 class="cells-title-compact">
+                Настройки отображения
+              </h4>
+            </div>
+
+            <div class="cells-scroll-container">
+              <div class="settings-grid">
+                <div class="setting-item">
+                  <label class="setting-label">
+                    <input
+                      v-model="newTable.show_fact_table"
+                      type="checkbox"
+                      class="setting-checkbox"
                     >
-                      Люди
+                    <span class="setting-text">Отображать таблицу "по факту"</span>
+                  </label>
+                  <span class="setting-hint">
+                    Будет показана дополнительная таблица с данными "по факту"
+                  </span>
+                </div>
+
+                <div
+                  v-if="newTable.show_fact_table"
+                  class="setting-item"
+                >
+                  <label class="form-label-compact">Подсказка для таблицы "по факту"</label>
+                  <TextConstructor
+                    v-model="newTable.fact_table_hint"
+                    :placeholder="getDefaultHint(newTable.table_type)"
+                    rows="3"
+                  />
+                </div>
+
+                <div class="setting-item">
+                  <label class="form-label-compact">Инструкция к таблице</label>
+                  <TextConstructor
+                    v-model="newTable.instruction"
+                    placeholder="Введите инструкцию для таблицы..."
+                    rows="4"
+                  />
+                </div>
+
+                <div class="setting-item">
+                  <h5 class="fields-preview-title">
+                    Поля таблицы:
+                  </h5>
+                  <div class="fields-preview">
+                    <div
+                      v-for="field in getTableFields(newTable.table_type)"
+                      :key="field.name"
+                      class="preview-field"
+                    >
+                      <span class="preview-field-name">{{ field.displayName }}</span>
+                      <span class="preview-field-type">{{ field.type }}</span>
                     </div>
                   </div>
-                </transition>
+                </div>
               </div>
             </div>
           </div>
         </div>
 
-        <!-- Правая часть - настройки -->
-        <div class="modal-cells-section">
-          <div class="cells-header-compact">
-            <h4 class="cells-title-compact">
-              Настройки отображения
-            </h4>
-          </div>
-
-          <div class="cells-scroll-container">
-            <div class="settings-grid">
-              <div class="setting-item">
-                <label class="setting-label">
-                  <input
-                    v-model="newTable.show_fact_table"
-                    type="checkbox"
-                    class="setting-checkbox"
-                  >
-                  <span class="setting-text">Отображать таблицу "по факту"</span>
-                </label>
-                <span class="setting-hint">
-                  Будет показана дополнительная таблица с данными "по факту"
-                </span>
-              </div>
-
-              <div
-                v-if="newTable.show_fact_table"
-                class="setting-item"
-              >
-                <label class="form-label-compact">Подсказка для таблицы "по факту"</label>
-                <TextConstructor
-                  v-model="newTable.fact_table_hint"
-                  :placeholder="getDefaultHint(newTable.table_type)"
-                  rows="3"
-                />
-              </div>
-
-              <div class="setting-item">
-                <label class="form-label-compact">Инструкция к таблице</label>
-                <TextConstructor
-                  v-model="newTable.instruction"
-                  placeholder="Введите инструкцию для таблицы..."
-                  rows="4"
-                />
-              </div>
-
-              <div class="setting-item">
-                <h5 class="fields-preview-title">
-                  Поля таблицы:
-                </h5>
-                <div class="fields-preview">
-                  <div
-                    v-for="field in getTableFields(newTable.table_type)"
-                    :key="field.name"
-                    class="preview-field"
-                  >
-                    <span class="preview-field-name">{{ field.displayName }}</span>
-                    <span class="preview-field-type">{{ field.type }}</span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
+        <div class="modal-footer">
+          <button
+            class="modal-btn modal-btn--cancel"
+            @click="handleClose"
+          >
+            Отмена
+          </button>
+          <button
+            class="modal-btn modal-btn--confirm"
+            @click="createTable"
+          >
+            Создать
+          </button>
         </div>
-      </div>
-
-      <div class="modal-footer">
-        <button
-          class="modal-btn modal-btn--cancel"
-          @click="handleClose"
-        >
-          Отмена
-        </button>
-        <button
-          class="modal-btn modal-btn--confirm"
-          @click="createTable"
-        >
-          Создать
-        </button>
       </div>
     </div>
-  </div>
+  </Teleport>
 </template>
 
 <script>
@@ -352,12 +354,13 @@ export default {
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.3);
+  background: rgba(0, 0, 0, 0.5);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 10000;
-  backdrop-filter: blur(1px);
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
   animation: overlayAppear 0.3s ease-out;
 }
 
@@ -367,8 +370,8 @@ export default {
     backdrop-filter: blur(0px);
   }
   to {
-    background: rgba(0, 0, 0, 0.3);
-    backdrop-filter: blur(1px);
+    background: rgba(0, 0, 0, 0.5);
+    backdrop-filter: blur(0.1px);
   }
 }
 

--- a/frontend/src/components/TableConstructorPhotoSection.vue
+++ b/frontend/src/components/TableConstructorPhotoSection.vue
@@ -67,46 +67,48 @@
     </div>
 
     <!-- Модальное окно просмотра фото -->
-    <transition name="modal-fade">
-      <div
-        v-if="showPhotoModal"
-        class="modal-overlay"
-        @click.self="showPhotoModal = false"
-      >
-        <div class="modal-content photo-view-modal">
-          <div class="modal-header">
-            <h3 class="modal-title">
-              {{ viewingPhoto?.file_name }}
-            </h3>
-            <button
-              class="modal-close"
-              @click="showPhotoModal = false"
-            >
-              <svg
-                width="10"
-                height="10"
-                viewBox="0 0 14 14"
-                fill="none"
+    <Teleport to="body">
+      <transition name="modal-fade">
+        <div
+          v-if="showPhotoModal"
+          class="modal-overlay"
+          @click.self="showPhotoModal = false"
+        >
+          <div class="modal-content photo-view-modal">
+            <div class="modal-header">
+              <h3 class="modal-title">
+                {{ viewingPhoto?.file_name }}
+              </h3>
+              <button
+                class="modal-close"
+                @click="showPhotoModal = false"
               >
-                <path
-                  d="M13 1L1 13M1 1L13 13"
-                  stroke="#666"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                />
-              </svg>
-            </button>
-          </div>
-          <div class="modal-body photo-view-body">
-            <img
-              :src="viewingPhoto?.photo_url"
-              class="full-photo"
-              alt="Full size"
-            >
+                <svg
+                  width="10"
+                  height="10"
+                  viewBox="0 0 14 14"
+                  fill="none"
+                >
+                  <path
+                    d="M13 1L1 13M1 1L13 13"
+                    stroke="#666"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                  />
+                </svg>
+              </button>
+            </div>
+            <div class="modal-body photo-view-body">
+              <img
+                :src="viewingPhoto?.photo_url"
+                class="full-photo"
+                alt="Full size"
+              >
+            </div>
           </div>
         </div>
-      </div>
-    </transition>
+      </transition>
+    </Teleport>
   </div>
 </template>
 
@@ -366,12 +368,13 @@ export default {
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.3);
+  background: rgba(0, 0, 0, 0.5);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 10000;
-  backdrop-filter: blur(1px);
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
   animation: overlayAppear 0.3s ease-out;
 }
 
@@ -381,8 +384,8 @@ export default {
     backdrop-filter: blur(0px);
   }
   to {
-    background: rgba(0, 0, 0, 0.3);
-    backdrop-filter: blur(1px);
+    background: rgba(0, 0, 0, 0.5);
+    backdrop-filter: blur(0.1px);
   }
 }
 

--- a/frontend/src/components/TablesComponent.vue
+++ b/frontend/src/components/TablesComponent.vue
@@ -25,41 +25,43 @@
     </div>
         
     <!-- Модальное окно с инструкцией -->
-    <div
-      v-if="showInstruction"
-      class="modal-overlay"
-      @click.self="showInstruction = false"
-    >
-      <div class="instruction-modal-large">
-        <div class="modal-header">
-          <h3>Инструкция по использованию таблицы <span class="blue">{{ tableDisplayName }}</span></h3>
-          <button
-            class="modal-close"
-            @click="showInstruction = false"
-          >
-            ×
-          </button>
-        </div>
-        <div class="instruction-content">
-          <div
-            v-if="tableInstruction"
-            class="text-constructor-content"
-            v-html="sanitizedInstruction"
-          />
-          <div
-            v-else
-            class="no-instruction"
-          >
-            <div class="no-instruction-icon">
-              📝
+    <Teleport to="body">
+      <div
+        v-if="showInstruction"
+        class="modal-overlay"
+        @click.self="showInstruction = false"
+      >
+        <div class="instruction-modal-large">
+          <div class="modal-header">
+            <h3>Инструкция по использованию таблицы <span class="blue">{{ tableDisplayName }}</span></h3>
+            <button
+              class="modal-close"
+              @click="showInstruction = false"
+            >
+              ×
+            </button>
+          </div>
+          <div class="instruction-content">
+            <div
+              v-if="tableInstruction"
+              class="text-constructor-content"
+              v-html="sanitizedInstruction"
+            />
+            <div
+              v-else
+              class="no-instruction"
+            >
+              <div class="no-instruction-icon">
+                📝
+              </div>
+              <h4>Инструкция не добавлена</h4>
+              <p>Для этой таблицы пока не создана и не написана инструкция.</p>
+              <p>Обратитесь к Бюро пропусков для добавления инструкции.</p>
             </div>
-            <h4>Инструкция не добавлена</h4>
-            <p>Для этой таблицы пока не создана и не написана инструкция.</p>
-            <p>Обратитесь к Бюро пропусков для добавления инструкции.</p>
           </div>
         </div>
       </div>
-    </div>
+    </Teleport>
 
     <div class="tables__filters">
       <div class="filters__fields">
@@ -789,12 +791,14 @@ export default {
     left: 0;
     right: 0;
     bottom: 0;
-    background: rgba(0, 0, 0, 0.05);
+    background: rgba(0, 0, 0, 0.5);
     display: flex;
     align-items: center;
     justify-content: center;
     z-index: 1000;
     padding: 20px;
+    backdrop-filter: blur(0.1px);
+    -webkit-backdrop-filter: blur(0.1px);
 }
 
 .instruction-modal-large {

--- a/frontend/src/components/UnloadPlaces/ScheduleTab.vue
+++ b/frontend/src/components/UnloadPlaces/ScheduleTab.vue
@@ -102,131 +102,133 @@
     </div>
 
     <!-- Модальное окно -->
-    <transition name="modal-fade">
-      <div
-        v-if="modalOpen"
-        class="modal-overlay"
-        @click.self="closeModal"
-      >
-        <div class="modal-content">
-          <div class="modal-header">
-            <h3 class="modal-title">
-              {{ editingSlotId ? 'Редактировать временнОе окно' : 'Добавить временнОе окно' }}
-            </h3>
-            <button
-              class="modal-close"
-              @click="closeModal"
-            >
-              <svg
-                width="10"
-                height="10"
-                viewBox="0 0 14 14"
+    <Teleport to="body">
+      <transition name="modal-fade">
+        <div
+          v-if="modalOpen"
+          class="modal-overlay"
+          @click.self="closeModal"
+        >
+          <div class="modal-content">
+            <div class="modal-header">
+              <h3 class="modal-title">
+                {{ editingSlotId ? 'Редактировать временнОе окно' : 'Добавить временнОе окно' }}
+              </h3>
+              <button
+                class="modal-close"
+                @click="closeModal"
               >
-                <path
-                  d="M13 1L1 13M1 1L13 13"
-                  stroke="#666"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                />
-              </svg>
-            </button>
-          </div>
+                <svg
+                  width="10"
+                  height="10"
+                  viewBox="0 0 14 14"
+                >
+                  <path
+                    d="M13 1L1 13M1 1L13 13"
+                    stroke="#666"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                  />
+                </svg>
+              </button>
+            </div>
 
-          <div class="modal-body">
-            <!-- Выбор дня с кастомным селектом -->
-            <div class="field">
-              <label class="field-label">День недели *</label>
-              <div
-                ref="selectRef"
-                class="custom-select"
-                @click="toggleDayDropdown"
-              >
-                <div class="select-trigger">
-                  <span>{{ getFullDayName(modalDay) }}</span>
-                  <img
-                    src="@/assets/icons/arrow.png"
-                    class="select-arrow"
-                    :class="{ open: dayDropdownOpen }"
-                    width="9"
-                    height="9"
+            <div class="modal-body">
+              <!-- Выбор дня с кастомным селектом -->
+              <div class="field">
+                <label class="field-label">День недели *</label>
+                <div
+                  ref="selectRef"
+                  class="custom-select"
+                  @click="toggleDayDropdown"
+                >
+                  <div class="select-trigger">
+                    <span>{{ getFullDayName(modalDay) }}</span>
+                    <img
+                      src="@/assets/icons/arrow.png"
+                      class="select-arrow"
+                      :class="{ open: dayDropdownOpen }"
+                      width="9"
+                      height="9"
+                    >
+                  </div>
+                  <transition name="dropdown">
+                    <div
+                      v-if="dayDropdownOpen"
+                      class="select-dropdown"
+                    >
+                      <div
+                        v-for="(dayName, idx) in fullDayNames"
+                        :key="idx"
+                        class="select-option"
+                        :class="{ selected: modalDay === idx }"
+                        @click="selectDay(idx)"
+                      >
+                        {{ dayName }}
+                      </div>
+                    </div>
+                  </transition>
+                </div>
+              </div>
+
+              <!-- Время -->
+              <div class="time-fields">
+                <div class="field time-field">
+                  <label class="field-label">Открытие *</label>
+                  <input
+                    v-model="modalOpenTime"
+                    type="time"
+                    class="modal-input"
+                    @change="validateTimes"
                   >
                 </div>
-                <transition name="dropdown">
-                  <div
-                    v-if="dayDropdownOpen"
-                    class="select-dropdown"
+                <div class="field time-field">
+                  <label class="field-label">Закрытие *</label>
+                  <input
+                    v-model="modalCloseTime"
+                    type="time"
+                    class="modal-input"
+                    @change="validateTimes"
                   >
-                    <div
-                      v-for="(dayName, idx) in fullDayNames"
-                      :key="idx"
-                      class="select-option"
-                      :class="{ selected: modalDay === idx }"
-                      @click="selectDay(idx)"
-                    >
-                      {{ dayName }}
-                    </div>
-                  </div>
-                </transition>
+                </div>
+              </div>
+
+              <!-- Сообщение об ошибке пересечения -->
+              <div
+                v-if="timeConflictError"
+                class="error-hint"
+              >
+                ⚠️ {{ timeConflictError }}
+              </div>
+
+              <!-- Подсказка о следующем дне -->
+              <div
+                v-if="modalNextDay && !timeConflictError"
+                class="next-day-hint"
+              >
+                ⏰ Закрытие на следующий день
               </div>
             </div>
 
-            <!-- Время -->
-            <div class="time-fields">
-              <div class="field time-field">
-                <label class="field-label">Открытие *</label>
-                <input
-                  v-model="modalOpenTime"
-                  type="time"
-                  class="modal-input"
-                  @change="validateTimes"
-                >
-              </div>
-              <div class="field time-field">
-                <label class="field-label">Закрытие *</label>
-                <input
-                  v-model="modalCloseTime"
-                  type="time"
-                  class="modal-input"
-                  @change="validateTimes"
-                >
-              </div>
+            <div class="modal-footer">
+              <button
+                class="modal-btn cancel"
+                @click="closeModal"
+              >
+                Отмена
+              </button>
+              <button
+                class="modal-btn confirm"
+                :disabled="!modalOpenTime || !modalCloseTime || isLoading || !!timeConflictError"
+                @click="saveSlot"
+              >
+                {{ editingSlotId ? 'Сохранить' : 'Добавить' }}
+              </button>
             </div>
-
-            <!-- Сообщение об ошибке пересечения -->
-            <div
-              v-if="timeConflictError"
-              class="error-hint"
-            >
-              ⚠️ {{ timeConflictError }}
-            </div>
-
-            <!-- Подсказка о следующем дне -->
-            <div
-              v-if="modalNextDay && !timeConflictError"
-              class="next-day-hint"
-            >
-              ⏰ Закрытие на следующий день
-            </div>
-          </div>
-
-          <div class="modal-footer">
-            <button
-              class="modal-btn cancel"
-              @click="closeModal"
-            >
-              Отмена
-            </button>
-            <button
-              class="modal-btn confirm"
-              :disabled="!modalOpenTime || !modalCloseTime || isLoading || !!timeConflictError"
-              @click="saveSlot"
-            >
-              {{ editingSlotId ? 'Сохранить' : 'Добавить' }}
-            </button>
           </div>
         </div>
-      </div>
-    </transition>
+      </transition>
+    </Teleport>
   </div>
 </template>
 
@@ -811,8 +813,9 @@ input:checked + .switch-slider:before {
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0,0,0,0.3);
-  backdrop-filter: blur(1px);
+  background: rgba(0,0,0,0.5);
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -821,7 +824,7 @@ input:checked + .switch-slider:before {
 }
 @keyframes overlayAppear {
   from { background: rgba(0,0,0,0); backdrop-filter: blur(0); }
-  to { background: rgba(0,0,0,0.3); backdrop-filter: blur(1px); }
+  to { background: rgba(0,0,0,0.5); backdrop-filter: blur(0.1px); }
 }
 
 .modal-content {

--- a/frontend/src/components/UnloadPlaces/UnloadPlacesContainer.vue
+++ b/frontend/src/components/UnloadPlaces/UnloadPlacesContainer.vue
@@ -349,121 +349,125 @@
     </div>
 
     <!-- Модальное окно добавления места -->
-    <transition name="modal-fade">
-      <div
-        v-if="showAddModal"
-        class="modal-overlay"
-        @click.self="closeModal"
-      >
-        <div class="modal-content">
-          <div class="modal-header">
-            <h3 class="modal-title">
-              Добавить место разгрузки
-            </h3>
-            <button
-              class="modal-close"
-              @click="closeModal"
-            >
-              <svg
-                width="10"
-                height="10"
-                viewBox="0 0 14 14"
-                fill="none"
+    <Teleport to="body">
+      <transition name="modal-fade">
+        <div
+          v-if="showAddModal"
+          class="modal-overlay"
+          @click.self="closeModal"
+        >
+          <div class="modal-content">
+            <div class="modal-header">
+              <h3 class="modal-title">
+                Добавить место разгрузки
+              </h3>
+              <button
+                class="modal-close"
+                @click="closeModal"
               >
-                <path
-                  d="M13 1L1 13M1 1L13 13"
-                  stroke="#666"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                />
-              </svg>
-            </button>
-          </div>
-          
-          <div class="modal-body">
-            <div class="input-group">
-              <label class="input-label">Наименование *</label>
-              <input
-                ref="nameInput"
-                v-model="newPlaceName"
-                placeholder="Введите название места"
-                class="modal-input"
-                @keyup.enter="addPlace"
-              >
+                <svg
+                  width="10"
+                  height="10"
+                  viewBox="0 0 14 14"
+                  fill="none"
+                >
+                  <path
+                    d="M13 1L1 13M1 1L13 13"
+                    stroke="#666"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                  />
+                </svg>
+              </button>
             </div>
+          
+            <div class="modal-body">
+              <div class="input-group">
+                <label class="input-label">Наименование *</label>
+                <input
+                  ref="nameInput"
+                  v-model="newPlaceName"
+                  placeholder="Введите название места"
+                  class="modal-input"
+                  @keyup.enter="addPlace"
+                >
+              </div>
             
-            <div class="input-group">
-              <label class="input-label">Описание</label>
-              <textarea
-                v-model="newPlaceDescription"
-                placeholder="Введите описание (необязательно)"
-                class="modal-textarea"
-                rows="3"
-              />
+              <div class="input-group">
+                <label class="input-label">Описание</label>
+                <textarea
+                  v-model="newPlaceDescription"
+                  placeholder="Введите описание (необязательно)"
+                  class="modal-textarea"
+                  rows="3"
+                />
+              </div>
             </div>
-          </div>
           
-          <div class="modal-footer">
-            <button
-              class="modal-btn modal-btn--cancel"
-              @click="closeModal"
-            >
-              Отмена
-            </button>
-            <button 
-              class="modal-btn modal-btn--confirm" 
-              :disabled="!newPlaceName.trim()"
-              :class="{'modal-btn--disabled': !newPlaceName.trim()}"
-              @click="addPlace"
-            >
-              Добавить
-            </button>
+            <div class="modal-footer">
+              <button
+                class="modal-btn modal-btn--cancel"
+                @click="closeModal"
+              >
+                Отмена
+              </button>
+              <button 
+                class="modal-btn modal-btn--confirm" 
+                :disabled="!newPlaceName.trim()"
+                :class="{'modal-btn--disabled': !newPlaceName.trim()}"
+                @click="addPlace"
+              >
+                Добавить
+              </button>
+            </div>
           </div>
         </div>
-      </div>
-    </transition>
+      </transition>
+    </Teleport>
 
     <!-- Модальное окно просмотра фото -->
-    <transition name="modal-fade">
-      <div
-        v-if="showPhotoModal"
-        class="modal-overlay"
-        @click.self="showPhotoModal = false"
-      >
-        <div class="modal-content photo-view-modal">
-          <div class="modal-header">
-            <h3 class="modal-title">
-              {{ viewingPhoto?.file_name }}
-            </h3>
-            <button
-              class="modal-close"
-              @click="showPhotoModal = false"
-            >
-              <svg
-                width="10"
-                height="10"
-                viewBox="0 0 14 14"
-                fill="none"
+    <Teleport to="body">
+      <transition name="modal-fade">
+        <div
+          v-if="showPhotoModal"
+          class="modal-overlay"
+          @click.self="showPhotoModal = false"
+        >
+          <div class="modal-content photo-view-modal">
+            <div class="modal-header">
+              <h3 class="modal-title">
+                {{ viewingPhoto?.file_name }}
+              </h3>
+              <button
+                class="modal-close"
+                @click="showPhotoModal = false"
               >
-                <path
-                  d="M13 1L1 13M1 1L13 13"
-                  stroke="#666"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                />
-              </svg>
-            </button>
-          </div>
-          <div class="modal-body photo-view-body">
-            <img
-              :src="viewingPhoto?.photo_url"
-              class="full-photo"
-              alt="Full size"
-            >
+                <svg
+                  width="10"
+                  height="10"
+                  viewBox="0 0 14 14"
+                  fill="none"
+                >
+                  <path
+                    d="M13 1L1 13M1 1L13 13"
+                    stroke="#666"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                  />
+                </svg>
+              </button>
+            </div>
+            <div class="modal-body photo-view-body">
+              <img
+                :src="viewingPhoto?.photo_url"
+                class="full-photo"
+                alt="Full size"
+              >
+            </div>
           </div>
         </div>
-      </div>
-    </transition>
+      </transition>
+    </Teleport>
 
     <!-- Уведомления -->
     <div
@@ -1548,12 +1552,13 @@ async uploadPhotos(event) {
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.3);
+  background: rgba(0, 0, 0, 0.5);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 10000;
-  backdrop-filter: blur(1px);
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
   animation: overlayAppear 0.3s ease-out;
 }
 
@@ -1563,8 +1568,8 @@ async uploadPhotos(event) {
     backdrop-filter: blur(0px);
   }
   to {
-    background: rgba(0, 0, 0, 0.3);
-    backdrop-filter: blur(1px);
+    background: rgba(0, 0, 0, 0.5);
+    backdrop-filter: blur(0.1px);
   }
 }
 

--- a/frontend/src/components/UserControl.vue
+++ b/frontend/src/components/UserControl.vue
@@ -1979,12 +1979,13 @@ export default {
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.3);
+  background: rgba(0, 0, 0, 0.5);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 10000;
-  backdrop-filter: blur(1px);
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
   animation: overlayAppear 0.3s ease-out;
 }
 
@@ -1994,8 +1995,8 @@ export default {
     backdrop-filter: blur(0px);
   }
   to {
-    background: rgba(0, 0, 0, 0.3);
-    backdrop-filter: blur(1px);
+    background: rgba(0, 0, 0, 0.5);
+    backdrop-filter: blur(0.1px);
   }
 }
 

--- a/frontend/src/components/UserTypes.vue
+++ b/frontend/src/components/UserTypes.vue
@@ -184,90 +184,92 @@
     </div>
 
     <!-- Модальное окно создания типа -->
-    <transition name="modal-fade">
-      <div
-        v-if="showAddModal"
-        class="modal-overlay"
-        @click.self="closeModal"
-      >
-        <div class="modal-content">
-          <div class="modal-header">
-            <h3 class="modal-title">
-              Создать новый тип пользователя
-            </h3>
-            <button
-              class="modal-close"
-              @click="closeModal"
-            >
-              <svg
-                width="10"
-                height="10"
-                viewBox="0 0 14 14"
-                fill="none"
+    <Teleport to="body">
+      <transition name="modal-fade">
+        <div
+          v-if="showAddModal"
+          class="modal-overlay"
+          @click.self="closeModal"
+        >
+          <div class="modal-content">
+            <div class="modal-header">
+              <h3 class="modal-title">
+                Создать новый тип пользователя
+              </h3>
+              <button
+                class="modal-close"
+                @click="closeModal"
               >
-                <path
-                  d="M13 1L1 13M1 1L13 13"
-                  stroke="#666"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                />
-              </svg>
-            </button>
-          </div>
-          
-          <div class="modal-body">
-            <div class="input-group">
-              <label class="input-label">Наименование типа *</label>
-              <input
-                ref="nameInput"
-                v-model="newType.name"
-                placeholder="Менеджер"
-                class="modal-input"
-                @keyup.enter="createType"
-              >
-              <div class="input-hint">
-                Обязательное поле
-              </div>
+                <svg
+                  width="10"
+                  height="10"
+                  viewBox="0 0 14 14"
+                  fill="none"
+                >
+                  <path
+                    d="M13 1L1 13M1 1L13 13"
+                    stroke="#666"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                  />
+                </svg>
+              </button>
             </div>
+          
+            <div class="modal-body">
+              <div class="input-group">
+                <label class="input-label">Наименование типа *</label>
+                <input
+                  ref="nameInput"
+                  v-model="newType.name"
+                  placeholder="Менеджер"
+                  class="modal-input"
+                  @keyup.enter="createType"
+                >
+                <div class="input-hint">
+                  Обязательное поле
+                </div>
+              </div>
             
-            <div class="input-group">
-              <label class="input-label">Системное имя *</label>
-              <input
-                v-model="newType.code"
-                placeholder="manager"
-                class="modal-input"
-                @input="validateSystemName"
-                @keyup.enter="createType"
-              >
-              <div class="input-hint">
-                Латинские буквы, цифры и подчеркивания
+              <div class="input-group">
+                <label class="input-label">Системное имя *</label>
+                <input
+                  v-model="newType.code"
+                  placeholder="manager"
+                  class="modal-input"
+                  @input="validateSystemName"
+                  @keyup.enter="createType"
+                >
+                <div class="input-hint">
+                  Латинские буквы, цифры и подчеркивания
+                </div>
+                <span
+                  v-if="nameError"
+                  class="form-error"
+                >{{ nameError }}</span>
               </div>
-              <span
-                v-if="nameError"
-                class="form-error"
-              >{{ nameError }}</span>
             </div>
-          </div>
           
-          <div class="modal-footer">
-            <button
-              class="modal-btn modal-btn--cancel"
-              @click="closeModal"
-            >
-              Отмена
-            </button>
-            <button 
-              class="modal-btn modal-btn--confirm" 
-              :disabled="!isFormValid"
-              :class="{'modal-btn--disabled': !isFormValid}"
-              @click="createType"
-            >
-              Создать
-            </button>
+            <div class="modal-footer">
+              <button
+                class="modal-btn modal-btn--cancel"
+                @click="closeModal"
+              >
+                Отмена
+              </button>
+              <button 
+                class="modal-btn modal-btn--confirm" 
+                :disabled="!isFormValid"
+                :class="{'modal-btn--disabled': !isFormValid}"
+                @click="createType"
+              >
+                Создать
+              </button>
+            </div>
           </div>
         </div>
-      </div>
-    </transition>
+      </transition>
+    </Teleport>
 
     <!-- Модальное окно подтверждения удаления -->
     <ConfirmationModal
@@ -949,12 +951,13 @@ export default {
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.3);
+  background: rgba(0, 0, 0, 0.5);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 1000;
-  backdrop-filter: blur(1px);
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
   animation: overlayAppear 0.3s ease-out;
 }
 
@@ -964,8 +967,8 @@ export default {
     backdrop-filter: blur(0px);
   }
   to {
-    background: rgba(0, 0, 0, 0.3);
-    backdrop-filter: blur(1px);
+    background: rgba(0, 0, 0, 0.5);
+    backdrop-filter: blur(0.1px);
   }
 }
 

--- a/frontend/src/components/ui/BaseModal.vue
+++ b/frontend/src/components/ui/BaseModal.vue
@@ -146,12 +146,13 @@ export default {
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.3);
+  background: rgba(0, 0, 0, 0.5);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 1000;
-  backdrop-filter: blur(1px);
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
 }
 
 .base-modal {

--- a/frontend/src/views/CarsView.vue
+++ b/frontend/src/views/CarsView.vue
@@ -310,205 +310,207 @@
     </div>
 
     <!-- Модальное окно добавления машины -->
-    <div
-      v-if="showModal && currentFilter !== 'all_system'"
-      class="modal-overlay"
-      data-testid="cars-view-modal"
-      @click="closeModal"
-    >
+    <Teleport to="body">
       <div
-        class="modal-content"
-        @click.stop
+        v-if="showModal && currentFilter !== 'all_system'"
+        class="modal-overlay"
+        data-testid="cars-view-modal"
+        @click="closeModal"
       >
-        <div class="modal-header">
-          <div class="modal-header__top">
-            <h3>{{ editingCar ? 'Редактирование' : 'Добавление Т/С' }}</h3>
-            <div
-              v-if="notification.show"
-              class="notification-badge"
-              :class="notification.type"
+        <div
+          class="modal-content"
+          @click.stop
+        >
+          <div class="modal-header">
+            <div class="modal-header__top">
+              <h3>{{ editingCar ? 'Редактирование' : 'Добавление Т/С' }}</h3>
+              <div
+                v-if="notification.show"
+                class="notification-badge"
+                :class="notification.type"
+              >
+                {{ notification.message }}
+              </div>
+            </div>
+            <button
+              class="modal-close"
+              data-testid="cars-view-modal-close"
+              @click="closeModal"
             >
-              {{ notification.message }}
-            </div>
+              ×
+            </button>
           </div>
-          <button
-            class="modal-close"
-            data-testid="cars-view-modal-close"
-            @click="closeModal"
-          >
-            ×
-          </button>
-        </div>
-        <div class="modal-body">
-          <div class="data__completion">
-            <div class="completion__format">
-              <div class="format__header">
-                <label class="format__label">Формат номеров</label>
-                <button
-                  class="add-button"
-                  :disabled="!canSaveCar"
-                  @click="saveCar"
-                >
-                  {{ editingCar ? 'Сохранить' : 'Добавить' }}
-                </button>
-              </div>
-              <div class="format__dropdown">
-                <button
-                  class="dropdown__button"
-                  data-testid="cars-view-format-dropdown"
-                  @click="toggleFormatDropdown"
-                >
-                  <div class="button__content">
-                    <span class="button__text">{{ selectedFormatText }}</span>
-                    <img
-                      src="@/assets/icons/arrow.png"
-                      class="button__arrow"
-                      :class="{ 'button__arrow--open': isFormatDropdownOpen }"
-                    >
-                  </div>
-                </button>
-                <transition name="dropdown">
-                  <div
-                    v-if="isFormatDropdownOpen"
-                    class="dropdown__menu"
+          <div class="modal-body">
+            <div class="data__completion">
+              <div class="completion__format">
+                <div class="format__header">
+                  <label class="format__label">Формат номеров</label>
+                  <button
+                    class="add-button"
+                    :disabled="!canSaveCar"
+                    @click="saveCar"
                   >
-                    <div 
-                      v-for="format in availableFormats" 
-                      :key="format.format.id"
-                      class="dropdown__item" 
-                      @click="selectFormat(format)"
-                    >
-                      <span class="item__text">{{ format.format.name }}</span>
-                    </div>
-                  </div>
-                </transition>
-              </div>
-            </div>
-                        
-            <div class="completion__fields">
-              <div class="completion__number">
-                <div class="completion__number-header">
-                  <label class="input__label">Номер Т/C <span class="required">*</span></label>
+                    {{ editingCar ? 'Сохранить' : 'Добавить' }}
+                  </button>
                 </div>
-                                
-                <!-- Динамический формат из базы данных -->
-                <div
-                  v-if="selectedFormat"
-                  class="number__field"
-                >
-                  <input 
-                    v-for="(cell, index) in selectedFormat.cells" 
-                    :key="index"
-                    v-model="numberParts[index]" 
-                    class="number__input"
-                    :placeholder="getPlaceholder(cell)"
-                    :maxlength="cell.max_length"
-                    :style="{ width: getInputWidth(cell) }"
-                    @input="validatePart(index, $event, cell)"
-                    @blur="formatPart(index, cell)"
+                <div class="format__dropdown">
+                  <button
+                    class="dropdown__button"
+                    data-testid="cars-view-format-dropdown"
+                    @click="toggleFormatDropdown"
                   >
-                </div>
-                <div
-                  v-else
-                  class="no-format-message"
-                >
-                  Выберите формат номера
-                </div>
-              </div>
-                            
-              <div class="completion__mark">
-                <div class="completion__mark-header">
-                  <label class="input__label">Марка Т/С <span class="required">*</span></label>
-                </div>
-                <div class="mark__field">
-                  <div class="mark__dropdown">
-                    <button
-                      class="mark__dropdown-button"
-                      @click="toggleMarkDropdown"
-                    >
-                      <div class="mark__button-content">
-                        <span class="mark__button-text">{{ selectedMark || 'Выберите марку' }}</span>
-                        <img
-                          src="@/assets/icons/arrow.png"
-                          class="mark__button-arrow"
-                          :class="{ 'mark__button-arrow--open': isMarkDropdownOpen }"
-                        >
-                      </div>
-                    </button>
-                    <transition name="dropdown">
-                      <div
-                        v-if="isMarkDropdownOpen"
-                        class="mark__dropdown-menu"
+                    <div class="button__content">
+                      <span class="button__text">{{ selectedFormatText }}</span>
+                      <img
+                        src="@/assets/icons/arrow.png"
+                        class="button__arrow"
+                        :class="{ 'button__arrow--open': isFormatDropdownOpen }"
                       >
-                        <div class="mark__search">
-                          <input 
-                            v-model="markSearch" 
-                            class="mark__search-input"
-                            placeholder="Поиск марки..."
-                            @input="filterMarks"
+                    </div>
+                  </button>
+                  <transition name="dropdown">
+                    <div
+                      v-if="isFormatDropdownOpen"
+                      class="dropdown__menu"
+                    >
+                      <div 
+                        v-for="format in availableFormats" 
+                        :key="format.format.id"
+                        class="dropdown__item" 
+                        @click="selectFormat(format)"
+                      >
+                        <span class="item__text">{{ format.format.name }}</span>
+                      </div>
+                    </div>
+                  </transition>
+                </div>
+              </div>
+                        
+              <div class="completion__fields">
+                <div class="completion__number">
+                  <div class="completion__number-header">
+                    <label class="input__label">Номер Т/C <span class="required">*</span></label>
+                  </div>
+                                
+                  <!-- Динамический формат из базы данных -->
+                  <div
+                    v-if="selectedFormat"
+                    class="number__field"
+                  >
+                    <input 
+                      v-for="(cell, index) in selectedFormat.cells" 
+                      :key="index"
+                      v-model="numberParts[index]" 
+                      class="number__input"
+                      :placeholder="getPlaceholder(cell)"
+                      :maxlength="cell.max_length"
+                      :style="{ width: getInputWidth(cell) }"
+                      @input="validatePart(index, $event, cell)"
+                      @blur="formatPart(index, cell)"
+                    >
+                  </div>
+                  <div
+                    v-else
+                    class="no-format-message"
+                  >
+                    Выберите формат номера
+                  </div>
+                </div>
+                            
+                <div class="completion__mark">
+                  <div class="completion__mark-header">
+                    <label class="input__label">Марка Т/С <span class="required">*</span></label>
+                  </div>
+                  <div class="mark__field">
+                    <div class="mark__dropdown">
+                      <button
+                        class="mark__dropdown-button"
+                        @click="toggleMarkDropdown"
+                      >
+                        <div class="mark__button-content">
+                          <span class="mark__button-text">{{ selectedMark || 'Выберите марку' }}</span>
+                          <img
+                            src="@/assets/icons/arrow.png"
+                            class="mark__button-arrow"
+                            :class="{ 'mark__button-arrow--open': isMarkDropdownOpen }"
                           >
                         </div>
-                        <div class="mark__dropdown-list">
-                          <div 
-                            v-for="mark in filteredMarks" 
-                            :key="mark"
-                            class="mark__dropdown-item"
-                            @click="selectMark(mark)"
-                          >
-                            <span class="mark__item-text">{{ mark }}</span>
+                      </button>
+                      <transition name="dropdown">
+                        <div
+                          v-if="isMarkDropdownOpen"
+                          class="mark__dropdown-menu"
+                        >
+                          <div class="mark__search">
+                            <input 
+                              v-model="markSearch" 
+                              class="mark__search-input"
+                              placeholder="Поиск марки..."
+                              @input="filterMarks"
+                            >
+                          </div>
+                          <div class="mark__dropdown-list">
+                            <div 
+                              v-for="mark in filteredMarks" 
+                              :key="mark"
+                              class="mark__dropdown-item"
+                              @click="selectMark(mark)"
+                            >
+                              <span class="mark__item-text">{{ mark }}</span>
+                            </div>
                           </div>
                         </div>
-                      </div>
-                    </transition>
+                      </transition>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
 
-            <!-- Привязка -->
-            <div
-              v-if="currentFilter !== 'all_system'"
-              class="completion__binding"
-            >
-              <label class="input__label">Привязка</label>
-              <div class="binding-info">
-                <p class="binding-note">
-                  <strong>Добавляемый автомобиль автоматически привязывается к аккаунту пользователя.</strong>
-                  Автомобиль можно привязать к организации или компании, для использования <strong>другими сотрудниками</strong>:
-                </p>
-              </div>
-              <div class="binding-options">
-                <label
-                  v-if="ownershipInfo && ownershipInfo.has_organization"
-                  class="binding-option"
-                >
-                  <input 
-                    v-model="bindToOrganization" 
-                    type="checkbox"
-                    :disabled="bindToCompany"
+              <!-- Привязка -->
+              <div
+                v-if="currentFilter !== 'all_system'"
+                class="completion__binding"
+              >
+                <label class="input__label">Привязка</label>
+                <div class="binding-info">
+                  <p class="binding-note">
+                    <strong>Добавляемый автомобиль автоматически привязывается к аккаунту пользователя.</strong>
+                    Автомобиль можно привязать к организации или компании, для использования <strong>другими сотрудниками</strong>:
+                  </p>
+                </div>
+                <div class="binding-options">
+                  <label
+                    v-if="ownershipInfo && ownershipInfo.has_organization"
+                    class="binding-option"
                   >
-                  <span>Привязать к организации</span>
-                </label>
-                <label
-                  v-if="ownershipInfo && ownershipInfo.has_company"
-                  class="binding-option"
-                >
-                  <input 
-                    v-model="bindToCompany" 
-                    type="checkbox"
-                    :disabled="bindToOrganization"
+                    <input 
+                      v-model="bindToOrganization" 
+                      type="checkbox"
+                      :disabled="bindToCompany"
+                    >
+                    <span>Привязать к организации</span>
+                  </label>
+                  <label
+                    v-if="ownershipInfo && ownershipInfo.has_company"
+                    class="binding-option"
                   >
-                  <span>Привязать к компании</span>
-                </label>
-                <div class="user-binding">
-                  <span class="user-binding-text"><strong class="red">Внимание!</strong> При привязке автомобиля к организации или компании, он будет доступен для отображения и использования для всех сотрудников, привязанных к организации/компании. </span>
+                    <input 
+                      v-model="bindToCompany" 
+                      type="checkbox"
+                      :disabled="bindToOrganization"
+                    >
+                    <span>Привязать к компании</span>
+                  </label>
+                  <div class="user-binding">
+                    <span class="user-binding-text"><strong class="red">Внимание!</strong> При привязке автомобиля к организации или компании, он будет доступен для отображения и использования для всех сотрудников, привязанных к организации/компании. </span>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    </Teleport>
     <ConfirmationModal
       :show="showDeleteCarModal"
       title="Подтверждение удаления"
@@ -1580,6 +1582,8 @@ export default {
     align-items: center;
     justify-content: center;
     z-index: 1000;
+    backdrop-filter: blur(0.1px);
+    -webkit-backdrop-filter: blur(0.1px);
 }
 
 .modal-content {

--- a/frontend/src/views/NewsAndReview.vue
+++ b/frontend/src/views/NewsAndReview.vue
@@ -152,397 +152,405 @@
     </div>
 
     <!-- Модальное окно управления -->
-    <transition name="modal-fade">
-      <div
-        v-if="showManageModal"
-        class="modal-overlay"
-        @click.self="closeManageModal"
-      >
-        <div class="modal-content manage-modal">
-          <div class="modal-header">
-            <h3 class="modal-title">
-              Управление контентом
-            </h3>
-            <button
-              class="modal-close"
-              @click="closeManageModal"
-            >
-              <svg
-                width="10"
-                height="10"
-                viewBox="0 0 14 14"
-                fill="none"
-              ><path
-                d="M13 1L1 13M1 1L13 13"
-                stroke="#666"
-                stroke-width="2"
-                stroke-linecap="round"
-              /></svg>
-            </button>
-          </div>
-
-          <div class="modal-body">
-            <div class="manage-tabs">
+    <Teleport to="body">
+      <transition name="modal-fade">
+        <div
+          v-if="showManageModal"
+          class="modal-overlay"
+          @click.self="closeManageModal"
+        >
+          <div class="modal-content manage-modal">
+            <div class="modal-header">
+              <h3 class="modal-title">
+                Управление контентом
+              </h3>
               <button
-                class="tab-btn"
-                :class="{ active: activeTab === 'news' }"
-                @click="activeTab = 'news'"
+                class="modal-close"
+                @click="closeManageModal"
               >
-                Новости
-              </button>
-              <button
-                class="tab-btn"
-                :class="{ active: activeTab === 'announcements' }"
-                @click="activeTab = 'announcements'"
-              >
-                Объявления
+                <svg
+                  width="10"
+                  height="10"
+                  viewBox="0 0 14 14"
+                  fill="none"
+                ><path
+                  d="M13 1L1 13M1 1L13 13"
+                  stroke="#666"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                /></svg>
               </button>
             </div>
 
-            <!-- Новости -->
-            <div
-              v-if="activeTab === 'news'"
-              class="manage-section"
-            >
-              <div class="section-header">
-                <div class="section-title">
-                  Список новостей
-                </div>
+            <div class="modal-body">
+              <div class="manage-tabs">
                 <button
-                  class="add-btn"
-                  @click="openCreateNewsModal"
+                  class="tab-btn"
+                  :class="{ active: activeTab === 'news' }"
+                  @click="activeTab = 'news'"
                 >
-                  + Добавить новость
+                  Новости
+                </button>
+                <button
+                  class="tab-btn"
+                  :class="{ active: activeTab === 'announcements' }"
+                  @click="activeTab = 'announcements'"
+                >
+                  Объявления
                 </button>
               </div>
-              <div class="items-list">
-                <div
-                  v-for="item in allNewsItems"
-                  :key="item.id"
-                  class="manage-item"
-                >
-                  <div class="item-main">
-                    <div class="item-title">
-                      {{ item.title }}
-                    </div>
-                    <div class="item-meta">
-                      <span>{{ formatDate(item.created_at) }}</span>
-                      <span>{{ item.created_by_name || 'Система' }}</span>
-                      <span class="status-text">{{ item.is_active ? 'Активна' : 'Скрыта' }}</span>
-                    </div>
-                  </div>
-                  <div class="item-actions">
-                    <button
-                      class="action-btn edit-btn"
-                      @click="editNewsItem(item)"
-                    >
-                      Редактировать
-                    </button>
-                    <button
-                      class="action-btn toggle-btn"
-                      @click="toggleNewsActive(item)"
-                    >
-                      {{ item.is_active ? 'Скрыть' : 'Показать' }}
-                    </button>
-                    <button
-                      class="action-btn delete-btn"
-                      @click="deleteNewsItem(item.id)"
-                    >
-                      Удалить
-                    </button>
-                  </div>
-                </div>
-                <div
-                  v-if="allNewsItems.length === 0"
-                  class="empty-manage"
-                >
-                  Нет новостей
-                </div>
-              </div>
-            </div>
 
-            <!-- Объявления -->
-            <div
-              v-if="activeTab === 'announcements'"
-              class="manage-section"
-            >
-              <div class="section-header">
-                <div class="section-title">
-                  Список объявлений
+              <!-- Новости -->
+              <div
+                v-if="activeTab === 'news'"
+                class="manage-section"
+              >
+                <div class="section-header">
+                  <div class="section-title">
+                    Список новостей
+                  </div>
+                  <button
+                    class="add-btn"
+                    @click="openCreateNewsModal"
+                  >
+                    + Добавить новость
+                  </button>
                 </div>
-                <button
-                  class="add-btn"
-                  @click="openCreateAnnouncementModal"
-                >
-                  + Добавить объявление
-                </button>
+                <div class="items-list">
+                  <div
+                    v-for="item in allNewsItems"
+                    :key="item.id"
+                    class="manage-item"
+                  >
+                    <div class="item-main">
+                      <div class="item-title">
+                        {{ item.title }}
+                      </div>
+                      <div class="item-meta">
+                        <span>{{ formatDate(item.created_at) }}</span>
+                        <span>{{ item.created_by_name || 'Система' }}</span>
+                        <span class="status-text">{{ item.is_active ? 'Активна' : 'Скрыта' }}</span>
+                      </div>
+                    </div>
+                    <div class="item-actions">
+                      <button
+                        class="action-btn edit-btn"
+                        @click="editNewsItem(item)"
+                      >
+                        Редактировать
+                      </button>
+                      <button
+                        class="action-btn toggle-btn"
+                        @click="toggleNewsActive(item)"
+                      >
+                        {{ item.is_active ? 'Скрыть' : 'Показать' }}
+                      </button>
+                      <button
+                        class="action-btn delete-btn"
+                        @click="deleteNewsItem(item.id)"
+                      >
+                        Удалить
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    v-if="allNewsItems.length === 0"
+                    class="empty-manage"
+                  >
+                    Нет новостей
+                  </div>
+                </div>
               </div>
-              <div class="info-message">
-                <span>Активно может быть только одно объявление</span>
-              </div>
-              <div class="items-list">
-                <div
-                  v-for="item in allAnnouncements"
-                  :key="item.id"
-                  class="manage-item"
-                >
-                  <div class="item-main">
-                    <div class="item-title">
-                      {{ item.title }}
-                      <span
-                        v-if="item.is_important"
-                        class="important-badge"
-                      >Важное</span>
-                      <span
+
+              <!-- Объявления -->
+              <div
+                v-if="activeTab === 'announcements'"
+                class="manage-section"
+              >
+                <div class="section-header">
+                  <div class="section-title">
+                    Список объявлений
+                  </div>
+                  <button
+                    class="add-btn"
+                    @click="openCreateAnnouncementModal"
+                  >
+                    + Добавить объявление
+                  </button>
+                </div>
+                <div class="info-message">
+                  <span>Активно может быть только одно объявление</span>
+                </div>
+                <div class="items-list">
+                  <div
+                    v-for="item in allAnnouncements"
+                    :key="item.id"
+                    class="manage-item"
+                  >
+                    <div class="item-main">
+                      <div class="item-title">
+                        {{ item.title }}
+                        <span
+                          v-if="item.is_important"
+                          class="important-badge"
+                        >Важное</span>
+                        <span
+                          v-if="item.is_active"
+                          class="active-badge"
+                        >Активно</span>
+                      </div>
+                      <div class="item-meta">
+                        <span>{{ formatDate(item.created_at) }}</span>
+                        <span>Создал: {{ item.created_by_name || 'Система' }}</span>
+                        <span v-if="item.activated_by_name">Активировал: {{ item.activated_by_name }}</span>
+                      </div>
+                    </div>
+                    <div class="item-actions">
+                      <button
+                        class="action-btn edit-btn"
+                        @click="editAnnouncement(item)"
+                      >
+                        Редактировать
+                      </button>
+                      <button
+                        v-if="!item.is_active"
+                        class="action-btn activate-btn"
+                        @click="setActiveAnnouncement(item.id)"
+                      >
+                        Активировать
+                      </button>
+                      <button
                         v-if="item.is_active"
-                        class="active-badge"
-                      >Активно</span>
-                    </div>
-                    <div class="item-meta">
-                      <span>{{ formatDate(item.created_at) }}</span>
-                      <span>Создал: {{ item.created_by_name || 'Система' }}</span>
-                      <span v-if="item.activated_by_name">Активировал: {{ item.activated_by_name }}</span>
+                        class="action-btn deactivate-btn"
+                        @click="deactivateAnnouncement(item.id)"
+                      >
+                        Деактивировать
+                      </button>
+                      <button
+                        class="action-btn delete-btn"
+                        @click="deleteAnnouncement(item.id)"
+                      >
+                        Удалить
+                      </button>
                     </div>
                   </div>
-                  <div class="item-actions">
-                    <button
-                      class="action-btn edit-btn"
-                      @click="editAnnouncement(item)"
-                    >
-                      Редактировать
-                    </button>
-                    <button
-                      v-if="!item.is_active"
-                      class="action-btn activate-btn"
-                      @click="setActiveAnnouncement(item.id)"
-                    >
-                      Активировать
-                    </button>
-                    <button
-                      v-if="item.is_active"
-                      class="action-btn deactivate-btn"
-                      @click="deactivateAnnouncement(item.id)"
-                    >
-                      Деактивировать
-                    </button>
-                    <button
-                      class="action-btn delete-btn"
-                      @click="deleteAnnouncement(item.id)"
-                    >
-                      Удалить
-                    </button>
+                  <div
+                    v-if="allAnnouncements.length === 0"
+                    class="empty-manage"
+                  >
+                    Нет объявлений
                   </div>
-                </div>
-                <div
-                  v-if="allAnnouncements.length === 0"
-                  class="empty-manage"
-                >
-                  Нет объявлений
                 </div>
               </div>
             </div>
-          </div>
 
-          <div class="modal-footer">
-            <button
-              class="btn close-btn"
-              @click="closeManageModal"
-            >
-              Закрыть
-            </button>
+            <div class="modal-footer">
+              <button
+                class="btn close-btn"
+                @click="closeManageModal"
+              >
+                Закрыть
+              </button>
+            </div>
           </div>
         </div>
-      </div>
-    </transition>
+      </transition>
+    </Teleport>
 
     <!-- Модальное окно создания/редактирования новости -->
-    <transition name="modal-fade">
-      <div
-        v-if="showNewsModal"
-        class="modal-overlay"
-        @click.self="closeNewsModal"
-      >
-        <div class="modal-content">
-          <div class="modal-header">
-            <h3 class="modal-title">
-              {{ editingNews ? 'Редактировать новость' : 'Создать новость' }}
-            </h3>
-            <button
-              class="modal-close"
-              @click="closeNewsModal"
-            >
-              <svg
-                width="10"
-                height="10"
-                viewBox="0 0 14 14"
-                fill="none"
-              ><path
-                d="M13 1L1 13M1 1L13 13"
-                stroke="#666"
-                stroke-width="2"
-                stroke-linecap="round"
-              /></svg>
-            </button>
-          </div>
-          <div class="modal-body">
-            <div class="form-group">
-              <label class="form-label">Заголовок</label><input
-                v-model="newsForm.title"
-                type="text"
-                class="form-input"
-                placeholder="Введите заголовок"
+    <Teleport to="body">
+      <transition name="modal-fade">
+        <div
+          v-if="showNewsModal"
+          class="modal-overlay"
+          @click.self="closeNewsModal"
+        >
+          <div class="modal-content">
+            <div class="modal-header">
+              <h3 class="modal-title">
+                {{ editingNews ? 'Редактировать новость' : 'Создать новость' }}
+              </h3>
+              <button
+                class="modal-close"
+                @click="closeNewsModal"
               >
+                <svg
+                  width="10"
+                  height="10"
+                  viewBox="0 0 14 14"
+                  fill="none"
+                ><path
+                  d="M13 1L1 13M1 1L13 13"
+                  stroke="#666"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                /></svg>
+              </button>
             </div>
-            <div class="form-group">
-              <label class="form-label">Краткое описание</label><textarea
-                v-model="newsForm.description"
-                class="form-textarea"
-                placeholder="Введите краткое описание"
-                rows="3"
-              />
+            <div class="modal-body">
+              <div class="form-group">
+                <label class="form-label">Заголовок</label><input
+                  v-model="newsForm.title"
+                  type="text"
+                  class="form-input"
+                  placeholder="Введите заголовок"
+                >
+              </div>
+              <div class="form-group">
+                <label class="form-label">Краткое описание</label><textarea
+                  v-model="newsForm.description"
+                  class="form-textarea"
+                  placeholder="Введите краткое описание"
+                  rows="3"
+                />
+              </div>
+              <div class="form-group">
+                <label class="form-label">Полный текст</label><textarea
+                  v-model="newsForm.fullText"
+                  class="form-textarea"
+                  placeholder="Введите полный текст"
+                  rows="5"
+                />
+              </div>
             </div>
-            <div class="form-group">
-              <label class="form-label">Полный текст</label><textarea
-                v-model="newsForm.fullText"
-                class="form-textarea"
-                placeholder="Введите полный текст"
-                rows="5"
-              />
+            <div class="modal-footer">
+              <button
+                class="btn cancel-btn"
+                @click="closeNewsModal"
+              >
+                Отмена
+              </button>
+              <button
+                class="btn save-btn"
+                @click="submitNews"
+              >
+                Сохранить
+              </button>
             </div>
-          </div>
-          <div class="modal-footer">
-            <button
-              class="btn cancel-btn"
-              @click="closeNewsModal"
-            >
-              Отмена
-            </button>
-            <button
-              class="btn save-btn"
-              @click="submitNews"
-            >
-              Сохранить
-            </button>
           </div>
         </div>
-      </div>
-    </transition>
+      </transition>
+    </Teleport>
 
     <!-- Модальное окно создания/редактирования объявления -->
-    <transition name="modal-fade">
-      <div
-        v-if="showAnnouncementModal"
-        class="modal-overlay"
-        @click.self="closeAnnouncementModal"
-      >
-        <div class="modal-content">
-          <div class="modal-header">
-            <h3 class="modal-title">
-              {{ editingAnnouncement ? 'Редактировать объявление' : 'Создать объявление' }}
-            </h3>
-            <button
-              class="modal-close"
-              @click="closeAnnouncementModal"
-            >
-              <svg
-                width="10"
-                height="10"
-                viewBox="0 0 14 14"
-                fill="none"
-              ><path
-                d="M13 1L1 13M1 1L13 13"
-                stroke="#666"
-                stroke-width="2"
-                stroke-linecap="round"
-              /></svg>
-            </button>
-          </div>
-          <div class="modal-body">
-            <div class="form-group">
-              <label class="form-label">Заголовок</label><input
-                v-model="announcementForm.title"
-                type="text"
-                class="form-input"
-                placeholder="Введите заголовок"
+    <Teleport to="body">
+      <transition name="modal-fade">
+        <div
+          v-if="showAnnouncementModal"
+          class="modal-overlay"
+          @click.self="closeAnnouncementModal"
+        >
+          <div class="modal-content">
+            <div class="modal-header">
+              <h3 class="modal-title">
+                {{ editingAnnouncement ? 'Редактировать объявление' : 'Создать объявление' }}
+              </h3>
+              <button
+                class="modal-close"
+                @click="closeAnnouncementModal"
               >
+                <svg
+                  width="10"
+                  height="10"
+                  viewBox="0 0 14 14"
+                  fill="none"
+                ><path
+                  d="M13 1L1 13M1 1L13 13"
+                  stroke="#666"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                /></svg>
+              </button>
             </div>
-            <div class="form-group">
-              <label class="form-label">Краткое описание</label><textarea
-                v-model="announcementForm.description"
-                class="form-textarea"
-                placeholder="Введите краткое описание"
-                rows="3"
-              />
+            <div class="modal-body">
+              <div class="form-group">
+                <label class="form-label">Заголовок</label><input
+                  v-model="announcementForm.title"
+                  type="text"
+                  class="form-input"
+                  placeholder="Введите заголовок"
+                >
+              </div>
+              <div class="form-group">
+                <label class="form-label">Краткое описание</label><textarea
+                  v-model="announcementForm.description"
+                  class="form-textarea"
+                  placeholder="Введите краткое описание"
+                  rows="3"
+                />
+              </div>
+              <div class="form-group">
+                <label class="form-label">Полный текст</label><textarea
+                  v-model="announcementForm.fullText"
+                  class="form-textarea"
+                  placeholder="Введите полный текст"
+                  rows="5"
+                />
+              </div>
+              <div class="form-group">
+                <label class="checkbox-label"><input
+                  v-model="announcementForm.isImportant"
+                  type="checkbox"
+                ><span>Важное объявление</span></label>
+              </div>
             </div>
-            <div class="form-group">
-              <label class="form-label">Полный текст</label><textarea
-                v-model="announcementForm.fullText"
-                class="form-textarea"
-                placeholder="Введите полный текст"
-                rows="5"
-              />
+            <div class="modal-footer">
+              <button
+                class="btn cancel-btn"
+                @click="closeAnnouncementModal"
+              >
+                Отмена
+              </button>
+              <button
+                class="btn save-btn"
+                @click="submitAnnouncement"
+              >
+                Сохранить
+              </button>
             </div>
-            <div class="form-group">
-              <label class="checkbox-label"><input
-                v-model="announcementForm.isImportant"
-                type="checkbox"
-              ><span>Важное объявление</span></label>
-            </div>
-          </div>
-          <div class="modal-footer">
-            <button
-              class="btn cancel-btn"
-              @click="closeAnnouncementModal"
-            >
-              Отмена
-            </button>
-            <button
-              class="btn save-btn"
-              @click="submitAnnouncement"
-            >
-              Сохранить
-            </button>
           </div>
         </div>
-      </div>
-    </transition>
+      </transition>
+    </Teleport>
 
     <!-- Модальное окно просмотра новости -->
-    <transition name="modal-fade">
-      <div
-        v-if="showNewsDetailsModal"
-        class="modal-overlay"
-        @click.self="closeNewsDetailsModal"
-      >
-        <div class="modal-content">
-          <div class="modal-body">
-            <div class="modal-info">
-              <time class="modal-date">{{ formatDate(selectedNews?.created_at) }}</time><span class="modal-type">Новость</span>
+    <Teleport to="body">
+      <transition name="modal-fade">
+        <div
+          v-if="showNewsDetailsModal"
+          class="modal-overlay"
+          @click.self="closeNewsDetailsModal"
+        >
+          <div class="modal-content">
+            <div class="modal-body">
+              <div class="modal-info">
+                <time class="modal-date">{{ formatDate(selectedNews?.created_at) }}</time><span class="modal-type">Новость</span>
+              </div>
+              <h3 class="modal-title">
+                {{ selectedNews?.title }}
+              </h3>
+              <p class="modal-description">
+                {{ selectedNews?.description }}
+              </p>
+              <div
+                v-if="selectedNews?.full_text"
+                class="modal-full-text"
+              >
+                {{ selectedNews.full_text }}
+              </div>
             </div>
-            <h3 class="modal-title">
-              {{ selectedNews?.title }}
-            </h3>
-            <p class="modal-description">
-              {{ selectedNews?.description }}
-            </p>
-            <div
-              v-if="selectedNews?.full_text"
-              class="modal-full-text"
-            >
-              {{ selectedNews.full_text }}
+            <div class="modal-footer">
+              <button
+                class="btn close-btn"
+                @click="closeNewsDetailsModal"
+              >
+                Закрыть
+              </button>
             </div>
-          </div>
-          <div class="modal-footer">
-            <button
-              class="btn close-btn"
-              @click="closeNewsDetailsModal"
-            >
-              Закрыть
-            </button>
           </div>
         </div>
-      </div>
-    </transition>
+      </transition>
+    </Teleport>
 
     <!-- Модальное окно просмотра объявления - используем AnnouncementModal -->
     <AnnouncementModal 
@@ -1378,7 +1386,8 @@ export default {
     align-items: center;
     justify-content: center;
     z-index: 1000;
-    backdrop-filter: blur(1px);
+    backdrop-filter: blur(0.1px);
+    -webkit-backdrop-filter: blur(0.1px);
 }
 
 .modal-fade-enter-active,

--- a/frontend/src/views/admin/SystemControl.vue
+++ b/frontend/src/views/admin/SystemControl.vue
@@ -392,12 +392,14 @@ export default {
 .sc__modal-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(15, 17, 41, 0.5);
+  background: rgba(0, 0, 0, 0.5);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 10000;
   padding: 20px;
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
 }
 .sc__modal {
   background: #fff;


### PR DESCRIPTION
## Что сделано
- BaseModal: backdrop унифицирован к ТЗ — rgba(0,0,0,0.5) + blur(0.1px) + -webkit-backdrop-filter
- 13 модалок обёрнуты в `<Teleport to="body">` (раньше Teleport был только в BaseModal)
- 40 файлов: backdrop opacity 0.3/0.5/0.75 → единый 0.5; blur различный → 0.1px
- PasswordRecoveryModal и ApplicationSuccessModal НЕ тронуты (запрет ТЗ — свежие)

## Объём
40 файлов изменены, ~5200 строк дифф. Большая часть — переиндентация template из-за Teleport-обёртки.

## Замечания ревьюера
- **Important**: рекомендуется smoke-test всех модалок руками после merge — много мехизменений
- blur(0.1px) визуально неотличим от blur(0) — это требование ТЗ, оставлено как есть
- ConfirmationModal имеет animation backdrop-filter — не GPU-friendly, но существующий код не трогал
- Не во всех файлах добавлен Teleport (где был fixed/z-index — оставлен fallback). Цель ТЗ 'overlay уровня приложения' = только Teleport, частично выполнена

## Зависимости
Этот PR должен мерджиться **после** PR #блок 8 (Pinia) — оба трогают OrganizationsManagement/CompaniesManagement/CitizenshipManagement/UserControl/CreateUserModal. Тимлид подтвердил что merge проходит без конфликтов в любом порядке.

Code review статус: ✅ готово к merge (с smoke-test после)