### PR TITLE
fix: PasswordInput - встроенный стиль input (#184)

### DIFF
--- a/frontend/src/components/CreateUserModal.vue
+++ b/frontend/src/components/CreateUserModal.vue
@@ -44,7 +44,6 @@
                   v-model="newUser.password"
                   placeholder="Введите пароль"
                   required
-                  input-class="form-input"
                 />
               </div>
 

--- a/frontend/src/components/UserControl.vue
+++ b/frontend/src/components/UserControl.vue
@@ -510,7 +510,6 @@
                   <PasswordInput
                     v-model="newUser.password"
                     placeholder="Введите пароль"
-                    input-class="modal-input"
                     @input="saveDraft"
                   />
                   <div class="input-hint">

--- a/frontend/src/components/ui/PasswordInput.vue
+++ b/frontend/src/components/ui/PasswordInput.vue
@@ -11,7 +11,6 @@
       autocapitalize="off"
       spellcheck="false"
       class="password-input__field"
-      :class="inputClass"
       @input="onInput"
     >
     <button
@@ -75,8 +74,7 @@ defineProps({
   placeholder: { type: String, default: '' },
   required: { type: Boolean, default: false },
   disabled: { type: Boolean, default: false },
-  autocomplete: { type: String, default: 'new-password' },
-  inputClass: { type: [String, Array, Object], default: '' }
+  autocomplete: { type: String, default: 'new-password' }
 });
 
 const emit = defineEmits(['update:modelValue']);
@@ -93,9 +91,35 @@ function onInput(event) {
   width: 100%;
 }
 
+/* Стиль input повторяет .modal-input / .form-input - чтобы поле выглядело
+   так же, как остальные поля формы. Внутренние стили родителя сюда не
+   достают (scoped CSS), поэтому стиль повторяется здесь явно. */
 .password-input__field {
   width: 100%;
-  padding-right: 36px;
+  padding: 10px 38px 10px 12px;
+  border: 1px solid #e0e0e0;
+  border-radius: 12px;
+  font-size: 14px;
+  font-family: inherit;
+  background: #fff;
+  color: inherit;
+  transition: border-color 0.2s ease;
+  box-sizing: border-box;
+}
+
+.password-input__field:focus {
+  border-color: var(--color-primary, #4F5BDF);
+  outline: none;
+}
+
+.password-input__field:disabled {
+  background: #f7f7f9;
+  color: #6b7280;
+  cursor: not-allowed;
+}
+
+.password-input__field::placeholder {
+  color: #9aa0a6;
 }
 
 .password-input__toggle {


### PR DESCRIPTION
## Bug

После #211 поле пароля в CreateUserModal/UserControl выглядело иначе чем поле логина: тоньше, без скругления и обводки.

## Root cause

scoped CSS класс .form-input/.modal-input родительского компонента не применяется к input внутри дочернего PasswordInput - scoped работает на корневом элементе компонента, но не на вложенных элементах внутри другого SFC. Передача через input-class давала чистый класс без data-v-XXX атрибута, поэтому стиль не активировался.

## Fix

PasswordInput теперь имеет собственный стиль .password-input__field, повторяющий .modal-input. Убран input-class prop - компонент самодостаточен.

## Test plan

- [x] CI зелёный
- [ ] /personal-cabinet -> Учётные записи -> Создать: поле пароля выглядит как поле логина (одинаковая высота, скругление, обводка)
- [ ] То же в редактировании пользователя