### PR TITLE
feat: PasswordInput - показ/скрытие пароля в формах ЛК (#184)

### DIFF
--- a/frontend/src/components/CreateUserModal.vue
+++ b/frontend/src/components/CreateUserModal.vue
@@ -40,17 +40,12 @@
 
               <div class="form-group">
                 <label class="form-label">Пароль:</label>
-                <input 
-                  v-model="newUser.password" 
-                  type="password" 
+                <PasswordInput
+                  v-model="newUser.password"
                   placeholder="Введите пароль"
-                  class="form-input"
                   required
-                  autocomplete="new-password"
-                  autocorrect="off"
-                  autocapitalize="off"
-                  spellcheck="false"
-                >
+                  input-class="form-input"
+                />
               </div>
 
               <div class="form-group form-group--full">
@@ -250,7 +245,9 @@ import { mapState, mapActions } from 'pinia';
 import { useOrganizationsStore } from '@/stores/organizations';
 import { useCompaniesStore } from '@/stores/companies';
 import { formatRussianPhone } from '@/composables/useRussianPhoneMask'
+import PasswordInput from '@/components/ui/PasswordInput.vue';
 export default {
+  components: { PasswordInput },
   props: {
     userTypes: {
       type: Array,

--- a/frontend/src/components/UserControl.vue
+++ b/frontend/src/components/UserControl.vue
@@ -507,14 +507,12 @@
                 </div>
                 <div class="input-group half">
                   <label class="input-label">Пароль <span class="required">*</span></label>
-                  <input
+                  <PasswordInput
                     v-model="newUser.password"
-                    type="password"
                     placeholder="Введите пароль"
-                    class="modal-input"
-                    @keyup="checkNewUserInputLanguage"
+                    input-class="modal-input"
                     @input="saveDraft"
-                  >
+                  />
                   <div class="input-hint">
                     Минимум 6 символов
                   </div>
@@ -790,13 +788,15 @@ import { formatShortName } from '@/utils/formatName'
 import SearchComponent from './SearchComponent.vue';
 import RefreshButton from './RefreshButton.vue';
 import PermissionTree from './PermissionTree.vue';
+import PasswordInput from './ui/PasswordInput.vue';
 import { getUserPermissions, updateUserPermissions, getPermissionTree } from '@/api/permissions';
 
 export default {
   components: {
     SearchComponent,
     RefreshButton,
-    PermissionTree
+    PermissionTree,
+    PasswordInput
   },
   props: {
     allUsers: {

--- a/frontend/src/components/ui/PasswordInput.vue
+++ b/frontend/src/components/ui/PasswordInput.vue
@@ -1,0 +1,134 @@
+<template>
+  <div class="password-input">
+    <input
+      :value="modelValue"
+      :type="visible ? 'text' : 'password'"
+      :placeholder="placeholder"
+      :required="required"
+      :disabled="disabled"
+      :autocomplete="autocomplete"
+      autocorrect="off"
+      autocapitalize="off"
+      spellcheck="false"
+      class="password-input__field"
+      :class="inputClass"
+      @input="onInput"
+    >
+    <button
+      type="button"
+      class="password-input__toggle"
+      :aria-label="visible ? 'Скрыть пароль' : 'Показать пароль'"
+      :title="visible ? 'Скрыть пароль' : 'Показать пароль'"
+      :disabled="disabled"
+      tabindex="-1"
+      @click="visible = !visible"
+    >
+      <svg
+        v-if="!visible"
+        viewBox="0 0 24 24"
+        width="18"
+        height="18"
+        aria-hidden="true"
+      >
+        <path
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.6"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7S2 12 2 12z"
+        />
+        <circle
+          cx="12"
+          cy="12"
+          r="3"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.6"
+        />
+      </svg>
+      <svg
+        v-else
+        viewBox="0 0 24 24"
+        width="18"
+        height="18"
+        aria-hidden="true"
+      >
+        <path
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.6"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M3 3l18 18M10.6 6.1A11 11 0 0 1 12 6c6.5 0 10 6 10 6a17.7 17.7 0 0 1-3.5 4.2M6.5 6.5C3.6 8.4 2 12 2 12s3.5 7 10 7c1.7 0 3.2-.4 4.5-1.1M9.9 9.9a3 3 0 0 0 4.2 4.2"
+        />
+      </svg>
+    </button>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+
+defineProps({
+  modelValue: { type: String, default: '' },
+  placeholder: { type: String, default: '' },
+  required: { type: Boolean, default: false },
+  disabled: { type: Boolean, default: false },
+  autocomplete: { type: String, default: 'new-password' },
+  inputClass: { type: [String, Array, Object], default: '' }
+});
+
+const emit = defineEmits(['update:modelValue']);
+const visible = ref(false);
+
+function onInput(event) {
+  emit('update:modelValue', event.target.value);
+}
+</script>
+
+<style scoped>
+.password-input {
+  position: relative;
+  width: 100%;
+}
+
+.password-input__field {
+  width: 100%;
+  padding-right: 36px;
+}
+
+.password-input__toggle {
+  position: absolute;
+  top: 50%;
+  right: 8px;
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: #6e7280;
+  cursor: pointer;
+  border-radius: 6px;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.password-input__toggle:hover:not(:disabled) {
+  background: #eef0ff;
+  color: var(--color-primary, #4F5BDF);
+}
+
+.password-input__toggle:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(79, 91, 223, 0.25);
+}
+
+.password-input__toggle:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+</style>


### PR DESCRIPTION
## Что закрывает в #184

- [x] **Учётные записи пользователей: добавить возможность скрывать/отображать пароль при вводе и генерации.**

## Что сделано

- `frontend/src/components/ui/PasswordInput.vue` - переиспользуемый компонент:
  - input с тогглом type=password <-> type=text
  - кнопка с SVG-глазом справа от поля
  - tabindex=-1 на toggle - не перехватывает фокус при Tab
  - aria-label/title для a11y
  - стили совместимы с form-input/modal-input через input-class prop
- `CreateUserModal.vue` - заменил input type=password на PasswordInput
- `UserControl.vue` - то же самое в редактировании пользователя

## Test plan

- [ ] CI зелёный
- [ ] /personal-cabinet -> Учётные записи -> создать пользователя - кнопка-глаз показывает/скрывает пароль
- [ ] То же при редактировании пользователя
- [ ] Tab из поля пароля идёт на следующее поле, не на toggle