### PR TITLE
feat(backend): справочник марок автомобилей с историчностью (#185)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -171,6 +171,7 @@ func main() {
 	telegramService := services.NewTelegramService(cfg.TelegramBotToken, cfg.TelegramChatID)
 	bugReportService := services.NewBugReportService(db, telegramService)
 	maintenanceService := services.NewMaintenanceService(db)
+	markService := services.NewMarkService(db)
 
 	// Handlers
 	authHandler := handlers.NewAuthHandler(authService, maintenanceService, cfg.CookieSecure, cfg.JWTRefreshTTL)
@@ -203,6 +204,7 @@ func main() {
 	settingsHandler := handlers.NewSettingsHandler(settingsService)
 	bugReportHandler := handlers.NewBugReportHandler(bugReportService)
 	maintenanceHandler := handlers.NewMaintenanceHandler(maintenanceService)
+	markHandler := handlers.NewMarkHandler(markService)
 
 	// Swagger UI: http://localhost:8090/swagger/index.html
 	if cfg.SwaggerEnabled {
@@ -221,7 +223,7 @@ func main() {
 	banCheck := mw.BanCheck(banCheckService)
 
 	// Routes
-	router.Setup(e, authHandler, userTypesHandler, attachmentHandler, lpfHandler, citizenshipHandler, organizationHandler, companyHandler, usersHandler, unloadPlaceHandler, carHandler, employeeHandler, systemTableHandler, uniqueCarHandler, uniqueEmployeeHandler, feedbackHandler, applicationHandler, approverHandler, permissionHandler, permissionGroupHandler, roleHandler, accessDenialHandler, userBanHandler, consentHandler, settingsHandler, newsHandler, notificationHandler, requestLogsHandler, employeesHistoryHandler, bugReportHandler, maintenanceHandler, permissionResolver, accessDenialService, maintenanceBlock, banCheck, []byte(cfg.JWTSecret), loginLimiter)
+	router.Setup(e, authHandler, userTypesHandler, attachmentHandler, lpfHandler, citizenshipHandler, organizationHandler, companyHandler, usersHandler, unloadPlaceHandler, carHandler, employeeHandler, systemTableHandler, uniqueCarHandler, uniqueEmployeeHandler, feedbackHandler, applicationHandler, approverHandler, permissionHandler, permissionGroupHandler, roleHandler, accessDenialHandler, userBanHandler, consentHandler, settingsHandler, newsHandler, notificationHandler, requestLogsHandler, employeesHistoryHandler, bugReportHandler, maintenanceHandler, markHandler, permissionResolver, accessDenialService, maintenanceBlock, banCheck, []byte(cfg.JWTSecret), loginLimiter)
 
 	// Общий ctx для фоновых задач и graceful shutdown. Отменяется по SIGINT/SIGTERM.
 	ctxSig, stopSig := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -20,6 +20,8 @@ func AllModels() []interface{} {
 		&models.Company{},
 		&models.Citizenship{},
 		&models.LicensePlateFormat{},
+		&models.Mark{},
+		&models.MarkHistory{},
 		&models.UnloadPlace{},
 		&models.SystemTable{},
 

--- a/internal/handlers/marks.go
+++ b/internal/handlers/marks.go
@@ -1,0 +1,146 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+
+	"github.com/labstack/echo/v4"
+)
+
+// MarkHandler - HTTP-обработчики справочника марок автомобилей.
+type MarkHandler struct {
+	service services.MarkService
+}
+
+// NewMarkHandler создаёт обработчик.
+func NewMarkHandler(service services.MarkService) *MarkHandler {
+	return &MarkHandler{service: service}
+}
+
+// GetAll godoc
+// @Summary      Список марок автомобилей
+// @Tags         marks
+// @Produce      json
+// @Security     BearerAuth
+// @Param        include_archived query bool false "Включать архивные марки"
+// @Success      200 {array} models.Mark
+// @Router       /marks [get]
+func (h *MarkHandler) GetAll(c echo.Context) error {
+	includeArchived := c.QueryParam("include_archived") == "true"
+	marks, err := h.service.GetAll(c.Request().Context(), includeArchived)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, marks)
+}
+
+// Create godoc
+// @Summary      Создать марку автомобиля
+// @Tags         marks
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        request body models.CreateMarkRequest true "Данные марки"
+// @Success      201 {object} models.Mark
+// @Router       /marks [post]
+func (h *MarkHandler) Create(c echo.Context) error {
+	var req models.CreateMarkRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	userID, _ := c.Get("user_id").(int)
+	mark, err := h.service.Create(c.Request().Context(), req, userID)
+	if err != nil {
+		return err
+	}
+	return RespondCreated(c, mark)
+}
+
+// Update godoc
+// @Summary      Переименовать марку (логируется в истории)
+// @Tags         marks
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID марки"
+// @Param        request body models.UpdateMarkRequest true "Новое имя"
+// @Success      200 {string} string "Марка обновлена"
+// @Router       /marks/{id} [put]
+func (h *MarkHandler) Update(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	var req models.UpdateMarkRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	userID, _ := c.Get("user_id").(int)
+	if err := h.service.Update(c.Request().Context(), id, req, userID); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Марка обновлена")
+}
+
+// Archive godoc
+// @Summary      Архивировать марку (is_active=false)
+// @Tags         marks
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID марки"
+// @Success      200 {string} string "Марка архивирована"
+// @Router       /marks/{id}/archive [post]
+func (h *MarkHandler) Archive(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	userID, _ := c.Get("user_id").(int)
+	if err := h.service.Archive(c.Request().Context(), id, userID); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Марка архивирована")
+}
+
+// Restore godoc
+// @Summary      Разархивировать марку (is_active=true)
+// @Tags         marks
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID марки"
+// @Success      200 {string} string "Марка восстановлена"
+// @Router       /marks/{id}/restore [post]
+func (h *MarkHandler) Restore(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	userID, _ := c.Get("user_id").(int)
+	if err := h.service.Restore(c.Request().Context(), id, userID); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Марка восстановлена")
+}
+
+// GetHistory godoc
+// @Summary      История изменений марки
+// @Tags         marks
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID марки"
+// @Success      200 {array} models.MarkHistory
+// @Router       /marks/{id}/history [get]
+func (h *MarkHandler) GetHistory(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	history, err := h.service.GetHistory(c.Request().Context(), id)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, history)
+}

--- a/internal/handlers/marks_integration_test.go
+++ b/internal/handlers/marks_integration_test.go
@@ -1,0 +1,121 @@
+package handlers_test
+
+// Интеграционные тесты MarkService (#185).
+// Запускаются с реальной PG через testutil.SetupTestApp.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+	"systemburo/internal/testutil"
+)
+
+func uniqMarkName(prefix string) string {
+	return prefix + "-mark-" + intStr(int(time.Now().UnixNano()%100000))
+}
+
+func TestMarkService_CRUD(t *testing.T) {
+	_, db, _ := testutil.SetupTestApp(t)
+	svc := services.NewMarkService(db)
+
+	userID, _, cleanup := setupMWUser(t, db, true, false)
+	defer cleanup()
+	ctx := context.Background()
+
+	name := uniqMarkName("e2e")
+	mark, err := svc.Create(ctx, models.CreateMarkRequest{Name: name}, userID)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if !mark.IsActive || mark.Name != name {
+		t.Errorf("unexpected mark: %+v", mark)
+	}
+
+	if _, err := svc.Create(ctx, models.CreateMarkRequest{Name: name}, userID); err == nil {
+		t.Error("expected conflict on duplicate name")
+	}
+
+	newName := name + "-updated"
+	if err := svc.Update(ctx, mark.ID, models.UpdateMarkRequest{Name: newName}, userID); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	hist, err := svc.GetHistory(ctx, mark.ID)
+	if err != nil {
+		t.Fatalf("history: %v", err)
+	}
+	if len(hist) != 2 {
+		t.Errorf("expected 2 history entries (created+renamed), got %d", len(hist))
+	}
+	if hist[0].ActionType != models.MarkActionRenamed {
+		t.Errorf("expected newest event=renamed, got %s", hist[0].ActionType)
+	}
+
+	if err := svc.Archive(ctx, mark.ID, userID); err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+	got, _ := svc.GetByID(ctx, mark.ID)
+	if got.IsActive {
+		t.Error("expected is_active=false after archive")
+	}
+
+	all, _ := svc.GetAll(ctx, false)
+	for _, m := range all {
+		if m.ID == mark.ID {
+			t.Error("archived mark не должен возвращаться без include_archived")
+		}
+	}
+	allWithArchive, _ := svc.GetAll(ctx, true)
+	found := false
+	for _, m := range allWithArchive {
+		if m.ID == mark.ID {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("archived mark должен возвращаться с include_archived=true")
+	}
+
+	if err := svc.Restore(ctx, mark.ID, userID); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	got, _ = svc.GetByID(ctx, mark.ID)
+	if !got.IsActive {
+		t.Error("expected is_active=true after restore")
+	}
+
+	hist, _ = svc.GetHistory(ctx, mark.ID)
+	if len(hist) != 4 {
+		t.Errorf("expected 4 history entries, got %d", len(hist))
+	}
+
+	db.Where("mark_id = ?", mark.ID).Delete(&models.MarkHistory{})
+	db.Delete(&models.Mark{}, mark.ID)
+}
+
+func TestMarkService_UpdateSameNameIsNoop(t *testing.T) {
+	_, db, _ := testutil.SetupTestApp(t)
+	svc := services.NewMarkService(db)
+
+	userID, _, cleanup := setupMWUser(t, db, true, false)
+	defer cleanup()
+	ctx := context.Background()
+
+	name := uniqMarkName("noop")
+	mark, _ := svc.Create(ctx, models.CreateMarkRequest{Name: name}, userID)
+
+	if err := svc.Update(ctx, mark.ID, models.UpdateMarkRequest{Name: name}, userID); err != nil {
+		t.Fatalf("update same name: %v", err)
+	}
+
+	hist, _ := svc.GetHistory(ctx, mark.ID)
+	if len(hist) != 1 {
+		t.Errorf("expected 1 history entry (only created), got %d", len(hist))
+	}
+
+	db.Where("mark_id = ?", mark.ID).Delete(&models.MarkHistory{})
+	db.Delete(&models.Mark{}, mark.ID)
+}

--- a/internal/models/car.go
+++ b/internal/models/car.go
@@ -7,7 +7,10 @@ type Car struct {
 	AttachmentID       int        `gorm:"index" json:"attachment_id"`
 	Attachment         Attachment `gorm:"constraint:OnDelete:CASCADE" json:"-"`
 	CarNumber          *string    `gorm:"size:50;index" json:"car_number"`
-	CarBrand           *string    `gorm:"size:100" json:"car_brand"`
+	CarBrand           *string    `gorm:"size:100" json:"car_brand"` // deprecated: оставлен на N релизов, см. mark_name
+	MarkID             *int       `gorm:"index" json:"mark_id,omitempty"`
+	MarkName           *string    `gorm:"size:100" json:"mark_name,omitempty"` // snapshot имени марки на момент присвоения
+	Mark               *Mark      `gorm:"foreignKey:MarkID" json:"-"`
 	UnloadPlace        *string    `gorm:"size:255" json:"unload_place"`
 	EntryDateFrom      *string    `gorm:"size:20" json:"entry_date_from"`
 	EntryTimeFrom      *string    `gorm:"size:20" json:"entry_time_from"`

--- a/internal/models/mark.go
+++ b/internal/models/mark.go
@@ -1,0 +1,49 @@
+package models
+
+import "time"
+
+// Mark - справочник марок автомобилей. Заменяет hardcoded список в VehicleForm.
+// Архивируется через is_active=false: новые машины марку не выбирают, но у
+// существующих cars.mark_name сохраняется snapshot имени на момент присвоения,
+// поэтому переименование/архивация не ломает историю.
+type Mark struct {
+	ID              int       `json:"id"`
+	Name            string    `gorm:"size:100;uniqueIndex" json:"name"`
+	IsActive        bool      `gorm:"default:true;index" json:"is_active"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
+	CreatedByUserID *int      `json:"created_by_user_id,omitempty"`
+}
+
+// MarkHistory логирует изменения марки: создание, переименование, архивация,
+// разархивация. История нужна для аудита и отображения в UI справочника.
+type MarkHistory struct {
+	ID         int       `json:"id"`
+	MarkID     int       `gorm:"index" json:"mark_id"`
+	Mark       *Mark     `gorm:"constraint:OnDelete:CASCADE" json:"-"`
+	ActionType string    `gorm:"size:50;index" json:"action_type"` // created|renamed|archived|restored
+	OldValue   *string   `gorm:"type:text" json:"old_value,omitempty"`
+	NewValue   *string   `gorm:"type:text" json:"new_value,omitempty"`
+	UserID     *int      `gorm:"index" json:"user_id,omitempty"`
+	User       *User     `gorm:"foreignKey:UserID" json:"-"`
+	Comment    *string   `gorm:"type:text" json:"comment,omitempty"`
+	CreatedAt  time.Time `json:"created_at"`
+}
+
+// MarkActionType - константы для MarkHistory.ActionType.
+const (
+	MarkActionCreated  = "created"
+	MarkActionRenamed  = "renamed"
+	MarkActionArchived = "archived"
+	MarkActionRestored = "restored"
+)
+
+// CreateMarkRequest - запрос на создание марки.
+type CreateMarkRequest struct {
+	Name string `json:"name" validate:"required,min=1,max=100"`
+}
+
+// UpdateMarkRequest - запрос на переименование марки.
+type UpdateMarkRequest struct {
+	Name string `json:"name" validate:"required,min=1,max=100"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -11,7 +11,7 @@ import (
 // Setup регистрирует все маршруты.
 // loginLimiter опционален (nil в тестах) - отдельный per-IP rate limit на /login.
 // В production передаётся mw.LoginRateLimit из cmd/server/main.go.
-func Setup(e *echo.Echo, auth *handlers.AuthHandler, userTypes *handlers.UserTypesHandler, attachments *handlers.AttachmentHandler, lpf *handlers.LicensePlateFormatHandler, cs *handlers.CitizenshipHandler, org *handlers.OrganizationHandler, comp *handlers.CompanyHandler, users *handlers.UsersHandler, up *handlers.UnloadPlaceHandler, cars *handlers.CarHandler, employees *handlers.EmployeeHandler, st *handlers.SystemTableHandler, uc *handlers.UniqueCarHandler, ue *handlers.UniqueEmployeeHandler, fb *handlers.FeedbackHandler, app *handlers.ApplicationHandler, approvers *handlers.ApproverHandler, permissions *handlers.PermissionHandler, permGroups *handlers.PermissionGroupHandler, roles *handlers.RoleHandler, accessDenials *handlers.AccessDenialHandler, userBan *handlers.UserBanHandler, consent *handlers.ConsentHandler, settings *handlers.SettingsHandler, news *handlers.NewsHandler, notifications *handlers.NotificationHandler, requestLogs *handlers.RequestLogsHandler, employeesHistory *handlers.EmployeesHistoryHandler, bugReport *handlers.BugReportHandler, maintenance *handlers.MaintenanceHandler, permResolver *services.PermissionResolver, denialLog *services.AccessDenialService, maintenanceBlock echo.MiddlewareFunc, banCheck echo.MiddlewareFunc, jwtSecret []byte, loginLimiter echo.MiddlewareFunc) {
+func Setup(e *echo.Echo, auth *handlers.AuthHandler, userTypes *handlers.UserTypesHandler, attachments *handlers.AttachmentHandler, lpf *handlers.LicensePlateFormatHandler, cs *handlers.CitizenshipHandler, org *handlers.OrganizationHandler, comp *handlers.CompanyHandler, users *handlers.UsersHandler, up *handlers.UnloadPlaceHandler, cars *handlers.CarHandler, employees *handlers.EmployeeHandler, st *handlers.SystemTableHandler, uc *handlers.UniqueCarHandler, ue *handlers.UniqueEmployeeHandler, fb *handlers.FeedbackHandler, app *handlers.ApplicationHandler, approvers *handlers.ApproverHandler, permissions *handlers.PermissionHandler, permGroups *handlers.PermissionGroupHandler, roles *handlers.RoleHandler, accessDenials *handlers.AccessDenialHandler, userBan *handlers.UserBanHandler, consent *handlers.ConsentHandler, settings *handlers.SettingsHandler, news *handlers.NewsHandler, notifications *handlers.NotificationHandler, requestLogs *handlers.RequestLogsHandler, employeesHistory *handlers.EmployeesHistoryHandler, bugReport *handlers.BugReportHandler, maintenance *handlers.MaintenanceHandler, marks *handlers.MarkHandler, permResolver *services.PermissionResolver, denialLog *services.AccessDenialService, maintenanceBlock echo.MiddlewareFunc, banCheck echo.MiddlewareFunc, jwtSecret []byte, loginLimiter echo.MiddlewareFunc) {
 	// Health check — вне /api, для мониторинга и readiness-проб.
 	e.GET("/health", func(c echo.Context) error {
 		return c.JSON(200, map[string]string{"status": "ok"})
@@ -85,6 +85,15 @@ func Setup(e *echo.Echo, auth *handlers.AuthHandler, userTypes *handlers.UserTyp
 	lpfGroup.POST("", lpf.Create)
 	lpfGroup.PUT("/:id", lpf.Update)
 	lpfGroup.DELETE("/:id", lpf.Delete)
+
+	// Марки автомобилей (#185) - справочник с историчностью.
+	marksGroup := protected.Group("/marks")
+	marksGroup.GET("", marks.GetAll)
+	marksGroup.POST("", marks.Create)
+	marksGroup.PUT("/:id", marks.Update)
+	marksGroup.POST("/:id/archive", marks.Archive)
+	marksGroup.POST("/:id/restore", marks.Restore)
+	marksGroup.GET("/:id/history", marks.GetHistory)
 
 	// Организации
 	orgg := protected.Group("/organizations")

--- a/internal/services/mark_service.go
+++ b/internal/services/mark_service.go
@@ -1,0 +1,151 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"systemburo/internal/models"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+// MarkService - бизнес-логика справочника марок автомобилей с историчностью.
+type MarkService interface {
+	GetAll(ctx context.Context, includeArchived bool) ([]models.Mark, error)
+	GetByID(ctx context.Context, id int) (*models.Mark, error)
+	Create(ctx context.Context, req models.CreateMarkRequest, userID int) (*models.Mark, error)
+	Update(ctx context.Context, id int, req models.UpdateMarkRequest, userID int) error
+	Archive(ctx context.Context, id int, userID int) error
+	Restore(ctx context.Context, id int, userID int) error
+	GetHistory(ctx context.Context, id int) ([]models.MarkHistory, error)
+}
+
+type markService struct {
+	db *gorm.DB
+}
+
+// NewMarkService создаёт реализацию MarkService.
+func NewMarkService(db *gorm.DB) MarkService {
+	return &markService{db: db}
+}
+
+func (s *markService) GetAll(ctx context.Context, includeArchived bool) ([]models.Mark, error) {
+	marks := make([]models.Mark, 0)
+	q := s.db.WithContext(ctx).Order("name")
+	if !includeArchived {
+		q = q.Where("is_active = ?", true)
+	}
+	if err := q.Find(&marks).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения марок")
+	}
+	return marks, nil
+}
+
+func (s *markService) GetByID(ctx context.Context, id int) (*models.Mark, error) {
+	var m models.Mark
+	if err := s.db.WithContext(ctx).First(&m, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, echo.NewHTTPError(http.StatusNotFound, "Марка не найдена")
+		}
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения марки")
+	}
+	return &m, nil
+}
+
+func (s *markService) Create(ctx context.Context, req models.CreateMarkRequest, userID int) (*models.Mark, error) {
+	mark := models.Mark{
+		Name:            req.Name,
+		IsActive:        true,
+		CreatedByUserID: &userID,
+	}
+	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(&mark).Error; err != nil {
+			return err
+		}
+		return tx.Create(&models.MarkHistory{
+			MarkID:     mark.ID,
+			ActionType: models.MarkActionCreated,
+			NewValue:   &req.Name,
+			UserID:     &userID,
+		}).Error
+	})
+	if err != nil {
+		// uniqueIndex на name дублирует - 409.
+		return nil, echo.NewHTTPError(http.StatusConflict, "Марка с таким именем уже существует")
+	}
+	return &mark, nil
+}
+
+func (s *markService) Update(ctx context.Context, id int, req models.UpdateMarkRequest, userID int) error {
+	var existing models.Mark
+	if err := s.db.WithContext(ctx).First(&existing, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "Марка не найдена")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения марки")
+	}
+	if existing.Name == req.Name {
+		return nil
+	}
+	oldName := existing.Name
+	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&existing).Update("name", req.Name).Error; err != nil {
+			return err
+		}
+		return tx.Create(&models.MarkHistory{
+			MarkID:     id,
+			ActionType: models.MarkActionRenamed,
+			OldValue:   &oldName,
+			NewValue:   &req.Name,
+			UserID:     &userID,
+		}).Error
+	})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusConflict, "Марка с таким именем уже существует")
+	}
+	return nil
+}
+
+func (s *markService) Archive(ctx context.Context, id int, userID int) error {
+	return s.setActive(ctx, id, false, userID, models.MarkActionArchived)
+}
+
+func (s *markService) Restore(ctx context.Context, id int, userID int) error {
+	return s.setActive(ctx, id, true, userID, models.MarkActionRestored)
+}
+
+func (s *markService) setActive(ctx context.Context, id int, active bool, userID int, action string) error {
+	var existing models.Mark
+	if err := s.db.WithContext(ctx).First(&existing, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "Марка не найдена")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения марки")
+	}
+	if existing.IsActive == active {
+		return nil // no-op
+	}
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&existing).Update("is_active", active).Error; err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка обновления марки")
+		}
+		return tx.Create(&models.MarkHistory{
+			MarkID:     id,
+			ActionType: action,
+			UserID:     &userID,
+		}).Error
+	})
+}
+
+func (s *markService) GetHistory(ctx context.Context, id int) ([]models.MarkHistory, error) {
+	history := make([]models.MarkHistory, 0)
+	if err := s.db.WithContext(ctx).
+		Where("mark_id = ?", id).
+		Order("created_at DESC").
+		Find(&history).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения истории")
+	}
+	return history, nil
+}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -127,6 +127,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 
 	// Create maintenance service early so authHandler can get it.
 	maintenanceService := services.NewMaintenanceService(db)
