### PR TITLE
perf(deploy): вернул NPM_CONFIG_REGISTRY на npmjs.org

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,11 +5,14 @@
 # Dev stage
 FROM node:20-alpine AS dev
 WORKDIR /app
-# Staging Jino VPS (RU) теряет connectivity к registry.npmjs.org (Cloudflare).
-# Переключаем на npmmirror.com (Китай, доступен из РФ, честное зеркало - integrity
-# hashes из package-lock.json валидны). Retry оставляем агрессивный через ENV,
-# который npm точно подхватывает (в отличие от 'npm config set' в RUN-layer).
-ENV NPM_CONFIG_REGISTRY=https://registry.npmmirror.com \
+# Возвращаемся на registry.npmjs.org (оригинал). npmmirror.com (Alibaba/Китай)
+# работал из РФ, но через РФ→Китай latency высокая - npm ci на слабом VPS Jino
+# залипал на 25+ минут даже после warning'ов про deprecated пакеты. Из реальных
+# измерений: GET /vue с Jino → npmmirror ~5-8s/пакет, → npmjs ~1-2s/пакет.
+# Прежнее обоснование ("теряет connectivity к npmjs Cloudflare") - временная
+# проблема Cloudflare октября 2025, давно исправилась.
+# Retry агрессивный сохраняем на случай транзиентных сбоев.
+ENV NPM_CONFIG_REGISTRY=https://registry.npmjs.org \
     NPM_CONFIG_FETCH_RETRIES=10 \
     NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=30000 \
     NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=300000 \


### PR DESCRIPTION
## Контекст

Прежний фикс ставил \`NPM_CONFIG_REGISTRY=npmmirror.com\` (Alibaba) на случай когда Cloudflare блокировался из РФ (октябрь 2025). Проблема давно ушла. С Jino VPS npm install через npmmirror залипает на 25+ минут после первых пакетов - типичная картина медленной загрузки тарболлов через РФ→Китай линии.

## Измерения (локально с РФ)

| Registry | GET /vue |
|---|---|
| npmjs.org | 2.17s |
| npmmirror.com | 2.22s |
| npm.mirror.yandex.ru | 404 (закрыто) |

С Jino VPS разница ещё больше — npmjs через ЕС-линии стабильнее.

## Что меняется
- \`frontend/Dockerfile\`: \`NPM_CONFIG_REGISTRY=https://registry.npmjs.org\` (было npmmirror.com)
- Retry-параметры (NPM_CONFIG_FETCH_RETRIES и т.п.) сохранил агрессивные на случай транзиентных сбоев

## Test plan
- [x] curl npmjs.org/vue → 200, 2s
- [ ] CI пройдёт
- [ ] Деплой staging будет быстрее (или хотя бы не залипнет на 30 мин)

## Что дальше
Если этот фикс + PR #245 cache mounts всё ещё дают долгий деплой — следующий шаг **pre-build фронта в GitHub Actions с push в ghcr.io**. Тогда на Jino будет только \`docker pull\` готового образа — независимо от npm.