### PR TITLE
test(e2e): AdminUsers + Notifications покрытие

### DIFF
--- a/frontend/e2e/pages/AdminUsersPage.cjs
+++ b/frontend/e2e/pages/AdminUsersPage.cjs
@@ -1,0 +1,44 @@
+class AdminUsersPage {
+  constructor(page) {
+    this.page = page;
+    this.title = page.getByRole('heading', { name: 'Управление пользователями' });
+    this.searchInput = page.locator('.admin-users__search-input');
+    this.rows = page.locator('.admin-users table tbody tr');
+    this.emptyMessage = page.locator('.admin-users').getByText(/Пользователи не найдены|Нет пользователей/);
+
+    // Right-side detail panel когда выбран юзер
+    this.detail = page.locator('.admin-users__detail, .admin-users__detail-panel').first();
+    this.tabInfo = page.getByRole('button', { name: 'Основные' });
+    this.tabPermissions = page.getByRole('button', { name: 'Разрешения' });
+    this.permissionsRoleGroupsButton = page.getByRole('button', { name: 'Роль и группы прав' });
+    this.resetPasswordButton = page.getByRole('button', { name: 'Сбросить пароль' });
+    this.deleteButton = page.getByRole('button', { name: 'Удалить' });
+
+    // Reset password modal
+    this.passwordModal = page.getByRole('dialog', { name: /Сброс пароля/ });
+    this.passwordInput = this.passwordModal.getByRole('textbox', { name: /пароль/i });
+    this.passwordSave = this.passwordModal.getByRole('button', { name: 'Сохранить' });
+    this.passwordCancel = this.passwordModal.getByRole('button', { name: /Отмена|Закрыть/ });
+  }
+
+  async goto() {
+    await this.page.goto('/admin/users');
+    await this.title.waitFor({ state: 'visible' });
+  }
+
+  async search(query) {
+    await this.searchInput.fill(query);
+    await this.page.waitForTimeout(200);
+  }
+
+  rowByLogin(login) {
+    return this.page.locator(`tr:has-text("${login}")`);
+  }
+
+  async selectUserByLogin(login) {
+    await this.rowByLogin(login).click();
+    await this.tabInfo.waitFor({ state: 'visible' });
+  }
+}
+
+module.exports = { AdminUsersPage };

--- a/frontend/e2e/pages/NotificationsDropdown.cjs
+++ b/frontend/e2e/pages/NotificationsDropdown.cjs
@@ -1,0 +1,31 @@
+class NotificationsDropdown {
+  constructor(page) {
+    this.page = page;
+    this.bell = page.locator('.user__notifications').first();
+    this.badge = this.bell.locator('.notification-badge, span').first();
+    this.panel = page.locator('.notifications').first();
+    this.title = this.panel.locator('.notifications__title');
+    this.unreadCount = this.panel.locator('.notifications__unread-count');
+    this.emptyText = this.panel.locator('.notifications__empty-text');
+    this.clearAllButton = this.panel.locator('.notifications__clear-btn');
+    this.items = this.panel.locator('.notification-item, .notifications__item');
+  }
+
+  async open() {
+    await this.bell.click();
+    await this.panel.waitFor({ state: 'visible' });
+  }
+
+  async close() {
+    if (await this.panel.isVisible().catch(() => false)) {
+      await this.bell.click();
+      await this.panel.waitFor({ state: 'hidden' }).catch(() => {});
+    }
+  }
+
+  async isOpen() {
+    return this.panel.isVisible().catch(() => false);
+  }
+}
+
+module.exports = { NotificationsDropdown };

