### PR TITLE
feat: сворачивание секций ЛК с плавной анимацией (#184)

### DIFF
--- a/frontend/src/components/AccountComponent.vue
+++ b/frontend/src/components/AccountComponent.vue
@@ -57,84 +57,82 @@
       <AccountSettings v-if="isBuroPropuskov" />
     </div>
 
-    <!-- Вторая строка: управление пользователями (если доступно) -->
-    <div
+    <CollapsibleSection
       v-if="isBuroPropuskov"
-      id="users"
-      class="dashboard-row"
+      title="Учётные записи пользователей"
+      anchor-id="users"
     >
-      <UserControl 
+      <UserControl
         :all-users="allUsers"
         class="dashboard-card dashboard-card-animated"
         @fetch-users="fetchAllUsers"
         @user-updated="handleUserUpdated"
       />
-    </div>
+    </CollapsibleSection>
 
-    <!-- Третья строка: управление организациями (если доступно) -->
-    <div
+    <CollapsibleSection
       v-if="isBuroPropuskov"
-      id="organizations"
-      class="dashboard-row"
+      title="Управление организациями"
+      anchor-id="organizations"
     >
       <OrganizationsManagement class="dashboard-card dashboard-card-animated" />
-    </div>
-    <div
+    </CollapsibleSection>
+    <CollapsibleSection
       v-if="isBuroPropuskov"
-      id="companies"
-      class="dashboard-row"
+      title="Управление компаниями"
+      anchor-id="companies"
     >
       <CompaniesManagement class="dashboard-card dashboard-card-animated" />
-    </div>
-    <div
+    </CollapsibleSection>
+    <CollapsibleSection
       v-if="isBuroPropuskov"
-      id="unload_place"
-      class="dashboard-row"
+      title="Управление местами разгрузки"
+      anchor-id="unload_place"
     >
       <UnloadPlacesContainer class="dashboard-card dashboard-card-animated" />
-    </div>
-    <div
+    </CollapsibleSection>
+    <CollapsibleSection
       v-if="isBuroPropuskov"
-      id="number"
-      class="dashboard-row"
+      title="Форматы номеров"
+      anchor-id="number"
     >
       <NumberFormat class="dashboard-card dashboard-card-animated" />
-    </div>
-    <div
+    </CollapsibleSection>
+    <CollapsibleSection
       v-if="isBuroPropuskov"
-      id="citizenships"
-      class="dashboard-row"
+      title="Гражданства"
+      anchor-id="citizenships"
     >
       <CitizenshipManagement class="dashboard-card dashboard-card-animated" />
-    </div>
-    <div
+    </CollapsibleSection>
+    <CollapsibleSection
       v-if="isBuroPropuskov"
-      id="tables"
-      class="dashboard-row"
+      title="Таблицы системы"
+      anchor-id="tables"
     >
       <TableConstructor class="dashboard-card dashboard-card-animated" />
-    </div>
-    <div
+    </CollapsibleSection>
+    <CollapsibleSection
       v-if="isBuroPropuskov"
-      id="user_types"
-      class="dashboard-row"
+      title="Типы пользователей"
+      anchor-id="user_types"
     >
       <UserTypes class="dashboard-card dashboard-card-animated" />
-    </div>
-    <div
+    </CollapsibleSection>
+    <CollapsibleSection
       v-if="isBuroPropuskov"
-      id="attachments"
-      class="dashboard-row"
+      title="Вложения заявок (бланки)"
+      anchor-id="attachments"
     >
       <AttachmentsManagement class="dashboard-card dashboard-card-animated" />
-    </div>
-    <div
+    </CollapsibleSection>
+    <CollapsibleSection
       v-if="isBuroPropuskov"
-      id="approvers"
-      class="dashboard-row"
+      title="Принимающие заявки"
+      anchor-id="approvers"
     >
       <ApplicationApprovers class="dashboard-card dashboard-card-animated" />
-    </div>
+    </CollapsibleSection>
   </div>
 </template>
 
@@ -155,6 +153,7 @@ import AccountSettings from './AccountSettings.vue';
 import CitizenshipManagement from './CitizenshipManagement.vue';
 import AttachmentsManagement from './AttachmentsManagement.vue';
 import ApplicationApprovers from './ApplicationApprovers.vue';
+import CollapsibleSection from './ui/CollapsibleSection.vue';
 import { SkeletonTransition, SkeletonBlock } from '@/components/ui';
 
 export default {
@@ -173,6 +172,7 @@ export default {
     CitizenshipManagement,
     AttachmentsManagement,
     ApplicationApprovers,
+    CollapsibleSection,
     SkeletonTransition,
     SkeletonBlock,
   },

--- a/frontend/src/components/ui/CollapsibleSection.vue
+++ b/frontend/src/components/ui/CollapsibleSection.vue
@@ -1,0 +1,142 @@
+<template>
+  <div
+    :id="anchorId"
+    class="collapsible-section dashboard-row"
+    :class="{ 'is-collapsed': collapsed }"
+  >
+    <button
+      type="button"
+      class="collapsible-section__toggle"
+      :aria-expanded="!collapsed"
+      :aria-controls="contentId"
+      :title="collapsed ? `Развернуть: ${title}` : `Свернуть: ${title}`"
+      :aria-label="collapsed ? `Развернуть: ${title}` : `Свернуть: ${title}`"
+      @click="collapsed = !collapsed"
+    >
+      <svg
+        class="collapsible-section__chevron"
+        :class="{ rotated: !collapsed }"
+        viewBox="0 0 24 24"
+        width="20"
+        height="20"
+        aria-hidden="true"
+      >
+        <path
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M6 9l6 6 6-6"
+        />
+      </svg>
+    </button>
+    <transition
+      name="collapse"
+      @enter="onEnter"
+      @after-enter="onAfterEnter"
+      @leave="onLeave"
+    >
+      <div
+        v-show="!collapsed"
+        :id="contentId"
+        ref="content"
+        class="collapsible-section__content"
+      >
+        <slot />
+      </div>
+    </transition>
+  </div>
+</template>
+
+<script>
+let uid = 0;
+
+export default {
+  name: 'CollapsibleSection',
+  props: {
+    title: { type: String, required: true },
+    anchorId: { type: String, default: '' },
+    initiallyCollapsed: { type: Boolean, default: false }
+  },
+  data() {
+    uid++;
+    return {
+      collapsed: this.initiallyCollapsed,
+      contentId: `collapsible-content-${uid}`
+    };
+  },
+  methods: {
+    onEnter(el) {
+      el.style.height = 'auto';
+      const target = el.scrollHeight + 'px';
+      el.style.height = '0';
+      requestAnimationFrame(() => { el.style.height = target; });
+    },
+    onAfterEnter(el) { el.style.height = ''; },
+    onLeave(el) {
+      el.style.height = el.scrollHeight + 'px';
+      requestAnimationFrame(() => { el.style.height = '0'; });
+    }
+  }
+};
+</script>
+
+<style scoped>
+.collapsible-section {
+  position: relative;
+}
+
+/* Кнопка-chevron в правом верхнем углу секции - не дублирует существующий
+   заголовок внутри слота, остаётся над ним. */
+.collapsible-section__toggle {
+  position: absolute;
+  top: 12px;
+  right: 14px;
+  z-index: 5;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 1px solid #e6e6e6;
+  background: #fff;
+  cursor: pointer;
+  border-radius: 8px;
+  color: #6e7280;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.collapsible-section__toggle:hover {
+  background: #eef0ff;
+  border-color: #4F5BDF;
+  color: #4F5BDF;
+}
+
+.collapsible-section__toggle:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(79, 91, 223, 0.25);
+}
+
+.collapsible-section__chevron {
+  transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.collapsible-section__chevron.rotated {
+  transform: rotate(180deg);
+}
+
+.collapsible-section__content {
+  overflow: hidden;
+}
+
+.collapse-enter-active,
+.collapse-leave-active {
+  transition: height 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.collapsible-section.is-collapsed .collapsible-section__content {
+  display: none;
+}
+</style>


### PR DESCRIPTION
## Что закрывает в #184

- [x] **Сворачивание вкладок настроек:** добавить возможность скрывать/раскрывать каждую вкладку с плавной анимацией (сворачивание в полосу и обратное разворачивание).

## Изменения

- ui/CollapsibleSection.vue - переиспользуемая обёртка с chevron-кнопкой в правом верхнем углу. aria-expanded для accessibility, smooth height-transition (300ms cubic-bezier)
- AccountComponent.vue: каждая dashboard-row обёрнута в CollapsibleSection с title (для aria-label) и anchor-id (сохраняет якоря для меню AccountSettings)
- кнопка не дублирует существующий внутренний заголовок секции - выведена в overlay поверх правого верхнего угла

## Test plan

- [ ] CI зелёный
- [ ] /personal-cabinet - chevron-кнопка в правом верхнем углу каждой секции
- [ ] Click - секция сворачивается с плавной анимацией
- [ ] Click повторно - разворачивается обратно
- [ ] Якоря из AccountSettings меню работают (scrollIntoView к свёрнутой секции)