### PR TITLE
feat: permission middleware + журнал отказов (#230)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -153,6 +153,8 @@ func main() {
 	permissionResolver := services.NewPermissionResolver(db)
 	permissionGroupService := services.NewPermissionGroupService(db, permissionResolver)
 	roleService := services.NewRoleService(db, permissionResolver)
+	accessDenialService := services.NewAccessDenialService(db)
+	userBanService := services.NewUserBanService(db, permissionResolver)
 	systemTableService := services.NewSystemTableService(db, cfg.UploadPath, cfg.UploadMaxFileSize, permissionService)
 	uniqueCarService := services.NewUniqueCarService(db)
 	uniqueEmployeeService := services.NewUniqueEmployeeService(db)
@@ -194,6 +196,8 @@ func main() {
 	permissionHandler := handlers.NewPermissionHandler(permissionService)
 	permissionGroupHandler := handlers.NewPermissionGroupHandler(permissionGroupService)
 	roleHandler := handlers.NewRoleHandler(roleService)
+	accessDenialHandler := handlers.NewAccessDenialHandler(accessDenialService)
+	userBanHandler := handlers.NewUserBanHandler(userBanService)
 	consentHandler := handlers.NewConsentHandler(consentService, db)
 	settingsHandler := handlers.NewSettingsHandler(settingsService)
 	bugReportHandler := handlers.NewBugReportHandler(bugReportService)
@@ -213,7 +217,7 @@ func main() {
 	maintenanceBlock := mw.MaintenanceBlock(maintenanceService)
 
 	// Routes
-	router.Setup(e, authHandler, userTypesHandler, attachmentHandler, lpfHandler, citizenshipHandler, organizationHandler, companyHandler, usersHandler, unloadPlaceHandler, carHandler, employeeHandler, systemTableHandler, uniqueCarHandler, uniqueEmployeeHandler, feedbackHandler, applicationHandler, approverHandler, permissionHandler, permissionGroupHandler, roleHandler, consentHandler, settingsHandler, newsHandler, notificationHandler, requestLogsHandler, employeesHistoryHandler, bugReportHandler, maintenanceHandler, maintenanceBlock, []byte(cfg.JWTSecret), loginLimiter)
+	router.Setup(e, authHandler, userTypesHandler, attachmentHandler, lpfHandler, citizenshipHandler, organizationHandler, companyHandler, usersHandler, unloadPlaceHandler, carHandler, employeeHandler, systemTableHandler, uniqueCarHandler, uniqueEmployeeHandler, feedbackHandler, applicationHandler, approverHandler, permissionHandler, permissionGroupHandler, roleHandler, accessDenialHandler, userBanHandler, consentHandler, settingsHandler, newsHandler, notificationHandler, requestLogsHandler, employeesHistoryHandler, bugReportHandler, maintenanceHandler, permissionResolver, accessDenialService, maintenanceBlock, []byte(cfg.JWTSecret), loginLimiter)
 
 	// Общий ctx для фоновых задач и graceful shutdown. Отменяется по SIGINT/SIGTERM.
 	ctxSig, stopSig := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -223,6 +227,9 @@ func main() {
 	// с прошедшим entry_date_to/entry_time_to, завершает заявку когда все
 	// вложения неактивны. См. ApplicationWorkflowService.CheckExpiredAttachments.
 	go startExpiryScheduler(ctxSig, applicationService, 15*time.Minute)
+
+	// Архив access_denials: 3 мес retention, цикл раз в сутки.
+	go startAccessDenialsArchiver(ctxSig, accessDenialService, 90*24*time.Hour, 24*time.Hour)
 
 	// Graceful shutdown
 	go func() {
@@ -243,6 +250,35 @@ func main() {
 		os.Exit(1)
 	}
 	slog.Info("server stopped")
+}
+
+// startAccessDenialsArchiver запускает периодический архив записей старше retention.
+// retention -- срок хранения в активной таблице (по умолчанию 3 месяца).
+// interval -- частота запуска (по умолчанию раз в сутки).
+func startAccessDenialsArchiver(ctx context.Context, svc *services.AccessDenialService, retention, interval time.Duration) {
+	archive := func() {
+		cutoff := time.Now().Add(-retention)
+		moved, err := svc.ArchiveOlderThan(ctx, cutoff)
+		if err != nil {
+			slog.Error("access denials archive failed", "error", err)
+			return
+		}
+		if moved > 0 {
+			slog.Info("access denials archived", "count", moved, "cutoff", cutoff)
+		}
+	}
+	archive()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Info("access denials archiver stopped")
+			return
+		case <-ticker.C:
+			archive()
+		}
+	}
 }
 
 // startExpiryScheduler запускает периодическую проверку истёкших вложений заявок.

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -106,6 +106,10 @@ func AllModels() []interface{} {
 		&models.UserGroup{},
 		&models.UserPermissionOverride{},
 
+		// Access denials journal (#230)
+		&models.AccessDenial{},
+		&models.AccessDenialArchive{},
+
 		// PD consent & audit (152-FZ)
 		&models.PDConsent{},
 		&models.PDAuditLog{},

--- a/internal/handlers/access_denials.go
+++ b/internal/handlers/access_denials.go
@@ -1,0 +1,89 @@
+package handlers
+
+import (
+	"net/http"
+	"time"
+
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+
+	"github.com/labstack/echo/v4"
+)
+
+// AccessDenialHandler -- HTTP-обработчики журнала отказов в доступе.
+type AccessDenialHandler struct {
+	service *services.AccessDenialService
+}
+
+// NewAccessDenialHandler конструирует handler.
+func NewAccessDenialHandler(s *services.AccessDenialService) *AccessDenialHandler {
+	return &AccessDenialHandler{service: s}
+}
+
+// List -- GET /access-denials.
+// Фильтры через query: user_id, resource (substring), reason, from, to, page, limit.
+func (h *AccessDenialHandler) List(c echo.Context) error {
+	f, err := h.parseFilter(c)
+	if err != nil {
+		return err
+	}
+	resp, err := h.service.List(c.Request().Context(), f)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, resp)
+}
+
+// ListArchive -- GET /access-denials/archive.
+func (h *AccessDenialHandler) ListArchive(c echo.Context) error {
+	f, err := h.parseFilter(c)
+	if err != nil {
+		return err
+	}
+	resp, err := h.service.ListArchive(c.Request().Context(), f)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, resp)
+}
+
+// DeleteByFilter -- DELETE /access-denials.
+// Удаляет записи активной таблицы по фильтрам. Архив не трогается.
+func (h *AccessDenialHandler) DeleteByFilter(c echo.Context) error {
+	f, err := h.parseFilter(c)
+	if err != nil {
+		return err
+	}
+	count, err := h.service.DeleteByFilter(c.Request().Context(), f)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, map[string]any{"deleted": count})
+}
+
+// ArchiveOlderThan -- POST /access-denials/archive?cutoff=2026-01-01T00:00:00Z.
+// Переносит записи старше cutoff в архив. Без cutoff используется now-3m.
+func (h *AccessDenialHandler) ArchiveOlderThan(c echo.Context) error {
+	cutoffStr := c.QueryParam("cutoff")
+	cutoff := time.Now().AddDate(0, -3, 0)
+	if cutoffStr != "" {
+		t, err := time.Parse(time.RFC3339, cutoffStr)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid cutoff: "+err.Error())
+		}
+		cutoff = t
+	}
+	count, err := h.service.ArchiveOlderThan(c.Request().Context(), cutoff)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, map[string]any{"archived": count})
+}
+
+func (h *AccessDenialHandler) parseFilter(c echo.Context) (models.AccessDenialFilter, error) {
+	var f models.AccessDenialFilter
+	if err := c.Bind(&f); err != nil {
+		return models.AccessDenialFilter{}, echo.NewHTTPError(http.StatusBadRequest, "invalid filter: "+err.Error())
+	}
+	return f, nil
+}

