### PR TITLE
feat: скрытие объявления + бейдж важного объявления с градиентом (#184)

### DIFF
--- a/frontend/src/components/TheHeader/TheHeader.vue
+++ b/frontend/src/components/TheHeader/TheHeader.vue
@@ -343,9 +343,20 @@ h3 {
 }
 
 .broadcast--important {
-  color: #B91C1C;
-  background: #FECACA;
-  border-color: #FECACA;
+  color: #fff;
+  background: linear-gradient(135deg, #FF6B6B 0%, #DC2626 50%, #B91C1C 100%);
+  border-color: transparent;
+  box-shadow: 0 2px 8px rgba(220, 38, 38, 0.25);
+  animation: broadcast-glow 2.4s ease-in-out infinite;
+}
+
+.broadcast--important:hover {
+  filter: brightness(1.05);
+}
+
+@keyframes broadcast-glow {
+  0%, 100% { box-shadow: 0 2px 8px rgba(220, 38, 38, 0.25); }
+  50% { box-shadow: 0 2px 14px rgba(220, 38, 38, 0.55); }
 }
 
 .time {

--- a/frontend/src/views/NewsAndReview.vue
+++ b/frontend/src/views/NewsAndReview.vue
@@ -317,14 +317,14 @@
                         class="action-btn activate-btn"
                         @click="setActiveAnnouncement(item.id)"
                       >
-                        Активировать
+                        Показать
                       </button>
                       <button
                         v-if="item.is_active"
                         class="action-btn deactivate-btn"
                         @click="deactivateAnnouncement(item.id)"
                       >
-                        Деактивировать
+                        Скрыть
                       </button>
                       <button
                         class="action-btn delete-btn"
@@ -751,17 +751,16 @@ export default {
       } catch (error) { console.error('Ошибка активации объявления:', error) }
     },
     async deactivateAnnouncement(id) {
-      if (!confirm('Деактивировать объявление?')) return
+      if (!confirm('Скрыть объявление?')) return
       try {
-        const response = await apiRequest(`/announcements/${id}`, {
-          method: 'PUT',
-          body: JSON.stringify({ is_active: false })
+        const response = await apiRequest(`/announcements/${id}/hide`, {
+          method: 'POST'
         })
         if (response.ok) {
           await this.fetchAllAnnouncements()
           await this.fetchActiveAnnouncement()
-        } else alert('Ошибка деактивации объявления')
-      } catch (error) { console.error('Ошибка деактивации объявления:', error) }
+        } else alert('Ошибка скрытия объявления')
+      } catch (error) { console.error('Ошибка скрытия объявления:', error) }
     },
     async deleteAnnouncement(id) {
       if (!confirm('Удалить объявление?')) return

--- a/internal/handlers/news.go
+++ b/internal/handlers/news.go
@@ -223,6 +223,30 @@ func (h *NewsHandler) SetActiveAnnouncement(c echo.Context) error {
 	return RespondMessage(c, "Активное объявление обновлено")
 }
 
+// HideAnnouncement godoc
+// @Summary      Скрытие объявления
+// @Description  Снимает is_active с конкретного объявления; не трогает остальные.
+// @Tags         announcements
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID объявления"
+// @Success      200 {string} string "Объявление скрыто"
+// @Failure      401 {object} models.HTTPError
+// @Failure      403 {object} models.HTTPError
+// @Failure      404 {object} models.HTTPError
+// @Router       /announcements/{id}/hide [post]
+func (h *NewsHandler) HideAnnouncement(c echo.Context) error {
+	typeID := GetTypeID(c)
+	id, err := ParseID(c, "id")
+	if err != nil {
+		return err
+	}
+	if err := h.service.HideAnnouncement(c.Request().Context(), typeID, id); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Объявление скрыто")
+}
+
 // UpdateAnnouncement godoc
 // @Summary      Обновление объявления
 // @Tags         announcements

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -283,6 +283,7 @@ func Setup(e *echo.Echo, auth *handlers.AuthHandler, userTypes *handlers.UserTyp
 	ag.GET("/all", news.GetAllAnnouncements)
 	ag.POST("", news.CreateAnnouncement)
 	ag.POST("/set-active", news.SetActiveAnnouncement)
+	ag.POST("/:id/hide", news.HideAnnouncement)
 	ag.PUT("/:id", news.UpdateAnnouncement)
 	ag.DELETE("/:id", news.DeleteAnnouncement)
 

--- a/internal/services/news_service.go
+++ b/internal/services/news_service.go
@@ -25,6 +25,7 @@ type NewsService interface {
 	GetAllAnnouncements(ctx context.Context, typeID int) ([]models.AnnouncementWithUser, error)
 	CreateAnnouncement(ctx context.Context, typeID int, userID int, req models.CreateAnnouncementRequest) (*models.AnnouncementWithUser, error)
 	SetActiveAnnouncement(ctx context.Context, typeID int, userID int, req models.SetActiveAnnouncementRequest) error
+	HideAnnouncement(ctx context.Context, typeID int, id int) error
 	UpdateAnnouncement(ctx context.Context, typeID int, userID int, id int, req models.UpdateAnnouncementRequest) (*models.AnnouncementWithUser, error)
 	DeleteAnnouncement(ctx context.Context, typeID int, id int) error
 }
@@ -319,6 +320,30 @@ func (s *newsService) SetActiveAnnouncement(ctx context.Context, typeID int, use
 
 		return nil
 	})
+}
+
+// HideAnnouncement снимает is_active с конкретного объявления (admin only).
+// Не активирует другое - текущим активным остаётся то, что было до, либо
+// никакого (если скрываемое было активным).
+func (s *newsService) HideAnnouncement(ctx context.Context, typeID int, id int) error {
+	if err := s.checkAdmin(ctx, typeID); err != nil {
+		return err
+	}
+
+	res := s.db.WithContext(ctx).Model(&models.Announcement{}).
+		Where("id = ?", id).
+		Updates(map[string]interface{}{
+			"is_active":    false,
+			"activated_at": nil,
+			"activated_by": nil,
+		})
+	if res.Error != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Error hiding announcement")
+	}
+	if res.RowsAffected == 0 {
+		return echo.NewHTTPError(http.StatusNotFound, "Announcement not found")
+	}
+	return nil
 }
 
 func (s *newsService) UpdateAnnouncement(ctx context.Context, typeID int, userID int, id int, req models.UpdateAnnouncementRequest) (*models.AnnouncementWithUser, error) {


### PR DESCRIPTION
## Что закрывает в #184

- [x] **Объявления: добавить возможность скрыть объявление и отобразить его** - admin может скрыть конкретное активное объявление без активации другого. Кнопка \"Скрыть\" / \"Показать\" в управлении.
- [x] **При установке ВАЖНОГО ОБЪЯВЛЕНИЯ в разделе \"Обзор и новости\" обновлять отображение в шапке. Бейдж сделать с градиентом, как в old_branch** - .broadcast--important теперь linear-gradient #FF6B6B -> #B91C1C с пульсирующим box-shadow (broadcast-glow 2.4s)

## Изменения

backend:
- internal/services/news_service.go: HideAnnouncement(typeID, id) - admin-only
- internal/handlers/news.go: HideAnnouncement handler
- internal/router/router.go: POST /announcements/{id}/hide

frontend:
- NewsAndReview.vue: кнопка \"Деактивировать\" -> \"Скрыть\" использует новый endpoint (раньше PUT с is_active=false silent fail-ил, потому что UpdateAnnouncementRequest не имеет поля is_active)
- кнопка \"Активировать\" -> \"Показать\" - единая семантика
- TheHeader.vue: .broadcast--important с linear-gradient + пульсирующая анимация

## Test plan

- [ ] CI зелёный
- [ ] /news -> Управление -> Скрыть активное объявление - в шапке исчезает бейдж
- [ ] /news -> Управление -> Показать ранее скрытое - в шапке появляется бейдж
- [ ] При is_important=true бейдж с градиентом красным и пульсирует