### PR TITLE
feat: /employeesview row click открывает EmployeeDetailsModal (#184)

### DIFF
--- a/frontend/src/views/EmployeeView.vue
+++ b/frontend/src/views/EmployeeView.vue
@@ -190,12 +190,16 @@
                 v-if="filteredEmployees.length > 0"
                 class="employees-body"
               >
-                <div 
-                  v-for="(employee) in sortedEmployees" 
-                  :key="employee.id" 
+                <div
+                  v-for="(employee) in sortedEmployees"
+                  :key="employee.id"
                   class="employee-item"
                 >
-                  <div class="employee-row">
+                  <div
+                    class="employee-row"
+                    title="Открыть детали сотрудника"
+                    @click="openEmployeeDetails(employee)"
+                  >
                     <div class="employee-col number-col">
                       {{ employee.id }}
                     </div>
@@ -219,7 +223,7 @@
                         v-if="canEditEmployee(employee)"
                         class="edit-btn"
                         title="Редактировать"
-                        @click="editEmployee(employee)"
+                        @click.stop="editEmployee(employee)"
                       >
                         <img
                           src="@/assets/icons/edit.png"
@@ -231,7 +235,7 @@
                         v-if="canEditEmployee(employee)"
                         class="delete-btn"
                         title="Удалить"
-                        @click="deleteEmployee(employee)"
+                        @click.stop="deleteEmployee(employee)"
                       >
                         <img
                           src="@/assets/icons/trashcan.png"
@@ -304,6 +308,17 @@
       @saved="onEmployeeSaved"
       @close="closeModal"
     />
+
+    <EmployeeDetailsModal
+      v-if="detailsEmployee"
+      :show="showDetailsModal"
+      :employee="detailsEmployee"
+      :all-tables="[]"
+      :current-user-id="ownershipInfo?.user_id || null"
+      :current-user-name="''"
+      source="employeesview"
+      @close="closeDetailsModal"
+    />
   </section>
 </template>
 
@@ -315,6 +330,7 @@ import SkeletonTransition from '@/components/ui/SkeletonTransition.vue';
 import SkeletonTable from '@/components/ui/SkeletonTable.vue';
 import StatusBadge from '@/components/ui/StatusBadge.vue';
 import EmployeeEditModal from '@/components/EmployeeEditModal.vue';
+import EmployeeDetailsModal from '@/components/CreateApplication/EmployeeDetailsModal.vue';
 
 export default {
     components: {
@@ -323,7 +339,8 @@ export default {
         SkeletonTransition,
         SkeletonTable,
         StatusBadge,
-        EmployeeEditModal
+        EmployeeEditModal,
+        EmployeeDetailsModal
     },
     data() {
         return {
@@ -337,7 +354,9 @@ export default {
             ownershipInfo: null,
             showModal: false,
             availableCitizenships: [],
-            editingEmployee: null
+            editingEmployee: null,
+            showDetailsModal: false,
+            detailsEmployee: null
         };
     },
     computed: {
@@ -528,6 +547,30 @@ export default {
         switchFilter(filterType) {
             this.currentFilter = filterType;
             this.fetchEmployees();
+        },
+
+        openEmployeeDetails(employee) {
+            // EmployeeDetailsModal читает snake_case (last_name, position, ...)
+            // и поддерживает source=employeesview - заголовок \"Информация о сотруднике\"
+            this.detailsEmployee = {
+                id: employee.id,
+                last_name: employee.last_name,
+                first_name: employee.first_name,
+                middle_name: employee.middle_name,
+                position: employee.position,
+                citizenshipName: employee.citizenship_name,
+                passport_series_number: employee.passport_series_number,
+                patent_number: employee.patent_number,
+                other_permission: employee.other_permission,
+                organization: employee.organization_name,
+                company: employee.company_name,
+                target_tables: []
+            };
+            this.showDetailsModal = true;
+        },
+        closeDetailsModal() {
+            this.showDetailsModal = false;
+            this.detailsEmployee = null;
         },
 
         showAddEmployeeModal() {


### PR DESCRIPTION
## Что закрывает в #184 (частично)

- [x] **Сотрудники:** При клике на employee-row открывать EmployeeDetailsModal.vue с базовой информацией.

Полные требования (история, все проходы, привязки, список заявок) - отдельная архитектурная задача, требующая расширения EmployeeDetailsModal данными из других сервисов. В этом PR только базовое открытие модалки по клику.

## Изменения

- @click=\"openEmployeeDetails\" на .employee-row
- Edit/Delete кнопки получили @click.stop - не пробрасывают клик к row
- openEmployeeDetails трансформирует employee в shape, который ожидает EmployeeDetailsModal (snake_case поля, organization/company как строки)

## Test plan

- [ ] CI зелёный
- [ ] /employeesview - клик на строку сотрудника открывает модалку с деталями
- [ ] Клик на Edit или Delete не открывает модалку (stop propagation)