### PR TITLE
feat: модели Role/PermissionGroup + permission resolver (#229)

### DIFF
--- a/cmd/seed/main.go
+++ b/cmd/seed/main.go
@@ -58,14 +58,17 @@ func main() {
 	lastName := "Администратор"
 	firstName := "Системный"
 
+	// is_super_admin=true дублирует type_id=6 для поэтапного отказа от хардкода (#187a).
+	// Старые проверки по type_id=6 продолжают работать; новые — через is_super_admin.
 	result := db.Exec(`
-		INSERT INTO users (username, password, organization_id, company_id, type_id, last_name, first_name)
-		VALUES ('buropropuskov', ?, ?, ?, ?, ?, ?)
+		INSERT INTO users (username, password, organization_id, company_id, type_id, is_super_admin, last_name, first_name)
+		VALUES ('buropropuskov', ?, ?, ?, ?, true, ?, ?)
 		ON CONFLICT (username) DO UPDATE SET
 			password = EXCLUDED.password,
 			organization_id = EXCLUDED.organization_id,
 			company_id = EXCLUDED.company_id,
-			type_id = EXCLUDED.type_id
+			type_id = EXCLUDED.type_id,
+			is_super_admin = true
 	`, hash, orgID, compID, typeID, lastName, firstName)
 
 	if result.Error != nil {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -150,6 +150,9 @@ func main() {
 	carService := services.NewCarService(db)
 	employeeService := services.NewEmployeeService(db)
 	permissionService := services.NewPermissionService(db)
+	permissionResolver := services.NewPermissionResolver(db)
+	permissionGroupService := services.NewPermissionGroupService(db, permissionResolver)
+	roleService := services.NewRoleService(db, permissionResolver)
 	systemTableService := services.NewSystemTableService(db, cfg.UploadPath, cfg.UploadMaxFileSize, permissionService)
 	uniqueCarService := services.NewUniqueCarService(db)
 	uniqueEmployeeService := services.NewUniqueEmployeeService(db)
@@ -189,6 +192,8 @@ func main() {
 	applicationHandler := handlers.NewApplicationHandler(applicationService)
 	approverHandler := handlers.NewApproverHandler(approverService)
 	permissionHandler := handlers.NewPermissionHandler(permissionService)
+	permissionGroupHandler := handlers.NewPermissionGroupHandler(permissionGroupService)
+	roleHandler := handlers.NewRoleHandler(roleService)
 	consentHandler := handlers.NewConsentHandler(consentService, db)
 	settingsHandler := handlers.NewSettingsHandler(settingsService)
 	bugReportHandler := handlers.NewBugReportHandler(bugReportService)
@@ -208,7 +213,7 @@ func main() {
 	maintenanceBlock := mw.MaintenanceBlock(maintenanceService)
 
 	// Routes
-	router.Setup(e, authHandler, userTypesHandler, attachmentHandler, lpfHandler, citizenshipHandler, organizationHandler, companyHandler, usersHandler, unloadPlaceHandler, carHandler, employeeHandler, systemTableHandler, uniqueCarHandler, uniqueEmployeeHandler, feedbackHandler, applicationHandler, approverHandler, permissionHandler, consentHandler, settingsHandler, newsHandler, notificationHandler, requestLogsHandler, employeesHistoryHandler, bugReportHandler, maintenanceHandler, maintenanceBlock, []byte(cfg.JWTSecret), loginLimiter)
+	router.Setup(e, authHandler, userTypesHandler, attachmentHandler, lpfHandler, citizenshipHandler, organizationHandler, companyHandler, usersHandler, unloadPlaceHandler, carHandler, employeeHandler, systemTableHandler, uniqueCarHandler, uniqueEmployeeHandler, feedbackHandler, applicationHandler, approverHandler, permissionHandler, permissionGroupHandler, roleHandler, consentHandler, settingsHandler, newsHandler, notificationHandler, requestLogsHandler, employeesHistoryHandler, bugReportHandler, maintenanceHandler, maintenanceBlock, []byte(cfg.JWTSecret), loginLimiter)
 
 	// Общий ctx для фоновых задач и graceful shutdown. Отменяется по SIGINT/SIGTERM.
 	ctxSig, stopSig := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -97,6 +97,15 @@ func AllModels() []interface{} {
 		&models.Permission{},
 		&models.UserPermission{},
 
+		// New permission system (#229): roles, groups, grants, overrides.
+		// PermissionGroup перед Role - RoleDefaultGroup ссылается на обе.
+		&models.PermissionGroup{},
+		&models.Role{},
+		&models.RoleDefaultGroup{},
+		&models.PermissionGroupGrant{},
+		&models.UserGroup{},
+		&models.UserPermissionOverride{},
+
 		// PD consent & audit (152-FZ)
 		&models.PDConsent{},
 		&models.PDAuditLog{},

--- a/internal/handlers/permission_groups.go
+++ b/internal/handlers/permission_groups.go
@@ -1,0 +1,130 @@
+package handlers
+
+import (
+	"net/http"
+
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+
+	"github.com/labstack/echo/v4"
+)
+
+// PermissionGroupHandler -- HTTP-обработчики для управления группами прав.
+type PermissionGroupHandler struct {
+	service *services.PermissionGroupService
+}
+
+// NewPermissionGroupHandler конструирует handler.
+func NewPermissionGroupHandler(service *services.PermissionGroupService) *PermissionGroupHandler {
+	return &PermissionGroupHandler{service: service}
+}
+
+// List -- GET /permission-groups.
+func (h *PermissionGroupHandler) List(c echo.Context) error {
+	groups, err := h.service.List(c.Request().Context())
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, groups)
+}
+
+// Get -- GET /permission-groups/:id.
+func (h *PermissionGroupHandler) Get(c echo.Context) error {
+	id, err := ParseID(c, "id")
+	if err != nil {
+		return err
+	}
+	group, err := h.service.Get(c.Request().Context(), id)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, group)
+}
+
+// Create -- POST /permission-groups.
+func (h *PermissionGroupHandler) Create(c echo.Context) error {
+	var req models.CreatePermissionGroupRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	group, err := h.service.Create(c.Request().Context(), req)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusCreated, map[string]any{"success": true, "data": group})
+}
+
+// Update -- PUT /permission-groups/:id.
+func (h *PermissionGroupHandler) Update(c echo.Context) error {
+	id, err := ParseID(c, "id")
+	if err != nil {
+		return err
+	}
+	var req models.UpdatePermissionGroupRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	if err := h.service.Update(c.Request().Context(), id, req); err != nil {
+		return err
+	}
+	return RespondSuccess(c, map[string]any{"updated": true})
+}
+
+// Delete -- DELETE /permission-groups/:id.
+func (h *PermissionGroupHandler) Delete(c echo.Context) error {
+	id, err := ParseID(c, "id")
+	if err != nil {
+		return err
+	}
+	if err := h.service.Delete(c.Request().Context(), id); err != nil {
+		return err
+	}
+	return RespondSuccess(c, map[string]any{"deleted": true})
+}
+
+// Merge -- POST /permission-groups/merge.
+func (h *PermissionGroupHandler) Merge(c echo.Context) error {
+	var req models.MergePermissionGroupsRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	grantedBy := GetUserID(c)
+	group, err := h.service.Merge(c.Request().Context(), req, grantedBy)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusCreated, map[string]any{"success": true, "data": group})
+}
+
+// AssignToUser -- POST /users/:user_id/permission-groups/:group_id.
+func (h *PermissionGroupHandler) AssignToUser(c echo.Context) error {
+	userID, err := ParseID(c, "user_id")
+	if err != nil {
+		return err
+	}
+	groupID, err := ParseID(c, "group_id")
+	if err != nil {
+		return err
+	}
+	grantedBy := GetUserID(c)
+	if err := h.service.AssignToUser(c.Request().Context(), userID, groupID, grantedBy); err != nil {
+		return err
+	}
+	return RespondSuccess(c, map[string]any{"assigned": true})
+}
+
+// UnassignFromUser -- DELETE /users/:user_id/permission-groups/:group_id.
+func (h *PermissionGroupHandler) UnassignFromUser(c echo.Context) error {
+	userID, err := ParseID(c, "user_id")
+	if err != nil {
+		return err
+	}
+	groupID, err := ParseID(c, "group_id")
+	if err != nil {
+		return err
+	}
+	if err := h.service.UnassignFromUser(c.Request().Context(), userID, groupID); err != nil {
+		return err
+	}
+	return RespondSuccess(c, map[string]any{"unassigned": true})
+}

--- a/internal/handlers/permission_resolver_integration_test.go
+++ b/internal/handlers/permission_resolver_integration_test.go
@@ -1,7 +1,15 @@
-package services_test
+package handlers_test
+
+// Resolver интеграционные тесты. Лежат в handlers_test, чтобы идти в одной
+// тестовой бинарке с другими handler tests -- это даёт sequential выполнение
+// (go test -p 4 параллелит между пакетами, но не внутри пакета). На общей
+// auto_registry_test БД параллельный CleanDB из соседнего пакета сносил наши
+// записи и ломал FK на user_types. Здесь race снят пока тесты сосуществуют.
 
 import (
 	"context"
+	"fmt"
+	"sync/atomic"
 	"testing"
 
 	"systemburo/internal/models"
@@ -11,12 +19,36 @@ import (
 	"gorm.io/gorm"
 )
 
-// seedRoleGroupUser -- хелпер для подготовки минимального state.
-// Возвращает userID, group1ID, group2ID.
-func seedRoleGroupUser(t *testing.T, db *gorm.DB) (int, int, int) {
+// uniqCounter гарантирует уникальность кодов/usernames между параллельными
+// тестами этого пакета и параллельными запусками с другими пакетами на одной БД.
+var uniqCounter int64
+
+func uniq(prefix string) string {
+	n := atomic.AddInt64(&uniqCounter, 1)
+	return fmt.Sprintf("%s-%d", prefix, n)
+}
+
+// createOwnUserType создаёт изолированный user_type, чтобы не race-иться
+// с CleanDB других тестов, которые чистят таблицу user_types.
+func createOwnUserType(t *testing.T, db *gorm.DB) models.UserType {
+	t.Helper()
+	ut := models.UserType{Name: uniq("test_type"), Code: uniq("tt")}
+	if err := db.Create(&ut).Error; err != nil {
+		t.Fatalf("create user_type: %v", err)
+	}
+	return ut
+}
+
+// seedRoleGroupUser создаёт изолированный set записей с уникальными
+// идентификаторами. CleanDB не вызывается -- мы работаем поверх существующих
+// данных, чтобы не race-иться с другими пакетами.
+// Возвращает userID, group1ID, group2ID + cleanup-функцию.
+func seedRoleGroupUser(t *testing.T, db *gorm.DB) (int, int, int, func()) {
 	t.Helper()
 
-	g1 := models.PermissionGroup{Name: "Базовый доступ"}
+	ut := createOwnUserType(t, db)
+
+	g1 := models.PermissionGroup{Name: uniq("Базовый доступ")}
 	if err := db.Create(&g1).Error; err != nil {
 		t.Fatalf("create group1: %v", err)
 	}
@@ -27,7 +59,7 @@ func seedRoleGroupUser(t *testing.T, db *gorm.DB) (int, int, int) {
 		t.Fatalf("create grants1: %v", err)
 	}
 
-	g2 := models.PermissionGroup{Name: "Удаление сотрудников"}
+	g2 := models.PermissionGroup{Name: uniq("Удаление сотрудников")}
 	if err := db.Create(&g2).Error; err != nil {
 		t.Fatalf("create group2: %v", err)
 	}
@@ -37,7 +69,7 @@ func seedRoleGroupUser(t *testing.T, db *gorm.DB) (int, int, int) {
 		t.Fatalf("create grants2: %v", err)
 	}
 
-	role := models.Role{Code: "tenant", Name: "Арендатор"}
+	role := models.Role{Code: uniq("tenant"), Name: "Арендатор"}
 	if err := db.Create(&role).Error; err != nil {
 		t.Fatalf("create role: %v", err)
 	}
@@ -46,20 +78,31 @@ func seedRoleGroupUser(t *testing.T, db *gorm.DB) (int, int, int) {
 	}
 
 	roleID := role.ID
-	user := models.User{Username: "tenant1", Password: "x", TypeID: 1, RoleID: &roleID}
+	user := models.User{Username: uniq("tenant"), Password: "x", TypeID: ut.ID, RoleID: &roleID}
 	if err := db.Create(&user).Error; err != nil {
 		t.Fatalf("create user: %v", err)
 	}
 
-	return user.ID, g1.ID, g2.ID
+	cleanup := func() {
+		// Удаляем строго свои записи в FK-safe порядке.
+		db.Where("user_id = ?", user.ID).Delete(&models.UserPermissionOverride{})
+		db.Where("user_id = ?", user.ID).Delete(&models.UserGroup{})
+		db.Delete(&user)
+		db.Where("role_id = ?", role.ID).Delete(&models.RoleDefaultGroup{})
+		db.Delete(&role)
+		db.Where("group_id IN ?", []int{g1.ID, g2.ID}).Delete(&models.PermissionGroupGrant{})
+		db.Delete(&models.PermissionGroup{}, []int{g1.ID, g2.ID})
+		db.Delete(&ut)
+	}
+
+	return user.ID, g1.ID, g2.ID, cleanup
 }
 
 func TestPermissionResolver_RoleDefaultGroupOnly(t *testing.T) {
-	_, db, cleanup := testutil.SetupTestApp(t)
-	defer cleanup()
-	testutil.CleanDB(t, db)
+	_, db, _ := testutil.SetupTestApp(t)
 
-	userID, _, _ := seedRoleGroupUser(t, db)
+	userID, _, _, cleanup := seedRoleGroupUser(t, db)
+	defer cleanup()
 
 	resolver := services.NewPermissionResolver(db)
 	set, err := resolver.Resolve(context.Background(), userID)
@@ -78,11 +121,10 @@ func TestPermissionResolver_RoleDefaultGroupOnly(t *testing.T) {
 }
 
 func TestPermissionResolver_AdditionalUserGroupAdds(t *testing.T) {
-	_, db, cleanup := testutil.SetupTestApp(t)
-	defer cleanup()
-	testutil.CleanDB(t, db)
+	_, db, _ := testutil.SetupTestApp(t)
 
-	userID, _, g2ID := seedRoleGroupUser(t, db)
+	userID, _, g2ID, cleanup := seedRoleGroupUser(t, db)
+	defer cleanup()
 	if err := db.Create(&models.UserGroup{UserID: userID, GroupID: g2ID}).Error; err != nil {
 		t.Fatalf("assign g2: %v", err)
 	}
@@ -98,11 +140,10 @@ func TestPermissionResolver_AdditionalUserGroupAdds(t *testing.T) {
 }
 
 func TestPermissionResolver_OverrideDenyWins(t *testing.T) {
-	_, db, cleanup := testutil.SetupTestApp(t)
-	defer cleanup()
-	testutil.CleanDB(t, db)
+	_, db, _ := testutil.SetupTestApp(t)
 
-	userID, _, _ := seedRoleGroupUser(t, db)
+	userID, _, _, cleanup := seedRoleGroupUser(t, db)
+	defer cleanup()
 	if err := db.Create(&models.UserPermissionOverride{
 		UserID: userID, PermissionKey: "page.center", Value: "deny",
 	}).Error; err != nil {
@@ -123,14 +164,16 @@ func TestPermissionResolver_OverrideDenyWins(t *testing.T) {
 }
 
 func TestPermissionResolver_SuperAdminBypass(t *testing.T) {
-	_, db, cleanup := testutil.SetupTestApp(t)
-	defer cleanup()
-	testutil.CleanDB(t, db)
+	_, db, _ := testutil.SetupTestApp(t)
 
-	user := models.User{Username: "super", Password: "x", TypeID: 1, IsSuperAdmin: true}
+	ut := createOwnUserType(t, db)
+	defer db.Delete(&ut)
+
+	user := models.User{Username: uniq("super"), Password: "x", TypeID: ut.ID, IsSuperAdmin: true}
 	if err := db.Create(&user).Error; err != nil {
 		t.Fatalf("create super: %v", err)
 	}
+	defer db.Delete(&user)
 
 	resolver := services.NewPermissionResolver(db)
 	set, err := resolver.Resolve(context.Background(), user.ID)
@@ -146,11 +189,10 @@ func TestPermissionResolver_SuperAdminBypass(t *testing.T) {
 }
 
 func TestPermissionResolver_CacheInvalidation(t *testing.T) {
-	_, db, cleanup := testutil.SetupTestApp(t)
-	defer cleanup()
-	testutil.CleanDB(t, db)
+	_, db, _ := testutil.SetupTestApp(t)
 
-	userID, _, g2ID := seedRoleGroupUser(t, db)
+	userID, _, g2ID, cleanup := seedRoleGroupUser(t, db)
+	defer cleanup()
 	resolver := services.NewPermissionResolver(db)
 
 	set, _ := resolver.Resolve(context.Background(), userID)

--- a/internal/handlers/roles.go
+++ b/internal/handlers/roles.go
@@ -1,0 +1,86 @@
+package handlers
+
+import (
+	"net/http"
+
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+
+	"github.com/labstack/echo/v4"
+)
+
+// RoleHandler -- HTTP-обработчики для управления ролями.
+type RoleHandler struct {
+	service *services.RoleService
+}
+
+// NewRoleHandler конструирует handler.
+func NewRoleHandler(service *services.RoleService) *RoleHandler {
+	return &RoleHandler{service: service}
+}
+
+// List -- GET /roles.
+func (h *RoleHandler) List(c echo.Context) error {
+	roles, err := h.service.List(c.Request().Context())
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, roles)
+}
+
+// Create -- POST /roles.
+func (h *RoleHandler) Create(c echo.Context) error {
+	var req models.CreateRoleRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	role, err := h.service.Create(c.Request().Context(), req)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusCreated, map[string]any{"success": true, "data": role})
+}
+
+// Update -- PUT /roles/:id.
+func (h *RoleHandler) Update(c echo.Context) error {
+	id, err := ParseID(c, "id")
+	if err != nil {
+		return err
+	}
+	var req models.UpdateRoleRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	if err := h.service.Update(c.Request().Context(), id, req); err != nil {
+		return err
+	}
+	return RespondSuccess(c, map[string]any{"updated": true})
+}
+
+// Delete -- DELETE /roles/:id.
+func (h *RoleHandler) Delete(c echo.Context) error {
+	id, err := ParseID(c, "id")
+	if err != nil {
+		return err
+	}
+	if err := h.service.Delete(c.Request().Context(), id); err != nil {
+		return err
+	}
+	return RespondSuccess(c, map[string]any{"deleted": true})
+}
+
+// SetDefaultGroups -- PUT /roles/:id/default-groups.
+func (h *RoleHandler) SetDefaultGroups(c echo.Context) error {
+	id, err := ParseID(c, "id")
+	if err != nil {
+		return err
+	}
+	var req models.SetRoleGroupsRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	if err := h.service.SetDefaultGroups(c.Request().Context(), id, req.GroupIDs); err != nil {
+		return err
+	}
+	return RespondSuccess(c, map[string]any{"updated": true})
+}

--- a/internal/models/permission.go
+++ b/internal/models/permission.go
@@ -1,5 +1,7 @@
 package models
 
+import "time"
+
 // Permission -- определение доступного разрешения в системе.
 type Permission struct {
 	ID          int     `json:"id"`
@@ -10,13 +12,88 @@ type Permission struct {
 	ParentKey   *string `gorm:"size:255;index" json:"parent_key"`
 }
 
-// UserPermission -- привязка разрешения к пользователю с конкретным значением.
+// UserPermission -- legacy таблица привязки разрешения к пользователю.
+// Сохранена для обратной совместимости. Новый код должен использовать
+// PermissionGroup + UserGroup + UserPermissionOverride.
 type UserPermission struct {
 	ID            int    `json:"id"`
 	UserID        int    `gorm:"index;uniqueIndex:idx_user_perm" json:"user_id"`
 	PermissionKey string `gorm:"size:255;uniqueIndex:idx_user_perm" json:"permission_key"`
 	Value         string `gorm:"size:50;default:deny" json:"value"`
 	GrantedBy     *int   `json:"granted_by"`
+}
+
+// PermissionGroup -- именованный набор прав ("Доступ к таблицам", "Управление заявками").
+// Группы переиспользуются: можно привязать к роли как default или назначить юзеру явно.
+// "Составная группа" в UI -- это >1 запись в UserGroup для одного юзера, в БД отдельной
+// сущности нет. Слияние групп создаёт новую simple-группу через эндпоинт merge.
+type PermissionGroup struct {
+	ID          int       `json:"id"`
+	Name        string    `gorm:"size:100" json:"name"`
+	Description *string   `gorm:"type:text" json:"description"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// PermissionGroupGrant -- связка "группа -> permission_key" со значением.
+// allow выдаёт право, deny явно запрещает (полезно для override на уровне группы).
+type PermissionGroupGrant struct {
+	GroupID       int             `gorm:"primaryKey;autoIncrement:false" json:"group_id"`
+	Group         PermissionGroup `gorm:"foreignKey:GroupID;constraint:OnDelete:CASCADE" json:"-"`
+	PermissionKey string          `gorm:"primaryKey;size:255" json:"permission_key"`
+	Value         string          `gorm:"size:10;default:'allow'" json:"value"`
+	CreatedAt     time.Time       `json:"created_at"`
+}
+
+// UserGroup -- явное назначение группы прав пользователю поверх роли.
+// Несколько записей у одного юзера = "Составная группа" в UI.
+type UserGroup struct {
+	UserID    int             `gorm:"primaryKey;autoIncrement:false" json:"user_id"`
+	User      User            `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"-"`
+	GroupID   int             `gorm:"primaryKey;autoIncrement:false" json:"group_id"`
+	Group     PermissionGroup `gorm:"foreignKey:GroupID;constraint:OnDelete:CASCADE" json:"-"`
+	GrantedBy *int            `json:"granted_by"`
+	GrantedAt time.Time       `json:"granted_at"`
+}
+
+// UserPermissionOverride -- точечный override на конкретный permission_key для юзера.
+// Применяется ПОСЛЕ объединения прав из роли и групп; deny здесь побеждает любое allow.
+type UserPermissionOverride struct {
+	UserID        int       `gorm:"primaryKey;autoIncrement:false" json:"user_id"`
+	User          User      `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"-"`
+	PermissionKey string    `gorm:"primaryKey;size:255" json:"permission_key"`
+	Value         string    `gorm:"size:10" json:"value"`
+	GrantedBy     *int      `json:"granted_by"`
+	GrantedAt     time.Time `json:"granted_at"`
+}
+
+// PermissionGroupResponse -- ответ с группой + её права.
+type PermissionGroupResponse struct {
+	ID          int      `json:"id"`
+	Name        string   `json:"name"`
+	Description *string  `json:"description"`
+	Keys        []string `json:"keys"`
+}
+
+// CreatePermissionGroupRequest -- запрос на создание группы.
+type CreatePermissionGroupRequest struct {
+	Name        string   `json:"name" validate:"required,min=2,max=100"`
+	Description *string  `json:"description"`
+	Keys        []string `json:"keys" validate:"required"`
+}
+
+// UpdatePermissionGroupRequest -- запрос на обновление группы.
+type UpdatePermissionGroupRequest struct {
+	Name        string   `json:"name" validate:"required,min=2,max=100"`
+	Description *string  `json:"description"`
+	Keys        []string `json:"keys" validate:"required"`
+}
+
+// MergePermissionGroupsRequest -- запрос на слияние групп юзера в одну новую.
+type MergePermissionGroupsRequest struct {
+	UserID         int    `json:"user_id" validate:"required,min=1"`
+	SourceGroupIDs []int  `json:"source_group_ids" validate:"required,min=2"`
+	NewGroupName   string `json:"new_group_name" validate:"required,min=2,max=100"`
 }
 
 // --- DTOs ---

--- a/internal/models/role.go
+++ b/internal/models/role.go
@@ -1,0 +1,52 @@
+package models
+
+import "time"
+
+// Role -- бизнес-роль пользователя (арендатор, охранник, руководитель).
+// Не путать с группой прав: роль определяет "кто", группа -- "что разрешено".
+// К каждой роли можно привязать несколько default-групп прав через RoleDefaultGroup.
+type Role struct {
+	ID          int       `json:"id"`
+	Code        string    `gorm:"uniqueIndex;size:50" json:"code"`
+	Name        string    `gorm:"size:100" json:"name"`
+	Description *string   `gorm:"type:text" json:"description"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// RoleDefaultGroup -- M:N связь "роль -> default-группа прав".
+// Юзеры с этой ролью получают права из всех привязанных групп при создании.
+type RoleDefaultGroup struct {
+	RoleID    int             `gorm:"primaryKey;autoIncrement:false" json:"role_id"`
+	Role      Role            `gorm:"foreignKey:RoleID;constraint:OnDelete:CASCADE" json:"-"`
+	GroupID   int             `gorm:"primaryKey;autoIncrement:false" json:"group_id"`
+	Group     PermissionGroup `gorm:"foreignKey:GroupID;constraint:OnDelete:CASCADE" json:"-"`
+	CreatedAt time.Time       `json:"created_at"`
+}
+
+// CreateRoleRequest -- запрос на создание роли.
+type CreateRoleRequest struct {
+	Code        string  `json:"code" validate:"required,min=2,max=50"`
+	Name        string  `json:"name" validate:"required,min=2,max=100"`
+	Description *string `json:"description"`
+}
+
+// UpdateRoleRequest -- запрос на обновление роли.
+type UpdateRoleRequest struct {
+	Name        string  `json:"name" validate:"required,min=2,max=100"`
+	Description *string `json:"description"`
+}
+
+// SetRoleGroupsRequest -- запрос на установку дефолтных групп для роли.
+type SetRoleGroupsRequest struct {
+	GroupIDs []int `json:"group_ids" validate:"required"`
+}
+
+// RoleResponse -- ответ с информацией о роли + привязанных группах.
+type RoleResponse struct {
+	ID            int                       `json:"id"`
+	Code          string                    `json:"code"`
+	Name          string                    `json:"name"`
+	Description   *string                   `json:"description"`
+	DefaultGroups []PermissionGroupResponse `json:"default_groups"`
+}

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -12,6 +12,9 @@ type User struct {
 	Company           Company      `json:"company,omitempty"`
 	TypeID            int          `gorm:"default:1" json:"type_id"`
 	UserType          UserType     `gorm:"foreignKey:TypeID" json:"user_type,omitempty"`
+	RoleID            *int         `json:"role_id"`
+	Role              *Role        `gorm:"foreignKey:RoleID" json:"role,omitempty"`
+	IsSuperAdmin      bool         `gorm:"default:false;index" json:"is_super_admin"`
 	LastName          *string      `gorm:"size:100" json:"last_name"`
 	FirstName         *string      `gorm:"size:100" json:"first_name"`
 	MiddleName        *string      `gorm:"size:100" json:"middle_name"`

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -10,7 +10,7 @@ import (
 // Setup регистрирует все маршруты.
 // loginLimiter опционален (nil в тестах) - отдельный per-IP rate limit на /login.
 // В production передаётся mw.LoginRateLimit из cmd/server/main.go.
-func Setup(e *echo.Echo, auth *handlers.AuthHandler, userTypes *handlers.UserTypesHandler, attachments *handlers.AttachmentHandler, lpf *handlers.LicensePlateFormatHandler, cs *handlers.CitizenshipHandler, org *handlers.OrganizationHandler, comp *handlers.CompanyHandler, users *handlers.UsersHandler, up *handlers.UnloadPlaceHandler, cars *handlers.CarHandler, employees *handlers.EmployeeHandler, st *handlers.SystemTableHandler, uc *handlers.UniqueCarHandler, ue *handlers.UniqueEmployeeHandler, fb *handlers.FeedbackHandler, app *handlers.ApplicationHandler, approvers *handlers.ApproverHandler, permissions *handlers.PermissionHandler, consent *handlers.ConsentHandler, settings *handlers.SettingsHandler, news *handlers.NewsHandler, notifications *handlers.NotificationHandler, requestLogs *handlers.RequestLogsHandler, employeesHistory *handlers.EmployeesHistoryHandler, bugReport *handlers.BugReportHandler, maintenance *handlers.MaintenanceHandler, maintenanceBlock echo.MiddlewareFunc, jwtSecret []byte, loginLimiter echo.MiddlewareFunc) {
+func Setup(e *echo.Echo, auth *handlers.AuthHandler, userTypes *handlers.UserTypesHandler, attachments *handlers.AttachmentHandler, lpf *handlers.LicensePlateFormatHandler, cs *handlers.CitizenshipHandler, org *handlers.OrganizationHandler, comp *handlers.CompanyHandler, users *handlers.UsersHandler, up *handlers.UnloadPlaceHandler, cars *handlers.CarHandler, employees *handlers.EmployeeHandler, st *handlers.SystemTableHandler, uc *handlers.UniqueCarHandler, ue *handlers.UniqueEmployeeHandler, fb *handlers.FeedbackHandler, app *handlers.ApplicationHandler, approvers *handlers.ApproverHandler, permissions *handlers.PermissionHandler, permGroups *handlers.PermissionGroupHandler, roles *handlers.RoleHandler, consent *handlers.ConsentHandler, settings *handlers.SettingsHandler, news *handlers.NewsHandler, notifications *handlers.NotificationHandler, requestLogs *handlers.RequestLogsHandler, employeesHistory *handlers.EmployeesHistoryHandler, bugReport *handlers.BugReportHandler, maintenance *handlers.MaintenanceHandler, maintenanceBlock echo.MiddlewareFunc, jwtSecret []byte, loginLimiter echo.MiddlewareFunc) {
 	// Health check — вне /api, для мониторинга и readiness-проб.
 	e.GET("/health", func(c echo.Context) error {
 		return c.JSON(200, map[string]string{"status": "ok"})
@@ -256,6 +256,25 @@ func Setup(e *echo.Echo, auth *handlers.AuthHandler, userTypes *handlers.UserTyp
 	permGroup.PUT("/user/:id", permissions.UpdateUserPermissions)
 	permGroup.GET("/tree", permissions.GetPermissionTree)
 	permGroup.POST("/auto-generate", permissions.AutoGenerate)
+
+	// Группы прав (#187a)
+	pgGroup := protected.Group("/permission-groups")
+	pgGroup.GET("", permGroups.List)
+	pgGroup.GET("/:id", permGroups.Get)
+	pgGroup.POST("", permGroups.Create)
+	pgGroup.PUT("/:id", permGroups.Update)
+	pgGroup.DELETE("/:id", permGroups.Delete)
+	pgGroup.POST("/merge", permGroups.Merge)
+	protected.POST("/users/:user_id/permission-groups/:group_id", permGroups.AssignToUser)
+	protected.DELETE("/users/:user_id/permission-groups/:group_id", permGroups.UnassignFromUser)
+
+	// Роли (#187a)
+	rolesGroup := protected.Group("/roles")
+	rolesGroup.GET("", roles.List)
+	rolesGroup.POST("", roles.Create)
+	rolesGroup.PUT("/:id", roles.Update)
+	rolesGroup.DELETE("/:id", roles.Delete)
+	rolesGroup.PUT("/:id/default-groups", roles.SetDefaultGroups)
 
 	// Согласие на обработку ПД (152-ФЗ)
 	consents := protected.Group("/consents")

--- a/internal/services/permission_group_service.go
+++ b/internal/services/permission_group_service.go
@@ -1,0 +1,246 @@
+package services
+
+import (
+	"context"
+	"fmt"
+
+	"systemburo/internal/models"
+
+	"gorm.io/gorm"
+)
+
+// PermissionGroupService управляет группами прав: CRUD + назначение юзерам + слияние.
+type PermissionGroupService struct {
+	db       *gorm.DB
+	resolver *PermissionResolver
+}
+
+// NewPermissionGroupService конструирует сервис.
+func NewPermissionGroupService(db *gorm.DB, resolver *PermissionResolver) *PermissionGroupService {
+	return &PermissionGroupService{db: db, resolver: resolver}
+}
+
+// List возвращает все группы прав с их ключами.
+func (s *PermissionGroupService) List(ctx context.Context) ([]models.PermissionGroupResponse, error) {
+	var groups []models.PermissionGroup
+	if err := s.db.WithContext(ctx).Order("id DESC").Find(&groups).Error; err != nil {
+		return nil, fmt.Errorf("failed to list groups: %w", err)
+	}
+	if len(groups) == 0 {
+		return []models.PermissionGroupResponse{}, nil
+	}
+
+	groupIDs := make([]int, len(groups))
+	for i, g := range groups {
+		groupIDs[i] = g.ID
+	}
+	var grants []models.PermissionGroupGrant
+	if err := s.db.WithContext(ctx).Where("group_id IN ?", groupIDs).Find(&grants).Error; err != nil {
+		return nil, fmt.Errorf("failed to load grants: %w", err)
+	}
+
+	keysByGroup := make(map[int][]string)
+	for _, g := range grants {
+		if g.Value == "allow" {
+			keysByGroup[g.GroupID] = append(keysByGroup[g.GroupID], g.PermissionKey)
+		}
+	}
+
+	result := make([]models.PermissionGroupResponse, len(groups))
+	for i, g := range groups {
+		keys := keysByGroup[g.ID]
+		if keys == nil {
+			keys = []string{}
+		}
+		result[i] = models.PermissionGroupResponse{
+			ID:          g.ID,
+			Name:        g.Name,
+			Description: g.Description,
+			Keys:        keys,
+		}
+	}
+	return result, nil
+}
+
+// Get возвращает одну группу по ID.
+func (s *PermissionGroupService) Get(ctx context.Context, groupID int) (models.PermissionGroupResponse, error) {
+	var group models.PermissionGroup
+	if err := s.db.WithContext(ctx).First(&group, groupID).Error; err != nil {
+		return models.PermissionGroupResponse{}, fmt.Errorf("group not found: %w", err)
+	}
+	var grants []models.PermissionGroupGrant
+	if err := s.db.WithContext(ctx).Where("group_id = ?", groupID).Find(&grants).Error; err != nil {
+		return models.PermissionGroupResponse{}, fmt.Errorf("failed to load grants: %w", err)
+	}
+	keys := make([]string, 0, len(grants))
+	for _, g := range grants {
+		if g.Value == "allow" {
+			keys = append(keys, g.PermissionKey)
+		}
+	}
+	return models.PermissionGroupResponse{
+		ID:          group.ID,
+		Name:        group.Name,
+		Description: group.Description,
+		Keys:        keys,
+	}, nil
+}
+
+// Create создаёт группу с указанными ключами.
+func (s *PermissionGroupService) Create(ctx context.Context, req models.CreatePermissionGroupRequest) (models.PermissionGroupResponse, error) {
+	var resp models.PermissionGroupResponse
+	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		group := models.PermissionGroup{Name: req.Name, Description: req.Description}
+		if err := tx.Create(&group).Error; err != nil {
+			return fmt.Errorf("failed to create group: %w", err)
+		}
+		grants := buildGrants(group.ID, req.Keys)
+		if len(grants) > 0 {
+			if err := tx.Create(&grants).Error; err != nil {
+				return fmt.Errorf("failed to create grants: %w", err)
+			}
+		}
+		resp = models.PermissionGroupResponse{
+			ID:          group.ID,
+			Name:        group.Name,
+			Description: group.Description,
+			Keys:        req.Keys,
+		}
+		return nil
+	})
+	if err == nil {
+		s.resolver.InvalidateAll()
+	}
+	return resp, err
+}
+
+// Update обновляет имя/описание/ключи группы (полная замена ключей).
+func (s *PermissionGroupService) Update(ctx context.Context, groupID int, req models.UpdatePermissionGroupRequest) error {
+	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&models.PermissionGroup{}).Where("id = ?", groupID).
+			Updates(map[string]any{"name": req.Name, "description": req.Description}).Error; err != nil {
+			return fmt.Errorf("failed to update group: %w", err)
+		}
+		if err := tx.Where("group_id = ?", groupID).Delete(&models.PermissionGroupGrant{}).Error; err != nil {
+			return fmt.Errorf("failed to clear grants: %w", err)
+		}
+		grants := buildGrants(groupID, req.Keys)
+		if len(grants) > 0 {
+			if err := tx.Create(&grants).Error; err != nil {
+				return fmt.Errorf("failed to insert grants: %w", err)
+			}
+		}
+		return nil
+	})
+	if err == nil {
+		s.resolver.InvalidateAll()
+	}
+	return err
+}
+
+// Delete удаляет группу. Все связи в user_groups и role_default_groups удаляются каскадом.
+func (s *PermissionGroupService) Delete(ctx context.Context, groupID int) error {
+	if err := s.db.WithContext(ctx).Delete(&models.PermissionGroup{}, groupID).Error; err != nil {
+		return fmt.Errorf("failed to delete group: %w", err)
+	}
+	s.resolver.InvalidateAll()
+	return nil
+}
+
+// Merge сливает несколько групп юзера в новую simple-группу.
+// Старые группы остаются в системе, у юзера в user_groups заменяются на новую.
+func (s *PermissionGroupService) Merge(ctx context.Context, req models.MergePermissionGroupsRequest, grantedBy int) (models.PermissionGroupResponse, error) {
+	var resp models.PermissionGroupResponse
+	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var existingGrants []models.PermissionGroupGrant
+		if err := tx.Where("group_id IN ? AND value = ?", req.SourceGroupIDs, "allow").
+			Find(&existingGrants).Error; err != nil {
+			return fmt.Errorf("failed to load source grants: %w", err)
+		}
+		uniqKeys := uniqueKeys(existingGrants)
+
+		newGroup := models.PermissionGroup{Name: req.NewGroupName}
+		if err := tx.Create(&newGroup).Error; err != nil {
+			return fmt.Errorf("failed to create merged group: %w", err)
+		}
+		grants := buildGrants(newGroup.ID, uniqKeys)
+		if len(grants) > 0 {
+			if err := tx.Create(&grants).Error; err != nil {
+				return fmt.Errorf("failed to create merged grants: %w", err)
+			}
+		}
+
+		// Заменяем у юзера: убираем source-группы, добавляем новую.
+		if err := tx.Where("user_id = ? AND group_id IN ?", req.UserID, req.SourceGroupIDs).
+			Delete(&models.UserGroup{}).Error; err != nil {
+			return fmt.Errorf("failed to remove source user_groups: %w", err)
+		}
+		ug := models.UserGroup{UserID: req.UserID, GroupID: newGroup.ID, GrantedBy: &grantedBy}
+		if err := tx.Create(&ug).Error; err != nil {
+			return fmt.Errorf("failed to assign merged group: %w", err)
+		}
+
+		resp = models.PermissionGroupResponse{
+			ID:   newGroup.ID,
+			Name: newGroup.Name,
+			Keys: uniqKeys,
+		}
+		return nil
+	})
+	if err == nil {
+		s.resolver.Invalidate(req.UserID)
+	}
+	return resp, err
+}
+
+// AssignToUser добавляет группу юзеру (или ничего не делает, если уже назначена).
+func (s *PermissionGroupService) AssignToUser(ctx context.Context, userID, groupID int, grantedBy int) error {
+	ug := models.UserGroup{UserID: userID, GroupID: groupID, GrantedBy: &grantedBy}
+	if err := s.db.WithContext(ctx).
+		Where("user_id = ? AND group_id = ?", userID, groupID).
+		FirstOrCreate(&ug).Error; err != nil {
+		return fmt.Errorf("failed to assign group: %w", err)
+	}
+	s.resolver.Invalidate(userID)
+	return nil
+}
+
+// UnassignFromUser убирает группу у юзера.
+func (s *PermissionGroupService) UnassignFromUser(ctx context.Context, userID, groupID int) error {
+	if err := s.db.WithContext(ctx).
+		Where("user_id = ? AND group_id = ?", userID, groupID).
+		Delete(&models.UserGroup{}).Error; err != nil {
+		return fmt.Errorf("failed to unassign group: %w", err)
+	}
+	s.resolver.Invalidate(userID)
+	return nil
+}
+
+// buildGrants строит slice grants из набора ключей (все со значением allow).
+func buildGrants(groupID int, keys []string) []models.PermissionGroupGrant {
+	seen := make(map[string]struct{}, len(keys))
+	grants := make([]models.PermissionGroupGrant, 0, len(keys))
+	for _, k := range keys {
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		seen[k] = struct{}{}
+		grants = append(grants, models.PermissionGroupGrant{
+			GroupID: groupID, PermissionKey: k, Value: "allow",
+		})
+	}
+	return grants
+}
+
+func uniqueKeys(grants []models.PermissionGroupGrant) []string {
+	seen := make(map[string]struct{}, len(grants))
+	keys := make([]string, 0, len(grants))
+	for _, g := range grants {
+		if _, ok := seen[g.PermissionKey]; ok {
+			continue
+		}
+		seen[g.PermissionKey] = struct{}{}
+		keys = append(keys, g.PermissionKey)
+	}
+	return keys
+}

--- a/internal/services/permission_keys.go
+++ b/internal/services/permission_keys.go
@@ -1,0 +1,94 @@
+package services
+
+// Permission key naming convention (#187):
+//
+//   page.<route>                     -- маршруты страниц (page.center, page.cars).
+//   tab.<name>                       -- вкладки внутри страниц (tab.applications).
+//   component.<name>.<verb>          -- компоненты (component.vehicle_history.export).
+//   action.<verb>.<entity>           -- действия (action.delete.employee).
+//   entity.<name>.<crud>             -- CRUD сущности (entity.cars.read|write|delete).
+//   table.<slug>.<verb>              -- динамические таблицы (генерируются AutoGenerateForTable).
+//
+// Ключи зашиты как константы здесь и используются в middleware/handler-ах.
+// Каталог валидных ключей передаётся фронту через GET /permissions/keys
+// для построения дерева в UI.
+
+// Префиксы permission keys (по namespace).
+const (
+	PrefixPage      = "page."
+	PrefixTab       = "tab."
+	PrefixComponent = "component."
+	PrefixAction    = "action."
+	PrefixEntity    = "entity."
+	PrefixTable     = "table."
+	PrefixAudit     = "permission.audit."
+)
+
+// Page-level keys (страницы навигационного меню).
+const (
+	KeyPageCenter        = "page.center"
+	KeyPageCars          = "page.cars"
+	KeyPageEmployees     = "page.employees"
+	KeyPageStatistics    = "page.statistics"
+	KeyPageReports       = "page.reports"
+	KeyPageNews          = "page.news"
+	KeyPageAdmin         = "page.admin"
+	KeyPagePersonal      = "page.personal_cabinet"
+	KeyPageSystemControl = "page.admin.system_control"
+	KeyPageAdminUsers    = "page.admin.users"
+	KeyPageAdminFeedback = "page.admin.feedback"
+)
+
+// Entity-level CRUD keys.
+const (
+	KeyEntityCarsRead       = "entity.cars.read"
+	KeyEntityCarsWrite      = "entity.cars.write"
+	KeyEntityCarsDelete     = "entity.cars.delete"
+	KeyEntityEmployeesRead  = "entity.employees.read"
+	KeyEntityEmployeesWrite = "entity.employees.write"
+	KeyEntityEmployeesDel   = "entity.employees.delete"
+)
+
+// Action-level keys (отдельные действия, не входящие в стандартный CRUD).
+const (
+	KeyActionExportApplications = "action.export.applications"
+	KeyActionApproveApplication = "action.approve.application"
+	KeyActionForwardApplication = "action.forward.application"
+	KeyActionBanUser            = "action.ban.user"
+)
+
+// Audit-level keys (просмотр и управление журналами).
+const (
+	KeyAuditRead   = "permission.audit.read"
+	KeyAuditManage = "permission.audit.manage"
+)
+
+// AllStaticKeys -- список всех известных static keys (без table.* которые auto-generate).
+// Используется для валидации входящих запросов и для seed дефолтных групп.
+func AllStaticKeys() []string {
+	return []string{
+		KeyPageCenter,
+		KeyPageCars,
+		KeyPageEmployees,
+		KeyPageStatistics,
+		KeyPageReports,
+		KeyPageNews,
+		KeyPageAdmin,
+		KeyPagePersonal,
+		KeyPageSystemControl,
+		KeyPageAdminUsers,
+		KeyPageAdminFeedback,
+		KeyEntityCarsRead,
+		KeyEntityCarsWrite,
+		KeyEntityCarsDelete,
+		KeyEntityEmployeesRead,
+		KeyEntityEmployeesWrite,
+		KeyEntityEmployeesDel,
+		KeyActionExportApplications,
+		KeyActionApproveApplication,
+		KeyActionForwardApplication,
+		KeyActionBanUser,
+		KeyAuditRead,
+		KeyAuditManage,
+	}
+}

--- a/internal/services/permission_resolver.go
+++ b/internal/services/permission_resolver.go
@@ -1,0 +1,218 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"systemburo/internal/models"
+
+	"gorm.io/gorm"
+)
+
+// PermissionResolver вычисляет финальный набор прав пользователя на основе
+// его роли (default-группы), явных групп и точечных override.
+//
+// Алгоритм (см. #187):
+//  1. Если IsSuperAdmin = true -> возвращает специальный allowAll set (HasPermission всегда true).
+//  2. Иначе union прав со всех групп: role.default_groups + user_groups.
+//  3. Поверх UserPermissionOverride: deny здесь побеждает любое allow из групп.
+//
+// Кэш: in-memory sync.Map с TTL 30s, инвалидируется по Invalidate(userID).
+type PermissionResolver struct {
+	db    *gorm.DB
+	cache sync.Map // userID -> *cacheEntry
+	ttl   time.Duration
+}
+
+type cacheEntry struct {
+	set       PermissionSet
+	expiresAt time.Time
+}
+
+// PermissionSet -- финальный набор прав юзера.
+// allowAll = true означает super-admin (HasPermission всегда true).
+type PermissionSet struct {
+	allowAll bool
+	allows   map[string]struct{}
+}
+
+// NewPermissionResolver конструирует resolver с кешом по умолчанию (30s TTL).
+func NewPermissionResolver(db *gorm.DB) *PermissionResolver {
+	return &PermissionResolver{db: db, ttl: 30 * time.Second}
+}
+
+// Has проверяет наличие конкретного permission_key у юзера.
+func (s *PermissionSet) Has(key string) bool {
+	if s.allowAll {
+		return true
+	}
+	_, ok := s.allows[key]
+	return ok
+}
+
+// Keys возвращает отсортированный список разрешённых ключей.
+// Для super-admin возвращает nil (всё разрешено, ключи перечислять нет смысла).
+func (s *PermissionSet) Keys() []string {
+	if s.allowAll {
+		return nil
+	}
+	keys := make([]string, 0, len(s.allows))
+	for k := range s.allows {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// IsSuperAdmin сообщает, что у юзера полный доступ.
+func (s *PermissionSet) IsSuperAdmin() bool {
+	return s.allowAll
+}
+
+// Resolve возвращает PermissionSet для юзера, используя кэш.
+func (r *PermissionResolver) Resolve(ctx context.Context, userID int) (PermissionSet, error) {
+	if v, ok := r.cache.Load(userID); ok {
+		entry := v.(*cacheEntry)
+		if time.Now().Before(entry.expiresAt) {
+			return entry.set, nil
+		}
+	}
+
+	set, err := r.computeSet(ctx, userID)
+	if err != nil {
+		return PermissionSet{}, fmt.Errorf("failed to compute permission set for user %d: %w", userID, err)
+	}
+
+	r.cache.Store(userID, &cacheEntry{
+		set:       set,
+		expiresAt: time.Now().Add(r.ttl),
+	})
+	return set, nil
+}
+
+// HasPermission -- удобный shortcut поверх Resolve.
+func (r *PermissionResolver) HasPermission(ctx context.Context, userID int, key string) (bool, error) {
+	set, err := r.Resolve(ctx, userID)
+	if err != nil {
+		return false, err
+	}
+	return set.Has(key), nil
+}
+
+// Invalidate сбрасывает кэш для конкретного юзера. Вызывается при изменении
+// роли, групп или override.
+func (r *PermissionResolver) Invalidate(userID int) {
+	r.cache.Delete(userID)
+}
+
+// InvalidateAll сбрасывает кэш для всех юзеров. Вызывается при изменении
+// permission_group_grants любой группы (broad invalidation -- проще, чем
+// отслеживать какие юзеры в каких группах).
+func (r *PermissionResolver) InvalidateAll() {
+	r.cache.Range(func(k, _ any) bool {
+		r.cache.Delete(k)
+		return true
+	})
+}
+
+// computeSet -- основная логика без кэша. Вынесена для тестируемости.
+func (r *PermissionResolver) computeSet(ctx context.Context, userID int) (PermissionSet, error) {
+	var user models.User
+	if err := r.db.WithContext(ctx).Select("id, role_id, is_super_admin").First(&user, userID).Error; err != nil {
+		return PermissionSet{}, fmt.Errorf("user not found: %w", err)
+	}
+
+	if user.IsSuperAdmin {
+		return PermissionSet{allowAll: true}, nil
+	}
+
+	allows := make(map[string]struct{})
+	denies := make(map[string]struct{})
+
+	// 1. Default-группы роли.
+	if user.RoleID != nil {
+		if err := r.collectGroupGrants(ctx, []int{*user.RoleID}, true, allows, denies); err != nil {
+			return PermissionSet{}, err
+		}
+	}
+
+	// 2. Явные группы юзера.
+	var userGroupIDs []int
+	if err := r.db.WithContext(ctx).
+		Model(&models.UserGroup{}).
+		Where("user_id = ?", userID).
+		Pluck("group_id", &userGroupIDs).Error; err != nil {
+		return PermissionSet{}, fmt.Errorf("failed to load user groups: %w", err)
+	}
+	if err := r.collectGroupGrants(ctx, userGroupIDs, false, allows, denies); err != nil {
+		return PermissionSet{}, err
+	}
+
+	// 3. User-level overrides (deny приоритетнее всего).
+	var overrides []models.UserPermissionOverride
+	if err := r.db.WithContext(ctx).
+		Where("user_id = ?", userID).
+		Find(&overrides).Error; err != nil {
+		return PermissionSet{}, fmt.Errorf("failed to load overrides: %w", err)
+	}
+	for _, o := range overrides {
+		if o.Value == "deny" {
+			denies[o.PermissionKey] = struct{}{}
+			delete(allows, o.PermissionKey)
+		} else if o.Value == "allow" {
+			delete(denies, o.PermissionKey)
+			allows[o.PermissionKey] = struct{}{}
+		}
+	}
+
+	// Вычитаем deny из allows (на всякий случай, после групповых deny).
+	for k := range denies {
+		delete(allows, k)
+	}
+
+	return PermissionSet{allows: allows}, nil
+}
+
+// collectGroupGrants добавляет права из указанных групп.
+// Если byRole = true, вместо groupIDs используются default-группы роли (groupIDs[0] = roleID).
+func (r *PermissionResolver) collectGroupGrants(ctx context.Context, groupIDs []int, byRole bool, allows, denies map[string]struct{}) error {
+	if len(groupIDs) == 0 {
+		return nil
+	}
+
+	resolvedGroupIDs := groupIDs
+	if byRole {
+		var ids []int
+		if err := r.db.WithContext(ctx).
+			Model(&models.RoleDefaultGroup{}).
+			Where("role_id IN ?", groupIDs).
+			Pluck("group_id", &ids).Error; err != nil {
+			return fmt.Errorf("failed to load role default groups: %w", err)
+		}
+		resolvedGroupIDs = ids
+	}
+	if len(resolvedGroupIDs) == 0 {
+		return nil
+	}
+
+	var grants []models.PermissionGroupGrant
+	if err := r.db.WithContext(ctx).
+		Where("group_id IN ?", resolvedGroupIDs).
+		Find(&grants).Error; err != nil {
+		return fmt.Errorf("failed to load group grants: %w", err)
+	}
+
+	for _, g := range grants {
+		switch g.Value {
+		case "allow":
+			if _, denied := denies[g.PermissionKey]; !denied {
+				allows[g.PermissionKey] = struct{}{}
+			}
+		case "deny":
+			denies[g.PermissionKey] = struct{}{}
+			delete(allows, g.PermissionKey)
+		}
+	}
+	return nil
+}

--- a/internal/services/permission_resolver_test.go
+++ b/internal/services/permission_resolver_test.go
@@ -1,0 +1,175 @@
+package services_test
+
+import (
+	"context"
+	"testing"
+
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+	"systemburo/internal/testutil"
+
+	"gorm.io/gorm"
+)
+
+// seedRoleGroupUser -- хелпер для подготовки минимального state.
+// Возвращает userID, group1ID, group2ID.
+func seedRoleGroupUser(t *testing.T, db *gorm.DB) (int, int, int) {
+	t.Helper()
+
+	g1 := models.PermissionGroup{Name: "Базовый доступ"}
+	if err := db.Create(&g1).Error; err != nil {
+		t.Fatalf("create group1: %v", err)
+	}
+	if err := db.Create(&[]models.PermissionGroupGrant{
+		{GroupID: g1.ID, PermissionKey: "page.center", Value: "allow"},
+		{GroupID: g1.ID, PermissionKey: "page.cars", Value: "allow"},
+	}).Error; err != nil {
+		t.Fatalf("create grants1: %v", err)
+	}
+
+	g2 := models.PermissionGroup{Name: "Удаление сотрудников"}
+	if err := db.Create(&g2).Error; err != nil {
+		t.Fatalf("create group2: %v", err)
+	}
+	if err := db.Create(&[]models.PermissionGroupGrant{
+		{GroupID: g2.ID, PermissionKey: "action.delete.employee", Value: "allow"},
+	}).Error; err != nil {
+		t.Fatalf("create grants2: %v", err)
+	}
+
+	role := models.Role{Code: "tenant", Name: "Арендатор"}
+	if err := db.Create(&role).Error; err != nil {
+		t.Fatalf("create role: %v", err)
+	}
+	if err := db.Create(&models.RoleDefaultGroup{RoleID: role.ID, GroupID: g1.ID}).Error; err != nil {
+		t.Fatalf("create role default: %v", err)
+	}
+
+	roleID := role.ID
+	user := models.User{Username: "tenant1", Password: "x", TypeID: 1, RoleID: &roleID}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	return user.ID, g1.ID, g2.ID
+}
+
+func TestPermissionResolver_RoleDefaultGroupOnly(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	userID, _, _ := seedRoleGroupUser(t, db)
+
+	resolver := services.NewPermissionResolver(db)
+	set, err := resolver.Resolve(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if !set.Has("page.center") {
+		t.Errorf("expected page.center allowed via role default group")
+	}
+	if !set.Has("page.cars") {
+		t.Errorf("expected page.cars allowed via role default group")
+	}
+	if set.Has("action.delete.employee") {
+		t.Errorf("expected delete denied (not in default group)")
+	}
+}
+
+func TestPermissionResolver_AdditionalUserGroupAdds(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	userID, _, g2ID := seedRoleGroupUser(t, db)
+	if err := db.Create(&models.UserGroup{UserID: userID, GroupID: g2ID}).Error; err != nil {
+		t.Fatalf("assign g2: %v", err)
+	}
+
+	resolver := services.NewPermissionResolver(db)
+	set, err := resolver.Resolve(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if !set.Has("page.center") || !set.Has("action.delete.employee") {
+		t.Errorf("expected union of role + extra group, got allows=%v", set.Keys())
+	}
+}
+
+func TestPermissionResolver_OverrideDenyWins(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	userID, _, _ := seedRoleGroupUser(t, db)
+	if err := db.Create(&models.UserPermissionOverride{
+		UserID: userID, PermissionKey: "page.center", Value: "deny",
+	}).Error; err != nil {
+		t.Fatalf("override: %v", err)
+	}
+
+	resolver := services.NewPermissionResolver(db)
+	set, err := resolver.Resolve(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if set.Has("page.center") {
+		t.Errorf("expected deny override to win over role allow")
+	}
+	if !set.Has("page.cars") {
+		t.Errorf("expected page.cars still allowed (only page.center overridden)")
+	}
+}
+
+func TestPermissionResolver_SuperAdminBypass(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	user := models.User{Username: "super", Password: "x", TypeID: 1, IsSuperAdmin: true}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("create super: %v", err)
+	}
+
+	resolver := services.NewPermissionResolver(db)
+	set, err := resolver.Resolve(context.Background(), user.ID)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if !set.IsSuperAdmin() {
+		t.Errorf("expected super-admin set")
+	}
+	if !set.Has("any.random.key") {
+		t.Errorf("super-admin should have any key")
+	}
+}
+
+func TestPermissionResolver_CacheInvalidation(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	userID, _, g2ID := seedRoleGroupUser(t, db)
+	resolver := services.NewPermissionResolver(db)
+
+	set, _ := resolver.Resolve(context.Background(), userID)
+	if set.Has("action.delete.employee") {
+		t.Fatalf("baseline expected no delete permission")
+	}
+
+	if err := db.Create(&models.UserGroup{UserID: userID, GroupID: g2ID}).Error; err != nil {
+		t.Fatalf("assign: %v", err)
+	}
+
+	set, _ = resolver.Resolve(context.Background(), userID)
+	if set.Has("action.delete.employee") {
+		t.Errorf("expected stale cache to hide new permission")
+	}
+
+	resolver.Invalidate(userID)
+	set, _ = resolver.Resolve(context.Background(), userID)
+	if !set.Has("action.delete.employee") {
+		t.Errorf("expected fresh cache to show new permission")
+	}
+}

--- a/internal/services/role_service.go
+++ b/internal/services/role_service.go
@@ -1,0 +1,172 @@
+package services
+
+import (
+	"context"
+	"fmt"
+
+	"systemburo/internal/models"
+
+	"gorm.io/gorm"
+)
+
+// RoleService управляет ролями и их default-группами.
+type RoleService struct {
+	db       *gorm.DB
+	resolver *PermissionResolver
+}
+
+// NewRoleService конструирует сервис.
+func NewRoleService(db *gorm.DB, resolver *PermissionResolver) *RoleService {
+	return &RoleService{db: db, resolver: resolver}
+}
+
+// List возвращает все роли с дефолтными группами.
+func (s *RoleService) List(ctx context.Context) ([]models.RoleResponse, error) {
+	var roles []models.Role
+	if err := s.db.WithContext(ctx).Order("id").Find(&roles).Error; err != nil {
+		return nil, fmt.Errorf("failed to list roles: %w", err)
+	}
+	if len(roles) == 0 {
+		return []models.RoleResponse{}, nil
+	}
+
+	roleIDs := make([]int, len(roles))
+	for i, r := range roles {
+		roleIDs[i] = r.ID
+	}
+
+	var defaults []models.RoleDefaultGroup
+	if err := s.db.WithContext(ctx).Where("role_id IN ?", roleIDs).Find(&defaults).Error; err != nil {
+		return nil, fmt.Errorf("failed to load role defaults: %w", err)
+	}
+
+	groupIDsByRole := make(map[int][]int)
+	allGroupIDs := make(map[int]struct{})
+	for _, d := range defaults {
+		groupIDsByRole[d.RoleID] = append(groupIDsByRole[d.RoleID], d.GroupID)
+		allGroupIDs[d.GroupID] = struct{}{}
+	}
+
+	groupResponses, err := s.fetchGroupResponses(ctx, allGroupIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]models.RoleResponse, len(roles))
+	for i, r := range roles {
+		groups := make([]models.PermissionGroupResponse, 0)
+		for _, gid := range groupIDsByRole[r.ID] {
+			if resp, ok := groupResponses[gid]; ok {
+				groups = append(groups, resp)
+			}
+		}
+		result[i] = models.RoleResponse{
+			ID:            r.ID,
+			Code:          r.Code,
+			Name:          r.Name,
+			Description:   r.Description,
+			DefaultGroups: groups,
+		}
+	}
+	return result, nil
+}
+
+// Create создаёт новую роль.
+func (s *RoleService) Create(ctx context.Context, req models.CreateRoleRequest) (models.Role, error) {
+	role := models.Role{Code: req.Code, Name: req.Name, Description: req.Description}
+	if err := s.db.WithContext(ctx).Create(&role).Error; err != nil {
+		return models.Role{}, fmt.Errorf("failed to create role: %w", err)
+	}
+	return role, nil
+}
+
+// Update обновляет имя/описание роли. Code менять нельзя (это API-контракт).
+func (s *RoleService) Update(ctx context.Context, roleID int, req models.UpdateRoleRequest) error {
+	if err := s.db.WithContext(ctx).Model(&models.Role{}).Where("id = ?", roleID).
+		Updates(map[string]any{"name": req.Name, "description": req.Description}).Error; err != nil {
+		return fmt.Errorf("failed to update role: %w", err)
+	}
+	s.resolver.InvalidateAll()
+	return nil
+}
+
+// Delete удаляет роль. Запрещено если есть юзеры с этой ролью.
+func (s *RoleService) Delete(ctx context.Context, roleID int) error {
+	var count int64
+	if err := s.db.WithContext(ctx).Model(&models.User{}).Where("role_id = ?", roleID).Count(&count).Error; err != nil {
+		return fmt.Errorf("failed to count users: %w", err)
+	}
+	if count > 0 {
+		return fmt.Errorf("cannot delete role: %d users still assigned", count)
+	}
+	if err := s.db.WithContext(ctx).Delete(&models.Role{}, roleID).Error; err != nil {
+		return fmt.Errorf("failed to delete role: %w", err)
+	}
+	return nil
+}
+
+// SetDefaultGroups полностью заменяет набор default-групп для роли.
+func (s *RoleService) SetDefaultGroups(ctx context.Context, roleID int, groupIDs []int) error {
+	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("role_id = ?", roleID).Delete(&models.RoleDefaultGroup{}).Error; err != nil {
+			return fmt.Errorf("failed to clear role defaults: %w", err)
+		}
+		if len(groupIDs) == 0 {
+			return nil
+		}
+		records := make([]models.RoleDefaultGroup, 0, len(groupIDs))
+		seen := make(map[int]struct{})
+		for _, gid := range groupIDs {
+			if _, dup := seen[gid]; dup {
+				continue
+			}
+			seen[gid] = struct{}{}
+			records = append(records, models.RoleDefaultGroup{RoleID: roleID, GroupID: gid})
+		}
+		if err := tx.Create(&records).Error; err != nil {
+			return fmt.Errorf("failed to insert role defaults: %w", err)
+		}
+		return nil
+	})
+	if err == nil {
+		s.resolver.InvalidateAll()
+	}
+	return err
+}
+
+func (s *RoleService) fetchGroupResponses(ctx context.Context, ids map[int]struct{}) (map[int]models.PermissionGroupResponse, error) {
+	if len(ids) == 0 {
+		return map[int]models.PermissionGroupResponse{}, nil
+	}
+	idList := make([]int, 0, len(ids))
+	for id := range ids {
+		idList = append(idList, id)
+	}
+	var groups []models.PermissionGroup
+	if err := s.db.WithContext(ctx).Where("id IN ?", idList).Find(&groups).Error; err != nil {
+		return nil, fmt.Errorf("failed to load groups: %w", err)
+	}
+	var grants []models.PermissionGroupGrant
+	if err := s.db.WithContext(ctx).Where("group_id IN ? AND value = ?", idList, "allow").
+		Find(&grants).Error; err != nil {
+		return nil, fmt.Errorf("failed to load grants: %w", err)
+	}
+	keysByGroup := make(map[int][]string)
+	for _, g := range grants {
+		keysByGroup[g.GroupID] = append(keysByGroup[g.GroupID], g.PermissionKey)
+	}
+	result := make(map[int]models.PermissionGroupResponse, len(groups))
+	for _, g := range groups {
+		keys := keysByGroup[g.ID]
+		if keys == nil {
+			keys = []string{}
+		}
+		result[g.ID] = models.PermissionGroupResponse{
+			ID:          g.ID,
+			Name:        g.Name,
+			Description: g.Description,
+			Keys:        keys,
+		}
+	}
+	return result, nil
+}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -37,6 +37,8 @@ const (
 var tables = []string{
 	"system_settings",
 	"pd_audit_logs", "pd_consents",
+	"user_permission_overrides", "user_groups", "permission_group_grants",
+	"role_default_groups", "permission_groups",
 	"user_permissions", "permissions",
 	"bug_reports",
 	"request_log", "request_logs", "notifications", "news", "announcements",
@@ -56,6 +58,7 @@ var tables = []string{
 	"citizenships",
 	"companies_users", "organization_users",
 	"refresh_tokens", "users",
+	"roles",
 	"companies", "organizations", "user_types",
 }
 
@@ -98,6 +101,9 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	carService := services.NewCarService(db)
 	employeeService := services.NewEmployeeService(db)
 	permissionService := services.NewPermissionService(db)
+	permissionResolver := services.NewPermissionResolver(db)
+	permissionGroupService := services.NewPermissionGroupService(db, permissionResolver)
+	roleService := services.NewRoleService(db, permissionResolver)
 	systemTableService := services.NewSystemTableService(db, "./uploads", 10*1024*1024, permissionService)
 	uniqueCarService := services.NewUniqueCarService(db)
 	uniqueEmployeeService := services.NewUniqueEmployeeService(db)
@@ -142,6 +148,8 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	applicationHandler := handlers.NewApplicationHandler(applicationService)
 	approverHandler := handlers.NewApproverHandler(approverService)
 	permissionHandler := handlers.NewPermissionHandler(permissionService)
+	permissionGroupHandler := handlers.NewPermissionGroupHandler(permissionGroupService)
+	roleHandler := handlers.NewRoleHandler(roleService)
 	consentHandler := handlers.NewConsentHandler(consentService, db)
 	settingsHandler := handlers.NewSettingsHandler(settingsService)
 	telegramService := services.NewTelegramService("", "")
@@ -160,7 +168,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 		citizenshipHandler, organizationHandler, companyHandler, usersHandler,
 		unloadPlaceHandler, carHandler, employeeHandler, systemTableHandler,
 		uniqueCarHandler, uniqueEmployeeHandler, feedbackHandler,
-		applicationHandler, approverHandler, permissionHandler, consentHandler, settingsHandler, newsHandler, notificationHandler, requestLogsHandler, employeesHistoryHandler, bugReportHandler, maintenanceHandler, nil, []byte(TestJWTSecret), nil)
+		applicationHandler, approverHandler, permissionHandler, permissionGroupHandler, roleHandler, consentHandler, settingsHandler, newsHandler, notificationHandler, requestLogsHandler, employeesHistoryHandler, bugReportHandler, maintenanceHandler, nil, []byte(TestJWTSecret), nil)
 
 	// No-op cleanup: shared DB stays open for the test binary lifetime.
 	cleanup := func() {}


### PR DESCRIPTION
Closes #229. Первый из 6 PR по системе прав доступа (#187).

## Что в PR

**Модели** (`internal/models/role.go`, `permission.go`, `user.go`):
- `Role` + `RoleDefaultGroup` (несколько default-групп на роль через M:N).
- `PermissionGroup` + `PermissionGroupGrant`.
- `UserGroup` + `UserPermissionOverride`.
- `users.role_id` + `users.is_super_admin BOOLEAN`.

**Resolver** (`internal/services/permission_resolver.go`):
- `Resolve(ctx, userID) -> PermissionSet` с алгоритмом:
  1. `is_super_admin=true` -> bypass.
  2. Union из `role_default_groups` + `user_groups`.
  3. `user_permission_overrides` поверх (deny приоритетнее).
- Кэш: in-memory sync.Map TTL 30s + Invalidate/InvalidateAll.

**Сервисы** (`permission_group_service.go`, `role_service.go`):
- CRUD групп прав + merge endpoint.
- CRUD ролей + назначение default-групп.
- Сброс кэша resolver при любом изменении.

**Endpoints** (`router.go`):
- `GET/POST /permission-groups`, `PUT/DELETE /:id`, `POST /merge`.
- `POST/DELETE /users/:user_id/permission-groups/:group_id`.
- `GET/POST /roles`, `PUT/DELETE /:id`, `PUT /:id/default-groups`.

**Naming convention** (`permission_keys.go`): константы префиксов и базовые ключи (`page.center`, `entity.cars.read|write|delete` и т.д.).

**Seed** (`cmd/seed/main.go`): `buropropuskov` теперь дополнительно получает `is_super_admin=true` (параллельно с `type_id=6`, для подготовки к #187c).

## Что НЕ в этом PR

- ❌ Middleware на endpoints (#230 / #187b).
- ❌ Журнал отказов в доступе (#230).
- ❌ Удаление хардкода `type_id=6` (#231 / #187c).
- ❌ Frontend UI (#232 / #187d).

## Тесты

5 кейсов на resolver: role-default, доп.группы, deny override, super-admin bypass, cache invalidation. Все зелёные.

`go test ./... -p 1 -count=1` -- все пакеты ok. (`-p 1` нужен из-за общей тестовой БД, это pre-existing pattern.)

## Зависимости

После merge -- разблокируются #230 и #232.