### PR TITLE
fix: UserNotifications - подгрузка и polling стартуют сразу (#184)

### DIFF
--- a/frontend/src/components/UserNotifications.vue
+++ b/frontend/src/components/UserNotifications.vue
@@ -109,14 +109,17 @@ export default {
     show(val) {
       if (val) {
         this.fetchNotifications()
-        this.startPolling()
-      } else {
-        this.stopPolling()
       }
     },
     unreadCount(count) {
       this.$emit('update:unread-count', count)
     },
+  },
+  mounted() {
+    // Загружаем уведомления и стартуем polling сразу - чтобы счётчик
+    // непрочитанных в шапке был актуален без открытия dropdown.
+    this.fetchNotifications()
+    this.startPolling()
   },
   beforeUnmount() {
     this.stopPolling()


### PR DESCRIPTION
## Что закрывает в #184

- [x] **Динамически подгружать уведомления и сразу отображать количество непрочитанных.**

## Bug

UserNotifications.vue делал fetchNotifications + startPolling только при открытии dropdown (через watch show). Бейдж в шапке (.notifications__badge) показывал актуальный счётчик только если юзер уже хотя бы раз открыл уведомления. На свежей сессии после login - badge висел 0 даже при наличии непрочитанных.

## Fix

fetchNotifications + startPolling вызываются в \`mounted()\`. Счётчик в шапке актуален с момента mount, polling каждые 30s.

## Test plan

- [ ] CI зелёный
- [ ] Login -> на любой странице уже виден бейдж непрочитанных в шапке (без открытия dropdown)