--- a/frontend/e2e/tests/admin-users.spec.cjs
+++ b/frontend/e2e/tests/admin-users.spec.cjs
@@ -1,0 +1,55 @@
+const { test, expect } = require('@playwright/test');
+const { loginAsSuperAdminUI } = require('../helpers/auth');
+const { AdminUsersPage } = require('../pages/AdminUsersPage');
+
+// Целевой юзер для не-destructive операций - изолированный seed-аккаунт.
+// На local CI seed создаёт e2e_user (type_id=1).
+// На staging вручную создан testuser_f5 для smoke-проверок.
+const TARGET_USER_LOGIN = process.env.E2E_TARGET_USER || 'e2e_user';
+
+test.describe('Admin / Users', () => {
+  test('страница списка пользователей открывается у супер-админа', async ({ page }) => {
+    await loginAsSuperAdminUI(page);
+    const usersPage = new AdminUsersPage(page);
+    await usersPage.goto();
+
+    await expect(usersPage.title).toBeVisible();
+    const count = await usersPage.rows.count();
+    expect(count).toBeGreaterThanOrEqual(1);
+  });
+
+  test('поиск фильтрует пользователей по логину', async ({ page }) => {
+    await loginAsSuperAdminUI(page);
+    const usersPage = new AdminUsersPage(page);
+    await usersPage.goto();
+
+    const totalBefore = await usersPage.rows.count();
+    await usersPage.search(TARGET_USER_LOGIN);
+
+    const filteredCount = await usersPage.rows.count();
+    expect(filteredCount).toBeGreaterThanOrEqual(1);
+    expect(filteredCount).toBeLessThanOrEqual(totalBefore);
+    await expect(usersPage.rowByLogin(TARGET_USER_LOGIN)).toBeVisible();
+  });
+
+  test('бессмысленный поиск показывает empty state', async ({ page }) => {
+    await loginAsSuperAdminUI(page);
+    const usersPage = new AdminUsersPage(page);
+    await usersPage.goto();
+
+    await usersPage.search('___no_such_user___xyz');
+    await expect(usersPage.emptyMessage).toBeVisible({ timeout: 5000 });
+  });
+
+  test('выбор пользователя показывает detail-панель с табами', async ({ page }) => {
+    await loginAsSuperAdminUI(page);
+    const usersPage = new AdminUsersPage(page);
+    await usersPage.goto();
+
+    await usersPage.selectUserByLogin(TARGET_USER_LOGIN);
+
+    await expect(usersPage.tabInfo).toBeVisible();
+    await expect(usersPage.permissionsRoleGroupsButton).toBeVisible();
+    await expect(usersPage.resetPasswordButton).toBeVisible();
+  });
+});

--- a/frontend/e2e/tests/notifications.spec.cjs
+++ b/frontend/e2e/tests/notifications.spec.cjs
@@ -1,0 +1,42 @@
+const { test, expect } = require('@playwright/test');
+const { loginAsSuperAdminUI } = require('../helpers/auth');
+const { NotificationsDropdown } = require('../pages/NotificationsDropdown');
+
+test.describe('Notifications dropdown', () => {
+  test('иконка уведомлений видна в шапке', async ({ page }) => {
+    await loginAsSuperAdminUI(page);
+    await page.goto('/news');
+
+    const dropdown = new NotificationsDropdown(page);
+    await expect(dropdown.bell).toBeVisible();
+  });
+
+  test('клик по иконке открывает панель уведомлений', async ({ page }) => {
+    await loginAsSuperAdminUI(page);
+    await page.goto('/news');
+
+    const dropdown = new NotificationsDropdown(page);
+    await dropdown.open();
+
+    await expect(dropdown.title).toHaveText(/Уведомления/);
+    // panel должна показать либо empty state, либо items - оба валидны
+    const itemsCount = await dropdown.items.count();
+    if (itemsCount === 0) {
+      await expect(dropdown.emptyText).toBeVisible();
+    } else {
+      expect(itemsCount).toBeGreaterThan(0);
+    }
+  });
+
+  test('повторный клик закрывает панель', async ({ page }) => {
+    await loginAsSuperAdminUI(page);
+    await page.goto('/news');
+
+    const dropdown = new NotificationsDropdown(page);
+    await dropdown.open();
+    await expect(dropdown.panel).toBeVisible();
+
+    await dropdown.close();
+    await expect(dropdown.panel).toBeHidden();
+  });
+});


### PR DESCRIPTION
AdminUsers spec: list, search, empty state, select user (4 теста).
Notifications dropdown spec: bell visible, open, close (3 теста).

CreateUserModal.vue существует в коде но НИГДЕ не используется (dead code или не подключённая feature) - тест создания юзера через UI не написан.