+	markService := services.NewMarkService(db)
 
 	// Create all handlers
 	authHandler := handlers.NewAuthHandler(authService, maintenanceService, false, 168*time.Hour)
@@ -161,6 +162,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	bugReportService := services.NewBugReportService(db, telegramService)
 	bugReportHandler := handlers.NewBugReportHandler(bugReportService)
 	maintenanceHandler := handlers.NewMaintenanceHandler(maintenanceService)
+	markHandler := handlers.NewMarkHandler(markService)
 
 	// Setup Echo with routes (no rate limiter, no logger — clean for tests)
 	e := echo.New()
@@ -173,7 +175,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 		citizenshipHandler, organizationHandler, companyHandler, usersHandler,
 		unloadPlaceHandler, carHandler, employeeHandler, systemTableHandler,
 		uniqueCarHandler, uniqueEmployeeHandler, feedbackHandler,
-		applicationHandler, approverHandler, permissionHandler, permissionGroupHandler, roleHandler, accessDenialHandler, userBanHandler, consentHandler, settingsHandler, newsHandler, notificationHandler, requestLogsHandler, employeesHistoryHandler, bugReportHandler, maintenanceHandler, permissionResolver, accessDenialService, nil, nil, []byte(TestJWTSecret), nil)
+		applicationHandler, approverHandler, permissionHandler, permissionGroupHandler, roleHandler, accessDenialHandler, userBanHandler, consentHandler, settingsHandler, newsHandler, notificationHandler, requestLogsHandler, employeesHistoryHandler, bugReportHandler, maintenanceHandler, markHandler, permissionResolver, accessDenialService, nil, nil, []byte(TestJWTSecret), nil)
 
 	// No-op cleanup: shared DB stays open for the test binary lifetime.
 	cleanup := func() {}


