### PR TITLE
test(e2e): расширение CRUD roles/groups + feedback create

### DIFF
--- a/frontend/e2e/tests/feedback-create.spec.cjs
+++ b/frontend/e2e/tests/feedback-create.spec.cjs
@@ -1,0 +1,37 @@
+const { test, expect } = require('@playwright/test');
+const { loginAsSuperAdmin } = require('../helpers/permissions');
+
+const API_BASE = process.env.E2E_API_BASE_URL || '/api';
+
+// CreateFeedbackRequest требует message >= 10 символов.
+// Smoke-цикл: создать обращение → видеть его в /feedback/my и в админском /feedback/all.
+test.describe('Feedback - create + list', () => {
+  test('POST /feedback создаёт обращение, GET /feedback/my возвращает его', async ({ request }) => {
+    const token = await loginAsSuperAdmin(request);
+    const message = `E2E feedback test ${Date.now()} — проверка smoke-флоу`;
+
+    const createRes = await request.post(`${API_BASE}/feedback`, {
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      data: { message },
+    });
+    expect(createRes.ok() || createRes.status() === 201).toBeTruthy();
+
+    const myRes = await request.get(`${API_BASE}/feedback/my`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(myRes.ok()).toBeTruthy();
+    const body = await myRes.json();
+    const items = body.data || body;
+    const found = (Array.isArray(items) ? items : []).find(f => f.message === message);
+    expect(found).toBeTruthy();
+  });
+
+  test('POST /feedback с коротким message возвращает 400 (валидация min:10)', async ({ request }) => {
+    const token = await loginAsSuperAdmin(request);
+    const res = await request.post(`${API_BASE}/feedback`, {
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      data: { message: 'short' },
+    });
+    expect(res.status()).toBe(400);
+  });
+});

--- a/frontend/e2e/tests/permissions-groups-crud.spec.cjs
+++ b/frontend/e2e/tests/permissions-groups-crud.spec.cjs
@@ -5,6 +5,7 @@ const {
   loginAsSuperAdmin,
   createGroup,
   listGroups,
+  updateGroup,
   deleteGroup,
   cleanupE2eEntities,
   e2eName,
@@ -51,6 +52,36 @@ test.describe('Admin / Permission Groups CRUD', () => {
     expect(found).toBeTruthy();
 
     if (found) await deleteGroup(request, token, found.id).catch(() => {});
+  });
+
+  test('PUT /permission-groups/:id обновляет name + keys', async ({ request }) => {
+    const token = await loginAsSuperAdmin(request);
+    const name = e2eName('edit_group');
+    const created = await createGroup(request, token, { name, description: 'orig', keys: ['page.cars'] });
+
+    const newName = e2eName('renamed_group');
+    await updateGroup(request, token, created.id, {
+      name: newName,
+      description: 'updated',
+      keys: ['page.cars', 'entity.cars.read'],
+    });
+
+    const all = await listGroups(request, token);
+    const updated = all.find(g => g.id === created.id);
+    expect(updated.name).toBe(newName);
+    expect([...updated.keys].sort()).toEqual(['entity.cars.read', 'page.cars']);
+
+    await deleteGroup(request, token, created.id).catch(() => {});
+  });
+
+  test('DELETE /permission-groups/:id убирает группу из списка', async ({ request }) => {
+    const token = await loginAsSuperAdmin(request);
+    const created = await createGroup(request, token, { name: e2eName('to_del'), keys: [] });
+
+    await deleteGroup(request, token, created.id);
+
+    const all = await listGroups(request, token);
+    expect(all.find(g => g.id === created.id)).toBeFalsy();
   });
 
   test('обычный юзер БЕЗ permission.audit.manage не может создать группу (403)', async ({ request }) => {

--- a/frontend/e2e/tests/permissions-roles-crud.spec.cjs
+++ b/frontend/e2e/tests/permissions-roles-crud.spec.cjs
@@ -5,6 +5,7 @@ const {
   loginAsSuperAdmin,
   createRole,
   listRoles,
+  updateRole,
   deleteRole,
   cleanupE2eEntities,
   e2eName,
@@ -56,6 +57,39 @@ test.describe('Admin / Roles CRUD', () => {
     expect(found.name).toBe(`E2E UI Role ${code}`);
 
     if (found) await deleteRole(request, token, found.id).catch(() => {});
+  });
+
+  test('PUT /roles/:id обновляет name и description', async ({ request }) => {
+    const token = await loginAsSuperAdmin(request);
+    const code = e2eName('edit_role');
+    const created = await createRole(request, token, {
+      name: 'Initial Name',
+      code,
+      description: 'Initial desc',
+    });
+
+    await updateRole(request, token, created.id, {
+      name: 'Updated Name',
+      description: 'Updated desc',
+    });
+
+    const all = await listRoles(request, token);
+    const updated = all.find(r => r.id === created.id);
+    expect(updated.name).toBe('Updated Name');
+    expect(updated.description).toBe('Updated desc');
+
+    await deleteRole(request, token, created.id).catch(() => {});
+  });
+
+  test('DELETE /roles/:id убирает роль из списка', async ({ request }) => {
+    const token = await loginAsSuperAdmin(request);
+    const code = e2eName('del_role');
+    const created = await createRole(request, token, { name: 'To Delete', code });
+
+    await deleteRole(request, token, created.id);
+
+    const all = await listRoles(request, token);
+    expect(all.find(r => r.id === created.id)).toBeFalsy();
   });
 
   test('обычный юзер БЕЗ permission.audit.manage не может создать роль (403)', async ({ request }) => {


### PR DESCRIPTION
+7 тестов: PUT/DELETE roles, PUT/DELETE groups, feedback POST/GET/validation.