### PR TITLE
fix(ci): docker build пушил frontend в Docker Hub вместо ghcr.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,6 @@ jobs:
           push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/dev' }}
           load: ${{ github.event_name != 'push' || github.ref != 'refs/heads/dev' }}
           tags: |
-            systemburo-frontend:ci
             ghcr.io/${{ steps.repo.outputs.lower }}-frontend:${{ github.sha }}
             ghcr.io/${{ steps.repo.outputs.lower }}-frontend:dev
           cache-from: type=gha,scope=systemburo-frontend


### PR DESCRIPTION
Среди tags первый был `systemburo-frontend:ci` без registry-префикса → buildx считал его Docker Hub, упирался в 401 при push. Оставил только ghcr.io тэги.