### PR TITLE
test(e2e): news/announcements GET active + hide

### DIFF
--- a/frontend/e2e/tests/announcements-api.spec.cjs
+++ b/frontend/e2e/tests/announcements-api.spec.cjs
@@ -47,6 +47,27 @@ test.describe('Announcements API', () => {
     expect(active?.id).toBe(created.id);
   });
 
+  test('POST /announcements/:id/hide делает is_active=false', async ({ request }) => {
+    const token = await loginAsSuperAdmin(request);
+    const createRes = await request.post(`${API_BASE}/announcements`, {
+      headers: headers(token),
+      data: { title: `E2E Hide ${Date.now()}`, description: 'for hide test', is_active: true },
+    });
+    const created = (await createRes.json()).data;
+    createdIds.push(created.id);
+
+    const hideRes = await request.post(`${API_BASE}/announcements/${created.id}/hide`, {
+      headers: headers(token),
+    });
+    expect(hideRes.ok()).toBeTruthy();
+
+    const allRes = await request.get(`${API_BASE}/announcements/all`, { headers: headers(token) });
+    const all = (await allRes.json()).data || [];
+    const found = all.find(a => a.id === created.id);
+    expect(found).toBeTruthy();
+    expect(found.is_active).toBeFalsy();
+  });
+
   test('PUT /announcements/:id и DELETE', async ({ request }) => {
     const token = await loginAsSuperAdmin(request);
     const createRes = await request.post(`${API_BASE}/announcements`, {

--- a/frontend/e2e/tests/news-api.spec.cjs
+++ b/frontend/e2e/tests/news-api.spec.cjs
@@ -57,6 +57,18 @@ test.describe('News API - CRUD', () => {
     expect(updated.title).toBe(newTitle);
   });
 
+  test('GET /news (active) возвращает массив активных', async ({ request }) => {
+    const token = await loginAsSuperAdmin(request);
+    const res = await request.get(`${API_BASE}/news`, { headers: headers(token) });
+    expect(res.ok()).toBeTruthy();
+    const list = (await res.json()).data || [];
+    expect(Array.isArray(list)).toBeTruthy();
+    // активные = is_active true (если есть)
+    for (const n of list) {
+      expect(n.is_active === undefined || n.is_active === true).toBeTruthy();
+    }
+  });
+
   test('DELETE /news/:id убирает новость', async ({ request }) => {
     const token = await loginAsSuperAdmin(request);
     const createRes = await request.post(`${API_BASE}/news`, {


### PR DESCRIPTION
## Summary
- \`GET /news\` (active) - проверка списка активных новостей
- \`POST /announcements/:id/hide\` - проверка скрытия (is_active=false)
- Закрывает оставшиеся ручки в news/announcements API

## Test plan
- [ ] CI shard 1-4 green