### PR TITLE
feat: FactTable circle-loader на Обновить (#184)

### DIFF
--- a/frontend/src/components/FactTable.vue
+++ b/frontend/src/components/FactTable.vue
@@ -10,7 +10,10 @@
         </h3>
       </div>
       <div class="card-header__settings">
-        <RefreshButton @refresh="fetchData" />
+        <RefreshButton
+          :loading="loading"
+          @refresh="$emit('refresh-data')"
+        />
       </div>
     </div>
     
@@ -280,7 +283,8 @@ export default {
     dateRangeEnd: { type: Date, default: null },
     selectedDate: { type: Date, default: null },
     currentUserId: { type: Number, default: null },
-    currentUserName: { type: String, default: '' }
+    currentUserName: { type: String, default: '' },
+    loading: { type: Boolean, default: false }
   },
   emits: ['refresh-data', 'open-application'],
   data() {

--- a/frontend/src/components/TablesComponent.vue
+++ b/frontend/src/components/TablesComponent.vue
@@ -146,6 +146,7 @@
           :selected-date="selectedDate"
           :current-user-id="currentUserId"
           :current-user-name="currentUserName"
+          :loading="isRefreshing"
           @refresh-data="refreshData"
           @open-application="handleOpenApplication"
         />


### PR DESCRIPTION
## Что закрывает в #184

- [x] **FactTable.vue:** при нажатии кнопки \"Обновить\" показывать circle-loader.

## Изменения

- FactTable получает prop loading: Boolean
- :loading=loading прокидывается в RefreshButton
- @refresh теперь \$emit('refresh-data') (раньше был привязан к несуществующему методу fetchData - silent no-op)
- TablesComponent пробрасывает :loading=\"isRefreshing\" в FactTable

## Test plan

- [ ] CI зелёный
- [ ] /table/{id} - клик \"Обновить\" в FactTable - circle-loader на кнопке до окончания запроса