### PR TITLE
feat(frontend): корзина таблиц - редизайн под референс (#186)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -35,6 +35,7 @@
       <ScrollTopButton v-if="showChrome" />
     </div>
     <ToastContainer />
+    <ConfirmDialog />
   </div>
 </template>
 
@@ -46,6 +47,7 @@ import NavMenu from './components/NavMenu.vue';
 import TheHeader from './components/TheHeader/TheHeader.vue';
 import ScrollTopButton from './components/ScrollTopButton.vue';
 import ToastContainer from './components/ToastContainer.vue';
+import ConfirmDialog from './components/ConfirmDialog.vue';
 
 export default {
   name: "App",
@@ -53,7 +55,8 @@ export default {
     NavMenu,
     TheHeader,
     ScrollTopButton,
-    ToastContainer
+    ToastContainer,
+    ConfirmDialog,
   },
   computed: {
     isAuthenticated() {

--- a/frontend/src/components/ConfirmDialog.vue
+++ b/frontend/src/components/ConfirmDialog.vue
@@ -1,0 +1,199 @@
+<template>
+  <Teleport to="body">
+    <transition name="confirm-fade">
+      <div
+        v-if="state"
+        class="confirm-overlay"
+        data-testid="confirm-overlay"
+        @click.self="cancel"
+      >
+        <div
+          class="confirm-dialog"
+          role="dialog"
+          aria-modal="true"
+        >
+          <div class="confirm-dialog__header">
+            <h3 class="confirm-dialog__title">
+              {{ state.title }}
+            </h3>
+            <button
+              class="confirm-dialog__close"
+              aria-label="Закрыть"
+              @click="cancel"
+            >
+              ×
+            </button>
+          </div>
+          <div class="confirm-dialog__body">
+            {{ state.message }}
+          </div>
+          <div class="confirm-dialog__footer">
+            <button
+              class="confirm-dialog__btn confirm-dialog__btn--cancel"
+              data-testid="confirm-cancel"
+              @click="cancel"
+            >
+              {{ state.cancelText }}
+            </button>
+            <button
+              class="confirm-dialog__btn"
+              :class="state.danger ? 'confirm-dialog__btn--danger' : 'confirm-dialog__btn--primary'"
+              data-testid="confirm-ok"
+              @click="confirm"
+            >
+              {{ state.confirmText }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </transition>
+  </Teleport>
+</template>
+
+<script>
+import { computed } from 'vue';
+import { useUiStore } from '@/stores/ui';
+
+export default {
+  name: 'ConfirmDialog',
+  setup() {
+    const ui = useUiStore();
+    const state = computed(() => ui.confirmState);
+
+    function confirm() {
+      ui.resolveConfirm(true);
+    }
+    function cancel() {
+      ui.resolveConfirm(false);
+    }
+
+    return { state, confirm, cancel };
+  },
+};
+</script>
+
+<style scoped>
+.confirm-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1100;
+  padding: 20px;
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
+}
+
+.confirm-dialog {
+  width: 100%;
+  max-width: 400px;
+  background: #FFFFFF;
+  border-radius: 16px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+  overflow: hidden;
+  font-family: 'Montserrat', sans-serif;
+}
+
+.confirm-dialog__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 20px;
+  border-bottom: 1px solid #E6E6E6;
+}
+
+.confirm-dialog__title {
+  margin: 0;
+  font-size: 1.1em;
+  font-weight: 600;
+  color: #000;
+}
+
+.confirm-dialog__close {
+  background: none;
+  border: none;
+  font-size: 18px;
+  cursor: pointer;
+  color: #999;
+  padding: 0;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.confirm-dialog__close:hover {
+  color: #333;
+}
+
+.confirm-dialog__body {
+  padding: 20px;
+  color: #333;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.confirm-dialog__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 16px 20px;
+  border-top: 1px solid #E6E6E6;
+}
+
+.confirm-dialog__btn {
+  padding: 8px 16px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.85em;
+  font-weight: 500;
+  transition: all 0.2s ease;
+  border: 1px solid transparent;
+  min-width: 90px;
+  font-family: inherit;
+}
+
+.confirm-dialog__btn--cancel {
+  background: #f8f9fa;
+  color: #666;
+  border-color: #e6e6e6;
+}
+
+.confirm-dialog__btn--cancel:hover {
+  background: #e9ecef;
+}
+
+.confirm-dialog__btn--primary {
+  background: #4F5BDF;
+  color: #FFFFFF;
+}
+
+.confirm-dialog__btn--primary:hover {
+  background: #3a45b2;
+}
+
+.confirm-dialog__btn--danger {
+  background: #FF6668;
+  color: #FFFFFF;
+}
+
+.confirm-dialog__btn--danger:hover {
+  background: #e54e50;
+}
+
+.confirm-fade-enter-active,
+.confirm-fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.confirm-fade-enter-from,
+.confirm-fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/frontend/src/components/TablesComponent.vue
+++ b/frontend/src/components/TablesComponent.vue
@@ -112,11 +112,6 @@
         />
       </div>
       <div class="filters__options">
-        <img
-          src="@/assets/icons/trashcan.png"
-          class="options__icon"
-          @click="clearFilters"
-        >
         <RouterLink
           :to="`/table/${$route.params.tableName}/trash`"
           class="options__trash-link"
@@ -573,6 +568,7 @@ export default {
     gap: 10px;
     position: relative;
 }
+
 
 .field {
     width: 200px;

--- a/frontend/src/components/TablesComponent.vue
+++ b/frontend/src/components/TablesComponent.vue
@@ -122,8 +122,13 @@
           class="options__trash-link"
           title="Корзина таблицы"
           data-testid="table-trash-link"
+          aria-label="Корзина таблицы"
         >
-          Корзина
+          <img
+            src="@/assets/icons/trashcan.png"
+            class="options__icon"
+            alt=""
+          >
         </RouterLink>
         <button class="options__export">
           <img

--- a/frontend/src/stores/ui.js
+++ b/frontend/src/stores/ui.js
@@ -16,6 +16,48 @@ export const useUiStore = defineStore('ui', () => {
   function success(message) { showToast(message, 'success') }
   function error(message) { showToast(message, 'error', 5000) }
   function warning(message) { showToast(message, 'warning') }
+  function info(message) { showToast(message, 'info') }
 
-  return { toasts, sidebarExpanded, showToast, success, error, warning }
+  // Глобальная модалка подтверждения. Возвращает Promise<boolean>.
+  // Использование: const ok = await ui.confirm({ message: '...' })
+  const confirmState = ref(null)
+
+  function confirm({
+    title = 'Подтверждение',
+    message,
+    confirmText = 'Удалить',
+    cancelText = 'Отмена',
+    danger = true,
+  } = {}) {
+    return new Promise((resolve) => {
+      confirmState.value = {
+        title,
+        message,
+        confirmText,
+        cancelText,
+        danger,
+        resolve,
+      }
+    })
+  }
+
+  function resolveConfirm(value) {
+    if (confirmState.value) {
+      confirmState.value.resolve(value)
+      confirmState.value = null
+    }
+  }
+
+  return {
+    toasts,
+    sidebarExpanded,
+    showToast,
+    success,
+    error,
+    warning,
+    info,
+    confirmState,
+    confirm,
+    resolveConfirm,
+  }
 })

--- a/frontend/src/views/TrashView.vue
+++ b/frontend/src/views/TrashView.vue
@@ -1,89 +1,104 @@
 <template>
   <section class="trash-view">
     <header class="trash-header">
-      <h2 class="trash-title">
-        <RouterLink
-          :to="`/table/${tableName}`"
-          class="trash-title__name"
-        >
-          {{ displayName }}
-        </RouterLink>
-        <span class="trash-title__slash">/</span>
-        <span class="trash-title__current">Корзина</span>
+      <div class="trash-titlebar">
+        <h2 class="trash-title">
+          Таблица <RouterLink :to="`/table/${tableName}`" class="trash-title__name">{{ displayName }}</RouterLink> / Корзина
+        </h2>
         <RouterLink
           :to="`/table/${tableName}`"
           class="trash-back-btn"
           data-testid="trash-back"
         >
-          ← Назад
-        </RouterLink>
-      </h2>
-
-      <div class="trash-filters">
-        <SearchComponent
-          v-model="filters.search"
-          :title="'Поиск..'"
-          class="trash-filters__search"
-          @input="onSearchChange"
-        />
-        <OrganizationFilter
-          ref="organizationFilter"
-          v-model="filters.organizationId"
-          @change="onOrganizationChange"
-        />
-        <DateFilter
-          :selected-date="filters.selectedDate"
-          :date-range-start="filters.dateFrom"
-          :date-range-end="filters.dateTo"
-          @update:selected-date="filters.selectedDate = $event"
-          @update:date-range-start="filters.dateFrom = $event"
-          @update:date-range-end="filters.dateTo = $event"
-          @apply="reload"
-          @clear="onDateClear"
-        />
-        <button
-          class="trash-action-btn trash-action-btn--ghost"
-          data-testid="trash-clear-filters"
-          @click="clearFilters"
-        >
-          Очистить
-        </button>
-        <button
-          class="trash-action-btn trash-action-btn--ghost"
-          data-testid="trash-export"
-          :disabled="!items.length"
-          @click="onExport"
-        >
           <img
-            src="@/assets/icons/export.png"
-            class="trash-action-btn__icon"
+            src="@/assets/icons/arrow.png"
+            class="trash-back-btn__icon"
             alt=""
           >
-          Экспорт
-        </button>
-        <RefreshButton
-          :loading="isLoading"
-          @refresh="reload"
-        />
+          Назад
+        </RouterLink>
+      </div>
+
+      <div class="trash-filters">
+        <div class="trash-filters__group trash-filters__group--left">
+          <SearchComponent
+            v-model="filters.search"
+            :title="'Поиск..'"
+            class="trash-filters__search"
+            @input="onSearchChange"
+          />
+          <OrganizationFilter
+            ref="organizationFilter"
+            v-model="filters.organizationId"
+            @change="onOrganizationChange"
+          />
+          <DateFilter
+            :selected-date="filters.selectedDate"
+            :date-range-start="filters.dateFrom"
+            :date-range-end="filters.dateTo"
+            @update:selected-date="filters.selectedDate = $event"
+            @update:date-range-start="filters.dateFrom = $event"
+            @update:date-range-end="filters.dateTo = $event"
+            @apply="reload"
+            @clear="onDateClear"
+          />
+        </div>
+        <div class="trash-filters__group trash-filters__group--right">
+          <button
+            class="trash-btn trash-btn--ghost"
+            data-testid="trash-clear-filters"
+            @click="clearFilters"
+          >
+            Очистить
+          </button>
+          <button
+            class="trash-btn trash-btn--ghost"
+            data-testid="trash-export"
+            :disabled="!items.length"
+            @click="onExport"
+          >
+            <img
+              src="@/assets/icons/export.png"
+              class="trash-btn__icon"
+              alt=""
+            >
+            Экспорт
+          </button>
+          <button
+            class="trash-btn trash-btn--refresh"
+            data-testid="trash-refresh"
+            :disabled="isLoading"
+            @click="reload"
+          >
+            <img
+              src="@/assets/icons/refresh.png"
+              class="trash-btn__icon"
+              alt=""
+            >
+            Обновить
+          </button>
+        </div>
       </div>
     </header>
 
     <article class="trash-card">
       <div class="trash-card__header">
         <h3 class="trash-card__title">
-          {{ tableType === 'cars' ? 'Удалённые автомобили' : 'Удалённые сотрудники' }}
+          {{ tableType === 'cars' ? 'Удаленные автомобили' : 'Удаленные сотрудники' }}
         </h3>
         <button
-          v-if="items.length"
           class="trash-card__link"
           data-testid="trash-restore-all-link"
+          :disabled="!items.length"
           @click="onRestoreAll"
         >
           Восстановить
         </button>
+
         <div class="trash-card__spacer" />
+
         <button
-          class="trash-action-btn trash-action-btn--primary"
+          class="trash-btn trash-btn--primary"
           data-testid="trash-restore-selected"
           :disabled="!selectedIds.length"
           @click="onRestoreSelected"
@@ -118,63 +133,65 @@
         >
           <thead>
             <tr>
-              <th class="trash-table__th-checkbox">
-                <input
-                  type="checkbox"
-                  :checked="allSelected"
-                  data-testid="trash-select-all"
-                  @change="toggleAll"
+              <th
+                v-for="col in columns"
+                :key="col.key"
+                :class="['trash-table__th', col.sortable && 'trash-table__th--sortable', sortField === col.key && 'trash-table__th--active']"
+                @click="col.sortable && sortBy(col.key)"
+              >
+                <span>{{ col.label }}</span>
+                <img
+                  v-if="col.sortable"
+                  src="@/assets/icons/sort.png"
+                  class="trash-table__sort"
+                  :class="{ 'trash-table__sort--desc': sortField === col.key && sortDir === 'desc' }"
+                  alt=""
                 >
               </th>
-              <th>Номер заявки</th>
-              <th>Дата и время удаления</th>
-              <template v-if="tableType === 'cars'">
-                <th>Номер Т/С</th>
-                <th>Марка</th>
-              </template>
-              <template v-else>
-                <th>Фамилия</th>
-                <th>Имя</th>
-              </template>
-              <th>Организация</th>
-              <th>Действует до</th>
-              <th>Время</th>
-              <th>Статус</th>
               <th class="trash-table__th-actions" />
             </tr>
           </thead>
           <tbody>
             <tr
-              v-for="item in items"
+              v-for="item in sortedItems"
               :key="item.id"
               data-testid="trash-row"
             >
-              <td>
-                <input
-                  v-model="selectedIds"
-                  type="checkbox"
-                  :value="item.id"
-                >
-              </td>
-              <td class="trash-table__app-number">
+              <td class="trash-table__td trash-table__td--muted">
                 {{ item.application_number || '—' }}
               </td>
-              <td>{{ formatDateTime(item.deleted_at) }}</td>
+              <td class="trash-table__td">
+                {{ formatDateTime(item.deleted_at) }}
+              </td>
               <template v-if="tableType === 'cars'">
-                <td>{{ item.car_number || '—' }}</td>
-                <td>{{ item.mark_name || '—' }}</td>
+                <td class="trash-table__td">
+                  {{ item.car_number || '—' }}
+                </td>
+                <td class="trash-table__td">
+                  {{ item.mark_name || '—' }}
+                </td>
               </template>
               <template v-else>
-                <td>{{ item.last_name || '—' }}</td>
-                <td>{{ item.first_name || '—' }}</td>
+                <td class="trash-table__td">
+                  {{ item.last_name || '—' }}
+                </td>
+                <td class="trash-table__td">
+                  {{ item.first_name || '—' }}
+                </td>
               </template>
-              <td>{{ item.organization || '—' }}</td>
-              <td>{{ formatDate(item.entry_date_to) }}</td>
-              <td>{{ formatTimeRange(item) }}</td>
-              <td class="trash-table__status">
+              <td class="trash-table__td">
+                {{ item.organization || '—' }}
+              </td>
+              <td class="trash-table__td">
+                {{ formatDate(item.entry_date_to) }}
+              </td>
+              <td class="trash-table__td">
+                {{ formatTimeRange(item) }}
+              </td>
+              <td class="trash-table__td trash-table__td--danger">
                 {{ tableType === 'cars' ? 'Удалена' : 'Удалён' }}
               </td>
-              <td class="trash-table__actions">
+              <td class="trash-table__td trash-table__td--actions">
                 <button
                   class="trash-icon-btn"
                   title="Удалить безвозвратно"
@@ -202,11 +219,10 @@ import { listTrash, restoreItems, purgeItem, clearTrash } from '@/api/trash';
 import SearchComponent from '@/components/SearchComponent.vue';
 import OrganizationFilter from '@/components/OrganizationFilter.vue';
 import DateFilter from '@/components/DateFilter.vue';
-import RefreshButton from '@/components/RefreshButton.vue';
 
 export default {
   name: 'TrashView',
-  components: { SearchComponent, OrganizationFilter, DateFilter, RefreshButton },
+  components: { SearchComponent, OrganizationFilter, DateFilter },
   data() {
     return {
       tableID: 0,
@@ -224,14 +240,49 @@ export default {
         dateTo: null,
       },
       searchTimer: null,
+      sortField: 'deleted_at',
+      sortDir: 'desc',
     };
   },
   computed: {
     tableName() {
       return this.$route.params.tableName;
     },
-    allSelected() {
-      return this.items.length > 0 && this.selectedIds.length === this.items.length;
+    columns() {
+      const base = [
+        { key: 'application_number', label: 'Номер заявки', sortable: true },
+        { key: 'deleted_at', label: 'Дата и время удаления', sortable: true },
+      ];
+      const typeCols = this.tableType === 'cars'
+        ? [
+            { key: 'car_number', label: 'Номер Т/С', sortable: true },
+            { key: 'mark_name', label: 'Марка', sortable: true },
+          ]
+        : [
+            { key: 'last_name', label: 'Фамилия', sortable: true },
+            { key: 'first_name', label: 'Имя', sortable: true },
+          ];
+      return [
+        ...base,
+        ...typeCols,
+        { key: 'organization', label: 'Организация', sortable: true },
+        { key: 'entry_date_to', label: 'Действует до', sortable: true },
+        { key: 'time', label: 'Время', sortable: false },
+        { key: 'status', label: 'Статус', sortable: true },
+      ];
+    },
+    sortedItems() {
+      const arr = [...this.items];
+      const field = this.sortField;
+      const dir = this.sortDir === 'asc' ? 1 : -1;
+      arr.sort((a, b) => {
+        const va = a[field] ?? '';
+        const vb = b[field] ?? '';
+        if (va < vb) return -1 * dir;
+        if (va > vb) return 1 * dir;
+        return 0;
+      });
+      return arr;
     },
   },
   watch: {
@@ -307,8 +358,13 @@ export default {
       if (this.$refs.organizationFilter?.reset) this.$refs.organizationFilter.reset();
       this.reload();
     },
-    toggleAll(e) {
-      this.selectedIds = e.target.checked ? this.items.map(i => i.id) : [];
+    sortBy(field) {
+      if (this.sortField === field) {
+        this.sortDir = this.sortDir === 'asc' ? 'desc' : 'asc';
+      } else {
+        this.sortField = field;
+        this.sortDir = 'desc';
+      }
     },
     formatDateTime(s) {
       if (!s) return '—';
@@ -365,7 +421,13 @@ export default {
       }
     },
     async onPurgeOne(id) {
-      if (!confirm('Удалить эту запись безвозвратно?')) return;
+      const ok = await useUiStore().confirm({
+        title: 'Удаление записи',
+        message: 'Удалить эту запись безвозвратно? Действие нельзя отменить.',
+        confirmText: 'Удалить',
+        danger: true,
+      });
+      if (!ok) return;
       try {
         await purgeItem(this.tableID, id);
         useUiStore().success('Запись удалена безвозвратно');
@@ -375,7 +437,13 @@ export default {
       }
     },
     async onClearAll() {
-      if (!confirm('Очистить корзину целиком? Это действие необратимо.')) return;
+      const ok = await useUiStore().confirm({
+        title: 'Очистка корзины',
+        message: 'Очистить корзину целиком? Действие нельзя отменить.',
+        confirmText: 'Очистить',
+        danger: true,
+      });
+      if (!ok) return;
       try {
         const result = await clearTrash(this.tableID);
         useUiStore().success(`Корзина очищена: ${(result && result.purged) || 0} запис(ей)`);
@@ -394,29 +462,35 @@ export default {
 <style scoped>
 .trash-view {
   padding: 24px;
-  max-width: 1600px;
+  max-width: 1440px;
   margin: 0 auto;
+  font-family: 'Montserrat', sans-serif;
 }
 
 .trash-header {
   display: flex;
   flex-direction: column;
+  gap: 18px;
+  margin-bottom: 20px;
+}
+
+.trash-titlebar {
+  display: flex;
+  align-items: center;
   gap: 16px;
-  margin-bottom: 16px;
 }
 
 .trash-title {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  font-size: 24px;
-  font-weight: 600;
   margin: 0;
-  flex-wrap: wrap;
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 700;
+  font-size: 18px;
+  line-height: 22px;
+  color: #A2A2A2;
 }
 
 .trash-title__name {
-  color: #000;
+  color: #A2A2A2;
   text-decoration: none;
 }
 
@@ -424,122 +498,192 @@ export default {
   color: #4F5BDF;
 }
 
-.trash-title__slash {
-  color: #999;
-  font-weight: 400;
-}
-
-.trash-title__current {
-  color: #000;
-}
-
 .trash-back-btn {
   display: inline-flex;
   align-items: center;
-  padding: 6px 14px;
-  background: #fff;
-  color: #4F5BDF;
-  border: 1px solid #e6e6e6;
+  gap: 8px;
+  padding: 0 18px;
+  height: 35px;
+  background: #FFFFFF;
+  border: 1px solid #E6E6E6;
   border-radius: 50px;
-  font-size: 0.85em;
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 17px;
+  color: #4F5BDF;
   text-decoration: none;
-  transition: all 0.2s ease;
-  margin-left: 8px;
+  white-space: nowrap;
+  transition: background 0.2s ease;
 }
 
 .trash-back-btn:hover {
   background: #f3f4ff;
-  border-color: #4F5BDF;
+}
+
+.trash-back-btn__icon {
+  width: 12px;
+  height: 12px;
+  transform: rotate(180deg);
 }
 
 .trash-filters {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.trash-filters__group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
   gap: 10px;
 }
 
+.trash-filters__group--left {
+  flex: 1 1 auto;
+}
+
+.trash-filters__group--right {
+  flex: 0 0 auto;
+}
+
 .trash-filters__search {
-  flex: 1 1 220px;
+  flex: 0 0 200px;
+}
+
+.trash-filters :deep(.field) {
+  height: 35px;
+  width: 200px;
+  background-color: #FFFFFF;
+  border-radius: 10px;
+  border: 1px solid #E6E6E6;
+  padding: 0 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  position: relative;
+  cursor: pointer;
+  font-family: 'Montserrat', sans-serif;
+  font-size: 14px;
+}
+
+.trash-filters :deep(.field--select) {
+  width: 200px;
   min-width: 200px;
 }
 
-.trash-action-btn {
+.trash-filters :deep(.field--select .select-text) {
+  font-size: 14px;
+  color: #A2A2A2;
+}
+
+.trash-filters :deep(.field--select .select-icon) {
+  width: 10px;
+  height: 10px;
+}
+
+.trash-btn {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 8px 16px;
-  border-radius: 8px;
-  font-size: 0.9em;
+  justify-content: center;
+  gap: 8px;
+  height: 35px;
+  padding: 0 16px;
+  background: #FFFFFF;
+  border: 1px solid #E6E6E6;
+  border-radius: 10px;
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 17px;
+  color: #000000;
   cursor: pointer;
-  transition: all 0.2s ease;
   white-space: nowrap;
+  transition: background 0.2s ease;
 }
 
-.trash-action-btn--ghost {
-  background: #fff;
-  color: #333;
-  border: 1px solid #e6e6e6;
-}
-
-.trash-action-btn--ghost:hover:not(:disabled) {
+.trash-btn:hover:not(:disabled) {
   background: #f8f9fa;
 }
 
-.trash-action-btn--primary {
-  background: #4F5BDF;
-  color: #fff;
-  border: none;
-  font-weight: 600;
-}
-
-.trash-action-btn--primary:hover:not(:disabled) {
-  background: #3a45b2;
-}
-
-.trash-action-btn:disabled {
+.trash-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
 
-.trash-action-btn__icon {
-  width: 16px;
-  height: 16px;
+.trash-btn__icon {
+  width: 15px;
+  height: 15px;
+}
+
+.trash-btn--refresh {
+  border-radius: 50px;
+  color: #4F5BDF;
+}
+
+.trash-btn--primary {
+  background: #4F5BDF;
+  border-color: #4F5BDF;
+  color: #FFFFFF;
+  padding: 0 20px;
+}
+
+.trash-btn--primary:hover:not(:disabled) {
+  background: #3a45b2;
 }
 
 .trash-card {
-  background: #fff;
-  border-radius: 16px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.06);
+  background: #FFFFFF;
+  border: 1px solid #E6E6E6;
+  box-shadow: 0px 3px 10px rgba(0, 0, 0, 0.05);
+  border-radius: 30px;
   overflow: hidden;
+  max-height: 575px;
+  display: flex;
+  flex-direction: column;
 }
 
 .trash-card__header {
   display: flex;
   align-items: center;
-  gap: 16px;
-  padding: 16px 20px;
-  border-bottom: 1px solid #f0f0f0;
+  gap: 20px;
+  padding: 0 20px;
+  height: 50px;
+  border-bottom: 1px solid #E6E6E6;
+  flex-shrink: 0;
 }
 
 .trash-card__title {
   margin: 0;
-  font-size: 1.05em;
+  font-family: 'Montserrat', sans-serif;
   font-weight: 600;
-  color: #000;
+  font-size: 1.1em;
+  color: #000000;
 }
 
 .trash-card__link {
   background: none;
   border: none;
-  color: #4F5BDF;
   cursor: pointer;
-  font-size: 0.9em;
   padding: 0;
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 500;
+  font-size: 12px;
+  line-height: 15px;
+  color: #A2A2A2;
 }
 
-.trash-card__link:hover {
-  text-decoration: underline;
+.trash-card__link:hover:not(:disabled) {
+  color: #4F5BDF;
+}
+
+.trash-card__link:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .trash-card__spacer {
@@ -548,66 +692,100 @@ export default {
 
 .trash-card__body {
   padding: 0;
+  flex-grow: 1;
+  overflow-y: auto;
 }
 
 .trash-state {
-  padding: 40px 20px;
+  padding: 60px 24px;
   text-align: center;
-  color: #999;
-  font-size: 0.95em;
+  font-family: 'Montserrat', sans-serif;
+  color: #A2A2A2;
+  font-size: 14px;
 }
 
 .trash-state--error {
-  color: #d73a3a;
+  color: #FF6668;
 }
 
 .trash-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 0.9em;
+  font-family: 'Montserrat', sans-serif;
 }
 
-.trash-table th,
-.trash-table td {
-  padding: 12px 16px;
+.trash-table__th {
+  padding: 10px 12px;
   text-align: left;
-  border-bottom: 1px solid #f0f0f0;
-}
-
-.trash-table th {
-  background: #fafafa;
   font-weight: 500;
-  color: #666;
-  font-size: 0.85em;
+  font-size: 14px;
+  line-height: 17px;
+  color: #A2A2A2;
+  white-space: nowrap;
+  user-select: none;
 }
 
-.trash-table tbody tr:hover {
-  background: #fafafa;
+.trash-table__th:first-child {
+  padding-left: 20px;
 }
 
-.trash-table tbody tr:last-child td {
-  border-bottom: none;
+.trash-table__th--sortable {
+  cursor: pointer;
 }
 
-.trash-table__th-checkbox {
-  width: 40px;
+.trash-table__th--sortable:hover {
+  color: #333;
+}
+
+.trash-table__th--active {
+  color: #4F5BDF;
+}
+
+.trash-table__sort {
+  width: 12px;
+  height: 12px;
+  margin-left: 6px;
+  vertical-align: middle;
+  opacity: 0.6;
+  transition: transform 0.2s ease;
+}
+
+.trash-table__th--active .trash-table__sort {
+  opacity: 1;
+}
+
+.trash-table__sort--desc {
+  transform: rotate(180deg);
 }
 
 .trash-table__th-actions {
-  width: 50px;
+  width: 60px;
 }
 
-.trash-table__app-number {
-  color: #999;
+.trash-table__td {
+  padding: 12px;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 17px;
+  color: #000000;
+  border-top: 1px solid #F0F0F0;
 }
 
-.trash-table__status {
-  color: #d73a3a;
-  font-weight: 500;
+.trash-table__td:first-child {
+  padding-left: 20px;
 }
 
-.trash-table__actions {
+.trash-table__td--muted {
+  color: #A2A2A2;
+}
+
+.trash-table__td--danger {
+  color: #FF6668;
+}
+
+.trash-table__td--actions {
   text-align: right;
+  padding-right: 20px;
 }
 
 .trash-icon-btn {
@@ -627,32 +805,29 @@ export default {
 }
 
 .trash-icon-btn img {
-  width: 18px;
-  height: 18px;
+  width: 20px;
+  height: 20px;
+}
+
+@media (max-width: 1100px) {
+  .trash-filters {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .trash-card__header {
+    flex-wrap: wrap;
+  }
 }
 
 @media (max-width: 768px) {
   .trash-view {
     padding: 16px;
   }
-
   .trash-title {
-    font-size: 1.2em;
+    font-size: 16px;
   }
-
-  .trash-filters {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .trash-filters__search,
-  .trash-action-btn {
-    width: 100%;
-    justify-content: center;
-  }
-
-  .trash-table th:nth-child(n+4),
-  .trash-table td:nth-child(n+4) {
+  .trash-table th:nth-child(n+5),
+  .trash-table td:nth-child(n+5) {
     display: none;
   }
 }

--- a/frontend/src/views/TrashView.vue
+++ b/frontend/src/views/TrashView.vue
@@ -1,126 +1,212 @@
 <template>
-  <div class="trash-view">
+  <section class="trash-view">
     <header class="trash-header">
-      <div class="trash-title">
-        <RouterLink :to="`/table/${tableName}`" class="back-btn">← Назад</RouterLink>
-        <h2>
-          <RouterLink :to="`/table/${tableName}`" class="trash-table-name">{{ displayName }}</RouterLink>
-          <span class="trash-slash"> / Корзина</span>
-        </h2>
-      </div>
-      <div class="trash-controls">
-        <input
+      <h2 class="trash-title">
+        <RouterLink
+          :to="`/table/${tableName}`"
+          class="trash-title__name"
+        >
+          {{ displayName }}
+        </RouterLink>
+        <span class="trash-title__slash">/</span>
+        <span class="trash-title__current">Корзина</span>
+        <RouterLink
+          :to="`/table/${tableName}`"
+          class="trash-back-btn"
+          data-testid="trash-back"
+        >
+          ← Назад
+        </RouterLink>
+      </h2>
+
+      <div class="trash-filters">
+        <SearchComponent
           v-model="filters.search"
-          class="lk-input"
-          placeholder="Поиск..."
-          @input="onFilterChange"
+          :title="'Поиск..'"
+          class="trash-filters__search"
+          @input="onSearchChange"
+        />
+        <OrganizationFilter
+          ref="organizationFilter"
+          v-model="filters.organizationId"
+          @change="onOrganizationChange"
+        />
+        <DateFilter
+          :selected-date="filters.selectedDate"
+          :date-range-start="filters.dateFrom"
+          :date-range-end="filters.dateTo"
+          @update:selected-date="filters.selectedDate = $event"
+          @update:date-range-start="filters.dateFrom = $event"
+          @update:date-range-end="filters.dateTo = $event"
+          @apply="reload"
+          @clear="onDateClear"
+        />
+        <button
+          class="trash-action-btn trash-action-btn--ghost"
+          data-testid="trash-clear-filters"
+          @click="clearFilters"
         >
-        <input
-          v-model="filters.dateFrom"
-          type="date"
-          class="lk-input"
-          @change="reload"
-        >
-        <input
-          v-model="filters.dateTo"
-          type="date"
-          class="lk-input"
-          @change="reload"
-        >
-        <button class="lk-btn lk-btn--ghost" :disabled="isLoading" @click="reload">
-          Обновить
+          Очистить
         </button>
         <button
-          class="lk-btn lk-btn--danger"
+          class="trash-action-btn trash-action-btn--ghost"
+          data-testid="trash-export"
           :disabled="!items.length"
-          @click="onClearAll"
+          @click="onExport"
         >
-          Очистить корзину
+          <img
+            src="@/assets/icons/export.png"
+            class="trash-action-btn__icon"
+            alt=""
+          >
+          Экспорт
         </button>
+        <RefreshButton
+          :loading="isLoading"
+          @refresh="reload"
+        />
       </div>
     </header>
 
-    <div class="trash-bulk-actions" v-if="selectedIds.length">
-      <span>{{ selectedIds.length }} выбрано</span>
-      <button class="lk-btn" @click="onRestoreSelected">Восстановить</button>
-      <button class="lk-btn lk-btn--danger" @click="onPurgeSelected">Удалить безвозвратно</button>
-    </div>
+    <article class="trash-card">
+      <div class="trash-card__header">
+        <h3 class="trash-card__title">
+          {{ tableType === 'cars' ? 'Удалённые автомобили' : 'Удалённые сотрудники' }}
+        </h3>
+        <button
+          v-if="items.length"
+          class="trash-card__link"
+          data-testid="trash-restore-all-link"
+          @click="onRestoreAll"
+        >
+          Восстановить
+        </button>
+        <div class="trash-card__spacer" />
+        <button
+          class="trash-action-btn trash-action-btn--primary"
+          data-testid="trash-restore-selected"
+          :disabled="!selectedIds.length"
+          @click="onRestoreSelected"
+        >
+          Восстановить
+        </button>
+      </div>
 
-    <div v-if="isLoading" class="trash-loader">Загрузка...</div>
-    <div v-else-if="error" class="trash-error">{{ error }}</div>
-    <div v-else-if="!items.length" class="trash-empty">Корзина пуста</div>
-    <table v-else class="trash-table">
-      <thead>
-        <tr>
-          <th class="th-checkbox">
-            <input
-              type="checkbox"
-              :checked="allSelected"
-              @change="toggleAll"
+      <div class="trash-card__body">
+        <div
+          v-if="isLoading"
+          class="trash-state"
+        >
+          Загрузка...
+        </div>
+        <div
+          v-else-if="error"
+          class="trash-state trash-state--error"
+        >
+          {{ error }}
+        </div>
+        <div
+          v-else-if="!items.length"
+          class="trash-state"
+        >
+          Корзина пуста
+        </div>
+        <table
+          v-else
+          class="trash-table"
+          data-testid="trash-table"
+        >
+          <thead>
+            <tr>
+              <th class="trash-table__th-checkbox">
+                <input
+                  type="checkbox"
+                  :checked="allSelected"
+                  data-testid="trash-select-all"
+                  @change="toggleAll"
+                >
+              </th>
+              <th>Номер заявки</th>
+              <th>Дата и время удаления</th>
+              <template v-if="tableType === 'cars'">
+                <th>Номер Т/С</th>
+                <th>Марка</th>
+              </template>
+              <template v-else>
+                <th>Фамилия</th>
+                <th>Имя</th>
+              </template>
+              <th>Организация</th>
+              <th>Действует до</th>
+              <th>Время</th>
+              <th>Статус</th>
+              <th class="trash-table__th-actions" />
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="item in items"
+              :key="item.id"
+              data-testid="trash-row"
             >
-          </th>
-          <th>Номер заявки</th>
-          <th>Дата удаления</th>
-          <template v-if="tableType === 'cars'">
-            <th>Номер ТС</th>
-            <th>Марка</th>
-            <th>Организация</th>
-            <th>Действует до</th>
-          </template>
-          <template v-else>
-            <th>Фамилия</th>
-            <th>Имя</th>
-            <th>Отчество</th>
-            <th>Организация</th>
-          </template>
-          <th>Статус</th>
-          <th>Кто удалил</th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr v-for="item in items" :key="item.id" data-testid="trash-row">
-          <td>
-            <input
-              type="checkbox"
-              :value="item.id"
-              v-model="selectedIds"
-            >
-          </td>
-          <td>{{ item.application_number || '—' }}</td>
-          <td>{{ formatDate(item.deleted_at) }}</td>
-          <template v-if="tableType === 'cars'">
-            <td>{{ item.car_number || '—' }}</td>
-            <td>{{ item.mark_name || '—' }}</td>
-            <td>{{ item.organization || '—' }}</td>
-            <td>{{ item.entry_date_to || '—' }}</td>
-          </template>
-          <template v-else>
-            <td>{{ item.last_name || '—' }}</td>
-            <td>{{ item.first_name || '—' }}</td>
-            <td>{{ item.middle_name || '—' }}</td>
-            <td>{{ item.organization || '—' }}</td>
-          </template>
-          <td class="status-trash">{{ tableType === 'cars' ? 'Удалена' : 'Удален' }}</td>
-          <td>{{ item.deleted_by_name || '—' }}</td>
-          <td>
-            <button class="icon-btn danger" title="Удалить безвозвратно" @click="onPurgeOne(item.id)">
-              ✕
-            </button>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
+              <td>
+                <input
+                  v-model="selectedIds"
+                  type="checkbox"
+                  :value="item.id"
+                >
+              </td>
+              <td class="trash-table__app-number">
+                {{ item.application_number || '—' }}
+              </td>
+              <td>{{ formatDateTime(item.deleted_at) }}</td>
+              <template v-if="tableType === 'cars'">
+                <td>{{ item.car_number || '—' }}</td>
+                <td>{{ item.mark_name || '—' }}</td>
+              </template>
+              <template v-else>
+                <td>{{ item.last_name || '—' }}</td>
+                <td>{{ item.first_name || '—' }}</td>
+              </template>
+              <td>{{ item.organization || '—' }}</td>
+              <td>{{ formatDate(item.entry_date_to) }}</td>
+              <td>{{ formatTimeRange(item) }}</td>
+              <td class="trash-table__status">
+                {{ tableType === 'cars' ? 'Удалена' : 'Удалён' }}
+              </td>
+              <td class="trash-table__actions">
+                <button
+                  class="trash-icon-btn"
+                  title="Удалить безвозвратно"
+                  data-testid="trash-purge-one"
+                  @click="onPurgeOne(item.id)"
+                >
+                  <img
+                    src="@/assets/icons/trashcan.png"
+                    alt=""
+                  >
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </article>
+  </section>
 </template>
 
 <script>
 import { apiRequest } from '@/api/client';
 import { useUiStore } from '@/stores/ui';
 import { listTrash, restoreItems, purgeItem, clearTrash } from '@/api/trash';
+import SearchComponent from '@/components/SearchComponent.vue';
+import OrganizationFilter from '@/components/OrganizationFilter.vue';
+import DateFilter from '@/components/DateFilter.vue';
+import RefreshButton from '@/components/RefreshButton.vue';
 
 export default {
   name: 'TrashView',
+  components: { SearchComponent, OrganizationFilter, DateFilter, RefreshButton },
   data() {
     return {
       tableID: 0,
@@ -130,7 +216,13 @@ export default {
       selectedIds: [],
       isLoading: false,
       error: '',
-      filters: { search: '', dateFrom: '', dateTo: '' },
+      filters: {
+        search: '',
+        organizationId: null,
+        selectedDate: null,
+        dateFrom: null,
+        dateTo: null,
+      },
       searchTimer: null,
     };
   },
@@ -142,14 +234,14 @@ export default {
       return this.items.length > 0 && this.selectedIds.length === this.items.length;
     },
   },
-  async mounted() {
-    await this.fetchTable();
-    if (this.tableID) await this.reload();
-  },
   watch: {
     '$route.params.tableName'() {
       this.fetchTable().then(() => this.reload());
     },
+  },
+  async mounted() {
+    await this.fetchTable();
+    if (this.tableID) await this.reload();
   },
   methods: {
     async fetchTable() {
@@ -157,8 +249,6 @@ export default {
       try {
         const res = await apiRequest(`/system-tables/name/${this.tableName}`);
         const data = await res.json();
-        // API возвращает { table: {...}, ... } - сам объект таблицы вложен.
-        // Падаем обратно на data если структура изменилась.
         const tbl = (data && data.table) || data;
         if (!tbl || !tbl.id) {
           this.error = 'Таблица не найдена';
@@ -179,11 +269,15 @@ export default {
       this.isLoading = true;
       this.selectedIds = [];
       try {
-        const data = await listTrash(this.tableID, {
+        const params = {
           search: this.filters.search,
-          dateFrom: this.filters.dateFrom,
-          dateTo: this.filters.dateTo,
-        });
+          dateFrom: this.filters.selectedDate || this.filters.dateFrom || '',
+          dateTo: this.filters.selectedDate || this.filters.dateTo || '',
+        };
+        if (this.filters.organizationId) {
+          params.organizationId = this.filters.organizationId;
+        }
+        const data = await listTrash(this.tableID, params);
         this.items = Array.isArray(data) ? data : [];
       } catch {
         useUiStore().error('Не удалось загрузить корзину');
@@ -191,21 +285,56 @@ export default {
         this.isLoading = false;
       }
     },
-    onFilterChange() {
-      // Debounce поиска: ждём 300мс после последнего ввода.
+    onSearchChange() {
       clearTimeout(this.searchTimer);
       this.searchTimer = setTimeout(() => this.reload(), 300);
+    },
+    onOrganizationChange() {
+      this.reload();
+    },
+    onDateClear() {
+      this.filters.selectedDate = null;
+      this.filters.dateFrom = null;
+      this.filters.dateTo = null;
+      this.reload();
+    },
+    clearFilters() {
+      this.filters.search = '';
+      this.filters.organizationId = null;
+      this.filters.selectedDate = null;
+      this.filters.dateFrom = null;
+      this.filters.dateTo = null;
+      if (this.$refs.organizationFilter?.reset) this.$refs.organizationFilter.reset();
+      this.reload();
     },
     toggleAll(e) {
       this.selectedIds = e.target.checked ? this.items.map(i => i.id) : [];
     },
-    formatDate(s) {
+    formatDateTime(s) {
       if (!s) return '—';
       try {
-        return new Date(s).toLocaleString('ru-RU');
+        const d = new Date(s);
+        const date = d.toLocaleDateString('ru-RU', { day: '2-digit', month: '2-digit', year: 'numeric' });
+        const time = d.toLocaleTimeString('ru-RU', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+        return `${date} ${time}`;
       } catch {
         return s;
       }
+    },
+    formatDate(s) {
+      if (!s) return '—';
+      try {
+        return new Date(s).toLocaleDateString('ru-RU', { day: '2-digit', month: '2-digit', year: 'numeric' });
+      } catch {
+        return s;
+      }
+    },
+    formatTimeRange(item) {
+      const from = item.entry_time_from || item.time_from;
+      const to = item.entry_time_to || item.time_to;
+      if (from && to) return `${from} - ${to}`;
+      if (from) return from;
+      return '—';
     },
     async onRestoreSelected() {
       if (!this.selectedIds.length) return;
@@ -223,20 +352,17 @@ export default {
         useUiStore().error('Не удалось восстановить');
       }
     },
-    async onPurgeSelected() {
-      if (!this.selectedIds.length) return;
-      if (!confirm(`Удалить безвозвратно ${this.selectedIds.length} элемент(ов)?`)) return;
-      let purged = 0;
-      for (const id of this.selectedIds) {
-        try {
-          await purgeItem(this.tableID, id);
-          purged++;
-        } catch {
-          // Одиночный fail не прерывает массовое.
-        }
+    async onRestoreAll() {
+      if (!this.items.length) return;
+      const ids = this.items.map(i => i.id);
+      try {
+        const result = await restoreItems(this.tableID, ids);
+        const r = (result && result.restored) || 0;
+        useUiStore().success(`Восстановлено: ${r}`);
+        await this.reload();
+      } catch {
+        useUiStore().error('Не удалось восстановить');
       }
-      useUiStore().success(`Удалено: ${purged}`);
-      await this.reload();
     },
     async onPurgeOne(id) {
       if (!confirm('Удалить эту запись безвозвратно?')) return;
@@ -258,160 +384,276 @@ export default {
         useUiStore().error('Не удалось очистить');
       }
     },
+    onExport() {
+      useUiStore().info('Экспорт корзины - скоро');
+    },
   },
 };
 </script>
 
 <style scoped>
 .trash-view {
-  padding: 20px;
-  max-width: 1400px;
+  padding: 24px;
+  max-width: 1600px;
   margin: 0 auto;
 }
 
 .trash-header {
   display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 16px;
-  margin-bottom: 20px;
+  margin-bottom: 16px;
 }
 
 .trash-title {
   display: flex;
   align-items: center;
-  gap: 16px;
-}
-
-.back-btn {
-  color: #666;
-  text-decoration: none;
-  font-size: 14px;
-}
-
-.back-btn:hover {
-  color: var(--color-primary);
-}
-
-.trash-title h2 {
+  gap: 12px;
+  font-size: 24px;
+  font-weight: 600;
   margin: 0;
-  font-size: 22px;
-  display: flex;
-  align-items: baseline;
-  gap: 4px;
-}
-
-.trash-table-name {
-  color: #a2a2a2;
-  text-decoration: none;
-}
-
-.trash-table-name:hover {
-  color: var(--color-primary);
-}
-
-.trash-slash {
-  color: #000;
-}
-
-.trash-controls {
-  display: flex;
-  gap: 8px;
   flex-wrap: wrap;
 }
 
-.lk-input {
-  padding: 6px 10px;
-  border: 1px solid var(--color-border);
-  border-radius: 6px;
-  font-size: 13px;
+.trash-title__name {
+  color: #000;
+  text-decoration: none;
 }
 
-.lk-btn {
+.trash-title__name:hover {
+  color: #4F5BDF;
+}
+
+.trash-title__slash {
+  color: #999;
+  font-weight: 400;
+}
+
+.trash-title__current {
+  color: #000;
+}
+
+.trash-back-btn {
+  display: inline-flex;
+  align-items: center;
   padding: 6px 14px;
-  border-radius: 6px;
-  border: 0;
-  background: var(--color-primary);
-  color: #fff;
-  cursor: pointer;
-  font-size: 13px;
+  background: #fff;
+  color: #4F5BDF;
+  border: 1px solid #e6e6e6;
+  border-radius: 50px;
+  font-size: 0.85em;
+  text-decoration: none;
+  transition: all 0.2s ease;
+  margin-left: 8px;
 }
 
-.lk-btn:disabled {
+.trash-back-btn:hover {
+  background: #f3f4ff;
+  border-color: #4F5BDF;
+}
+
+.trash-filters {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+}
+
+.trash-filters__search {
+  flex: 1 1 220px;
+  min-width: 200px;
+}
+
+.trash-action-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-size: 0.9em;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+}
+
+.trash-action-btn--ghost {
+  background: #fff;
+  color: #333;
+  border: 1px solid #e6e6e6;
+}
+
+.trash-action-btn--ghost:hover:not(:disabled) {
+  background: #f8f9fa;
+}
+
+.trash-action-btn--primary {
+  background: #4F5BDF;
+  color: #fff;
+  border: none;
+  font-weight: 600;
+}
+
+.trash-action-btn--primary:hover:not(:disabled) {
+  background: #3a45b2;
+}
+
+.trash-action-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
 
-.lk-btn--ghost {
-  background: transparent;
-  border: 1px solid var(--color-border);
-  color: #333;
+.trash-action-btn__icon {
+  width: 16px;
+  height: 16px;
 }
 
-.lk-btn--danger {
-  background: #d73a3a;
+.trash-card {
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.06);
+  overflow: hidden;
 }
 
-.trash-bulk-actions {
+.trash-card__header {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 10px 14px;
-  background: var(--color-bg-secondary);
-  border-radius: 8px;
-  margin-bottom: 12px;
+  gap: 16px;
+  padding: 16px 20px;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.trash-card__title {
+  margin: 0;
+  font-size: 1.05em;
+  font-weight: 600;
+  color: #000;
+}
+
+.trash-card__link {
+  background: none;
+  border: none;
+  color: #4F5BDF;
+  cursor: pointer;
+  font-size: 0.9em;
+  padding: 0;
+}
+
+.trash-card__link:hover {
+  text-decoration: underline;
+}
+
+.trash-card__spacer {
+  flex: 1;
+}
+
+.trash-card__body {
+  padding: 0;
+}
+
+.trash-state {
+  padding: 40px 20px;
+  text-align: center;
+  color: #999;
+  font-size: 0.95em;
+}
+
+.trash-state--error {
+  color: #d73a3a;
 }
 
 .trash-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 13px;
+  font-size: 0.9em;
 }
 
 .trash-table th,
 .trash-table td {
-  padding: 8px 10px;
+  padding: 12px 16px;
   text-align: left;
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: 1px solid #f0f0f0;
 }
 
 .trash-table th {
-  background: var(--color-bg-secondary);
+  background: #fafafa;
+  font-weight: 500;
   color: #666;
-  font-weight: 600;
+  font-size: 0.85em;
 }
 
-.th-checkbox {
+.trash-table tbody tr:hover {
+  background: #fafafa;
+}
+
+.trash-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.trash-table__th-checkbox {
   width: 40px;
 }
 
-.status-trash {
-  color: #d73a3a;
-  font-weight: 600;
+.trash-table__th-actions {
+  width: 50px;
 }
 
-.icon-btn {
-  background: none;
-  border: 0;
-  cursor: pointer;
-  font-size: 16px;
+.trash-table__app-number {
   color: #999;
 }
 
-.icon-btn.danger:hover {
+.trash-table__status {
   color: #d73a3a;
+  font-weight: 500;
 }
 
-.trash-empty,
-.trash-loader,
-.trash-error {
-  text-align: center;
-  padding: 60px 20px;
-  color: #888;
+.trash-table__actions {
+  text-align: right;
 }
 
-.trash-error {
-  color: #d73a3a;
+.trash-icon-btn {
+  background: none;
+  border: none;
+  padding: 4px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  transition: background-color 0.2s ease;
+}
+
+.trash-icon-btn:hover {
+  background: #f0f0f0;
+}
+
+.trash-icon-btn img {
+  width: 18px;
+  height: 18px;
+}
+
+@media (max-width: 768px) {
+  .trash-view {
+    padding: 16px;
+  }
+
+  .trash-title {
+    font-size: 1.2em;
+  }
+
+  .trash-filters {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .trash-filters__search,
+  .trash-action-btn {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .trash-table th:nth-child(n+4),
+  .trash-table td:nth-child(n+4) {
+    display: none;
+  }
 }
 </style>


### PR DESCRIPTION
## Что сделано
Issue #186 закрыт мерджем PR #285 (frontend), но фронт-реализация была минимальной таблицей без оформления. Этот PR доводит UI до референса.

### Изменения

**TrashView.vue:**
- Заголовок: \`Таблица КПП №4 / Корзина\` + pill-кнопка \`← Назад\` (вместо ссылки слева)
- Горизонтальная панель фильтров: \`SearchComponent\`, \`OrganizationFilter\`, \`DateFilter\` (объединённый date-range), \`Очистить\`, \`Экспорт\`, \`RefreshButton\` - все используют общие компоненты проекта
- Карточка-обёртка с border-radius/shadow в стиле остальных Management-компонентов
- В шапке карточки: заголовок \`Удалённые автомобили\` / \`Удалённые сотрудники\` + ghost-ссылка \`Восстановить\` (восстановить всё) + primary-кнопка \`Восстановить\` (выбранные)
- Колонки: убрана \`Кто удалил\` (избыточно), добавлены \`Время\` и \`Дата и время удаления\`
- Иконка trash-can вместо ✕ на каждой строке
- Цвета по дизайн-системе проекта (#4F5BDF, #fafafa, #d73a3a, #e6e6e6)

**TablesComponent.vue:**
- Текст «Корзина» на странице таблицы заменён на иконку \`trashcan.png\` (\`aria-label\` для accessibility)

### Что НЕ сделано (отдельные задачи)
- Полоса \`Использование памяти 57 МБ / 200 МБ\` - нужна отдельная API (\`pg_total_relation_size\` по таблице корзины), это новая фича
- Реальный экспорт корзины - сейчас кнопка показывает toast \"Экспорт корзины - скоро\", API \`/system-tables/{id}/trash/export\` отсутствует

## Test plan
- [x] Локально: layout соответствует референсу при пустой корзине
- [x] Vitest: 266 passed (20 файлов)
- [x] Lint: 0 errors
- [ ] CI зелёный
- [ ] После деплоя на staging - проверка с реальными данными