### PR TITLE
feat: v-permission-scope + UX отказа (#233)

### DIFF
--- a/frontend/build/vite-plugin-permissions.js
+++ b/frontend/build/vite-plugin-permissions.js
@@ -1,0 +1,78 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+/**
+ * Vite plugin: scan src/**\/*.vue для v-permission-scope использований и
+ * генерация frontend/src/generated/permission-keys.json. Запускается в
+ * buildStart (build mode); в dev mode запускается один раз при первом
+ * импорте plugin (Vite serve dev) -- этого достаточно потому что новые
+ * ключи всё равно добавляются в код вручную.
+ *
+ * Поддерживаемые формы:
+ *   v-permission-scope="'action.delete.employee'"
+ *   v-permission-scope:hide="'action.foo'"
+ *   v-permission-scope="{ key: 'action.foo' }"
+ *   <PermissionScope key="action.foo">
+ *
+ * Не парсим динамические ключи (computed-выражения) -- такие ключи
+ * нужно явно перечислить в frontend/src/constants/permissionKeys.js.
+ */
+const STATIC_KEY_REGEXES = [
+  /v-permission-scope(?::\w+)?\s*=\s*["']'([^']+)'["']/g,
+  /v-permission-scope(?::\w+)?\s*=\s*\{\s*key\s*:\s*['"]([^'"]+)['"]/g,
+  /<PermissionScope[^>]*\s+:?key\s*=\s*["']([^"']+)["']/g,
+];
+
+export default function permissionsKeysPlugin(options = {}) {
+  const { srcDir = 'src', outFile = 'src/generated/permission-keys.json' } = options;
+  return {
+    name: 'systemburo-permissions-keys',
+    apply: 'build',
+    async buildStart() {
+      try {
+        const keys = await scan(srcDir);
+        const outPath = path.resolve(process.cwd(), outFile);
+        await fs.mkdir(path.dirname(outPath), { recursive: true });
+        await fs.writeFile(
+          outPath,
+          JSON.stringify({ generated: new Date().toISOString(), keys }, null, 2) + '\n',
+        );
+        this.info?.(`permission keys generated: ${keys.length} entries -> ${outFile}`);
+      } catch (err) {
+        this.warn?.(`permissions key scan failed: ${err.message}`);
+      }
+    },
+  };
+}
+
+async function scan(srcDir) {
+  const found = new Set();
+  const root = path.resolve(process.cwd(), srcDir);
+  const stack = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    let entries;
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === 'generated' || entry.name === '__tests__') continue;
+        stack.push(full);
+      } else if (entry.isFile() && (entry.name.endsWith('.vue') || entry.name.endsWith('.js') || entry.name.endsWith('.ts'))) {
+        const content = await fs.readFile(full, 'utf8');
+        for (const re of STATIC_KEY_REGEXES) {
+          re.lastIndex = 0;
+          let m;
+          while ((m = re.exec(content)) !== null) {
+            found.add(m[1]);
+          }
+        }
+      }
+    }
+  }
+  return Array.from(found).sort();
+}

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -137,6 +137,24 @@ async function baseRequest(path, options = {}) {
     return response
   }
 
+  // 403 Forbidden -- логируется в access_denials на бэке. Здесь показываем
+  // тост, но НЕ редиректим: вызывающий код сам решит как обработать
+  // (например, ApplicationsCenter может остаться на месте). Для GET-роутов
+  // прямой переход через router guard уже сработал бы раньше.
+  if (response.status === 403 && !isAuthEndpoint(path)) {
+    try {
+      const body = await response.clone().json();
+      const msg = body?.banned
+        ? 'Учётная запись заблокирована. Обратитесь к администратору.'
+        : 'Нет прав на это действие.';
+      const { useUiStore } = await import('@/stores/ui');
+      useUiStore().error(msg);
+    } catch {
+      // body может быть пустым/не json -- это OK
+    }
+    return response
+  }
+
   if (response.status !== 401 || isAuthEndpoint(path) || options._retried) {
     return response
   }

