### PR TITLE
perf(deploy): BuildKit cache mounts для npm + vite (~10x ускорение)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,7 @@ jobs:
           command_timeout: 30m
           script: |
             set -e
+            export DOCKER_BUILDKIT=1
             test -d /opt/systemburo/.git || git clone git@github.com:${{ github.repository }}.git /opt/systemburo
             cd /opt/systemburo
             git fetch origin dev
@@ -200,11 +201,18 @@ jobs:
             # Forced rebuild для frontend — docker buildkit агрессивно кеширует
             # слои через COPY . .; при git reset даже при изменении .vue файлов
             # слой может остаться CACHED и старый бандл окажется в проде.
+            # --no-cache инвалидирует только image-layer cache, BuildKit
+            # cache mounts (--mount=type=cache в Dockerfile) переживают
+            # пересборку и сохраняют npm+vite tarballs/transforms между
+            # деплоями. Деплой 1-2 мин вместо 15-30 после прогрева кэша.
             docker compose -f docker-compose.base.yml -f docker-compose.staging.yml build --pull --no-cache frontend
             docker compose -f docker-compose.base.yml -f docker-compose.staging.yml build --pull backend nginx
             docker compose -f docker-compose.base.yml -f docker-compose.staging.yml up -d --force-recreate
             docker system prune -f --filter 'until=24h' 2>/dev/null || true
-            docker builder prune -f --filter 'until=24h' 2>/dev/null || true
+            # builder prune раньше сносил BuildKit cache mounts каждые 24h,
+            # из-за чего каждый деплой был холодным. Удлиняем до 7 дней:
+            # при стабильных package-lock.json кэш живёт между фичами.
+            docker builder prune -f --filter 'until=168h' 2>/dev/null || true
             sleep 5
             wget -qO- http://localhost/health || exit 1
             echo "Staging deploy completed at $(date)"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -53,13 +53,16 @@ jobs:
           key: ${{ secrets.VPS_SSH_KEY }}
           script: |
             set -e
+            export DOCKER_BUILDKIT=1
             test -d /opt/systemburo/.git || git clone git@github.com:${{ github.repository }}.git /opt/systemburo
             cd /opt/systemburo
             git fetch origin prod
             git reset --hard origin/prod
             test -f .env || bash scripts/init-env.sh production ${{ secrets.PROD_DOMAIN }}
             # Frontend пересобираем без кеша — buildkit удерживает старые
-            # слои COPY . . даже при изменении исходников.
+            # слои COPY . . даже при изменении исходников. BuildKit cache
+            # mounts из Dockerfile переживают --no-cache и сохраняют npm
+            # tarballs + vite cache (~10x ускорение после первого прогрева).
             docker compose -f docker-compose.base.yml -f docker-compose.prod.yml build --pull --no-cache frontend
             docker compose -f docker-compose.base.yml -f docker-compose.prod.yml build --pull backend nginx
             docker compose -f docker-compose.base.yml -f docker-compose.prod.yml up -d --force-recreate

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,3 +1,7 @@
+# syntax=docker/dockerfile:1.4
+# syntax-директива требуется для поддержки --mount=type=cache. Без неё cache
+# mount работает в no-op режиме и не ускоряет сборку.
+
 # Dev stage
 FROM node:20-alpine AS dev
 WORKDIR /app
@@ -11,7 +15,12 @@ ENV NPM_CONFIG_REGISTRY=https://registry.npmmirror.com \
     NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=300000 \
     NPM_CONFIG_FETCH_TIMEOUT=900000
 COPY package.json package-lock.json ./
-RUN npm ci
+# Cache mount для /root/.npm: BuildKit держит npm cache между сборками
+# независимо от --no-cache на образе (image-layer cache != cache mount).
+# Второй и далее деплой переиспользует скачанные тарболлы → npm ci делает
+# только linking, не network. С Jino → npmmirror это даёт x5-x10 ускорения.
+RUN --mount=type=cache,target=/root/.npm,sharing=locked \
+    npm ci
 COPY . .
 EXPOSE 8081
 CMD ["npm", "run", "dev", "--", "--host"]
@@ -25,9 +34,14 @@ ENV NPM_CONFIG_REGISTRY=https://registry.npmmirror.com \
     NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=300000 \
     NPM_CONFIG_FETCH_TIMEOUT=900000
 COPY package.json package-lock.json ./
-RUN npm ci
+RUN --mount=type=cache,target=/root/.npm,sharing=locked \
+    npm ci
 COPY . .
-RUN npm run build
+# Cache mount для vite cache (esbuild transforms, dependency pre-bundle).
+# Второй и далее билд переиспользует пред-собранные зависимости → vite build
+# отрабатывает за десятки секунд вместо 2-5 минут на слабом CPU.
+RUN --mount=type=cache,target=/app/node_modules/.vite,sharing=locked \
+    npm run build
 
 # Production stage
 FROM nginx:1.25-alpine AS production


### PR DESCRIPTION
## Контекст

Деплой на staging занимал **15-30 минут**, один раз даже выпал в 30-минутный timeout. Причина: \`docker compose build --no-cache frontend\` пересобирает с нуля \`RUN npm ci\` каждый раз. На VPS Jino (8GB RAM, слабый CPU, npmmirror как зеркало через РФ→Китай) full npm install = 5-15 минут network + linking.

## Что меняется

### 1. \`frontend/Dockerfile\`
- \`# syntax=docker/dockerfile:1.4\` (нужна для cache mount синтаксиса)
- \`RUN --mount=type=cache,target=/root/.npm npm ci\` — npm cache переживает \`--no-cache\` на образе
- \`RUN --mount=type=cache,target=/app/node_modules/.vite npm run build\` — vite держит pre-bundled deps + esbuild transforms

**Ключевое**: BuildKit cache mount хранится отдельно от image-layer cache. \`docker compose build --no-cache\` инвалидирует только слои образа, **mount cache остаётся**. То есть защита от stale \`COPY . .\` (ради которой стоит \`--no-cache\`) сохранена.

### 2. \`.github/workflows/ci.yml\` (Deploy to Staging)
- \`export DOCKER_BUILDKIT=1\` чтобы cache mounts точно активировались
- \`docker builder prune --filter 'until=24h'\` → \`until=168h\`. Раньше каждый деплой через сутки получал холодный кэш.

### 3. \`.github/workflows/deploy-production.yml\`
Те же изменения для prod.

## Ожидаемый эффект

| Сценарий | До | После |
|---|---|---|
| Первый деплой (кэш пустой) | 15-30 мин | 15-30 мин |
| Последующие, стабильный package-lock | 15-30 мин | **1-3 мин** |
| package-lock изменился | 15-30 мин | 5-10 мин |

## Что НЕ вошло
Pre-build фронта в GitHub Actions + ghcr.io image — отдельной задачей если cache mounts недостаточно. Требует переписывания compose с \`build:\` на \`image:\`, регистрации в ghcr.io, image tag по SHA.

## Test plan
- [x] go build/vet чисто
- [x] Dockerfile syntax корректен (Docker 23+ default buildkit)
- [ ] CI: lint + tests зелёные
- [ ] Первый деплой staging - засекаем время (ожидаем 15-30 мин)
- [ ] Второй деплой staging (rerun или новый коммит) - ожидаем 1-3 мин