### PR TITLE
feat(backend): модели и CRUD для Excel-бланков (#183)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -172,6 +172,7 @@ func main() {
 	bugReportService := services.NewBugReportService(db, telegramService)
 	maintenanceService := services.NewMaintenanceService(db)
 	markService := services.NewMarkService(db)
+	attachmentTemplateService := services.NewAttachmentTemplateService(db, cfg.UploadPath)
 
 	// Handlers
 	authHandler := handlers.NewAuthHandler(authService, maintenanceService, cfg.CookieSecure, cfg.JWTRefreshTTL)
@@ -205,6 +206,7 @@ func main() {
 	bugReportHandler := handlers.NewBugReportHandler(bugReportService)
 	maintenanceHandler := handlers.NewMaintenanceHandler(maintenanceService)
 	markHandler := handlers.NewMarkHandler(markService)
+	attachmentTemplateHandler := handlers.NewAttachmentTemplateHandler(attachmentTemplateService)
 
 	// Swagger UI: http://localhost:8090/swagger/index.html
 	if cfg.SwaggerEnabled {
@@ -223,7 +225,7 @@ func main() {
 	banCheck := mw.BanCheck(banCheckService)
 
 	// Routes
-	router.Setup(e, authHandler, userTypesHandler, attachmentHandler, lpfHandler, citizenshipHandler, organizationHandler, companyHandler, usersHandler, unloadPlaceHandler, carHandler, employeeHandler, systemTableHandler, uniqueCarHandler, uniqueEmployeeHandler, feedbackHandler, applicationHandler, approverHandler, permissionHandler, permissionGroupHandler, roleHandler, accessDenialHandler, userBanHandler, consentHandler, settingsHandler, newsHandler, notificationHandler, requestLogsHandler, employeesHistoryHandler, bugReportHandler, maintenanceHandler, markHandler, permissionResolver, accessDenialService, maintenanceBlock, banCheck, []byte(cfg.JWTSecret), loginLimiter)
+	router.Setup(e, authHandler, userTypesHandler, attachmentHandler, lpfHandler, citizenshipHandler, organizationHandler, companyHandler, usersHandler, unloadPlaceHandler, carHandler, employeeHandler, systemTableHandler, uniqueCarHandler, uniqueEmployeeHandler, feedbackHandler, applicationHandler, approverHandler, permissionHandler, permissionGroupHandler, roleHandler, accessDenialHandler, userBanHandler, consentHandler, settingsHandler, newsHandler, notificationHandler, requestLogsHandler, employeesHistoryHandler, bugReportHandler, maintenanceHandler, markHandler, attachmentTemplateHandler, permissionResolver, accessDenialService, maintenanceBlock, banCheck, []byte(cfg.JWTSecret), loginLimiter)
 
 	// Общий ctx для фоновых задач и graceful shutdown. Отменяется по SIGINT/SIGTERM.
 	ctxSig, stopSig := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -67,6 +67,12 @@ func AllModels() []interface{} {
 		// Attachments (depends on Application, UniqueAttachment)
 		&models.Attachment{},
 
+		// Attachment templates (#183: Excel-бланки)
+		&models.AttachmentTemplate{},
+		&models.AttachmentTemplateMapping{},
+		&models.AttachmentCustomField{},
+		&models.AttachmentCustomValue{},
+
 		// Cars (depends on Attachment)
 		&models.Car{},
 		&models.CarHistory{},

--- a/internal/handlers/attachment_templates.go
+++ b/internal/handlers/attachment_templates.go
@@ -1,0 +1,253 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+
+	"github.com/labstack/echo/v4"
+)
+
+// AttachmentTemplateHandler - HTTP API настроек Excel-бланков (#183).
+type AttachmentTemplateHandler struct {
+	service services.AttachmentTemplateService
+}
+
+// NewAttachmentTemplateHandler создаёт handler.
+func NewAttachmentTemplateHandler(s services.AttachmentTemplateService) *AttachmentTemplateHandler {
+	return &AttachmentTemplateHandler{service: s}
+}
+
+// GetTemplate godoc
+// @Summary      Получить настройки бланка вложения
+// @Tags         attachment-templates
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID UniqueAttachment"
+// @Success      200 {object} models.AttachmentTemplate
+// @Router       /attachments/{id}/template [get]
+func (h *AttachmentTemplateHandler) Get(c echo.Context) error {
+	uaID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	t, err := h.service.Get(c.Request().Context(), uaID)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, t)
+}
+
+// Upload godoc
+// @Summary      Загрузить .xlsx шаблон бланка
+// @Tags         attachment-templates
+// @Accept       multipart/form-data
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID UniqueAttachment"
+// @Param        file formData file true ".xlsx файл"
+// @Param        list_start_row formData int true "Начало строк списка"
+// @Param        list_end_row formData int true "Конец строк списка"
+// @Param        max_list_rows formData int false "Макс. записей (авто = end-start+1)"
+// @Success      201 {object} models.AttachmentTemplate
+// @Router       /attachments/{id}/template [post]
+func (h *AttachmentTemplateHandler) Upload(c echo.Context) error {
+	uaID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	file, err := c.FormFile("file")
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "file required")
+	}
+	// Проверка расширения и MIME для .xlsx.
+	if !strings.HasSuffix(strings.ToLower(file.Filename), ".xlsx") {
+		return echo.NewHTTPError(http.StatusBadRequest, "Файл должен быть .xlsx")
+	}
+	startRow, _ := strconv.Atoi(c.FormValue("list_start_row"))
+	endRow, _ := strconv.Atoi(c.FormValue("list_end_row"))
+	maxRows, _ := strconv.Atoi(c.FormValue("max_list_rows"))
+	if startRow < 1 || endRow < startRow {
+		return echo.NewHTTPError(http.StatusBadRequest, "Некорректный диапазон строк")
+	}
+
+	userID, _ := c.Get("user_id").(int)
+	t, err := h.service.Upload(c.Request().Context(), uaID, file, models.CreateTemplateRequest{
+		ListStartRow: startRow,
+		ListEndRow:   endRow,
+		MaxListRows:  maxRows,
+	}, userID)
+	if err != nil {
+		return err
+	}
+	return RespondCreated(c, t)
+}
+
+// UpdateMappings godoc
+// @Summary      Обновить маппинг ячеек на поля
+// @Tags         attachment-templates
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID UniqueAttachment"
+// @Param        request body models.UpdateMappingsRequest true "Список маппингов"
+// @Success      200 {string} string "Маппинги обновлены"
+// @Router       /attachments/{id}/template/mappings [put]
+func (h *AttachmentTemplateHandler) UpdateMappings(c echo.Context) error {
+	uaID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	var req models.UpdateMappingsRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	if err := h.service.UpdateMappings(c.Request().Context(), uaID, req); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Маппинги обновлены")
+}
+
+// Delete godoc
+// @Summary      Удалить шаблон бланка
+// @Tags         attachment-templates
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID UniqueAttachment"
+// @Success      200 {string} string "Шаблон удалён"
+// @Router       /attachments/{id}/template [delete]
+func (h *AttachmentTemplateHandler) Delete(c echo.Context) error {
+	uaID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	if err := h.service.Delete(c.Request().Context(), uaID); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Шаблон удалён")
+}
+
+// GetFields godoc
+// @Summary      Справочник полей доступных для маппинга
+// @Tags         attachment-templates
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID UniqueAttachment"
+// @Success      200 {array} services.TemplateFieldGroup
+// @Router       /attachments/{id}/template-fields [get]
+func (h *AttachmentTemplateHandler) GetFields(c echo.Context) error {
+	uaID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	// Встроенные поля + динамические custom-поля этого UA.
+	groups := services.BuiltinTemplateFields()
+	customs, err := h.service.ListCustomFields(c.Request().Context(), uaID)
+	if err == nil && len(customs) > 0 {
+		customGroup := services.TemplateFieldGroup{
+			Group: "custom",
+			Label: "Дополнительные поля",
+		}
+		for _, cf := range customs {
+			customGroup.Fields = append(customGroup.Fields, services.TemplateField{
+				Path:  "custom." + strconv.Itoa(cf.ID),
+				Label: cf.Label,
+			})
+		}
+		groups = append(groups, customGroup)
+	}
+	return RespondSuccess(c, groups)
+}
+
+// ListCustomFields godoc
+// @Summary      Список кастомных полей вложения
+// @Tags         attachment-templates
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID UniqueAttachment"
+// @Success      200 {array} models.AttachmentCustomField
+// @Router       /attachments/{id}/custom-fields [get]
+func (h *AttachmentTemplateHandler) ListCustomFields(c echo.Context) error {
+	uaID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	list, err := h.service.ListCustomFields(c.Request().Context(), uaID)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, list)
+}
+
+// CreateCustomField godoc
+// @Summary      Создать кастомное поле
+// @Tags         attachment-templates
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID UniqueAttachment"
+// @Param        request body models.CreateCustomFieldRequest true "Данные поля"
+// @Success      201 {object} models.AttachmentCustomField
+// @Router       /attachments/{id}/custom-fields [post]
+func (h *AttachmentTemplateHandler) CreateCustomField(c echo.Context) error {
+	uaID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	var req models.CreateCustomFieldRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	cf, err := h.service.CreateCustomField(c.Request().Context(), uaID, req)
+	if err != nil {
+		return err
+	}
+	return RespondCreated(c, cf)
+}
+
+// UpdateCustomField godoc
+// @Summary      Обновить кастомное поле
+// @Tags         attachment-templates
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        fid path int true "ID поля"
+// @Param        request body models.CreateCustomFieldRequest true "Данные"
+// @Success      200 {string} string "Поле обновлено"
+// @Router       /attachments/custom-fields/{fid} [put]
+func (h *AttachmentTemplateHandler) UpdateCustomField(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("fid"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	var req models.CreateCustomFieldRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	if err := h.service.UpdateCustomField(c.Request().Context(), id, req); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Поле обновлено")
+}
+
+// DeleteCustomField godoc
+// @Summary      Удалить кастомное поле (soft delete)
+// @Tags         attachment-templates
+// @Produce      json
+// @Security     BearerAuth
+// @Param        fid path int true "ID поля"
+// @Success      200 {string} string "Поле удалено"
+// @Router       /attachments/custom-fields/{fid} [delete]
+func (h *AttachmentTemplateHandler) DeleteCustomField(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("fid"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	if err := h.service.DeleteCustomField(c.Request().Context(), id); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Поле удалено")
+}

--- a/internal/models/attachment_template.go
+++ b/internal/models/attachment_template.go
@@ -1,0 +1,91 @@
+package models
+
+import "time"
+
+// AttachmentTemplate - настройки Excel-бланка для UniqueAttachment (#183).
+// Один шаблон на UniqueAttachment, поэтому unique_attachment_id с UNIQUE.
+// file_path - путь к загруженному .xlsx в uploads/templates/.
+type AttachmentTemplate struct {
+	ID                  int                          `json:"id"`
+	UniqueAttachmentID  int                          `gorm:"uniqueIndex" json:"unique_attachment_id"`
+	UniqueAttachment    *UniqueAttachment            `gorm:"foreignKey:UniqueAttachmentID" json:"-"`
+	FilePath            string                       `gorm:"size:500" json:"file_path"`
+	OriginalFileName    string                       `gorm:"size:255" json:"original_file_name"`
+	ListStartRow        int                          `json:"list_start_row"`
+	ListEndRow          int                          `json:"list_end_row"`
+	MaxListRows         int                          `json:"max_list_rows"`
+	UploadedByUserID    *int                         `json:"uploaded_by_user_id,omitempty"`
+	CreatedAt           time.Time                    `json:"created_at"`
+	UpdatedAt           time.Time                    `json:"updated_at"`
+	Mappings            []AttachmentTemplateMapping  `gorm:"foreignKey:TemplateID" json:"mappings,omitempty"`
+}
+
+// AttachmentTemplateMapping - связь между ячейкой Excel и полем заявки.
+// cell_ref - адрес ячейки ("A1", "B12"); field_path - точечный путь
+// из словаря (см. attachment_template_fields.go). Для list-полей
+// IsListField=true означает что эта пара заполняется по каждой строке списка.
+type AttachmentTemplateMapping struct {
+	ID          int        `json:"id"`
+	TemplateID  int        `gorm:"index" json:"template_id"`
+	CellRef     string     `gorm:"size:10" json:"cell_ref"`
+	FieldPath   string     `gorm:"size:100" json:"field_path"`
+	IsListField bool       `gorm:"default:false" json:"is_list_field"`
+	CreatedAt   time.Time  `json:"-"`
+}
+
+// AttachmentCustomField - дополнительное поле для UniqueAttachment.
+// Отображается в форме создания заявки и доступно для маппинга в Excel.
+type AttachmentCustomField struct {
+	ID                 int       `json:"id"`
+	UniqueAttachmentID int       `gorm:"index" json:"unique_attachment_id"`
+	Label              string    `gorm:"size:200" json:"label"`
+	Placeholder        *string   `gorm:"size:200" json:"placeholder,omitempty"`
+	SortOrder          int       `gorm:"default:0" json:"sort_order"`
+	IsActive           bool      `gorm:"default:true;index" json:"is_active"`
+	CreatedAt          time.Time `json:"created_at"`
+	UpdatedAt          time.Time `json:"updated_at"`
+}
+
+// AttachmentCustomValue - значение кастомного поля для конкретного экземпляра
+// Attachment (привязано к заявке). Каждый Attachment может иметь N значений.
+type AttachmentCustomValue struct {
+	ID            int       `json:"id"`
+	AttachmentID  int       `gorm:"index" json:"attachment_id"`
+	CustomFieldID int       `gorm:"index" json:"custom_field_id"`
+	Value         string    `gorm:"type:text" json:"value"`
+	CreatedAt     time.Time `json:"-"`
+	UpdatedAt     time.Time `json:"-"`
+}
+
+// CreateTemplateRequest - данные при загрузке/обновлении шаблона
+// (multipart form: file + form fields).
+type CreateTemplateRequest struct {
+	ListStartRow int `form:"list_start_row" json:"list_start_row" validate:"min=1"`
+	ListEndRow   int `form:"list_end_row" json:"list_end_row" validate:"min=1"`
+	MaxListRows  int `form:"max_list_rows" json:"max_list_rows" validate:"min=0"`
+}
+
+// UpdateMappingsRequest - bulk-обновление mappings одним запросом.
+type UpdateMappingsRequest struct {
+	Mappings []MappingInput `json:"mappings" validate:"required,dive"`
+}
+
+// MappingInput - элемент списка mappings (без ID, его выдаст БД).
+type MappingInput struct {
+	CellRef     string `json:"cell_ref" validate:"required,max=10"`
+	FieldPath   string `json:"field_path" validate:"required,max=100"`
+	IsListField bool   `json:"is_list_field"`
+}
+
+// CreateCustomFieldRequest - создать/обновить custom field.
+type CreateCustomFieldRequest struct {
+	Label       string  `json:"label" validate:"required,min=1,max=200"`
+	Placeholder *string `json:"placeholder" validate:"omitempty,max=200"`
+	SortOrder   int     `json:"sort_order"`
+}
+
+// CustomValueInput - значение кастомного поля при создании attachment.
+type CustomValueInput struct {
+	CustomFieldID int    `json:"custom_field_id" validate:"required"`
+	Value         string `json:"value"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -11,7 +11,7 @@ import (
 // Setup регистрирует все маршруты.
 // loginLimiter опционален (nil в тестах) - отдельный per-IP rate limit на /login.
 // В production передаётся mw.LoginRateLimit из cmd/server/main.go.
-func Setup(e *echo.Echo, auth *handlers.AuthHandler, userTypes *handlers.UserTypesHandler, attachments *handlers.AttachmentHandler, lpf *handlers.LicensePlateFormatHandler, cs *handlers.CitizenshipHandler, org *handlers.OrganizationHandler, comp *handlers.CompanyHandler, users *handlers.UsersHandler, up *handlers.UnloadPlaceHandler, cars *handlers.CarHandler, employees *handlers.EmployeeHandler, st *handlers.SystemTableHandler, uc *handlers.UniqueCarHandler, ue *handlers.UniqueEmployeeHandler, fb *handlers.FeedbackHandler, app *handlers.ApplicationHandler, approvers *handlers.ApproverHandler, permissions *handlers.PermissionHandler, permGroups *handlers.PermissionGroupHandler, roles *handlers.RoleHandler, accessDenials *handlers.AccessDenialHandler, userBan *handlers.UserBanHandler, consent *handlers.ConsentHandler, settings *handlers.SettingsHandler, news *handlers.NewsHandler, notifications *handlers.NotificationHandler, requestLogs *handlers.RequestLogsHandler, employeesHistory *handlers.EmployeesHistoryHandler, bugReport *handlers.BugReportHandler, maintenance *handlers.MaintenanceHandler, marks *handlers.MarkHandler, permResolver *services.PermissionResolver, denialLog *services.AccessDenialService, maintenanceBlock echo.MiddlewareFunc, banCheck echo.MiddlewareFunc, jwtSecret []byte, loginLimiter echo.MiddlewareFunc) {
+func Setup(e *echo.Echo, auth *handlers.AuthHandler, userTypes *handlers.UserTypesHandler, attachments *handlers.AttachmentHandler, lpf *handlers.LicensePlateFormatHandler, cs *handlers.CitizenshipHandler, org *handlers.OrganizationHandler, comp *handlers.CompanyHandler, users *handlers.UsersHandler, up *handlers.UnloadPlaceHandler, cars *handlers.CarHandler, employees *handlers.EmployeeHandler, st *handlers.SystemTableHandler, uc *handlers.UniqueCarHandler, ue *handlers.UniqueEmployeeHandler, fb *handlers.FeedbackHandler, app *handlers.ApplicationHandler, approvers *handlers.ApproverHandler, permissions *handlers.PermissionHandler, permGroups *handlers.PermissionGroupHandler, roles *handlers.RoleHandler, accessDenials *handlers.AccessDenialHandler, userBan *handlers.UserBanHandler, consent *handlers.ConsentHandler, settings *handlers.SettingsHandler, news *handlers.NewsHandler, notifications *handlers.NotificationHandler, requestLogs *handlers.RequestLogsHandler, employeesHistory *handlers.EmployeesHistoryHandler, bugReport *handlers.BugReportHandler, maintenance *handlers.MaintenanceHandler, marks *handlers.MarkHandler, attachmentTemplates *handlers.AttachmentTemplateHandler, permResolver *services.PermissionResolver, denialLog *services.AccessDenialService, maintenanceBlock echo.MiddlewareFunc, banCheck echo.MiddlewareFunc, jwtSecret []byte, loginLimiter echo.MiddlewareFunc) {
 	// Health check — вне /api, для мониторинга и readiness-проб.
 	e.GET("/health", func(c echo.Context) error {
 		return c.JSON(200, map[string]string{"status": "ok"})
@@ -94,6 +94,18 @@ func Setup(e *echo.Echo, auth *handlers.AuthHandler, userTypes *handlers.UserTyp
 	marksGroup.POST("/:id/archive", marks.Archive)
 	marksGroup.POST("/:id/restore", marks.Restore)
 	marksGroup.GET("/:id/history", marks.GetHistory)
+
+	// Attachment Excel-templates (#183) - вложенные ручки под /attachments/:id/...
+	attRoot := protected.Group("/attachments")
+	attRoot.GET("/:id/template", attachmentTemplates.Get)
+	attRoot.POST("/:id/template", attachmentTemplates.Upload)
+	attRoot.PUT("/:id/template/mappings", attachmentTemplates.UpdateMappings)
+	attRoot.DELETE("/:id/template", attachmentTemplates.Delete)
+	attRoot.GET("/:id/template-fields", attachmentTemplates.GetFields)
+	attRoot.GET("/:id/custom-fields", attachmentTemplates.ListCustomFields)
+	attRoot.POST("/:id/custom-fields", attachmentTemplates.CreateCustomField)
+	attRoot.PUT("/custom-fields/:fid", attachmentTemplates.UpdateCustomField)
+	attRoot.DELETE("/custom-fields/:fid", attachmentTemplates.DeleteCustomField)
 
 	// Организации
 	orgg := protected.Group("/organizations")

--- a/internal/services/attachment_template_fields.go
+++ b/internal/services/attachment_template_fields.go
@@ -1,0 +1,103 @@
+package services
+
+// TemplateField описывает одно поле, доступное для маппинга на ячейку Excel.
+// Path - точечный путь, используется при заполнении бланка для resolveValue.
+// IsList - принадлежит ли поле "табличной" части (список cars/employees/items).
+type TemplateField struct {
+	Path   string `json:"path"`
+	Label  string `json:"label"`
+	IsList bool   `json:"is_list,omitempty"`
+}
+
+// TemplateFieldGroup - группа полей для UI (Заявка / Авто / Сотрудник / ...).
+type TemplateFieldGroup struct {
+	Group  string          `json:"group"`
+	Label  string          `json:"label"`
+	Fields []TemplateField `json:"fields"`
+}
+
+// BuiltinTemplateFields - whitelist полей, доступных для маппинга в Excel.
+// Backend проверяет что field_path в маппинге принадлежит этому списку
+// (см. attachment_blank_service.go::resolveValue).
+//
+// Custom-поля (attachment_custom_fields) добавляются динамически на основе
+// настроек конкретного UniqueAttachment в getTemplateFields() handler-а.
+func BuiltinTemplateFields() []TemplateFieldGroup {
+	return []TemplateFieldGroup{
+		{
+			Group: "application",
+			Label: "Заявка",
+			Fields: []TemplateField{
+				{Path: "application.application_number", Label: "Номер заявки"},
+				{Path: "application.sending_datetime", Label: "Дата подачи"},
+				{Path: "application.status", Label: "Статус"},
+				{Path: "application.confirmation", Label: "Состояние согласования"},
+				{Path: "application.message", Label: "Сообщение"},
+				{Path: "application.organization", Label: "Организация"},
+				{Path: "application.company", Label: "Компания"},
+				{Path: "application.sender.full_name", Label: "ФИО отправителя"},
+				{Path: "application.sender.short_name", Label: "Фамилия И.О. отправителя"},
+				{Path: "application.sender.last_name", Label: "Фамилия отправителя"},
+				{Path: "application.sender.first_name", Label: "Имя отправителя"},
+			},
+		},
+		{
+			Group: "attachment",
+			Label: "Вложение",
+			Fields: []TemplateField{
+				{Path: "attachment.entry_date_from", Label: "Дата с"},
+				{Path: "attachment.entry_date_to", Label: "Дата по"},
+				{Path: "attachment.entry_time_from", Label: "Время с"},
+				{Path: "attachment.entry_time_to", Label: "Время по"},
+			},
+		},
+		{
+			Group: "car",
+			Label: "Автомобиль (список)",
+			Fields: []TemplateField{
+				{Path: "car.row_number", Label: "Порядковый номер", IsList: true},
+				{Path: "car.car_number", Label: "Номер ТС", IsList: true},
+				{Path: "car.mark_name", Label: "Марка", IsList: true},
+				{Path: "car.unload_place", Label: "Место разгрузки", IsList: true},
+				{Path: "car.entry_date_from", Label: "Дата с", IsList: true},
+				{Path: "car.entry_date_to", Label: "Дата по", IsList: true},
+			},
+		},
+		{
+			Group: "employee",
+			Label: "Сотрудник (список)",
+			Fields: []TemplateField{
+				{Path: "employee.row_number", Label: "Порядковый номер", IsList: true},
+				{Path: "employee.last_name", Label: "Фамилия", IsList: true},
+				{Path: "employee.first_name", Label: "Имя", IsList: true},
+				{Path: "employee.middle_name", Label: "Отчество", IsList: true},
+				{Path: "employee.full_name", Label: "ФИО полностью", IsList: true},
+				{Path: "employee.position", Label: "Должность", IsList: true},
+				{Path: "employee.citizenship", Label: "Гражданство", IsList: true},
+				{Path: "employee.passport_series_number", Label: "Серия и номер паспорта", IsList: true},
+			},
+		},
+		{
+			Group: "item",
+			Label: "Имущество (список)",
+			Fields: []TemplateField{
+				{Path: "item.row_number", Label: "Порядковый номер", IsList: true},
+				{Path: "item.name", Label: "Наименование", IsList: true},
+				{Path: "item.count", Label: "Количество", IsList: true},
+			},
+		},
+	}
+}
+
+// IsValidFieldPath проверяет принадлежит ли path встроенному словарю.
+// Кастомные поля проверяются отдельно (по uniqueAttachmentID).
+func IsValidFieldPath(path string) bool {
+	for _, g := range BuiltinTemplateFields() {
+		for _, f := range g.Fields {
+			if f.Path == path {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/services/attachment_template_service.go
+++ b/internal/services/attachment_template_service.go
@@ -1,0 +1,224 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"systemburo/internal/models"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+// AttachmentTemplateService - CRUD шаблонов Excel-бланков (#183).
+// Генерация .xlsx вынесена в отдельный сервис AttachmentBlankService
+// (будет реализована в следующем PR).
+type AttachmentTemplateService interface {
+	Get(ctx context.Context, uniqueAttachmentID int) (*models.AttachmentTemplate, error)
+	Upload(ctx context.Context, uniqueAttachmentID int, file *multipart.FileHeader, req models.CreateTemplateRequest, userID int) (*models.AttachmentTemplate, error)
+	UpdateMappings(ctx context.Context, uniqueAttachmentID int, req models.UpdateMappingsRequest) error
+	Delete(ctx context.Context, uniqueAttachmentID int) error
+	// Custom fields
+	ListCustomFields(ctx context.Context, uniqueAttachmentID int) ([]models.AttachmentCustomField, error)
+	CreateCustomField(ctx context.Context, uniqueAttachmentID int, req models.CreateCustomFieldRequest) (*models.AttachmentCustomField, error)
+	UpdateCustomField(ctx context.Context, id int, req models.CreateCustomFieldRequest) error
+	DeleteCustomField(ctx context.Context, id int) error
+}
+
+type attachmentTemplateService struct {
+	db         *gorm.DB
+	uploadPath string // базовый путь, обычно cfg.UploadPath. Шаблоны в <uploadPath>/templates/
+}
+
+// NewAttachmentTemplateService создаёт сервис.
+func NewAttachmentTemplateService(db *gorm.DB, uploadPath string) AttachmentTemplateService {
+	return &attachmentTemplateService{db: db, uploadPath: uploadPath}
+}
+
+func (s *attachmentTemplateService) Get(ctx context.Context, uaID int) (*models.AttachmentTemplate, error) {
+	var t models.AttachmentTemplate
+	err := s.db.WithContext(ctx).
+		Preload("Mappings").
+		Where("unique_attachment_id = ?", uaID).
+		First(&t).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, echo.NewHTTPError(http.StatusNotFound, "Шаблон не настроен")
+		}
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения шаблона")
+	}
+	return &t, nil
+}
+
+func (s *attachmentTemplateService) Upload(ctx context.Context, uaID int, file *multipart.FileHeader, req models.CreateTemplateRequest, userID int) (*models.AttachmentTemplate, error) {
+	// Проверяем что UniqueAttachment существует.
+	var ua models.UniqueAttachment
+	if err := s.db.WithContext(ctx).First(&ua, uaID).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusNotFound, "Вложение не найдено")
+	}
+
+	// Сохраняем файл в uploads/templates/<uaID>.xlsx (перезаписывает существующий).
+	dir := filepath.Join(s.uploadPath, "templates")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Не удалось создать директорию шаблонов")
+	}
+	dst := filepath.Join(dir, strconv.Itoa(uaID)+".xlsx")
+	if err := saveMultipartFile(file, dst); err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Не удалось сохранить файл")
+	}
+
+	// Удаляем старую запись (вместе с mappings через cascade нет - сделаем явно).
+	s.db.WithContext(ctx).Where("template_id IN (SELECT id FROM attachment_templates WHERE unique_attachment_id = ?)", uaID).
+		Delete(&models.AttachmentTemplateMapping{})
+	s.db.WithContext(ctx).Where("unique_attachment_id = ?", uaID).Delete(&models.AttachmentTemplate{})
+
+	t := models.AttachmentTemplate{
+		UniqueAttachmentID: uaID,
+		FilePath:           dst,
+		OriginalFileName:   file.Filename,
+		ListStartRow:       req.ListStartRow,
+		ListEndRow:         req.ListEndRow,
+		MaxListRows:        req.MaxListRows,
+		UploadedByUserID:   &userID,
+	}
+	if t.MaxListRows == 0 && t.ListStartRow > 0 && t.ListEndRow >= t.ListStartRow {
+		t.MaxListRows = t.ListEndRow - t.ListStartRow + 1
+	}
+	if err := s.db.WithContext(ctx).Create(&t).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Не удалось сохранить шаблон")
+	}
+	return &t, nil
+}
+
+func (s *attachmentTemplateService) UpdateMappings(ctx context.Context, uaID int, req models.UpdateMappingsRequest) error {
+	var t models.AttachmentTemplate
+	if err := s.db.WithContext(ctx).Where("unique_attachment_id = ?", uaID).First(&t).Error; err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, "Шаблон не настроен")
+	}
+
+	// Валидация: все field_path должны быть либо встроенными, либо custom-полями этого UA.
+	customIDs := map[string]struct{}{}
+	var customFields []models.AttachmentCustomField
+	s.db.WithContext(ctx).Where("unique_attachment_id = ?", uaID).Find(&customFields)
+	for _, cf := range customFields {
+		customIDs[fmt.Sprintf("custom.%d", cf.ID)] = struct{}{}
+	}
+	for _, m := range req.Mappings {
+		if !IsValidFieldPath(m.FieldPath) {
+			if _, ok := customIDs[m.FieldPath]; !ok {
+				return echo.NewHTTPError(http.StatusBadRequest,
+					fmt.Sprintf("Неизвестное поле: %s", m.FieldPath))
+			}
+		}
+	}
+
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("template_id = ?", t.ID).Delete(&models.AttachmentTemplateMapping{}).Error; err != nil {
+			return err
+		}
+		if len(req.Mappings) == 0 {
+			return nil
+		}
+		rows := make([]models.AttachmentTemplateMapping, 0, len(req.Mappings))
+		for _, m := range req.Mappings {
+			rows = append(rows, models.AttachmentTemplateMapping{
+				TemplateID:  t.ID,
+				CellRef:     m.CellRef,
+				FieldPath:   m.FieldPath,
+				IsListField: m.IsListField,
+			})
+		}
+		return tx.Create(&rows).Error
+	})
+}
+
+func (s *attachmentTemplateService) Delete(ctx context.Context, uaID int) error {
+	var t models.AttachmentTemplate
+	if err := s.db.WithContext(ctx).Where("unique_attachment_id = ?", uaID).First(&t).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка")
+	}
+	_ = os.Remove(t.FilePath)
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("template_id = ?", t.ID).Delete(&models.AttachmentTemplateMapping{}).Error; err != nil {
+			return err
+		}
+		return tx.Delete(&t).Error
+	})
+}
+
+func (s *attachmentTemplateService) ListCustomFields(ctx context.Context, uaID int) ([]models.AttachmentCustomField, error) {
+	fields := make([]models.AttachmentCustomField, 0)
+	err := s.db.WithContext(ctx).
+		Where("unique_attachment_id = ? AND is_active = ?", uaID, true).
+		Order("sort_order, id").
+		Find(&fields).Error
+	if err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения полей")
+	}
+	return fields, nil
+}
+
+func (s *attachmentTemplateService) CreateCustomField(ctx context.Context, uaID int, req models.CreateCustomFieldRequest) (*models.AttachmentCustomField, error) {
+	cf := models.AttachmentCustomField{
+		UniqueAttachmentID: uaID,
+		Label:              req.Label,
+		Placeholder:        req.Placeholder,
+		SortOrder:          req.SortOrder,
+		IsActive:           true,
+	}
+	if err := s.db.WithContext(ctx).Create(&cf).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Не удалось создать поле")
+	}
+	return &cf, nil
+}
+
+func (s *attachmentTemplateService) UpdateCustomField(ctx context.Context, id int, req models.CreateCustomFieldRequest) error {
+	updates := map[string]any{
+		"label":       req.Label,
+		"placeholder": req.Placeholder,
+		"sort_order":  req.SortOrder,
+	}
+	res := s.db.WithContext(ctx).Model(&models.AttachmentCustomField{}).Where("id = ?", id).Updates(updates)
+	if res.Error != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Не удалось обновить поле")
+	}
+	if res.RowsAffected == 0 {
+		return echo.NewHTTPError(http.StatusNotFound, "Поле не найдено")
+	}
+	return nil
+}
+
+func (s *attachmentTemplateService) DeleteCustomField(ctx context.Context, id int) error {
+	// Soft delete: is_active=false. Старые значения для уже поданных заявок остаются.
+	res := s.db.WithContext(ctx).Model(&models.AttachmentCustomField{}).Where("id = ?", id).Update("is_active", false)
+	if res.RowsAffected == 0 {
+		return echo.NewHTTPError(http.StatusNotFound, "Поле не найдено")
+	}
+	return nil
+}
+
+// saveMultipartFile - helper для сохранения multipart-файла на диск.
+func saveMultipartFile(file *multipart.FileHeader, dst string) error {
+	src, err := file.Open()
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	_, err = io.Copy(out, src)
+	return err
+}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -128,6 +128,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	// Create maintenance service early so authHandler can get it.
 	maintenanceService := services.NewMaintenanceService(db)
 	markService := services.NewMarkService(db)
+	attachmentTemplateService := services.NewAttachmentTemplateService(db, "./uploads")
 
 	// Create all handlers
 	authHandler := handlers.NewAuthHandler(authService, maintenanceService, false, 168*time.Hour)
@@ -163,6 +164,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	bugReportHandler := handlers.NewBugReportHandler(bugReportService)
 	maintenanceHandler := handlers.NewMaintenanceHandler(maintenanceService)
 	markHandler := handlers.NewMarkHandler(markService)
+	attachmentTemplateHandler := handlers.NewAttachmentTemplateHandler(attachmentTemplateService)
 
 	// Setup Echo with routes (no rate limiter, no logger — clean for tests)
 	e := echo.New()
@@ -175,7 +177,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 		citizenshipHandler, organizationHandler, companyHandler, usersHandler,
 		unloadPlaceHandler, carHandler, employeeHandler, systemTableHandler,
 		uniqueCarHandler, uniqueEmployeeHandler, feedbackHandler,
-		applicationHandler, approverHandler, permissionHandler, permissionGroupHandler, roleHandler, accessDenialHandler, userBanHandler, consentHandler, settingsHandler, newsHandler, notificationHandler, requestLogsHandler, employeesHistoryHandler, bugReportHandler, maintenanceHandler, markHandler, permissionResolver, accessDenialService, nil, nil, []byte(TestJWTSecret), nil)
+		applicationHandler, approverHandler, permissionHandler, permissionGroupHandler, roleHandler, accessDenialHandler, userBanHandler, consentHandler, settingsHandler, newsHandler, notificationHandler, requestLogsHandler, employeesHistoryHandler, bugReportHandler, maintenanceHandler, markHandler, attachmentTemplateHandler, permissionResolver, accessDenialService, nil, nil, []byte(TestJWTSecret), nil)
 
 	// No-op cleanup: shared DB stays open for the test binary lifetime.
 	cleanup := func() {}


### PR DESCRIPTION
Часть 1/3 фичи #183. Только модели + CRUD без генерации .xlsx.

## Что внутри
- 4 новые таблицы: \`attachment_templates\`, \`attachment_template_mappings\`, \`attachment_custom_fields\`, \`attachment_custom_values\`
- Сервис \`AttachmentTemplateService\` (CRUD шаблонов + кастомных полей)
- Whitelist полей для маппинга (\`attachment_template_fields.go\`)
- HTTP API под \`/attachments/:id/template\`, \`/template-fields\`, \`/custom-fields\`

## Что НЕ в этом PR
- Генерация .xlsx (нужна excelize lib) - отдельным PR
- Endpoints \`/applications/:id/blank\` (download) - вместе с генерацией
- Frontend - отдельный PR после генерации

## Test plan
- [x] go build + vet чисто
- [ ] CI green
- [ ] Следующий: PR2 - генерация .xlsx через excelize