### PR TITLE
test(e2e): groups UI tree/delete + denials manage

### DIFF
--- a/frontend/e2e/pages/AdminPermissionGroupsPage.cjs
+++ b/frontend/e2e/pages/AdminPermissionGroupsPage.cjs
@@ -82,6 +82,21 @@ class AdminPermissionGroupsPage {
     }
     await this.treeModal.getByText(key, { exact: false }).first().click();
   }
+
+  /**
+   * Открыть rename-модалку для редактирования имени/описания группы.
+   * В AdminPermissionGroups.vue нет отдельной кнопки rename - "Редактировать"
+   * открывает PermissionTreeModal. Тест только подтверждает что нажатие
+   * корректно открывает дерево.
+   */
+  async clickEditTree(name) {
+    await this.card(name).getByRole('button', { name: 'Редактировать' }).click();
+    await this.treeModal.waitFor({ state: 'visible' });
+  }
+
+  async clickDelete(name) {
+    await this.card(name).getByRole('button', { name: 'Удалить' }).click();
+  }
 }
 
 module.exports = { AdminPermissionGroupsPage };

--- a/frontend/e2e/tests/admin-denials-manage-api.spec.cjs
+++ b/frontend/e2e/tests/admin-denials-manage-api.spec.cjs
@@ -1,0 +1,37 @@
+const { test, expect } = require('@playwright/test');
+const { loginAsSuperAdmin } = require('../helpers/permissions');
+
+const API_BASE = process.env.E2E_API_BASE_URL || '/api';
+
+function headers(token) {
+  return { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+}
+
+test.describe('AccessDenials - manage actions API', () => {
+  test('GET /access-denials/archive возвращает архив', async ({ request }) => {
+    const token = await loginAsSuperAdmin(request);
+    const res = await request.get(`${API_BASE}/access-denials/archive`, { headers: headers(token) });
+    expect(res.ok()).toBeTruthy();
+    const body = await res.json();
+    const data = body.data || body;
+    expect(Array.isArray(data) || Array.isArray(data.items) || 'total' in data).toBeTruthy();
+  });
+
+  test('POST /access-denials/archive с пустым фильтром не падает', async ({ request }) => {
+    const token = await loginAsSuperAdmin(request);
+    // ArchiveOlderThan endpoint - принимает cutoff в payload или query
+    const res = await request.post(`${API_BASE}/access-denials/archive`, {
+      headers: headers(token),
+      data: { cutoff: new Date('2020-01-01').toISOString() },
+    });
+    // OK или 400 при невалидном payload - всё кроме 5xx приемлемо
+    expect(res.status()).toBeLessThan(500);
+  });
+
+  test('DELETE /access-denials с фильтром по несуществующему user_id', async ({ request }) => {
+    const token = await loginAsSuperAdmin(request);
+    const res = await request.delete(`${API_BASE}/access-denials?user_id=999999`, { headers: headers(token) });
+    // Может вернуть 200 (0 удалено) либо 204
+    expect(res.status()).toBeLessThan(500);
+  });
+});

--- a/frontend/e2e/tests/admin-groups-ui-delete.spec.cjs
+++ b/frontend/e2e/tests/admin-groups-ui-delete.spec.cjs
@@ -1,0 +1,56 @@
+const { test, expect } = require('@playwright/test');
+const { loginAsSuperAdminUI } = require('../helpers/auth');
+const { AdminPermissionGroupsPage } = require('../pages/AdminPermissionGroupsPage');
+const {
+  loginAsSuperAdmin,
+  createGroup,
+  listGroups,
+  cleanupE2eEntities,
+  e2eName,
+} = require('../helpers/permissions');
+
+test.describe('AdminPermissionGroups - UI delete + tree open', () => {
+  test.afterAll(async ({ request }) => {
+    await cleanupE2eEntities(request).catch(() => {});
+  });
+
+  test('Клик Редактировать открывает PermissionTreeModal с правами группы', async ({ page, request }) => {
+    const token = await loginAsSuperAdmin(request);
+    const name = e2eName('ui_tree');
+    await createGroup(request, token, { name, keys: ['page.cars'] });
+
+    await loginAsSuperAdminUI(page);
+    const groupsPage = new AdminPermissionGroupsPage(page);
+    await groupsPage.goto();
+
+    await groupsPage.clickEditTree(name);
+    await expect(groupsPage.treeModal).toBeVisible();
+    // page.cars должен быть выбран (он в группе)
+    const carsKey = groupsPage.treeKey('page.cars');
+    await groupsPage.expandGroup('page');
+    await expect(carsKey).toBeVisible();
+    const checkbox = carsKey.locator('input[type="checkbox"]');
+    await expect(checkbox).toBeChecked();
+
+    await groupsPage.treeCancel.click();
+    await expect(groupsPage.treeModal).toBeHidden();
+  });
+
+  test('Delete группы через UI убирает карточку и удаляет в API', async ({ page, request }) => {
+    const token = await loginAsSuperAdmin(request);
+    const name = e2eName('ui_del_grp');
+    const created = await createGroup(request, token, { name, keys: [] });
+
+    await loginAsSuperAdminUI(page);
+    const groupsPage = new AdminPermissionGroupsPage(page);
+    await groupsPage.goto();
+
+    page.once('dialog', dialog => dialog.accept().catch(() => {}));
+    await groupsPage.clickDelete(name);
+
+    await expect(groupsPage.card(name)).toHaveCount(0, { timeout: 5000 });
+
+    const all = await listGroups(request, token);
+    expect(all.find(g => g.id === created.id)).toBeFalsy();
+  });
+});


### PR DESCRIPTION
+5 тестов.