### PR TITLE
fix(ci): apk add openssl в staging nginx - починил basic auth

### DIFF
--- a/nginx/Dockerfile.staging
+++ b/nginx/Dockerfile.staging
@@ -1,4 +1,5 @@
 FROM nginx:1.25-alpine
-# Раньше тут был "apk add apache2-utils" для htpasswd.
-# Теперь генерируем .htpasswd через openssl (встроен в alpine-base) - см. staging-entrypoint.sh.
-# Это избавляет от зависимости от alpine repos в build-стадии и runtime.
+# openssl нужен entrypoint-скрипту /docker-entrypoint.d/40-htpasswd.sh для
+# генерации apr1-хеша в .htpasswd. В nginx:alpine он НЕ предустановлен.
+# Без этого entrypoint падает с "openssl: not found" и basic auth не работает.
+RUN apk add --no-cache openssl


### PR DESCRIPTION
## Проблема
Коммит c535991 переключил `staging-entrypoint.sh` с `htpasswd` (apache2-utils) на `openssl passwd -apr1`, мотивируя что openssl "встроен в alpine-base". Это **неверно** - `nginx:1.25-alpine` НЕ содержит openssl.

В результате:
- entrypoint падает с `openssl: not found`
- `.htpasswd` остаётся с пустым хешем (только `admin:`)
- basic auth не пускает никого с 18.05

## Фикс
`RUN apk add --no-cache openssl` в `nginx/Dockerfile.staging`.

## Test plan
- [ ] CI зелёный
- [ ] На staging после деплоя: `.htpasswd` содержит `admin:\$apr1\$...`
- [ ] `curl -u 'admin:IQRR...' https://stagingburo.washka17.site/` возвращает не 401

## Срочный workaround (без этого PR)
На VPS вручную сгенерить хеш и положить в `.htpasswd`:
\`\`\`sh
HASH=\$(openssl passwd -apr1 'IQRRyXUT4jE3r3Ty')
docker compose -f docker-compose.base.yml -f docker-compose.staging.yml exec -T nginx sh -c "printf 'admin:%s\n' '\$HASH' > /etc/nginx/.htpasswd && nginx -s reload"
\`\`\`