### PR TITLE
feat: ограничения редактирования в /employeesview /carsview (#184)

### DIFF
--- a/frontend/src/views/CarsView.vue
+++ b/frontend/src/views/CarsView.vue
@@ -229,33 +229,34 @@
                       <StatusBadge :status="car.status ? 'Активна' : 'Неактивна'" />
                     </div>
                     <div class="car-col actions-col">
-                      <button 
-                        v-if="currentFilter !== 'all_system'"
-                        class="edit-btn" 
+                      <button
+                        v-if="canEditCar(car)"
+                        class="edit-btn"
                         title="Редактировать"
                         @click="editCar(car)"
                       >
-                        <img 
-                          src="@/assets/icons/edit.png" 
-                          alt="Редактировать" 
+                        <img
+                          src="@/assets/icons/edit.png"
+                          alt="Редактировать"
                           class="edit-icon"
                         >
                       </button>
                       <button
-                        v-if="currentFilter !== 'all_system'"
+                        v-if="canEditCar(car)"
                         class="delete-btn"
                         title="Удалить"
                         @click="openDeleteCarConfirmation(car)"
                       >
-                        <img 
-                          src="@/assets/icons/trashcan.png" 
-                          alt="Удалить" 
+                        <img
+                          src="@/assets/icons/trashcan.png"
+                          alt="Удалить"
                           class="delete-icon"
                         >
                       </button>
                       <span
-                        v-if="currentFilter === 'all_system'"
+                        v-if="!canEditCar(car)"
                         class="read-only-text"
+                        :title="canEditTooltip(car)"
                       >
                         Только просмотр
                       </span>
@@ -726,6 +727,28 @@ export default {
         });
     },
     methods: {
+        /**
+         * Можно ли текущему пользователю редактировать/удалять машину.
+         * Логика совпадает с backend canEditCar (unique_car_service.go):
+         * автор, или организация совпадает, или компания совпадает.
+         * filter=all_system - read-only по согласованию (PR #198).
+         */
+        canEditCar(car) {
+            if (this.currentFilter === 'all_system') return false;
+            if (!this.ownershipInfo) return false;
+            if (car.user_id != null && car.user_id === this.ownershipInfo.user_id) return true;
+            if (car.organization_id != null && this.ownershipInfo.organization_id != null
+                && car.organization_id === this.ownershipInfo.organization_id) return true;
+            if (car.company_id != null && this.ownershipInfo.company_id != null
+                && car.company_id === this.ownershipInfo.company_id) return true;
+            return false;
+        },
+        canEditTooltip(car) {
+            if (this.currentFilter === 'all_system') return 'В режиме «Все в системе» редактирование запрещено';
+            if (this.canEditCar(car)) return '';
+            return 'Машина не привязана к вашей организации/компании - редактирование запрещено';
+        },
+
         async fetchCars() {
             this.loading = true;
             try {

--- a/frontend/src/views/EmployeeView.vue
+++ b/frontend/src/views/EmployeeView.vue
@@ -215,28 +215,37 @@
                       <StatusBadge :status="employee.status ? 'Активен' : 'Неактивен'" />
                     </div>
                     <div class="employee-col actions-col">
-                      <button 
-                        class="edit-btn" 
+                      <button
+                        v-if="canEditEmployee(employee)"
+                        class="edit-btn"
                         title="Редактировать"
                         @click="editEmployee(employee)"
                       >
-                        <img 
-                          src="@/assets/icons/edit.png" 
-                          alt="Редактировать" 
+                        <img
+                          src="@/assets/icons/edit.png"
+                          alt="Редактировать"
                           class="edit-icon"
                         >
                       </button>
-                      <button 
-                        class="delete-btn" 
+                      <button
+                        v-if="canEditEmployee(employee)"
+                        class="delete-btn"
                         title="Удалить"
                         @click="deleteEmployee(employee)"
                       >
-                        <img 
-                          src="@/assets/icons/trashcan.png" 
-                          alt="Удалить" 
+                        <img
+                          src="@/assets/icons/trashcan.png"
+                          alt="Удалить"
                           class="delete-icon"
                         >
                       </button>
+                      <span
+                        v-if="!canEditEmployee(employee)"
+                        class="read-only-text"
+                        :title="canEditTooltip(employee)"
+                      >
+                        Только просмотр
+                      </span>
                     </div>
                   </div>
                 </div>
@@ -411,6 +420,25 @@ export default {
         await this.fetchEmployees();
     },
     methods: {
+        /**
+         * Можно ли редактировать/удалять сотрудника. Совпадает с backend
+         * canEditEmployee (unique_employee_service.go).
+         */
+        canEditEmployee(emp) {
+            if (this.currentFilter === 'all_system') return false;
+            if (!this.ownershipInfo) return false;
+            if (emp.user_id != null && emp.user_id === this.ownershipInfo.user_id) return true;
+            if (emp.organization_id != null && this.ownershipInfo.organization_id != null
+                && emp.organization_id === this.ownershipInfo.organization_id) return true;
+            if (emp.company_id != null && this.ownershipInfo.company_id != null
+                && emp.company_id === this.ownershipInfo.company_id) return true;
+            return false;
+        },
+        canEditTooltip(emp) {
+            if (this.currentFilter === 'all_system') return 'В режиме «Все в системе» редактирование запрещено';
+            if (this.canEditEmployee(emp)) return '';
+            return 'Сотрудник не привязан к вашей организации/компании - редактирование запрещено';
+        },
         async fetchEmployees() {
             this.loading = true;
             try {


### PR DESCRIPTION
## Что закрывает в #184

- [x] **Сотрудники:** запретить редактирование/удаление сотрудников, привязанных к организации/компании, если они не привязаны к текущему пользователю.
- [x] **Автомобили:** запретить редактирование/удаление машин, привязанных к организации/компании, если они не привязаны к текущему пользователю.

## Изменения

В CarsView и EmployeeView добавлены methods:
- canEditCar(car) / canEditEmployee(emp) - дублирует backend canEditCar/canEditEmployee из unique_*_service.go (автор, или совпадение организации, или совпадение компании)
- canEditTooltip(...) - возвращает причину запрета

Edit/Delete кнопки теперь под v-if=canEdit*. Если нет прав - показывается \"Только просмотр\" с tooltip-причиной.

Раньше edit/delete были видимы всегда (кроме filter=all_system) - бэкенд просто возвращал 403, что выглядело как silent fail.

## Test plan

- [ ] CI зелёный
- [ ] /employeesview: фильтр Сотрудники компании - видны сотрудники чужих организаций без edit/delete (только tooltip)
- [ ] /carsview: то же для машин