### PR TITLE
feat: визуальный редактор xlsx-бланков (#183)

### DIFF
--- a/frontend/src/api/attachment-templates.js
+++ b/frontend/src/api/attachment-templates.js
@@ -76,6 +76,17 @@ export async function deleteCustomField(fieldID) {
   return res.json();
 }
 
+// --- Template File (preview) ---
+
+export async function getTemplateFile(uniqueAttachmentID) {
+  const { apiRequestRaw } = await import('./client');
+  const res = await apiRequestRaw(`/attachments/${uniqueAttachmentID}/template/file`);
+  if (!res.ok) {
+    throw new Error(`Failed to get template file: ${res.status}`);
+  }
+  return res.arrayBuffer();
+}
+
 // --- Download ---
 
 /**

--- a/frontend/src/components/admin/AttachmentTemplateEditor.vue
+++ b/frontend/src/components/admin/AttachmentTemplateEditor.vue
@@ -22,7 +22,7 @@
             строки списка {{ template.list_start_row }}-{{ template.list_end_row }} (макс {{ template.max_list_rows }})
           </span>
           <button class="te-link-btn" @click="showUpload = true">Заменить</button>
-          <button class="te-link-btn danger" @click="onDeleteTemplate">Удалить шаблон</button>
+          <button class="te-link-btn danger" @click="onDeleteTemplate">Удалить шаб��он</button>
         </div>
         <form v-if="!template || !template.file_path || showUpload" class="te-upload-form" @submit.prevent="onUpload">
           <input type="file" accept=".xlsx" @change="onFileChange" required>
@@ -49,58 +49,82 @@
         </form>
       </div>
 
-      <!-- Маппинг ячеек -->
-      <div v-if="template && template.file_path" class="te-block">
-        <h4>Связь ячейки → поля заявки</h4>
-        <table class="te-mapping-table">
-          <thead>
-            <tr>
-              <th class="th-cell">Ячейка</th>
-              <th>Поле</th>
-              <th>Список</th>
-              <th></th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="(m, idx) in mappings" :key="idx">
-              <td>
-                <input
-                  v-model="m.cell_ref"
-                  placeholder="A1"
-                  maxlength="10"
-                  class="te-input cell-input"
+      <!-- Визуальный редактор маппинга -->
+      <div v-if="template && template.file_path" class="te-block te-visual-editor">
+        <h4>Привязка полей к ячейкам</h4>
+        <p class="te-hint">
+          Выберите поле справа, затем кликните на ячейку в превью для привязки.
+          Зеленые ячейки уже привязаны.
+        </p>
+        <div class="te-split-panel">
+          <!-- Левая часть: превью xlsx -->
+          <div class="te-panel-left">
+            <XlsxViewer
+              :file-buffer="templateFileBuffer"
+              :mappings="enrichedMappings"
+              :selected-cell="pendingCellRef"
+              @cell-click="onCellClick"
+            />
+          </div>
+          <!-- Правая часть: список полей + маппинги -->
+          <div class="te-panel-right">
+            <!-- Выбор поля для привязки -->
+            <div class="te-field-picker">
+              <h5>Поле для привязки</h5>
+              <div
+                v-for="g in fieldGroups"
+                :key="g.group"
+                class="te-field-group"
+              >
+                <span class="te-field-group-label">{{ g.label }}</span>
+                <button
+                  v-for="f in g.fields"
+                  :key="f.path"
+                  class="te-field-chip"
+                  :class="{
+                    active: pendingFieldPath === f.path,
+                    used: fieldPathUsed(f.path),
+                  }"
+                  @click="selectField(f)"
                 >
-              </td>
-              <td>
-                <select v-model="m.field_path" class="te-select" @change="onFieldChange(m)">
-                  <option value="" disabled>Выберите поле</option>
-                  <optgroup v-for="g in fieldGroups" :key="g.group" :label="g.label">
-                    <option v-for="f in g.fields" :key="f.path" :value="f.path">{{ f.label }}</option>
-                  </optgroup>
-                </select>
-              </td>
-              <td>
-                <input type="checkbox" :checked="m.is_list_field" disabled>
-              </td>
-              <td>
-                <button class="te-link-btn danger" @click="mappings.splice(idx, 1)">Удалить</button>
-              </td>
-            </tr>
-            <tr v-if="!mappings.length">
-              <td colspan="4" class="te-empty">Нет маппингов. Добавьте первый.</td>
-            </tr>
-          </tbody>
-        </table>
-        <div class="te-mapping-actions">
-          <button class="te-link-btn" @click="addMapping">+ Добавить маппинг</button>
-          <button class="te-btn" :disabled="savingMappings" @click="saveMappings">
-            {{ savingMappings ? 'Сохранение...' : 'Сохранить маппинги' }}
-          </button>
+                  {{ f.label }}
+                  <span v-if="fieldPathUsed(f.path)" class="te-chip-mapped">
+                    ({{ fieldCellRef(f.path) }})
+                  </span>
+                </button>
+              </div>
+            </div>
+
+            <!-- Текущие маппинги -->
+            <div class="te-mappings-list">
+              <h5>Привязки ({{ mappings.length }})</h5>
+              <div v-if="!mappings.length" class="te-empty-mappings">
+                Нет привязок. Выберите поле и кликните на ячейку.
+              </div>
+              <div
+                v-for="(m, idx) in enrichedMappings"
+                :key="idx"
+                class="te-mapping-row"
+                :class="{ highlight: pendingCellRef === m.cell_ref }"
+              >
+                <span class="te-mapping-cell">{{ m.cell_ref }}</span>
+                <span class="te-mapping-field">{{ m.fieldLabel || m.field_path }}</span>
+                <span v-if="m.is_list_field" class="te-list-badge">список</span>
+                <button class="te-remove-btn" @click="removeMapping(idx)">×</button>
+              </div>
+            </div>
+
+            <div class="te-save-actions">
+              <button class="te-btn" :disabled="savingMappings" @click="saveMappings">
+                {{ savingMappings ? 'Сохранение...' : 'Сохранить привязки' }}
+              </button>
+            </div>
+          </div>
         </div>
       </div>
     </div>
 
-    <!-- Кастомные поля - всегда доступны (не зависят от toggle бланка) -->
+    <!-- Кастомные поля - всегда доступны -->
     <div class="te-block">
       <h4>Дополнительные поля вложения</h4>
       <table class="te-custom-table">
@@ -140,12 +164,14 @@
 import { useUiStore } from '@/stores/ui';
 import {
   getTemplate, uploadTemplate, updateMappings, deleteTemplate,
-  getTemplateFields,
+  getTemplateFields, getTemplateFile,
   listCustomFields, createCustomField, updateCustomField, deleteCustomField,
 } from '@/api/attachment-templates';
+import XlsxViewer from './XlsxViewer.vue';
 
 export default {
   name: 'AttachmentTemplateEditor',
+  components: { XlsxViewer },
   props: {
     uniqueAttachmentId: { type: Number, required: true },
   },
@@ -161,7 +187,19 @@ export default {
       form: { file: null, listStartRow: 1, listEndRow: 1, maxListRows: 0 },
       uploading: false,
       savingMappings: false,
+      templateFileBuffer: null,
+      pendingFieldPath: '',
+      pendingFieldLabel: '',
+      pendingCellRef: '',
     };
+  },
+  computed: {
+    enrichedMappings() {
+      return this.mappings.map(m => ({
+        ...m,
+        fieldLabel: this.getFieldLabel(m.field_path),
+      }));
+    },
   },
   watch: {
     uniqueAttachmentId: {
@@ -184,10 +222,19 @@ export default {
         this.form.listStartRow = data && data.list_start_row || 1;
         this.form.listEndRow = data && data.list_end_row || 1;
         this.form.maxListRows = data && data.max_list_rows || 0;
+        if (this.enabled) this.loadTemplateFile();
       } catch {
         this.template = null;
         this.mappings = [];
         this.enabled = false;
+        this.templateFileBuffer = null;
+      }
+    },
+    async loadTemplateFile() {
+      try {
+        this.templateFileBuffer = await getTemplateFile(this.uniqueAttachmentId);
+      } catch {
+        this.templateFileBuffer = null;
       }
     },
     async loadCustomFields() {
@@ -242,30 +289,71 @@ export default {
       try {
         await deleteTemplate(this.uniqueAttachmentId);
         useUiStore().success('Шаблон удалён');
+        this.templateFileBuffer = null;
         await this.loadTemplate();
       } catch {
         useUiStore().error('Не удалось удалить шаблон');
       }
     },
-    addMapping() {
-      this.mappings.push({ cell_ref: '', field_path: '', is_list_field: false });
-    },
-    onFieldChange(m) {
-      // Авто-выставление is_list_field на основе field_path.
-      for (const g of this.fieldGroups) {
-        const f = g.fields.find(x => x.path === m.field_path);
-        if (f) {
-          m.is_list_field = !!f.is_list;
-          return;
-        }
+    selectField(field) {
+      if (this.pendingFieldPath === field.path) {
+        this.pendingFieldPath = '';
+        this.pendingFieldLabel = '';
+      } else {
+        this.pendingFieldPath = field.path;
+        this.pendingFieldLabel = field.label;
       }
+    },
+    onCellClick(cellRef) {
+      if (this.pendingFieldPath) {
+        const existingIdx = this.mappings.findIndex(m => m.cell_ref === cellRef);
+        if (existingIdx >= 0) {
+          this.mappings[existingIdx].field_path = this.pendingFieldPath;
+          this.mappings[existingIdx].is_list_field = this.isListField(this.pendingFieldPath);
+        } else {
+          this.mappings.push({
+            cell_ref: cellRef,
+            field_path: this.pendingFieldPath,
+            is_list_field: this.isListField(this.pendingFieldPath),
+          });
+        }
+        this.pendingFieldPath = '';
+        this.pendingFieldLabel = '';
+        this.pendingCellRef = '';
+      } else {
+        this.pendingCellRef = cellRef;
+      }
+    },
+    removeMapping(idx) {
+      this.mappings.splice(idx, 1);
+    },
+    isListField(fieldPath) {
+      for (const g of this.fieldGroups) {
+        const f = g.fields.find(x => x.path === fieldPath);
+        if (f) return !!f.is_list;
+      }
+      return false;
+    },
+    fieldPathUsed(path) {
+      return this.mappings.some(m => m.field_path === path);
+    },
+    fieldCellRef(path) {
+      const m = this.mappings.find(x => x.field_path === path);
+      return m ? m.cell_ref : '';
+    },
+    getFieldLabel(fieldPath) {
+      for (const g of this.fieldGroups) {
+        const f = g.fields.find(x => x.path === fieldPath);
+        if (f) return f.label;
+      }
+      return fieldPath;
     },
     async saveMappings() {
       this.savingMappings = true;
       try {
         const payload = this.mappings.filter(m => m.cell_ref && m.field_path);
         await updateMappings(this.uniqueAttachmentId, payload);
-        useUiStore().success('Маппинги сохранены');
+        useUiStore().success('Привязки сохранены');
         await this.loadTemplate();
       } catch (err) {
         useUiStore().error(err.message || 'Не удалось сохранить');
@@ -302,7 +390,7 @@ export default {
       }
     },
     async deleteCF(cf) {
-      if (!confirm(`Удалить поле «${cf.label}»?`)) return;
+      if (!confirm(`Удалить поле "${cf.label}"?`)) return;
       try {
         await deleteCustomField(cf.id);
         await this.loadCustomFields();
@@ -356,6 +444,12 @@ export default {
   color: #444;
 }
 
+.te-hint {
+  margin: 0 0 12px;
+  font-size: 12px;
+  color: #888;
+}
+
 .te-existing {
   display: flex;
   flex-wrap: wrap;
@@ -386,7 +480,159 @@ export default {
   gap: 10px;
 }
 
-.te-mapping-table,
+/* Split panel */
+.te-split-panel {
+  display: grid;
+  grid-template-columns: 1fr 320px;
+  gap: 16px;
+  min-height: 400px;
+}
+
+.te-panel-left {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.te-panel-right {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  overflow-y: auto;
+  max-height: 560px;
+}
+
+.te-panel-right h5 {
+  margin: 0 0 8px;
+  font-size: 13px;
+  color: #555;
+}
+
+/* Field picker */
+.te-field-picker {
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  padding: 10px;
+  background: #fff;
+}
+
+.te-field-group {
+  margin-bottom: 8px;
+}
+
+.te-field-group-label {
+  display: block;
+  font-size: 11px;
+  color: #888;
+  margin-bottom: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.te-field-chip {
+  display: inline-block;
+  padding: 3px 8px;
+  margin: 2px 3px 2px 0;
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  font-size: 11px;
+  background: #fff;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.te-field-chip:hover {
+  border-color: var(--color-primary);
+  background: #f0f7ff;
+}
+
+.te-field-chip.active {
+  background: var(--color-primary);
+  color: #fff;
+  border-color: var(--color-primary);
+}
+
+.te-field-chip.used {
+  background: #e8f8e8;
+  border-color: #4caf50;
+}
+
+.te-chip-mapped {
+  font-size: 10px;
+  opacity: 0.7;
+}
+
+/* Mappings list */
+.te-mappings-list {
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  padding: 10px;
+  background: #fff;
+  flex: 1;
+  overflow-y: auto;
+}
+
+.te-empty-mappings {
+  font-size: 12px;
+  color: #999;
+  text-align: center;
+  padding: 12px 0;
+}
+
+.te-mapping-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 6px;
+  border-radius: 4px;
+  font-size: 12px;
+  transition: background 0.1s;
+}
+
+.te-mapping-row:hover {
+  background: #f5f5f5;
+}
+
+.te-mapping-row.highlight {
+  background: #e8f4fd;
+}
+
+.te-mapping-cell {
+  font-weight: 600;
+  min-width: 36px;
+  color: var(--color-primary);
+}
+
+.te-mapping-field {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.te-list-badge {
+  font-size: 10px;
+  background: #e3f2fd;
+  color: #1565c0;
+  padding: 1px 5px;
+  border-radius: 8px;
+}
+
+.te-remove-btn {
+  background: none;
+  border: none;
+  color: #d73a3a;
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 0 4px;
+}
+
+.te-save-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+/* Custom fields table */
 .te-custom-table {
   width: 100%;
   border-collapse: collapse;
@@ -394,8 +640,6 @@ export default {
   margin-bottom: 10px;
 }
 
-.te-mapping-table th,
-.te-mapping-table td,
 .te-custom-table th,
 .te-custom-table td {
   padding: 6px 8px;
@@ -403,7 +647,6 @@ export default {
   border-bottom: 1px solid var(--color-border);
 }
 
-.th-cell { width: 90px; }
 .th-order { width: 60px; }
 
 .te-input {
@@ -414,16 +657,7 @@ export default {
   font-size: 13px;
 }
 
-.cell-input { width: 70px; }
 .order-input { width: 60px; }
-
-.te-select {
-  width: 100%;
-  padding: 5px 8px;
-  border: 1px solid var(--color-border);
-  border-radius: 4px;
-  font-size: 13px;
-}
 
 .te-empty {
   text-align: center;
@@ -431,14 +665,10 @@ export default {
   padding: 16px 0;
 }
 
-.te-mapping-actions,
 .te-custom-add {
   display: flex;
   gap: 10px;
   align-items: center;
-}
-
-.te-custom-add {
   margin-top: 10px;
 }
 
@@ -468,5 +698,14 @@ export default {
 
 .te-link-btn.danger {
   color: #d73a3a;
+}
+
+@media (max-width: 900px) {
+  .te-split-panel {
+    grid-template-columns: 1fr;
+  }
+  .te-panel-right {
+    max-height: none;
+  }
 }
 </style>

--- a/frontend/src/components/admin/XlsxViewer.vue
+++ b/frontend/src/components/admin/XlsxViewer.vue
@@ -1,0 +1,356 @@
+<template>
+  <div class="xlsx-viewer" :class="{ loading }">
+    <div v-if="loading" class="xv-loading">
+      <span>Загрузка превью...</span>
+    </div>
+    <div v-else-if="error" class="xv-error">{{ error }}</div>
+    <div v-else-if="sheets.length" class="xv-content">
+      <div v-if="sheets.length > 1" class="xv-tabs">
+        <button
+          v-for="(sheet, idx) in sheets"
+          :key="idx"
+          class="xv-tab"
+          :class="{ active: activeSheet === idx }"
+          @click="activeSheet = idx"
+        >
+          {{ sheet.name }}
+        </button>
+      </div>
+      <div class="xv-table-wrap">
+        <table class="xv-table">
+          <thead>
+            <tr>
+              <th class="xv-corner"></th>
+              <th
+                v-for="col in currentSheet.cols"
+                :key="col"
+                class="xv-col-header"
+              >
+                {{ col }}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="row in currentSheet.rows" :key="row.num">
+              <td class="xv-row-header">{{ row.num }}</td>
+              <td
+                v-for="cell in row.cells"
+                :key="cell.ref"
+                class="xv-cell"
+                :class="{
+                  selected: selectedCell === cell.ref,
+                  mapped: mappedCells.has(cell.ref),
+                  'has-value': cell.value,
+                }"
+                :style="cell.style"
+                :colspan="cell.colspan || 1"
+                :rowspan="cell.rowspan || 1"
+                @click="onCellClick(cell)"
+              >
+                <span class="xv-cell-text">{{ cell.display }}</span>
+                <span v-if="mappedCells.has(cell.ref)" class="xv-mapped-badge">
+                  {{ mappedCells.get(cell.ref) }}
+                </span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <div v-else class="xv-empty">Файл не загружен</div>
+  </div>
+</template>
+
+<script>
+import ExcelJS from 'exceljs';
+
+export default {
+  name: 'XlsxViewer',
+  props: {
+    fileBuffer: { type: ArrayBuffer, default: null },
+    mappings: { type: Array, default: () => [] },
+    selectedCell: { type: String, default: '' },
+  },
+  emits: ['cell-click'],
+  data() {
+    return {
+      sheets: [],
+      activeSheet: 0,
+      loading: false,
+      error: '',
+    };
+  },
+  computed: {
+    currentSheet() {
+      return this.sheets[this.activeSheet] || { cols: [], rows: [] };
+    },
+    mappedCells() {
+      const map = new Map();
+      for (const m of this.mappings) {
+        if (m.cell_ref) {
+          const label = m.fieldLabel || m.field_path || '';
+          map.set(m.cell_ref.toUpperCase(), label);
+        }
+      }
+      return map;
+    },
+  },
+  watch: {
+    fileBuffer: {
+      immediate: true,
+      handler(buf) {
+        if (buf) this.parseWorkbook(buf);
+        else this.sheets = [];
+      },
+    },
+  },
+  methods: {
+    async parseWorkbook(buffer) {
+      this.loading = true;
+      this.error = '';
+      try {
+        const workbook = new ExcelJS.Workbook();
+        await workbook.xlsx.load(buffer);
+        this.sheets = workbook.worksheets.map(ws => this.parseSheet(ws));
+        this.activeSheet = 0;
+      } catch (e) {
+        this.error = 'Не удалось прочитать файл: ' + (e.message || e);
+        this.sheets = [];
+      } finally {
+        this.loading = false;
+      }
+    },
+    parseSheet(ws) {
+      const colCount = Math.min(ws.columnCount || 0, 30);
+      const rowCount = Math.min(ws.rowCount || 0, 100);
+      const cols = [];
+      for (let c = 1; c <= colCount; c++) {
+        cols.push(this.colLetter(c));
+      }
+      const rows = [];
+      for (let r = 1; r <= rowCount; r++) {
+        const row = ws.getRow(r);
+        const cells = [];
+        for (let c = 1; c <= colCount; c++) {
+          const cell = row.getCell(c);
+          const ref = this.colLetter(c) + r;
+          cells.push({
+            ref,
+            value: cell.value,
+            display: this.formatCellValue(cell),
+            style: this.extractStyle(cell),
+            colspan: 1,
+            rowspan: 1,
+          });
+        }
+        rows.push({ num: r, cells });
+      }
+      return { name: ws.name, cols, rows };
+    },
+    colLetter(num) {
+      let s = '';
+      while (num > 0) {
+        num--;
+        s = String.fromCharCode(65 + (num % 26)) + s;
+        num = Math.floor(num / 26);
+      }
+      return s;
+    },
+    formatCellValue(cell) {
+      if (cell.value === null || cell.value === undefined) return '';
+      if (typeof cell.value === 'object') {
+        if (cell.value.richText) {
+          return cell.value.richText.map(r => r.text).join('');
+        }
+        if (cell.value.text) return cell.value.text;
+        if (cell.value.result !== undefined) return String(cell.value.result);
+        return '';
+      }
+      return String(cell.value);
+    },
+    extractStyle(cell) {
+      const style = {};
+      if (cell.font) {
+        if (cell.font.bold) style.fontWeight = 'bold';
+        if (cell.font.italic) style.fontStyle = 'italic';
+        if (cell.font.size) style.fontSize = Math.min(cell.font.size, 14) + 'px';
+        if (cell.font.color && cell.font.color.argb) {
+          style.color = '#' + cell.font.color.argb.slice(2);
+        }
+      }
+      if (cell.fill && cell.fill.fgColor && cell.fill.fgColor.argb) {
+        const hex = '#' + cell.fill.fgColor.argb.slice(2);
+        if (hex !== '#000000') style.backgroundColor = hex;
+      }
+      if (cell.alignment) {
+        if (cell.alignment.horizontal) style.textAlign = cell.alignment.horizontal;
+      }
+      return style;
+    },
+    onCellClick(cell) {
+      this.$emit('cell-click', cell.ref);
+    },
+  },
+};
+</script>
+
+<style scoped>
+.xlsx-viewer {
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  overflow: hidden;
+  background: #fff;
+  min-height: 200px;
+  display: flex;
+  flex-direction: column;
+}
+
+.xlsx-viewer.loading {
+  opacity: 0.7;
+}
+
+.xv-loading,
+.xv-error,
+.xv-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 20px;
+  color: #888;
+  font-size: 13px;
+}
+
+.xv-error {
+  color: #d73a3a;
+}
+
+.xv-content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
+.xv-tabs {
+  display: flex;
+  gap: 2px;
+  padding: 4px 8px 0;
+  background: #f5f5f5;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.xv-tab {
+  padding: 4px 12px;
+  border: 1px solid var(--color-border);
+  border-bottom: none;
+  border-radius: 4px 4px 0 0;
+  background: #fff;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.xv-tab.active {
+  background: var(--color-primary);
+  color: #fff;
+  border-color: var(--color-primary);
+}
+
+.xv-table-wrap {
+  overflow: auto;
+  flex: 1;
+  max-height: 500px;
+}
+
+.xv-table {
+  border-collapse: collapse;
+  font-size: 11px;
+  min-width: 100%;
+  table-layout: auto;
+}
+
+.xv-table th,
+.xv-table td {
+  border: 1px solid #ddd;
+  padding: 2px 4px;
+  white-space: nowrap;
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.xv-corner {
+  width: 32px;
+  min-width: 32px;
+  background: #f0f0f0;
+}
+
+.xv-col-header {
+  background: #f0f0f0;
+  text-align: center;
+  font-weight: 600;
+  font-size: 10px;
+  color: #666;
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+
+.xv-row-header {
+  background: #f0f0f0;
+  text-align: center;
+  font-weight: 600;
+  font-size: 10px;
+  color: #666;
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
+
+.xv-cell {
+  cursor: pointer;
+  position: relative;
+  transition: background-color 0.1s;
+  min-width: 40px;
+}
+
+.xv-cell:hover {
+  background-color: #e8f4fd !important;
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
+}
+
+.xv-cell.selected {
+  background-color: #d0e8ff !important;
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
+}
+
+.xv-cell.mapped {
+  background-color: #e8f8e8 !important;
+}
+
+.xv-cell.mapped:hover {
+  background-color: #d0f0d0 !important;
+}
+
+.xv-cell-text {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.xv-mapped-badge {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background: var(--color-primary);
+  color: #fff;
+  font-size: 8px;
+  padding: 1px 3px;
+  border-radius: 0 0 0 4px;
+  max-width: 60px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+</style>

--- a/internal/handlers/attachment_templates.go
+++ b/internal/handlers/attachment_templates.go
@@ -130,6 +130,29 @@ func (h *AttachmentTemplateHandler) Delete(c echo.Context) error {
 	return RespondMessage(c, "Шаблон удалён")
 }
 
+// DownloadFile godoc
+// @Summary      Скачать файл шаблона для предпросмотра
+// @Tags         attachment-templates
+// @Produce      application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+// @Security     BearerAuth
+// @Param        id path int true "ID UniqueAttachment"
+// @Success      200 {file} binary
+// @Router       /attachments/{id}/template/file [get]
+func (h *AttachmentTemplateHandler) DownloadFile(c echo.Context) error {
+	uaID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	t, err := h.service.Get(c.Request().Context(), uaID)
+	if err != nil {
+		return err
+	}
+	if t.FilePath == "" {
+		return echo.NewHTTPError(http.StatusNotFound, "Файл шаблона не загружен")
+	}
+	return c.File(t.FilePath)
+}
+
 // GetFields godoc
 // @Summary      Справочник полей доступных для маппинга
 // @Tags         attachment-templates

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -192,6 +192,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	attRoot := protected.Group("/attachments")
 	attRoot.GET("/:id/template", attachmentTemplates.Get)
 	attRoot.POST("/:id/template", attachmentTemplates.Upload)
+	attRoot.GET("/:id/template/file", attachmentTemplates.DownloadFile)
 	attRoot.PUT("/:id/template/mappings", attachmentTemplates.UpdateMappings)
 	attRoot.DELETE("/:id/template", attachmentTemplates.Delete)
 	attRoot.GET("/:id/template-fields", attachmentTemplates.GetFields)


### PR DESCRIPTION
## Summary
- Добавлен визуальный превью xlsx-шаблона через ExcelJS (парсинг + HTML-рендер)
- Новый компонент `XlsxViewer` - отображает ячейки с подсветкой маппингов
- Переработан `AttachmentTemplateEditor` - split-panel: слева превью, справа список полей
- Интерактивный маппинг: выбрал поле -> кликнул ячейку -> привязка создана
- Бэкенд: endpoint `GET /attachments/:id/template/file` для скачивания xlsx-файла шаблона
- 0 новых зависимостей (ExcelJS уже в проекте)

## Что изменилось
- `XlsxViewer.vue` (new) - парсинг xlsx, рендер HTML-таблицы, визуализация маппингов
- `AttachmentTemplateEditor.vue` - split-panel layout с визуальным редактором
- `attachment-templates.js` - API-метод `getTemplateFile()`
- `attachment_templates.go` - handler `DownloadFile` (c.File)
- `router.go` - роут `GET /:id/template/file`

## Test plan
- [ ] Загрузить xlsx-шаблон, убедиться что превью отображается
- [ ] Проверить что ячейки кликабельны и подсвечиваются
- [ ] Выбрать поле справа, кликнуть ячейку - привязка должна создаться
- [ ] Привязанные ячейки зеленые с бейджем
- [ ] Сохранить привязки, перезагрузить - привязки на месте
- [ ] Адаптивность: на мобильных панели должны стекаться вертикально