### PR TITLE
test(e2e): site smoke crawler по 19 роутам

### DIFF
--- a/.github/workflows/site-smoke.yml
+++ b/.github/workflows/site-smoke.yml
@@ -1,0 +1,50 @@
+name: Site smoke crawler
+
+# Тяжёлый smoke-обход всех роутов фронта с проверкой console errors.
+# Только manual triger - ~5 минут прогон, не нужен на каждом PR.
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Target environment'
+        required: true
+        default: 'staging'
+        type: choice
+        options:
+          - staging
+
+concurrency:
+  group: site-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  crawl:
+    name: Crawl ${{ inputs.target }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: staging
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-frontend
+      - uses: ./.github/actions/playwright-cache
+        with:
+          browser: chromium
+      - name: Run crawler against ${{ inputs.target }}
+        working-directory: frontend
+        env:
+          E2E_BASE_URL: https://stagingburo.washka17.site
+          E2E_HTTP_USER: ${{ secrets.STAGING_BASIC_AUTH_USER }}
+          E2E_HTTP_PASSWORD: ${{ secrets.STAGING_BASIC_AUTH_PASSWORD }}
+          E2E_SUPERADMIN_USER: buropropuskov
+          E2E_SUPERADMIN_PASSWORD: ${{ secrets.STAGING_SUPERADMIN_PASSWORD }}
+          E2E_API_BASE_URL: https://stagingburo.washka17.site/api
+        run: npx playwright test e2e/tests/site-smoke-crawler.spec.cjs --workers=1 --reporter=list
+      - name: Upload crawl report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: site-crawl-report
+          path: |
+            frontend/site-crawl-reports/
+            frontend/playwright-report/
+          retention-days: 14

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -21,3 +21,6 @@ pnpm-debug.log*
 *.njsproj
 *.sln
 *.sw?
+
+# Site smoke crawler reports
+site-crawl-reports/

--- a/frontend/e2e/helpers/site-crawler.cjs
+++ b/frontend/e2e/helpers/site-crawler.cjs
@@ -1,0 +1,198 @@
+/**
+ * Утилиты для site-smoke-crawler.spec.cjs.
+ * Перехват console/pageerror, фильтрация safe-to-click элементов, helper'ы для безопасной навигации.
+ */
+
+// Кнопки/линки которые НЕЛЬЗЯ кликать в смок-обходе:
+// - destructive: удаляют, сбрасывают, блокируют, выходят
+// - submit: создают/сохраняют сущности (мусор в staging)
+// - confirm в модалках
+const DESTRUCTIVE_REGEX = /(удалить|сбросить|заблокировать|забанить|очистить|выйти|выход|сохранить|создать|подтвердить|применить|архивировать|разбанить|разблокировать|снять блок|delete|remove|reset|ban|logout|save|create|confirm|apply|archive)/i;
+
+// href которые ведут вовне сайта или меняют контекст
+const DANGEROUS_HREF = /^(mailto:|tel:|javascript:|https?:\/\/(?!stagingburo\.washka17\.site))/i;
+
+// Известные ложные console.error - не считаем регрессией
+const EXPECTED_ERRORS_WHITELIST = [
+  'ResizeObserver loop limit exceeded',
+  'ResizeObserver loop completed with undelivered notifications',
+  'Failed to load resource: net::ERR_BLOCKED_BY_CLIENT', // adblock и подобное
+  // 401 на /api/refresh-token нормален - SPA пробует refresh при загрузке,
+  // если cookie уже актуальна - всё хорошо; если протухла - 401 и редирект на login
+  '/api/refresh-token',
+  // 401/403 на других /api/* возникают как race при logout-flow
+  'status of 401 ()',
+  'Missing or invalid authorization header',
+];
+
+// Регексы для путей которые часто дают 404 на картинки/превью (но не для критичных API/JS)
+const EXPECTED_404_PATHS = [
+  /\/uploads\//, // отсутствующие аватары/превью
+  /\/static\/.+\.(png|jpg|jpeg|svg|webp)/,
+  /\.(png|jpg|jpeg|svg|webp|gif|ico)$/i,
+];
+
+function isWhitelisted(message, urlContext = '') {
+  if (!message) return false;
+  const combined = `${message} ${urlContext}`;
+  if (EXPECTED_ERRORS_WHITELIST.some((w) => combined.includes(w))) return true;
+  // 404 на картинки - не баг
+  if (combined.includes('status of 404') && EXPECTED_404_PATHS.some((r) => r.test(combined))) return true;
+  return false;
+}
+
+/**
+ * Привязывает слушатели к page. Возвращает геттеры для собранных ошибок.
+ * Слушатели снимаются автоматически при закрытии page.
+ */
+function setupErrorCollectors(page) {
+  const pageErrors = [];
+  const consoleErrors = [];
+  const consoleWarnings = [];
+
+  page.on('pageerror', (err) => {
+    pageErrors.push({
+      message: err.message,
+      stack: err.stack,
+      at: new Date().toISOString(),
+    });
+  });
+
+  page.on('console', (msg) => {
+    const text = msg.text();
+    const location = msg.location();
+    if (isWhitelisted(text, location?.url || '')) return;
+    const entry = { text, location, at: new Date().toISOString() };
+    if (msg.type() === 'error') consoleErrors.push(entry);
+    else if (msg.type() === 'warning') consoleWarnings.push(entry);
+  });
+
+  return {
+    getPageErrors: () => [...pageErrors],
+    getConsoleErrors: () => [...consoleErrors],
+    getConsoleWarnings: () => [...consoleWarnings],
+    snapshot: () => ({
+      pageErrors: pageErrors.length,
+      consoleErrors: consoleErrors.length,
+      consoleWarnings: consoleWarnings.length,
+    }),
+  };
+}
+
+/**
+ * Собирает все clickable элементы на странице с фильтрами безопасности.
+ * Не дёргает .all() сразу - возвращает Locator чтобы можно было лениво итерировать.
+ */
+function getClickables(page) {
+  // button, a[href], [role="button"], [role="tab"], [role="link"]
+  return page.locator(
+    'button:visible:not([disabled]), ' +
+    'a[href]:visible, ' +
+    '[role="button"]:visible:not([aria-disabled="true"]), ' +
+    '[role="tab"]:visible, ' +
+    '[role="link"]:visible',
+  );
+}
+
+/**
+ * Проверяет является ли клик опасным (destructive/submit/navigation outside).
+ */
+async function isSafeToClick(locator) {
+  try {
+    const text = (await locator.innerText({ timeout: 500 }).catch(() => ''))?.trim() || '';
+    if (DESTRUCTIVE_REGEX.test(text)) {
+      return { safe: false, reason: `destructive text: "${text.slice(0, 50)}"` };
+    }
+    const href = await locator.getAttribute('href').catch(() => null);
+    if (href && DANGEROUS_HREF.test(href)) {
+      return { safe: false, reason: `dangerous href: ${href.slice(0, 80)}` };
+    }
+    return { safe: true, text };
+  } catch (e) {
+    return { safe: false, reason: `cant-inspect: ${e.message}` };
+  }
+}
+
+/**
+ * Закрывает открытые overlays/модалки/dropdowns через Escape + клик в пустое место.
+ * Best-effort, не падает если ничего не открыто.
+ */
+async function closeOpenedOverlays(page) {
+  try {
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(150);
+    // Иногда модалка не закрывается на Escape - клик по body вне модалки
+    const overlay = page.locator('.modal-overlay, .form-modal, .rename-modal, .permission-tree-modal').first();
+    if (await overlay.isVisible({ timeout: 200 }).catch(() => false)) {
+      await page.keyboard.press('Escape');
+      await page.waitForTimeout(150);
+    }
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Кликает по элементу с safety-проверками. Возвращает результат:
+ * { clicked, skipped, reason, urlBefore, urlAfter, urlChanged }
+ */
+async function clickSafe(page, locator) {
+  const check = await isSafeToClick(locator);
+  if (!check.safe) {
+    return { clicked: false, skipped: true, reason: check.reason };
+  }
+  const urlBefore = page.url();
+  try {
+    await locator.click({ timeout: 2000, force: false });
+    await page.waitForTimeout(300); // ждём реакции UI
+  } catch (e) {
+    return { clicked: false, skipped: false, reason: `click-failed: ${e.message.slice(0, 100)}` };
+  }
+  const urlAfter = page.url();
+  return {
+    clicked: true,
+    skipped: false,
+    text: check.text,
+    urlBefore,
+    urlAfter,
+    urlChanged: urlBefore !== urlAfter,
+  };
+}
+
+/**
+ * Формирует markdown-фрагмент отчёта для одного route.
+ */
+function formatRouteReport({ route, results, errors }) {
+  const lines = [];
+  lines.push(`## ${route.path} (${route.name})\n`);
+  lines.push(`- clickables найдено: ${results.totalFound}`);
+  lines.push(`- кликов выполнено: ${results.clicked}`);
+  lines.push(`- skip по safety: ${results.skipped}`);
+  lines.push(`- click failures: ${results.failures.length}`);
+  if (errors.pageErrors.length) {
+    lines.push(`\n### pageerror (${errors.pageErrors.length})`);
+    errors.pageErrors.forEach((e) => lines.push(`- \`${e.message}\``));
+  }
+  if (errors.consoleErrors.length) {
+    lines.push(`\n### console.error (${errors.consoleErrors.length})`);
+    errors.consoleErrors.slice(0, 20).forEach((e) => lines.push(`- \`${e.text.slice(0, 200)}\``));
+  }
+  if (results.failures.length) {
+    lines.push(`\n### click failures`);
+    results.failures.slice(0, 20).forEach((f) => lines.push(`- "${f.text}": ${f.reason}`));
+  }
+  return lines.join('\n') + '\n';
+}
+
+module.exports = {
+  DESTRUCTIVE_REGEX,
+  DANGEROUS_HREF,
+  EXPECTED_ERRORS_WHITELIST,
+  isWhitelisted,
+  setupErrorCollectors,
+  getClickables,
+  isSafeToClick,
+  closeOpenedOverlays,
+  clickSafe,
+  formatRouteReport,
+};

--- a/frontend/e2e/tests/site-smoke-crawler.spec.cjs
+++ b/frontend/e2e/tests/site-smoke-crawler.spec.cjs
@@ -1,0 +1,158 @@
+/**
+ * Site smoke crawler.
+ *
+ * Каждый route - отдельный test. Логин раз на worker через beforeAll
+ * (StorageState переиспользуется на serial-тестах внутри describe).
+ *
+ * Алгоритм для каждого route:
+ * 1. setupErrorCollectors на page
+ * 2. navigate(route)
+ * 3. waitForLoadState networkidle (5s soft timeout)
+ * 4. собрать clickables
+ * 5. кликнуть каждый safe-clickable, после клика - закрыть overlays, вернуться на route если URL изменился
+ * 6. assert: 0 pageerror, 0 неотфильтрованных console.error
+ *
+ * Запуск:
+ *   E2E_BASE_URL=https://stagingburo.washka17.site \
+ *   E2E_HTTP_USER=admin E2E_HTTP_PASSWORD=... \
+ *   E2E_SUPERADMIN_USER=buropropuskov E2E_SUPERADMIN_PASSWORD=admin123 \
+ *     npx playwright test e2e/tests/site-smoke-crawler.spec.cjs --reporter=list
+ */
+
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const path = require('node:path');
+const { loginAsSuperAdminUI } = require('../helpers/auth');
+const {
+  setupErrorCollectors,
+  getClickables,
+  clickSafe,
+  closeOpenedOverlays,
+  formatRouteReport,
+} = require('../helpers/site-crawler.cjs');
+
+const MAX_CLICKS_PER_PAGE = Number(process.env.E2E_CRAWL_MAX_CLICKS) || 50;
+const REPORT_DIR = path.resolve(__dirname, '..', '..', 'site-crawl-reports');
+
+// Список роутов взят из frontend/src/router.js. Пропущены:
+// - / (redirect на /news для authenticated)
+// - /submit-form (redirect на /new-application)
+// - /table (redirect на /personal-cabinet)
+// - /table/:tableName (нужен параметр - не unit-навигация)
+const ROUTES = [
+  { path: '/news', name: 'NewsAndReview' },
+  { path: '/personal-cabinet', name: 'Account' },
+  { path: '/carsview', name: 'CarsView' },
+  { path: '/center', name: 'ApplicationsCenter' },
+  { path: '/employeesview', name: 'EmployeeView' },
+  { path: '/table-constructor', name: 'TableConstructor' },
+  { path: '/number-format', name: 'NumberFormat' },
+  { path: '/new-application', name: 'NewApplication' },
+  { path: '/admin/feedback', name: 'FeedbackPage' },
+  { path: '/admin/requests', name: 'RequestsView' },
+  { path: '/admin/settings', name: 'AdminSettings' },
+  { path: '/admin/users', name: 'AdminUsers' },
+  { path: '/admin/permission-groups', name: 'AdminPermissionGroups' },
+  { path: '/admin/roles', name: 'AdminRoles' },
+  { path: '/admin/access-denials', name: 'AccessDenialsLog' },
+  { path: '/admin/system-control', name: 'SystemControl' },
+  { path: '/403', name: 'Forbidden' },
+  { path: '/maintenance', name: 'Maintenance' },
+  { path: '/500', name: 'Error500' },
+];
+
+if (!fs.existsSync(REPORT_DIR)) fs.mkdirSync(REPORT_DIR, { recursive: true });
+
+const REPORT_PATH = path.join(REPORT_DIR, `crawl-${Date.now()}.md`);
+const reportSink = fs.createWriteStream(REPORT_PATH, { flags: 'a' });
+reportSink.write(`# Site smoke crawl\n\nbase: ${process.env.E2E_BASE_URL || 'http://localhost:8081'}\nstarted: ${new Date().toISOString()}\n\n`);
+
+// retries=0 чтобы не множить отчёты при flakiness и не упираться в rate-limit /login
+test.describe.configure({ retries: 0 });
+
+test.describe('Site smoke crawler', () => {
+  // Логинимся один раз через storageState чтобы переиспользовать на всех routes.
+  // Не используем worker fixture - serial выполнение всех routes в одном browser context.
+  let authState;
+
+  test.beforeAll(async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await loginAsSuperAdminUI(page);
+    authState = await context.storageState();
+    await context.close();
+  });
+
+  for (const route of ROUTES) {
+    test(`route ${route.path} (${route.name})`, async ({ browser }) => {
+      test.setTimeout(120_000);
+
+      const context = await browser.newContext({ storageState: authState });
+      const page = await context.newPage();
+      const collectors = setupErrorCollectors(page);
+
+      const results = {
+        totalFound: 0,
+        clicked: 0,
+        skipped: 0,
+        failures: [],
+      };
+
+      try {
+        await page.goto(route.path, { waitUntil: 'domcontentloaded', timeout: 30_000 });
+        await page.waitForLoadState('networkidle', { timeout: 5_000 }).catch(() => {});
+        // дать SPA время отрисоваться
+        await page.waitForTimeout(500);
+
+        const clickables = getClickables(page);
+        const count = await clickables.count();
+        results.totalFound = count;
+        const clicksToTry = Math.min(count, MAX_CLICKS_PER_PAGE);
+
+        for (let i = 0; i < clicksToTry; i++) {
+          // Каждый раз заново получаем locator - DOM мог измениться после прошлого клика
+          const locator = getClickables(page).nth(i);
+          if (!(await locator.isVisible({ timeout: 200 }).catch(() => false))) continue;
+
+          const res = await clickSafe(page, locator);
+          if (res.skipped) {
+            results.skipped++;
+            continue;
+          }
+          if (!res.clicked) {
+            results.failures.push({ text: '<click-failed>', reason: res.reason });
+            continue;
+          }
+          results.clicked++;
+
+          // если URL изменился - возвращаемся на route
+          if (res.urlChanged && !page.url().endsWith(route.path)) {
+            await page.goto(route.path, { waitUntil: 'domcontentloaded', timeout: 15_000 }).catch(() => {});
+            await page.waitForTimeout(300);
+          }
+          // закрываем любую открывшуюся модалку/dropdown
+          await closeOpenedOverlays(page);
+        }
+      } finally {
+        const errors = {
+          pageErrors: collectors.getPageErrors(),
+          consoleErrors: collectors.getConsoleErrors(),
+          consoleWarnings: collectors.getConsoleWarnings(),
+        };
+        reportSink.write(formatRouteReport({ route, results, errors }));
+        await context.close();
+
+        // soft asserts через expect - можно увидеть несколько проблем сразу
+        expect.soft(errors.pageErrors, `pageerror на ${route.path}:\n${JSON.stringify(errors.pageErrors, null, 2)}`).toHaveLength(0);
+        expect.soft(errors.consoleErrors, `console.error на ${route.path}:\n${JSON.stringify(errors.consoleErrors.slice(0, 5), null, 2)}`).toHaveLength(0);
+      }
+    });
+  }
+
+  test.afterAll(() => {
+    reportSink.write(`\nfinished: ${new Date().toISOString()}\n`);
+    reportSink.end();
+    // eslint-disable-next-line no-console
+    console.log(`\n[site-smoke-crawler] report: ${REPORT_PATH}`);
+  });
+});

--- a/frontend/playwright.config.cjs
+++ b/frontend/playwright.config.cjs
@@ -20,6 +20,9 @@ module.exports = defineConfig({
     '**/navigation.spec.{js,cjs}',
     '**/cabinet.spec.{js,cjs}',
     '**/admin-access.spec.{js,cjs}',
+    // Тяжёлый smoke-crawler ~3-5 минут, требует staging credentials.
+    // Запускается отдельным workflow site-smoke.yml через workflow_dispatch.
+    '**/site-smoke-crawler.spec.{js,cjs}',
   ],
   use: {
     baseURL: process.env.E2E_BASE_URL || 'http://localhost:8081',


### PR DESCRIPTION
Краулер обходит все роуты фронта (19 routes из router.js), кликает все безопасные кнопки кроме destructive (Удалить/Сбросить/Сохранить и т.п.), собирает pageerror + console.error.

**Прогон против staging локально: ALL 19 PASS за ~3.5 мин, 0 console errors.**

Запуск manual через workflow_dispatch (`.github/workflows/site-smoke.yml`) или локально:

```
E2E_BASE_URL=https://stagingburo.washka17.site \
E2E_HTTP_USER=admin E2E_HTTP_PASSWORD=*** \
E2E_SUPERADMIN_USER=buropropuskov E2E_SUPERADMIN_PASSWORD=admin123 \
E2E_API_BASE_URL=https://stagingburo.washka17.site/api \
  npx playwright test e2e/tests/site-smoke-crawler.spec.cjs --workers=1 --reporter=list
```

Отчёт в `frontend/site-crawl-reports/crawl-*.md` (gitignored).

В обычном CI этот spec **не запускается** (добавлен в `playwright.config.cjs testIgnore`) - тяжёлый, нужны staging credentials.

## Перед запуском workflow на CI
Добавить в repo secrets для environment 'staging':
- STAGING_BASIC_AUTH_USER, STAGING_BASIC_AUTH_PASSWORD (basic auth nginx)
- STAGING_SUPERADMIN_PASSWORD (пароль buropropuskov)