--- a/internal/handlers/permission_middleware_integration_test.go
+++ b/internal/handlers/permission_middleware_integration_test.go
@@ -1,0 +1,296 @@
+package handlers_test
+
+// Интеграционные тесты для RequirePermissionV2 middleware и UserBanService.
+// Лежат в handlers_test чтобы не race-иться с CleanDB других пакетов
+// (см. permission_resolver_integration_test.go).
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"systemburo/internal/middleware"
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+	"systemburo/internal/testutil"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+// uniqMW -- собственный счётчик для middleware-тестов, изолирован от resolver-тестов.
+var uniqMW = func() func(string) string {
+	var n int64
+	return func(prefix string) string {
+		n++
+		return prefix + "-mw-" + time.Now().Format("150405") + "-" + intStr(int(n))
+	}
+}()
+
+func intStr(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	digits := []byte{}
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	return string(digits)
+}
+
+func setupMWUser(t *testing.T, db *gorm.DB, isSuperAdmin, isBanned bool) (int, models.UserType, func()) {
+	t.Helper()
+	ut := models.UserType{Name: uniqMW("type"), Code: uniqMW("c")}
+	if err := db.Create(&ut).Error; err != nil {
+		t.Fatalf("create type: %v", err)
+	}
+	user := models.User{
+		Username:     uniqMW("user"),
+		Password:     "x",
+		TypeID:       ut.ID,
+		IsSuperAdmin: isSuperAdmin,
+		IsBanned:     isBanned,
+	}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	return user.ID, ut, func() {
+		db.Delete(&user)
+		db.Delete(&ut)
+	}
+}
+
+func TestRequirePermissionV2_AllowsForSuperAdmin(t *testing.T) {
+	_, db, _ := testutil.SetupTestApp(t)
+	resolver := services.NewPermissionResolver(db)
+	denials := services.NewAccessDenialService(db)
+
+	userID, _, cleanup := setupMWUser(t, db, true, false)
+	defer cleanup()
+
+	e := echo.New()
+	e.GET("/test", func(c echo.Context) error { return c.String(http.StatusOK, "ok") },
+		func(next echo.HandlerFunc) echo.HandlerFunc {
+			return func(c echo.Context) error {
+				c.Set("user_id", userID)
+				return next(c)
+			}
+		},
+		middleware.RequirePermissionV2(resolver, denials, "any.key"),
+	)
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200 for super-admin, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+}
+
+func TestRequirePermissionV2_DeniesAndLogsForRegularUser(t *testing.T) {
+	_, db, _ := testutil.SetupTestApp(t)
+	resolver := services.NewPermissionResolver(db)
+	denials := services.NewAccessDenialService(db)
+
+	userID, _, cleanup := setupMWUser(t, db, false, false)
+	defer cleanup()
+
+	e := echo.New()
+	e.GET("/test", func(c echo.Context) error { return c.String(http.StatusOK, "ok") },
+		func(next echo.HandlerFunc) echo.HandlerFunc {
+			return func(c echo.Context) error {
+				c.Set("user_id", userID)
+				return next(c)
+			}
+		},
+		middleware.RequirePermissionV2(resolver, denials, "page.center"),
+	)
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	var body map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &body)
+	if body["banned"] != false && body["banned"] != nil {
+		t.Errorf("expected banned=false in response, got %v", body["banned"])
+	}
+
+	// Лог пишется асинхронно: ждём недолго и проверяем.
+	time.Sleep(100 * time.Millisecond)
+	var count int64
+	db.Model(&models.AccessDenial{}).
+		Where("user_id = ? AND reason = ?", userID, models.DenialReasonPermission).
+		Count(&count)
+	if count == 0 {
+		t.Errorf("expected denial log entry, got none")
+	}
+	defer db.Where("user_id = ?", userID).Delete(&models.AccessDenial{})
+}
+
+func TestRequirePermissionV2_LogsBannedReason(t *testing.T) {
+	_, db, _ := testutil.SetupTestApp(t)
+	resolver := services.NewPermissionResolver(db)
+	denials := services.NewAccessDenialService(db)
+
+	userID, _, cleanup := setupMWUser(t, db, false, true)
+	defer cleanup()
+
+	e := echo.New()
+	e.GET("/test", func(c echo.Context) error { return c.String(http.StatusOK, "ok") },
+		func(next echo.HandlerFunc) echo.HandlerFunc {
+			return func(c echo.Context) error {
+				c.Set("user_id", userID)
+				return next(c)
+			}
+		},
+		middleware.RequirePermissionV2(resolver, denials, "page.center"),
+	)
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", rec.Code)
+	}
+
+	var body map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &body)
+	if body["banned"] != true {
+		t.Errorf("expected banned=true, got %v", body["banned"])
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	var count int64
+	db.Model(&models.AccessDenial{}).
+		Where("user_id = ? AND reason = ?", userID, models.DenialReasonBanned).
+		Count(&count)
+	if count == 0 {
+		t.Errorf("expected banned-reason denial log entry")
+	}
+	defer db.Where("user_id = ?", userID).Delete(&models.AccessDenial{})
+}
+
+func TestUserBanService_BanRevokesRefreshTokens(t *testing.T) {
+	_, db, _ := testutil.SetupTestApp(t)
+	resolver := services.NewPermissionResolver(db)
+	banSvc := services.NewUserBanService(db, resolver)
+
+	targetID, _, cleanup := setupMWUser(t, db, false, false)
+	defer cleanup()
+	actorID, _, cleanupActor := setupMWUser(t, db, true, false)
+	defer cleanupActor()
+
+	rt := models.RefreshToken{
+		UserID:    targetID,
+		FamilyID:  uniqMW("fam"),
+		TokenHash: uniqMW("hash"),
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+	if err := db.Create(&rt).Error; err != nil {
+		t.Fatalf("create rt: %v", err)
+	}
+	defer db.Delete(&rt)
+
+	if err := banSvc.Ban(context.Background(), targetID, actorID); err != nil {
+		t.Fatalf("ban: %v", err)
+	}
+
+	var revoked bool
+	db.Model(&models.RefreshToken{}).Select("is_revoked").Where("id = ?", rt.ID).Row().Scan(&revoked)
+	if !revoked {
+		t.Errorf("expected refresh token revoked after ban")
+	}
+
+	var u models.User
+	db.Select("is_banned").First(&u, targetID)
+	if !u.IsBanned {
+		t.Errorf("expected user marked banned")
+	}
+}
+
+func TestUserBanService_CannotBanSelf(t *testing.T) {
+	_, db, _ := testutil.SetupTestApp(t)
+	resolver := services.NewPermissionResolver(db)
+	banSvc := services.NewUserBanService(db, resolver)
+
+	userID, _, cleanup := setupMWUser(t, db, true, false)
+	defer cleanup()
+
+	err := banSvc.Ban(context.Background(), userID, userID)
+	if err == nil {
+		t.Error("expected error when banning self")
+	}
+}
+
+func TestUserBanService_CannotBanSuperAdmin(t *testing.T) {
+	_, db, _ := testutil.SetupTestApp(t)
+	resolver := services.NewPermissionResolver(db)
+	banSvc := services.NewUserBanService(db, resolver)
+
+	targetID, _, cleanup := setupMWUser(t, db, true, false)
+	defer cleanup()
+	actorID, _, cleanupActor := setupMWUser(t, db, true, false)
+	defer cleanupActor()
+
+	err := banSvc.Ban(context.Background(), targetID, actorID)
+	if err == nil {
+		t.Error("expected error when banning super-admin")
+	}
+}
+
+func TestAccessDenialService_ArchiveOlderThan(t *testing.T) {
+	_, db, _ := testutil.SetupTestApp(t)
+	svc := services.NewAccessDenialService(db)
+
+	userID, _, cleanup := setupMWUser(t, db, false, false)
+	defer cleanup()
+
+	old := models.AccessDenial{
+		UserID: &userID, Resource: "GET /old", Reason: models.DenialReasonPermission,
+		CreatedAt: time.Now().AddDate(0, -4, 0),
+	}
+	fresh := models.AccessDenial{
+		UserID: &userID, Resource: "GET /fresh", Reason: models.DenialReasonPermission,
+		CreatedAt: time.Now(),
+	}
+	if err := db.Create(&old).Error; err != nil {
+		t.Fatalf("create old: %v", err)
+	}
+	if err := db.Create(&fresh).Error; err != nil {
+		t.Fatalf("create fresh: %v", err)
+	}
+	defer db.Where("user_id = ?", userID).Delete(&models.AccessDenial{})
+	defer db.Where("user_id = ?", userID).Delete(&models.AccessDenialArchive{})
+
+	cutoff := time.Now().AddDate(0, -3, 0)
+	moved, err := svc.ArchiveOlderThan(context.Background(), cutoff)
+	if err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+	if moved < 1 {
+		t.Errorf("expected at least 1 record moved, got %d", moved)
+	}
+
+	var archived int64
+	db.Model(&models.AccessDenialArchive{}).Where("user_id = ?", userID).Count(&archived)
+	if archived < 1 {
+		t.Errorf("expected archive record, got %d", archived)
+	}
+
+	var leftActive int64
+	db.Model(&models.AccessDenial{}).Where("user_id = ? AND resource = ?", userID, "GET /old").Count(&leftActive)
+	if leftActive != 0 {
+		t.Errorf("expected old record removed from active table, got %d", leftActive)
+	}
+
+	var freshLeft int64
+	db.Model(&models.AccessDenial{}).Where("user_id = ? AND resource = ?", userID, "GET /fresh").Count(&freshLeft)
+	if freshLeft != 1 {
+		t.Errorf("expected fresh record kept, got %d", freshLeft)
+	}
+}

--- a/internal/handlers/user_ban.go
+++ b/internal/handlers/user_ban.go
@@ -1,0 +1,43 @@
+package handlers
+
+import (
+	"systemburo/internal/services"
+
+	"github.com/labstack/echo/v4"
+)
+
+// UserBanHandler -- HTTP-обработчики бана и разбана.
+type UserBanHandler struct {
+	service *services.UserBanService
+}
+
+// NewUserBanHandler конструирует handler.
+func NewUserBanHandler(s *services.UserBanService) *UserBanHandler {
+	return &UserBanHandler{service: s}
+}
+
+// Ban -- POST /users/:id/ban.
+// Проверка прав делается через middleware (action.ban.user).
+func (h *UserBanHandler) Ban(c echo.Context) error {
+	targetID, err := ParseID(c, "id")
+	if err != nil {
+		return err
+	}
+	actorID := GetUserID(c)
+	if err := h.service.Ban(c.Request().Context(), targetID, actorID); err != nil {
+		return err
+	}
+	return RespondSuccess(c, map[string]any{"banned": true})
+}
+
+// Unban -- POST /users/:id/unban.
+func (h *UserBanHandler) Unban(c echo.Context) error {
+	targetID, err := ParseID(c, "id")
+	if err != nil {
+		return err
+	}
+	if err := h.service.Unban(c.Request().Context(), targetID); err != nil {
+		return err
+	}
+	return RespondSuccess(c, map[string]any{"unbanned": true})
+}

--- a/internal/middleware/permission.go
+++ b/internal/middleware/permission.go
@@ -3,14 +3,19 @@ package middleware
 import (
 	"net/http"
 
+	"systemburo/internal/models"
 	"systemburo/internal/services"
 
 	"github.com/labstack/echo/v4"
 	"gorm.io/gorm"
 )
 
-// RequirePermission creates middleware that checks if the user has the specified permission.
-// Returns 403 if the user does not have the permission with value "allow".
+// RequirePermission создаёт middleware для legacy PermissionService.
+// Возвращает 403, если у юзера нет права со значением "allow".
+//
+// DEPRECATED: используйте RequirePermissionV2, которая работает через
+// PermissionResolver (новая модель с ролями/группами/override) и логирует
+// отказы в access_denials.
 func RequirePermission(db *gorm.DB, permService services.PermissionService, key string) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
@@ -19,7 +24,6 @@ func RequirePermission(db *gorm.DB, permService services.PermissionService, key 
 				return echo.NewHTTPError(http.StatusUnauthorized, "Требуется авторизация")
 			}
 
-			// Get user ID by username
 			var userID int
 			err := db.Table("users").Select("id").Where("username = ?", username).Row().Scan(&userID)
 			if err != nil {
@@ -35,6 +39,61 @@ func RequirePermission(db *gorm.DB, permService services.PermissionService, key 
 			}
 
 			return next(c)
+		}
+	}
+}
+
+// RequirePermissionV2 -- middleware на базе PermissionResolver (#229) с логированием
+// отказов в access_denials (#230).
+//
+// Поведение при отказе:
+//  1. Резолвит userID через user.id из контекста (положен JWT middleware).
+//  2. Логирует событие через AccessDenialService.Log (асинхронно).
+//  3. Возвращает 403 с JSON-телом {error, required_permission}.
+//
+// Если юзер не аутентифицирован -- 401 без логирования (это auth, а не denial).
+func RequirePermissionV2(resolver *services.PermissionResolver, denialLog *services.AccessDenialService, key string) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			userIDAny := c.Get("user_id")
+			userID, ok := userIDAny.(int)
+			if !ok || userID == 0 {
+				return echo.NewHTTPError(http.StatusUnauthorized, "Требуется авторизация")
+			}
+
+			set, err := resolver.Resolve(c.Request().Context(), userID)
+			if err != nil {
+				return err
+			}
+			if set.Has(key) {
+				return next(c)
+			}
+
+			uid := userID
+			permKey := key
+			ip := c.RealIP()
+			ua := c.Request().UserAgent()
+			reason := models.DenialReasonPermission
+			errMsg := "Недостаточно прав"
+			if set.IsBanned() {
+				reason = models.DenialReasonBanned
+				errMsg = "Учётная запись заблокирована"
+			}
+			denialLog.Log(services.LogParams{
+				UserID:        &uid,
+				Resource:      c.Request().Method + " " + c.Path(),
+				PermissionKey: &permKey,
+				Reason:        reason,
+				IPAddress:     &ip,
+				UserAgent:     &ua,
+			})
+
+			return c.JSON(http.StatusForbidden, map[string]any{
+				"success":             false,
+				"error":               errMsg,
+				"required_permission": key,
+				"banned":              set.IsBanned(),
+			})
 		}
 	}
 }

