### PR TITLE
feat(backend): корзина таблиц #186

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -174,6 +174,8 @@ func main() {
 	markService := services.NewMarkService(db)
 	attachmentTemplateService := services.NewAttachmentTemplateService(db, cfg.UploadPath)
 	attachmentBlankService := services.NewAttachmentBlankService(db)
+	trashService := services.NewTrashService(db)
+	trashDBRef := services.NewTrashDBRef(db)
 
 	// Handlers
 	authHandler := handlers.NewAuthHandler(authService, maintenanceService, cfg.CookieSecure, cfg.JWTRefreshTTL)
@@ -209,6 +211,7 @@ func main() {
 	markHandler := handlers.NewMarkHandler(markService)
 	attachmentTemplateHandler := handlers.NewAttachmentTemplateHandler(attachmentTemplateService)
 	attachmentBlankHandler := handlers.NewAttachmentBlankHandler(attachmentBlankService)
+	trashHandler := handlers.NewTrashHandler(trashService, trashDBRef)
 
 	// Swagger UI: http://localhost:8090/swagger/index.html
 	if cfg.SwaggerEnabled {
@@ -261,6 +264,7 @@ func main() {
 		Marks:               markHandler,
 		AttachmentTemplates: attachmentTemplateHandler,
 		AttachmentBlanks:    attachmentBlankHandler,
+		Trash:               trashHandler,
 		PermResolver:        permissionResolver,
 		DenialLog:           accessDenialService,
 		MaintenanceBlock:    maintenanceBlock,

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -101,6 +101,8 @@ func AllModels() []interface{} {
 		// Logging
 		&models.RequestLog{},
 		&models.RequestLogs{},
+		// Trash history для system_tables (#186)
+		&models.SystemTableTrashHistory{},
 
 		// Permissions
 		&models.Permission{},

--- a/internal/handlers/trash.go
+++ b/internal/handlers/trash.go
@@ -33,10 +33,10 @@ func NewTrashHandler(s services.TrashService, dbRef DBRef) *TrashHandler {
 // @Produce      json
 // @Security     BearerAuth
 // @Param        id path int true "ID SystemTable"
-// @Param        search query string false ""
-// @Param        organization_id query int false ""
-// @Param        date_from query string false "YYYY-MM-DD"
-// @Param        date_to query string false "YYYY-MM-DD"
+// @Param        search query string false "Поиск по номеру/ФИО"
+// @Param        organization_id query int false "Фильтр по организации"
+// @Param        date_from query string false "Дата удаления с (YYYY-MM-DD)"
+// @Param        date_to query string false "Дата удаления по (YYYY-MM-DD)"
 // @Success      200 {array} models.TrashItem
 // @Router       /system-tables/{id}/trash [get]
 func (h *TrashHandler) List(c echo.Context) error {

--- a/internal/handlers/trash.go
+++ b/internal/handlers/trash.go
@@ -1,0 +1,184 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+
+	"github.com/labstack/echo/v4"
+)
+
+// TrashHandler - HTTP API корзины таблиц (#186).
+type TrashHandler struct {
+	service services.TrashService
+	db      DBRef // нужен для определения table_type (cars/people) по systemTableID
+}
+
+// DBRef - минимальный интерфейс для одного запроса (выявить тип таблицы).
+// Не зависит от gorm импорта в handler-пакете.
+type DBRef interface {
+	GetTableType(tableID int) (string, error)
+}
+
+// NewTrashHandler создаёт handler.
+func NewTrashHandler(s services.TrashService, dbRef DBRef) *TrashHandler {
+	return &TrashHandler{service: s, db: dbRef}
+}
+
+// List godoc
+// @Summary      Список элементов в корзине таблицы
+// @Tags         trash
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID SystemTable"
+// @Param        search query string false ""
+// @Param        organization_id query int false ""
+// @Param        date_from query string false "YYYY-MM-DD"
+// @Param        date_to query string false "YYYY-MM-DD"
+// @Success      200 {array} models.TrashItem
+// @Router       /system-tables/{id}/trash [get]
+func (h *TrashHandler) List(c echo.Context) error {
+	tableID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid table id")
+	}
+	tableType, err := h.db.GetTableType(tableID)
+	if err != nil {
+		return err
+	}
+	filter := models.TrashFilter{
+		Search:         c.QueryParam("search"),
+		DateFrom:       c.QueryParam("date_from"),
+		DateTo:         c.QueryParam("date_to"),
+	}
+	if oid, _ := strconv.Atoi(c.QueryParam("organization_id")); oid > 0 {
+		filter.OrganizationID = oid
+	}
+	var items []models.TrashItem
+	switch tableType {
+	case "cars":
+		items, err = h.service.ListCarsTrash(c.Request().Context(), tableID, filter)
+	case "people":
+		items, err = h.service.ListEmployeesTrash(c.Request().Context(), tableID, filter)
+	default:
+		return echo.NewHTTPError(http.StatusBadRequest, "Тип таблицы не поддерживает корзину")
+	}
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, items)
+}
+
+// Restore godoc
+// @Summary      Восстановить элементы из корзины
+// @Tags         trash
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID SystemTable"
+// @Param        request body models.RestoreTrashRequest true "IDs"
+// @Success      200 {object} map[string]int
+// @Router       /system-tables/{id}/trash/restore [post]
+func (h *TrashHandler) Restore(c echo.Context) error {
+	tableID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid table id")
+	}
+	var req models.RestoreTrashRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	tableType, err := h.db.GetTableType(tableID)
+	if err != nil {
+		return err
+	}
+	userID, _ := c.Get("user_id").(int)
+	var restored int
+	switch tableType {
+	case "cars":
+		restored, err = h.service.RestoreCars(c.Request().Context(), tableID, req.IDs, userID)
+	case "people":
+		restored, err = h.service.RestoreEmployees(c.Request().Context(), tableID, req.IDs, userID)
+	default:
+		return echo.NewHTTPError(http.StatusBadRequest, "Тип таблицы не поддерживает корзину")
+	}
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, map[string]any{
+		"restored": restored,
+		"requested": len(req.IDs),
+	})
+}
+
+// PurgeOne godoc
+// @Summary      Окончательно удалить элемент из корзины
+// @Tags         trash
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID SystemTable"
+// @Param        item_id path int true "ID элемента"
+// @Success      200 {string} string "Удалено безвозвратно"
+// @Router       /system-tables/{id}/trash/{item_id} [delete]
+func (h *TrashHandler) PurgeOne(c echo.Context) error {
+	tableID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid table id")
+	}
+	itemID, err := strconv.Atoi(c.Param("item_id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid item id")
+	}
+	tableType, err := h.db.GetTableType(tableID)
+	if err != nil {
+		return err
+	}
+	userID, _ := c.Get("user_id").(int)
+	switch tableType {
+	case "cars":
+		err = h.service.PurgeCar(c.Request().Context(), itemID, userID)
+	case "people":
+		err = h.service.PurgeEmployee(c.Request().Context(), itemID, userID)
+	default:
+		return echo.NewHTTPError(http.StatusBadRequest, "Тип таблицы не поддерживает корзину")
+	}
+	if err != nil {
+		return err
+	}
+	return RespondMessage(c, "Удалено безвозвратно")
+}
+
+// ClearAll godoc
+// @Summary      Очистить корзину таблицы целиком
+// @Tags         trash
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID SystemTable"
+// @Success      200 {object} map[string]int
+// @Router       /system-tables/{id}/trash [delete]
+func (h *TrashHandler) ClearAll(c echo.Context) error {
+	tableID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid table id")
+	}
+	tableType, err := h.db.GetTableType(tableID)
+	if err != nil {
+		return err
+	}
+	userID, _ := c.Get("user_id").(int)
+	var purged int
+	switch tableType {
+	case "cars":
+		purged, err = h.service.ClearCarsTrash(c.Request().Context(), tableID, userID)
+	case "people":
+		purged, err = h.service.ClearEmployeesTrash(c.Request().Context(), tableID, userID)
+	default:
+		return echo.NewHTTPError(http.StatusBadRequest, "Тип таблицы не поддерживает корзину")
+	}
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, map[string]int{"purged": purged})
+}

