### PR TITLE
perf(deploy): pre-build фронта в GA + push в ghcr.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,9 +135,24 @@ jobs:
     runs-on: ubuntu-latest
     needs: [paths, backend-test, frontend-test]
     if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v4
+      # Логинимся в ghcr.io только когда пушим (push в dev/main).
+      # Для PR/manual builds логин пропускаем - в этих случаях push: false.
+      - name: Log in to ghcr.io
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main')
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set lowercase repo for ghcr.io
+        id: repo
+        run: echo "lower=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
       - name: Build backend image (cached)
         uses: docker/build-push-action@v7
         with:
@@ -147,13 +162,22 @@ jobs:
           load: true
           cache-from: type=gha,scope=systemburo-backend
           cache-to: type=gha,mode=max,scope=systemburo-backend
-      - name: Build frontend image (cached)
+      # Frontend image пушим в ghcr.io для деплоя - на слабом VPS Jino
+      # npm ci + vite build занимали 30+ минут (I/O bottleneck linking
+      # node_modules). На GA runner это <2 минут, и deploy на VPS
+      # сводится к docker pull (~30s) + up. Тэгируем SHA для воспроизводимости
+      # + dev для последнего.
+      - name: Build frontend image (cached + push на dev)
         uses: docker/build-push-action@v7
         with:
           context: ./frontend
           target: production
-          tags: systemburo-frontend:ci
-          load: true
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/dev' }}
+          load: ${{ github.event_name != 'push' || github.ref != 'refs/heads/dev' }}
+          tags: |
+            systemburo-frontend:ci
+            ghcr.io/${{ steps.repo.outputs.lower }}-frontend:${{ github.sha }}
+            ghcr.io/${{ steps.repo.outputs.lower }}-frontend:dev
           cache-from: type=gha,scope=systemburo-frontend
           cache-to: type=gha,mode=max,scope=systemburo-frontend
       - name: Verify backend image runs as non-root
@@ -187,31 +211,29 @@ jobs:
           username: ${{ secrets.VPS_USER }}
           password: ${{ secrets.VPS_PASSWORD }}
           key: ${{ secrets.VPS_SSH_KEY }}
-          # Default command_timeout=10m - не хватает на полный npm ci + Docker rebuild
-          # с npmmirror (медленнее чем прежний Cloudflare-кеш). Ставим 30m.
-          command_timeout: 30m
+          # Frontend image теперь pre-built в ghcr.io через docker-build job
+          # (GA runner быстрее VPS Jino x100). На VPS только pull + up.
+          # Backend и nginx собираются на VPS (быстро, ~30s).
+          command_timeout: 15m
           script: |
             set -e
             export DOCKER_BUILDKIT=1
+            export FRONTEND_IMAGE_TAG="${{ github.sha }}"
             test -d /opt/systemburo/.git || git clone git@github.com:${{ github.repository }}.git /opt/systemburo
             cd /opt/systemburo
             git fetch origin dev
             git reset --hard origin/dev
             test -f .env || bash scripts/init-env.sh staging ${{ secrets.STAGING_DOMAIN }}
-            # Forced rebuild для frontend — docker buildkit агрессивно кеширует
-            # слои через COPY . .; при git reset даже при изменении .vue файлов
-            # слой может остаться CACHED и старый бандл окажется в проде.
-            # --no-cache инвалидирует только image-layer cache, BuildKit
-            # cache mounts (--mount=type=cache в Dockerfile) переживают
-            # пересборку и сохраняют npm+vite tarballs/transforms между
-            # деплоями. Деплой 1-2 мин вместо 15-30 после прогрева кэша.
-            docker compose -f docker-compose.base.yml -f docker-compose.staging.yml build --pull --no-cache frontend
+            # ghcr.io public images: pull без auth. Если в будущем
+            # package станет private - добавить docker login в скрипт.
+            REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+            export FRONTEND_IMAGE="ghcr.io/${REPO_LOWER}-frontend:${{ github.sha }}"
+            echo "Pulling pre-built frontend: $FRONTEND_IMAGE"
+            docker pull "$FRONTEND_IMAGE"
+            # Backend и nginx собираем на VPS - они маленькие и быстро.
             docker compose -f docker-compose.base.yml -f docker-compose.staging.yml build --pull backend nginx
             docker compose -f docker-compose.base.yml -f docker-compose.staging.yml up -d --force-recreate
             docker system prune -f --filter 'until=24h' 2>/dev/null || true
-            # builder prune раньше сносил BuildKit cache mounts каждые 24h,
-            # из-за чего каждый деплой был холодным. Удлиняем до 7 дней:
-            # при стабильных package-lock.json кэш живёт между фичами.
             docker builder prune -f --filter 'until=168h' 2>/dev/null || true
             sleep 5
             wget -qO- http://localhost/health || exit 1

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -3,6 +3,13 @@ services:
     environment:
       LOG_LEVEL: ${LOG_LEVEL:-debug}
 
+  # Frontend pre-built в GitHub Actions, pull из ghcr.io.
+  # Override от docker-compose.base.yml (build: → image:).
+  # FRONTEND_IMAGE подставляет deploy script с SHA коммита.
+  frontend:
+    image: ${FRONTEND_IMAGE:-ghcr.io/buropropuskov/systemburo-frontend:dev}
+    build: !reset null
+
   nginx:
     build:
       context: ./nginx


### PR DESCRIPTION
Cache mount помогает с network, но не с I/O. npm ci linking 3000+ файлов node_modules на Jino всё равно 30 мин.

Фикс: фронт билдится на GA runner (быстрый), готовый image пушится в ghcr.io, на VPS только docker pull (~30s).

После merge нужно один раз руками: открыть https://github.com/users/buropropuskov/packages/container/systemburo-frontend/settings и поставить visibility: public. Иначе VPS не сможет pull без auth.