### PR TITLE
feat: расширил cmd/seed-demo до полного объёма UI-сценариев (#84)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ make deploy-seed    # создать админа на production
 | `make bash` | Shell в контейнере бэкенда |
 | `make db-shell` | psql к БД |
 | `make seed [PASS=...]` | Создать тестового админа (dev) |
+| `make seed-demo [PASS=...]` | Создать админа + полный демо-набор (12 заявок в разных статусах, организации, машины, сотрудники, история, объявления) |
 | `make staging-seed [PASS=...]` | Создать админа на staging |
+| `make staging-seed-demo [PASS=...]` | Демо-набор на staging |
 | `make deploy-seed [PASS=...]` | Создать админа на production |
 | `make prod-build` | Собрать production образ |
 | `make security` | govulncheck + npm audit |

--- a/cmd/seed/demo.go
+++ b/cmd/seed/demo.go
@@ -8,59 +8,96 @@ import (
 	"gorm.io/gorm"
 )
 
-// seedDemoData создаёт минимальный демо-набор для проверки UI-сценариев из issue #64.
-// Идемпотентно: повторный запуск не ломает данные — используем ON CONFLICT / проверку существования.
+// seedDemoData создаёт полный демо-набор для ручного QA и e2e: справочники,
+// заявки в разных статусах (включая архивные), вложения, машины, сотрудники,
+// история, уведомления и объявления. Идемпотентно: проверки WHERE NOT EXISTS
+// и DEMO/* номера заявок гарантируют отсутствие дубликатов при повторе.
 //
-// Создаёт:
-// - Unload places (2 шт) и license plate formats (1 шт)
-// - UniqueAttachment-шаблоны: cars, people, items
-// - Активное объявление (для /news карточки справа и TheHeader "Важное объявление")
-// - Обычную новость (для /news ленты слева)
-// - Уведомление для пользователя (для UserNotificationsInline в кабинете)
-// - Заявку "В работе" с вложением cars, двумя машинами и 3 записями истории (для VehicleDetailsModal)
+// См. issue #84 - покрывает acceptance criteria для разблокировки UI-сценариев.
 func seedDemoData(db *gorm.DB, orgID, compID, userID int) {
-	if err := seedDictionaries(db); err != nil {
+	orgIDs, compIDs, placeNames, err := seedExtendedDictionaries(db, orgID, compID)
+	if err != nil {
 		log.Printf("demo seed: dictionaries failed: %v", err)
 		return
 	}
-	uaCarsID := seedUniqueAttachments(db)
-	if uaCarsID == 0 {
+	uaIDs := seedUniqueAttachments(db)
+	if uaIDs.cars == 0 {
 		log.Printf("demo seed: no cars unique attachment, aborting")
 		return
 	}
-	seedNewsAndAnnouncement(db, userID)
-	seedNotification(db, userID)
-	seedCarsApplication(db, orgID, compID, userID, uaCarsID)
-	fmt.Println("Demo data seeded.")
+	seedNewsAndAnnouncements(db, userID)
+	seedNotifications(db, userID)
+	seedExtendedApplications(db, orgIDs, compIDs, userID, uaIDs, placeNames)
+	fmt.Println("Demo data seeded (extended).")
 }
 
-func seedDictionaries(db *gorm.DB) error {
-	// unload_places: нет UNIQUE-constraint на name, поэтому ON CONFLICT не работает.
-	// Используем INSERT ... SELECT ... WHERE NOT EXISTS для идемпотентности.
-	placeNames := []string{"Склад №1", "Склад №2", "Рампа А"}
+// uniqueAttachmentIDs хранит шаблоны вложений по типу.
+type uniqueAttachmentIDs struct {
+	cars   int
+	people int
+	items  int
+}
+
+func seedExtendedDictionaries(db *gorm.DB, defaultOrgID, defaultCompID int) ([]int, []int, []string, error) {
+	// Организации: оставляем дефолтную + добавляем демо-3 если их нет.
+	orgNames := []string{"ООО Демо-Партнёр", "АО Демо-Логистика", "ИП Иванов И.И."}
+	orgIDs := []int{defaultOrgID}
+	for _, name := range orgNames {
+		var id int
+		db.Raw(`SELECT id FROM organizations WHERE name = ? LIMIT 1`, name).Scan(&id)
+		if id == 0 {
+			db.Raw(`INSERT INTO organizations (name) VALUES (?) RETURNING id`, name).Scan(&id)
+		}
+		if id != 0 {
+			orgIDs = append(orgIDs, id)
+		}
+	}
+
+	compNames := []string{"ООО Демо-Сервис", "АО Демо-Транс", "ИП Петров П.П."}
+	compIDs := []int{defaultCompID}
+	for _, name := range compNames {
+		var id int
+		db.Raw(`SELECT id FROM companies WHERE name = ? LIMIT 1`, name).Scan(&id)
+		if id == 0 {
+			db.Raw(`INSERT INTO companies (name) VALUES (?) RETURNING id`, name).Scan(&id)
+		}
+		if id != 0 {
+			compIDs = append(compIDs, id)
+		}
+	}
+
+	// Места разгрузки: 5 шт для тестирования селекторов.
+	placeNames := []string{"Склад №1", "Склад №2", "Рампа А", "Рампа Б", "Северный въезд"}
 	for _, name := range placeNames {
 		if err := db.Exec(`
 			INSERT INTO unload_places (name)
 			SELECT ? WHERE NOT EXISTS (SELECT 1 FROM unload_places WHERE name = ?)
 		`, name, name).Error; err != nil {
-			return fmt.Errorf("unload_places %q: %w", name, err)
+			return nil, nil, nil, fmt.Errorf("unload_places %q: %w", name, err)
 		}
 	}
 
-	// License plate formats — проверим что таблица существует и вставим если пусто.
-	var count int64
-	if err := db.Raw("SELECT COUNT(*) FROM license_plate_formats").Scan(&count).Error; err != nil {
-		return nil
+	// License plate formats: 3 региональных формата.
+	lpfSpecs := []struct {
+		name    string
+		pattern string
+	}{
+		{"Россия", `^[АВЕКМНОРСТУХ]\d{3}[АВЕКМНОРСТУХ]{2}\d{2,3}$`},
+		{"Беларусь", `^\d{4}[A-Z]{2}-\d$`},
+		{"Казахстан", `^\d{3}[A-Z]{3}\d{2}$`},
 	}
-	if count == 0 {
-		db.Exec(`INSERT INTO license_plate_formats (name, pattern) VALUES ('Россия', '^[АВЕКМНОРСТУХ]\d{3}[АВЕКМНОРСТУХ]{2}\d{2,3}$')`)
+	for _, s := range lpfSpecs {
+		db.Exec(`
+			INSERT INTO license_plate_formats (name, pattern)
+			SELECT ?, ? WHERE NOT EXISTS (SELECT 1 FROM license_plate_formats WHERE name = ?)
+		`, s.name, s.pattern, s.name)
 	}
-	return nil
+
+	return orgIDs, compIDs, placeNames, nil
 }
 
-// seedUniqueAttachments создаёт шаблоны вложений: cars/people/items.
-// Возвращает ID cars-шаблона (нужен для привязки к заявке).
-func seedUniqueAttachments(db *gorm.DB) int {
+// seedUniqueAttachments создаёт три шаблона: cars/people/items. Возвращает их ID.
+func seedUniqueAttachments(db *gorm.DB) uniqueAttachmentIDs {
 	templates := []struct {
 		attachmentType string
 		name           string
@@ -72,75 +109,206 @@ func seedUniqueAttachments(db *gorm.DB) int {
 		{"items", "items_demo", "Имущество (демо)", "Имущество"},
 	}
 	for _, t := range templates {
-		// Нет UNIQUE constraint на name — используем INSERT ... WHERE NOT EXISTS.
 		db.Exec(`
 			INSERT INTO unique_attachments (attachment_type, name, display_name, title, is_active)
 			SELECT ?, ?, ?, ?, true
 			WHERE NOT EXISTS (SELECT 1 FROM unique_attachments WHERE name = ?)
 		`, t.attachmentType, t.name, t.displayName, t.title, t.name)
 	}
-	var uaCarsID int
-	db.Raw(`SELECT id FROM unique_attachments WHERE name = 'cars_demo' LIMIT 1`).Scan(&uaCarsID)
-	return uaCarsID
+	var ids uniqueAttachmentIDs
+	db.Raw(`SELECT id FROM unique_attachments WHERE name = 'cars_demo' LIMIT 1`).Scan(&ids.cars)
+	db.Raw(`SELECT id FROM unique_attachments WHERE name = 'people_demo' LIMIT 1`).Scan(&ids.people)
+	db.Raw(`SELECT id FROM unique_attachments WHERE name = 'items_demo' LIMIT 1`).Scan(&ids.items)
+	return ids
 }
 
-func seedNewsAndAnnouncement(db *gorm.DB, userID int) {
-	db.Exec(`
-		INSERT INTO news (title, description, full_text, created_by, is_active)
-		SELECT 'Демо-новость', 'Это пример новости для /news', 'Полный текст демо-новости. Создано cmd/seed-demo.', ?, true
-		WHERE NOT EXISTS (SELECT 1 FROM news WHERE title = 'Демо-новость')
-	`, userID)
-
-	// Активное объявление: одно, с is_important.
-	var annCount int64
-	db.Raw("SELECT COUNT(*) FROM announcements WHERE is_active = true").Scan(&annCount)
-	if annCount == 0 {
-		now := time.Now()
+func seedNewsAndAnnouncements(db *gorm.DB, userID int) {
+	// Новости: 2 шт.
+	newsSpecs := []struct {
+		title       string
+		description string
+		fullText    string
+	}{
+		{"Демо-новость", "Это пример новости для /news", "Полный текст демо-новости. Создано cmd/seed-demo."},
+		{"Запуск нового склада", "Открыт склад №3 в северной части территории", "Подробности про новый склад. График работы 24/7."},
+	}
+	for _, n := range newsSpecs {
 		db.Exec(`
-			INSERT INTO announcements (title, description, full_text, is_important, is_active, created_by, activated_at, activated_by)
-			VALUES ('Важное демо-объявление', 'Это активное объявление для проверки UI', 'Полный текст объявления. Видно в /news и в шапке.', true, true, ?, ?, ?)
-		`, userID, now, userID)
+			INSERT INTO news (title, description, full_text, created_by, is_active)
+			SELECT ?, ?, ?, ?, true
+			WHERE NOT EXISTS (SELECT 1 FROM news WHERE title = ?)
+		`, n.title, n.description, n.fullText, userID, n.title)
+	}
+
+	// Объявления: одно активное + одно архивное.
+	now := time.Now()
+	annSpecs := []struct {
+		title       string
+		description string
+		fullText    string
+		isImportant bool
+		isActive    bool
+	}{
+		{"Важное демо-объявление", "Это активное объявление для проверки UI", "Полный текст объявления. Видно в /news и в шапке.", true, true},
+		{"Архивное объявление", "Объявление, которое уже скрыто", "Это объявление осталось в истории как пример архивного.", false, false},
+	}
+	for _, a := range annSpecs {
+		var exists int64
+		db.Raw(`SELECT COUNT(*) FROM announcements WHERE title = ?`, a.title).Scan(&exists)
+		if exists > 0 {
+			continue
+		}
+		if a.isActive {
+			db.Exec(`
+				INSERT INTO announcements (title, description, full_text, is_important, is_active, created_by, activated_at, activated_by)
+				VALUES (?, ?, ?, ?, true, ?, ?, ?)
+			`, a.title, a.description, a.fullText, a.isImportant, userID, now, userID)
+		} else {
+			db.Exec(`
+				INSERT INTO announcements (title, description, full_text, is_important, is_active, created_by)
+				VALUES (?, ?, ?, ?, false, ?)
+			`, a.title, a.description, a.fullText, a.isImportant, userID)
+		}
 	}
 }
 
-func seedNotification(db *gorm.DB, userID int) {
-	db.Exec(`
-		INSERT INTO notifications (user_id, type, title, message, is_read, created_at)
-		SELECT ?, 'info', 'Добро пожаловать', 'Это демо-уведомление, создано cmd/seed-demo.', false, NOW()
-		WHERE NOT EXISTS (
-			SELECT 1 FROM notifications WHERE user_id = ? AND title = 'Добро пожаловать'
-		)
-	`, userID, userID)
+func seedNotifications(db *gorm.DB, userID int) {
+	notifSpecs := []struct {
+		notifType string
+		title     string
+		message   string
+		isRead    bool
+	}{
+		{"info", "Добро пожаловать", "Это демо-уведомление, создано cmd/seed-demo.", false},
+		{"warning", "Запланированные работы", "В субботу с 02:00 до 04:00 возможны кратковременные перебои.", false},
+		{"success", "Заявка согласована", "Ваша заявка DEMO/003 успешно прошла согласование.", true},
+	}
+	for _, n := range notifSpecs {
+		db.Exec(`
+			INSERT INTO notifications (user_id, type, title, message, is_read, created_at)
+			SELECT ?, ?, ?, ?, ?, NOW()
+			WHERE NOT EXISTS (
+				SELECT 1 FROM notifications WHERE user_id = ? AND title = ?
+			)
+		`, userID, n.notifType, n.title, n.message, n.isRead, userID, n.title)
+	}
 }
 
-// seedCarsApplication создаёт заявку "В работе" с вложением cars, двумя машинами и 3 записями истории.
-// Активна сегодня (для фильтра active_today) и имеет cars_history (для VehicleDetailsModal).
-func seedCarsApplication(db *gorm.DB, orgID, compID, userID, uaCarsID int) {
-	// Проверяем что демо-заявки ещё нет.
-	var appID int
-	db.Raw(`SELECT id FROM applications WHERE application_number = 'DEMO/001' LIMIT 1`).Scan(&appID)
-	if appID != 0 {
+// appSpec описывает желаемое состояние демо-заявки. Поля - всё что важно
+// для разнообразия UI-сценариев: статусы, периоды, наполнение.
+type appSpec struct {
+	number         string
+	status         string
+	confirmation   string // "Согласовано" / "Не согласовано" / "Согласование"
+	dataApproval   string // "true" если ApproverComplete
+	daysOffset     int    // entry_date_from относительно today (- прошлое, + будущее)
+	durationDays   int    // длительность активности
+	withCars       bool
+	withPeople     bool
+	withItems      bool
+	message        string
+	completedAfter bool // simulate confirmation_datetime в прошлом для архива
+}
+
+func seedExtendedApplications(db *gorm.DB, orgIDs, compIDs []int, userID int, uaIDs uniqueAttachmentIDs, placeNames []string) {
+	specs := []appSpec{
+		{number: "DEMO/001", status: "В работе", confirmation: "Согласовано", dataApproval: "true",
+			daysOffset: 0, durationDays: 30, withCars: true, withPeople: true,
+			message: "Заявка на завоз материалов", completedAfter: false},
+		{number: "DEMO/002", status: "Непрочитано", confirmation: "Согласование", dataApproval: "false",
+			daysOffset: 1, durationDays: 7, withCars: true,
+			message: "Новая заявка от подрядчика"},
+		{number: "DEMO/003", status: "В обработке", confirmation: "Согласование", dataApproval: "false",
+			daysOffset: 0, durationDays: 14, withCars: true, withItems: true,
+			message: "Доставка оборудования"},
+		{number: "DEMO/004", status: "Согласование", confirmation: "Согласование", dataApproval: "false",
+			daysOffset: 2, durationDays: 10, withPeople: true,
+			message: "Запрос на пропуск сотрудников"},
+		{number: "DEMO/005", status: "Не согласовано", confirmation: "Не согласовано", dataApproval: "false",
+			daysOffset: -3, durationDays: 5, withCars: true,
+			message: "Заявка отклонена из-за неполных данных"},
+		{number: "DEMO/006", status: "В работе", confirmation: "Согласовано", dataApproval: "true",
+			daysOffset: -1, durationDays: 14, withCars: true, withPeople: true, withItems: true,
+			message: "Комплексная заявка: машины + сотрудники + имущество"},
+		{number: "DEMO/007", status: "Завершено", confirmation: "Согласовано", dataApproval: "true",
+			daysOffset: -7, durationDays: 7, withCars: true,
+			message: "Недавно завершённая заявка", completedAfter: true},
+		{number: "DEMO/008", status: "Завершено", confirmation: "Согласовано", dataApproval: "true",
+			daysOffset: -60, durationDays: 7, withCars: true,
+			message: "Архивная заявка (60 дней назад)", completedAfter: true},
+		{number: "DEMO/009", status: "Завершено", confirmation: "Согласовано", dataApproval: "true",
+			daysOffset: -45, durationDays: 14, withPeople: true,
+			message: "Архивная заявка с сотрудниками", completedAfter: true},
+		{number: "DEMO/010", status: "Отказано", confirmation: "Не согласовано", dataApproval: "false",
+			daysOffset: -10, durationDays: 5, withItems: true,
+			message: "Заявка отказана администратором"},
+		{number: "DEMO/011", status: "Согласование", confirmation: "Согласование", dataApproval: "false",
+			daysOffset: 7, durationDays: 30, withCars: true,
+			message: "Будущая заявка (через неделю)"},
+		{number: "DEMO/012", status: "В работе", confirmation: "Согласовано", dataApproval: "true",
+			daysOffset: 0, durationDays: 60, withCars: true, withPeople: true,
+			message: "Долгая заявка - 2 месяца"},
+	}
+
+	for i, spec := range specs {
+		orgID := orgIDs[i%len(orgIDs)]
+		compID := compIDs[i%len(compIDs)]
+		seedOneApp(db, spec, orgID, compID, userID, uaIDs, placeNames)
+	}
+}
+
+func seedOneApp(db *gorm.DB, spec appSpec, orgID, compID, userID int, uaIDs uniqueAttachmentIDs, placeNames []string) {
+	var existingID int
+	db.Raw(`SELECT id FROM applications WHERE application_number = ? LIMIT 1`, spec.number).Scan(&existingID)
+	if existingID != 0 {
 		return
 	}
 
 	now := time.Now()
-	today := now.Format("2006-01-02")
-	oneMonthLater := now.AddDate(0, 1, 0).Format("2006-01-02")
+	from := now.AddDate(0, 0, spec.daysOffset)
+	to := from.AddDate(0, 0, spec.durationDays)
+	fromStr := from.Format("2006-01-02")
+	toStr := to.Format("2006-01-02")
 
+	var confirmationDatetime *time.Time
+	if spec.completedAfter {
+		t := from.AddDate(0, 0, spec.durationDays)
+		confirmationDatetime = &t
+	}
+
+	var appID int
 	db.Raw(`
 		INSERT INTO applications (
 			application_number, confirmation, sending_datetime, organization_id, company_id,
-			sender_user_id, message, status, data_approval
+			sender_user_id, message, status, data_approval, confirmation_datetime
 		)
-		VALUES ('DEMO/001', 'Согласовано', ?, ?, ?, ?, 'Демо-заявка из cmd/seed-demo', 'В работе', 'true')
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		RETURNING id
-	`, now, orgID, compID, userID).Scan(&appID)
+	`, spec.number, spec.confirmation, now, orgID, compID, userID, spec.message, spec.status, spec.dataApproval, confirmationDatetime).Scan(&appID)
 	if appID == 0 {
-		log.Printf("demo seed: failed to create application")
+		log.Printf("demo seed: failed to create application %s", spec.number)
 		return
 	}
 
-	// Вложение cars.
+	if spec.withCars && uaIDs.cars != 0 {
+		seedAttachmentCars(db, appID, uaIDs.cars, fromStr, toStr, userID, placeNames)
+	}
+	if spec.withPeople && uaIDs.people != 0 {
+		seedAttachmentPeople(db, appID, uaIDs.people, fromStr, toStr)
+	}
+	if spec.withItems && uaIDs.items != 0 {
+		seedAttachmentItems(db, appID, uaIDs.items, fromStr, toStr)
+	}
+
+	db.Exec(`
+		INSERT INTO application_responsible_users (application_id, user_id, is_primary, required_approval)
+		VALUES (?, ?, true, false)
+		ON CONFLICT DO NOTHING
+	`, appID, userID)
+}
+
+// seedAttachmentCars создаёт вложение cars с 2 машинами и cars_history.
+func seedAttachmentCars(db *gorm.DB, appID, uaCarsID int, fromStr, toStr string, userID int, placeNames []string) {
 	var attachmentID int
 	db.Raw(`
 		INSERT INTO attachments (
@@ -150,21 +318,23 @@ func seedCarsApplication(db *gorm.DB, orgID, compID, userID, uaCarsID int) {
 		)
 		VALUES (?, 'cars', 'cars_demo', 'Автомобили (демо)', ?, ?, '09:00:00', '18:00:00', ?, 1, NOW(), NOW())
 		RETURNING id
-	`, appID, today, oneMonthLater, uaCarsID).Scan(&attachmentID)
+	`, appID, fromStr, toStr, uaCarsID).Scan(&attachmentID)
 	if attachmentID == 0 {
-		log.Printf("demo seed: failed to create attachment")
 		return
 	}
 
-	// Машины.
-	type demoCar struct {
+	cars := []struct {
 		number string
 		brand  string
+	}{
+		{fmt.Sprintf("А%03d%s777", appID%1000, "БВ"), "Toyota Camry"},
+		{fmt.Sprintf("Х%03d%s199", appID%1000, "ЕТ"), "Kamaz 65117"},
 	}
-	cars := []demoCar{
-		{"А123БВ777", "Toyota Camry"},
-		{"Х456ЕТ199", "Kamaz 65117"},
+	place := placeNames[0]
+	if len(placeNames) > 1 {
+		place = placeNames[appID%len(placeNames)]
 	}
+
 	var firstCarID int
 	for i, c := range cars {
 		var carID int
@@ -174,39 +344,99 @@ func seedCarsApplication(db *gorm.DB, orgID, compID, userID, uaCarsID int) {
 				entry_date_from, entry_time_from, entry_date_to, entry_time_to,
 				status, date_added
 			)
-			VALUES (?, ?, ?, 'Склад №1', ?, '09:00:00', ?, '18:00:00', 1, NOW())
+			VALUES (?, ?, ?, ?, ?, '09:00:00', ?, '18:00:00', 1, NOW())
 			RETURNING id
-		`, attachmentID, c.number, c.brand, today, oneMonthLater).Scan(&carID)
+		`, attachmentID, c.number, c.brand, place, fromStr, toStr).Scan(&carID)
 		if i == 0 {
 			firstCarID = carID
 		}
 	}
 
-	// cars_history — 3 записи для первой машины.
-	if firstCarID != 0 {
-		historyEntries := []struct {
-			actionType string
-			comment    string
-			offset     time.Duration
-		}{
-			{"create", "Создана запись об автомобиле", -48 * time.Hour},
-			{"entry", "Прибытие на территорию", -24 * time.Hour},
-			{"exit", "Убытие с территории", -1 * time.Hour},
-		}
-		for _, h := range historyEntries {
-			db.Exec(`
-				INSERT INTO cars_history (car_id, user_id, action_type, comment, created_at)
-				VALUES (?, ?, ?, ?, ?)
-			`, firstCarID, userID, h.actionType, h.comment, now.Add(h.offset))
-		}
+	if firstCarID == 0 {
+		return
 	}
+	now := time.Now()
+	history := []struct {
+		action  string
+		comment string
+		offset  time.Duration
+	}{
+		{"create", "Создана запись об автомобиле", -48 * time.Hour},
+		{"update", "Обновлены данные водителя", -36 * time.Hour},
+		{"entry", "Прибытие на территорию", -24 * time.Hour},
+		{"exit", "Убытие с территории", -1 * time.Hour},
+	}
+	for _, h := range history {
+		db.Exec(`
+			INSERT INTO cars_history (car_id, user_id, action_type, comment, created_at)
+			VALUES (?, ?, ?, ?, ?)
+		`, firstCarID, userID, h.action, h.comment, now.Add(h.offset))
+	}
+}
 
-	// Привязка ответственного пользователя к заявке.
-	db.Exec(`
-		INSERT INTO application_responsible_users (application_id, user_id, is_primary, required_approval)
-		VALUES (?, ?, true, false)
-		ON CONFLICT DO NOTHING
-	`, appID, userID)
+func seedAttachmentPeople(db *gorm.DB, appID, uaPeopleID int, fromStr, toStr string) {
+	var attachmentID int
+	db.Raw(`
+		INSERT INTO attachments (
+			application_id, attachment_type, attachment_name, attachment_display_name,
+			entry_date_from, entry_date_to, entry_time_from, entry_time_to,
+			unique_attachment_id, status, created_at, updated_at
+		)
+		VALUES (?, 'people', 'people_demo', 'Сотрудники (демо)', ?, ?, '09:00:00', '18:00:00', ?, 1, NOW(), NOW())
+		RETURNING id
+	`, appID, fromStr, toStr, uaPeopleID).Scan(&attachmentID)
+	if attachmentID == 0 {
+		return
+	}
+	employees := []struct {
+		last  string
+		first string
+		mid   string
+		pos   string
+	}{
+		{"Иванов", "Иван", "Иванович", "Водитель"},
+		{"Петров", "Пётр", "Петрович", "Грузчик"},
+		{"Сидоров", "Алексей", "Сергеевич", "Сопровождающий"},
+	}
+	for _, e := range employees {
+		db.Exec(`
+			INSERT INTO employees (
+				attachment_id, last_name, first_name, middle_name, position,
+				status, created_at, updated_at, date_created
+			)
+			VALUES (?, ?, ?, ?, ?, 1, NOW(), NOW(), NOW())
+		`, attachmentID, e.last, e.first, e.mid, e.pos)
+	}
+}
 
-	fmt.Printf("Demo application created: id=%d (DEMO/001), car_history entries: 3\n", appID)
+func seedAttachmentItems(db *gorm.DB, appID, uaItemsID int, fromStr, toStr string) {
+	var attachmentID int
+	db.Raw(`
+		INSERT INTO attachments (
+			application_id, attachment_type, attachment_name, attachment_display_name,
+			entry_date_from, entry_date_to, entry_time_from, entry_time_to,
+			unique_attachment_id, status, created_at, updated_at
+		)
+		VALUES (?, 'items', 'items_demo', 'Имущество (демо)', ?, ?, '09:00:00', '18:00:00', ?, 1, NOW(), NOW())
+		RETURNING id
+	`, appID, fromStr, toStr, uaItemsID).Scan(&attachmentID)
+	if attachmentID == 0 {
+		return
+	}
+	items := []struct {
+		name string
+		qty  int
+	}{
+		{"Ноутбуки Dell Latitude", 5},
+		{"Серверная стойка 42U", 1},
+		{"Коробки с документами", 10},
+	}
+	for _, it := range items {
+		db.Exec(`
+			INSERT INTO items (
+				attachment_id, name, count, date_created, created_at, updated_at
+			)
+			VALUES (?, ?, ?, NOW(), NOW(), NOW())
+		`, attachmentID, it.name, it.qty)
+	}
 }


### PR DESCRIPTION
Closes #84.

## Что создаётся

\`make seed-demo\` (и аналоги staging/deploy) теперь генерирует:

**Справочники:**
- 4 организации (1 дефолтная + 3 демо)
- 4 компании (1 дефолтная + 3 демо)
- 5 unload_places (Склад №1/2, Рампа А/Б, Северный въезд)
- 3 license-plate-formats (Россия, Беларусь, Казахстан)
- 3 unique_attachments (cars, people, items)

**Заявки (12 шт, DEMO/001..DEMO/012):**
- 2 \"В работе\" с разным наполнением (cars+people, cars+people+items)
- 2 \"Непрочитано\" / \"В обработке\"
- 1 \"Согласование\" (на согласовании)
- 1 \"Не согласовано\"
- 2 архивных \"Завершено\" (-60 и -45 дней)
- 1 свежее \"Завершено\" (-7 дней)
- 1 \"Отказано\"
- 1 будущая (+7 дней)
- 1 долгая (60 дней активности)

**Вложения к заявкам:**
- cars: 2 машины + 4 cars_history-записи (create/update/entry/exit) для первой
- people: 3 сотрудника (last_name/first_name/middle_name/position)
- items: 3 позиции имущества

**Прочее:**
- 2 новости, 2 объявления (1 активное+важное, 1 архивное)
- 3 уведомления разного типа (info/warning/success)

## Acceptance criteria

- [x] 3-5 организаций + 3-5 компаний
- [x] 3-5 UniqueAttachment
- [x] 5-10 unload_places
- [x] 3-5 license_plate_formats
- [x] 10-15 заявок в разных состояниях
- [x] Архивные заявки (entry_date_to > 30 дней назад)
- [x] Каждая заявка 1-3 вложения
- [x] cars 2-3 машины + cars_history
- [x] people 2-3 сотрудника
- [x] 2-3 notification
- [x] 2-3 announcement
- [x] Идемпотентность (DEMO/NNN номера + WHERE NOT EXISTS)
- [x] Makefile targets (seed-demo / staging-seed-demo / deploy-seed-demo)
- [x] README обновлён

## Test plan
- [x] go build ./... (зелёный)
- [x] go vet ./... (зелёный)
- [ ] CI зелёный
- [ ] Ручной прогон \`make seed-demo\` после мерджа в dev (на dev compose-стеке)
- [ ] \`make staging-seed-demo\` после деплоя - проверить что центр заявок показывает 12 разных заявок, есть архив, vehicleDetailsModal показывает историю