### PR TITLE
fix: gorm:"-" для CustomValues, обновил golden file (#183)

### DIFF
--- a/internal/handlers/testdata/applications_list.golden
+++ b/internal/handlers/testdata/applications_list.golden
@@ -5,6 +5,7 @@ data[].company_name
 data[].confirmation
 data[].confirmation_datetime
 data[].data_approval
+data[].has_blank_template
 data[].id
 data[].message
 data[].organization_id

--- a/internal/services/application_service.go
+++ b/internal/services/application_service.go
@@ -388,7 +388,7 @@ type AttachmentInfo struct {
 	UniqueAttachmentTitle       *string    `json:"unique_attachment_title"`
 	UniqueAttachmentDisplayName *string             `json:"unique_attachment_display_name"`
 	HasTemplate                 bool                `json:"has_template"`
-	CustomValues                []CustomValueDetail `json:"custom_values,omitempty"`
+	CustomValues                []CustomValueDetail `gorm:"-" json:"custom_values,omitempty"`
 }
 
 // CustomValueDetail значение кастомного поля для отображения.


### PR DESCRIPTION
## Summary
- Добавил `gorm:"-"` тег на `AttachmentInfo.CustomValues` - GORM пытался интерпретировать как relation
- Обновил golden file `applications_list.golden` - добавил `has_blank_template` поле

Fixes Go Tests failure from #293