### PR TITLE
fix: кодировка имени файла, новые поля маппинга (#183)

### DIFF
--- a/frontend/src/api/attachment-templates.js
+++ b/frontend/src/api/attachment-templates.js
@@ -91,8 +91,11 @@ export async function downloadBlank(applicationID, attachmentID) {
   const blob = await res.blob();
   // Извлекаем имя файла из Content-Disposition.
   const cd = res.headers.get('Content-Disposition') || '';
-  const match = cd.match(/filename="?([^"]+)"?/);
-  const filename = match ? match[1] : `blank_${applicationID}_${attachmentID}.xlsx`;
+  const utf8Match = cd.match(/filename\*=UTF-8''(.+)/i);
+  const basicMatch = cd.match(/filename="?([^";]+)"?/);
+  const filename = utf8Match
+    ? decodeURIComponent(utf8Match[1])
+    : basicMatch ? basicMatch[1] : `blank_${applicationID}_${attachmentID}.xlsx`;
   return { blob, filename };
 }
 

--- a/internal/handlers/attachment_blank.go
+++ b/internal/handlers/attachment_blank.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -44,8 +45,9 @@ func (h *AttachmentBlankHandler) Download(c echo.Context) error {
 	}
 	c.Response().Header().Set("Content-Type",
 		"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+	encoded := url.PathEscape(filename)
 	c.Response().Header().Set("Content-Disposition",
-		`attachment; filename="`+sanitizeHeader(filename)+`"`)
+		`attachment; filename="blank.xlsx"; filename*=UTF-8''`+encoded)
 	return c.Stream(http.StatusOK,
 		"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", reader)
 }

--- a/internal/services/attachment_blank_resolver.go
+++ b/internal/services/attachment_blank_resolver.go
@@ -107,6 +107,26 @@ func resolveAttachment(bctx *BlankContext, path string) string {
 		return derefStr(a.EntryTimeFrom)
 	case "attachment.entry_time_to":
 		return derefStr(a.EntryTimeTo)
+	case "attachment.entry_date_range":
+		from := formatDate(derefStr(a.EntryDateFrom))
+		to := formatDate(derefStr(a.EntryDateTo))
+		if from != "" && to != "" {
+			return from + " - " + to
+		}
+		if from != "" {
+			return from
+		}
+		return to
+	case "attachment.entry_time_range":
+		from := formatTime(derefStr(a.EntryTimeFrom))
+		to := formatTime(derefStr(a.EntryTimeTo))
+		if from != "" && to != "" {
+			return from + " - " + to
+		}
+		if from != "" {
+			return from
+		}
+		return to
 	}
 	return ""
 }
@@ -152,6 +172,10 @@ func resolveEmployee(bctx *BlankContext, e *models.Employee, path string, rowIdx
 		}
 	case "employee.passport_series_number":
 		return derefStr(e.PassportSeriesNumber)
+	case "employee.patent_number":
+		return derefStr(e.PatentNumber)
+	case "employee.other_permission":
+		return derefStr(e.OtherPermission)
 	}
 	return ""
 }
@@ -168,6 +192,28 @@ func resolveItem(it *models.Item, path string, rowIdx int) string {
 		}
 	}
 	return ""
+}
+
+func formatDate(s string) string {
+	if s == "" {
+		return ""
+	}
+	t, err := time.Parse("2006-01-02", s[:min(len(s), 10)])
+	if err != nil {
+		return s
+	}
+	return t.Format("02.01.2006")
+}
+
+func formatTime(s string) string {
+	if s == "" {
+		return ""
+	}
+	parts := strings.SplitN(s, ":", 3)
+	if len(parts) >= 2 {
+		return parts[0] + ":" + parts[1]
+	}
+	return s
 }
 
 func derefStr(p *string) string {

--- a/internal/services/attachment_template_fields.go
+++ b/internal/services/attachment_template_fields.go
@@ -47,8 +47,10 @@ func BuiltinTemplateFields() []TemplateFieldGroup {
 			Fields: []TemplateField{
 				{Path: "attachment.entry_date_from", Label: "Дата с"},
 				{Path: "attachment.entry_date_to", Label: "Дата по"},
+				{Path: "attachment.entry_date_range", Label: "Период действия (дата с - дата по)"},
 				{Path: "attachment.entry_time_from", Label: "Время с"},
 				{Path: "attachment.entry_time_to", Label: "Время по"},
+				{Path: "attachment.entry_time_range", Label: "Время пребывания (с - по)"},
 			},
 		},
 		{
@@ -75,6 +77,8 @@ func BuiltinTemplateFields() []TemplateFieldGroup {
 				{Path: "employee.position", Label: "Должность", IsList: true},
 				{Path: "employee.citizenship", Label: "Гражданство", IsList: true},
 				{Path: "employee.passport_series_number", Label: "Серия и номер паспорта", IsList: true},
+				{Path: "employee.patent_number", Label: "Номер патента", IsList: true},
+				{Path: "employee.other_permission", Label: "Иное разрешение на работы", IsList: true},
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
- Content-Disposition: RFC 5987 (filename*=UTF-8'') для корректного скачивания файлов с кириллицей
- Фронтенд: парсинг filename* из заголовка ответа
- Новые поля маппинга: entry_date_range ("01.05.2026 - 31.05.2026"), entry_time_range ("09:00 - 18:00")
- Новые поля сотрудника: patent_number, other_permission
- Resolver для всех новых полей + helper-функции formatDate/formatTime

## Test plan
- [ ] Скачать бланк - имя файла на кириллице отображается корректно
- [ ] В маппинге доступны "Период действия" и "Время пребывания"
- [ ] В маппинге доступны "Номер патента" и "Иное разрешение на работы"
- [ ] Значения комбинированных полей корректно вставляются в ячейки