### PR TITLE
fix(ci): site-smoke spec блокировался testIgnore

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -113,7 +113,9 @@ jobs:
 
       - name: Run Playwright tests (shard ${{ matrix.shard }}/${{ matrix.totalShards }})
         working-directory: frontend
-        run: npx playwright test --project=chromium --shard=${{ matrix.shard }}/${{ matrix.totalShards }}
+        # --grep-invert site-smoke - тяжёлый crawler (5+ мин против staging)
+        # запускается отдельно через site-smoke.yml workflow_dispatch.
+        run: npx playwright test --project=chromium --shard=${{ matrix.shard }}/${{ matrix.totalShards }} --grep-invert "Site smoke"
 
       - name: Upload Playwright report
         if: failure()

--- a/frontend/playwright.config.cjs
+++ b/frontend/playwright.config.cjs
@@ -20,9 +20,6 @@ module.exports = defineConfig({
     '**/navigation.spec.{js,cjs}',
     '**/cabinet.spec.{js,cjs}',
     '**/admin-access.spec.{js,cjs}',
-    // Тяжёлый smoke-crawler ~3-5 минут, требует staging credentials.
-    // Запускается отдельным workflow site-smoke.yml через workflow_dispatch.
-    '**/site-smoke-crawler.spec.{js,cjs}',
   ],
   use: {
     baseURL: process.env.E2E_BASE_URL || 'http://localhost:8081',


### PR DESCRIPTION
testIgnore работает даже когда playwright test указывает конкретный файл - 'No tests found'. Убрал из testIgnore, обычный e2e CI shards добавил --grep-invert 'Site smoke'.