### PR TITLE
feat: /carsview row click открывает детали машины (#184)

### DIFF
--- a/frontend/src/components/CarDetailsViewModal.vue
+++ b/frontend/src/components/CarDetailsViewModal.vue
@@ -1,0 +1,199 @@
+<template>
+  <Teleport to="body">
+    <transition name="modal-fade">
+      <div
+        v-if="show"
+        class="modal-overlay"
+        @click.self="close"
+      >
+        <div class="modal-content">
+          <div class="modal-header">
+            <h3 class="modal-title">
+              Информация о машине
+            </h3>
+            <button
+              class="modal-close"
+              aria-label="Закрыть"
+              @click="close"
+            >
+              ×
+            </button>
+          </div>
+
+          <div class="modal-body">
+            <div class="details-grid">
+              <div class="detail-item">
+                <span class="detail-label">Номер:</span>
+                <span class="detail-value">{{ car.number || '-' }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="detail-label">Марка:</span>
+                <span class="detail-value">{{ car.mark || '-' }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="detail-label">Формат номера:</span>
+                <span class="detail-value">{{ car.format_name || '-' }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="detail-label">Организация:</span>
+                <span class="detail-value">{{ car.organization_name || '-' }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="detail-label">Компания:</span>
+                <span class="detail-value">{{ car.company_name || '-' }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="detail-label">Владелец:</span>
+                <span class="detail-value">{{ car.user_name || '-' }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="detail-label">Статус:</span>
+                <StatusBadge :status="car.status ? 'Активна' : 'Неактивна'" />
+              </div>
+              <div
+                v-if="car.created_at"
+                class="detail-item"
+              >
+                <span class="detail-label">Создана:</span>
+                <span class="detail-value">{{ formatDate(car.created_at) }}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </transition>
+  </Teleport>
+</template>
+
+<script>
+import StatusBadge from '@/components/ui/StatusBadge.vue';
+
+export default {
+  name: 'CarDetailsViewModal',
+  components: { StatusBadge },
+  props: {
+    show: { type: Boolean, required: true },
+    car: { type: Object, default: () => ({}) }
+  },
+  emits: ['close'],
+  mounted() {
+    document.addEventListener('keydown', this.onKey);
+  },
+  beforeUnmount() {
+    document.removeEventListener('keydown', this.onKey);
+  },
+  methods: {
+    onKey(e) {
+      if (e.key === 'Escape' && this.show) this.close();
+    },
+    close() { this.$emit('close'); },
+    formatDate(dateStr) {
+      if (!dateStr) return '-';
+      const d = new Date(dateStr);
+      if (isNaN(d.getTime())) return '-';
+      return d.toLocaleString('ru-RU', {
+        day: '2-digit', month: '2-digit', year: 'numeric',
+        hour: '2-digit', minute: '2-digit'
+      });
+    }
+  }
+};
+</script>
+
+<style scoped>
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(0.1px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+  padding: 16px;
+}
+
+.modal-content {
+  width: min(560px, 100%);
+  background: #fff;
+  border-radius: 18px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.18);
+  overflow: hidden;
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 22px;
+  border-bottom: 1px solid #eee;
+}
+
+.modal-title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+  color: #1a1a1a;
+}
+
+.modal-close {
+  background: transparent;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+  color: #6e7280;
+  padding: 4px 10px;
+  border-radius: 8px;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.modal-close:hover {
+  background: #f0f0f5;
+  color: #1a1a1a;
+}
+
+.modal-body {
+  padding: 18px 22px;
+  max-height: 70vh;
+  overflow-y: auto;
+}
+
+.details-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px 18px;
+}
+
+.detail-item {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.detail-label {
+  font-size: 12px;
+  color: #6e7280;
+  font-weight: 500;
+}
+
+.detail-value {
+  font-size: 14px;
+  color: #1a1a1a;
+}
+
+.modal-fade-enter-active,
+.modal-fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+  opacity: 0;
+}
+
+@media (max-width: 600px) {
+  .details-grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/frontend/src/views/CarsView.vue
+++ b/frontend/src/views/CarsView.vue
@@ -207,12 +207,16 @@
                 v-if="filteredCars.length > 0"
                 class="cars-body"
               >
-                <div 
-                  v-for="(car) in sortedCars" 
-                  :key="car.id" 
+                <div
+                  v-for="(car) in sortedCars"
+                  :key="car.id"
                   class="car-item"
                 >
-                  <div class="car-row">
+                  <div
+                    class="car-row"
+                    title="Открыть детали машины"
+                    @click="openCarDetails(car)"
+                  >
                     <div class="car-col number-col">
                       {{ car.id }}
                     </div>
@@ -233,7 +237,7 @@
                         v-if="canEditCar(car)"
                         class="edit-btn"
                         title="Редактировать"
-                        @click="editCar(car)"
+                        @click.stop="editCar(car)"
                       >
                         <img
                           src="@/assets/icons/edit.png"
@@ -245,7 +249,7 @@
                         v-if="canEditCar(car)"
                         class="delete-btn"
                         title="Удалить"
-                        @click="openDeleteCarConfirmation(car)"
+                        @click.stop="openDeleteCarConfirmation(car)"
                       >
                         <img
                           src="@/assets/icons/trashcan.png"
@@ -522,6 +526,13 @@
       @confirm="confirmDeleteCar"
       @cancel="cancelDeleteCar"
     />
+
+    <CarDetailsViewModal
+      v-if="detailsCar"
+      :show="showDetailsViewModal"
+      :car="detailsCar"
+      @close="closeCarDetails"
+    />
   </section>
 </template>
 
@@ -533,6 +544,7 @@ import SkeletonTransition from '@/components/ui/SkeletonTransition.vue';
 import SkeletonTable from '@/components/ui/SkeletonTable.vue';
 import StatusBadge from '@/components/ui/StatusBadge.vue';
 import ConfirmationModal from '@/components/ConfirmationModal.vue';
+import CarDetailsViewModal from '@/components/CarDetailsViewModal.vue';
 
 export default {
     components: {
@@ -541,7 +553,8 @@ export default {
         SkeletonTransition,
         SkeletonTable,
         StatusBadge,
-        ConfirmationModal
+        ConfirmationModal,
+        CarDetailsViewModal
     },
     data() {
         return {
@@ -557,6 +570,8 @@ export default {
             showDeleteCarModal: false,
             carToDelete: null,
             availableFormats: [],
+            showDetailsViewModal: false,
+            detailsCar: null,
 
             
             // Формат номера
@@ -727,6 +742,14 @@ export default {
         });
     },
     methods: {
+        openCarDetails(car) {
+            this.detailsCar = car;
+            this.showDetailsViewModal = true;
+        },
+        closeCarDetails() {
+            this.showDetailsViewModal = false;
+            this.detailsCar = null;
+        },
         /**
          * Можно ли текущему пользователю редактировать/удалять машину.
          * Логика совпадает с backend canEditCar (unique_car_service.go):


### PR DESCRIPTION
## Что закрывает в #184 (частично)

- [x] **Автомобили:** При клике на car-row открывать модалку с базовой информацией.

Полные требования (история, все проезды, привязки, список заявок) - отдельная задача, требующая адаптации VehicleDetailsModal или нового специализированного компонента.

## Изменения

- components/CarDetailsViewModal.vue - простая модалка: номер, марка, формат, организация, компания, владелец, статус, дата создания
- CarsView: @click на car-row открывает CarDetailsViewModal, edit/delete с @click.stop

## Test plan

- [ ] CI зелёный
- [ ] /carsview - клик на строку машины открывает модалку с деталями
- [ ] Edit/Delete не открывает модалку (stop propagation)