### PR TITLE
fix(security): глобальный ban-check middleware (#271)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -154,7 +154,8 @@ func main() {
 	permissionGroupService := services.NewPermissionGroupService(db, permissionResolver)
 	roleService := services.NewRoleService(db, permissionResolver)
 	accessDenialService := services.NewAccessDenialService(db)
-	userBanService := services.NewUserBanService(db, permissionResolver)
+	banCheckService := services.NewBanCheckService(db, 30*time.Second)
+	userBanService := services.NewUserBanService(db, permissionResolver, banCheckService)
 	systemTableService := services.NewSystemTableService(db, cfg.UploadPath, cfg.UploadMaxFileSize, permissionService)
 	uniqueCarService := services.NewUniqueCarService(db)
 	uniqueEmployeeService := services.NewUniqueEmployeeService(db)
@@ -217,9 +218,10 @@ func main() {
 	// (повышаем в CI/e2e чтобы серия тестов не упёрлась в лимит).
 	loginLimiter := mw.LoginRateLimit(cfg.LoginRateLimitMax, time.Duration(cfg.LoginRateLimitWindowSec)*time.Second)
 	maintenanceBlock := mw.MaintenanceBlock(maintenanceService)
+	banCheck := mw.BanCheck(banCheckService)
 
 	// Routes
-	router.Setup(e, authHandler, userTypesHandler, attachmentHandler, lpfHandler, citizenshipHandler, organizationHandler, companyHandler, usersHandler, unloadPlaceHandler, carHandler, employeeHandler, systemTableHandler, uniqueCarHandler, uniqueEmployeeHandler, feedbackHandler, applicationHandler, approverHandler, permissionHandler, permissionGroupHandler, roleHandler, accessDenialHandler, userBanHandler, consentHandler, settingsHandler, newsHandler, notificationHandler, requestLogsHandler, employeesHistoryHandler, bugReportHandler, maintenanceHandler, permissionResolver, accessDenialService, maintenanceBlock, []byte(cfg.JWTSecret), loginLimiter)
+	router.Setup(e, authHandler, userTypesHandler, attachmentHandler, lpfHandler, citizenshipHandler, organizationHandler, companyHandler, usersHandler, unloadPlaceHandler, carHandler, employeeHandler, systemTableHandler, uniqueCarHandler, uniqueEmployeeHandler, feedbackHandler, applicationHandler, approverHandler, permissionHandler, permissionGroupHandler, roleHandler, accessDenialHandler, userBanHandler, consentHandler, settingsHandler, newsHandler, notificationHandler, requestLogsHandler, employeesHistoryHandler, bugReportHandler, maintenanceHandler, permissionResolver, accessDenialService, maintenanceBlock, banCheck, []byte(cfg.JWTSecret), loginLimiter)
 
 	// Общий ctx для фоновых задач и graceful shutdown. Отменяется по SIGINT/SIGTERM.
 	ctxSig, stopSig := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/frontend/e2e/tests/ban-check-middleware.spec.cjs
+++ b/frontend/e2e/tests/ban-check-middleware.spec.cjs
@@ -1,0 +1,74 @@
+const { test, expect } = require('@playwright/test');
+const {
+  loginAsSuperAdmin,
+  banUser,
+  unbanUser,
+} = require('../helpers/permissions');
+
+const API_BASE = process.env.E2E_API_BASE_URL || '/api';
+
+const BAN_TARGET_USERNAME = process.env.E2E_BAN_TARGET_USERNAME;
+
+/**
+ * Регресс на issue #271: глобальный ban-check middleware должен немедленно
+ * возвращать 403 для забаненного пользователя даже с валидным access-токеном.
+ *
+ * До фикса JWTAuth просто декодировал токен и пускал юзера на любую protected
+ * ручку до exp - бан не работал для API-only клиентов.
+ *
+ * Требует E2E_BAN_TARGET_* как и permissions-ban-flow, без них тест skip.
+ */
+test.describe('Ban check middleware', () => {
+  test.skip(
+    !BAN_TARGET_USERNAME,
+    'E2E_BAN_TARGET_USERNAME не задан - тест пропущен',
+  );
+
+  test('забаненный юзер с валидным access-токеном получает 403 на protected ручке', async ({
+    request,
+  }) => {
+    const targetId = Number(process.env.E2E_BAN_TARGET_ID);
+    const targetPassword = process.env.E2E_BAN_TARGET_PASSWORD;
+    expect(targetId).toBeGreaterThan(0);
+    expect(targetPassword).toBeTruthy();
+    expect(targetId).not.toBe(1);
+
+    // 1. Login юзером, получаем access-токен.
+    const loginRes = await request.post(`${API_BASE}/login`, {
+      data: { username: BAN_TARGET_USERNAME, password: targetPassword },
+    });
+    expect(loginRes.ok()).toBeTruthy();
+    const userToken = (await loginRes.json()).data.token;
+    expect(userToken).toBeTruthy();
+
+    // 2. До бана - access работает.
+    const beforeBan = await request.get(`${API_BASE}/users/me`, {
+      headers: { Authorization: `Bearer ${userToken}` },
+    });
+    expect(beforeBan.status()).toBe(200);
+
+    // 3. Баним.
+    const adminToken = await loginAsSuperAdmin(request);
+    await banUser(request, adminToken, targetId);
+
+    try {
+      // 4. С тем же access (без refresh) - 403. Окно кэша 30s, поэтому
+      // в worst-case первый запрос ещё пройдёт. Делаем несколько попыток
+      // с интервалом чтобы дождаться обновления кэша.
+      const start = Date.now();
+      let lastStatus = 200;
+      while (Date.now() - start < 35_000) {
+        const res = await request.get(`${API_BASE}/users/me`, {
+          headers: { Authorization: `Bearer ${userToken}` },
+        });
+        lastStatus = res.status();
+        if (lastStatus === 403) break;
+        await new Promise(r => setTimeout(r, 2000));
+      }
+      expect(lastStatus).toBe(403);
+    } finally {
+      // 5. Разбан - очищаем кэш, восстанавливаем доступ.
+      await unbanUser(request, adminToken, targetId).catch(() => {});
+    }
+  });
+});

--- a/internal/handlers/permission_middleware_integration_test.go
+++ b/internal/handlers/permission_middleware_integration_test.go
@@ -178,7 +178,7 @@ func TestRequirePermissionV2_LogsBannedReason(t *testing.T) {
 func TestUserBanService_BanRevokesRefreshTokens(t *testing.T) {
 	_, db, _ := testutil.SetupTestApp(t)
 	resolver := services.NewPermissionResolver(db)
-	banSvc := services.NewUserBanService(db, resolver)
+	banSvc := services.NewUserBanService(db, resolver, nil)
 
 	targetID, _, cleanup := setupMWUser(t, db, false, false)
 	defer cleanup()
@@ -216,7 +216,7 @@ func TestUserBanService_BanRevokesRefreshTokens(t *testing.T) {
 func TestUserBanService_CannotBanSelf(t *testing.T) {
 	_, db, _ := testutil.SetupTestApp(t)
 	resolver := services.NewPermissionResolver(db)
-	banSvc := services.NewUserBanService(db, resolver)
+	banSvc := services.NewUserBanService(db, resolver, nil)
 
 	userID, _, cleanup := setupMWUser(t, db, true, false)
 	defer cleanup()
@@ -230,7 +230,7 @@ func TestUserBanService_CannotBanSelf(t *testing.T) {
 func TestUserBanService_CannotBanSuperAdmin(t *testing.T) {
 	_, db, _ := testutil.SetupTestApp(t)
 	resolver := services.NewPermissionResolver(db)
-	banSvc := services.NewUserBanService(db, resolver)
+	banSvc := services.NewUserBanService(db, resolver, nil)
 
 	targetID, _, cleanup := setupMWUser(t, db, true, false)
 	defer cleanup()
@@ -240,6 +240,93 @@ func TestUserBanService_CannotBanSuperAdmin(t *testing.T) {
 	err := banSvc.Ban(context.Background(), targetID, actorID)
 	if err == nil {
 		t.Error("expected error when banning super-admin")
+	}
+}
+
+func TestBanCheck_AllowsActiveUser(t *testing.T) {
+	_, db, _ := testutil.SetupTestApp(t)
+	svc := services.NewBanCheckService(db, time.Minute)
+
+	userID, _, cleanup := setupMWUser(t, db, false, false)
+	defer cleanup()
+
+	e := echo.New()
+	e.GET("/test", func(c echo.Context) error { return c.String(http.StatusOK, "ok") },
+		func(next echo.HandlerFunc) echo.HandlerFunc {
+			return func(c echo.Context) error {
+				c.Set("user_id", userID)
+				return next(c)
+			}
+		},
+		middleware.BanCheck(svc),
+	)
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200 for active user, got %d", rec.Code)
+	}
+}
+
+func TestBanCheck_DeniesBannedUser(t *testing.T) {
+	_, db, _ := testutil.SetupTestApp(t)
+	svc := services.NewBanCheckService(db, time.Minute)
+
+	userID, _, cleanup := setupMWUser(t, db, false, true)
+	defer cleanup()
+
+	e := echo.New()
+	e.GET("/test", func(c echo.Context) error { return c.String(http.StatusOK, "ok") },
+		func(next echo.HandlerFunc) echo.HandlerFunc {
+			return func(c echo.Context) error {
+				c.Set("user_id", userID)
+				return next(c)
+			}
+		},
+		middleware.BanCheck(svc),
+	)
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected 403 for banned user, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+}
+
+func TestBanCheck_InvalidationAfterBanReflectsImmediately(t *testing.T) {
+	// Регресс на issue #271: после Ban() кэш ban-чекера должен инвалидироваться,
+	// чтобы следующий же запрос забаненного юзера получил 403 без ожидания TTL.
+	_, db, _ := testutil.SetupTestApp(t)
+	banCache := services.NewBanCheckService(db, time.Hour)
+	resolver := services.NewPermissionResolver(db)
+	banSvc := services.NewUserBanService(db, resolver, banCache)
+
+	targetID, _, cleanup := setupMWUser(t, db, false, false)
+	defer cleanup()
+	actorID, _, cleanupActor := setupMWUser(t, db, true, false)
+	defer cleanupActor()
+
+	// 1. До бана IsBanned=false, заполняется кэш.
+	banned, err := banCache.IsBanned(context.Background(), targetID)
+	if err != nil {
+		t.Fatalf("ban check: %v", err)
+	}
+	if banned {
+		t.Fatalf("expected not banned before Ban()")
+	}
+
+	// 2. Баним - должен инвалидировать кэш.
+	if err := banSvc.Ban(context.Background(), targetID, actorID); err != nil {
+		t.Fatalf("ban: %v", err)
+	}
+
+	// 3. Сразу читаем - должен быть true (кэш сброшен, идём в БД).
+	banned, err = banCache.IsBanned(context.Background(), targetID)
+	if err != nil {
+		t.Fatalf("ban check after ban: %v", err)
+	}
+	if !banned {
+		t.Errorf("expected banned=true after Ban() even with long TTL")
 	}
 }
 

--- a/internal/middleware/ban_check.go
+++ b/internal/middleware/ban_check.go
@@ -1,0 +1,39 @@
+package middleware
+
+import (
+	"log/slog"
+	"net/http"
+
+	"systemburo/internal/services"
+
+	"github.com/labstack/echo/v4"
+)
+
+// BanCheck блокирует забаненных пользователей на КАЖДОМ protected-запросе.
+//
+// Без этого middleware забаненный юзер с валидным access-токеном может
+// работать до истечения exp - это окно опасно для API-only клиентов
+// (без фронт-полинга /permissions/my).
+//
+// Должен стоять после JWTAuth (нужен user_id в context).
+func BanCheck(svc *services.BanCheckService) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			userID, _ := c.Get("user_id").(int)
+			if userID == 0 {
+				return next(c)
+			}
+			banned, err := svc.IsBanned(c.Request().Context(), userID)
+			if err != nil {
+				// Ошибка БД на горячем пути - пропускаем (fail-open),
+				// иначе любой временный сбой положит весь API. Логируем.
+				slog.Warn("ban_check: db lookup failed, fail-open", "user_id", userID, "error", err)
+				return next(c)
+			}
+			if banned {
+				return echo.NewHTTPError(http.StatusForbidden, "Учётная запись заблокирована")
+			}
+			return next(c)
+		}
+	}
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -11,7 +11,7 @@ import (
 // Setup регистрирует все маршруты.
 // loginLimiter опционален (nil в тестах) - отдельный per-IP rate limit на /login.
 // В production передаётся mw.LoginRateLimit из cmd/server/main.go.
-func Setup(e *echo.Echo, auth *handlers.AuthHandler, userTypes *handlers.UserTypesHandler, attachments *handlers.AttachmentHandler, lpf *handlers.LicensePlateFormatHandler, cs *handlers.CitizenshipHandler, org *handlers.OrganizationHandler, comp *handlers.CompanyHandler, users *handlers.UsersHandler, up *handlers.UnloadPlaceHandler, cars *handlers.CarHandler, employees *handlers.EmployeeHandler, st *handlers.SystemTableHandler, uc *handlers.UniqueCarHandler, ue *handlers.UniqueEmployeeHandler, fb *handlers.FeedbackHandler, app *handlers.ApplicationHandler, approvers *handlers.ApproverHandler, permissions *handlers.PermissionHandler, permGroups *handlers.PermissionGroupHandler, roles *handlers.RoleHandler, accessDenials *handlers.AccessDenialHandler, userBan *handlers.UserBanHandler, consent *handlers.ConsentHandler, settings *handlers.SettingsHandler, news *handlers.NewsHandler, notifications *handlers.NotificationHandler, requestLogs *handlers.RequestLogsHandler, employeesHistory *handlers.EmployeesHistoryHandler, bugReport *handlers.BugReportHandler, maintenance *handlers.MaintenanceHandler, permResolver *services.PermissionResolver, denialLog *services.AccessDenialService, maintenanceBlock echo.MiddlewareFunc, jwtSecret []byte, loginLimiter echo.MiddlewareFunc) {
+func Setup(e *echo.Echo, auth *handlers.AuthHandler, userTypes *handlers.UserTypesHandler, attachments *handlers.AttachmentHandler, lpf *handlers.LicensePlateFormatHandler, cs *handlers.CitizenshipHandler, org *handlers.OrganizationHandler, comp *handlers.CompanyHandler, users *handlers.UsersHandler, up *handlers.UnloadPlaceHandler, cars *handlers.CarHandler, employees *handlers.EmployeeHandler, st *handlers.SystemTableHandler, uc *handlers.UniqueCarHandler, ue *handlers.UniqueEmployeeHandler, fb *handlers.FeedbackHandler, app *handlers.ApplicationHandler, approvers *handlers.ApproverHandler, permissions *handlers.PermissionHandler, permGroups *handlers.PermissionGroupHandler, roles *handlers.RoleHandler, accessDenials *handlers.AccessDenialHandler, userBan *handlers.UserBanHandler, consent *handlers.ConsentHandler, settings *handlers.SettingsHandler, news *handlers.NewsHandler, notifications *handlers.NotificationHandler, requestLogs *handlers.RequestLogsHandler, employeesHistory *handlers.EmployeesHistoryHandler, bugReport *handlers.BugReportHandler, maintenance *handlers.MaintenanceHandler, permResolver *services.PermissionResolver, denialLog *services.AccessDenialService, maintenanceBlock echo.MiddlewareFunc, banCheck echo.MiddlewareFunc, jwtSecret []byte, loginLimiter echo.MiddlewareFunc) {
 	// Health check — вне /api, для мониторинга и readiness-проб.
 	e.GET("/health", func(c echo.Context) error {
 		return c.JSON(200, map[string]string{"status": "ok"})
@@ -40,6 +40,12 @@ func Setup(e *echo.Echo, auth *handlers.AuthHandler, userTypes *handlers.UserTyp
 	// проходит, остальным 503. Передаём nil в тестах чтобы не блочить.
 	if maintenanceBlock != nil {
 		protected.Use(maintenanceBlock)
+	}
+	// BanCheck - после JWTAuth (нужен user_id). Забаненный получает 403 даже с
+	// валидным access-токеном до истечения exp. Кэш TTL 30s. Инвалидируется при
+	// Ban/Unban из UserBanService. nil в тестах чтобы не требовать service.
+	if banCheck != nil {
+		protected.Use(banCheck)
 	}
 
 	protected.POST("/logout", auth.Logout)

--- a/internal/services/ban_check_service.go
+++ b/internal/services/ban_check_service.go
@@ -1,0 +1,59 @@
+package services
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"systemburo/internal/models"
+
+	"gorm.io/gorm"
+)
+
+// BanCheckService проверяет users.is_banned с in-memory кэшем.
+// Используется глобальным middleware на каждом protected-запросе,
+// поэтому SQL не должен срабатывать чаще раза в TTL.
+//
+// Инвалидация - явная, при Ban()/Unban() в UserBanService.
+type BanCheckService struct {
+	db    *gorm.DB
+	ttl   time.Duration
+	cache sync.Map
+}
+
+type banEntry struct {
+	banned    bool
+	expiresAt time.Time
+}
+
+// NewBanCheckService создаёт сервис с заданным TTL кэша (рекомендуется 30s).
+func NewBanCheckService(db *gorm.DB, ttl time.Duration) *BanCheckService {
+	return &BanCheckService{db: db, ttl: ttl}
+}
+
+// IsBanned возвращает true если у пользователя is_banned=true.
+// На cache miss или истёкшую запись делает один SELECT.
+func (s *BanCheckService) IsBanned(ctx context.Context, userID int) (bool, error) {
+	if v, ok := s.cache.Load(userID); ok {
+		entry := v.(banEntry)
+		if time.Now().Before(entry.expiresAt) {
+			return entry.banned, nil
+		}
+	}
+
+	var user models.User
+	if err := s.db.WithContext(ctx).Select("id, is_banned").First(&user, userID).Error; err != nil {
+		return false, err
+	}
+	s.cache.Store(userID, banEntry{
+		banned:    user.IsBanned,
+		expiresAt: time.Now().Add(s.ttl),
+	})
+	return user.IsBanned, nil
+}
+
+// Invalidate сбрасывает кэш для конкретного пользователя.
+// Вызывается из UserBanService при Ban/Unban.
+func (s *BanCheckService) Invalidate(userID int) {
+	s.cache.Delete(userID)
+}

--- a/internal/services/user_ban_service.go
+++ b/internal/services/user_ban_service.go
@@ -17,11 +17,13 @@ import (
 type UserBanService struct {
 	db       *gorm.DB
 	resolver *PermissionResolver
+	banCache *BanCheckService
 }
 
-// NewUserBanService конструирует сервис.
-func NewUserBanService(db *gorm.DB, resolver *PermissionResolver) *UserBanService {
-	return &UserBanService{db: db, resolver: resolver}
+// NewUserBanService конструирует сервис. banCache опционален: если nil,
+// инвалидация ban-кэша пропускается (полезно для тестов).
+func NewUserBanService(db *gorm.DB, resolver *PermissionResolver, banCache *BanCheckService) *UserBanService {
+	return &UserBanService{db: db, resolver: resolver, banCache: banCache}
 }
 
 // Ban блокирует пользователя и отзывает его активные refresh-токены.
@@ -58,6 +60,9 @@ func (s *UserBanService) Ban(ctx context.Context, targetUserID, actorUserID int)
 	})
 	if err == nil {
 		s.resolver.Invalidate(targetUserID)
+		if s.banCache != nil {
+			s.banCache.Invalidate(targetUserID)
+		}
 	}
 	return err
 }
@@ -75,5 +80,8 @@ func (s *UserBanService) Unban(ctx context.Context, targetUserID int) error {
 		return fmt.Errorf("unban: %w", err)
 	}
 	s.resolver.Invalidate(targetUserID)
+	if s.banCache != nil {
+		s.banCache.Invalidate(targetUserID)
+	}
 	return nil
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -106,7 +106,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	permissionGroupService := services.NewPermissionGroupService(db, permissionResolver)
 	roleService := services.NewRoleService(db, permissionResolver)
 	accessDenialService := services.NewAccessDenialService(db)
-	userBanService := services.NewUserBanService(db, permissionResolver)
+	userBanService := services.NewUserBanService(db, permissionResolver, nil)
 	systemTableService := services.NewSystemTableService(db, "./uploads", 10*1024*1024, permissionService)
 	uniqueCarService := services.NewUniqueCarService(db)
 	uniqueEmployeeService := services.NewUniqueEmployeeService(db)
@@ -173,7 +173,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 		citizenshipHandler, organizationHandler, companyHandler, usersHandler,
 		unloadPlaceHandler, carHandler, employeeHandler, systemTableHandler,
 		uniqueCarHandler, uniqueEmployeeHandler, feedbackHandler,
-		applicationHandler, approverHandler, permissionHandler, permissionGroupHandler, roleHandler, accessDenialHandler, userBanHandler, consentHandler, settingsHandler, newsHandler, notificationHandler, requestLogsHandler, employeesHistoryHandler, bugReportHandler, maintenanceHandler, permissionResolver, accessDenialService, nil, []byte(TestJWTSecret), nil)
+		applicationHandler, approverHandler, permissionHandler, permissionGroupHandler, roleHandler, accessDenialHandler, userBanHandler, consentHandler, settingsHandler, newsHandler, notificationHandler, requestLogsHandler, employeesHistoryHandler, bugReportHandler, maintenanceHandler, permissionResolver, accessDenialService, nil, nil, []byte(TestJWTSecret), nil)
 
 	// No-op cleanup: shared DB stays open for the test binary lifetime.
 	cleanup := func() {}


### PR DESCRIPTION
Closes #271.

## Summary
- Новый \`BanCheck\` middleware после \`JWTAuth\`: на каждом protected-запросе делает \`SELECT is_banned\` с in-memory кэшем TTL 30s.
- \`UserBanService.Ban/Unban\` теперь инвалидируют кэш - изменение применяется мгновенно, без ожидания TTL.
- Fail-open при ошибке БД (логируем warning) - чтобы временный сбой PG не положил весь API.
- Покрыто 3 unit-тестами + e2e регресс-тест.

## До фикса
Забаненный юзер с валидным access мог работать на любой ручке без \`RequirePermissionV2\` до \`exp\` (15м). API-клиенты (curl, мобилка, скрипт) обходили бан полностью.

## После фикса
\`GET /users/me\` с access-токеном после \`Ban()\` возвращает 403 в течение 30 секунд (TTL кэша) - на практике мгновенно благодаря инвалидации в \`Ban()\`.

## Тесты
- \`TestBanCheck_AllowsActiveUser\`
- \`TestBanCheck_DeniesBannedUser\`
- \`TestBanCheck_InvalidationAfterBanReflectsImmediately\` (регресс)
- \`ban-check-middleware.spec.cjs\` - e2e на staging

## Test plan
- [ ] CI Go-тесты green
- [ ] CI Playwright shard 1-4 green