### PR TITLE
fix: общая история PeopleTable - все события сотрудников таблицы (#184)

### DIFF
--- a/internal/services/employees_history_service.go
+++ b/internal/services/employees_history_service.go
@@ -210,12 +210,20 @@ func (s *employeesHistoryService) GetCurrentStatus(ctx context.Context) ([]Emplo
 	return items, nil
 }
 
+// GetByTable возвращает историю сотрудников, относящихся к конкретной таблице.
+// Включает не только entry/exit с прямым eh.table_id, но и все события (create,
+// update, delete, data_changed) сотрудников, привязанных к этой таблице через
+// employee_target_tables - чтобы общая история таблицы показывала полный контекст,
+// а не только проходы.
 func (s *employeesHistoryService) GetByTable(ctx context.Context, tableID int) ([]EmployeeHistoryItem, error) {
 	rows := make([]employeeHistoryRow, 0)
 	err := s.db.WithContext(ctx).Raw(baseSelectSQL+`
 		WHERE eh.table_id = ?
+		   OR eh.employee_id IN (
+		     SELECT ett.employee_id FROM employee_target_tables ett WHERE ett.table_id = ?
+		   )
 		ORDER BY eh.created_at DESC
-	`, tableID).Scan(&rows).Error
+	`, tableID, tableID).Scan(&rows).Error
 	if err != nil {
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching employee history by table")
 	}


### PR DESCRIPTION
## Что закрывает в #184

- [x] **PeopleTable: История** - не записывалась общая история таблицы EmployeesTableHistoryModal.vue (только для конкретного человека). Добавить.

## Изменения

GetByTable в employees_history_service.go теперь возвращает не только entry/exit по конкретному eh.table_id, но и все остальные события (create/update/delete/data_changed) сотрудников, привязанных к этой таблице через employee_target_tables.

Раньше модалка истории таблицы показывала только проходы. Теперь видно полный контекст: создание, удаление, изменения данных сотрудников, относящихся к таблице.

SQL: \`WHERE eh.table_id = ? OR eh.employee_id IN (SELECT ett.employee_id FROM employee_target_tables ett WHERE ett.table_id = ?)\`

## Test plan

- [ ] CI зелёный
- [ ] /table/{id}/people -> История таблицы - видны events create/delete/update сотрудников, привязанных к этой таблице (не только entry/exit)