### PR TITLE
fix(ci): docker login ghcr.io на VPS перед pull

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,7 @@ jobs:
     environment: staging
     permissions:
       contents: write
+      packages: read
     steps:
       - uses: actions/checkout@v6
         with:
@@ -204,31 +205,33 @@ jobs:
           fetch-depth: 0
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v1
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           host: ${{ secrets.VPS_HOST }}
           port: ${{ secrets.VPS_PORT }}
           username: ${{ secrets.VPS_USER }}
           password: ${{ secrets.VPS_PASSWORD }}
           key: ${{ secrets.VPS_SSH_KEY }}
-          # Frontend image теперь pre-built в ghcr.io через docker-build job
-          # (GA runner быстрее VPS Jino x100). На VPS только pull + up.
-          # Backend и nginx собираются на VPS (быстро, ~30s).
+          # Передаём GITHUB_TOKEN на VPS чтобы docker login в ghcr.io
+          # (org buropropuskov не разрешает public packages, нужна auth).
+          envs: GHCR_USER,GHCR_TOKEN
           command_timeout: 15m
           script: |
             set -e
             export DOCKER_BUILDKIT=1
-            export FRONTEND_IMAGE_TAG="${{ github.sha }}"
             test -d /opt/systemburo/.git || git clone git@github.com:${{ github.repository }}.git /opt/systemburo
             cd /opt/systemburo
             git fetch origin dev
             git reset --hard origin/dev
             test -f .env || bash scripts/init-env.sh staging ${{ secrets.STAGING_DOMAIN }}
-            # ghcr.io public images: pull без auth. Если в будущем
-            # package станет private - добавить docker login в скрипт.
             REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
             export FRONTEND_IMAGE="ghcr.io/${REPO_LOWER}-frontend:${{ github.sha }}"
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
             echo "Pulling pre-built frontend: $FRONTEND_IMAGE"
             docker pull "$FRONTEND_IMAGE"
+            docker logout ghcr.io
             # Backend и nginx собираем на VPS - они маленькие и быстро.
             docker compose -f docker-compose.base.yml -f docker-compose.staging.yml build --pull backend nginx
             docker compose -f docker-compose.base.yml -f docker-compose.staging.yml up -d --force-recreate


### PR DESCRIPTION
Org buropropuskov запрещает public packages, нужна auth. Передаю GITHUB_TOKEN через ssh-action envs и делаю docker login на VPS перед pull, logout после.