### PR TITLE
fix(ci): npm audit с --omit=dev, dev-deps информационно

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,9 +29,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-frontend
-      - name: npm audit (strict, high+)
+      - name: npm audit (production deps, high+)
         working-directory: frontend
-        run: npm audit --audit-level=high
+        run: npm audit --omit=dev --audit-level=high
+      - name: npm audit (dev deps, informational)
+        working-directory: frontend
+        run: npm audit --audit-level=high || true
 
   trivy-scan:
     name: Trivy Image Scan


### PR DESCRIPTION
## Проблема
Security workflow начал валить все PR с 23.05 (последний зелёный 18.05, PR #287). Между датами `package-lock.json` не менялся - это новые advisory от GitHub Security DB:

- **HIGH** \`js-cookie@3.0.5\` (GHSA-qjx8-664m-686j) - через \`@vue/test-utils\` → \`js-beautify\` → \`editorconfig\` → \`js-cookie\`
- moderate brace-expansion (eslint)
- moderate uuid (через exceljs)

js-cookie HIGH живёт **только в dev-зависимостях** (js-beautify нужен для test-utils форматирования). В production-бандл фронта он не попадает. Upstream-фикса нет - js-beautify ещё не обновил editorconfig.

## Решение
\`npm audit --omit=dev --audit-level=high\` для строгой проверки runtime-deps. Второй шаг \`npm audit --audit-level=high || true\` - информационный отчёт по dev-deps без блокировки CI.

Альтернативы (audit-ci/whitelist, обновление js-beautify) - не подходят: лишняя зависимость или upstream-блокер.

## Test plan
- [x] Локально \`npm audit --omit=dev --audit-level=high\` → exit 0 (показывает moderate, но не валит)
- [ ] Security workflow на этом PR зелёный
- [ ] CI Summary зелёный