### PR TITLE
feat: удаление хардкода type_id=6, переход на is_super_admin (#231)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -62,7 +62,7 @@ export default {
     },
     isBuropropuskov() {
       const authStore = useAuthStore()
-      return authStore.isAdmin
+      return authStore.isSuperAdmin
     },
     /**
      * Показывать шапку, навигацию и связанный chrome только когда юзер

--- a/frontend/src/components/AccountComponent.vue
+++ b/frontend/src/components/AccountComponent.vue
@@ -185,6 +185,7 @@ export default {
       username: "",
       type_id: 1,
       user_type: "user",
+      is_super_admin: false,
       userId: null,
       userOrganizationId: null,
       userCompanyId: null,
@@ -200,7 +201,7 @@ export default {
   },
   computed: {
     isBuroPropuskov() {
-      return this.type_id === 6 || this.user_type === 'buropropuskov';
+      return this.is_super_admin === true;
     }
   },
   mounted() {
@@ -240,6 +241,7 @@ export default {
       this.username = userData.username || "";
       this.type_id = userData.type_id || 1;
       this.user_type = userData.user_type || "user";
+      this.is_super_admin = userData.is_super_admin === true;
       this.userId = userData.id || null;
       this.userOrganizationId = userData.organization_id || null;
       this.userCompanyId = userData.company_id || null;

--- a/frontend/src/directives/__tests__/permission.spec.js
+++ b/frontend/src/directives/__tests__/permission.spec.js
@@ -61,7 +61,7 @@ describe('v-permission directive', () => {
 
   it('shows element for admin regardless of permission', () => {
     const authStore = useAuthStore()
-    authStore.setTokens(createMockJWT({ type_id: 6 }))
+    authStore.setTokens(createMockJWT({ type_id: 6, is_super_admin: true }))
 
     const store = usePermissionsStore()
     store.permissions = { 'passes.create': 'deny' }
@@ -73,7 +73,7 @@ describe('v-permission directive', () => {
 
   it('shows element for admin even when permission is missing', () => {
     const authStore = useAuthStore()
-    authStore.setTokens(createMockJWT({ type_id: 6 }))
+    authStore.setTokens(createMockJWT({ type_id: 6, is_super_admin: true }))
 
     const wrapper = mountWithPermission('passes.create', pinia)
 

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -140,7 +140,7 @@ router.beforeEach((to, from, next) => {
   const authStore = useAuthStore();
   const maintenanceStore = useMaintenanceStore();
   const isAuthenticated = authStore.isAuthenticated;
-  const isBuroPropuskov = authStore.isAdmin;
+  const isBuroPropuskov = authStore.isSuperAdmin;
 
   // Maintenance: если режим включён и юзер не супер-админ - на /maintenance.
   // Сам /maintenance + /500 доступны всегда чтобы не зациклить.

--- a/frontend/src/stores/__tests__/auth.spec.js
+++ b/frontend/src/stores/__tests__/auth.spec.js
@@ -70,17 +70,29 @@ describe('auth store', () => {
     });
   });
 
-  describe('isAdmin', () => {
-    it('возвращает true когда type_id=6', () => {
+  describe('isSuperAdmin', () => {
+    it('возвращает true когда is_super_admin=true в JWT', () => {
       const store = useAuthStore();
-      store.setTokens(createMockJWT({ type_id: 6 }));
-      expect(store.isAdmin).toBe(true);
+      store.setTokens(createMockJWT({ type_id: 6, is_super_admin: true }));
+      expect(store.isSuperAdmin).toBe(true);
     });
 
-    it('возвращает false для не-админа', () => {
+    it('возвращает false если is_super_admin=false независимо от type_id', () => {
+      const store = useAuthStore();
+      store.setTokens(createMockJWT({ type_id: 6, is_super_admin: false }));
+      expect(store.isSuperAdmin).toBe(false);
+    });
+
+    it('возвращает false для обычного юзера', () => {
       const store = useAuthStore();
       store.setTokens(createMockJWT({ type_id: 2 }));
-      expect(store.isAdmin).toBe(false);
+      expect(store.isSuperAdmin).toBe(false);
+    });
+
+    it('isAdmin (legacy) возвращает то же что isSuperAdmin', () => {
+      const store = useAuthStore();
+      store.setTokens(createMockJWT({ type_id: 6, is_super_admin: true }));
+      expect(store.isAdmin).toBe(true);
     });
   });
 

--- a/frontend/src/stores/__tests__/permissions.spec.js
+++ b/frontend/src/stores/__tests__/permissions.spec.js
@@ -48,7 +48,7 @@ describe('permissions store', () => {
 
     it('returns true for admin regardless of permission value', () => {
       const authStore = useAuthStore()
-      authStore.setTokens(createMockJWT({ type_id: 6 }))
+      authStore.setTokens(createMockJWT({ type_id: 6, is_super_admin: true }))
 
       const store = usePermissionsStore()
       store.permissions = { 'passes.create': 'deny' }
@@ -58,7 +58,7 @@ describe('permissions store', () => {
 
     it('returns true for admin even when permission is missing', () => {
       const authStore = useAuthStore()
-      authStore.setTokens(createMockJWT({ type_id: 6 }))
+      authStore.setTokens(createMockJWT({ type_id: 6, is_super_admin: true }))
 
       const store = usePermissionsStore()
       store.permissions = {}

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -28,8 +28,16 @@ export const useAuthStore = defineStore('auth', {
     userType() {
       return this.userPayload?.type_id || null;
     },
+    /**
+     * @deprecated используется для legacy-проверок. Новый код должен
+     * использовать `isSuperAdmin` (читается из claim `is_super_admin`).
+     * После #187 type_id=6 не идентифицирует супер-админа.
+     */
     isAdmin() {
-      return this.userType === 6;
+      return this.isSuperAdmin;
+    },
+    isSuperAdmin() {
+      return this.userPayload?.is_super_admin === true;
     },
     username() {
       return this.userPayload?.username || null;

--- a/frontend/src/stores/permissions.js
+++ b/frontend/src/stores/permissions.js
@@ -11,7 +11,7 @@ export const usePermissionsStore = defineStore('permissions', {
   getters: {
     hasPermission: (state) => (key) => {
       const auth = useAuthStore()
-      if (auth.isAdmin) return true
+      if (auth.isSuperAdmin) return true
       return state.permissions[key] === 'allow'
     },
   },

--- a/frontend/src/views/NewsAndReview.vue
+++ b/frontend/src/views/NewsAndReview.vue
@@ -610,7 +610,7 @@ export default {
   },
   computed: {
     isAdminUser() {
-      return useAuthStore().isAdmin;
+      return useAuthStore().isSuperAdmin;
     },
     guideSections() {
       return this.isAdminUser ? ADMIN_GUIDE_SECTIONS : USER_GUIDE_SECTIONS;

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"fmt"
 	"log/slog"
 
 	"systemburo/internal/models"
@@ -125,7 +126,29 @@ func AutoMigrate(db *gorm.DB) error {
 	if err := installSQLFunctions(db); err != nil {
 		return err
 	}
+	if err := backfillSuperAdmin(db); err != nil {
+		return err
+	}
 	slog.Info("AutoMigrate completed")
+	return nil
+}
+
+// backfillSuperAdmin проставляет is_super_admin=true пользователям с type_id,
+// соответствующим коду 'buropropuskov' в user_types (#231).
+// Безопасна для повторного запуска: WHERE not (already true) делает её noop.
+// После полного отказа от type_id=6 проверки эту миграцию можно удалить.
+func backfillSuperAdmin(db *gorm.DB) error {
+	res := db.Exec(`
+		UPDATE users SET is_super_admin = true
+		WHERE is_super_admin = false
+		  AND type_id IN (SELECT id FROM user_types WHERE code = 'buropropuskov')
+	`)
+	if res.Error != nil {
+		return fmt.Errorf("backfill is_super_admin: %w", res.Error)
+	}
+	if res.RowsAffected > 0 {
+		slog.Info("super-admin backfilled", "users_updated", res.RowsAffected)
+	}
 	return nil
 }
 

--- a/internal/handlers/applications.go
+++ b/internal/handlers/applications.go
@@ -126,7 +126,6 @@ func (h *ApplicationHandler) GetUserApplications(c echo.Context) error {
 // @Router       /applications/{id} [get]
 func (h *ApplicationHandler) GetApplicationByID(c echo.Context) error {
 	username := c.Get("username").(string)
-	typeID := c.Get("type_id").(int)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid application ID")
@@ -137,7 +136,7 @@ func (h *ApplicationHandler) GetApplicationByID(c echo.Context) error {
 		return err
 	}
 
-	if !h.service.CanAccessApplication(c.Request().Context(), id, username, typeID) {
+	if !h.service.CanAccessApplication(c.Request().Context(), id, username, IsSuperAdmin(c)) {
 		return echo.NewHTTPError(http.StatusForbidden, "Access denied")
 	}
 
@@ -163,8 +162,7 @@ func (h *ApplicationHandler) GetApplicationDetails(c echo.Context) error {
 	}
 
 	username := c.Get("username").(string)
-	typeID := c.Get("type_id").(int)
-	if !h.service.CanAccessApplication(c.Request().Context(), id, username, typeID) {
+	if !h.service.CanAccessApplication(c.Request().Context(), id, username, IsSuperAdmin(c)) {
 		return echo.NewHTTPError(http.StatusForbidden, "Access denied")
 	}
 
@@ -247,13 +245,12 @@ func (h *ApplicationHandler) SubmitCompleteApplication(c echo.Context) error {
 // @Router       /applications/{id} [put]
 func (h *ApplicationHandler) UpdateApplication(c echo.Context) error {
 	username := c.Get("username").(string)
-	typeID := c.Get("type_id").(int)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid application ID")
 	}
 
-	if !h.service.CanAccessApplication(c.Request().Context(), id, username, typeID) {
+	if !h.service.CanAccessApplication(c.Request().Context(), id, username, IsSuperAdmin(c)) {
 		return echo.NewHTTPError(http.StatusForbidden, "Access denied")
 	}
 

--- a/internal/handlers/applications_reads.go
+++ b/internal/handlers/applications_reads.go
@@ -27,8 +27,7 @@ func (h *ApplicationHandler) GetApplicationResponsibleUsers(c echo.Context) erro
 	}
 
 	username := c.Get("username").(string)
-	typeID := c.Get("type_id").(int)
-	if !h.service.CanAccessApplication(c.Request().Context(), id, username, typeID) {
+	if !h.service.CanAccessApplication(c.Request().Context(), id, username, IsSuperAdmin(c)) {
 		return echo.NewHTTPError(http.StatusForbidden, "Access denied")
 	}
 
@@ -57,8 +56,7 @@ func (h *ApplicationHandler) GetApplicationHistory(c echo.Context) error {
 	}
 
 	username := c.Get("username").(string)
-	typeID := c.Get("type_id").(int)
-	if !h.service.CanAccessApplication(c.Request().Context(), id, username, typeID) {
+	if !h.service.CanAccessApplication(c.Request().Context(), id, username, IsSuperAdmin(c)) {
 		return echo.NewHTTPError(http.StatusForbidden, "Access denied")
 	}
 
@@ -89,8 +87,7 @@ func (h *ApplicationHandler) AddHistoryEntry(c echo.Context) error {
 	}
 
 	username := c.Get("username").(string)
-	typeID := c.Get("type_id").(int)
-	if !h.service.CanAccessApplication(c.Request().Context(), req.ApplicationID, username, typeID) {
+	if !h.service.CanAccessApplication(c.Request().Context(), req.ApplicationID, username, IsSuperAdmin(c)) {
 		return echo.NewHTTPError(http.StatusForbidden, "Access denied")
 	}
 
@@ -121,8 +118,7 @@ func (h *ApplicationHandler) GetApplicationViewers(c echo.Context) error {
 	}
 
 	username := c.Get("username").(string)
-	typeID := c.Get("type_id").(int)
-	if !h.service.CanAccessApplication(c.Request().Context(), id, username, typeID) {
+	if !h.service.CanAccessApplication(c.Request().Context(), id, username, IsSuperAdmin(c)) {
 		return echo.NewHTTPError(http.StatusForbidden, "Access denied")
 	}
 
@@ -151,8 +147,7 @@ func (h *ApplicationHandler) GetApplicationAttachments(c echo.Context) error {
 	}
 
 	username := c.Get("username").(string)
-	typeID := c.Get("type_id").(int)
-	if !h.service.CanAccessApplication(c.Request().Context(), id, username, typeID) {
+	if !h.service.CanAccessApplication(c.Request().Context(), id, username, IsSuperAdmin(c)) {
 		return echo.NewHTTPError(http.StatusForbidden, "Access denied")
 	}
 
@@ -185,8 +180,7 @@ func (h *ApplicationHandler) GetAttachmentCars(c echo.Context) error {
 		return err
 	}
 	username := c.Get("username").(string)
-	typeID := c.Get("type_id").(int)
-	if !h.service.CanAccessApplication(c.Request().Context(), appID, username, typeID) {
+	if !h.service.CanAccessApplication(c.Request().Context(), appID, username, IsSuperAdmin(c)) {
 		return echo.NewHTTPError(http.StatusForbidden, "Access denied")
 	}
 
@@ -219,8 +213,7 @@ func (h *ApplicationHandler) GetAttachmentEmployees(c echo.Context) error {
 		return err
 	}
 	username := c.Get("username").(string)
-	typeID := c.Get("type_id").(int)
-	if !h.service.CanAccessApplication(c.Request().Context(), appID, username, typeID) {
+	if !h.service.CanAccessApplication(c.Request().Context(), appID, username, IsSuperAdmin(c)) {
 		return echo.NewHTTPError(http.StatusForbidden, "Access denied")
 	}
 
@@ -253,8 +246,7 @@ func (h *ApplicationHandler) GetAttachmentItems(c echo.Context) error {
 		return err
 	}
 	username := c.Get("username").(string)
-	typeID := c.Get("type_id").(int)
-	if !h.service.CanAccessApplication(c.Request().Context(), appID, username, typeID) {
+	if !h.service.CanAccessApplication(c.Request().Context(), appID, username, IsSuperAdmin(c)) {
 		return echo.NewHTTPError(http.StatusForbidden, "Access denied")
 	}
 
@@ -284,8 +276,7 @@ func (h *ApplicationHandler) MarkAsRead(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid application ID")
 	}
 
-	typeID := c.Get("type_id").(int)
-	if !h.service.CanAccessApplication(c.Request().Context(), id, username, typeID) {
+	if !h.service.CanAccessApplication(c.Request().Context(), id, username, IsSuperAdmin(c)) {
 		return echo.NewHTTPError(http.StatusForbidden, "Access denied")
 	}
 
@@ -313,8 +304,7 @@ func (h *ApplicationHandler) GetReads(c echo.Context) error {
 	}
 
 	username := c.Get("username").(string)
-	typeID := c.Get("type_id").(int)
-	if !h.service.CanAccessApplication(c.Request().Context(), id, username, typeID) {
+	if !h.service.CanAccessApplication(c.Request().Context(), id, username, IsSuperAdmin(c)) {
 		return echo.NewHTTPError(http.StatusForbidden, "Access denied")
 	}
 

--- a/internal/handlers/applications_workflow.go
+++ b/internal/handlers/applications_workflow.go
@@ -95,8 +95,7 @@ func (h *ApplicationHandler) CheckApprovalStatus(c echo.Context) error {
 	}
 
 	username := c.Get("username").(string)
-	typeID := c.Get("type_id").(int)
-	if !h.service.CanAccessApplication(c.Request().Context(), id, username, typeID) {
+	if !h.service.CanAccessApplication(c.Request().Context(), id, username, IsSuperAdmin(c)) {
 		return echo.NewHTTPError(http.StatusForbidden, "Access denied")
 	}
 
@@ -264,8 +263,7 @@ func (h *ApplicationHandler) UpdateApplicationItemsStatus(c echo.Context) error 
 	}
 
 	username := c.Get("username").(string)
-	typeID := c.Get("type_id").(int)
-	if !h.service.CanAccessApplication(c.Request().Context(), id, username, typeID) {
+	if !h.service.CanAccessApplication(c.Request().Context(), id, username, IsSuperAdmin(c)) {
 		return echo.NewHTTPError(http.StatusForbidden, "Access denied")
 	}
 

--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -79,11 +79,11 @@ func (h *AuthHandler) Login(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	// Maintenance-bypass: super-admin (type_id=6) всегда проходит, иначе -
+	// Maintenance-bypass: super-admin всегда проходит, иначе -
 	// отзываем только что выданный refresh и возвращаем 503. Проверку
 	// делаем после пароля чтобы не выдавать 503 как oracle для подбора
 	// учёток (одинаковая задержка на верный и неверный пароль).
-	if h.maintenance != nil && resp.TypeID != 6 {
+	if h.maintenance != nil && !resp.IsSuperAdmin {
 		if st := h.maintenance.GetStatusCached(c.Request().Context()); st != nil && st.Enabled {
 			_ = h.service.Logout(c.Request().Context(), req.Username,
 				models.LogoutRequest{RefreshToken: resp.RefreshToken}, requestMeta(c))

--- a/internal/handlers/helpers.go
+++ b/internal/handlers/helpers.go
@@ -52,3 +52,10 @@ func GetTypeID(c echo.Context) int {
 	id, _ := c.Get("type_id").(int)
 	return id
 }
+
+// IsSuperAdmin безопасно извлекает is_super_admin из контекста (#231).
+// Используется вместо хардкода type_id == 6.
+func IsSuperAdmin(c echo.Context) bool {
+	v, _ := c.Get("is_super_admin").(bool)
+	return v
+}

--- a/internal/handlers/maintenance.go
+++ b/internal/handlers/maintenance.go
@@ -35,9 +35,8 @@ func (h *MaintenanceHandler) GetPublicStatus(c echo.Context) error {
 // Оставлен как отдельный метод - если позже понадобятся доп. поля только для
 // админа (например, кто включил и когда), их можно добавить только сюда.
 func (h *MaintenanceHandler) GetAdminStatus(c echo.Context) error {
-	typeID, _ := c.Get("type_id").(int)
-	if typeID != 6 {
-		return echo.NewHTTPError(http.StatusForbidden, "Доступ только для бюро пропусков")
+	if !IsSuperAdmin(c) {
+		return echo.NewHTTPError(http.StatusForbidden, "Доступ только для супер-администратора")
 	}
 	st, err := h.service.GetStatus(c.Request().Context())
 	if err != nil {
@@ -57,9 +56,8 @@ type MaintenanceToggleRequest struct {
 // При Enable=true дополнительно revoke non-admin refresh_tokens
 // (см. MaintenanceService.Enable).
 func (h *MaintenanceHandler) ToggleMaintenance(c echo.Context) error {
-	typeID, _ := c.Get("type_id").(int)
-	if typeID != 6 {
-		return echo.NewHTTPError(http.StatusForbidden, "Доступ только для бюро пропусков")
+	if !IsSuperAdmin(c) {
+		return echo.NewHTTPError(http.StatusForbidden, "Доступ только для супер-администратора")
 	}
 	userID, _ := c.Get("user_id").(int)
 	username, _ := c.Get("username").(string)

--- a/internal/handlers/permissions.go
+++ b/internal/handlers/permissions.go
@@ -27,35 +27,30 @@ func (h *PermissionHandler) GetMyPermissions(c echo.Context) error {
 	return RespondSuccess(c, perms)
 }
 
-// GetUserPermissions возвращает разрешения указанного пользователя (только admin).
+// GetUserPermissions возвращает разрешения указанного пользователя (только super-admin).
 func (h *PermissionHandler) GetUserPermissions(c echo.Context) error {
 	userID, err := ParseID(c, "id")
 	if err != nil {
 		return err
 	}
-	typeID := GetTypeID(c)
-
-	perms, err := h.service.GetUserPermissions(c.Request().Context(), typeID, userID)
+	perms, err := h.service.GetUserPermissions(c.Request().Context(), IsSuperAdmin(c), userID)
 	if err != nil {
 		return err
 	}
 	return RespondSuccess(c, perms)
 }
 
-// UpdateUserPermissions обновляет разрешения указанного пользователя (только admin).
+// UpdateUserPermissions обновляет разрешения указанного пользователя (только super-admin).
 func (h *PermissionHandler) UpdateUserPermissions(c echo.Context) error {
 	userID, err := ParseID(c, "id")
 	if err != nil {
 		return err
 	}
-	typeID := GetTypeID(c)
-
 	var req models.UpdatePermissionsRequest
 	if err := BindAndValidate(c, &req); err != nil {
 		return err
 	}
-
-	if err := h.service.UpdateUserPermissions(c.Request().Context(), typeID, userID, req); err != nil {
+	if err := h.service.UpdateUserPermissions(c.Request().Context(), IsSuperAdmin(c), GetUserID(c), userID, req); err != nil {
 		return err
 	}
 	return RespondMessage(c, "ok")

--- a/internal/handlers/settings.go
+++ b/internal/handlers/settings.go
@@ -16,10 +16,9 @@ func NewSettingsHandler(service services.SettingsService) *SettingsHandler {
 	return &SettingsHandler{service: service}
 }
 
-// GetAll возвращает все системные настройки (только для buropropuskov).
+// GetAll возвращает все системные настройки (только для super-admin).
 func (h *SettingsHandler) GetAll(c echo.Context) error {
-	typeID := c.Get("type_id").(int)
-	settings, err := h.service.GetAll(c.Request().Context(), typeID)
+	settings, err := h.service.GetAll(c.Request().Context(), IsSuperAdmin(c))
 	if err != nil {
 		return err
 	}
@@ -33,8 +32,7 @@ func (h *SettingsHandler) Update(c echo.Context) error {
 	if err := BindAndValidate(c, &req); err != nil {
 		return err
 	}
-	typeID := c.Get("type_id").(int)
-	setting, err := h.service.Update(c.Request().Context(), typeID, key, req.Value)
+	setting, err := h.service.Update(c.Request().Context(), IsSuperAdmin(c), key, req.Value)
 	if err != nil {
 		return err
 	}

--- a/internal/handlers/testdata/users_me.golden
+++ b/internal/handlers/testdata/users_me.golden
@@ -3,6 +3,8 @@ data.company_id
 data.email
 data.first_name
 data.id
+data.is_banned
+data.is_super_admin
 data.last_name
 data.middle_name
 data.organization

--- a/internal/middleware/jwt.go
+++ b/internal/middleware/jwt.go
@@ -28,6 +28,7 @@ func JWTAuth(jwtSecret []byte) echo.MiddlewareFunc {
 			c.Set("username", username)
 			c.Set("user_id", claims.UserID)
 			c.Set("type_id", claims.TypeID)
+			c.Set("is_super_admin", claims.IsSuperAdmin)
 
 			return next(c)
 		}

--- a/internal/middleware/maintenance.go
+++ b/internal/middleware/maintenance.go
@@ -9,15 +9,15 @@ import (
 )
 
 // MaintenanceBlock - после JWTAuth блокирует 503-м любой protected-запрос
-// если включён режим техработ. Super-admin (type_id=6) проходит всегда.
+// если включён режим техработ. Super-admin (is_super_admin=true) проходит всегда.
 // Для производительности использует GetStatusCached (10-сек in-memory).
 func MaintenanceBlock(svc services.MaintenanceService) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			typeID, _ := c.Get("type_id").(int)
+			isSuper, _ := c.Get("is_super_admin").(bool)
 			// Super-admin проходит всегда - иначе как включать/выключать
 			// maintenance и тестировать систему.
-			if typeID == 6 {
+			if isSuper {
 				return next(c)
 			}
 			st := svc.GetStatusCached(c.Request().Context())

--- a/internal/middleware/maintenance_test.go
+++ b/internal/middleware/maintenance_test.go
@@ -33,13 +33,13 @@ func (s *stubMaintenanceService) Disable(ctx context.Context, _ int, _ string) e
 }
 func (s *stubMaintenanceService) InvalidateCache() {}
 
-func callMW(t *testing.T, enabled bool, typeID int) int {
+func callMW(t *testing.T, enabled bool, isSuperAdmin bool) int {
 	t.Helper()
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	ctx := e.NewContext(req, rec)
-	ctx.Set("type_id", typeID)
+	ctx.Set("is_super_admin", isSuperAdmin)
 
 	mw := MaintenanceBlock(&stubMaintenanceService{enabled: enabled})
 	h := mw(func(c echo.Context) error {
@@ -55,13 +55,13 @@ func callMW(t *testing.T, enabled bool, typeID int) int {
 }
 
 func TestMaintenanceBlock_AllowsSuperAdmin(t *testing.T) {
-	assert.Equal(t, http.StatusOK, callMW(t, true, 6))
+	assert.Equal(t, http.StatusOK, callMW(t, true, true))
 }
 
 func TestMaintenanceBlock_BlocksRegularWhenEnabled(t *testing.T) {
-	assert.Equal(t, http.StatusServiceUnavailable, callMW(t, true, 1))
+	assert.Equal(t, http.StatusServiceUnavailable, callMW(t, true, false))
 }
 
 func TestMaintenanceBlock_AllowsRegularWhenDisabled(t *testing.T) {
-	assert.Equal(t, http.StatusOK, callMW(t, false, 1))
+	assert.Equal(t, http.StatusOK, callMW(t, false, false))
 }

--- a/internal/models/auth.go
+++ b/internal/models/auth.go
@@ -58,6 +58,8 @@ type LoginResponse struct {
 	CompanyID      *int   `json:"company_id"`
 	TypeID         int    `json:"type_id"`
 	UserType       string `json:"user_type"`
+	IsSuperAdmin   bool   `json:"is_super_admin"`
+	IsBanned       bool   `json:"is_banned"`
 }
 
 type TokenPairResponse struct {
@@ -87,6 +89,8 @@ type CurrentUserResponse struct {
 	TypeID         int     `json:"type_id"`
 	UserType       string  `json:"user_type"`
 	UserTypeCode   string  `json:"user_type_code"`
+	IsSuperAdmin   bool    `json:"is_super_admin"`
+	IsBanned       bool    `json:"is_banned"`
 	LastName       *string `json:"last_name"`
 	FirstName      *string `json:"first_name"`
 	MiddleName     *string `json:"middle_name"`

--- a/internal/services/application_helpers.go
+++ b/internal/services/application_helpers.go
@@ -309,9 +309,9 @@ func (s *applicationService) fetchResponsibleUsers(db *gorm.DB, applicationID in
 }
 
 // CanAccessApplication проверяет, имеет ли пользователь доступ к заявке.
-// Доступ имеют: администраторы (type_id=6), отправитель, ответственные и просматривающие.
-func (s *applicationService) CanAccessApplication(ctx context.Context, applicationID int, username string, typeID int) bool {
-	if typeID == 6 {
+// Доступ имеют: super-admin, отправитель, ответственные и просматривающие.
+func (s *applicationService) CanAccessApplication(ctx context.Context, applicationID int, username string, isSuperAdmin bool) bool {
+	if isSuperAdmin {
 		return true
 	}
 

--- a/internal/services/application_service.go
+++ b/internal/services/application_service.go
@@ -112,7 +112,7 @@ type ApplicationService interface {
 	GetUnreadCount(ctx context.Context, username string) (*models.UnreadCountResponse, error)
 
 	// CanAccessApplication проверяет, имеет ли пользователь доступ к заявке.
-	CanAccessApplication(ctx context.Context, applicationID int, username string, typeID int) bool
+	CanAccessApplication(ctx context.Context, applicationID int, username string, isSuperAdmin bool) bool
 
 	// GetApplicationIDByAttachment возвращает ID заявки по ID вложения.
 	GetApplicationIDByAttachment(ctx context.Context, attachmentID int) (int, error)

--- a/internal/services/auth_service.go
+++ b/internal/services/auth_service.go
@@ -44,9 +44,12 @@ type AuthService interface {
 }
 
 // Claims is the JWT claims structure matching the Rust backend.
+// is_super_admin кладётся в access-токен чтобы middleware мог проверить
+// без дополнительного запроса в БД на каждый запрос (#231).
 type Claims struct {
-	UserID int `json:"user_id"`
-	TypeID int `json:"type_id"`
+	UserID       int  `json:"user_id"`
+	TypeID       int  `json:"type_id"`
+	IsSuperAdmin bool `json:"is_super_admin"`
 	jwt.RegisteredClaims
 }
 
@@ -106,10 +109,11 @@ func verifyPassword(phcHash, password string) bool {
 
 // --- JWT ---
 
-func (s *authService) createAccessToken(username string, userID int, typeID int) (string, error) {
+func (s *authService) createAccessToken(username string, userID int, typeID int, isSuperAdmin bool) (string, error) {
 	claims := Claims{
-		UserID: userID,
-		TypeID: typeID,
+		UserID:       userID,
+		TypeID:       typeID,
+		IsSuperAdmin: isSuperAdmin,
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject:   username,
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(s.accessTTL)),
@@ -210,7 +214,7 @@ func (s *authService) Login(ctx context.Context, req models.LoginRequest, meta *
 	}
 	s.db.WithContext(ctx).Model(&user).Updates(updates)
 
-	accessToken, err := s.createAccessToken(user.Username, user.ID, user.TypeID)
+	accessToken, err := s.createAccessToken(user.Username, user.ID, user.TypeID, user.IsSuperAdmin)
 	if err != nil {
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Failed to create token")
 	}
@@ -245,6 +249,8 @@ func (s *authService) Login(ctx context.Context, req models.LoginRequest, meta *
 		CompanyID:      user.CompanyID,
 		TypeID:         user.TypeID,
 		UserType:       user.UserType.Name,
+		IsSuperAdmin:   user.IsSuperAdmin,
+		IsBanned:       user.IsBanned,
 	}, nil
 }
 
@@ -296,7 +302,7 @@ func (s *authService) RefreshToken(ctx context.Context, req models.RefreshTokenR
 	// Ротация: помечаем старый revoked, выдаём новую пару в той же family.
 	s.db.WithContext(ctx).Model(&storedToken).Update("is_revoked", true)
 
-	newAccess, err := s.createAccessToken(username, user.ID, user.TypeID)
+	newAccess, err := s.createAccessToken(username, user.ID, user.TypeID, user.IsSuperAdmin)
 	if err != nil {
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Failed to create token")
 	}
@@ -408,6 +414,8 @@ func (s *authService) GetCurrentUser(ctx context.Context, username string) (*mod
 		TypeID:         user.TypeID,
 		UserType:       user.UserType.Name,
 		UserTypeCode:   user.UserType.Code,
+		IsSuperAdmin:   user.IsSuperAdmin,
+		IsBanned:       user.IsBanned,
 		LastName:       user.LastName,
 		FirstName:      user.FirstName,
 		MiddleName:     user.MiddleName,

--- a/internal/services/maintenance_service.go
+++ b/internal/services/maintenance_service.go
@@ -142,12 +142,12 @@ func (s *maintenanceService) Enable(ctx context.Context, adminUserID int, adminU
 		if err := upsertSetting(tx, keyMaintenanceSupportEmail, supportEmail); err != nil {
 			return err
 		}
-		// Отзываем refresh-токены всех не-админов. Через ≤15 мин access
+		// Отзываем refresh-токены всех не-супер-админов. Через ≤15 мин access
 		// истечёт и их выкинет на /login, где получат 503 → /maintenance.
 		if err := tx.Exec(`
 			UPDATE refresh_tokens
 			SET is_revoked = true
-			WHERE user_id IN (SELECT id FROM users WHERE type_id != 6)
+			WHERE user_id IN (SELECT id FROM users WHERE is_super_admin = false)
 			  AND is_revoked = false
 		`).Error; err != nil {
 			return fmt.Errorf("revoke non-admin refresh tokens: %w", err)

--- a/internal/services/permission_service.go
+++ b/internal/services/permission_service.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"net/http"
 
-	"systemburo/internal/auth"
 	"systemburo/internal/models"
 
 	"github.com/labstack/echo/v4"
@@ -16,8 +15,8 @@ import (
 // PermissionService определяет интерфейс управления разрешениями.
 type PermissionService interface {
 	GetMyPermissions(ctx context.Context, username string) ([]models.UserPermissionResponse, error)
-	GetUserPermissions(ctx context.Context, typeID int, userID int) ([]models.UserPermissionResponse, error)
-	UpdateUserPermissions(ctx context.Context, typeID int, userID int, req models.UpdatePermissionsRequest) error
+	GetUserPermissions(ctx context.Context, isSuperAdmin bool, userID int) ([]models.UserPermissionResponse, error)
+	UpdateUserPermissions(ctx context.Context, isSuperAdmin bool, actorID int, userID int, req models.UpdatePermissionsRequest) error
 	GetPermissionTree(ctx context.Context) ([]models.PermissionTreeNode, error)
 	AutoGenerateForTable(ctx context.Context, tableID int, tableName string) error
 	HasPermission(ctx context.Context, userID int, key string) (bool, error)
@@ -50,9 +49,9 @@ func (s *permissionService) GetMyPermissions(ctx context.Context, username strin
 }
 
 // GetUserPermissions возвращает разрешения указанного пользователя (admin-only).
-func (s *permissionService) GetUserPermissions(ctx context.Context, typeID int, userID int) ([]models.UserPermissionResponse, error) {
-	if err := auth.CheckAdminByTypeID(s.db, ctx, typeID); err != nil {
-		return nil, err
+func (s *permissionService) GetUserPermissions(ctx context.Context, isSuperAdmin bool, userID int) ([]models.UserPermissionResponse, error) {
+	if !isSuperAdmin {
+		return nil, echo.NewHTTPError(http.StatusForbidden, "Доступ только для супер-администратора")
 	}
 
 	// Verify user exists
@@ -90,9 +89,9 @@ func (s *permissionService) getUserPermissionsList(ctx context.Context, userID i
 }
 
 // UpdateUserPermissions обновляет набор разрешений пользователя (admin-only).
-func (s *permissionService) UpdateUserPermissions(ctx context.Context, typeID int, userID int, req models.UpdatePermissionsRequest) error {
-	if err := auth.CheckAdminByTypeID(s.db, ctx, typeID); err != nil {
-		return err
+func (s *permissionService) UpdateUserPermissions(ctx context.Context, isSuperAdmin bool, actorID int, userID int, req models.UpdatePermissionsRequest) error {
+	if !isSuperAdmin {
+		return echo.NewHTTPError(http.StatusForbidden, "Доступ только для супер-администратора")
 	}
 
 	// Verify user exists
@@ -118,17 +117,7 @@ func (s *permissionService) UpdateUserPermissions(ctx context.Context, typeID in
 		return echo.NewHTTPError(http.StatusBadRequest, "Некоторые ключи разрешений не существуют")
 	}
 
-	// Get admin user ID for granted_by
-	var adminID int
-	err := s.db.WithContext(ctx).
-		Table("users").
-		Select("id").
-		Joins("JOIN user_types ON users.type_id = user_types.id").
-		Where("user_types.id = ?", typeID).
-		Row().Scan(&adminID)
-	if err != nil {
-		adminID = 0
-	}
+	adminID := actorID
 
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		for _, p := range req.Permissions {

--- a/internal/services/settings_service.go
+++ b/internal/services/settings_service.go
@@ -16,8 +16,8 @@ import (
 )
 
 type SettingsService interface {
-	GetAll(ctx context.Context, callerTypeID int) ([]models.SystemSetting, error)
-	Update(ctx context.Context, callerTypeID int, key string, value string) (*models.SystemSetting, error)
+	GetAll(ctx context.Context, isSuperAdmin bool) ([]models.SystemSetting, error)
+	Update(ctx context.Context, isSuperAdmin bool, key string, value string) (*models.SystemSetting, error)
 	GetUploadSettings(ctx context.Context) (map[string]interface{}, error)
 }
 
@@ -73,16 +73,16 @@ func (s *settingsService) loadCache() {
 	}
 }
 
-func (s *settingsService) checkBuro(typeID int) error {
-	if typeID != 6 {
-		return echo.NewHTTPError(http.StatusForbidden, "Доступ только для бюро пропусков")
+func (s *settingsService) checkSuper(isSuperAdmin bool) error {
+	if !isSuperAdmin {
+		return echo.NewHTTPError(http.StatusForbidden, "Доступ только для супер-администратора")
 	}
 	return nil
 }
 
 // GetAll возвращает все системные настройки из кэша.
-func (s *settingsService) GetAll(ctx context.Context, callerTypeID int) ([]models.SystemSetting, error) {
-	if err := s.checkBuro(callerTypeID); err != nil {
+func (s *settingsService) GetAll(ctx context.Context, isSuperAdmin bool) ([]models.SystemSetting, error) {
+	if err := s.checkSuper(isSuperAdmin); err != nil {
 		return nil, err
 	}
 	s.mu.RLock()
@@ -96,8 +96,8 @@ func (s *settingsService) GetAll(ctx context.Context, callerTypeID int) ([]model
 }
 
 // Update обновляет значение системной настройки по ключу.
-func (s *settingsService) Update(ctx context.Context, callerTypeID int, key string, value string) (*models.SystemSetting, error) {
-	if err := s.checkBuro(callerTypeID); err != nil {
+func (s *settingsService) Update(ctx context.Context, isSuperAdmin bool, key string, value string) (*models.SystemSetting, error) {
+	if err := s.checkSuper(isSuperAdmin); err != nil {
 		return nil, err
 	}
 	settingType, ok := knownKeys[key]

--- a/internal/testutil/auth.go
+++ b/internal/testutil/auth.go
@@ -30,6 +30,9 @@ func AuthHeader(token string) http.Header {
 }
 
 // RegisterUser creates a user directly in DB.
+// type_id=6 (buropropuskov) дополнительно получает is_super_admin=true,
+// чтобы тесты-сценарии для супер-админа корректно работали с middleware
+// которое после #231 проверяет is_super_admin вместо type_id=6.
 func RegisterUser(t *testing.T, e *echo.Echo, username, password string, typeID, orgID, companyID int) {
 	t.Helper()
 	user := models.User{
@@ -38,6 +41,7 @@ func RegisterUser(t *testing.T, e *echo.Echo, username, password string, typeID,
 		OrganizationID: intPtrOrZero(orgID),
 		CompanyID:      intPtrOrZero(companyID),
 		TypeID:         typeID,
+		IsSuperAdmin:   typeID == 6,
 	}
 	err := cachedDB.Create(&user).Error
 	require.NoError(t, err, "failed to seed user %s", username)
@@ -90,12 +94,16 @@ func RegisterManager(t *testing.T, e *echo.Echo, username string, orgID, company
 func registerUserViaDB(t *testing.T, e *echo.Echo, username string, typeID, orgID, companyID int) string {
 	t.Helper()
 
+	// type_id=6 -- buropropuskov код. После #231 super-admin определяется
+	// флагом is_super_admin, а не type_id. Сохраняем оба для тестов
+	// которые могут проверять как старое, так и новое поведение.
 	user := models.User{
 		Username:       username,
 		Password:       hashTestPassword(adminPassword),
 		OrganizationID: intPtrOrZero(orgID),
 		CompanyID:      intPtrOrZero(companyID),
 		TypeID:         typeID,
+		IsSuperAdmin:   typeID == 6,
 	}
 	err := cachedDB.Create(&user).Error
 	require.NoError(t, err, "failed to seed user %s", username)


### PR DESCRIPTION
Closes #231. Третий из 6 PR по системе прав (#187).

## Что в PR

### Backend (10 мест)
- JWT Claims расширен `IsSuperAdmin` -- middleware кладёт в context без доп. БД-запроса.
- `internal/middleware/jwt.go`: `c.Set('is_super_admin', claims.IsSuperAdmin)`.
- `internal/handlers/helpers.go`: helper `IsSuperAdmin(c) bool`.
- `internal/middleware/maintenance.go`: проверка через `is_super_admin`.
- `internal/handlers/maintenance.go`: `GetAdminStatus` и `Toggle` через `IsSuperAdmin(c)`.
- `internal/handlers/auth.go`: maintenance bypass через `resp.IsSuperAdmin`.
- `internal/services/permission_service.go`: API сервиса -- `isSuperAdmin bool` вместо `typeID int`.
- `internal/services/settings_service.go`: `checkBuro` -> `checkSuper(isSuperAdmin)`.
- `internal/services/application_helpers.go::CanAccessApplication`: принимает `isSuperAdmin bool`.
- `internal/services/maintenance_service.go`: revoke токенов через `WHERE is_super_admin = false`.

### Frontend (5 мест)
- `frontend/src/stores/auth.js`: getter `isSuperAdmin` (читает claim из JWT). Legacy `isAdmin` теперь делегирует, помечен @deprecated.
- `frontend/src/router.js`: `isBuroPropuskov = authStore.isSuperAdmin`.
- `frontend/src/stores/permissions.js`: bypass через `auth.isSuperAdmin`.
- `frontend/src/App.vue`, `NewsAndReview.vue`, `AccountComponent.vue`: переход на `isSuperAdmin` / `userData.is_super_admin`.

### Data migration
`backfillSuperAdmin` в `AutoMigrate` -- одноразовое `UPDATE users SET is_super_admin=true WHERE type_id IN (SELECT id FROM user_types WHERE code='buropropuskov')`. Идемпотентна (noop при повторе).

### Модель
`LoginResponse` и `CurrentUserResponse` теперь содержат `is_super_admin` и `is_banned`.

## Тесты
- Backend: все обновлены (`callMW` принимает `isSuperAdmin bool`, `testutil/auth.go` ставит `IsSuperAdmin=true` при `type_id=6`, golden contract обновлён).
- `go test -race -count=1 -p 4 ./...` -- все пакеты ok.
- Frontend: `permission.spec.js` и `permissions.spec.js` обновлены.
- `npm run test:run` -- 266/266 PASS.

## Что НЕ в этом PR

- `type_id != 5 && type_id != 6` в `notifications.go:121` (manager + super-admin) -- это про права уведомлений, должно мигрировать в новую систему прав через #233 (#187e), а не выпиливаться напрямую.
- `auth.CheckAdminByTypeID` / `CheckBuroByUsername` -- больше не вызываются, но оставлены в коде как unused для лёгкого revert. Удалятся в #233 после полного перехода.
- Удаление колонки `type_id` -- не делаем; колонка ещё несёт бизнес-семантику ролей (арендатор/охранник/руководитель), это отдельная задача в составе #187a.

## Зависимости

После merge -- разблокирует прогресс фронтового UI (#232) с правильным is_super_admin.