### PR TITLE
chore(security/infra): goroutine timeout, mem_limit, nginx login rate-limit

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -48,7 +48,7 @@ jobs:
           load: true
           cache-from: type=gha,scope=systemburo-backend
       - name: Run Trivy
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.36.0
         with:
           image-ref: 'systemburo:scan'
           format: 'table'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -48,7 +48,7 @@ jobs:
           load: true
           cache-from: type=gha,scope=systemburo-backend
       - name: Run Trivy
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: 'systemburo:scan'
           format: 'table'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -48,7 +48,7 @@ jobs:
           load: true
           cache-from: type=gha,scope=systemburo-backend
       - name: Run Trivy
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           image-ref: 'systemburo:scan'
           format: 'table'

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -14,6 +14,8 @@ services:
       retries: 5
       start_period: 10s
     restart: always
+    mem_limit: 1g
+    memswap_limit: 1g
 
   backend:
     build:
@@ -38,6 +40,8 @@ services:
       db:
         condition: service_healthy
     restart: always
+    mem_limit: 512m
+    memswap_limit: 512m
 
   frontend:
     build:
@@ -46,6 +50,8 @@ services:
     depends_on:
       - backend
     restart: always
+    mem_limit: 256m
+    memswap_limit: 256m
 
 volumes:
   pgdata:

--- a/internal/middleware/pd_audit.go
+++ b/internal/middleware/pd_audit.go
@@ -1,8 +1,10 @@
 package middleware
 
 import (
+	"context"
 	"log/slog"
 	"strings"
+	"time"
 
 	"systemburo/internal/models"
 
@@ -11,6 +13,10 @@ import (
 )
 
 var pdPaths = []string{"/employees", "/unique-employees", "/attachments"}
+
+// auditWriteTimeout - максимальное время на запись лога в БД. Если БД легла или
+// горутина зависла, не блокируем graceful shutdown навсегда.
+const auditWriteTimeout = 5 * time.Second
 
 func PDAudit(db *gorm.DB) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
@@ -29,20 +35,29 @@ func PDAudit(db *gorm.DB) echo.MiddlewareFunc {
 				return err
 			}
 
+			// Снапшот данных запроса ДО горутины: c.Response()/c.RealIP() могут
+			// быть невалидны после возврата из handler-а (data race).
 			username, _ := c.Get("username").(string)
 			method := c.Request().Method
+			ip := c.RealIP()
+			statusCode := c.Response().Status
 
 			go func() {
+				// Отдельный context с таймаутом, не привязанный к request-context
+				// (тот отменится сразу после ответа). Защита от висящих горутин
+				// при медленной БД.
+				ctx, cancel := context.WithTimeout(context.Background(), auditWriteTimeout)
+				defer cancel()
 				log := models.PDAuditLog{
 					Username:   username,
 					Action:     methodToAction(method),
 					Resource:   pathToResource(path),
-					IPAddress:  c.RealIP(),
+					IPAddress:  ip,
 					Method:     method,
 					Path:       path,
-					StatusCode: c.Response().Status,
+					StatusCode: statusCode,
 				}
-				if err := db.Create(&log).Error; err != nil {
+				if err := db.WithContext(ctx).Create(&log).Error; err != nil {
 					slog.Error("failed to write PD audit log", "error", err, "path", path)
 				}
 			}()

--- a/internal/middleware/request_logger.go
+++ b/internal/middleware/request_logger.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"log/slog"
 	"time"
 
@@ -9,6 +10,10 @@ import (
 	"github.com/labstack/echo/v4"
 	"gorm.io/gorm"
 )
+
+// requestLogWriteTimeout - таймаут на запись лога в БД из фоновой горутины.
+// Защита от висящих горутин при медленной БД (например, во время shutdown).
+const requestLogWriteTimeout = 5 * time.Second
 
 // RequestLogger записывает все HTTP-запросы в таблицу request_logs.
 func RequestLogger(db *gorm.DB) echo.MiddlewareFunc {
@@ -35,6 +40,10 @@ func RequestLogger(db *gorm.DB) echo.MiddlewareFunc {
 			}
 
 			go func() {
+				// Отдельный context с таймаутом - request-context уже отменён
+				// после возврата из handler-а.
+				ctx, cancel := context.WithTimeout(context.Background(), requestLogWriteTimeout)
+				defer cancel()
 				log := models.RequestLogs{
 					UserID:         userID,
 					Username:       username,
@@ -44,7 +53,7 @@ func RequestLogger(db *gorm.DB) echo.MiddlewareFunc {
 					DurationMs:     &durationInt,
 					CreatedAt:      start,
 				}
-				if dbErr := db.Create(&log).Error; dbErr != nil {
+				if dbErr := db.WithContext(ctx).Create(&log).Error; dbErr != nil {
 					slog.Error("failed to write request log", "error", dbErr, "url", url)
 				}
 			}()

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -6,6 +6,11 @@ upstream frontend {
     server frontend:80;
 }
 
+# Rate-limit zone для /api/login (10 запросов/мин на IP). Это вторая линия защиты
+# поверх per-user lockout и per-IP-limiter внутри Go-middleware: ловит burst-атаки
+# и DDoS на уровне nginx до достижения backend-а.
+limit_req_zone $binary_remote_addr zone=login_zone:10m rate=10r/m;
+
 server {
     listen 80;
     server_name _;
@@ -13,6 +18,19 @@ server {
     # Health check (мониторинг и readiness probe)
     location = /health {
         proxy_pass http://backend;
+    }
+
+    # Login - дополнительный rate-limit поверх backend-middleware (защита от
+    # bypass через несколько вкладок/IP). burst=5 - принять короткий всплеск,
+    # дальше 429.
+    location = /api/login {
+        limit_req zone=login_zone burst=5 nodelay;
+        limit_req_status 429;
+        proxy_pass http://backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     # API — всё под /api/ проксируется на backend (router.Setup использует api := e.Group("/api")).


### PR DESCRIPTION
Cleanup из аудита антипаттернов.

## Что внутри
1. **Goroutine timeout** (\`pd_audit.go\`, \`request_logger.go\`): фоновые go func() для записи логов теперь используют \`context.WithTimeout(5s)\` вместо незавершаемых горутин. Снапшот данных запроса до go func() - data race fix (раньше \`c.Response().Status\` мог быть невалиден).
2. **mem_limit** в \`docker-compose.base.yml\`: db (1g), backend (512m), frontend (256m). Защита от OOM на 8GB машинах.
3. **nginx login rate-limit**: limit_req_zone \`login_zone\` (10r/m, burst=5) на \`/api/login\` - вторая линия защиты поверх Go-middleware.
4. **trivy-action**: закреплён на \`@0.28.0\` вместо \`@master\` (CI воспроизводимость).

Не сделал из аудита (по решению пользователя): README пароль, hardcoded admin123 в seed - это dev-дефолты, на prod не попадают.

## Test plan
- [x] go build + vet чисто
- [ ] CI green