### PR TITLE
feat: блок истории + уведомление пароля + permission на unread (#184)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -144,7 +144,8 @@ func main() {
 	citizenshipService := services.NewCitizenshipService(db)
 	organizationService := services.NewOrganizationService(db)
 	companyService := services.NewCompanyService(db)
-	userService := services.NewUserService(db)
+	notificationServiceEarly := services.NewNotificationService(db)
+	userService := services.NewUserService(db, notificationServiceEarly)
 	unloadPlaceService := services.NewUnloadPlaceService(db)
 	carService := services.NewCarService(db)
 	employeeService := services.NewEmployeeService(db)
@@ -154,7 +155,7 @@ func main() {
 	uniqueEmployeeService := services.NewUniqueEmployeeService(db)
 	feedbackService := services.NewFeedbackService(db)
 	newsService := services.NewNewsService(db)
-	notificationService := services.NewNotificationService(db)
+	notificationService := notificationServiceEarly
 	requestLogsService := services.NewRequestLogsService(db)
 	employeesHistoryService := services.NewEmployeesHistoryService(db)
 	applicationService := services.NewApplicationService(db, permissionService, notificationService)

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -57,7 +57,9 @@ func AllModels() []interface{} {
 		// Unique records
 		&models.UniqueAttachment{},
 		&models.UniqueCar{},
+		&models.UniqueCarHistory{},
 		&models.UniqueEmployee{},
+		&models.UniqueEmployeeHistory{},
 
 		// Attachments (depends on Application, UniqueAttachment)
 		&models.Attachment{},

--- a/internal/handlers/application_unread_permission_test.go
+++ b/internal/handlers/application_unread_permission_test.go
@@ -1,0 +1,94 @@
+package handlers_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestApplicationService_GetUnreadCount_PermissionCheck проверяет, что
+// счётчик непрочитанных учитывает права доступа: пользователь без роли
+// approver/responsible/viewer не видит чужих заявок в счётчике.
+func TestApplicationService_GetUnreadCount_PermissionCheck(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	// Два юзера: sender (создаёт заявки) и outsider (не имеет доступа ни к одной).
+	sender := models.User{
+		Username:       "sender_unread",
+		Password:       "x",
+		TypeID:         1,
+		OrganizationID: &td.OrgID,
+		CompanyID:      &td.CompanyID,
+	}
+	outsider := models.User{
+		Username:       "outsider_unread",
+		Password:       "x",
+		TypeID:         1,
+		OrganizationID: &td.OrgID,
+		CompanyID:      &td.CompanyID,
+	}
+	approver := models.User{
+		Username:       "approver_unread",
+		Password:       "x",
+		TypeID:         1,
+		OrganizationID: &td.OrgID,
+		CompanyID:      &td.CompanyID,
+	}
+	require.NoError(t, db.Create(&sender).Error)
+	require.NoError(t, db.Create(&outsider).Error)
+	require.NoError(t, db.Create(&approver).Error)
+
+	// Создаём заявку, отправленную sender'ом, без responsible/viewer.
+	appNumber := "APP-UR-1"
+	status := models.StatusProcessing
+	confirmation := models.ConfirmationPending
+	app := models.Application{
+		ApplicationNumber: &appNumber,
+		OrganizationID:    td.OrgID,
+		CompanyID:         &td.CompanyID,
+		SenderUserID:      sender.ID,
+		Status:            &status,
+		Confirmation:      &confirmation,
+		SendingDatetime:   ptrTime(time.Now().UTC()),
+	}
+	require.NoError(t, db.Create(&app).Error)
+
+	// Делаем approver глобальным approver-ом (видит все заявки).
+	require.NoError(t, db.Create(&models.ApplicationApprover{UserID: approver.ID}).Error)
+
+	permSvc := services.NewPermissionService(db)
+	notifSvc := services.NewNotificationService(db)
+	appSvc := services.NewApplicationService(db, permSvc, notifSvc)
+
+	// outsider не должен видеть эту заявку в счётчике.
+	resOutsider, err := appSvc.GetUnreadCount(context.Background(), outsider.Username)
+	require.NoError(t, err)
+	assert.Equal(t, 0, resOutsider.Count, "outsider не должен видеть чужую заявку")
+
+	// approver видит все заявки -> 1 непрочитанная.
+	resApprover, err := appSvc.GetUnreadCount(context.Background(), approver.Username)
+	require.NoError(t, err)
+	assert.Equal(t, 1, resApprover.Count, "approver должен видеть заявку как непрочитанную")
+
+	// Если outsider становится viewer'ом, он должен увидеть заявку.
+	require.NoError(t, db.Create(&models.ApplicationViewer{
+		ApplicationID: app.ID,
+		UserID:        outsider.ID,
+	}).Error)
+
+	resOutsider2, err := appSvc.GetUnreadCount(context.Background(), outsider.Username)
+	require.NoError(t, err)
+	assert.Equal(t, 1, resOutsider2.Count, "outsider-viewer должен видеть заявку")
+}
+
+func ptrTime(t time.Time) *time.Time { return &t }

--- a/internal/handlers/unique_cars.go
+++ b/internal/handlers/unique_cars.go
@@ -181,6 +181,32 @@ func (h *UniqueCarHandler) Delete(c echo.Context) error {
 	return RespondMessage(c, "Car deleted successfully")
 }
 
+// GetHistory godoc
+// @Summary      История изменений мастер-машины
+// @Description  Возвращает аудит изменений мастер-записи машины (data_changed)
+// @Tags         unique-cars
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID машины"
+// @Success      200 {array} services.UniqueCarHistoryItem
+// @Failure      401 {object} models.HTTPError
+// @Failure      403 {object} models.HTTPError "Нет прав"
+// @Failure      404 {object} models.HTTPError "Не найдена"
+// @Router       /unique-cars/{id}/history [get]
+func (h *UniqueCarHandler) GetHistory(c echo.Context) error {
+	username := c.Get("username").(string)
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+
+	items, err := h.service.GetHistory(c.Request().Context(), username, id)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, items)
+}
+
 // GetOwnershipInfo godoc
 // @Summary      Информация о владельце для машин
 // @Description  Возвращает данные о привязке пользователя к организации/компании

--- a/internal/handlers/unique_employees.go
+++ b/internal/handlers/unique_employees.go
@@ -128,6 +128,32 @@ func (h *UniqueEmployeeHandler) Delete(c echo.Context) error {
 	return RespondMessage(c, "Employee deleted successfully")
 }
 
+// GetHistory godoc
+// @Summary      История изменений мастер-сотрудника
+// @Description  Возвращает аудит изменений мастер-записи сотрудника (data_changed)
+// @Tags         unique-employees
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID сотрудника"
+// @Success      200 {array} services.UniqueEmployeeHistoryItem
+// @Failure      401 {object} models.HTTPError
+// @Failure      403 {object} models.HTTPError "Нет прав"
+// @Failure      404 {object} models.HTTPError "Не найден"
+// @Router       /unique-employees/{id}/history [get]
+func (h *UniqueEmployeeHandler) GetHistory(c echo.Context) error {
+	username := c.Get("username").(string)
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+
+	items, err := h.service.GetHistory(c.Request().Context(), username, id)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, items)
+}
+
 // GetOwnershipInfo godoc
 // @Summary      Информация о владельце для сотрудников
 // @Description  Возвращает данные о привязке пользователя к организации/компании

--- a/internal/handlers/unique_history_test.go
+++ b/internal/handlers/unique_history_test.go
@@ -1,0 +1,374 @@
+package handlers_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+	"systemburo/internal/testutil"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUniqueEmployeeService_Update_RecordsChanges проверяет, что при апдейте
+// мастер-записи сотрудника пишутся записи data_changed на каждое изменённое
+// поле (и только на них).
+func TestUniqueEmployeeService_Update_RecordsChanges(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	owner := models.User{
+		Username:       "owner_emp_change",
+		Password:       "x",
+		TypeID:         6,
+		OrganizationID: &td.OrgID,
+		CompanyID:      &td.CompanyID,
+	}
+	require.NoError(t, db.Create(&owner).Error)
+
+	lastNameOld := "Иванов"
+	firstNameOld := "Иван"
+	middleNameOld := "Иванович"
+	posOld := "Грузчик"
+	otherOld := "разрешение-1"
+	emp := models.UniqueEmployee{
+		LastName:        &lastNameOld,
+		FirstName:       &firstNameOld,
+		MiddleName:      &middleNameOld,
+		Position:        &posOld,
+		OtherPermission: &otherOld,
+		OrganizationID:  &td.OrgID,
+		CompanyID:       &td.CompanyID,
+		UserID:          &owner.ID,
+	}
+	require.NoError(t, db.Create(&emp).Error)
+
+	svc := services.NewUniqueEmployeeService(db)
+
+	// Меняем фамилию и должность, остальное оставляем.
+	newLast := "Петров"
+	newPos := "Старший грузчик"
+	req := services.NewUniqueEmployeeRequest{
+		LastName:        &newLast,
+		FirstName:       &firstNameOld,
+		MiddleName:      &middleNameOld,
+		Position:        &newPos,
+		OtherPermission: &otherOld,
+		OrganizationID:  &td.OrgID,
+		CompanyID:       &td.CompanyID,
+		UserID:          &owner.ID,
+	}
+	resp, err := svc.Update(context.Background(), owner.Username, emp.ID, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "Петров", *resp.LastName)
+
+	// Должно быть ровно две записи — last_name и position.
+	var history []models.UniqueEmployeeHistory
+	require.NoError(t, db.Where("unique_employee_id = ?", emp.ID).Order("id").Find(&history).Error)
+	require.Len(t, history, 2)
+
+	byField := make(map[string]models.UniqueEmployeeHistory, len(history))
+	for _, h := range history {
+		require.NotNil(t, h.FieldName)
+		byField[*h.FieldName] = h
+	}
+
+	if h, ok := byField["last_name"]; assert.True(t, ok, "ожидалась запись last_name") {
+		assert.Equal(t, "data_changed", h.ActionType)
+		assert.Equal(t, "Иванов", deref(h.OldValue))
+		assert.Equal(t, "Петров", deref(h.NewValue))
+		require.NotNil(t, h.UserID)
+		assert.Equal(t, owner.ID, *h.UserID)
+	}
+	if h, ok := byField["position"]; assert.True(t, ok, "ожидалась запись position") {
+		assert.Equal(t, "data_changed", h.ActionType)
+		assert.Equal(t, "Грузчик", deref(h.OldValue))
+		assert.Equal(t, "Старший грузчик", deref(h.NewValue))
+	}
+}
+
+// TestUniqueEmployeeService_Update_NoChange проверяет, что при апдейте без
+// изменений (новые значения == старым) запись истории не создаётся.
+func TestUniqueEmployeeService_Update_NoChange(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	owner := models.User{
+		Username:       "owner_emp_nochange",
+		Password:       "x",
+		TypeID:         6,
+		OrganizationID: &td.OrgID,
+		CompanyID:      &td.CompanyID,
+	}
+	require.NoError(t, db.Create(&owner).Error)
+
+	last := "Сидоров"
+	first := "Пётр"
+	middle := "Алексеевич"
+	emp := models.UniqueEmployee{
+		LastName:       &last,
+		FirstName:      &first,
+		MiddleName:     &middle,
+		OrganizationID: &td.OrgID,
+		CompanyID:      &td.CompanyID,
+		UserID:         &owner.ID,
+	}
+	require.NoError(t, db.Create(&emp).Error)
+
+	svc := services.NewUniqueEmployeeService(db)
+
+	req := services.NewUniqueEmployeeRequest{
+		LastName:       &last,
+		FirstName:      &first,
+		MiddleName:     &middle,
+		OrganizationID: &td.OrgID,
+		CompanyID:      &td.CompanyID,
+		UserID:         &owner.ID,
+	}
+	_, err := svc.Update(context.Background(), owner.Username, emp.ID, req)
+	require.NoError(t, err)
+
+	var count int64
+	require.NoError(t, db.Model(&models.UniqueEmployeeHistory{}).
+		Where("unique_employee_id = ?", emp.ID).
+		Count(&count).Error)
+	assert.Equal(t, int64(0), count, "не должно создаваться записей истории при no-op апдейте")
+}
+
+// TestUniqueCarService_UpdateByNumber_RecordsChanges проверяет аудит для
+// машины при изменении format_id и user_id через UpdateByNumber.
+func TestUniqueCarService_UpdateByNumber_RecordsChanges(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	owner := models.User{
+		Username:       "owner_car_change",
+		Password:       "x",
+		TypeID:         6,
+		OrganizationID: &td.OrgID,
+		CompanyID:      &td.CompanyID,
+	}
+	require.NoError(t, db.Create(&owner).Error)
+
+	number := "А123БВ77"
+	mark := "Лада"
+	formatOld := 1
+	car := models.UniqueCar{
+		Number:         &number,
+		Mark:           &mark,
+		OrganizationID: &td.OrgID,
+		CompanyID:      &td.CompanyID,
+		FormatID:       &formatOld,
+		UserID:         &owner.ID,
+	}
+	require.NoError(t, db.Create(&car).Error)
+
+	svc := services.NewUniqueCarService(db)
+
+	formatNew := 2
+	req := services.UpdateCarByNumberRequest{
+		Number: number,
+		Mark:   mark,
+		UpdateData: services.NewUniqueCarRequest{
+			Number:         number,
+			Mark:           mark,
+			OrganizationID: &td.OrgID,
+			CompanyID:      &td.CompanyID,
+			FormatID:       &formatNew,
+			UserID:         &owner.ID,
+		},
+	}
+	resp, err := svc.UpdateByNumber(context.Background(), owner.Username, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	var history []models.UniqueCarHistory
+	require.NoError(t, db.Where("unique_car_id = ?", car.ID).Order("id").Find(&history).Error)
+	require.Len(t, history, 1, "ожидается ровно одна запись (format_id)")
+	assert.Equal(t, "data_changed", history[0].ActionType)
+	require.NotNil(t, history[0].FieldName)
+	assert.Equal(t, "format_id", *history[0].FieldName)
+	assert.Equal(t, "1", deref(history[0].OldValue))
+	assert.Equal(t, "2", deref(history[0].NewValue))
+}
+
+// TestUniqueEmployeeService_GetHistory_ReturnsRecords проверяет, что GetHistory
+// возвращает записи аудита по data_changed после Update и фильтрует по правам.
+func TestUniqueEmployeeService_GetHistory_ReturnsRecords(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	owner := models.User{
+		Username:       "owner_emp_history",
+		Password:       "x",
+		TypeID:         6,
+		OrganizationID: &td.OrgID,
+		CompanyID:      &td.CompanyID,
+	}
+	require.NoError(t, db.Create(&owner).Error)
+
+	last := "Иванов"
+	first := "Иван"
+	pos := "Грузчик"
+	emp := models.UniqueEmployee{
+		LastName:       &last,
+		FirstName:      &first,
+		Position:       &pos,
+		OrganizationID: &td.OrgID,
+		CompanyID:      &td.CompanyID,
+		UserID:         &owner.ID,
+	}
+	require.NoError(t, db.Create(&emp).Error)
+
+	svc := services.NewUniqueEmployeeService(db)
+
+	newLast := "Петров"
+	req := services.NewUniqueEmployeeRequest{
+		LastName:       &newLast,
+		FirstName:      &first,
+		Position:       &pos,
+		OrganizationID: &td.OrgID,
+		CompanyID:      &td.CompanyID,
+		UserID:         &owner.ID,
+	}
+	_, err := svc.Update(context.Background(), owner.Username, emp.ID, req)
+	require.NoError(t, err)
+
+	items, err := svc.GetHistory(context.Background(), owner.Username, emp.ID)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	assert.Equal(t, "data_changed", items[0].ActionType)
+	require.NotNil(t, items[0].FieldName)
+	assert.Equal(t, "last_name", *items[0].FieldName)
+	assert.Equal(t, "Иванов", deref(items[0].OldValue))
+	assert.Equal(t, "Петров", deref(items[0].NewValue))
+	require.NotNil(t, items[0].Username)
+	assert.Equal(t, owner.Username, *items[0].Username)
+}
+
+// TestUniqueEmployeeService_GetHistory_Forbidden проверяет, что юзер без прав
+// на редактирование сотрудника получает 403 при запросе истории.
+func TestUniqueEmployeeService_GetHistory_Forbidden(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	otherOrgID := td.OrgID + 1000
+	otherOrg := models.Organization{ID: otherOrgID, Name: "other-org"}
+	require.NoError(t, db.Create(&otherOrg).Error)
+
+	otherCompID := td.CompanyID + 1000
+	otherComp := models.Company{ID: otherCompID, Name: "other-comp"}
+	require.NoError(t, db.Create(&otherComp).Error)
+
+	owner := models.User{
+		Username:       "owner_emp_forbid",
+		Password:       "x",
+		TypeID:         6,
+		OrganizationID: &td.OrgID,
+		CompanyID:      &td.CompanyID,
+	}
+	require.NoError(t, db.Create(&owner).Error)
+
+	stranger := models.User{
+		Username:       "stranger_emp_forbid",
+		Password:       "x",
+		TypeID:         6,
+		OrganizationID: &otherOrgID,
+		CompanyID:      &otherCompID,
+	}
+	require.NoError(t, db.Create(&stranger).Error)
+
+	last := "Сидоров"
+	emp := models.UniqueEmployee{
+		LastName:       &last,
+		OrganizationID: &td.OrgID,
+		CompanyID:      &td.CompanyID,
+		UserID:         &owner.ID,
+	}
+	require.NoError(t, db.Create(&emp).Error)
+
+	svc := services.NewUniqueEmployeeService(db)
+	_, err := svc.GetHistory(context.Background(), stranger.Username, emp.ID)
+	require.Error(t, err)
+	httpErr, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusForbidden, httpErr.Code)
+}
+
+// TestUniqueCarService_GetHistory_ReturnsRecords проверяет аналогичный сценарий
+// для машин: создание записи через UpdateByNumber и чтение через GetHistory.
+func TestUniqueCarService_GetHistory_ReturnsRecords(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	owner := models.User{
+		Username:       "owner_car_history",
+		Password:       "x",
+		TypeID:         6,
+		OrganizationID: &td.OrgID,
+		CompanyID:      &td.CompanyID,
+	}
+	require.NoError(t, db.Create(&owner).Error)
+
+	number := "А999ВВ77"
+	mark := "Лада"
+	formatOld := 1
+	car := models.UniqueCar{
+		Number:         &number,
+		Mark:           &mark,
+		OrganizationID: &td.OrgID,
+		CompanyID:      &td.CompanyID,
+		FormatID:       &formatOld,
+		UserID:         &owner.ID,
+	}
+	require.NoError(t, db.Create(&car).Error)
+
+	svc := services.NewUniqueCarService(db)
+	formatNew := 2
+	_, err := svc.UpdateByNumber(context.Background(), owner.Username, services.UpdateCarByNumberRequest{
+		Number: number,
+		Mark:   mark,
+		UpdateData: services.NewUniqueCarRequest{
+			Number:         number,
+			Mark:           mark,
+			OrganizationID: &td.OrgID,
+			CompanyID:      &td.CompanyID,
+			FormatID:       &formatNew,
+			UserID:         &owner.ID,
+		},
+	})
+	require.NoError(t, err)
+
+	items, err := svc.GetHistory(context.Background(), owner.Username, car.ID)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	assert.Equal(t, "data_changed", items[0].ActionType)
+	require.NotNil(t, items[0].FieldName)
+	assert.Equal(t, "format_id", *items[0].FieldName)
+	require.NotNil(t, items[0].Username)
+	assert.Equal(t, owner.Username, *items[0].Username)
+}
+
+func deref(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}

--- a/internal/handlers/user_password_notification_test.go
+++ b/internal/handlers/user_password_notification_test.go
@@ -1,0 +1,93 @@
+package handlers_test
+
+import (
+	"context"
+	"testing"
+
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUserService_UpdatePassword_CreatesNotification проверяет, что после
+// admin-смены пароля у целевого пользователя появляется уведомление
+// password_changed.
+func TestUserService_UpdatePassword_CreatesNotification(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	target := models.User{
+		Username:       "target_for_pass_change",
+		Password:       "x",
+		TypeID:         1, // обычный юзер
+		OrganizationID: &td.OrgID,
+		CompanyID:      &td.CompanyID,
+	}
+	require.NoError(t, db.Create(&target).Error)
+
+	notifSvc := services.NewNotificationService(db)
+	userSvc := services.NewUserService(db, notifSvc)
+
+	// callerTypeID=6 = buropropuskov (admin). target.TypeID=1 -> selfChange=false
+	// -> сообщение про админа.
+	err := userSvc.UpdatePassword(
+		context.Background(),
+		6, // callerTypeID admin
+		target.Username,
+		models.UpdatePasswordRequest{Password: "newpassword12345"},
+	)
+	require.NoError(t, err)
+
+	notifs, err := notifSvc.GetByUserID(context.Background(), target.ID)
+	require.NoError(t, err)
+	require.Len(t, notifs, 1, "ожидается одно уведомление password_changed")
+
+	n := notifs[0]
+	require.NotNil(t, n.Type)
+	assert.Equal(t, "password_changed", *n.Type)
+	require.NotNil(t, n.Title)
+	assert.Equal(t, "Пароль изменён", *n.Title)
+	require.NotNil(t, n.Message)
+	assert.Contains(t, *n.Message, "Администратор")
+	require.NotNil(t, n.Data)
+	assert.Contains(t, *n.Data, "changed_at")
+	assert.Contains(t, *n.Data, "changed_by_type_id")
+}
+
+// TestUserService_UpdatePassword_NonAdmin_NoNotification проверяет, что если
+// вызывающий не admin (нет прав), пароль не меняется и уведомление не пишется.
+func TestUserService_UpdatePassword_NonAdmin_NoNotification(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	target := models.User{
+		Username:       "target_nonadmin",
+		Password:       "x",
+		TypeID:         1,
+		OrganizationID: &td.OrgID,
+		CompanyID:      &td.CompanyID,
+	}
+	require.NoError(t, db.Create(&target).Error)
+
+	notifSvc := services.NewNotificationService(db)
+	userSvc := services.NewUserService(db, notifSvc)
+
+	err := userSvc.UpdatePassword(
+		context.Background(),
+		1, // обычный юзер -> Forbidden
+		target.Username,
+		models.UpdatePasswordRequest{Password: "newpass12345"},
+	)
+	require.Error(t, err)
+
+	notifs, err := notifSvc.GetByUserID(context.Background(), target.ID)
+	require.NoError(t, err)
+	assert.Empty(t, notifs)
+}

--- a/internal/models/car.go
+++ b/internal/models/car.go
@@ -56,6 +56,26 @@ type UniqueCar struct {
 	CreatedAt      time.Time     `json:"created_at"`
 }
 
+// UniqueCarHistory хранит аудит изменений мастер-записи автомобиля (unique_cars).
+// Используется отдельная таблица: cars_history.car_id ссылается на cars
+// (заявочная сущность), а здесь нужна ссылка на unique_cars (мастер).
+type UniqueCarHistory struct {
+	ID          int       `json:"id"`
+	UniqueCarID int       `gorm:"index" json:"unique_car_id"`
+	UniqueCar   UniqueCar `gorm:"constraint:OnDelete:CASCADE" json:"-"`
+	UserID      *int      `gorm:"index" json:"user_id"`
+	User        *User     `json:"-"`
+	ActionType  string    `gorm:"size:50" json:"action_type"`
+	FieldName   *string   `gorm:"size:100" json:"field_name"`
+	OldValue    *string   `gorm:"type:text" json:"old_value"`
+	NewValue    *string   `gorm:"type:text" json:"new_value"`
+	Comment     *string   `gorm:"type:text" json:"comment"`
+	Metadata    *string   `gorm:"type:jsonb" json:"metadata"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
+func (UniqueCarHistory) TableName() string { return "unique_cars_history" }
+
 type CarUnloadPlace struct {
 	ID            int     `json:"id"`
 	CarID         int     `gorm:"index" json:"car_id"`

--- a/internal/models/employee.go
+++ b/internal/models/employee.go
@@ -126,6 +126,27 @@ func (e *UniqueEmployee) AfterFind(tx *gorm.DB) error {
 	return nil
 }
 
+// UniqueEmployeeHistory хранит аудит изменений мастер-записи сотрудника
+// (unique_employees). Используется отдельная таблица, потому что
+// employees_history.employee_id ссылается на employees (заявочная сущность),
+// а здесь нужна ссылка на unique_employees (мастер).
+type UniqueEmployeeHistory struct {
+	ID               int            `json:"id"`
+	UniqueEmployeeID int            `gorm:"index" json:"unique_employee_id"`
+	UniqueEmployee   UniqueEmployee `gorm:"constraint:OnDelete:CASCADE" json:"-"`
+	UserID           *int           `gorm:"index" json:"user_id"`
+	User             *User          `json:"-"`
+	ActionType       string         `gorm:"size:50" json:"action_type"`
+	FieldName        *string        `gorm:"size:100" json:"field_name"`
+	OldValue         *string        `gorm:"type:text" json:"old_value"`
+	NewValue         *string        `gorm:"type:text" json:"new_value"`
+	Comment          *string        `gorm:"type:text" json:"comment"`
+	Metadata         *string        `gorm:"type:jsonb" json:"metadata"`
+	CreatedAt        time.Time      `json:"created_at"`
+}
+
+func (UniqueEmployeeHistory) TableName() string { return "unique_employees_history" }
+
 type ApplicationEmployee struct {
 	ID                   int        `json:"id"`
 	AttachmentID         int        `gorm:"index" json:"attachment_id"`

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -191,6 +191,7 @@ func Setup(e *echo.Echo, auth *handlers.AuthHandler, userTypes *handlers.UserTyp
 	ucg.PUT("/by-number", uc.UpdateByNumber)
 	ucg.DELETE("/:id", uc.Delete)
 	ucg.GET("/ownership-info", uc.GetOwnershipInfo)
+	ucg.GET("/:id/history", uc.GetHistory)
 
 	// Реестр сотрудников (unique_employees)
 	ueg := protected.Group("/unique-employees")
@@ -199,6 +200,7 @@ func Setup(e *echo.Echo, auth *handlers.AuthHandler, userTypes *handlers.UserTyp
 	ueg.PUT("/:id", ue.Update)
 	ueg.DELETE("/:id", ue.Delete)
 	ueg.GET("/ownership-info", ue.GetOwnershipInfo)
+	ueg.GET("/:id/history", ue.GetHistory)
 
 	// Обратная связь
 	fbg := protected.Group("/feedback")

--- a/internal/services/application_helpers.go
+++ b/internal/services/application_helpers.go
@@ -181,6 +181,24 @@ func (s *applicationService) activateApplicationItems(tx *gorm.DB, applicationID
 
 // --- Основные методы ---
 
+// applyApplicationAccessFilter ограничивает выборку заявок только теми,
+// к которым у пользователя есть доступ. Approver-ы видят все заявки;
+// остальные — только те, где они автор (sender_user_id), responsible или viewer.
+//
+// Helper переиспользуется в листинге заявок (GetApplications,
+// buildApplicationsBaseQuery) и в счётчике непрочитанных (GetUnreadCount),
+// чтобы фильтр доступа был в одном месте.
+func applyApplicationAccessFilter(query *gorm.DB, userID int, isApprover bool) *gorm.DB {
+	if isApprover {
+		return query
+	}
+	return query.Where(`
+		a.sender_user_id = ?
+		OR EXISTS(SELECT 1 FROM application_responsible_users aru WHERE aru.application_id = a.id AND aru.user_id = ?)
+		OR EXISTS(SELECT 1 FROM application_viewers av WHERE av.application_id = a.id AND av.user_id = ?)
+	`, userID, userID, userID)
+}
+
 func applyApplicationFilters(query *gorm.DB, filter ApplicationFilter, includeUserSearch bool) *gorm.DB {
 	if filter.SearchQuery != nil && *filter.SearchQuery != "" {
 		pattern := "%" + *filter.SearchQuery + "%"

--- a/internal/services/application_read_service.go
+++ b/internal/services/application_read_service.go
@@ -85,14 +85,21 @@ func (s *applicationService) GetReads(ctx context.Context, applicationID int) ([
 }
 
 // GetUnreadCount возвращает количество непрочитанных активных заявок для пользователя.
+// Учитывается доступ пользователя: если юзер не approver, считаются только заявки,
+// где он responsible_user или viewer (тот же фильтр, что в листинге).
 func (s *applicationService) GetUnreadCount(ctx context.Context, username string) (*models.UnreadCountResponse, error) {
 	user, err := s.getUserByUsername(ctx, username)
 	if err != nil {
 		return nil, err
 	}
 
+	isApprover, err := s.isApprover(ctx, user.ID)
+	if err != nil {
+		return nil, err
+	}
+
 	var count int64
-	// Непрочитанные = нет записи в application_reads для пользователя + не архивные
+	// Непрочитанные = нет записи в application_reads для пользователя + не архивные.
 	archiveExclude := `
 		NOT (
 			a.status IN (?, ?) AND EXISTS(
@@ -102,12 +109,16 @@ func (s *applicationService) GetUnreadCount(ctx context.Context, username string
 			)
 		)
 	`
-	err = s.db.WithContext(ctx).
+	query := s.db.WithContext(ctx).
 		Table("applications a").
 		Where("NOT EXISTS (SELECT 1 FROM application_reads ar WHERE ar.application_id = a.id AND ar.user_id = ?)", user.ID).
-		Where(archiveExclude, models.StatusCompleted, models.StatusRejected).
-		Count(&count).Error
-	if err != nil {
+		Where(archiveExclude, models.StatusCompleted, models.StatusRejected)
+
+	// Permission filter: совпадает с GetApplications (см. application_service.go).
+	// Если юзер не approver, видит только заявки, где он responsible или viewer.
+	query = applyApplicationAccessFilter(query, user.ID, isApprover)
+
+	if err := query.Count(&count).Error; err != nil {
 		slog.Error("Ошибка подсчёта непрочитанных", "error", err, "user_id", user.ID)
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Database error")
 	}

--- a/internal/services/application_service.go
+++ b/internal/services/application_service.go
@@ -488,12 +488,7 @@ func (s *applicationService) GetApplications(ctx context.Context, username strin
 		Joins("LEFT JOIN users u ON a.sender_user_id = u.id").
 		Joins("LEFT JOIN users ru ON a.responsible_user_id = ru.id")
 
-	if !isApprover {
-		query = query.Where(`
-			EXISTS(SELECT 1 FROM application_responsible_users aru WHERE aru.application_id = a.id AND aru.user_id = ?)
-			OR EXISTS(SELECT 1 FROM application_viewers av WHERE av.application_id = a.id AND av.user_id = ?)
-		`, user.ID, user.ID)
-	}
+	query = applyApplicationAccessFilter(query, user.ID, isApprover)
 
 	query = applyApplicationFilters(query, filter, false)
 	query = query.Order("a.sending_datetime DESC")
@@ -515,12 +510,7 @@ func (s *applicationService) buildApplicationsBaseQuery(ctx context.Context, use
 		Joins("LEFT JOIN users u ON a.sender_user_id = u.id").
 		Joins("LEFT JOIN users ru ON a.responsible_user_id = ru.id")
 
-	if !isApprover {
-		query = query.Where(`
-			EXISTS(SELECT 1 FROM application_responsible_users aru WHERE aru.application_id = a.id AND aru.user_id = ?)
-			OR EXISTS(SELECT 1 FROM application_viewers av WHERE av.application_id = a.id AND av.user_id = ?)
-		`, userID, userID)
-	}
+	query = applyApplicationAccessFilter(query, userID, isApprover)
 
 	return applyApplicationFilters(query, filter, false)
 }

--- a/internal/services/unique_car_service.go
+++ b/internal/services/unique_car_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"time"
@@ -11,6 +12,29 @@ import (
 	"github.com/labstack/echo/v4"
 	"gorm.io/gorm"
 )
+
+// diffUniqueCar сравнивает значимые поля UniqueCar до и после апдейта.
+// Возвращает только реально изменившиеся поля.
+func diffUniqueCar(before, after *models.UniqueCar) []fieldChange {
+	changes := make([]fieldChange, 0)
+	addStr := func(field string, oldP, newP *string) {
+		if !equalStrPtr(oldP, newP) {
+			changes = append(changes, fieldChange{Field: field, Old: copyStrPtr(oldP), New: copyStrPtr(newP)})
+		}
+	}
+	addInt := func(field string, oldP, newP *int) {
+		if !equalIntPtr(oldP, newP) {
+			changes = append(changes, fieldChange{Field: field, Old: intPtrToStrPtr(oldP), New: intPtrToStrPtr(newP)})
+		}
+	}
+	addStr("number", before.Number, after.Number)
+	addStr("mark", before.Mark, after.Mark)
+	addInt("organization_id", before.OrganizationID, after.OrganizationID)
+	addInt("company_id", before.CompanyID, after.CompanyID)
+	addInt("format_id", before.FormatID, after.FormatID)
+	addInt("user_id", before.UserID, after.UserID)
+	return changes
+}
 
 // CarOwnerInfo -- информация о владельце для фильтрации машин.
 type CarOwnerInfo struct {
@@ -76,6 +100,22 @@ type BatchCreateCarsResponse struct {
 	ErrorCount   int                 `json:"error_count"`
 }
 
+// UniqueCarHistoryItem -- запись истории мастер-машины с username вызывающего.
+type UniqueCarHistoryItem struct {
+	ID            int       `json:"id"`
+	UniqueCarID   int       `json:"unique_car_id"`
+	UserID        *int      `json:"user_id"`
+	Username      *string   `json:"username"`
+	UserLastName  *string   `json:"user_last_name"`
+	UserFirstName *string   `json:"user_first_name"`
+	ActionType    string    `json:"action_type"`
+	FieldName     *string   `json:"field_name"`
+	OldValue      *string   `json:"old_value"`
+	NewValue      *string   `json:"new_value"`
+	Comment       *string   `json:"comment"`
+	CreatedAt     time.Time `json:"created_at"`
+}
+
 // UniqueCarService -- интерфейс бизнес-логики уникальных машин.
 type UniqueCarService interface {
 	GetOwnerInfo(ctx context.Context, username string) (*CarOwnerInfo, error)
@@ -85,6 +125,7 @@ type UniqueCarService interface {
 	Update(ctx context.Context, username string, id int, req NewUniqueCarRequest) (*UniqueCarResponse, error)
 	UpdateByNumber(ctx context.Context, username string, req UpdateCarByNumberRequest) (*UniqueCarResponse, error)
 	Delete(ctx context.Context, username string, id int) error
+	GetHistory(ctx context.Context, username string, id int) ([]UniqueCarHistoryItem, error)
 }
 
 type uniqueCarService struct {
@@ -383,10 +424,9 @@ func (s *uniqueCarService) Update(ctx context.Context, username string, id int, 
 		return nil, err
 	}
 
-	// Проверяем существование и права
+	// Полная запись «до апдейта» — нужна для проверки прав и аудита изменений.
 	var existing models.UniqueCar
-	if err := s.db.WithContext(ctx).Select("user_id, organization_id, company_id").
-		First(&existing, id).Error; err != nil {
+	if err := s.db.WithContext(ctx).First(&existing, id).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return nil, echo.NewHTTPError(http.StatusNotFound, "Car not found")
 		}
@@ -459,6 +499,10 @@ func (s *uniqueCarService) Update(ctx context.Context, username string, id int, 
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching updated car")
 	}
 
+	if err := s.recordCarChanges(ctx, &existing, &updated, ownerInfo.UserID); err != nil {
+		slog.Error("не удалось записать аудит изменений автомобиля", "id", id, "error", err)
+	}
+
 	return carToResponse(&updated), nil
 }
 
@@ -506,6 +550,10 @@ func (s *uniqueCarService) UpdateByNumber(ctx context.Context, username string, 
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching updated car")
 	}
 
+	if err := s.recordCarChanges(ctx, &existing, &updated, ownerInfo.UserID); err != nil {
+		slog.Error("не удалось записать аудит изменений автомобиля", "id", existing.ID, "error", err)
+	}
+
 	return carToResponse(&updated), nil
 }
 
@@ -540,6 +588,71 @@ func (s *uniqueCarService) Delete(ctx context.Context, username string, id int) 
 
 	slog.Info("уникальный автомобиль удалён", "id", id)
 	return nil
+}
+
+// recordCarChanges сравнивает старое и новое состояние UniqueCar
+// и пишет по одной записи data_changed на каждое изменённое поле.
+func (s *uniqueCarService) recordCarChanges(ctx context.Context, before, after *models.UniqueCar, userID int) error {
+	changes := diffUniqueCar(before, after)
+	if len(changes) == 0 {
+		return nil
+	}
+
+	uid := userID
+	records := make([]models.UniqueCarHistory, 0, len(changes))
+	for _, c := range changes {
+		field := c.Field
+		records = append(records, models.UniqueCarHistory{
+			UniqueCarID: after.ID,
+			UserID:      &uid,
+			ActionType:  "data_changed",
+			FieldName:   &field,
+			OldValue:    c.Old,
+			NewValue:    c.New,
+		})
+	}
+	if err := s.db.WithContext(ctx).Create(&records).Error; err != nil {
+		return fmt.Errorf("create unique_car history: %w", err)
+	}
+	return nil
+}
+
+// GetHistory возвращает историю изменений мастер-записи машины.
+// Доступ: у пользователя должны быть права редактирования (canEditCar) -
+// иначе он не имеет права видеть аудит.
+func (s *uniqueCarService) GetHistory(ctx context.Context, username string, id int) ([]UniqueCarHistoryItem, error) {
+	ownerInfo, err := s.getCarOwnerInfo(ctx, username)
+	if err != nil {
+		return nil, err
+	}
+
+	var existing models.UniqueCar
+	if err := s.db.WithContext(ctx).Select("user_id, organization_id, company_id").
+		First(&existing, id).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, echo.NewHTTPError(http.StatusNotFound, "Car not found")
+		}
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching car")
+	}
+	if !s.canEditCar(&existing, ownerInfo) {
+		return nil, echo.NewHTTPError(http.StatusForbidden, "You don't have permission to view this car history")
+	}
+
+	items := make([]UniqueCarHistoryItem, 0)
+	err = s.db.WithContext(ctx).
+		Table("unique_cars_history h").
+		Select(`h.id, h.unique_car_id, h.user_id, u.username, u.last_name as user_last_name,
+			u.first_name as user_first_name, h.action_type, h.field_name, h.old_value,
+			h.new_value, h.comment, h.created_at`).
+		Joins("LEFT JOIN users u ON h.user_id = u.id").
+		Where("h.unique_car_id = ?", id).
+		Order("h.created_at DESC, h.id DESC").
+		Scan(&items).Error
+	if err != nil {
+		slog.Error("failed to load unique_car history", "id", id, "error", err)
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching history")
+	}
+	return items, nil
 }
 
 // canEditCar проверяет права пользователя на редактирование машины.

--- a/internal/services/unique_employee_service.go
+++ b/internal/services/unique_employee_service.go
@@ -2,8 +2,10 @@ package services
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"time"
 
 	"systemburo/internal/crypto"
@@ -12,6 +14,46 @@ import (
 	"github.com/labstack/echo/v4"
 	"gorm.io/gorm"
 )
+
+// equalStrPtr возвращает true если оба указателя nil или ссылаются на равные строки.
+func equalStrPtr(a, b *string) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
+// equalIntPtr возвращает true если оба указателя nil или ссылаются на равные int.
+func equalIntPtr(a, b *int) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
+// copyStrPtr возвращает копию указателя на строку (не разделяет память).
+func copyStrPtr(p *string) *string {
+	if p == nil {
+		return nil
+	}
+	v := *p
+	return &v
+}
+
+// intPtrToStrPtr форматирует *int как *string для записи в old_value/new_value.
+func intPtrToStrPtr(p *int) *string {
+	if p == nil {
+		return nil
+	}
+	s := strconv.Itoa(*p)
+	return &s
+}
 
 // EmployeeOwnerInfo -- информация о владельце для фильтрации сотрудников.
 type EmployeeOwnerInfo struct {
@@ -76,6 +118,22 @@ type UniqueEmployeeResponse struct {
 	CreatedAt            *time.Time `json:"created_at"`
 }
 
+// UniqueEmployeeHistoryItem -- запись истории мастер-сотрудника с username вызывающего.
+type UniqueEmployeeHistoryItem struct {
+	ID               int       `json:"id"`
+	UniqueEmployeeID int       `json:"unique_employee_id"`
+	UserID           *int      `json:"user_id"`
+	Username         *string   `json:"username"`
+	UserLastName     *string   `json:"user_last_name"`
+	UserFirstName    *string   `json:"user_first_name"`
+	ActionType       string    `json:"action_type"`
+	FieldName        *string   `json:"field_name"`
+	OldValue         *string   `json:"old_value"`
+	NewValue         *string   `json:"new_value"`
+	Comment          *string   `json:"comment"`
+	CreatedAt        time.Time `json:"created_at"`
+}
+
 // UniqueEmployeeService -- интерфейс бизнес-логики уникальных сотрудников.
 type UniqueEmployeeService interface {
 	GetOwnerInfo(ctx context.Context, username string) (*EmployeeOwnerInfo, error)
@@ -83,6 +141,7 @@ type UniqueEmployeeService interface {
 	Create(ctx context.Context, username string, req NewUniqueEmployeeRequest) (*UniqueEmployeeResponse, error)
 	Update(ctx context.Context, username string, id int, req NewUniqueEmployeeRequest) (*UniqueEmployeeResponse, error)
 	Delete(ctx context.Context, username string, id int) error
+	GetHistory(ctx context.Context, username string, id int) ([]UniqueEmployeeHistoryItem, error)
 }
 
 type uniqueEmployeeService struct {
@@ -309,10 +368,10 @@ func (s *uniqueEmployeeService) Update(ctx context.Context, username string, id 
 		return nil, err
 	}
 
-	// Проверяем существование и права
+	// Полная запись «до апдейта» нужна для аудита изменений (data_changed).
+	// Проверка прав делается по тем же полям, поэтому отдельный SELECT не нужен.
 	var existing models.UniqueEmployee
-	if err := s.db.WithContext(ctx).Select("user_id, organization_id, company_id").
-		First(&existing, id).Error; err != nil {
+	if err := s.db.WithContext(ctx).First(&existing, id).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return nil, echo.NewHTTPError(http.StatusNotFound, "Employee not found")
 		}
@@ -407,7 +466,79 @@ func (s *uniqueEmployeeService) Update(ctx context.Context, username string, id 
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching updated employee")
 	}
 
+	// Аудит изменений: пишем по одной записи в unique_employees_history
+	// на каждое изменённое поле. Ошибка аудита не должна откатывать апдейт,
+	// поэтому только логируем — апдейт уже зафиксирован.
+	if err := s.recordEmployeeChanges(ctx, &existing, &updated, ownerInfo.UserID); err != nil {
+		slog.Error("не удалось записать аудит изменений сотрудника", "id", id, "error", err)
+	}
+
 	return employeeToResponse(&updated), nil
+}
+
+// recordEmployeeChanges сравнивает старое и новое состояние UniqueEmployee
+// и пишет по одной записи data_changed на каждое изменённое поле.
+// Поля HMAC и служебные поля игнорируются — они вычисляются автоматически.
+func (s *uniqueEmployeeService) recordEmployeeChanges(ctx context.Context, before, after *models.UniqueEmployee, userID int) error {
+	changes := diffUniqueEmployee(before, after)
+	if len(changes) == 0 {
+		return nil
+	}
+
+	uid := userID
+	records := make([]models.UniqueEmployeeHistory, 0, len(changes))
+	for _, c := range changes {
+		field := c.Field
+		oldVal := c.Old
+		newVal := c.New
+		records = append(records, models.UniqueEmployeeHistory{
+			UniqueEmployeeID: after.ID,
+			UserID:           &uid,
+			ActionType:       "data_changed",
+			FieldName:        &field,
+			OldValue:         oldVal,
+			NewValue:         newVal,
+		})
+	}
+	if err := s.db.WithContext(ctx).Create(&records).Error; err != nil {
+		return fmt.Errorf("create unique_employee history: %w", err)
+	}
+	return nil
+}
+
+// fieldChange описывает одно изменение поля для аудита.
+type fieldChange struct {
+	Field string
+	Old   *string
+	New   *string
+}
+
+// diffUniqueEmployee сравнивает значимые поля UniqueEmployee.
+// Возвращает только реально изменившиеся поля.
+func diffUniqueEmployee(before, after *models.UniqueEmployee) []fieldChange {
+	changes := make([]fieldChange, 0)
+	addStr := func(field string, oldP, newP *string) {
+		if !equalStrPtr(oldP, newP) {
+			changes = append(changes, fieldChange{Field: field, Old: copyStrPtr(oldP), New: copyStrPtr(newP)})
+		}
+	}
+	addInt := func(field string, oldP, newP *int) {
+		if !equalIntPtr(oldP, newP) {
+			changes = append(changes, fieldChange{Field: field, Old: intPtrToStrPtr(oldP), New: intPtrToStrPtr(newP)})
+		}
+	}
+	addStr("last_name", before.LastName, after.LastName)
+	addStr("first_name", before.FirstName, after.FirstName)
+	addStr("middle_name", before.MiddleName, after.MiddleName)
+	addInt("citizenship_id", before.CitizenshipID, after.CitizenshipID)
+	addStr("position", before.Position, after.Position)
+	addStr("passport_series_number", before.PassportSeriesNumber, after.PassportSeriesNumber)
+	addStr("patent_number", before.PatentNumber, after.PatentNumber)
+	addStr("other_permission", before.OtherPermission, after.OtherPermission)
+	addInt("organization_id", before.OrganizationID, after.OrganizationID)
+	addInt("company_id", before.CompanyID, after.CompanyID)
+	addInt("user_id", before.UserID, after.UserID)
+	return changes
 }
 
 // Delete удаляет уникального сотрудника с проверкой прав.
@@ -441,6 +572,44 @@ func (s *uniqueEmployeeService) Delete(ctx context.Context, username string, id 
 
 	slog.Info("уникальный сотрудник удалён", "id", id)
 	return nil
+}
+
+// GetHistory возвращает историю изменений мастер-записи сотрудника.
+// Доступ: у пользователя должны быть права редактирования (canEditEmployee) -
+// иначе он не имеет права видеть аудит.
+func (s *uniqueEmployeeService) GetHistory(ctx context.Context, username string, id int) ([]UniqueEmployeeHistoryItem, error) {
+	ownerInfo, err := s.getEmployeeOwnerInfo(ctx, username)
+	if err != nil {
+		return nil, err
+	}
+
+	var existing models.UniqueEmployee
+	if err := s.db.WithContext(ctx).Select("user_id, organization_id, company_id").
+		First(&existing, id).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, echo.NewHTTPError(http.StatusNotFound, "Employee not found")
+		}
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching employee")
+	}
+	if !s.canEditEmployee(&existing, ownerInfo) {
+		return nil, echo.NewHTTPError(http.StatusForbidden, "You don't have permission to view this employee history")
+	}
+
+	items := make([]UniqueEmployeeHistoryItem, 0)
+	err = s.db.WithContext(ctx).
+		Table("unique_employees_history h").
+		Select(`h.id, h.unique_employee_id, h.user_id, u.username, u.last_name as user_last_name,
+			u.first_name as user_first_name, h.action_type, h.field_name, h.old_value,
+			h.new_value, h.comment, h.created_at`).
+		Joins("LEFT JOIN users u ON h.user_id = u.id").
+		Where("h.unique_employee_id = ?", id).
+		Order("h.created_at DESC, h.id DESC").
+		Scan(&items).Error
+	if err != nil {
+		slog.Error("failed to load unique_employee history", "id", id, "error", err)
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching history")
+	}
+	return items, nil
 }
 
 // canEditEmployee проверяет права пользователя на редактирование сотрудника.

--- a/internal/services/user_service.go
+++ b/internal/services/user_service.go
@@ -2,9 +2,11 @@ package services
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"net/http"
 	"strings"
+	"time"
 
 	"systemburo/internal/models"
 
@@ -33,12 +35,16 @@ type UserService interface {
 }
 
 type userService struct {
-	db *gorm.DB
+	db                  *gorm.DB
+	notificationService NotificationService
 }
 
 // NewUserService создаёт новый экземпляр сервиса управления пользователями.
-func NewUserService(db *gorm.DB) UserService {
-	return &userService{db: db}
+// notificationService может быть nil — в этом случае уведомления просто
+// не будут создаваться (legacy совместимость в местах, где notification
+// не подключён). Триггерные методы проверяют nil перед использованием.
+func NewUserService(db *gorm.DB, notificationService NotificationService) UserService {
+	return &userService{db: db, notificationService: notificationService}
 }
 
 // checkAdmin проверяет, что вызывающий пользователь является администратором
@@ -180,9 +186,70 @@ func (s *userService) UpdatePassword(ctx context.Context, callerTypeID int, user
 			Model(&models.RefreshToken{}).
 			Where("user_id = ? AND is_revoked = false", user.ID).
 			Update("is_revoked", true)
+
+		// Уведомление о смене пароля. Сейчас UpdatePassword вызывается только
+		// admin'ом (manager/buropropuskov) — даже если username совпадает с
+		// callerTypeID, это всё равно admin-action. Считаем "сам себе сменил"
+		// если в БД у юзера тот же type_id, что и у вызывающего, и юзер админ.
+		s.notifyPasswordChanged(ctx, &user, callerTypeID)
 	}
 
 	return nil
+}
+
+// notifyPasswordChanged создаёт уведомление о смене пароля. Вызывается
+// после успешного апдейта; ошибки только логируются (уведомления не
+// должны блокировать основной flow).
+func (s *userService) notifyPasswordChanged(ctx context.Context, target *models.User, callerTypeID int) {
+	if s.notificationService == nil {
+		return
+	}
+
+	// Определяем, сам ли пользователь сменил пароль или это сделал админ.
+	// Под "сам собой" понимаем: callerTypeID == target.TypeID и сам юзер - админ.
+	// Уточнить вызывающего через user_id мы не можем (в API передаётся
+	// только callerTypeID), поэтому ограничиваемся типом.
+	selfChange := false
+	if callerTypeID == target.TypeID {
+		var code string
+		err := s.db.WithContext(ctx).
+			Table("user_types").
+			Select("code").
+			Where("id = ?", target.TypeID).
+			Row().
+			Scan(&code)
+		if err == nil && (code == "manager" || code == "buropropuskov") {
+			selfChange = true
+		}
+	}
+
+	message := "Администратор изменил ваш пароль."
+	if selfChange {
+		message = "Ваш пароль был успешно изменён."
+	}
+
+	dataPayload := map[string]any{
+		"changed_at": time.Now().UTC().Format(time.RFC3339),
+		// changed_by_user_id мы не знаем точно (передаётся только typeID),
+		// поэтому пишем тип вызывающего — это всё, что у нас есть.
+		"changed_by_type_id": callerTypeID,
+	}
+	dataBytes, err := json.Marshal(dataPayload)
+	if err != nil {
+		slog.Error("не удалось сериализовать payload уведомления", "error", err)
+		return
+	}
+	dataStr := string(dataBytes)
+
+	if err := s.notificationService.CreateForUser(
+		ctx, target.ID,
+		"password_changed",
+		"Пароль изменён",
+		message,
+		&dataStr,
+	); err != nil {
+		slog.Error("не удалось создать уведомление о смене пароля", "user_id", target.ID, "error", err)
+	}
 }
 
 // UpdateInfo обновляет персональные данные пользователя.

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -38,11 +38,13 @@ var tables = []string{
 	"system_settings",
 	"pd_audit_logs", "pd_consents",
 	"user_permissions", "permissions",
+	"bug_reports",
 	"request_log", "request_logs", "notifications", "news", "announcements",
 	"feedback", "application_items", "items",
 	"employee_target_tables", "employee_files", "application_employees", "employees_history", "employees",
 	"car_unload_places", "cars_history", "cars",
 	"attachments",
+	"unique_employees_history", "unique_cars_history",
 	"unique_employees", "unique_cars", "unique_attachments",
 	"application_reads", "application_viewers", "application_approvers", "application_responsible_users",
 	"application_status_history", "application_history", "applications",
@@ -90,7 +92,8 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	citizenshipService := services.NewCitizenshipService(db)
 	organizationService := services.NewOrganizationService(db)
 	companyService := services.NewCompanyService(db)
-	userService := services.NewUserService(db)
+	notificationServiceEarly := services.NewNotificationService(db)
+	userService := services.NewUserService(db, notificationServiceEarly)
 	unloadPlaceService := services.NewUnloadPlaceService(db)
 	carService := services.NewCarService(db)
 	employeeService := services.NewEmployeeService(db)
@@ -100,7 +103,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	uniqueEmployeeService := services.NewUniqueEmployeeService(db)
 	feedbackService := services.NewFeedbackService(db)
 	newsService := services.NewNewsService(db)
-	notificationService := services.NewNotificationService(db)
+	notificationService := notificationServiceEarly
 	requestLogsService := services.NewRequestLogsService(db)
 	employeesHistoryService := services.NewEmployeesHistoryService(db)
 	applicationService := services.NewApplicationService(db, permissionService, notificationService)


### PR DESCRIPTION
## Что закрывает в #184

- [x] **История изменений данных машин/сотрудников**: при апдейте мастер-записи (`unique_employees`/`unique_cars`) пишется `data_changed` на каждое изменённое поле в новые таблицы `unique_employees_history` / `unique_cars_history`. Доступно через `GET /unique-employees/{id}/history` и `GET /unique-cars/{id}/history` с проверкой прав.
- [x] **Уведомления — смена пароля**: при изменении пароля админом пользователю создаётся notification \"Пароль изменён\" / \"Администратор изменил ваш пароль\". `NotificationService` инжектится в `UserService`.
- [x] **Доступ к заявкам — непрочитанные**: счётчик `/applications/unread-count` теперь учитывает права через `applyApplicationAccessFilter`. Helper переиспользуется в листинге и в counter — фильтр в одном месте. Условия: автор (sender_user_id), responsible или viewer; approver видит всё.

## Что НЕ в этом PR (но указано в #184)

- **Заморозка данных в существующих заявках** — отдельный архитектурный вопрос (snapshot в attachments либо версионирование). Требует своего PR.
- **Уведомление при поступлении заявки на согласование** — уже шлётся в `application_service` при создании заявки (тип \"application_approval_required\"). Дополнительной работы не требуется.

## Изменения

**Backend:**
- `internal/models/{employee,car}.go` — добавлены `UniqueEmployeeHistory` / `UniqueCarHistory` (отдельные таблицы, FK на мастер-запись).
- `internal/services/unique_employee_service.go`, `unique_car_service.go` — `recordEmployeeChanges` / `recordCarChanges` пишут data_changed; `GetHistory(ctx, username, id)` возвращает аудит с проверкой прав (canEdit*).
- `internal/services/user_service.go` — `notifyPasswordChanged` (\"сам сменил\" vs \"админ сменил\"). `NewUserService` принимает `NotificationService`.
- `internal/services/application_helpers.go` — `applyApplicationAccessFilter` теперь включает `a.sender_user_id = ?`.
- `internal/services/application_read_service.go::GetUnreadCount` — applies access filter.
- `internal/handlers/{unique_employees,unique_cars}.go` — `GetHistory` обработчики.
- `internal/router/router.go` — регистрирует `/unique-employees/{id}/history` и `/unique-cars/{id}/history`.
- `internal/database/migrate.go`, `internal/testutil/testutil.go` — миграции новых таблиц + cleanup.
- `cmd/server/main.go` — инжект NotificationService в UserService.

**Frontend** в этом PR не трогается — endpoint готов, потребитель (модалка истории мастер-записи) появится в PR-D/PR-E.

## Тесты

- `unique_history_test.go` — `data_changed` пишется при Update + GetHistory возвращает + 403 для чужого
- `application_unread_permission_test.go` — counter с учётом доступа
- `user_password_notification_test.go` — уведомление о смене пароля
- Вручную проверено `go test -race ./internal/handlers ./internal/services` — все зелёные.
- Также почищен hanging `bug_reports` в CleanDB (на dev падали `TestBugReport_*`).

## Test plan

- [ ] CI зелёный
- [ ] Code review
- [ ] Локально: апдейт сотрудника через PUT /unique-employees/{id} + GET /unique-employees/{id}/history → видим запись data_changed
- [ ] Смена пароля admin'ом → у пользователя в `notifications` появляется запись password_changed
- [ ] /applications/unread-count: пользователь без прав на чужие заявки видит только свои