### PR TITLE
test(e2e): API CRUD news + announcements + notifications

### DIFF
--- a/frontend/e2e/tests/announcements-api.spec.cjs
+++ b/frontend/e2e/tests/announcements-api.spec.cjs
@@ -1,0 +1,68 @@
+const { test, expect } = require('@playwright/test');
+const { loginAsSuperAdmin } = require('../helpers/permissions');
+
+const API_BASE = process.env.E2E_API_BASE_URL || '/api';
+
+function headers(token) {
+  return { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+}
+
+test.describe('Announcements API', () => {
+  const createdIds = [];
+
+  test.afterAll(async ({ request }) => {
+    const token = await loginAsSuperAdmin(request).catch(() => null);
+    if (!token) return;
+    for (const id of createdIds) {
+      await request.delete(`${API_BASE}/announcements/${id}`, { headers: headers(token) }).catch(() => {});
+    }
+  });
+
+  test('POST /announcements + GET /announcements/all + set-active', async ({ request }) => {
+    const token = await loginAsSuperAdmin(request);
+    const title = `E2E Announcement ${Date.now()}`;
+    const res = await request.post(`${API_BASE}/announcements`, {
+      headers: headers(token),
+      data: { title, description: 'тестовое объявление', is_important: false },
+    });
+    expect(res.ok() || res.status() === 201).toBeTruthy();
+    const created = (await res.json()).data;
+    createdIds.push(created.id);
+    expect(created.title).toBe(title);
+
+    const allRes = await request.get(`${API_BASE}/announcements/all`, { headers: headers(token) });
+    const all = (await allRes.json()).data || [];
+    expect(all.find(a => a.id === created.id)).toBeTruthy();
+
+    // set-active: делаем объявление активным
+    const setActiveRes = await request.post(`${API_BASE}/announcements/set-active`, {
+      headers: headers(token),
+      data: { announcement_id: created.id },
+    });
+    expect(setActiveRes.ok()).toBeTruthy();
+
+    // GET /active возвращает наше объявление
+    const activeRes = await request.get(`${API_BASE}/announcements/active`, { headers: headers(token) });
+    const active = (await activeRes.json()).data;
+    expect(active?.id).toBe(created.id);
+  });
+
+  test('PUT /announcements/:id и DELETE', async ({ request }) => {
+    const token = await loginAsSuperAdmin(request);
+    const createRes = await request.post(`${API_BASE}/announcements`, {
+      headers: headers(token),
+      data: { title: `E2E Upd ${Date.now()}`, description: 'orig' },
+    });
+    const created = (await createRes.json()).data;
+
+    const newTitle = `Updated ${Date.now()}`;
+    const upRes = await request.put(`${API_BASE}/announcements/${created.id}`, {
+      headers: headers(token),
+      data: { title: newTitle },
+    });
+    expect(upRes.ok()).toBeTruthy();
+
+    const delRes = await request.delete(`${API_BASE}/announcements/${created.id}`, { headers: headers(token) });
+    expect(delRes.ok() || delRes.status() === 204).toBeTruthy();
+  });
+});

--- a/frontend/e2e/tests/news-api.spec.cjs
+++ b/frontend/e2e/tests/news-api.spec.cjs
@@ -1,0 +1,74 @@
+const { test, expect } = require('@playwright/test');
+const { loginAsSuperAdmin } = require('../helpers/permissions');
+
+const API_BASE = process.env.E2E_API_BASE_URL || '/api';
+
+function headers(token) {
+  return { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+}
+
+test.describe('News API - CRUD', () => {
+  const createdIds = [];
+
+  test.afterAll(async ({ request }) => {
+    const token = await loginAsSuperAdmin(request).catch(() => null);
+    if (!token) return;
+    for (const id of createdIds) {
+      await request.delete(`${API_BASE}/news/${id}`, { headers: headers(token) }).catch(() => {});
+    }
+  });
+
+  test('POST /news создаёт новость, GET /news/all возвращает её', async ({ request }) => {
+    const token = await loginAsSuperAdmin(request);
+    const title = `E2E News ${Date.now()}`;
+    const res = await request.post(`${API_BASE}/news`, {
+      headers: headers(token),
+      data: { title, description: 'e2e desc', is_active: true },
+    });
+    expect(res.ok() || res.status() === 201).toBeTruthy();
+    const created = (await res.json()).data;
+    createdIds.push(created.id);
+    expect(created.title).toBe(title);
+
+    const listRes = await request.get(`${API_BASE}/news/all`, { headers: headers(token) });
+    expect(listRes.ok()).toBeTruthy();
+    const all = (await listRes.json()).data || [];
+    expect(all.find(n => n.id === created.id)).toBeTruthy();
+  });
+
+  test('PUT /news/:id обновляет title', async ({ request }) => {
+    const token = await loginAsSuperAdmin(request);
+    const createRes = await request.post(`${API_BASE}/news`, {
+      headers: headers(token),
+      data: { title: 'Initial', description: 'd', is_active: true },
+    });
+    const created = (await createRes.json()).data;
+    createdIds.push(created.id);
+
+    const newTitle = `Updated ${Date.now()}`;
+    const upRes = await request.put(`${API_BASE}/news/${created.id}`, {
+      headers: headers(token),
+      data: { title: newTitle },
+    });
+    expect(upRes.ok()).toBeTruthy();
+
+    const listRes = await request.get(`${API_BASE}/news/all`, { headers: headers(token) });
+    const updated = ((await listRes.json()).data || []).find(n => n.id === created.id);
+    expect(updated.title).toBe(newTitle);
+  });
+
+  test('DELETE /news/:id убирает новость', async ({ request }) => {
+    const token = await loginAsSuperAdmin(request);
+    const createRes = await request.post(`${API_BASE}/news`, {
+      headers: headers(token),
+      data: { title: 'To delete', is_active: true },
+    });
+    const created = (await createRes.json()).data;
+
+    const delRes = await request.delete(`${API_BASE}/news/${created.id}`, { headers: headers(token) });
+    expect(delRes.ok() || delRes.status() === 204).toBeTruthy();
+
+    const listRes = await request.get(`${API_BASE}/news/all`, { headers: headers(token) });
+    expect(((await listRes.json()).data || []).find(n => n.id === created.id)).toBeFalsy();
+  });
+});

--- a/frontend/e2e/tests/notifications-api.spec.cjs
+++ b/frontend/e2e/tests/notifications-api.spec.cjs
@@ -1,0 +1,50 @@
+const { test, expect } = require('@playwright/test');
+const { loginAsSuperAdmin } = require('../helpers/permissions');
+
+const API_BASE = process.env.E2E_API_BASE_URL || '/api';
+
+function headers(token) {
+  return { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+}
+
+// Получаем user_id из JWT - нужно чтобы создать notification для самого себя
+function userIdFromToken(token) {
+  const payload = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString());
+  return payload.user_id;
+}
+
+test.describe('Notifications API', () => {
+  test('POST /notifications + GET /notifications + mark-read + delete', async ({ request }) => {
+    const token = await loginAsSuperAdmin(request);
+    const myId = userIdFromToken(token);
+
+    const title = `E2E Notif ${Date.now()}`;
+    const createRes = await request.post(`${API_BASE}/notifications`, {
+      headers: headers(token),
+      data: { user_id: myId, title, message: 'test message', type: 'info' },
+    });
+    expect(createRes.ok() || createRes.status() === 201).toBeTruthy();
+    const created = (await createRes.json()).data;
+    expect(created.title).toBe(title);
+
+    // GET /notifications возвращает мои уведомления
+    const listRes = await request.get(`${API_BASE}/notifications`, { headers: headers(token) });
+    expect(listRes.ok()).toBeTruthy();
+    const body = await listRes.json();
+    const list = body.data || body;
+    const items = Array.isArray(list) ? list : (list.items || []);
+    const found = items.find(n => n.id === created.id);
+    expect(found).toBeTruthy();
+
+    // mark-read
+    const readRes = await request.put(`${API_BASE}/notifications/${created.id}/read`, {
+      headers: headers(token),
+      data: { is_read: true },
+    });
+    expect(readRes.ok()).toBeTruthy();
+
+    // delete
+    const delRes = await request.delete(`${API_BASE}/notifications/${created.id}`, { headers: headers(token) });
+    expect(delRes.ok() || delRes.status() === 204).toBeTruthy();
+  });
+});


### PR DESCRIPTION
+7 тестов через API: news CRUD, announcements CRUD + set-active, notifications create/mark-read/delete.