### PR TITLE
feat(frontend): UI справочника марок автомобилей (#185)

### DIFF
--- a/frontend/src/api/marks.js
+++ b/frontend/src/api/marks.js
@@ -1,0 +1,43 @@
+import { apiRequest } from './client';
+
+/**
+ * API клиент справочника марок автомобилей (#185).
+ * Все методы возвращают unwrapped data (см. apiRequest.wrapJsonUnwrap в client.js).
+ */
+
+export async function listMarks({ includeArchived = false } = {}) {
+  const qs = includeArchived ? '?include_archived=true' : '';
+  const res = await apiRequest(`/marks${qs}`);
+  return res.json();
+}
+
+export async function createMark({ name }) {
+  const res = await apiRequest('/marks', {
+    method: 'POST',
+    body: JSON.stringify({ name }),
+  });
+  return res.json();
+}
+
+export async function renameMark(id, { name }) {
+  const res = await apiRequest(`/marks/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify({ name }),
+  });
+  return res.json();
+}
+
+export async function archiveMark(id) {
+  const res = await apiRequest(`/marks/${id}/archive`, { method: 'POST' });
+  return res.json();
+}
+
+export async function restoreMark(id) {
+  const res = await apiRequest(`/marks/${id}/restore`, { method: 'POST' });
+  return res.json();
+}
+
+export async function getMarkHistory(id) {
+  const res = await apiRequest(`/marks/${id}/history`);
+  return res.json();
+}

--- a/frontend/src/components/AccountComponent.vue
+++ b/frontend/src/components/AccountComponent.vue
@@ -107,6 +107,13 @@
     </CollapsibleSection>
     <CollapsibleSection
       v-if="isBuroPropuskov"
+      title="Марки автомобилей"
+      anchor-id="marks"
+    >
+      <MarksManagement class="dashboard-card dashboard-card-animated" />
+    </CollapsibleSection>
+    <CollapsibleSection
+      v-if="isBuroPropuskov"
       title="Таблицы системы"
       anchor-id="tables"
     >
@@ -151,6 +158,7 @@ import TableConstructor from './TableConstructor.vue';
 import UserTypes from './UserTypes.vue';
 import AccountSettings from './AccountSettings.vue';
 import CitizenshipManagement from './CitizenshipManagement.vue';
+import MarksManagement from './MarksManagement.vue';
 import AttachmentsManagement from './AttachmentsManagement.vue';
 import ApplicationApprovers from './ApplicationApprovers.vue';
 import CollapsibleSection from './ui/CollapsibleSection.vue';
@@ -170,6 +178,7 @@ export default {
     UserTypes,
     AccountSettings,
     CitizenshipManagement,
+    MarksManagement,
     AttachmentsManagement,
     ApplicationApprovers,
     CollapsibleSection,

--- a/frontend/src/components/MarkHistoryModal.vue
+++ b/frontend/src/components/MarkHistoryModal.vue
@@ -1,0 +1,166 @@
+<template>
+  <div class="modal-overlay" data-testid="mark-history-modal" @click.self="$emit('close')">
+    <div class="modal-content">
+      <h3 class="modal-title">История марки «{{ mark.name }}»</h3>
+      <div v-if="isLoading" class="loader">Загрузка...</div>
+      <div v-else-if="!history.length" class="empty">Записей нет</div>
+      <ul v-else class="history-list">
+        <li
+          v-for="h in history"
+          :key="h.id"
+          class="history-item"
+        >
+          <div class="history-action">{{ actionLabel(h.action_type) }}</div>
+          <div v-if="h.old_value || h.new_value" class="history-values">
+            <span v-if="h.old_value" class="old">{{ h.old_value }}</span>
+            <span v-if="h.old_value && h.new_value" class="arrow">→</span>
+            <span v-if="h.new_value" class="new">{{ h.new_value }}</span>
+          </div>
+          <div class="history-meta">
+            {{ formatDate(h.created_at) }}
+          </div>
+        </li>
+      </ul>
+      <div class="modal-actions">
+        <button class="lk-btn" @click="$emit('close')">Закрыть</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { getMarkHistory } from '@/api/marks';
+
+const ACTION_LABELS = {
+  created: 'Создана',
+  renamed: 'Переименована',
+  archived: 'Архивирована',
+  restored: 'Восстановлена',
+};
+
+export default {
+  name: 'MarkHistoryModal',
+  props: {
+    mark: { type: Object, required: true },
+  },
+  emits: ['close'],
+  data() {
+    return { history: [], isLoading: false };
+  },
+  mounted() {
+    this.load();
+  },
+  methods: {
+    async load() {
+      this.isLoading = true;
+      try {
+        const data = await getMarkHistory(this.mark.id);
+        this.history = Array.isArray(data) ? data : [];
+      } finally {
+        this.isLoading = false;
+      }
+    },
+    actionLabel(t) {
+      return ACTION_LABELS[t] || t;
+    },
+    formatDate(s) {
+      if (!s) return '';
+      const d = new Date(s);
+      return d.toLocaleString('ru-RU');
+    },
+  },
+};
+</script>
+
+<style scoped>
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modal-content {
+  background: #fff;
+  border-radius: 12px;
+  padding: 24px;
+  width: 480px;
+  max-width: 92vw;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.modal-title {
+  margin: 0 0 16px;
+  font-size: 18px;
+}
+
+.loader,
+.empty {
+  text-align: center;
+  color: #888;
+  padding: 20px 0;
+}
+
+.history-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.history-item {
+  padding: 10px 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.history-item:last-child {
+  border-bottom: 0;
+}
+
+.history-action {
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.history-values {
+  font-size: 13px;
+  margin-bottom: 4px;
+}
+
+.history-values .old {
+  color: #888;
+  text-decoration: line-through;
+}
+
+.history-values .arrow {
+  margin: 0 6px;
+  color: #888;
+}
+
+.history-values .new {
+  color: var(--color-primary);
+}
+
+.history-meta {
+  font-size: 12px;
+  color: #888;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 16px;
+}
+
+.lk-btn {
+  padding: 8px 16px;
+  border-radius: 8px;
+  border: 0;
+  background: var(--color-primary);
+  color: #fff;
+  cursor: pointer;
+}
+</style>

--- a/frontend/src/components/MarksManagement.vue
+++ b/frontend/src/components/MarksManagement.vue
@@ -1,0 +1,432 @@
+<template>
+  <div class="marks-container dashboard-card">
+    <div class="management-header">
+      <h3 class="management-title">
+        Управление марками автомобилей
+      </h3>
+      <div class="header-controls">
+        <SearchComponent
+          v-model="searchQuery"
+          :title="'Поиск марок...'"
+        />
+        <button
+          class="add-header-button"
+          data-testid="marks-add-btn"
+          @click="openAddModal"
+        >
+          Добавить
+        </button>
+        <RefreshButton
+          :loading="isLoading"
+          @refresh="refresh"
+        />
+      </div>
+    </div>
+
+    <div class="filter-tabs">
+      <button
+        class="filter-tab"
+        :class="{ active: filter === 'active' }"
+        @click="filter = 'active'"
+      >
+        Активные
+      </button>
+      <button
+        class="filter-tab"
+        :class="{ active: filter === 'archived' }"
+        @click="filter = 'archived'"
+      >
+        Архив
+      </button>
+    </div>
+
+    <div class="table-wrap">
+      <table class="marks-table">
+        <thead>
+          <tr>
+            <th class="th-id">ID</th>
+            <th>Наименование</th>
+            <th class="th-actions">Действия</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="m in filteredMarks"
+            :key="m.id"
+            data-testid="marks-row"
+          >
+            <td>{{ m.id }}</td>
+            <td>{{ m.name }}</td>
+            <td class="actions">
+              <button
+                class="link-btn"
+                data-testid="marks-edit"
+                @click="openEditModal(m)"
+              >
+                Переименовать
+              </button>
+              <button
+                class="link-btn"
+                data-testid="marks-history"
+                @click="openHistory(m)"
+              >
+                История
+              </button>
+              <button
+                v-if="m.is_active"
+                class="link-btn danger"
+                data-testid="marks-archive"
+                @click="onArchive(m)"
+              >
+                В архив
+              </button>
+              <button
+                v-else
+                class="link-btn"
+                data-testid="marks-restore"
+                @click="onRestore(m)"
+              >
+                Восстановить
+              </button>
+            </td>
+          </tr>
+          <tr v-if="!filteredMarks.length && !isLoading">
+            <td colspan="3" class="empty">Марок не найдено</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Add / Edit modal -->
+    <div
+      v-if="modalMode"
+      class="modal-overlay"
+      data-testid="marks-modal"
+      @click.self="closeModal"
+    >
+      <div class="modal-content">
+        <h3 class="modal-title">
+          {{ modalMode === 'add' ? 'Новая марка' : 'Переименование марки' }}
+        </h3>
+        <input
+          v-model.trim="form.name"
+          type="text"
+          placeholder="Например, Toyota"
+          maxlength="100"
+          class="lk-input"
+          data-testid="marks-input-name"
+          @keyup.enter="onSubmit"
+        >
+        <div v-if="error" class="form-error">{{ error }}</div>
+        <div class="modal-actions">
+          <button
+            class="lk-btn lk-btn--ghost"
+            data-testid="marks-modal-cancel"
+            @click="closeModal"
+          >
+            Отмена
+          </button>
+          <button
+            class="lk-btn"
+            :disabled="!form.name || isSubmitting"
+            data-testid="marks-modal-save"
+            @click="onSubmit"
+          >
+            {{ modalMode === 'add' ? 'Создать' : 'Сохранить' }}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <MarkHistoryModal
+      v-if="historyForMark"
+      :mark="historyForMark"
+      @close="historyForMark = null"
+    />
+  </div>
+</template>
+
+<script>
+import SearchComponent from './SearchComponent.vue';
+import RefreshButton from './RefreshButton.vue';
+import MarkHistoryModal from './MarkHistoryModal.vue';
+import { useUiStore } from '@/stores/ui';
+import {
+  listMarks,
+  createMark,
+  renameMark,
+  archiveMark,
+  restoreMark,
+} from '@/api/marks';
+
+export default {
+  name: 'MarksManagement',
+  components: { SearchComponent, RefreshButton, MarkHistoryModal },
+  data() {
+    return {
+      marks: [],
+      searchQuery: '',
+      filter: 'active',
+      isLoading: false,
+      modalMode: null, // 'add' | 'edit' | null
+      editingId: null,
+      form: { name: '' },
+      error: '',
+      isSubmitting: false,
+      historyForMark: null,
+    };
+  },
+  computed: {
+    filteredMarks() {
+      const q = this.searchQuery.trim().toLowerCase();
+      const filtered = this.marks.filter(m =>
+        this.filter === 'archived' ? !m.is_active : m.is_active,
+      );
+      if (!q) return filtered;
+      return filtered.filter(m => m.name.toLowerCase().includes(q));
+    },
+  },
+  mounted() {
+    this.refresh();
+  },
+  methods: {
+    async refresh() {
+      this.isLoading = true;
+      try {
+        const data = await listMarks({ includeArchived: true });
+        this.marks = Array.isArray(data) ? data : [];
+      } catch {
+        useUiStore().error('Не удалось загрузить марки');
+      } finally {
+        this.isLoading = false;
+      }
+    },
+    openAddModal() {
+      this.modalMode = 'add';
+      this.editingId = null;
+      this.form.name = '';
+      this.error = '';
+    },
+    openEditModal(mark) {
+      this.modalMode = 'edit';
+      this.editingId = mark.id;
+      this.form.name = mark.name;
+      this.error = '';
+    },
+    closeModal() {
+      this.modalMode = null;
+      this.editingId = null;
+      this.form.name = '';
+      this.error = '';
+    },
+    async onSubmit() {
+      if (!this.form.name.trim()) return;
+      this.isSubmitting = true;
+      this.error = '';
+      try {
+        if (this.modalMode === 'add') {
+          await createMark({ name: this.form.name });
+          useUiStore().success('Марка создана');
+        } else {
+          await renameMark(this.editingId, { name: this.form.name });
+          useUiStore().success('Марка переименована');
+        }
+        this.closeModal();
+        await this.refresh();
+      } catch (e) {
+        this.error = e?.message || 'Не удалось сохранить';
+      } finally {
+        this.isSubmitting = false;
+      }
+    },
+    async onArchive(mark) {
+      try {
+        await archiveMark(mark.id);
+        useUiStore().success('Марка архивирована');
+        await this.refresh();
+      } catch {
+        useUiStore().error('Не удалось архивировать');
+      }
+    },
+    async onRestore(mark) {
+      try {
+        await restoreMark(mark.id);
+        useUiStore().success('Марка восстановлена');
+        await this.refresh();
+      } catch {
+        useUiStore().error('Не удалось восстановить');
+      }
+    },
+    openHistory(mark) {
+      this.historyForMark = mark;
+    },
+  },
+};
+</script>
+
+<style scoped>
+.marks-container {
+  padding: 20px;
+}
+
+.management-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.management-title {
+  margin: 0;
+  font-size: 18px;
+}
+
+.header-controls {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.filter-tabs {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.filter-tab {
+  padding: 6px 14px;
+  border-radius: 16px;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-secondary);
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.filter-tab.active {
+  background: var(--color-primary);
+  color: #fff;
+  border-color: var(--color-primary);
+}
+
+.table-wrap {
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.marks-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.marks-table th,
+.marks-table td {
+  padding: 10px 12px;
+  text-align: left;
+  border-bottom: 1px solid var(--color-border);
+  font-size: 14px;
+}
+
+.marks-table th {
+  background: var(--color-bg-secondary);
+  font-weight: 600;
+  color: #666;
+}
+
+.th-id {
+  width: 60px;
+}
+
+.th-actions {
+  width: 320px;
+}
+
+.actions {
+  display: flex;
+  gap: 12px;
+}
+
+.link-btn {
+  background: none;
+  border: 0;
+  color: var(--color-primary);
+  cursor: pointer;
+  font-size: 13px;
+  padding: 0;
+}
+
+.link-btn.danger {
+  color: #d73a3a;
+}
+
+.empty {
+  text-align: center;
+  color: #999;
+  padding: 30px 0;
+}
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modal-content {
+  background: #fff;
+  border-radius: 12px;
+  padding: 24px;
+  width: 400px;
+  max-width: 90vw;
+}
+
+.modal-title {
+  margin: 0 0 16px;
+  font-size: 18px;
+}
+
+.lk-input {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  font-size: 14px;
+  margin-bottom: 12px;
+}
+
+.form-error {
+  color: #d73a3a;
+  font-size: 13px;
+  margin-bottom: 8px;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 8px;
+}
+
+.lk-btn {
+  padding: 8px 16px;
+  border-radius: 8px;
+  border: 0;
+  background: var(--color-primary);
+  color: #fff;
+  cursor: pointer;
+}
+
+.lk-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.lk-btn--ghost {
+  background: transparent;
+  border: 1px solid var(--color-border);
+  color: #333;
+}
+</style>

--- a/frontend/src/components/SubmitForm.vue
+++ b/frontend/src/components/SubmitForm.vue
@@ -129,7 +129,7 @@
           v-for="(car, index) in formData.cars"
           :key="index"
         >
-          {{ car.car_number }} | {{ car.car_brand }} | {{ car.unload_place }}
+          {{ car.car_number }} | {{ car.mark_name || car.car_brand }} | {{ car.unload_place }}
         </li>
       </ul>
     </div>
@@ -168,10 +168,10 @@ export default {
       carBrand: '',
       unloadPlace: '',
       existingCars: [],
-      carBrands: [
-        "Митсубиси", "Тойота", "Хонда", "Форд", "Шевроле",
-        "БМВ", "Мерседес", "Ауди", "Киа", "Ниссан"
-      ],
+      // carBrands заполняется из API /marks (активные), см. fetchMarks.
+      // Раньше был hardcoded список - теперь динамический справочник (#185).
+      carBrands: [],
+      markId: null,
     };
   },
   computed: {
@@ -184,6 +184,7 @@ export default {
   },
   async mounted() {
     await this.fetchOrganization();
+    await this.fetchMarks();
   },
   methods: {
     formatPart1() {
@@ -201,6 +202,19 @@ export default {
     },
     formatPart4() {
       this.carNumber.part4 = this.carNumber.part4.replace(/[^0-9]/g, '');
+    },
+    async fetchMarks() {
+      try {
+        const { listMarks } = await import('@/api/marks');
+        const data = await listMarks({ includeArchived: false });
+        const arr = Array.isArray(data) ? data : [];
+        // v-select поддерживает options как массив объектов или строк.
+        // Используем массив {label, value} - label отображается, value идёт в v-model.
+        this.carBrands = arr.map(m => ({ label: m.name, value: m.id, name: m.name }));
+      } catch {
+        // Fallback на пустой список - юзер сможет ввести вручную.
+        this.carBrands = [];
+      }
     },
     async fetchOrganization() {
       const authStore = useAuthStore();
@@ -262,9 +276,15 @@ export default {
           }
         }
 
+        // carBrand может быть объектом (выбран из справочника) или строкой (ручной ввод).
+        // Передаём обе формы - backend решает: при наличии mark_id сохраняет
+        // snapshot имени в mark_name, иначе используется свободный car_brand.
+        const isMarkObject = this.carBrand && typeof this.carBrand === 'object';
         const car = {
           car_number: this.fullCarNumber,
-          car_brand: this.carBrand,
+          car_brand: isMarkObject ? this.carBrand.name : this.carBrand,
+          mark_id: isMarkObject ? this.carBrand.value : null,
+          mark_name: isMarkObject ? this.carBrand.name : this.carBrand,
           unload_place: this.unloadPlace
         };
         


### PR DESCRIPTION
Закрывает frontend-часть #185 поверх backend PR #278.

## Новые компоненты
- \`MarksManagement.vue\` - CRUD с табами Активные/Архив, поиск, переименовать/история/архив/восстановить
- \`MarkHistoryModal.vue\` - лог изменений
- \`api/marks.js\` - клиент /marks/*

## Интеграция
- \`AccountComponent.vue\` - новая секция \"Марки автомобилей\" между Гражданствами и Таблицами системы
- \`SubmitForm.vue\` - убран hardcoded carBrands, динамическая подгрузка из /marks, передача mark_id + mark_name (snapshot)

## Test plan
- [x] Frontend Unit (266 passed)
- [x] Lint 0 errors
- [ ] CI green
- [ ] Ручная проверка: создать марку -> подать заявку -> переименовать марку -> заявка показывает СТАРОЕ имя