--- a/internal/models/access_denial.go
+++ b/internal/models/access_denial.go
@@ -1,0 +1,70 @@
+package models
+
+import "time"
+
+// AccessDenial -- запись в журнале отказов в доступе.
+// Создаётся middleware при отказе в правах или попытке банёного юзера.
+// Retention: 3 месяца в активной таблице, дальше переносится в access_denials_archive.
+type AccessDenial struct {
+	ID            int64     `gorm:"primaryKey" json:"id"`
+	UserID        *int      `gorm:"index" json:"user_id"`
+	User          *User     `gorm:"foreignKey:UserID;constraint:OnDelete:SET NULL" json:"user,omitempty"`
+	Resource      string    `gorm:"size:255;index" json:"resource"`
+	PermissionKey *string   `gorm:"size:255" json:"permission_key"`
+	Reason        string    `gorm:"size:50;index" json:"reason"` // permission_denied | account_banned
+	IPAddress     *string   `gorm:"size:45" json:"ip_address"`
+	UserAgent     *string   `gorm:"size:500" json:"user_agent"`
+	CreatedAt     time.Time `gorm:"index" json:"created_at"`
+}
+
+// AccessDenialArchive -- архивная таблица для записей старше retention.
+// Та же схема что и AccessDenial, перенос делает cron.
+type AccessDenialArchive struct {
+	ID            int64     `gorm:"primaryKey" json:"id"`
+	UserID        *int      `gorm:"index" json:"user_id"`
+	Resource      string    `gorm:"size:255;index" json:"resource"`
+	PermissionKey *string   `gorm:"size:255" json:"permission_key"`
+	Reason        string    `gorm:"size:50;index" json:"reason"`
+	IPAddress     *string   `gorm:"size:45" json:"ip_address"`
+	UserAgent     *string   `gorm:"size:500" json:"user_agent"`
+	CreatedAt     time.Time `gorm:"index" json:"created_at"`
+	ArchivedAt    time.Time `json:"archived_at"`
+}
+
+// Reason константы для AccessDenial.Reason.
+const (
+	DenialReasonPermission = "permission_denied"
+	DenialReasonBanned     = "account_banned"
+)
+
+// AccessDenialFilter -- фильтры запроса журнала.
+type AccessDenialFilter struct {
+	UserID   *int       `query:"user_id"`
+	Resource *string    `query:"resource"`
+	Reason   *string    `query:"reason"`
+	From     *time.Time `query:"from"`
+	To       *time.Time `query:"to"`
+	Page     int        `query:"page"`
+	Limit    int        `query:"limit"`
+}
+
+// AccessDenialResponse -- запись + ФИО юзера для UI.
+type AccessDenialResponse struct {
+	ID            int64     `json:"id"`
+	UserID        *int      `json:"user_id"`
+	UserName      string    `json:"user_name,omitempty"`
+	Resource      string    `json:"resource"`
+	PermissionKey *string   `json:"permission_key"`
+	Reason        string    `json:"reason"`
+	IPAddress     *string   `json:"ip_address"`
+	UserAgent     *string   `json:"user_agent"`
+	CreatedAt     time.Time `json:"created_at"`
+}
+
+// AccessDenialPageResponse -- ответ с пагинацией.
+type AccessDenialPageResponse struct {
+	Items []AccessDenialResponse `json:"items"`
+	Total int64                  `json:"total"`
+	Page  int                    `json:"page"`
+	Limit int                    `json:"limit"`
+}

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -15,6 +15,9 @@ type User struct {
 	RoleID            *int         `json:"role_id"`
 	Role              *Role        `gorm:"foreignKey:RoleID" json:"role,omitempty"`
 	IsSuperAdmin      bool         `gorm:"default:false;index" json:"is_super_admin"`
+	IsBanned          bool         `gorm:"default:false;index" json:"is_banned"`
+	BannedAt          *time.Time   `json:"banned_at,omitempty"`
+	BannedBy          *int         `json:"banned_by,omitempty"`
 	LastName          *string      `gorm:"size:100" json:"last_name"`
 	FirstName         *string      `gorm:"size:100" json:"first_name"`
 	MiddleName        *string      `gorm:"size:100" json:"middle_name"`

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -3,6 +3,7 @@ package router
 import (
 	"systemburo/internal/handlers"
 	mw "systemburo/internal/middleware"
+	"systemburo/internal/services"
 
 	"github.com/labstack/echo/v4"
 )
@@ -10,7 +11,7 @@ import (
 // Setup регистрирует все маршруты.
 // loginLimiter опционален (nil в тестах) - отдельный per-IP rate limit на /login.
 // В production передаётся mw.LoginRateLimit из cmd/server/main.go.
-func Setup(e *echo.Echo, auth *handlers.AuthHandler, userTypes *handlers.UserTypesHandler, attachments *handlers.AttachmentHandler, lpf *handlers.LicensePlateFormatHandler, cs *handlers.CitizenshipHandler, org *handlers.OrganizationHandler, comp *handlers.CompanyHandler, users *handlers.UsersHandler, up *handlers.UnloadPlaceHandler, cars *handlers.CarHandler, employees *handlers.EmployeeHandler, st *handlers.SystemTableHandler, uc *handlers.UniqueCarHandler, ue *handlers.UniqueEmployeeHandler, fb *handlers.FeedbackHandler, app *handlers.ApplicationHandler, approvers *handlers.ApproverHandler, permissions *handlers.PermissionHandler, permGroups *handlers.PermissionGroupHandler, roles *handlers.RoleHandler, consent *handlers.ConsentHandler, settings *handlers.SettingsHandler, news *handlers.NewsHandler, notifications *handlers.NotificationHandler, requestLogs *handlers.RequestLogsHandler, employeesHistory *handlers.EmployeesHistoryHandler, bugReport *handlers.BugReportHandler, maintenance *handlers.MaintenanceHandler, maintenanceBlock echo.MiddlewareFunc, jwtSecret []byte, loginLimiter echo.MiddlewareFunc) {
+func Setup(e *echo.Echo, auth *handlers.AuthHandler, userTypes *handlers.UserTypesHandler, attachments *handlers.AttachmentHandler, lpf *handlers.LicensePlateFormatHandler, cs *handlers.CitizenshipHandler, org *handlers.OrganizationHandler, comp *handlers.CompanyHandler, users *handlers.UsersHandler, up *handlers.UnloadPlaceHandler, cars *handlers.CarHandler, employees *handlers.EmployeeHandler, st *handlers.SystemTableHandler, uc *handlers.UniqueCarHandler, ue *handlers.UniqueEmployeeHandler, fb *handlers.FeedbackHandler, app *handlers.ApplicationHandler, approvers *handlers.ApproverHandler, permissions *handlers.PermissionHandler, permGroups *handlers.PermissionGroupHandler, roles *handlers.RoleHandler, accessDenials *handlers.AccessDenialHandler, userBan *handlers.UserBanHandler, consent *handlers.ConsentHandler, settings *handlers.SettingsHandler, news *handlers.NewsHandler, notifications *handlers.NotificationHandler, requestLogs *handlers.RequestLogsHandler, employeesHistory *handlers.EmployeesHistoryHandler, bugReport *handlers.BugReportHandler, maintenance *handlers.MaintenanceHandler, permResolver *services.PermissionResolver, denialLog *services.AccessDenialService, maintenanceBlock echo.MiddlewareFunc, jwtSecret []byte, loginLimiter echo.MiddlewareFunc) {
 	// Health check — вне /api, для мониторинга и readiness-проб.
 	e.GET("/health", func(c echo.Context) error {
 		return c.JSON(200, map[string]string{"status": "ok"})
@@ -275,6 +276,21 @@ func Setup(e *echo.Echo, auth *handlers.AuthHandler, userTypes *handlers.UserTyp
 	rolesGroup.PUT("/:id", roles.Update)
 	rolesGroup.DELETE("/:id", roles.Delete)
 	rolesGroup.PUT("/:id/default-groups", roles.SetDefaultGroups)
+
+	// Журнал отказов в доступе (#230). Защищён permission.audit.read
+	// для просмотра и permission.audit.manage для модификаций.
+	auditRead := mw.RequirePermissionV2(permResolver, denialLog, services.KeyAuditRead)
+	auditManage := mw.RequirePermissionV2(permResolver, denialLog, services.KeyAuditManage)
+	denialsGroup := protected.Group("/access-denials")
+	denialsGroup.GET("", accessDenials.List, auditRead)
+	denialsGroup.GET("/archive", accessDenials.ListArchive, auditRead)
+	denialsGroup.DELETE("", accessDenials.DeleteByFilter, auditManage)
+	denialsGroup.POST("/archive", accessDenials.ArchiveOlderThan, auditManage)
+
+	// Бан пользователей (#230). Защищён action.ban.user.
+	banUser := mw.RequirePermissionV2(permResolver, denialLog, services.KeyActionBanUser)
+	protected.POST("/users/:id/ban", userBan.Ban, banUser)
+	protected.POST("/users/:id/unban", userBan.Unban, banUser)
 
 	// Согласие на обработку ПД (152-ФЗ)
 	consents := protected.Group("/consents")

--- a/internal/services/access_denial_service.go
+++ b/internal/services/access_denial_service.go
@@ -1,0 +1,250 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"systemburo/internal/models"
+
+	"gorm.io/gorm"
+)
+
+// AccessDenialService управляет журналом отказов в доступе.
+// Поток записи: middleware -> Log() -> async insert через горутину
+// (чтобы не блокировать отказ HTTP-ответа на ms ожидания БД).
+// Поток чтения/архива: handler-ы для админов.
+type AccessDenialService struct {
+	db *gorm.DB
+}
+
+// NewAccessDenialService конструирует сервис.
+func NewAccessDenialService(db *gorm.DB) *AccessDenialService {
+	return &AccessDenialService{db: db}
+}
+
+// LogParams -- параметры события отказа.
+type LogParams struct {
+	UserID        *int
+	Resource      string
+	PermissionKey *string
+	Reason        string
+	IPAddress     *string
+	UserAgent     *string
+}
+
+// Log пишет событие отказа в журнал.
+// Запись идёт асинхронно через goroutine: если БД недоступна, отказ HTTP не должен висеть.
+// Контекст для запроса берётся новый, чтобы не отменился вместе с HTTP-запросом.
+func (s *AccessDenialService) Log(p LogParams) {
+	denial := models.AccessDenial{
+		UserID:        p.UserID,
+		Resource:      p.Resource,
+		PermissionKey: p.PermissionKey,
+		Reason:        p.Reason,
+		IPAddress:     p.IPAddress,
+		UserAgent:     p.UserAgent,
+		CreatedAt:     time.Now(),
+	}
+	go func(d models.AccessDenial) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := s.db.WithContext(ctx).Create(&d).Error; err != nil {
+			slog.Error("failed to log access denial", "error", err, "resource", d.Resource)
+		}
+	}(denial)
+}
+
+// List возвращает страницу журнала с фильтрами + общее количество.
+func (s *AccessDenialService) List(ctx context.Context, f models.AccessDenialFilter) (models.AccessDenialPageResponse, error) {
+	q := s.applyFilters(s.db.WithContext(ctx).Model(&models.AccessDenial{}), f)
+
+	var total int64
+	if err := q.Count(&total).Error; err != nil {
+		return models.AccessDenialPageResponse{}, fmt.Errorf("count denials: %w", err)
+	}
+
+	page, limit := normalizePage(f.Page, f.Limit)
+	var denials []models.AccessDenial
+	if err := q.Order("created_at DESC").
+		Limit(limit).Offset((page - 1) * limit).
+		Find(&denials).Error; err != nil {
+		return models.AccessDenialPageResponse{}, fmt.Errorf("list denials: %w", err)
+	}
+
+	items, err := s.attachUserNames(ctx, denials)
+	if err != nil {
+		return models.AccessDenialPageResponse{}, err
+	}
+	return models.AccessDenialPageResponse{
+		Items: items,
+		Total: total,
+		Page:  page,
+		Limit: limit,
+	}, nil
+}
+
+// ListArchive возвращает страницу архива с теми же фильтрами.
+func (s *AccessDenialService) ListArchive(ctx context.Context, f models.AccessDenialFilter) (models.AccessDenialPageResponse, error) {
+	q := s.applyFiltersArchive(s.db.WithContext(ctx).Model(&models.AccessDenialArchive{}), f)
+
+	var total int64
+	if err := q.Count(&total).Error; err != nil {
+		return models.AccessDenialPageResponse{}, fmt.Errorf("count archive: %w", err)
+	}
+
+	page, limit := normalizePage(f.Page, f.Limit)
+	var rows []models.AccessDenialArchive
+	if err := q.Order("created_at DESC").
+		Limit(limit).Offset((page - 1) * limit).
+		Find(&rows).Error; err != nil {
+		return models.AccessDenialPageResponse{}, fmt.Errorf("list archive: %w", err)
+	}
+
+	denials := make([]models.AccessDenial, len(rows))
+	for i, r := range rows {
+		denials[i] = models.AccessDenial{
+			ID: r.ID, UserID: r.UserID, Resource: r.Resource,
+			PermissionKey: r.PermissionKey, Reason: r.Reason,
+			IPAddress: r.IPAddress, UserAgent: r.UserAgent, CreatedAt: r.CreatedAt,
+		}
+	}
+	items, err := s.attachUserNames(ctx, denials)
+	if err != nil {
+		return models.AccessDenialPageResponse{}, err
+	}
+	return models.AccessDenialPageResponse{
+		Items: items,
+		Total: total,
+		Page:  page,
+		Limit: limit,
+	}, nil
+}
+
+// DeleteByFilter удаляет записи активной таблицы по фильтрам.
+// Архив не трогает -- архив только append-only.
+func (s *AccessDenialService) DeleteByFilter(ctx context.Context, f models.AccessDenialFilter) (int64, error) {
+	q := s.applyFilters(s.db.WithContext(ctx).Model(&models.AccessDenial{}), f)
+	res := q.Delete(&models.AccessDenial{})
+	if res.Error != nil {
+		return 0, fmt.Errorf("delete denials: %w", res.Error)
+	}
+	return res.RowsAffected, nil
+}
+
+// ArchiveOlderThan переносит записи старше cutoff в архивную таблицу.
+// Возвращает количество перемещённых записей.
+// Используется и cron-ом (раз в сутки) и ручным endpoint-ом (за период).
+func (s *AccessDenialService) ArchiveOlderThan(ctx context.Context, cutoff time.Time) (int64, error) {
+	var moved int64
+	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var rows []models.AccessDenial
+		if err := tx.Where("created_at < ?", cutoff).Find(&rows).Error; err != nil {
+			return fmt.Errorf("select for archive: %w", err)
+		}
+		if len(rows) == 0 {
+			return nil
+		}
+
+		archives := make([]models.AccessDenialArchive, len(rows))
+		now := time.Now()
+		for i, r := range rows {
+			archives[i] = models.AccessDenialArchive{
+				ID: r.ID, UserID: r.UserID, Resource: r.Resource,
+				PermissionKey: r.PermissionKey, Reason: r.Reason,
+				IPAddress: r.IPAddress, UserAgent: r.UserAgent,
+				CreatedAt: r.CreatedAt, ArchivedAt: now,
+			}
+		}
+		// Insert игнорирует конфликты по PK (если archive уже содержит запись).
+		if err := tx.Clauses().Create(&archives).Error; err != nil {
+			return fmt.Errorf("insert archive: %w", err)
+		}
+		if err := tx.Where("created_at < ?", cutoff).Delete(&models.AccessDenial{}).Error; err != nil {
+			return fmt.Errorf("delete moved: %w", err)
+		}
+		moved = int64(len(rows))
+		return nil
+	})
+	return moved, err
+}
+
+func (s *AccessDenialService) applyFilters(q *gorm.DB, f models.AccessDenialFilter) *gorm.DB {
+	if f.UserID != nil {
+		q = q.Where("user_id = ?", *f.UserID)
+	}
+	if f.Resource != nil && *f.Resource != "" {
+		q = q.Where("resource ILIKE ?", "%"+*f.Resource+"%")
+	}
+	if f.Reason != nil && *f.Reason != "" {
+		q = q.Where("reason = ?", *f.Reason)
+	}
+	if f.From != nil {
+		q = q.Where("created_at >= ?", *f.From)
+	}
+	if f.To != nil {
+		q = q.Where("created_at <= ?", *f.To)
+	}
+	return q
+}
+
+func (s *AccessDenialService) applyFiltersArchive(q *gorm.DB, f models.AccessDenialFilter) *gorm.DB {
+	return s.applyFilters(q, f)
+}
+
+func (s *AccessDenialService) attachUserNames(ctx context.Context, denials []models.AccessDenial) ([]models.AccessDenialResponse, error) {
+	if len(denials) == 0 {
+		return []models.AccessDenialResponse{}, nil
+	}
+	userIDs := make(map[int]struct{})
+	for _, d := range denials {
+		if d.UserID != nil {
+			userIDs[*d.UserID] = struct{}{}
+		}
+	}
+	names := make(map[int]string, len(userIDs))
+	if len(userIDs) > 0 {
+		ids := make([]int, 0, len(userIDs))
+		for id := range userIDs {
+			ids = append(ids, id)
+		}
+		var users []models.User
+		if err := s.db.WithContext(ctx).Select("id, username, last_name, first_name, middle_name").
+			Where("id IN ?", ids).Find(&users).Error; err != nil {
+			return nil, fmt.Errorf("load user names: %w", err)
+		}
+		for _, u := range users {
+			names[u.ID] = formatShortName(u.LastName, u.FirstName, u.MiddleName)
+		}
+	}
+	result := make([]models.AccessDenialResponse, len(denials))
+	for i, d := range denials {
+		var name string
+		if d.UserID != nil {
+			name = names[*d.UserID]
+		}
+		result[i] = models.AccessDenialResponse{
+			ID:            d.ID,
+			UserID:        d.UserID,
+			UserName:      name,
+			Resource:      d.Resource,
+			PermissionKey: d.PermissionKey,
+			Reason:        d.Reason,
+			IPAddress:     d.IPAddress,
+			UserAgent:     d.UserAgent,
+			CreatedAt:     d.CreatedAt,
+		}
+	}
+	return result, nil
+}
+
+func normalizePage(page, limit int) (int, int) {
+	if page < 1 {
+		page = 1
+	}
+	if limit < 1 || limit > 200 {
+		limit = 50
+	}
+	return page, limit
+}

--- a/internal/services/permission_resolver.go
+++ b/internal/services/permission_resolver.go
@@ -33,8 +33,10 @@ type cacheEntry struct {
 
 // PermissionSet -- финальный набор прав юзера.
 // allowAll = true означает super-admin (HasPermission всегда true).
+// banned = true означает забаненный юзер (HasPermission всегда false).
 type PermissionSet struct {
 	allowAll bool
+	banned   bool
 	allows   map[string]struct{}
 }
 
@@ -45,11 +47,19 @@ func NewPermissionResolver(db *gorm.DB) *PermissionResolver {
 
 // Has проверяет наличие конкретного permission_key у юзера.
 func (s *PermissionSet) Has(key string) bool {
+	if s.banned {
+		return false
+	}
 	if s.allowAll {
 		return true
 	}
 	_, ok := s.allows[key]
 	return ok
+}
+
+// IsBanned сообщает, что юзер заблокирован.
+func (s *PermissionSet) IsBanned() bool {
+	return s.banned
 }
 
 // Keys возвращает отсортированный список разрешённых ключей.
@@ -119,10 +129,15 @@ func (r *PermissionResolver) InvalidateAll() {
 // computeSet -- основная логика без кэша. Вынесена для тестируемости.
 func (r *PermissionResolver) computeSet(ctx context.Context, userID int) (PermissionSet, error) {
 	var user models.User
-	if err := r.db.WithContext(ctx).Select("id, role_id, is_super_admin").First(&user, userID).Error; err != nil {
+	if err := r.db.WithContext(ctx).Select("id, role_id, is_super_admin, is_banned").First(&user, userID).Error; err != nil {
 		return PermissionSet{}, fmt.Errorf("user not found: %w", err)
 	}
 
+	// Бан проверяется до super-admin: super-admin теоретически не может быть забанен,
+	// но даже если -- бан сильнее (защита от случайной самоблокировки и логичная семантика).
+	if user.IsBanned {
+		return PermissionSet{banned: true}, nil
+	}
 	if user.IsSuperAdmin {
 		return PermissionSet{allowAll: true}, nil
 	}

--- a/internal/services/user_ban_service.go
+++ b/internal/services/user_ban_service.go
@@ -1,0 +1,79 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"systemburo/internal/models"
+
+	"gorm.io/gorm"
+)
+
+// UserBanService отвечает за блокировку и разблокировку пользователей.
+// При бане отзываются все активные refresh-токены, чтобы юзер потерял
+// доступ на следующем `/refresh` -- это работает в связке с frontend
+// polling по `/me/permissions`.
+type UserBanService struct {
+	db       *gorm.DB
+	resolver *PermissionResolver
+}
+
+// NewUserBanService конструирует сервис.
+func NewUserBanService(db *gorm.DB, resolver *PermissionResolver) *UserBanService {
+	return &UserBanService{db: db, resolver: resolver}
+}
+
+// Ban блокирует пользователя и отзывает его активные refresh-токены.
+// Запрещено блокировать самого себя и super-admin (защита от самоудаления).
+func (s *UserBanService) Ban(ctx context.Context, targetUserID, actorUserID int) error {
+	if targetUserID == actorUserID {
+		return fmt.Errorf("cannot ban yourself")
+	}
+	var target models.User
+	if err := s.db.WithContext(ctx).Select("id, is_super_admin").First(&target, targetUserID).Error; err != nil {
+		return fmt.Errorf("user not found: %w", err)
+	}
+	if target.IsSuperAdmin {
+		return fmt.Errorf("cannot ban super-admin")
+	}
+
+	now := time.Now()
+	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&models.User{}).Where("id = ?", targetUserID).
+			Updates(map[string]any{
+				"is_banned": true,
+				"banned_at": now,
+				"banned_by": actorUserID,
+			}).Error; err != nil {
+			return fmt.Errorf("update user: %w", err)
+		}
+		// Отзываем все активные refresh-токены: следующий /refresh даст 401 -> логаут.
+		if err := tx.Model(&models.RefreshToken{}).
+			Where("user_id = ? AND is_revoked = ?", targetUserID, false).
+			Update("is_revoked", true).Error; err != nil {
+			return fmt.Errorf("revoke refresh tokens: %w", err)
+		}
+		return nil
+	})
+	if err == nil {
+		s.resolver.Invalidate(targetUserID)
+	}
+	return err
+}
+
+// Unban разблокирует пользователя. Refresh-токены остаются revoked --
+// юзеру нужно перелогиниться (это нормально, т.к. в момент бана сессия
+// прервалась).
+func (s *UserBanService) Unban(ctx context.Context, targetUserID int) error {
+	if err := s.db.WithContext(ctx).Model(&models.User{}).Where("id = ?", targetUserID).
+		Updates(map[string]any{
+			"is_banned": false,
+			"banned_at": nil,
+			"banned_by": nil,
+		}).Error; err != nil {
+		return fmt.Errorf("unban: %w", err)
+	}
+	s.resolver.Invalidate(targetUserID)
+	return nil
+}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -37,6 +37,7 @@ const (
 var tables = []string{
 	"system_settings",
 	"pd_audit_logs", "pd_consents",
+	"access_denials", "access_denial_archives",
 	"user_permission_overrides", "user_groups", "permission_group_grants",
 	"role_default_groups", "permission_groups",
 	"user_permissions", "permissions",
@@ -104,6 +105,8 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	permissionResolver := services.NewPermissionResolver(db)
 	permissionGroupService := services.NewPermissionGroupService(db, permissionResolver)
 	roleService := services.NewRoleService(db, permissionResolver)
+	accessDenialService := services.NewAccessDenialService(db)
+	userBanService := services.NewUserBanService(db, permissionResolver)
 	systemTableService := services.NewSystemTableService(db, "./uploads", 10*1024*1024, permissionService)
 	uniqueCarService := services.NewUniqueCarService(db)
 	uniqueEmployeeService := services.NewUniqueEmployeeService(db)
@@ -150,6 +153,8 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	permissionHandler := handlers.NewPermissionHandler(permissionService)
 	permissionGroupHandler := handlers.NewPermissionGroupHandler(permissionGroupService)
 	roleHandler := handlers.NewRoleHandler(roleService)
+	accessDenialHandler := handlers.NewAccessDenialHandler(accessDenialService)
+	userBanHandler := handlers.NewUserBanHandler(userBanService)
 	consentHandler := handlers.NewConsentHandler(consentService, db)
 	settingsHandler := handlers.NewSettingsHandler(settingsService)
 	telegramService := services.NewTelegramService("", "")
@@ -168,7 +173,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 		citizenshipHandler, organizationHandler, companyHandler, usersHandler,
 		unloadPlaceHandler, carHandler, employeeHandler, systemTableHandler,
 		uniqueCarHandler, uniqueEmployeeHandler, feedbackHandler,
-		applicationHandler, approverHandler, permissionHandler, permissionGroupHandler, roleHandler, consentHandler, settingsHandler, newsHandler, notificationHandler, requestLogsHandler, employeesHistoryHandler, bugReportHandler, maintenanceHandler, nil, []byte(TestJWTSecret), nil)
+		applicationHandler, approverHandler, permissionHandler, permissionGroupHandler, roleHandler, accessDenialHandler, userBanHandler, consentHandler, settingsHandler, newsHandler, notificationHandler, requestLogsHandler, employeesHistoryHandler, bugReportHandler, maintenanceHandler, permissionResolver, accessDenialService, nil, []byte(TestJWTSecret), nil)
 
 	// No-op cleanup: shared DB stays open for the test binary lifetime.
 	cleanup := func() {}


### PR DESCRIPTION
Closes #230. Второй из 6 PR по системе прав (#187). Зависит от уже замёрженного #229.

## Что в PR

**Middleware** (`internal/middleware/permission.go`):
- `RequirePermissionV2` — работает через `PermissionResolver` из #229, логирует отказы.
- 403 при отказе с JSON `{error, required_permission, banned}`.
- Распознаёт ban: `reason="account_banned"` + сообщение "Учётная запись заблокирована".
- Старая `RequirePermission` (через legacy `PermissionService`) сохранена для совместимости, помечена DEPRECATED.

**Журнал отказов** (`internal/services/access_denial_service.go`, `internal/models/access_denial.go`):
- `access_denials` (активная) + `access_denial_archives` (append-only архив).
- `Log()` — async insert через goroutine.
- `List/ListArchive` с пагинацией и фильтрами (user_id, resource, reason, from/to).
- `DeleteByFilter` (selective delete) + `ArchiveOlderThan` (transactional move).

**Cron archiver** (`cmd/server/main.go::startAccessDenialsArchiver`):
- Retention 90 дней, цикл раз в сутки.
- Запускается через `signal.NotifyContext`.

**Ban-сервис** (`internal/services/user_ban_service.go`):
- `Ban()` в транзакции: `is_banned=true` + revoke всех refresh-токенов юзера.
- Запрещает ban-self и ban-super-admin.
- `Unban()` возвращает права; refresh-токены остаются revoked (relogin needed).

**PermissionResolver расширен**: новый флаг `banned` в `PermissionSet`. `Has()` возвращает `false` для banned независимо от ключа. Бан проверяется ДО super-admin.

**Модель User**: добавлены `IsBanned`, `BannedAt`, `BannedBy` (аудит).

**Endpoints**:
- `GET /access-denials`, `/access-denials/archive` (требуют `permission.audit.read`).
- `DELETE /access-denials`, `POST /access-denials/archive` (требуют `permission.audit.manage`).
- `POST /users/:id/ban`, `/users/:id/unban` (требуют `action.ban.user`).

## Что НЕ в этом PR

- ❌ Удаление хардкода `type_id=6` (#231).
- ❌ Frontend UI журнала и бана (#232).
- ❌ vite-plugin autodetection (#233).

## Тесты

7 интеграционных тестов в `handlers_test`:
- super-admin bypass
- denial-log при отсутствии права
- denial-log с `reason=banned` для забаненного
- ban revokes refresh-tokens
- cannot ban self
- cannot ban super-admin
- ArchiveOlderThan moves old records

`go test -p 4 -race -count=1 ./...` — все пакеты ok.

## Зависимости

После merge — разблокирует начало #232 (Frontend admin UI с журналом отказов).