### PR TITLE
feat: circle-loader на Обновить во всех компонентах ЛК (#184)

### DIFF
--- a/frontend/src/components/ApplicationApprovers.vue
+++ b/frontend/src/components/ApplicationApprovers.vue
@@ -16,7 +16,10 @@
         >
           Добавить принимающего
         </button>
-        <RefreshButton @refresh="refreshData" />
+        <RefreshButton
+          :loading="refreshing"
+          @refresh="refreshData"
+        />
       </div>
     </div>
 
@@ -316,6 +319,7 @@ export default {
   data() {
     return {
       searchQuery: '',
+      refreshing: false,
       approvers: [],
       allUsers: [],
       selectedApprover: null,
@@ -471,10 +475,15 @@ export default {
     },
 
     async refreshData() {
-      await Promise.all([
-        this.fetchApprovers(),
-        this.fetchAllUsers()
-      ]);
+      this.refreshing = true;
+      try {
+        await Promise.all([
+          this.fetchApprovers(),
+          this.fetchAllUsers()
+        ]);
+      } finally {
+        this.refreshing = false;
+      }
     },
 
     async fetchApprovers() {

--- a/frontend/src/components/AttachmentsManagement.vue
+++ b/frontend/src/components/AttachmentsManagement.vue
@@ -23,7 +23,10 @@
         >
           Создать вложение
         </button>
-        <RefreshButton @refresh="refreshData" />
+        <RefreshButton
+          :loading="refreshing"
+          @refresh="refreshData"
+        />
       </div>
     </div>
 
@@ -559,6 +562,7 @@ export default {
   data() {
     return {
       searchQuery: '',
+      refreshing: false,
       newAttachment: {
         name: '',
         display_name: '',
@@ -733,7 +737,12 @@ export default {
     },
     
     async refreshData() {
-      await this.fetchAllAttachments();
+      this.refreshing = true;
+      try {
+        await this.fetchAllAttachments();
+      } finally {
+        this.refreshing = false;
+      }
     },
     
     async fetchAllAttachments() {

--- a/frontend/src/components/NumberFormat.vue
+++ b/frontend/src/components/NumberFormat.vue
@@ -15,7 +15,10 @@
         >
           Добавить
         </button>
-        <RefreshButton @refresh="refreshData" />
+        <RefreshButton
+          :loading="refreshing"
+          @refresh="refreshData"
+        />
       </div>
     </div>
 
@@ -609,6 +612,7 @@ export default {
   data() {
     return {
       searchQuery: '',
+      refreshing: false,
       newFormat: {
         name: '',
         country_code: '',
@@ -683,7 +687,12 @@ export default {
   },
   methods: {
     async refreshData() {
-      await this.fetchFormats();
+      this.refreshing = true;
+      try {
+        await this.fetchFormats();
+      } finally {
+        this.refreshing = false;
+      }
     },
     async fetchFormats() {
       try {

--- a/frontend/src/components/TableConstructor.vue
+++ b/frontend/src/components/TableConstructor.vue
@@ -15,7 +15,10 @@
         >
           Создать таблицу
         </button>
-        <RefreshButton @refresh="refreshData" />
+        <RefreshButton
+          :loading="refreshing"
+          @refresh="refreshData"
+        />
       </div>
     </div>
 
@@ -508,6 +511,7 @@ export default {
   data() {
     return {
       searchQuery: '',
+      refreshing: false,
       tables: [],
       showAddModal: false,
       selectedTable: null,
@@ -599,7 +603,12 @@ export default {
     },
 
     async refreshData() {
-      await this.fetchTables();
+      this.refreshing = true;
+      try {
+        await this.fetchTables();
+      } finally {
+        this.refreshing = false;
+      }
     },
     
     async fetchTables() {

--- a/frontend/src/components/UserControl.vue
+++ b/frontend/src/components/UserControl.vue
@@ -15,7 +15,10 @@
         >
           Создать
         </button>
-        <RefreshButton @refresh="refreshAllData" />
+        <RefreshButton
+          :loading="refreshing"
+          @refresh="refreshAllData"
+        />
       </div>
     </div>
 
@@ -811,6 +814,7 @@ export default {
   data() {
     return {
       userSearch: '',
+      refreshing: false,
       selectedUser: null,
       showNewPass: false,
       currentLanguage: '',
@@ -970,11 +974,18 @@ export default {
       }
     },
 
-    refreshAllData() {
-      this.fetchOrganizations();
-      this.fetchCompanies();
-      this.fetchUserTypes();
-      this.fetchAllUsers();
+    async refreshAllData() {
+      this.refreshing = true;
+      try {
+        await Promise.all([
+          this.fetchOrganizations(),
+          this.fetchCompanies(),
+          this.fetchUserTypes(),
+          this.fetchAllUsers()
+        ]);
+      } finally {
+        this.refreshing = false;
+      }
     },
 
     handleClickOutside(event) {

--- a/frontend/src/components/UserTypes.vue
+++ b/frontend/src/components/UserTypes.vue
@@ -15,7 +15,10 @@
         >
           Создать тип
         </button>
-        <RefreshButton @refresh="refreshData" />
+        <RefreshButton
+          :loading="refreshing"
+          @refresh="refreshData"
+        />
       </div>
     </div>
 
@@ -309,6 +312,7 @@ export default {
   data() {
     return {
       searchQuery: '',
+      refreshing: false,
       newType: {
         name: '',
         code: ''
@@ -407,7 +411,12 @@ export default {
       }
     },
     async refreshData() {
-      await this.fetchTypes();
+      this.refreshing = true;
+      try {
+        await this.fetchTypes();
+      } finally {
+        this.refreshing = false;
+      }
     },
     async fetchTypes() {
       try {


### PR DESCRIPTION
## Что закрывает в #184

- [x] **Кнопка \"Обновить\":** во всех компонентах личного кабинета при нажатии запускать анимацию circle-loader до завершения загрузки данных. _(дополняет PR #198 для Companies/Organizations/Citizenship)_

## Изменения

В каждом из 6 компонентов:
- data: добавлен \`refreshing: false\`
- refreshData/refreshAllData оборачивает try/finally с set refreshing
- RefreshButton получает \`:loading=\"refreshing\"\`

Покрыто:
- UserControl (Promise.all для 4 параллельных fetch)
- UserTypes
- TableConstructor
- ApplicationApprovers
- AttachmentsManagement
- NumberFormat

## Test plan

- [ ] CI зелёный
- [ ] /personal-cabinet -> Учётные записи / Типы пользователей / Таблицы / Принимающие / Бланки / Авто-номера: клик \"Обновить\" - circle-loader на кнопке до окончания запроса