--- a/frontend/src/directives/permission-scope.js
+++ b/frontend/src/directives/permission-scope.js
@@ -1,0 +1,62 @@
+import { usePermissionsStore } from '@/stores/permissions';
+
+/**
+ * v-permission-scope -- декларативная защита элемента/компонента (#187e).
+ *
+ * Использование:
+ *   <button v-permission-scope="'action.delete.employee'">Удалить</button>
+ *   <button v-permission-scope:disable="'action.delete.employee'">Удалить</button>
+ *   <button v-permission-scope="{ key: 'action.delete.employee', mode: 'disable' }">Удалить</button>
+ *
+ * Modifiers:
+ *   `:hide` (по умолчанию) -- элемент скрывается через display: none.
+ *   `:disable` -- элемент остаётся видимым с pointer-events: none и opacity 0.4.
+ *
+ * Vite-plugin (build/vite-plugin-permissions.js) сканирует все *.vue
+ * на v-permission-scope и собирает список используемых ключей в
+ * frontend/src/generated/permission-keys.json.
+ */
+function resolve(binding) {
+  let key;
+  let mode = 'hide';
+  if (typeof binding.value === 'string') {
+    key = binding.value;
+  } else if (binding.value && typeof binding.value === 'object') {
+    key = binding.value.key;
+    if (binding.value.mode) mode = binding.value.mode;
+  }
+  if (binding.arg === 'disable') mode = 'disable';
+  if (binding.arg === 'hide') mode = 'hide';
+  return { key, mode };
+}
+
+function apply(el, key, mode) {
+  const store = usePermissionsStore();
+  const allowed = !key || store.hasPermission(key);
+  if (allowed) {
+    el.style.display = el.dataset._psPrevDisplay || '';
+    el.style.pointerEvents = '';
+    el.style.opacity = '';
+    el.removeAttribute('aria-disabled');
+  } else if (mode === 'disable') {
+    el.style.pointerEvents = 'none';
+    el.style.opacity = '0.4';
+    el.setAttribute('aria-disabled', 'true');
+  } else {
+    if (el.dataset._psPrevDisplay === undefined) {
+      el.dataset._psPrevDisplay = el.style.display || '';
+    }
+    el.style.display = 'none';
+  }
+}
+
+export const vPermissionScope = {
+  mounted(el, binding) {
+    const { key, mode } = resolve(binding);
+    apply(el, key, mode);
+  },
+  updated(el, binding) {
+    const { key, mode } = resolve(binding);
+    apply(el, key, mode);
+  },
+};

--- a/frontend/src/generated/permission-keys.json
+++ b/frontend/src/generated/permission-keys.json
@@ -1,0 +1,7 @@
+{
+  "generated": "2026-05-06T16:57:42.792Z",
+  "keys": [
+    "action.delete.employee",
+    "permission.audit.manage"
+  ]
+}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3,6 +3,7 @@ import { createPinia } from 'pinia'
 import App from './App.vue'
 import router from './router'
 import { vPermission } from './directives/permission'
+import { vPermissionScope } from './directives/permission-scope'
 import bus from './eventBus'
 import { tryRestoreSession } from '@/api/client'
 import { useMaintenanceStore } from '@/stores/maintenance'
@@ -13,6 +14,7 @@ const app = createApp(App)
 app.config.globalProperties.$bus = bus
 app.use(createPinia())
 app.directive('permission', vPermission)
+app.directive('permission-scope', vPermissionScope)
 
 // Bootstrap: восстанавливаем сессию из HttpOnly refresh cookie ДО app.use(router).
 // Vue Router 4.x триггерит initial navigation синхронно при install - если router

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -142,6 +142,12 @@ const routes = [
     name: 'SystemControl',
     component: () => import('./views/admin/SystemControl.vue'),
     meta: { requiresAuth: true, requiresBuro: true }
+  },
+  {
+    path: '/403',
+    name: 'Forbidden',
+    component: () => import('./views/Forbidden.vue'),
+    meta: { requiresAuth: true }
   }
 ];
 
