### PR TITLE
fix: /new-application EmployeeDetailsModal + сброс данных после подачи (#184)

### DIFF
--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -277,7 +277,7 @@
       :show="showSuccessModal"
       :application-number="createdApplicationNumber"
       :attachments-data="createdAttachmentsData"
-      @close="showSuccessModal = false; clearAllAttachments()"
+      @close="onSuccessClose"
     />
   </div>
 </template>
@@ -1583,6 +1583,11 @@ export default {
             this.showBindingModal = false;
             this.newVehiclesToBind = [];
             this.newEmployeesToBind = [];
+        },
+
+        onSuccessClose() {
+            this.showSuccessModal = false;
+            this.resetForm();
         },
 
         clearAllAttachments() {

--- a/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
@@ -18,14 +18,15 @@
               </h3>
               <div class="header-actions">
                 <button
+                  v-if="showHistoryButton"
                   class="history-btn"
                   @click="openFullHistory"
                 >
                   <span>Полная история</span>
                 </button>
-                <button 
-                  v-if="source !== 'application' && employee?.applicationId" 
-                  class="application-btn" 
+                <button
+                  v-if="source !== 'application' && employee?.applicationId"
+                  class="application-btn"
                   @click="openApplication"
                 >
                   <span>Открыть заявку</span>
@@ -85,19 +86,13 @@
                         <span class="detail-label">Гражданство:</span>
                         <span class="detail-value">{{ employee.citizenshipName || 'Не указано' }}</span>
                       </div>
-                      <div
-                        v-if="employee.organization"
-                        class="detail-item"
-                      >
+                      <div class="detail-item">
                         <span class="detail-label">Организация:</span>
-                        <span class="detail-value">{{ employee.organization }}</span>
+                        <span class="detail-value">{{ employee.organization || '-' }}</span>
                       </div>
-                      <div
-                        v-if="employee.company"
-                        class="detail-item"
-                      >
+                      <div class="detail-item">
                         <span class="detail-label">Компания:</span>
-                        <span class="detail-value">{{ employee.company }}</span>
+                        <span class="detail-value">{{ employee.company || '-' }}</span>
                       </div>
                       <div class="detail-item">
                         <span class="detail-label">Действует до:</span>
@@ -394,12 +389,15 @@ export default {
     },
     computed: {
         modalTitle() {
-            if (this.source === 'application') {
+            if (this.source === 'application' || this.source === 'employeeslist') {
                 return 'Информация о сотруднике';
-            } else if (this.source === 'employeeslist' || this.source === 'peopletable') {
+            } else if (this.source === 'peopletable') {
                 return 'Информация';
             }
             return 'Детальная информация о сотруднике';
+        },
+        showHistoryButton() {
+            return this.source !== 'employeeslist';
         },
         entryExitHistory() {
             return this.history.filter(item => item.action_type === 'entry' || item.action_type === 'exit');


### PR DESCRIPTION
## Что закрывает в #184

### EmployeesList.vue -> EmployeeDetailsModal.vue (часть)

- [x] Заголовок изменить на \"Информация о сотруднике\"
- [x] Убрать кнопку \"Полная история\" (только в этом модальном окне)
- [x] Поля \"Организация\"/\"Компания\" - убрана v-if=employee.organization, теперь всегда отображаются (с прочерком если данных нет)

### Подача заявки

- [x] После успешной подачи заявки все вложения и данные на странице должны сбрасываться - после закрытия ApplicationSuccessModal вызывается resetForm() (полный сброс) вместо clearAllAttachments() (частичный)

## Не в этом PR

- Автовыбор места разгрузки/прохода (с toast) - зависит от Toast компонента из PR-D
- Кастомные иконки деталей в EmployeesList/VehicleList - дизайн-задача, отложена

## Test plan

- [ ] CI зелёный
- [ ] /new-application -> добавить сотрудника -> Детали - заголовок \"Информация о сотруднике\", нет кнопки \"Полная история\"
- [ ] Поля Организация/Компания/Действует до/Время прохода видны (хотя бы с прочерком)
- [ ] Подать заявку -> закрыть успех-модалку -> форма очищена (новый applicationNumber, нет вложений)