--- a/internal/models/car.go
+++ b/internal/models/car.go
@@ -21,6 +21,11 @@ type Car struct {
 	Status             *int       `gorm:"index" json:"status"`
 	DateAdded          *time.Time `json:"date_added"`
 	DateRemoved        *time.Time `json:"date_removed"`
+	// IsPurged - финальное удаление из корзины (#186). Запись остаётся в БД для
+	// аудита, но скрывается даже из корзины. Восстановление невозможно.
+	IsPurged           bool       `gorm:"default:false;index" json:"is_purged"`
+	PurgedAt           *time.Time `json:"purged_at,omitempty"`
+	PurgedByUserID     *int       `json:"purged_by_user_id,omitempty"`
 	CreatedAt          time.Time  `json:"created_at"`
 	UpdatedAt          time.Time  `json:"updated_at"`
 	TerritoryExitTime  *time.Time `json:"territory_exit_time"`

--- a/internal/models/employee.go
+++ b/internal/models/employee.go
@@ -28,6 +28,11 @@ type Employee struct {
 	Status                   *int         `gorm:"index" json:"status"`
 	DateCreated              *time.Time   `json:"date_created"`
 	DateDeleted              *time.Time   `json:"date_deleted"`
+	// IsPurged - финальное удаление из корзины (#186). Запись остаётся в БД для
+	// аудита, но скрывается даже из корзины. Восстановление невозможно.
+	IsPurged                 bool         `gorm:"default:false;index" json:"is_purged"`
+	PurgedAt                 *time.Time   `json:"purged_at,omitempty"`
+	PurgedByUserID           *int         `json:"purged_by_user_id,omitempty"`
 	CreatedAt                time.Time    `json:"created_at"`
 	UpdatedAt                time.Time    `json:"updated_at"`
 }

--- a/internal/models/system_table_trash_history.go
+++ b/internal/models/system_table_trash_history.go
@@ -1,0 +1,57 @@
+package models
+
+import "time"
+
+// SystemTableTrashHistory логирует массовые действия с корзиной таблицы (#186):
+// очистка (cleared) и массовое восстановление (bulk_restored). Действия с
+// отдельными элементами логируются в cars_history/employees_history.
+type SystemTableTrashHistory struct {
+	ID            int       `json:"id"`
+	SystemTableID int       `gorm:"index" json:"system_table_id"`
+	ActionType    string    `gorm:"size:30;index" json:"action_type"` // cleared | bulk_restored | purged_one
+	AffectedCount int       `json:"affected_count"`
+	UserID        *int      `gorm:"index" json:"user_id,omitempty"`
+	User          *User     `gorm:"foreignKey:UserID" json:"-"`
+	CreatedAt     time.Time `json:"created_at"`
+}
+
+// TrashActionType - константы для SystemTableTrashHistory.ActionType.
+const (
+	TrashActionCleared       = "cleared"
+	TrashActionBulkRestored  = "bulk_restored"
+	TrashActionPurgedOne     = "purged_one"
+)
+
+// TrashItem - универсальный элемент корзины для API (car или employee).
+// Type определяет какие поля заполнены (для cars: car_number, mark_name;
+// для employees: last_name, first_name, middle_name).
+type TrashItem struct {
+	ID              int        `json:"id"`
+	Type            string     `json:"type"` // car | employee
+	ApplicationNum  *string    `json:"application_number,omitempty"`
+	DeletedAt       *time.Time `json:"deleted_at,omitempty"`
+	DeletedByName   string     `json:"deleted_by_name,omitempty"`
+	// Cars-only
+	CarNumber       *string    `json:"car_number,omitempty"`
+	MarkName        *string    `json:"mark_name,omitempty"`
+	Organization    string     `json:"organization,omitempty"`
+	EntryDateTo     *string    `json:"entry_date_to,omitempty"`
+	EntryTimeTo     *string    `json:"entry_time_to,omitempty"`
+	// Employees-only
+	LastName        *string    `json:"last_name,omitempty"`
+	FirstName       *string    `json:"first_name,omitempty"`
+	MiddleName      *string    `json:"middle_name,omitempty"`
+}
+
+// RestoreTrashRequest - тело запроса POST /system-tables/:id/trash/restore.
+type RestoreTrashRequest struct {
+	IDs []int `json:"ids" validate:"required,min=1"`
+}
+
+// TrashFilter - фильтры списка корзины.
+type TrashFilter struct {
+	Search         string `query:"search"`
+	OrganizationID int    `query:"organization_id"`
+	DateFrom       string `query:"date_from"`
+	DateTo         string `query:"date_to"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -48,6 +48,7 @@ type Dependencies struct {
 	Marks               *handlers.MarkHandler
 	AttachmentTemplates *handlers.AttachmentTemplateHandler
 	AttachmentBlanks    *handlers.AttachmentBlankHandler
+	Trash               *handlers.TrashHandler
 
 	// Services (для middleware и audit)
 	PermResolver *services.PermissionResolver
@@ -97,6 +98,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	marks := d.Marks
 	attachmentTemplates := d.AttachmentTemplates
 	attachmentBlanks := d.AttachmentBlanks
+	trash := d.Trash
 	permResolver := d.PermResolver
 	denialLog := d.DenialLog
 	maintenanceBlock := d.MaintenanceBlock
@@ -300,6 +302,14 @@ func Setup(e *echo.Echo, d Dependencies) {
 	stg.POST("/:id/photos", st.UploadPhoto)
 	stg.DELETE("/:table_id/photos/:photo_id", st.DeletePhoto)
 	stg.POST("/:table_id/photos/:photo_id/main", st.SetMainPhoto)
+
+	// Корзина таблицы (#186) - удалённые элементы с возможностью восстановить
+	// или окончательно удалить. Тип элементов определяется по table_type
+	// системной таблицы (cars или people).
+	stg.GET("/:id/trash", trash.List)
+	stg.POST("/:id/trash/restore", trash.Restore)
+	stg.DELETE("/:id/trash/:item_id", trash.PurgeOne)
+	stg.DELETE("/:id/trash", trash.ClearAll)
 
 	// Реестр автомобилей (unique_cars)
 	ucg := protected.Group("/unique-cars")

--- a/internal/services/trash_db_ref.go
+++ b/internal/services/trash_db_ref.go
@@ -1,0 +1,35 @@
+package services
+
+import (
+	"errors"
+	"net/http"
+
+	"systemburo/internal/models"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+// TrashDBRef - адаптер для TrashHandler.DBRef: один SQL-запрос на определение
+// table_type (cars|people) по systemTableID. Вынесен в services чтобы не
+// плодить GORM в handlers.
+type TrashDBRef struct {
+	db *gorm.DB
+}
+
+// NewTrashDBRef создаёт адаптер.
+func NewTrashDBRef(db *gorm.DB) *TrashDBRef {
+	return &TrashDBRef{db: db}
+}
+
+// GetTableType возвращает "cars"/"people" по ID таблицы.
+func (r *TrashDBRef) GetTableType(tableID int) (string, error) {
+	var st models.SystemTable
+	if err := r.db.Select("id, table_type").First(&st, tableID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return "", echo.NewHTTPError(http.StatusNotFound, "Таблица не найдена")
+		}
+		return "", echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения таблицы")
+	}
+	return st.TableType, nil
+}

--- a/internal/services/trash_service.go
+++ b/internal/services/trash_service.go
@@ -1,0 +1,296 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"systemburo/internal/models"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+// TrashService - корзина для cars/employees (#186). Использует существующий
+// soft-delete (status=0, date_removed/date_deleted) и новое поле is_purged
+// для финального удаления. Восстановление разрешено только при наличии
+// действующей согласованной заявки на эту запись.
+type TrashService interface {
+	ListCarsTrash(ctx context.Context, systemTableID int, filter models.TrashFilter) ([]models.TrashItem, error)
+	ListEmployeesTrash(ctx context.Context, systemTableID int, filter models.TrashFilter) ([]models.TrashItem, error)
+	RestoreCars(ctx context.Context, systemTableID int, ids []int, userID int) (int, error)
+	RestoreEmployees(ctx context.Context, systemTableID int, ids []int, userID int) (int, error)
+	PurgeCar(ctx context.Context, id, userID int) error
+	PurgeEmployee(ctx context.Context, id, userID int) error
+	ClearCarsTrash(ctx context.Context, systemTableID, userID int) (int, error)
+	ClearEmployeesTrash(ctx context.Context, systemTableID, userID int) (int, error)
+	CanRestoreCar(ctx context.Context, id int) (bool, string)
+	CanRestoreEmployee(ctx context.Context, id int) (bool, string)
+}
+
+type trashService struct {
+	db *gorm.DB
+}
+
+// NewTrashService создаёт сервис корзины.
+func NewTrashService(db *gorm.DB) TrashService {
+	return &trashService{db: db}
+}
+
+// ListCarsTrash возвращает удалённые машины таблицы. Привязка car → system_table
+// идёт через attachment → application_responsible_users или через cars_history.table_id.
+// Используем cars_history.table_id - проще и надёжней.
+func (s *trashService) ListCarsTrash(ctx context.Context, systemTableID int, filter models.TrashFilter) ([]models.TrashItem, error) {
+	rows, err := s.queryCarsTrash(ctx, systemTableID, filter)
+	if err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения корзины")
+	}
+	return rows, nil
+}
+
+func (s *trashService) queryCarsTrash(ctx context.Context, tableID int, f models.TrashFilter) ([]models.TrashItem, error) {
+	q := s.db.WithContext(ctx).
+		Table("cars c").
+		Select(`c.id, 'car' AS type,
+			a.application_number, c.entry_date_to, c.entry_time_to,
+			COALESCE(c.mark_name, c.car_brand) AS mark_name, c.car_number,
+			COALESCE(org.name, '') AS organization,
+			c.date_removed AS deleted_at,
+			COALESCE(format_short_name(u.last_name, u.first_name, u.middle_name), '') AS deleted_by_name`).
+		Joins(`JOIN attachments att ON att.id = c.attachment_id`).
+		Joins(`JOIN applications a ON a.id = att.application_id`).
+		Joins(`LEFT JOIN organizations org ON org.id = a.organization_id`).
+		Joins(`LEFT JOIN cars_history ch ON ch.car_id = c.id AND ch.action_type = 'delete' AND ch.table_id = ?`, tableID).
+		Joins(`LEFT JOIN users u ON u.id = ch.user_id`).
+		Where("c.status = 0 AND c.date_removed IS NOT NULL AND c.is_purged = false")
+	if f.Search != "" {
+		q = q.Where("(c.car_number ILIKE ? OR COALESCE(c.mark_name, c.car_brand) ILIKE ?)", "%"+f.Search+"%", "%"+f.Search+"%")
+	}
+	if f.OrganizationID > 0 {
+		q = q.Where("a.organization_id = ?", f.OrganizationID)
+	}
+	if f.DateFrom != "" {
+		q = q.Where("c.date_removed >= ?", f.DateFrom)
+	}
+	if f.DateTo != "" {
+		q = q.Where("c.date_removed <= ?", f.DateTo+" 23:59:59")
+	}
+	q = q.Order("c.date_removed DESC")
+
+	rows := make([]models.TrashItem, 0)
+	if err := q.Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func (s *trashService) ListEmployeesTrash(ctx context.Context, systemTableID int, filter models.TrashFilter) ([]models.TrashItem, error) {
+	q := s.db.WithContext(ctx).
+		Table("employees e").
+		Select(`e.id, 'employee' AS type,
+			a.application_number, e.last_name, e.first_name, e.middle_name,
+			COALESCE(org.name, '') AS organization,
+			e.date_deleted AS deleted_at,
+			COALESCE(format_short_name(u.last_name, u.first_name, u.middle_name), '') AS deleted_by_name`).
+		Joins(`JOIN attachments att ON att.id = e.attachment_id`).
+		Joins(`JOIN applications a ON a.id = att.application_id`).
+		Joins(`LEFT JOIN organizations org ON org.id = a.organization_id`).
+		Joins(`LEFT JOIN employees_history eh ON eh.employee_id = e.id AND eh.action_type = 'delete' AND eh.table_id = ?`, systemTableID).
+		Joins(`LEFT JOIN users u ON u.id = eh.user_id`).
+		Where("e.status = 0 AND e.date_deleted IS NOT NULL AND e.is_purged = false")
+	if filter.Search != "" {
+		q = q.Where("(e.last_name ILIKE ? OR e.first_name ILIKE ?)", "%"+filter.Search+"%", "%"+filter.Search+"%")
+	}
+	if filter.OrganizationID > 0 {
+		q = q.Where("a.organization_id = ?", filter.OrganizationID)
+	}
+	if filter.DateFrom != "" {
+		q = q.Where("e.date_deleted >= ?", filter.DateFrom)
+	}
+	if filter.DateTo != "" {
+		q = q.Where("e.date_deleted <= ?", filter.DateTo+" 23:59:59")
+	}
+	q = q.Order("e.date_deleted DESC")
+
+	rows := make([]models.TrashItem, 0)
+	if err := q.Scan(&rows).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения корзины")
+	}
+	return rows, nil
+}
+
+// CanRestoreCar - проверка что есть действующая согласованная заявка на эту машину.
+func (s *trashService) CanRestoreCar(ctx context.Context, id int) (bool, string) {
+	var cnt int64
+	err := s.db.WithContext(ctx).
+		Table("cars c").
+		Joins("JOIN attachments a ON a.id = c.attachment_id").
+		Joins("JOIN applications app ON app.id = a.application_id").
+		Where("c.id = ?", id).
+		Where("app.confirmation = ?", models.ConfirmationApproved).
+		Where("app.status NOT IN ?", []string{models.StatusCompleted, models.StatusRefused}).
+		Where("a.entry_date_to IS NULL OR a.entry_date_to::date >= CURRENT_DATE").
+		Count(&cnt).Error
+	if err != nil || cnt == 0 {
+		return false, "Нет активной согласованной заявки - восстановление невозможно"
+	}
+	return true, ""
+}
+
+func (s *trashService) CanRestoreEmployee(ctx context.Context, id int) (bool, string) {
+	var cnt int64
+	err := s.db.WithContext(ctx).
+		Table("employees e").
+		Joins("JOIN attachments a ON a.id = e.attachment_id").
+		Joins("JOIN applications app ON app.id = a.application_id").
+		Where("e.id = ?", id).
+		Where("app.confirmation = ?", models.ConfirmationApproved).
+		Where("app.status NOT IN ?", []string{models.StatusCompleted, models.StatusRefused}).
+		Where("a.entry_date_to IS NULL OR a.entry_date_to::date >= CURRENT_DATE").
+		Count(&cnt).Error
+	if err != nil || cnt == 0 {
+		return false, "Нет активной согласованной заявки - восстановление невозможно"
+	}
+	return true, ""
+}
+
+func (s *trashService) RestoreCars(ctx context.Context, systemTableID int, ids []int, userID int) (int, error) {
+	restored := 0
+	for _, id := range ids {
+		ok, _ := s.CanRestoreCar(ctx, id)
+		if !ok {
+			continue
+		}
+		err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+			res := tx.Model(&models.Car{}).Where("id = ? AND status = 0 AND is_purged = false", id).
+				Updates(map[string]any{"status": 1, "date_removed": nil})
+			if res.Error != nil || res.RowsAffected == 0 {
+				return errors.New("not in trash")
+			}
+			tableID := systemTableID
+			return tx.Create(&models.CarHistory{
+				CarID:      id,
+				UserID:     &userID,
+				ActionType: "restore",
+				TableID:    &tableID,
+			}).Error
+		})
+		if err == nil {
+			restored++
+		}
+	}
+	if restored > 1 {
+		tid := systemTableID
+		s.db.WithContext(ctx).Create(&models.SystemTableTrashHistory{
+			SystemTableID: tid, ActionType: models.TrashActionBulkRestored,
+			AffectedCount: restored, UserID: &userID,
+		})
+	}
+	return restored, nil
+}
+
+func (s *trashService) RestoreEmployees(ctx context.Context, systemTableID int, ids []int, userID int) (int, error) {
+	restored := 0
+	for _, id := range ids {
+		ok, _ := s.CanRestoreEmployee(ctx, id)
+		if !ok {
+			continue
+		}
+		err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+			res := tx.Model(&models.Employee{}).Where("id = ? AND status = 0 AND is_purged = false", id).
+				Updates(map[string]any{"status": 1, "date_deleted": nil})
+			if res.Error != nil || res.RowsAffected == 0 {
+				return errors.New("not in trash")
+			}
+			tableID := systemTableID
+			return tx.Create(&models.EmployeeHistory{
+				EmployeeID: id,
+				UserID:     &userID,
+				ActionType: "restore",
+				TableID:    &tableID,
+			}).Error
+		})
+		if err == nil {
+			restored++
+		}
+	}
+	if restored > 1 {
+		s.db.WithContext(ctx).Create(&models.SystemTableTrashHistory{
+			SystemTableID: systemTableID, ActionType: models.TrashActionBulkRestored,
+			AffectedCount: restored, UserID: &userID,
+		})
+	}
+	return restored, nil
+}
+
+func (s *trashService) PurgeCar(ctx context.Context, id, userID int) error {
+	now := time.Now().UTC()
+	res := s.db.WithContext(ctx).Model(&models.Car{}).
+		Where("id = ? AND status = 0 AND is_purged = false", id).
+		Updates(map[string]any{"is_purged": true, "purged_at": now, "purged_by_user_id": userID})
+	if res.Error != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка удаления")
+	}
+	if res.RowsAffected == 0 {
+		return echo.NewHTTPError(http.StatusNotFound, "Запись не в корзине")
+	}
+	return nil
+}
+
+func (s *trashService) PurgeEmployee(ctx context.Context, id, userID int) error {
+	now := time.Now().UTC()
+	res := s.db.WithContext(ctx).Model(&models.Employee{}).
+		Where("id = ? AND status = 0 AND is_purged = false", id).
+		Updates(map[string]any{"is_purged": true, "purged_at": now, "purged_by_user_id": userID})
+	if res.Error != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка удаления")
+	}
+	if res.RowsAffected == 0 {
+		return echo.NewHTTPError(http.StatusNotFound, "Запись не в корзине")
+	}
+	return nil
+}
+
+// ClearCarsTrash покрывает все cars в корзине этой таблицы (через cars_history.table_id).
+func (s *trashService) ClearCarsTrash(ctx context.Context, systemTableID, userID int) (int, error) {
+	now := time.Now().UTC()
+	// Подзапрос: cars где есть запись 'delete' в cars_history с нужным table_id.
+	subq := s.db.Table("cars_history").
+		Select("DISTINCT car_id").
+		Where("action_type = 'delete' AND table_id = ?", systemTableID)
+	res := s.db.WithContext(ctx).Model(&models.Car{}).
+		Where("status = 0 AND is_purged = false AND id IN (?)", subq).
+		Updates(map[string]any{"is_purged": true, "purged_at": now, "purged_by_user_id": userID})
+	if res.Error != nil {
+		return 0, echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Ошибка очистки: %v", res.Error))
+	}
+	if res.RowsAffected > 0 {
+		s.db.WithContext(ctx).Create(&models.SystemTableTrashHistory{
+			SystemTableID: systemTableID, ActionType: models.TrashActionCleared,
+			AffectedCount: int(res.RowsAffected), UserID: &userID,
+		})
+	}
+	return int(res.RowsAffected), nil
+}
+
+func (s *trashService) ClearEmployeesTrash(ctx context.Context, systemTableID, userID int) (int, error) {
+	now := time.Now().UTC()
+	subq := s.db.Table("employees_history").
+		Select("DISTINCT employee_id").
+		Where("action_type = 'delete' AND table_id = ?", systemTableID)
+	res := s.db.WithContext(ctx).Model(&models.Employee{}).
+		Where("status = 0 AND is_purged = false AND id IN (?)", subq).
+		Updates(map[string]any{"is_purged": true, "purged_at": now, "purged_by_user_id": userID})
+	if res.Error != nil {
+		return 0, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка очистки")
+	}
+	if res.RowsAffected > 0 {
+		s.db.WithContext(ctx).Create(&models.SystemTableTrashHistory{
+			SystemTableID: systemTableID, ActionType: models.TrashActionCleared,
+			AffectedCount: int(res.RowsAffected), UserID: &userID,
+		})
+	}
+	return int(res.RowsAffected), nil
+}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -130,6 +130,8 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	markService := services.NewMarkService(db)
 	attachmentTemplateService := services.NewAttachmentTemplateService(db, "./uploads")
 	attachmentBlankService := services.NewAttachmentBlankService(db)
+	trashService := services.NewTrashService(db)
+	trashDBRef := services.NewTrashDBRef(db)
 
 	// Create all handlers
 	authHandler := handlers.NewAuthHandler(authService, maintenanceService, false, 168*time.Hour)
@@ -167,6 +169,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	markHandler := handlers.NewMarkHandler(markService)
 	attachmentTemplateHandler := handlers.NewAttachmentTemplateHandler(attachmentTemplateService)
 	attachmentBlankHandler := handlers.NewAttachmentBlankHandler(attachmentBlankService)
+	trashHandler := handlers.NewTrashHandler(trashService, trashDBRef)
 
 	// Setup Echo with routes (no rate limiter, no logger — clean for tests)
 	e := echo.New()
@@ -209,6 +212,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 		Marks:               markHandler,
 		AttachmentTemplates: attachmentTemplateHandler,
 		AttachmentBlanks:    attachmentBlankHandler,
+		Trash:               trashHandler,
 		PermResolver:        permissionResolver,
 		DenialLog:           accessDenialService,
 		JWTSecret:           []byte(TestJWTSecret),


### PR DESCRIPTION
Backend часть #186. Frontend - отдельным PR.

## Архитектура
Без новых cars/employees таблиц - используем существующий soft-delete (status=0).
Добавлены 3 поля: \`is_purged\`, \`purged_at\`, \`purged_by_user_id\`.

\`SystemTableTrashHistory\` - новая таблица для логов массовых действий.

## API
\`\`\`
GET    /system-tables/:id/trash               - список + фильтры
POST   /system-tables/:id/trash/restore       - bulk restore (с проверкой)
DELETE /system-tables/:id/trash/:item_id      - окончательное удаление
DELETE /system-tables/:id/trash               - очистить корзину
\`\`\`

## Условие восстановления
\`\`\`sql
app.confirmation = 'Согласовано'
  AND app.status NOT IN ('Завершено', 'Отказано')
  AND a.entry_date_to >= CURRENT_DATE
\`\`\`
Иначе - 'Нет активной согласованной заявки, восстановление невозможно'.

## Test plan
- [x] go build + vet чисто
- [ ] CI green
- [ ] Frontend следующим PR