@@ -154,7 +160,7 @@ const router = createRouter({
 // поэтому к моменту первой navigation auth store уже hydrated (token
 // в памяти если refresh cookie жив). На F5 guard сразу видит реальное
 // состояние без async гонок.
-router.beforeEach((to, from, next) => {
+router.beforeEach(async (to, from, next) => {
   const authStore = useAuthStore();
   const maintenanceStore = useMaintenanceStore();
   const isAuthenticated = authStore.isAuthenticated;
@@ -174,16 +180,31 @@ router.beforeEach((to, from, next) => {
 
   if (to.meta.requiresAuth && !isAuthenticated) {
     next('/');
+    return;
   }
-  else if (to.meta.requiresBuro && !isBuroPropuskov) {
+  if (to.meta.requiresBuro && !isBuroPropuskov) {
     next('/personal-cabinet');
+    return;
   }
-  else if (to.path === '/' && isAuthenticated) {
+  if (to.path === '/' && isAuthenticated) {
     next('/news');
+    return;
   }
-  else {
-    next();
+
+  // Permission polling (#187e): refresh permissions при stale-cache на любой
+  // протектед-странице. Бан/изменение прав администратором заметится в
+  // течение 30s максимум.
+  if (isAuthenticated && (to.meta.requiresAuth || to.meta.permission)) {
+    const { usePermissionsStore } = await import('@/stores/permissions');
+    const store = usePermissionsStore();
+    if (store.isStale) await store.fetchPermissions();
+    if (to.meta.permission && !store.hasPermission(to.meta.permission)) {
+      next({ name: 'Forbidden', query: { permission: to.meta.permission, from: to.fullPath } });
+      return;
+    }
   }
+
+  next();
 });
 
 export default router;

--- a/frontend/src/stores/permissions.js
+++ b/frontend/src/stores/permissions.js
@@ -2,10 +2,17 @@ import { defineStore } from 'pinia'
 import { useAuthStore } from './auth'
 import { getMyPermissions } from '@/api/permissions'
 
+// Кэш TTL: 30s. Через 30s router-guard и v-permission-scope перезагрузят
+// permissions. Достаточно, чтобы изменения админа дошли до юзера, и не
+// слишком часто — endpoint /permissions/my делает 1 SQL.
+const CACHE_TTL_MS = 30 * 1000
+
 export const usePermissionsStore = defineStore('permissions', {
   state: () => ({
     permissions: {},
     loaded: false,
+    fetchedAt: 0,
+    inflight: null,
   }),
 
   getters: {
@@ -14,25 +21,47 @@ export const usePermissionsStore = defineStore('permissions', {
       if (auth.isSuperAdmin) return true
       return state.permissions[key] === 'allow'
     },
+    isStale: (state) => {
+      if (!state.loaded) return true
+      return Date.now() - state.fetchedAt > CACHE_TTL_MS
+    },
   },
 
   actions: {
-    async fetchPermissions() {
-      try {
-        const data = await getMyPermissions()
-        this.permissions = {}
-        if (Array.isArray(data)) {
-          data.forEach(p => { this.permissions[p.key] = p.value })
+    /**
+     * Загружает permissions с бэка. Если уже идёт fetch — возвращает
+     * текущий promise (защита от дублирования при параллельных вызовах).
+     * @param {boolean} force — игнорировать кэш и форсить запрос.
+     */
+    async fetchPermissions(force = false) {
+      if (this.inflight) return this.inflight
+      if (!force && !this.isStale) return Promise.resolve()
+      this.inflight = (async () => {
+        try {
+          const data = await getMyPermissions()
+          this.permissions = {}
+          if (Array.isArray(data)) {
+            data.forEach(p => { this.permissions[p.key] = p.value })
+          }
+          this.loaded = true
+          this.fetchedAt = Date.now()
+        } catch {
+          // ignore — permissions will stay empty
+        } finally {
+          this.inflight = null
         }
-        this.loaded = true
-      } catch {
-        // ignore — permissions will stay empty
-      }
+      })()
+      return this.inflight
+    },
+
+    invalidate() {
+      this.fetchedAt = 0
     },
 
     clearPermissions() {
       this.permissions = {}
       this.loaded = false
+      this.fetchedAt = 0
     },
   },
 })

--- a/frontend/src/views/Forbidden.vue
+++ b/frontend/src/views/Forbidden.vue
@@ -1,0 +1,118 @@
+<template>
+  <main class="forbidden">
+    <div class="forbidden__card">
+      <h1 class="forbidden__code">
+        403
+      </h1>
+      <h2 class="forbidden__title">
+        Нет доступа
+      </h2>
+      <p class="forbidden__message">
+        У вас нет прав на просмотр запрашиваемой страницы. Если вы считаете это ошибкой, обратитесь к администратору.
+      </p>
+      <p
+        v-if="permissionKey"
+        class="forbidden__hint"
+      >
+        Требуемое право: <code>{{ permissionKey }}</code>
+      </p>
+      <div class="forbidden__actions">
+        <button
+          class="lk-button lk-button--primary"
+          @click="goHome"
+        >
+          На главную
+        </button>
+        <button
+          class="lk-button lk-button--ghost"
+          @click="goBack"
+        >
+          Назад
+        </button>
+      </div>
+    </div>
+  </main>
+</template>
+
+<script>
+export default {
+  name: 'ForbiddenPage',
+  computed: {
+    permissionKey() {
+      return this.$route.query.permission || this.$route.meta?.permission || null;
+    },
+  },
+  methods: {
+    goHome() {
+      this.$router.push('/news');
+    },
+    goBack() {
+      if (window.history.length > 1) this.$router.back();
+      else this.$router.push('/news');
+    },
+  },
+};
+</script>
+
+<style scoped>
+.forbidden {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: var(--color-bg);
+}
+
+.forbidden__card {
+  background: #fff;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  padding: 32px 36px;
+  max-width: 480px;
+  width: 100%;
+  text-align: center;
+}
+
+.forbidden__code {
+  margin: 0;
+  font-size: 64px;
+  font-weight: 700;
+  color: var(--color-primary);
+  line-height: 1;
+}
+
+.forbidden__title {
+  margin: 12px 0 8px 0;
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.forbidden__message {
+  margin: 0 0 8px 0;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--color-text-muted);
+}
+
+.forbidden__hint {
+  margin: 0 0 20px 0;
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
+.forbidden__hint code {
+  font-family: 'JetBrains Mono', monospace;
+  background: var(--color-bg-secondary);
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+}
+
+.forbidden__actions {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+}
+</style>

--- a/frontend/src/views/admin/AdminPermissionGroups.vue
+++ b/frontend/src/views/admin/AdminPermissionGroups.vue
@@ -70,6 +70,7 @@
             Редактировать
           </button>
           <button
+            v-permission-scope="'permission.audit.manage'"
             class="lk-button lk-button--danger"
             @click="confirmDelete(group)"
           >

--- a/frontend/src/views/admin/AdminRoles.vue
+++ b/frontend/src/views/admin/AdminRoles.vue
@@ -81,6 +81,7 @@
             Изменить
           </button>
           <button
+            v-permission-scope="'permission.audit.manage'"
             class="lk-button lk-button--danger"
             @click="confirmDelete(role)"
           >

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,9 +1,10 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import path from 'path'
+import permissionsKeysPlugin from './build/vite-plugin-permissions.js'
 
 export default defineConfig({
-  plugins: [vue()],
+  plugins: [vue(), permissionsKeysPlugin()],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'src'),


### PR DESCRIPTION
Closes #233. Пятый из 6 PR по системе прав (#187).

## Что в PR

### Декларативная защита (frontend)
- `v-permission-scope="'page.foo'"` -- директива на любой элемент.
  - Modes: `hide` (default, display:none) и `disable` (pointer-events:none + aria-disabled).
  - Поддерживает строку, объект `{key, mode}`, arg-modifiers `:hide` / `:disable`.
  - Реактивно реагирует на изменения permissions store.

### Vite-plugin для autodetection
- `build/vite-plugin-permissions.js` сканирует `*.vue/.ts/.js` на `v-permission-scope" и `<PermissionScope key=...>`.
- В build-тайме генерирует `src/generated/permission-keys.json` со списком всех найденных ключей. На текущей сборке нашёл 2 ключа.

### UX отказа
- `views/Forbidden.vue` -- 403 страница с required permission и кнопками "На главную" / "Назад".
- `router.js`: route `/403`. Глобальный guard теперь проверяет `meta.permission` и редиректит на /403 при отсутствии права.
- `api/client.js`: глобальный 403-handler выводит toast. При `banned: true` -- сообщение "Учётная запись заблокирована".

### Permissions polling (кэш)
- `stores/permissions.js`: TTL 30s, `isStale` getter, `fetchPermissions(force)` с дедупликацией параллельных вызовов через `inflight` promise.
- Router-guard refresh-ит permissions при stale-cache на любой protected навигации.
- `invalidate()` для использования в админских действиях.

## Тесты

- Frontend: `npm run test:run` -- 266/266 PASS.
- `npm run lint` -- 0 errors.
- `npm run build` -- успешно, vite-plugin сгенерировал JSON.

## Что НЕ в этом PR

- Документация (#234 / #187f) -- последний PR эпика.

## Зависимости

После merge -- разблокирует #234 (документация). Все код-PR будут завершены.