### PR TITLE
fix(security): grace-window 10s на refresh reuse detection (#272)

### DIFF
--- a/internal/handlers/auth_test.go
+++ b/internal/handlers/auth_test.go
@@ -656,6 +656,13 @@ func TestRefresh_ReuseDetection_InvalidatesFamily(t *testing.T) {
 	}
 	require.NotEmpty(t, refresh2)
 
+	// Симулируем что между ротацией и reuse прошло > grace-window (10s).
+	// Иначе попадём в grace-режим и family не убьём (см. #272).
+	pastTime := time.Now().Add(-1 * time.Hour)
+	db.Model(&models.RefreshToken{}).
+		Where("user_id = (SELECT id FROM users WHERE username = ?) AND is_revoked = true", "replayuser").
+		Update("revoked_at", pastTime)
+
 	// Attacker пробует заюзать revoked refresh1 - должно триггернуть reuse detection.
 	rec = testutil.POST(t, e, "/refresh-token", "{}", h1)
 	require.Equal(t, http.StatusUnauthorized, rec.Code)

--- a/internal/handlers/auth_test.go
+++ b/internal/handlers/auth_test.go
@@ -302,6 +302,74 @@ func TestRefreshToken_RevokedToken(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 }
 
+// TestRefreshToken_GraceWindowDoesNotKillFamily проверяет регресс на issue #272.
+// Если refresh пришёл с только что отозванным токеном (грейс-окно), family
+// должна остаться активной - это race-condition двух табов, не reuse-атака.
+func TestRefreshToken_GraceWindowDoesNotKillFamily(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	testutil.RegisterUser(t, e, "graceuser", "pass123", 1, td.OrgID, td.CompanyID)
+	_, refreshToken := testutil.LoginUser(t, e, "graceuser", "pass123")
+
+	h := http.Header{}
+	h.Set("Cookie", "refresh_token="+refreshToken)
+	rec := testutil.POST(t, e, "/refresh-token", "{}", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Сразу повторно с тем же токеном - попадаем в grace-window: 401 retry,
+	// но family НЕ убита.
+	rec = testutil.POST(t, e, "/refresh-token", "{}", h)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Contains(t, rec.Body.String(), "Token recently rotated")
+
+	// Свежий refresh-токен из первого вызова должен ещё работать -
+	// family жива. Берём cookie из последнего успешного ответа.
+	// Для упрощения теста: проверяем что в БД есть активный токен в этой family.
+	var activeCount int64
+	db.Model(&models.RefreshToken{}).
+		Where("user_id = (SELECT id FROM users WHERE username = ?) AND is_revoked = false", "graceuser").
+		Count(&activeCount)
+	assert.Equal(t, int64(1), activeCount, "family должна остаться с одним активным токеном")
+}
+
+// TestRefreshToken_AfterGraceWindowKillsFamily проверяет что после истечения
+// grace-window повторное использование revoked-токена убивает всю family.
+func TestRefreshToken_AfterGraceWindowKillsFamily(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	testutil.RegisterUser(t, e, "killuser", "pass123", 1, td.OrgID, td.CompanyID)
+	_, refreshToken := testutil.LoginUser(t, e, "killuser", "pass123")
+
+	h := http.Header{}
+	h.Set("Cookie", "refresh_token="+refreshToken)
+	rec := testutil.POST(t, e, "/refresh-token", "{}", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Симулируем что прошло > grace-window: правим revoked_at в прошлое.
+	pastTime := time.Now().Add(-1 * time.Hour)
+	db.Model(&models.RefreshToken{}).
+		Where("user_id = (SELECT id FROM users WHERE username = ?) AND is_revoked = true", "killuser").
+		Update("revoked_at", pastTime)
+
+	// Повторный refresh старым токеном - reuse detection, family kill.
+	rec = testutil.POST(t, e, "/refresh-token", "{}", h)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Contains(t, rec.Body.String(), "reuse detected")
+
+	// Все токены family должны быть revoked.
+	var activeCount int64
+	db.Model(&models.RefreshToken{}).
+		Where("user_id = (SELECT id FROM users WHERE username = ?) AND is_revoked = false", "killuser").
+		Count(&activeCount)
+	assert.Equal(t, int64(0), activeCount, "family должна быть полностью убита")
+}
+
 // --- POST /logout ---
 
 func TestLogout_Success(t *testing.T) {

--- a/internal/models/refresh_token.go
+++ b/internal/models/refresh_token.go
@@ -14,7 +14,8 @@ type RefreshToken struct {
 	TokenHash string    `gorm:"uniqueIndex" json:"token_hash"`
 	ExpiresAt time.Time `json:"expires_at"`
 	CreatedAt time.Time `json:"created_at"`
-	IsRevoked bool      `gorm:"default:false" json:"is_revoked"`
-	IPAddress *string   `gorm:"size:45" json:"ip_address"`
-	UserAgent *string   `json:"user_agent"`
+	IsRevoked bool       `gorm:"default:false" json:"is_revoked"`
+	RevokedAt *time.Time `json:"revoked_at,omitempty"`
+	IPAddress *string    `gorm:"size:45" json:"ip_address"`
+	UserAgent *string    `json:"user_agent"`
 }

--- a/internal/services/auth_service.go
+++ b/internal/services/auth_service.go
@@ -171,6 +171,13 @@ func hashRefreshToken(token string) string {
 const (
 	maxFailedLoginsBeforeLock = 10
 	accountLockDuration       = 30 * time.Minute
+	// refreshReuseGraceWindow: окно, в течение которого только что отозванный
+	// refresh-токен НЕ считается reuse-атакой. Защита от ложного срабатывания
+	// при параллельных refresh из двух табов (общий cookie). Внутри окна -
+	// 401 "retry" без family kill, после - полноценный reuse detection.
+	// 10s выбрано как компромисс: легитимные race-условия проходят, окно
+	// для атакующего минимальное (Auth0 дефолт 0-30s).
+	refreshReuseGraceWindow = 10 * time.Second
 )
 
 // Login выполняет аутентификацию пользователя и возвращает пару токенов.
@@ -285,13 +292,26 @@ func (s *authService) RefreshToken(ctx context.Context, req models.RefreshTokenR
 	}
 
 	if storedToken.IsRevoked {
-		// Reuse detection: токен валиден по подписи, но уже отозван.
+		// Grace-window: если токен был revoked совсем недавно (< refreshReuseGraceWindow),
+		// это скорее race-condition между двумя табами (общий HttpOnly cookie),
+		// чем настоящий reuse. Возвращаем 401 retry без family kill -
+		// клиент повторит refresh, теперь уже с обновлённым cookie от первого таба.
+		if storedToken.RevokedAt != nil &&
+			time.Since(*storedToken.RevokedAt) < refreshReuseGraceWindow {
+			slog.Info("refresh token grace-window hit, treating as race not reuse",
+				"user_id", user.ID, "family_id", storedToken.FamilyID,
+				"revoked_age_ms", time.Since(*storedToken.RevokedAt).Milliseconds())
+			return nil, echo.NewHTTPError(http.StatusUnauthorized, "Token recently rotated, please retry")
+		}
+
+		// Reuse detection: токен валиден по подписи, отозван давно.
 		// Инвалидируем всю семью - включая текущий активный refresh attacker-а
 		// или legitimate user-а. Оба будут вынуждены перелогиниться.
+		now := time.Now().UTC()
 		s.db.WithContext(ctx).
 			Model(&models.RefreshToken{}).
 			Where("family_id = ? AND is_revoked = false", storedToken.FamilyID).
-			Update("is_revoked", true)
+			Updates(map[string]any{"is_revoked": true, "revoked_at": now})
 		slog.Warn("refresh token reuse detected - family invalidated",
 			"user_id", user.ID, "family_id", storedToken.FamilyID)
 		s.recordAuthEvent(ctx, &user.ID, user.Username, models.AuthEventTokenReuseDetected, false, meta,
@@ -299,8 +319,10 @@ func (s *authService) RefreshToken(ctx context.Context, req models.RefreshTokenR
 		return nil, echo.NewHTTPError(http.StatusUnauthorized, "Refresh token reuse detected, please log in again")
 	}
 
-	// Ротация: помечаем старый revoked, выдаём новую пару в той же family.
-	s.db.WithContext(ctx).Model(&storedToken).Update("is_revoked", true)
+	// Ротация: помечаем старый revoked + revoked_at, выдаём новую пару в той же family.
+	now := time.Now().UTC()
+	s.db.WithContext(ctx).Model(&storedToken).
+		Updates(map[string]any{"is_revoked": true, "revoked_at": now})
 
 	newAccess, err := s.createAccessToken(username, user.ID, user.TypeID, user.IsSuperAdmin)
 	if err != nil {
@@ -356,10 +378,11 @@ func (s *authService) LogoutAll(ctx context.Context, username string) (int, erro
 		return 0, echo.NewHTTPError(http.StatusUnauthorized, "User not found")
 	}
 
+	now := time.Now().UTC()
 	result := s.db.WithContext(ctx).
 		Model(&models.RefreshToken{}).
 		Where("user_id = ? AND is_revoked = false", user.ID).
-		Update("is_revoked", true)
+		Updates(map[string]any{"is_revoked": true, "revoked_at": now})
 	if result.Error != nil {
 		return 0, echo.NewHTTPError(http.StatusInternalServerError, "Failed to revoke sessions")
 	}

--- a/internal/services/user_ban_service.go
+++ b/internal/services/user_ban_service.go
@@ -53,7 +53,7 @@ func (s *UserBanService) Ban(ctx context.Context, targetUserID, actorUserID int)
 		// Отзываем все активные refresh-токены: следующий /refresh даст 401 -> логаут.
 		if err := tx.Model(&models.RefreshToken{}).
 			Where("user_id = ? AND is_revoked = ?", targetUserID, false).
-			Update("is_revoked", true).Error; err != nil {
+			Updates(map[string]any{"is_revoked": true, "revoked_at": now}).Error; err != nil {
 			return fmt.Errorf("revoke refresh tokens: %w", err)
 		}
 		return nil


### PR DESCRIPTION
Closes #272.

## Проблема
Reuse detection срабатывал ложно при параллельном F5 в двух табах: оба таба отправляют refresh с одним cookie, первый ротирует токен, второй приходит со старым (только что revoked) -> family kill -> разлогин в обоих табах.

## Решение
Колонка \`refresh_tokens.revoked_at\` + проверка возраста revoked-токена в \`auth_service.RefreshToken\`:

- \`revoked_at < 10s ago\` -> 401 \"Token recently rotated, please retry\", **family жива**
- \`revoked_at >= 10s ago\` -> reuse detected, family kill (как было)

## Тесты
- \`TestRefreshToken_RevokedToken\` (существующий) - 401 на повтор работает
- \`TestRefreshToken_GraceWindowDoesNotKillFamily\` - повтор внутри 10s оставляет family активной
- \`TestRefreshToken_AfterGraceWindowKillsFamily\` - имитирует \`revoked_at\` час назад -> family kill подтверждён

## Test plan
- [ ] CI Go Tests green (новые 2 теста)
- [ ] CI Playwright green