### PR TITLE
fix: xlsx - merged cells, границы, картинки, hover линий, кастомные поля (#183)

### DIFF
--- a/frontend/src/components/AttachmentsManagement.vue
+++ b/frontend/src/components/AttachmentsManagement.vue
@@ -308,6 +308,12 @@
                 />
               </div>
 
+              <!-- Дополнительные поля (#183) -->
+              <AttachmentCustomFields
+                v-if="selectedAttachment.is_active"
+                :unique-attachment-id="selectedAttachment.id"
+              />
+
               <!-- Excel-бланк (#183) -->
               <AttachmentTemplateEditor
                 v-if="selectedAttachment.is_active"
@@ -567,6 +573,7 @@ import RefreshButton from './RefreshButton.vue';
 import SearchComponent from './SearchComponent.vue';
 import TextConstructor from './TextConstructor.vue';
 import AttachmentTemplateEditor from './admin/AttachmentTemplateEditor.vue';
+import AttachmentCustomFields from './admin/AttachmentCustomFields.vue';
 
 export default {
   name: 'AttachmentsManagement',
@@ -575,6 +582,7 @@ export default {
     RefreshButton,
     TextConstructor,
     AttachmentTemplateEditor,
+    AttachmentCustomFields,
   },
   data() {
     return {

--- a/frontend/src/components/admin/AttachmentCustomFields.vue
+++ b/frontend/src/components/admin/AttachmentCustomFields.vue
@@ -1,0 +1,236 @@
+<template>
+  <section class="acf-section">
+    <header class="acf-header">
+      <h4>Дополнительные поля вложения</h4>
+    </header>
+    <table class="acf-table">
+      <thead>
+        <tr>
+          <th>Заголовок</th>
+          <th>Плейсхолдер</th>
+          <th class="acf-th-order">
+            N
+          </th>
+          <th class="acf-th-actions" />
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          v-for="cf in customFields"
+          :key="cf.id"
+        >
+          <td>
+            <input
+              v-model="cf.label"
+              class="lk-input acf-input"
+            >
+          </td>
+          <td>
+            <input
+              v-model="cf.placeholder"
+              class="lk-input acf-input"
+            >
+          </td>
+          <td>
+            <input
+              v-model.number="cf.sort_order"
+              type="number"
+              class="lk-input acf-input acf-input-order"
+            >
+          </td>
+          <td class="acf-row-actions">
+            <button
+              class="lk-button lk-button--ghost acf-btn"
+              @click="updateCF(cf)"
+            >
+              Сохранить
+            </button>
+            <button
+              class="lk-button lk-button--danger acf-btn"
+              @click="deleteCF(cf)"
+            >
+              Удалить
+            </button>
+          </td>
+        </tr>
+        <tr v-if="!customFields.length">
+          <td
+            colspan="4"
+            class="acf-empty"
+          >
+            Кастомных полей нет
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="acf-add-row">
+      <input
+        v-model="newCF.label"
+        placeholder="Заголовок"
+        class="lk-input acf-add-input"
+      >
+      <input
+        v-model="newCF.placeholder"
+        placeholder="Плейсхолдер"
+        class="lk-input acf-add-input"
+      >
+      <button
+        class="lk-button lk-button--primary acf-btn"
+        :disabled="!newCF.label"
+        @click="addCF"
+      >
+        + Добавить поле
+      </button>
+    </div>
+  </section>
+</template>
+
+<script>
+import { useUiStore } from '@/stores/ui';
+import {
+  listCustomFields, createCustomField, updateCustomField, deleteCustomField,
+} from '@/api/attachment-templates';
+
+export default {
+  name: 'AttachmentCustomFields',
+  props: {
+    uniqueAttachmentId: { type: Number, required: true },
+  },
+  data() {
+    return {
+      customFields: [],
+      newCF: { label: '', placeholder: '' },
+    };
+  },
+  watch: {
+    uniqueAttachmentId: {
+      immediate: true,
+      handler(v) {
+        if (v) this.load();
+      },
+    },
+  },
+  methods: {
+    async load() {
+      try {
+        const data = await listCustomFields(this.uniqueAttachmentId);
+        this.customFields = Array.isArray(data) ? data : [];
+      } catch {
+        this.customFields = [];
+      }
+    },
+    async addCF() {
+      if (!this.newCF.label) return;
+      try {
+        await createCustomField(this.uniqueAttachmentId, {
+          label: this.newCF.label,
+          placeholder: this.newCF.placeholder,
+          sortOrder: this.customFields.length,
+        });
+        this.newCF = { label: '', placeholder: '' };
+        await this.load();
+        useUiStore().success('Поле добавлено');
+      } catch {
+        useUiStore().error('Не удалось добавить поле');
+      }
+    },
+    async updateCF(cf) {
+      try {
+        await updateCustomField(cf.id, {
+          label: cf.label,
+          placeholder: cf.placeholder || '',
+          sortOrder: cf.sort_order || 0,
+        });
+        useUiStore().success('Поле обновлено');
+      } catch {
+        useUiStore().error('Не удалось обновить');
+      }
+    },
+    async deleteCF(cf) {
+      if (!confirm(`Удалить поле "${cf.label}"?`)) return;
+      try {
+        await deleteCustomField(cf.id);
+        await this.load();
+        useUiStore().success('Поле удалено');
+      } catch {
+        useUiStore().error('Не удалось удалить');
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.acf-section {
+  margin-top: 16px;
+  border-top: 1px solid var(--color-border);
+  padding-top: 16px;
+}
+
+.acf-header h4 {
+  margin: 0 0 12px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.acf-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+  margin-bottom: 12px;
+}
+
+.acf-table th {
+  padding: 8px 10px;
+  text-align: left;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  border-bottom: 2px solid var(--color-border);
+}
+
+.acf-table td {
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--color-border);
+  vertical-align: middle;
+}
+
+.acf-th-order { width: 60px; }
+.acf-th-actions { width: 180px; }
+
+.acf-input {
+  padding: 5px 8px !important;
+  font-size: 13px !important;
+}
+
+.acf-input-order { width: 60px; }
+
+.acf-row-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.acf-btn {
+  padding: 4px 10px !important;
+  font-size: 11px !important;
+}
+
+.acf-empty {
+  text-align: center;
+  color: var(--color-text-muted);
+  padding: 16px 0 !important;
+}
+
+.acf-add-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.acf-add-input {
+  flex: 1;
+  padding: 6px 10px !important;
+  font-size: 13px !important;
+}
+</style>

--- a/frontend/src/components/admin/AttachmentTemplateEditor.vue
+++ b/frontend/src/components/admin/AttachmentTemplateEditor.vue
@@ -9,109 +9,111 @@
   >
     <div class="te-modal-body">
       <!-- Верхняя панель: управление -->
-      <div class="te-toolbar">
-        <div class="te-toolbar-left">
-          <label class="te-toggle">
-            <input
-              type="checkbox"
-              :checked="enabled"
-              @change="onToggle"
-            >
-            <span>Генерация бланка</span>
-          </label>
-        </div>
-        <div
-          v-if="enabled && template && template.file_path"
-          class="te-toolbar-right"
-        >
-          <div class="te-file-info">
-            <span class="te-file-name">{{ template.original_file_name || 'template.xlsx' }}</span>
-            <span class="te-file-meta">
-              строки {{ template.list_start_row }}-{{ template.list_end_row }}
-            </span>
+      <div class="te-section">
+        <div class="te-toolbar">
+          <div class="te-toolbar-left">
+            <label class="te-toggle">
+              <input
+                type="checkbox"
+                :checked="enabled"
+                @change="onToggle"
+              >
+              <span>Генерация бланка</span>
+            </label>
           </div>
-          <button
-            class="lk-button lk-button--ghost te-btn-sm"
-            @click="showUpload = true"
+          <div
+            v-if="enabled && template && template.file_path"
+            class="te-toolbar-right"
           >
-            Заменить
-          </button>
-          <button
-            class="lk-button lk-button--danger te-btn-sm"
-            @click="onDeleteTemplate"
-          >
-            Удалить
-          </button>
-        </div>
-      </div>
-
-      <!-- Форма загрузки шаблона -->
-      <div
-        v-if="enabled && (!template || !template.file_path || showUpload)"
-        class="te-upload-section"
-      >
-        <form
-          class="te-upload-form"
-          @submit.prevent="onUpload"
-        >
-          <div class="te-upload-file">
-            <input
-              type="file"
-              accept=".xlsx"
-              required
-              @change="onFileChange"
-            >
-          </div>
-          <div class="te-upload-fields">
-            <div class="te-form-field">
-              <label>Начальная строка списка</label>
-              <input
-                v-model.number="form.listStartRow"
-                type="number"
-                min="1"
-                class="lk-input"
-                required
-              >
+            <div class="te-file-info">
+              <span class="te-file-name">{{ template.original_file_name || 'template.xlsx' }}</span>
+              <span class="te-file-meta">
+                строки {{ template.list_start_row }}-{{ template.list_end_row }}
+              </span>
             </div>
-            <div class="te-form-field">
-              <label>Конечная строка списка</label>
-              <input
-                v-model.number="form.listEndRow"
-                type="number"
-                min="1"
-                class="lk-input"
-                required
-              >
-            </div>
-            <div class="te-form-field">
-              <label>Макс. записей</label>
-              <input
-                v-model.number="form.maxListRows"
-                type="number"
-                min="0"
-                class="lk-input"
-                placeholder="авто"
-              >
-            </div>
-          </div>
-          <div class="te-upload-actions">
             <button
-              v-if="template && template.file_path"
-              type="button"
               class="lk-button lk-button--ghost te-btn-sm"
-              @click="showUpload = false"
+              @click="showUpload = true"
             >
-              Отмена
+              Заменить
             </button>
             <button
-              type="submit"
-              class="lk-button lk-button--primary te-btn-sm"
-              :disabled="!form.file || uploading"
+              class="lk-button lk-button--danger te-btn-sm"
+              @click="onDeleteTemplate"
             >
-              {{ uploading ? 'Загрузка...' : 'Загрузить' }}
+              Удалить
             </button>
           </div>
-        </form>
+        </div>
+
+        <!-- Форма загрузки шаблона -->
+        <div
+          v-if="enabled && (!template || !template.file_path || showUpload)"
+          class="te-upload-area"
+        >
+          <form
+            class="te-upload-form"
+            @submit.prevent="onUpload"
+          >
+            <div class="te-upload-file">
+              <input
+                type="file"
+                accept=".xlsx"
+                required
+                @change="onFileChange"
+              >
+            </div>
+            <div class="te-upload-fields">
+              <div class="te-form-field">
+                <label>Начальная строка списка</label>
+                <input
+                  v-model.number="form.listStartRow"
+                  type="number"
+                  min="1"
+                  class="lk-input"
+                  required
+                >
+              </div>
+              <div class="te-form-field">
+                <label>Конечная строка списка</label>
+                <input
+                  v-model.number="form.listEndRow"
+                  type="number"
+                  min="1"
+                  class="lk-input"
+                  required
+                >
+              </div>
+              <div class="te-form-field">
+                <label>Макс. записей</label>
+                <input
+                  v-model.number="form.maxListRows"
+                  type="number"
+                  min="0"
+                  class="lk-input"
+                  placeholder="авто"
+                >
+              </div>
+            </div>
+            <div class="te-upload-actions">
+              <button
+                v-if="template && template.file_path"
+                type="button"
+                class="lk-button lk-button--ghost te-btn-sm"
+                @click="showUpload = false"
+              >
+                Отмена
+              </button>
+              <button
+                type="submit"
+                class="lk-button lk-button--primary te-btn-sm"
+                :disabled="!form.file || uploading"
+              >
+                {{ uploading ? 'Загрузка...' : 'Загрузить' }}
+              </button>
+            </div>
+          </form>
+        </div>
       </div>
 
       <!-- Визуальный редактор -->
@@ -172,6 +174,10 @@
               :key="line.id"
               :d="line.d"
               class="te-path-line"
+              :class="{
+                'te-path-dimmed': hoveredFieldPath && line.fieldPath !== hoveredFieldPath,
+                'te-path-highlighted': hoveredFieldPath && line.fieldPath === hoveredFieldPath,
+              }"
               :style="{ stroke: line.color }"
             />
             <circle
@@ -181,6 +187,10 @@
               :cy="line.y2"
               r="3"
               :fill="line.color"
+              class="te-path-dot"
+              :class="{
+                'te-path-dimmed': hoveredFieldPath && line.fieldPath !== hoveredFieldPath,
+              }"
             />
             <circle
               v-for="line in pathLines"
@@ -189,6 +199,10 @@
               :cy="line.y1"
               r="3"
               :fill="line.color"
+              class="te-path-dot"
+              :class="{
+                'te-path-dimmed': hoveredFieldPath && line.fieldPath !== hoveredFieldPath,
+              }"
             />
           </svg>
 
@@ -222,46 +236,50 @@
                   Кликните на ячейку слева
                 </span>
               </div>
-              <div
-                v-for="g in filteredFieldGroups"
-                :key="g.group"
-                class="te-field-group"
-              >
-                <span class="te-field-group-label">{{ g.label }}</span>
-                <div class="te-field-chips">
-                  <button
-                    v-for="f in g.fields"
-                    :key="f.path"
-                    :data-field-path="f.path"
-                    class="te-field-chip"
-                    :class="{
-                      active: pendingFieldPath === f.path,
-                      used: fieldPathUsed(f.path),
-                    }"
-                    @click="selectField(f)"
-                  >
-                    <span class="te-chip-label">{{ f.label }}</span>
-                    <span
-                      v-if="fieldPathUsed(f.path)"
-                      class="te-chip-ref"
+              <div class="te-field-picker-scroll">
+                <div
+                  v-for="g in filteredFieldGroups"
+                  :key="g.group"
+                  class="te-field-group"
+                >
+                  <span class="te-field-group-label">{{ g.label }}</span>
+                  <div class="te-field-chips">
+                    <button
+                      v-for="f in g.fields"
+                      :key="f.path"
+                      :data-field-path="f.path"
+                      class="te-field-chip"
+                      :class="{
+                        active: pendingFieldPath === f.path,
+                        used: fieldPathUsed(f.path),
+                      }"
+                      @click="selectField(f)"
+                      @mouseenter="onChipHover(f.path)"
+                      @mouseleave="onChipHover('')"
                     >
-                      {{ fieldCellRef(f.path) }}
-                    </span>
-                    <span
-                      v-if="fieldPathUsed(f.path)"
-                      class="te-chip-remove"
-                      @click.stop="removeMappingByPath(f.path)"
-                    >
-                      &times;
-                    </span>
-                  </button>
+                      <span class="te-chip-label">{{ f.label }}</span>
+                      <span
+                        v-if="fieldPathUsed(f.path)"
+                        class="te-chip-ref"
+                      >
+                        {{ fieldCellRef(f.path) }}
+                      </span>
+                      <span
+                        v-if="fieldPathUsed(f.path)"
+                        class="te-chip-remove"
+                        @click.stop="removeMappingByPath(f.path)"
+                      >
+                        &times;
+                      </span>
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <div
-                v-if="filteredFieldGroups.length === 0"
-                class="te-no-results"
-              >
-                Поля не найдены
+                <div
+                  v-if="filteredFieldGroups.length === 0"
+                  class="te-no-results"
+                >
+                  Поля не найдены
+                </div>
               </div>
             </div>
 
@@ -283,6 +301,8 @@
                   :key="idx"
                   class="te-mapping-row"
                   :class="{ highlight: pendingCellRef === m.cell_ref }"
+                  @mouseenter="onChipHover(m.field_path)"
+                  @mouseleave="onChipHover('')"
                 >
                   <span class="te-mapping-cell">{{ m.cell_ref }}</span>
                   <span class="te-mapping-field">{{ m.fieldLabel || m.field_path }}</span>
@@ -301,92 +321,6 @@
               </div>
             </div>
           </div>
-        </div>
-      </div>
-
-      <!-- Кастомные поля -->
-      <div class="te-custom-section">
-        <div class="te-section-header">
-          <h4>Дополнительные поля вложения</h4>
-        </div>
-        <table class="te-custom-table">
-          <thead>
-            <tr>
-              <th>Заголовок</th>
-              <th>Плейсхолдер</th>
-              <th class="th-order">
-                N
-              </th>
-              <th class="th-actions" />
-            </tr>
-          </thead>
-          <tbody>
-            <tr
-              v-for="cf in customFields"
-              :key="cf.id"
-            >
-              <td>
-                <input
-                  v-model="cf.label"
-                  class="lk-input te-table-input"
-                >
-              </td>
-              <td>
-                <input
-                  v-model="cf.placeholder"
-                  class="lk-input te-table-input"
-                >
-              </td>
-              <td>
-                <input
-                  v-model.number="cf.sort_order"
-                  type="number"
-                  class="lk-input te-table-input te-order-input"
-                >
-              </td>
-              <td class="te-row-actions">
-                <button
-                  class="lk-button lk-button--ghost te-btn-xs"
-                  @click="updateCF(cf)"
-                >
-                  Сохранить
-                </button>
-                <button
-                  class="lk-button lk-button--danger te-btn-xs"
-                  @click="deleteCF(cf)"
-                >
-                  Удалить
-                </button>
-              </td>
-            </tr>
-            <tr v-if="!customFields.length">
-              <td
-                colspan="4"
-                class="te-empty-cell"
-              >
-                Кастомных полей нет
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <div class="te-custom-add">
-          <input
-            v-model="newCF.label"
-            placeholder="Заголовок"
-            class="lk-input te-add-input"
-          >
-          <input
-            v-model="newCF.placeholder"
-            placeholder="Плейсхолдер"
-            class="lk-input te-add-input"
-          >
-          <button
-            class="lk-button lk-button--primary te-btn-sm"
-            :disabled="!newCF.label"
-            @click="addCF"
-          >
-            + Добавить поле
-          </button>
         </div>
       </div>
     </div>
@@ -415,7 +349,6 @@ import { useUiStore } from '@/stores/ui';
 import {
   getTemplate, uploadTemplate, updateMappings, deleteTemplate,
   getTemplateFields, getTemplateFile,
-  listCustomFields, createCustomField, updateCustomField, deleteCustomField,
 } from '@/api/attachment-templates';
 import BaseModal from '@/components/ui/BaseModal.vue';
 import XlsxViewer from './XlsxViewer.vue';
@@ -438,8 +371,6 @@ export default {
       template: null,
       mappings: [],
       fieldGroups: [],
-      customFields: [],
-      newCF: { label: '', placeholder: '' },
       enabled: false,
       showUpload: false,
       form: { file: null, listStartRow: 1, listEndRow: 1, maxListRows: 0 },
@@ -452,6 +383,7 @@ export default {
       searchQuery: '',
       activeCategory: '',
       showPaths: false,
+      hoveredFieldPath: '',
       pathLines: [],
       svgWidth: 0,
       svgHeight: 0,
@@ -511,7 +443,7 @@ export default {
   },
   methods: {
     async loadAll() {
-      await Promise.all([this.loadTemplate(), this.loadCustomFields(), this.loadFields()]);
+      await Promise.all([this.loadTemplate(), this.loadFields()]);
     },
     async loadTemplate() {
       try {
@@ -535,14 +467,6 @@ export default {
         this.templateFileBuffer = await getTemplateFile(this.uniqueAttachmentId);
       } catch {
         this.templateFileBuffer = null;
-      }
-    },
-    async loadCustomFields() {
-      try {
-        const data = await listCustomFields(this.uniqueAttachmentId);
-        this.customFields = Array.isArray(data) ? data : [];
-      } catch {
-        this.customFields = [];
       }
     },
     async loadFields() {
@@ -621,12 +545,7 @@ export default {
         this.pendingFieldLabel = '';
         this.pendingCellRef = '';
       } else {
-        const mappedIdx = this.mappings.findIndex(m => m.cell_ref === cellRef);
-        if (mappedIdx >= 0) {
-          this.pendingCellRef = cellRef;
-        } else {
-          this.pendingCellRef = cellRef;
-        }
+        this.pendingCellRef = cellRef;
       }
     },
     removeMapping(idx) {
@@ -670,44 +589,8 @@ export default {
         this.savingMappings = false;
       }
     },
-    async addCF() {
-      if (!this.newCF.label) return;
-      try {
-        await createCustomField(this.uniqueAttachmentId, {
-          label: this.newCF.label,
-          placeholder: this.newCF.placeholder,
-          sortOrder: this.customFields.length,
-        });
-        this.newCF = { label: '', placeholder: '' };
-        await this.loadCustomFields();
-        await this.loadFields();
-        useUiStore().success('Поле добавлено');
-      } catch {
-        useUiStore().error('Не удалось добавить поле');
-      }
-    },
-    async updateCF(cf) {
-      try {
-        await updateCustomField(cf.id, {
-          label: cf.label,
-          placeholder: cf.placeholder || '',
-          sortOrder: cf.sort_order || 0,
-        });
-        useUiStore().success('Поле обновлено');
-      } catch {
-        useUiStore().error('Не удалось обновить');
-      }
-    },
-    async deleteCF(cf) {
-      if (!confirm(`Удалить поле "${cf.label}"?`)) return;
-      try {
-        await deleteCustomField(cf.id);
-        await this.loadCustomFields();
-        await this.loadFields();
-        useUiStore().success('Поле удалено');
-      } catch {
-        useUiStore().error('Не удалось удалить');
-      }
+    onChipHover(fieldPath) {
+      this.hoveredFieldPath = fieldPath;
     },
 
     setupPathListeners() {
@@ -783,6 +666,7 @@ export default {
 
         lines.push({
           id: m.field_path + '-' + m.cell_ref,
+          fieldPath: m.field_path,
           d,
           x1, y1, x2, y2,
           color: PATH_COLORS[i % PATH_COLORS.length],
@@ -796,12 +680,19 @@ export default {
 </script>
 
 <style scoped>
-/* Modal body override */
 .te-modal-body {
   display: flex;
   flex-direction: column;
   gap: 16px;
   min-height: 0;
+}
+
+/* Секция с рамкой */
+.te-section {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 16px;
+  background: #fff;
 }
 
 /* Toolbar */
@@ -811,9 +702,6 @@ export default {
   justify-content: space-between;
   flex-wrap: wrap;
   gap: 12px;
-  padding: 12px 16px;
-  background: var(--color-bg-secondary);
-  border-radius: var(--radius-sm);
 }
 
 .te-toolbar-left {
@@ -860,17 +748,16 @@ export default {
 .te-file-meta {
   font-size: 12px;
   color: var(--color-text-muted);
-  background: #fff;
+  background: var(--color-bg-secondary);
   padding: 2px 8px;
   border-radius: var(--radius-sm);
 }
 
-/* Upload section */
-.te-upload-section {
-  border: 2px dashed var(--color-border);
-  border-radius: var(--radius-sm);
-  padding: 16px;
-  background: #fff;
+/* Upload area */
+.te-upload-area {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid var(--color-border);
 }
 
 .te-upload-form {
@@ -913,6 +800,10 @@ export default {
   align-items: center;
   gap: 12px;
   flex-wrap: wrap;
+  padding: 10px 14px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: #fff;
 }
 
 .te-search-wrap {
@@ -977,7 +868,7 @@ export default {
   position: relative;
   flex: 1;
   min-height: 0;
-  height: calc(60vh - 100px);
+  height: calc(60vh - 80px);
 }
 
 .te-path-overlay {
@@ -995,6 +886,24 @@ export default {
   fill: none;
   stroke-width: 1.5;
   opacity: 0.6;
+  transition: opacity 0.25s ease, stroke-width 0.25s ease;
+}
+
+.te-path-line.te-path-highlighted {
+  opacity: 0.85;
+  stroke-width: 2.5;
+}
+
+.te-path-line.te-path-dimmed {
+  opacity: 0;
+}
+
+.te-path-dot {
+  transition: opacity 0.25s ease;
+}
+
+.te-path-dot.te-path-dimmed {
+  opacity: 0;
 }
 
 .te-panel-left {
@@ -1013,7 +922,6 @@ export default {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  overflow-y: auto;
   min-height: 0;
 }
 
@@ -1021,15 +929,20 @@ export default {
 .te-field-picker {
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
-  padding: 12px;
   background: #fff;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1;
 }
 
 .te-picker-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 10px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--color-border);
+  flex-shrink: 0;
 }
 
 .te-picker-header h4 {
@@ -1049,6 +962,13 @@ export default {
 @keyframes te-pulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.5; }
+}
+
+.te-field-picker-scroll {
+  overflow-y: auto;
+  padding: 10px 12px;
+  flex: 1;
+  min-height: 0;
 }
 
 .te-field-group {
@@ -1153,8 +1073,8 @@ export default {
   border-radius: var(--radius-sm);
   padding: 12px;
   background: #fff;
-  flex: 1;
-  min-height: 0;
+  flex-shrink: 0;
+  max-height: 200px;
   display: flex;
   flex-direction: column;
 }
@@ -1163,7 +1083,8 @@ export default {
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-bottom: 10px;
+  margin-bottom: 8px;
+  flex-shrink: 0;
 }
 
 .te-section-header h4 {
@@ -1186,7 +1107,7 @@ export default {
   font-size: 12px;
   color: var(--color-text-muted);
   text-align: center;
-  padding: 16px 0;
+  padding: 12px 0;
 }
 
 .te-mappings-list {
@@ -1198,7 +1119,7 @@ export default {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 6px 8px;
+  padding: 5px 8px;
   border-radius: 6px;
   font-size: 12px;
   transition: background 0.1s;
@@ -1256,78 +1177,10 @@ export default {
   color: var(--color-danger);
 }
 
-/* Custom fields */
-.te-custom-section {
-  border-top: 1px solid var(--color-border);
-  padding-top: 16px;
-}
-
-.te-custom-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 13px;
-  margin-bottom: 12px;
-}
-
-.te-custom-table th {
-  padding: 8px 10px;
-  text-align: left;
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--color-text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.3px;
-  border-bottom: 2px solid var(--color-border);
-}
-
-.te-custom-table td {
-  padding: 6px 8px;
-  border-bottom: 1px solid var(--color-border);
-  vertical-align: middle;
-}
-
-.th-order { width: 60px; }
-.th-actions { width: 180px; }
-
-.te-table-input {
-  padding: 5px 8px !important;
-  font-size: 13px !important;
-}
-
-.te-order-input { width: 60px; }
-
-.te-row-actions {
-  display: flex;
-  gap: 6px;
-}
-
-.te-empty-cell {
-  text-align: center;
-  color: var(--color-text-muted);
-  padding: 16px 0 !important;
-}
-
-.te-custom-add {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-}
-
-.te-add-input {
-  flex: 1;
-  padding: 6px 10px !important;
-  font-size: 13px !important;
-}
-
 /* Button sizes */
 .te-btn-sm {
   padding: 6px 14px !important;
   font-size: 12px !important;
-}
-
-.te-btn-xs {
-  padding: 4px 10px !important;
-  font-size: 11px !important;
 }
 
 /* Responsive */

--- a/frontend/src/components/admin/XlsxViewer.vue
+++ b/frontend/src/components/admin/XlsxViewer.vue
@@ -34,7 +34,18 @@
         </button>
       </div>
       <div class="xv-table-wrap">
-        <table class="xv-table">
+        <table
+          class="xv-table"
+          :style="{ tableLayout: 'fixed', width: currentSheet.tableWidth + 'px' }"
+        >
+          <colgroup>
+            <col class="xv-col-num">
+            <col
+              v-for="cw in currentSheet.colWidths"
+              :key="cw.letter"
+              :style="{ width: cw.width + 'px' }"
+            >
+          </colgroup>
           <thead>
             <tr>
               <th class="xv-corner" />
@@ -51,12 +62,14 @@
             <tr
               v-for="row in currentSheet.rows"
               :key="row.num"
+              :style="row.height ? { height: row.height + 'px' } : {}"
             >
               <td class="xv-row-header">
                 {{ row.num }}
               </td>
               <td
                 v-for="cell in row.cells"
+                v-show="!cell.hidden"
                 :key="cell.ref"
                 :data-cell-ref="cell.ref"
                 class="xv-cell"
@@ -71,6 +84,13 @@
                 @click="onCellClick(cell)"
               >
                 <span class="xv-cell-text">{{ cell.display }}</span>
+                <img
+                  v-for="img in cell.images"
+                  :key="img.src"
+                  :src="img.src"
+                  class="xv-cell-image"
+                  :style="img.style"
+                >
                 <span
                   v-if="mappedCells.has(cell.ref)"
                   class="xv-mapped-badge"
@@ -95,6 +115,12 @@
 <script>
 import ExcelJS from 'exceljs';
 
+const DEFAULT_COL_WIDTH = 64;
+const DEFAULT_ROW_HEIGHT = 20;
+const COL_WIDTH_FACTOR = 7.5;
+const ROW_HEIGHT_FACTOR = 1.33;
+const ROW_NUM_COL_WIDTH = 32;
+
 export default {
   name: 'XlsxViewer',
   props: {
@@ -113,7 +139,7 @@ export default {
   },
   computed: {
     currentSheet() {
-      return this.sheets[this.activeSheet] || { cols: [], rows: [] };
+      return this.sheets[this.activeSheet] || { cols: [], rows: [], colWidths: [], tableWidth: 0 };
     },
     mappedCells() {
       const map = new Map();
@@ -142,7 +168,7 @@ export default {
       try {
         const workbook = new ExcelJS.Workbook();
         await workbook.xlsx.load(buffer);
-        this.sheets = workbook.worksheets.map(ws => this.parseSheet(ws));
+        this.sheets = workbook.worksheets.map(ws => this.parseSheet(ws, workbook));
         this.activeSheet = 0;
       } catch (e) {
         this.error = 'Не удалось прочитать файл: ' + (e.message || e);
@@ -151,32 +177,129 @@ export default {
         this.loading = false;
       }
     },
-    parseSheet(ws) {
+    parseSheet(ws, workbook) {
       const colCount = Math.min(ws.columnCount || 0, 30);
       const rowCount = Math.min(ws.rowCount || 0, 100);
+
+      const merges = this.parseMerges(ws);
+      const imageMap = this.parseImages(ws, workbook);
+
       const cols = [];
+      const colWidths = [];
       for (let c = 1; c <= colCount; c++) {
-        cols.push(this.colLetter(c));
+        const letter = this.colLetter(c);
+        cols.push(letter);
+        const col = ws.getColumn(c);
+        const w = col.width ? Math.round(col.width * COL_WIDTH_FACTOR) : DEFAULT_COL_WIDTH;
+        colWidths.push({ letter, width: w });
       }
+
+      const tableWidth = ROW_NUM_COL_WIDTH + colWidths.reduce((sum, cw) => sum + cw.width, 0);
+
       const rows = [];
       for (let r = 1; r <= rowCount; r++) {
         const row = ws.getRow(r);
+        const rowHeight = row.height ? Math.round(row.height * ROW_HEIGHT_FACTOR) : DEFAULT_ROW_HEIGHT;
         const cells = [];
         for (let c = 1; c <= colCount; c++) {
           const cell = row.getCell(c);
           const ref = this.colLetter(c) + r;
+
+          const mergeInfo = merges.get(ref);
+          const hidden = mergeInfo && mergeInfo.hidden;
+          const colspan = mergeInfo ? mergeInfo.colspan : 1;
+          const rowspan = mergeInfo ? mergeInfo.rowspan : 1;
+
+          const cellImages = imageMap.get(ref) || [];
+
           cells.push({
             ref,
             value: cell.value,
-            display: this.formatCellValue(cell),
-            style: this.extractStyle(cell),
-            colspan: 1,
-            rowspan: 1,
+            display: hidden ? '' : this.formatCellValue(cell),
+            style: this.extractStyle(cell, mergeInfo),
+            colspan,
+            rowspan,
+            hidden,
+            images: cellImages,
           });
         }
-        rows.push({ num: r, cells });
+        rows.push({ num: r, cells, height: rowHeight });
       }
-      return { name: ws.name, cols, rows };
+      return { name: ws.name, cols, rows, colWidths, tableWidth };
+    },
+    parseMerges(ws) {
+      const map = new Map();
+      if (!ws.model || !ws.model.merges) return map;
+      for (const mergeRange of ws.model.merges) {
+        const parts = mergeRange.split(':');
+        if (parts.length !== 2) continue;
+        const tl = this.parseRef(parts[0]);
+        const br = this.parseRef(parts[1]);
+        if (!tl || !br) continue;
+
+        const colspan = br.col - tl.col + 1;
+        const rowspan = br.row - tl.row + 1;
+
+        const tlRef = parts[0].toUpperCase();
+        map.set(tlRef, { colspan, rowspan, hidden: false });
+
+        for (let r = tl.row; r <= br.row; r++) {
+          for (let c = tl.col; c <= br.col; c++) {
+            const ref = this.colLetter(c) + r;
+            if (ref !== tlRef) {
+              map.set(ref, { colspan: 1, rowspan: 1, hidden: true });
+            }
+          }
+        }
+      }
+      return map;
+    },
+    parseRef(ref) {
+      const m = ref.toUpperCase().match(/^([A-Z]+)(\d+)$/);
+      if (!m) return null;
+      let col = 0;
+      for (const ch of m[1]) {
+        col = col * 26 + (ch.charCodeAt(0) - 64);
+      }
+      return { col, row: parseInt(m[2], 10) };
+    },
+    parseImages(ws, workbook) {
+      const map = new Map();
+      if (!ws.getImages) return map;
+      const wsImages = ws.getImages();
+      for (const img of wsImages) {
+        const mediaImage = workbook.model.media.find(m => m.index === img.imageId);
+        if (!mediaImage || !mediaImage.buffer) continue;
+
+        const ext = mediaImage.extension || 'png';
+        const mime = ext === 'jpeg' || ext === 'jpg' ? 'image/jpeg' : `image/${ext}`;
+        const b64 = this.bufferToBase64(mediaImage.buffer);
+        const src = `data:${mime};base64,${b64}`;
+
+        let cellRef = '';
+        const style = {};
+        if (img.range) {
+          const tl = img.range.tl;
+          cellRef = this.colLetter(Math.floor(tl.col) + 1) + (Math.floor(tl.row) + 1);
+          if (img.range.ext) {
+            style.maxWidth = Math.round(img.range.ext.width / 9525) + 'px';
+            style.maxHeight = Math.round(img.range.ext.height / 9525) + 'px';
+          }
+        }
+        if (!cellRef) continue;
+
+        if (!map.has(cellRef)) map.set(cellRef, []);
+        map.get(cellRef).push({ src, style });
+      }
+      return map;
+    },
+    bufferToBase64(buffer) {
+      const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+      let binary = '';
+      for (let i = 0; i < bytes.length; i++) {
+        binary += String.fromCharCode(bytes[i]);
+      }
+      return btoa(binary);
     },
     colLetter(num) {
       let s = '';
@@ -199,26 +322,72 @@ export default {
       }
       return String(cell.value);
     },
-    extractStyle(cell) {
+    extractStyle(cell, mergeInfo) {
       const style = {};
+
       if (cell.font) {
         if (cell.font.bold) style.fontWeight = 'bold';
         if (cell.font.italic) style.fontStyle = 'italic';
-        if (cell.font.size) style.fontSize = Math.min(cell.font.size, 14) + 'px';
+        if (cell.font.underline) style.textDecoration = 'underline';
+        if (cell.font.size) style.fontSize = Math.min(cell.font.size, 16) + 'px';
+        if (cell.font.name) style.fontFamily = cell.font.name + ', sans-serif';
         if (cell.font.color && cell.font.color.argb) {
           style.color = '#' + cell.font.color.argb.slice(2);
         }
       }
-      if (cell.fill && cell.fill.fgColor && cell.fill.fgColor.argb) {
-        const hex = '#' + cell.fill.fgColor.argb.slice(2);
-        if (hex !== '#000000') style.backgroundColor = hex;
+
+      if (cell.fill) {
+        if (cell.fill.type === 'pattern' && cell.fill.fgColor && cell.fill.fgColor.argb) {
+          const hex = '#' + cell.fill.fgColor.argb.slice(2);
+          if (hex.toLowerCase() !== '#000000') style.backgroundColor = hex;
+        }
       }
+
       if (cell.alignment) {
         if (cell.alignment.horizontal) style.textAlign = cell.alignment.horizontal;
+        if (cell.alignment.vertical) {
+          const vmap = { top: 'top', middle: 'middle', bottom: 'bottom' };
+          style.verticalAlign = vmap[cell.alignment.vertical] || 'middle';
+        }
+        if (cell.alignment.wrapText) {
+          style.whiteSpace = 'pre-wrap';
+          style.wordBreak = 'break-word';
+        }
       }
+
+      if (cell.border) {
+        const toBorder = (b) => {
+          if (!b || !b.style) return '';
+          const styleMap = {
+            thin: '1px solid',
+            medium: '2px solid',
+            thick: '3px solid',
+            dotted: '1px dotted',
+            dashed: '1px dashed',
+            double: '3px double',
+            hair: '1px solid',
+          };
+          const bStyle = styleMap[b.style] || '1px solid';
+          let color = '#000';
+          if (b.color && b.color.argb) {
+            color = '#' + b.color.argb.slice(2);
+          }
+          return `${bStyle} ${color}`;
+        };
+        if (cell.border.top) style.borderTop = toBorder(cell.border.top);
+        if (cell.border.bottom) style.borderBottom = toBorder(cell.border.bottom);
+        if (cell.border.left) style.borderLeft = toBorder(cell.border.left);
+        if (cell.border.right) style.borderRight = toBorder(cell.border.right);
+      }
+
+      if (mergeInfo && !mergeInfo.hidden && (mergeInfo.colspan > 1 || mergeInfo.rowspan > 1)) {
+        style.overflow = 'visible';
+      }
+
       return style;
     },
     onCellClick(cell) {
+      if (cell.hidden) return;
       this.$emit('cell-click', cell.ref);
     },
   },
@@ -291,21 +460,22 @@ export default {
   flex: 1;
 }
 
+.xv-col-num {
+  width: 32px;
+}
+
 .xv-table {
   border-collapse: collapse;
   font-size: 11px;
-  min-width: 100%;
-  table-layout: auto;
 }
 
 .xv-table th,
 .xv-table td {
-  border: 1px solid #ddd;
+  border: 1px solid #d0d0d0;
   padding: 2px 4px;
-  white-space: nowrap;
-  max-width: 200px;
   overflow: hidden;
   text-overflow: ellipsis;
+  vertical-align: middle;
 }
 
 .xv-corner {
@@ -334,13 +504,14 @@ export default {
   position: sticky;
   left: 0;
   z-index: 1;
+  width: 32px;
+  min-width: 32px;
 }
 
 .xv-cell {
   cursor: pointer;
   position: relative;
   transition: background-color 0.1s;
-  min-width: 40px;
 }
 
 .xv-cell:hover {
@@ -367,6 +538,13 @@ export default {
   display: block;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.xv-cell-image {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  object-fit: contain;
 }
 
 .xv-mapped-badge {


### PR DESCRIPTION
## Summary

- XlsxViewer полностью переработан: merged cells (colspan/rowspan), ширина столбцов из xlsx, границы ячеек (все стороны), font family/underline, картинки в ячейках (base64)
- "Показать пути" hover-эффект: при наведении на поле остается только его линия (остальные исчезают с анимацией), линия становится жирнее
- Дополнительные поля вложения вынесены из модалки обратно в настройки вложения (AttachmentCustomFields.vue)
- te-field-picker теперь скроллится, секции обведены рамками
- Поиск полей + фильтр по категории работают

## Test plan

- [ ] Открыть xlsx с объединенными ячейками - проверить что отображаются корректно
- [ ] Ширина столбцов соответствует оригинальному документу
- [ ] Границы ячеек отображаются (тонкие, жирные, разные стороны)
- [ ] Картинки в xlsx отображаются в превью
- [ ] "Показать пути" + hover на поле: остается одна линия, остальные исчезают
- [ ] Дополнительные поля отображаются в настройках вложения (не в модалке)
- [ ] Поиск полей фильтрует корректно
- [ ] Привязки создаются и удаляются (крестик на chip + крестик в списке)