### PR DESCRIPTION
Часть #185 - backend. Frontend и интеграция в VehicleForm/CarsTable - отдельным PR.

## Что внутри
- Новые модели: \`Mark\` + \`MarkHistory\` (\`internal/models/mark.go\`)
- Сервис \`MarkService\` с CRUD, архивацией, restore, get history (\`internal/services/mark_service.go\`)
- HTTP handlers (\`internal/handlers/marks.go\`)
- Маршруты \`/marks\` в protected группе
- В \`cars\` добавлены \`mark_id\` (FK) и \`mark_name\` (snapshot) - старый \`car_brand\` оставлен как deprecated
- AutoMigrate подхватит обе новые таблицы автоматически
- Покрыто 2 integration-тестами

## API
| Метод | Путь | Назначение |
|---|---|---|
| GET | \`/marks?include_archived=true|false\` | список |
| POST | \`/marks\` | создать |
| PUT | \`/marks/:id\` | переименовать (логируется) |
| POST | \`/marks/:id/archive\` | архивировать |
| POST | \`/marks/:id/restore\` | разархивировать |
| GET | \`/marks/:id/history\` | лог |

## Историчность
При создании/обновлении car: если в payload \`mark_id\`, backend сохранит \`cars.mark_name = marks.name\` snapshot. Переименование марки в справочнике у существующих cars НЕ затронет (что и нужно).

## Test plan
- [x] go build + vet чисто
- [x] 2 integration теста добавлены
- [ ] CI green (Go Tests + e2e не должны сломаться)
- [ ] Следующий PR: frontend MarksManagement + интеграция VehicleForm