### PR TITLE
feat: полная переработка UX Excel-редактора (#183)

### DIFF
--- a/frontend/src/components/admin/AttachmentTemplateEditor.vue
+++ b/frontend/src/components/admin/AttachmentTemplateEditor.vue
@@ -4,26 +4,136 @@
     title="Excel-бланк"
     width="95vw"
     closable
-    :close-on-overlay="false"
-    @close="$emit('close')"
+    :close-on-overlay="!rebindingMode"
+    @close="onClose"
   >
-    <div class="te-modal-body">
-      <!-- Верхняя панель: управление -->
-      <div class="te-section">
-        <div class="te-toolbar">
-          <div class="te-toolbar-left">
-            <label class="te-toggle">
-              <input
-                type="checkbox"
-                :checked="enabled"
-                @change="onToggle"
-              >
-              <span>Генерация бланка</span>
-            </label>
-          </div>
+    <div
+      ref="modalBody"
+      class="te-modal-body"
+    >
+      <!-- Баннер перепривязки -->
+      <div
+        v-if="rebindingMode"
+        class="te-rebind-banner"
+      >
+        <span>
+          Перепривязка: <strong>{{ getFieldLabel(rebindMapping.field_path) }}</strong>
+          ({{ rebindMapping.old_cell_ref }}) - кликните на новую ячейку
+        </span>
+        <button
+          class="lk-button lk-button--ghost te-btn-sm"
+          @click="cancelRebind"
+        >
+          Отмена
+        </button>
+      </div>
+
+      <!-- SVG линии поверх всего -->
+      <svg
+        v-if="showPaths && pathLines.length"
+        ref="pathSvg"
+        class="te-path-overlay"
+        :viewBox="`0 0 ${svgWidth} ${svgHeight}`"
+      >
+        <path
+          v-for="line in pathLines"
+          :key="line.id"
+          :d="line.d"
+          class="te-path-line"
+          :class="{
+            'te-path-dimmed': hoveredFieldPath && line.fieldPath !== hoveredFieldPath,
+            'te-path-highlighted': hoveredFieldPath === line.fieldPath,
+          }"
+          :style="{ stroke: line.color, opacity: line.opacity }"
+          @mouseenter="onPathHover(line)"
+          @mouseleave="onPathLeave"
+          @click="onPathClick(line, $event)"
+        />
+        <circle
+          v-for="line in pathLines"
+          :key="line.id + '-dot-l'"
+          :cx="line.x2"
+          :cy="line.y2"
+          r="3"
+          :fill="line.color"
+          class="te-path-dot"
+          :class="{ 'te-path-dimmed': hoveredFieldPath && line.fieldPath !== hoveredFieldPath }"
+          :style="{ opacity: line.opacity }"
+        />
+        <circle
+          v-for="line in pathLines"
+          :key="line.id + '-dot-r'"
+          :cx="line.x1"
+          :cy="line.y1"
+          r="3"
+          :fill="line.color"
+          class="te-path-dot"
+          :class="{ 'te-path-dimmed': hoveredFieldPath && line.fieldPath !== hoveredFieldPath }"
+          :style="{ opacity: line.opacity }"
+        />
+        <!-- Кнопка удаления на пути -->
+        <foreignObject
+          v-if="pathPopup"
+          :x="pathPopup.x - 36"
+          :y="pathPopup.y - 14"
+          width="72"
+          height="28"
+          style="pointer-events: auto;"
+        >
+          <button
+            class="te-path-delete-btn"
+            @click="confirmPathDelete"
+          >
+            Удалить
+          </button>
+        </foreignObject>
+      </svg>
+
+      <!-- Левая панель: превью документа -->
+      <div
+        ref="previewPanel"
+        class="te-preview-panel"
+      >
+        <XlsxViewer
+          v-if="enabled && templateFileBuffer"
+          ref="xlsxViewer"
+          :file-buffer="templateFileBuffer"
+          :mappings="enrichedMappings"
+          :selected-cell="activeCellRef"
+          :cell-colors="cellColorMap"
+          @cell-click="onCellClick"
+        />
+        <div
+          v-else
+          class="te-preview-empty"
+        >
+          <span>Загрузите .xlsx файл для предпросмотра</span>
+        </div>
+      </div>
+
+      <!-- Правая панель: настройки -->
+      <div
+        ref="settingsPanel"
+        class="te-settings-panel"
+      >
+        <!-- Генерация бланка -->
+        <div class="te-section">
+          <ToggleSwitch
+            :model-value="enabled"
+            @update:model-value="onToggleEnabled"
+          >
+            Генерация бланка
+          </ToggleSwitch>
+        </div>
+
+        <!-- Файл шаблона -->
+        <div
+          v-if="enabled"
+          class="te-section"
+        >
           <div
-            v-if="enabled && template && template.file_path"
-            class="te-toolbar-right"
+            v-if="template && template.file_path && !showUpload"
+            class="te-file-block"
           >
             <div class="te-file-info">
               <span class="te-file-name">{{ template.original_file_name || 'template.xlsx' }}</span>
@@ -31,56 +141,88 @@
                 строки {{ template.list_start_row }}-{{ template.list_end_row }}
               </span>
             </div>
-            <button
-              class="lk-button lk-button--ghost te-btn-sm"
-              @click="showUpload = true"
-            >
-              Заменить
-            </button>
-            <button
-              class="lk-button lk-button--danger te-btn-sm"
-              @click="onDeleteTemplate"
-            >
-              Удалить
-            </button>
-          </div>
-        </div>
-
-        <!-- Форма загрузки шаблона -->
-        <div
-          v-if="enabled && (!template || !template.file_path || showUpload)"
-          class="te-upload-area"
-        >
-          <form
-            class="te-upload-form"
-            @submit.prevent="onUpload"
-          >
-            <div class="te-upload-file">
-              <input
-                type="file"
-                accept=".xlsx"
-                required
-                @change="onFileChange"
+            <div class="te-file-actions">
+              <button
+                class="lk-button lk-button--ghost te-btn-sm"
+                @click="downloadCurrentTemplate"
               >
+                Скачать
+              </button>
+              <button
+                class="lk-button lk-button--ghost te-btn-sm"
+                @click="showUpload = true"
+              >
+                Заменить
+              </button>
+              <button
+                class="lk-button lk-button--danger te-btn-sm"
+                @click="onDeleteTemplate"
+              >
+                Удалить
+              </button>
+            </div>
+          </div>
+
+          <!-- Drag & Drop загрузка -->
+          <div
+            v-if="!template || !template.file_path || showUpload"
+            class="te-upload-area"
+          >
+            <div
+              class="te-dropzone"
+              :class="{ 'te-dropzone--active': isDragging, 'te-dropzone--has-file': form.file }"
+              @dragenter.prevent="isDragging = true"
+              @dragover.prevent
+              @dragleave.prevent="isDragging = false"
+              @drop.prevent="onDrop"
+            >
+              <div
+                v-if="form.file"
+                class="te-dropzone__file"
+              >
+                <span class="te-dropzone__filename">{{ form.file.name }}</span>
+                <button
+                  class="te-dropzone__clear"
+                  @click.stop="form.file = null"
+                >
+                  &times;
+                </button>
+              </div>
+              <div
+                v-else
+                class="te-dropzone__placeholder"
+              >
+                <span class="te-dropzone__hint">Перетащите .xlsx файл сюда</span>
+                <span class="te-dropzone__or">или</span>
+                <label class="lk-button lk-button--ghost te-btn-sm te-dropzone__browse">
+                  Выберите файл
+                  <input
+                    type="file"
+                    accept=".xlsx"
+                    hidden
+                    @change="onFileChange"
+                  >
+                </label>
+              </div>
             </div>
             <div class="te-upload-fields">
               <div class="te-form-field">
-                <label>Начальная строка списка</label>
+                <label>Начало списка</label>
                 <input
                   v-model.number="form.listStartRow"
                   type="number"
                   min="1"
-                  class="lk-input"
+                  class="lk-input te-compact-input"
                   required
                 >
               </div>
               <div class="te-form-field">
-                <label>Конечная строка списка</label>
+                <label>Конец списка</label>
                 <input
                   v-model.number="form.listEndRow"
                   type="number"
                   min="1"
-                  class="lk-input"
+                  class="lk-input te-compact-input"
                   required
                 >
               </div>
@@ -90,7 +232,7 @@
                   v-model.number="form.maxListRows"
                   type="number"
                   min="0"
-                  class="lk-input"
+                  class="lk-input te-compact-input"
                   placeholder="авто"
                 >
               </div>
@@ -105,242 +247,179 @@
                 Отмена
               </button>
               <button
-                type="submit"
                 class="lk-button lk-button--primary te-btn-sm"
                 :disabled="!form.file || uploading"
+                @click="onUpload"
               >
                 {{ uploading ? 'Загрузка...' : 'Загрузить' }}
               </button>
             </div>
-          </form>
-        </div>
-      </div>
-
-      <!-- Визуальный редактор -->
-      <div
-        v-if="enabled && template && template.file_path"
-        class="te-editor"
-      >
-        <!-- Панель поиска и фильтров -->
-        <div class="te-filters">
-          <div class="te-search-wrap">
-            <input
-              v-model="searchQuery"
-              type="text"
-              class="lk-input te-search-input"
-              placeholder="Поиск полей..."
-            >
           </div>
+        </div>
+
+        <!-- Поиск и фильтры -->
+        <div
+          v-if="enabled && template && template.file_path"
+          class="te-section te-section--compact"
+        >
+          <input
+            v-model="searchQuery"
+            type="text"
+            class="lk-input te-compact-input"
+            placeholder="Поиск полей..."
+          >
           <div class="te-category-filter">
-            <button
-              class="te-cat-btn"
-              :class="{ active: activeCategory === '' }"
-              @click="activeCategory = ''"
-            >
-              Все
-            </button>
             <button
               v-for="g in fieldGroups"
               :key="g.group"
               class="te-cat-btn"
               :class="{ active: activeCategory === g.group }"
-              @click="activeCategory = g.group"
+              @click="activeCategory = activeCategory === g.group ? '' : g.group"
             >
               {{ g.label }}
             </button>
           </div>
-          <label class="te-paths-toggle">
-            <input
-              v-model="showPaths"
-              type="checkbox"
-            >
-            <span>Показать пути</span>
-          </label>
         </div>
 
-        <!-- Split panel: xlsx + поля -->
+        <!-- Поля для привязки -->
         <div
-          ref="splitPanel"
-          class="te-split-panel"
+          v-if="enabled && template && template.file_path"
+          class="te-field-picker"
         >
-          <!-- SVG линии -->
-          <svg
-            v-if="showPaths && pathLines.length"
-            class="te-path-overlay"
-            :viewBox="`0 0 ${svgWidth} ${svgHeight}`"
-          >
-            <path
-              v-for="line in pathLines"
-              :key="line.id"
-              :d="line.d"
-              class="te-path-line"
-              :class="{
-                'te-path-dimmed': hoveredFieldPath && line.fieldPath !== hoveredFieldPath,
-                'te-path-highlighted': hoveredFieldPath && line.fieldPath === hoveredFieldPath,
-              }"
-              :style="{ stroke: line.color }"
-            />
-            <circle
-              v-for="line in pathLines"
-              :key="line.id + '-dot-l'"
-              :cx="line.x2"
-              :cy="line.y2"
-              r="3"
-              :fill="line.color"
-              class="te-path-dot"
-              :class="{
-                'te-path-dimmed': hoveredFieldPath && line.fieldPath !== hoveredFieldPath,
-              }"
-            />
-            <circle
-              v-for="line in pathLines"
-              :key="line.id + '-dot-r'"
-              :cx="line.x1"
-              :cy="line.y1"
-              r="3"
-              :fill="line.color"
-              class="te-path-dot"
-              :class="{
-                'te-path-dimmed': hoveredFieldPath && line.fieldPath !== hoveredFieldPath,
-              }"
-            />
-          </svg>
-
-          <!-- Левая панель: xlsx -->
-          <div
-            ref="panelLeft"
-            class="te-panel-left"
-          >
-            <XlsxViewer
-              ref="xlsxViewer"
-              :file-buffer="templateFileBuffer"
-              :mappings="enrichedMappings"
-              :selected-cell="pendingCellRef"
-              @cell-click="onCellClick"
-            />
+          <div class="te-picker-header">
+            <h4>Поля</h4>
+            <span
+              v-if="pendingFieldPath"
+              class="te-pick-hint"
+            >
+              Кликните на ячейку
+            </span>
           </div>
-
-          <!-- Правая панель: поля + привязки -->
           <div
-            ref="panelRight"
-            class="te-panel-right"
+            ref="fieldPickerScroll"
+            class="te-field-picker-scroll"
           >
-            <!-- Поля -->
-            <div class="te-field-picker">
-              <div class="te-picker-header">
-                <h4>Поля для привязки</h4>
-                <span
-                  v-if="pendingFieldPath"
-                  class="te-pick-hint"
-                >
-                  Кликните на ячейку слева
-                </span>
-              </div>
-              <div class="te-field-picker-scroll">
-                <div
-                  v-for="g in filteredFieldGroups"
-                  :key="g.group"
-                  class="te-field-group"
-                >
-                  <span class="te-field-group-label">{{ g.label }}</span>
-                  <div class="te-field-chips">
-                    <button
-                      v-for="f in g.fields"
-                      :key="f.path"
-                      :data-field-path="f.path"
-                      class="te-field-chip"
-                      :class="{
-                        active: pendingFieldPath === f.path,
-                        used: fieldPathUsed(f.path),
-                      }"
-                      @click="selectField(f)"
-                      @mouseenter="onChipHover(f.path)"
-                      @mouseleave="onChipHover('')"
-                    >
-                      <span class="te-chip-label">{{ f.label }}</span>
-                      <span
-                        v-if="fieldPathUsed(f.path)"
-                        class="te-chip-ref"
-                      >
-                        {{ fieldCellRef(f.path) }}
-                      </span>
-                      <span
-                        v-if="fieldPathUsed(f.path)"
-                        class="te-chip-remove"
-                        @click.stop="removeMappingByPath(f.path)"
-                      >
-                        &times;
-                      </span>
-                    </button>
-                  </div>
-                </div>
-                <div
-                  v-if="filteredFieldGroups.length === 0"
-                  class="te-no-results"
-                >
-                  Поля не найдены
-                </div>
-              </div>
-            </div>
-
-            <!-- Привязки -->
-            <div class="te-mappings-section">
-              <div class="te-section-header">
-                <h4>Привязки</h4>
-                <span class="te-mappings-count">{{ mappings.length }}</span>
-              </div>
-              <div
-                v-if="!mappings.length"
-                class="te-empty-state"
-              >
-                Нет привязок. Выберите поле и кликните на ячейку.
-              </div>
-              <div class="te-mappings-list">
-                <div
-                  v-for="(m, idx) in enrichedMappings"
-                  :key="idx"
-                  class="te-mapping-row"
-                  :class="{ highlight: pendingCellRef === m.cell_ref }"
-                  @mouseenter="onChipHover(m.field_path)"
+            <div
+              v-for="g in filteredFieldGroups"
+              :key="g.group"
+              class="te-field-group"
+            >
+              <span class="te-field-group-label">{{ g.label }}</span>
+              <div class="te-field-chips">
+                <button
+                  v-for="f in g.fields"
+                  :key="f.path"
+                  :data-field-path="f.path"
+                  class="te-field-chip"
+                  :class="{
+                    active: pendingFieldPath === f.path,
+                    used: fieldPathUsed(f.path),
+                  }"
+                  :style="chipStyle(f.path)"
+                  @click="selectField(f)"
+                  @mouseenter="onChipHover(f.path)"
                   @mouseleave="onChipHover('')"
                 >
-                  <span class="te-mapping-cell">{{ m.cell_ref }}</span>
-                  <span class="te-mapping-field">{{ m.fieldLabel || m.field_path }}</span>
+                  <span class="te-chip-label">{{ f.label }}</span>
                   <span
-                    v-if="m.is_list_field"
-                    class="te-list-badge"
-                  >список</span>
-                  <button
-                    class="te-mapping-remove"
-                    title="Удалить привязку"
-                    @click="removeMapping(idx)"
+                    v-if="fieldPathUsed(f.path)"
+                    class="te-chip-ref"
+                  >
+                    {{ fieldCellRefs(f.path) }}
+                  </span>
+                  <span
+                    v-if="fieldPathUsed(f.path)"
+                    class="te-chip-remove"
+                    @click.stop="removeMappingsByPath(f.path)"
                   >
                     &times;
-                  </button>
-                </div>
+                  </span>
+                </button>
               </div>
             </div>
+            <div
+              v-if="filteredFieldGroups.length === 0"
+              class="te-no-results"
+            >
+              Поля не найдены
+            </div>
           </div>
+        </div>
+
+        <!-- Привязки (collapsible) -->
+        <div
+          v-if="enabled && template && template.file_path"
+          class="te-mappings-section"
+        >
+          <button
+            class="te-section-toggle"
+            @click="showMappings = !showMappings"
+          >
+            <h4>Привязки</h4>
+            <span class="te-mappings-count">{{ mappings.length }}</span>
+            <span
+              class="te-chevron"
+              :class="{ open: showMappings }"
+            >&#9656;</span>
+          </button>
+          <div
+            v-show="showMappings"
+            class="te-mappings-body"
+          >
+            <div
+              v-if="!mappings.length"
+              class="te-empty-state"
+            >
+              Нет привязок
+            </div>
+            <div
+              v-for="(m, idx) in enrichedMappings"
+              :key="idx"
+              class="te-mapping-row"
+              :class="{ highlight: activeCellRef === m.cell_ref }"
+            >
+              <span class="te-mapping-cell">{{ m.cell_ref }}</span>
+              <span class="te-mapping-field">{{ m.fieldLabel || m.field_path }}</span>
+              <span
+                v-if="m.is_list_field"
+                class="te-list-badge"
+              >список</span>
+              <button
+                class="te-mapping-remove"
+                title="Удалить привязку"
+                @click="removeMapping(idx)"
+              >
+                &times;
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <!-- Показать пути -->
+        <div
+          v-if="enabled && template && template.file_path"
+          class="te-section te-section--compact"
+        >
+          <ToggleSwitch v-model="showPaths">
+            Показать пути
+          </ToggleSwitch>
+        </div>
+
+        <!-- Сохранить -->
+        <div
+          v-if="enabled && template && template.file_path"
+          class="te-save-area"
+        >
+          <button
+            class="lk-button lk-button--primary"
+            :disabled="savingMappings"
+            @click="saveMappings"
+          >
+            {{ savingMappings ? 'Сохранение...' : 'Сохранить привязки' }}
+          </button>
         </div>
       </div>
     </div>
-
-    <template #actions>
-      <button
-        v-if="enabled && template && template.file_path"
-        class="lk-button lk-button--primary"
-        :disabled="savingMappings"
-        @click="saveMappings"
-      >
-        {{ savingMappings ? 'Сохранение...' : 'Сохранить привязки' }}
-      </button>
-      <button
-        class="lk-button lk-button--ghost"
-        @click="$emit('close')"
-      >
-        Закрыть
-      </button>
-    </template>
   </BaseModal>
 </template>
 
@@ -348,9 +427,10 @@
 import { useUiStore } from '@/stores/ui';
 import {
   getTemplate, uploadTemplate, updateMappings, deleteTemplate,
-  getTemplateFields, getTemplateFile,
+  getTemplateFields, getTemplateFile, saveBlobAs,
 } from '@/api/attachment-templates';
 import BaseModal from '@/components/ui/BaseModal.vue';
+import ToggleSwitch from '@/components/ui/ToggleSwitch.vue';
 import XlsxViewer from './XlsxViewer.vue';
 
 const PATH_COLORS = [
@@ -360,7 +440,7 @@ const PATH_COLORS = [
 
 export default {
   name: 'AttachmentTemplateEditor',
-  components: { BaseModal, XlsxViewer },
+  components: { BaseModal, ToggleSwitch, XlsxViewer },
   props: {
     show: { type: Boolean, required: true },
     uniqueAttachmentId: { type: Number, required: true },
@@ -373,6 +453,7 @@ export default {
       fieldGroups: [],
       enabled: false,
       showUpload: false,
+      isDragging: false,
       form: { file: null, listStartRow: 1, listEndRow: 1, maxListRows: 0 },
       uploading: false,
       savingMappings: false,
@@ -383,7 +464,11 @@ export default {
       searchQuery: '',
       activeCategory: '',
       showPaths: false,
+      showMappings: false,
       hoveredFieldPath: '',
+      pathPopup: null,
+      rebindingMode: false,
+      rebindMapping: null,
       pathLines: [],
       svgWidth: 0,
       svgHeight: 0,
@@ -414,6 +499,19 @@ export default {
       }
       return groups;
     },
+    activeCellRef() {
+      if (this.rebindingMode && this.rebindMapping) return this.rebindMapping.old_cell_ref;
+      return this.pendingCellRef;
+    },
+    cellColorMap() {
+      if (!this.showPaths) return new Map();
+      const map = new Map();
+      this.mappings.forEach((m, i) => {
+        const color = PATH_COLORS[i % PATH_COLORS.length];
+        map.set(m.cell_ref.toUpperCase(), color);
+      });
+      return map;
+    },
   },
   watch: {
     show(val) {
@@ -421,6 +519,7 @@ export default {
         this.loadAll();
       } else {
         this.cleanupPathListeners();
+        this.resetState();
       }
     },
     showPaths(val) {
@@ -429,6 +528,7 @@ export default {
       } else {
         this.cleanupPathListeners();
         this.pathLines = [];
+        this.pathPopup = null;
       }
     },
     mappings: {
@@ -442,6 +542,21 @@ export default {
     this.cleanupPathListeners();
   },
   methods: {
+    resetState() {
+      this.pendingFieldPath = '';
+      this.pendingCellRef = '';
+      this.rebindingMode = false;
+      this.rebindMapping = null;
+      this.pathPopup = null;
+      this.hoveredFieldPath = '';
+    },
+    onClose() {
+      if (this.rebindingMode) {
+        this.cancelRebind();
+        return;
+      }
+      this.$emit('close');
+    },
     async loadAll() {
       await Promise.all([this.loadTemplate(), this.loadFields()]);
     },
@@ -477,19 +592,22 @@ export default {
         this.fieldGroups = [];
       }
     },
-    onToggle(e) {
-      this.enabled = e.target.checked;
-      if (!this.enabled && this.template && this.template.file_path) {
-        if (!confirm('Отключить генерацию бланка? Текущий шаблон будет удален.')) {
-          this.enabled = true;
-          e.target.checked = true;
-          return;
-        }
+    onToggleEnabled(val) {
+      if (!val && this.template && this.template.file_path) {
+        if (!confirm('Отключить генерацию бланка? Текущий шаблон будет удален.')) return;
         this.onDeleteTemplate();
       }
+      this.enabled = val;
     },
     onFileChange(e) {
       this.form.file = e.target.files[0] || null;
+    },
+    onDrop(e) {
+      this.isDragging = false;
+      const files = e.dataTransfer.files;
+      if (files.length > 0 && files[0].name.endsWith('.xlsx')) {
+        this.form.file = files[0];
+      }
     },
     async onUpload() {
       if (!this.form.file) return;
@@ -502,6 +620,7 @@ export default {
         });
         useUiStore().success('Шаблон загружен');
         this.showUpload = false;
+        this.form.file = null;
         await this.loadTemplate();
       } catch (err) {
         useUiStore().error(err.message || 'Не удалось загрузить шаблон');
@@ -519,7 +638,18 @@ export default {
         useUiStore().error('Не удалось удалить шаблон');
       }
     },
+    async downloadCurrentTemplate() {
+      try {
+        const buf = this.templateFileBuffer || await getTemplateFile(this.uniqueAttachmentId);
+        const blob = new Blob([buf], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+        saveBlobAs(blob, this.template.original_file_name || 'template.xlsx');
+      } catch {
+        useUiStore().error('Не удалось скачать шаблон');
+      }
+    },
+
     selectField(field) {
+      if (this.rebindingMode) return;
       if (this.pendingFieldPath === field.path) {
         this.pendingFieldPath = '';
         this.pendingFieldLabel = '';
@@ -529,31 +659,79 @@ export default {
       }
     },
     onCellClick(cellRef) {
+      this.pathPopup = null;
+
+      if (this.rebindingMode) {
+        this.finishRebind(cellRef);
+        return;
+      }
+
       if (this.pendingFieldPath) {
-        const existingIdx = this.mappings.findIndex(m => m.cell_ref === cellRef);
-        if (existingIdx >= 0) {
-          this.mappings[existingIdx].field_path = this.pendingFieldPath;
-          this.mappings[existingIdx].is_list_field = this.isListField(this.pendingFieldPath);
-        } else {
-          this.mappings.push({
-            cell_ref: cellRef,
-            field_path: this.pendingFieldPath,
-            is_list_field: this.isListField(this.pendingFieldPath),
-          });
+        const existing = this.mappings.find(m => m.cell_ref === cellRef);
+        if (existing && existing.field_path !== this.pendingFieldPath) {
+          useUiStore().error(`Ячейка ${cellRef} уже привязана к "${this.getFieldLabel(existing.field_path)}"`);
+          return;
         }
+        const duplicate = this.mappings.find(
+          m => m.cell_ref === cellRef && m.field_path === this.pendingFieldPath
+        );
+        if (duplicate) {
+          this.pendingFieldPath = '';
+          return;
+        }
+        this.mappings.push({
+          cell_ref: cellRef,
+          field_path: this.pendingFieldPath,
+          is_list_field: this.isListField(this.pendingFieldPath),
+        });
         this.pendingFieldPath = '';
         this.pendingFieldLabel = '';
-        this.pendingCellRef = '';
-      } else {
-        this.pendingCellRef = cellRef;
+        return;
       }
+
+      const mapped = this.mappings.find(m => m.cell_ref === cellRef);
+      if (mapped) {
+        this.startRebind(mapped, cellRef);
+        return;
+      }
+
+      this.pendingCellRef = cellRef;
     },
+
+    startRebind(mapping, cellRef) {
+      const idx = this.mappings.findIndex(
+        m => m.cell_ref === cellRef && m.field_path === mapping.field_path
+      );
+      this.rebindingMode = true;
+      this.rebindMapping = {
+        index: idx,
+        field_path: mapping.field_path,
+        old_cell_ref: cellRef,
+      };
+    },
+    finishRebind(newCellRef) {
+      if (!this.rebindMapping) return;
+      const existing = this.mappings.find(m => m.cell_ref === newCellRef);
+      if (existing && existing.field_path !== this.rebindMapping.field_path) {
+        useUiStore().error(`Ячейка ${newCellRef} уже привязана к "${this.getFieldLabel(existing.field_path)}"`);
+        return;
+      }
+      if (this.rebindMapping.index >= 0) {
+        this.mappings[this.rebindMapping.index].cell_ref = newCellRef;
+      }
+      this.rebindingMode = false;
+      this.rebindMapping = null;
+    },
+    cancelRebind() {
+      this.rebindingMode = false;
+      this.rebindMapping = null;
+    },
+
     removeMapping(idx) {
       this.mappings.splice(idx, 1);
     },
-    removeMappingByPath(fieldPath) {
-      const idx = this.mappings.findIndex(m => m.field_path === fieldPath);
-      if (idx >= 0) this.mappings.splice(idx, 1);
+    removeMappingsByPath(fieldPath) {
+      this.mappings = this.mappings.filter(m => m.field_path !== fieldPath);
     },
     isListField(fieldPath) {
       for (const g of this.fieldGroups) {
@@ -565,9 +743,11 @@ export default {
     fieldPathUsed(path) {
       return this.mappings.some(m => m.field_path === path);
     },
-    fieldCellRef(path) {
-      const m = this.mappings.find(x => x.field_path === path);
-      return m ? m.cell_ref : '';
+    fieldCellRefs(path) {
+      return this.mappings
+        .filter(m => m.field_path === path)
+        .map(m => m.cell_ref)
+        .join(', ');
     },
     getFieldLabel(fieldPath) {
       for (const g of this.fieldGroups) {
@@ -575,6 +755,14 @@ export default {
         if (f) return f.label;
       }
       return fieldPath;
+    },
+    getFieldColor(fieldPath) {
+      const idx = this.mappings.findIndex(m => m.field_path === fieldPath);
+      return idx >= 0 ? PATH_COLORS[idx % PATH_COLORS.length] : '';
+    },
+    chipStyle(fieldPath) {
+      if (!this.showPaths || !this.fieldPathUsed(fieldPath)) return {};
+      return { borderColor: this.getFieldColor(fieldPath), borderWidth: '2px' };
     },
     async saveMappings() {
       this.savingMappings = true;
@@ -589,32 +777,62 @@ export default {
         this.savingMappings = false;
       }
     },
+
     onChipHover(fieldPath) {
       this.hoveredFieldPath = fieldPath;
+    },
+    onPathHover(line) {
+      this.hoveredFieldPath = line.fieldPath;
+    },
+    onPathLeave() {
+      this.hoveredFieldPath = '';
+    },
+    onPathClick(line, e) {
+      e.stopPropagation();
+      this.pathPopup = {
+        x: (line.x1 + line.x2) / 2,
+        y: (line.y1 + line.y2) / 2,
+        fieldPath: line.fieldPath,
+        cellRef: line.cellRef,
+      };
+    },
+    confirmPathDelete() {
+      if (!this.pathPopup) return;
+      const idx = this.mappings.findIndex(
+        m => m.field_path === this.pathPopup.fieldPath && m.cell_ref === this.pathPopup.cellRef
+      );
+      if (idx >= 0) this.mappings.splice(idx, 1);
+      this.pathPopup = null;
     },
 
     setupPathListeners() {
       this.cleanupPathListeners();
-      const panel = this.$refs.splitPanel;
-      if (!panel) return;
+      const body = this.$refs.modalBody;
+      if (!body) return;
 
-      const scrollables = panel.querySelectorAll('.te-panel-left, .te-panel-right, .xv-table-wrap');
+      const scrollables = body.querySelectorAll(
+        '.te-preview-panel, .xv-table-wrap, .te-field-picker-scroll, .te-settings-panel'
+      );
       this._scrollHandler = () => {
         if (this.rafId) cancelAnimationFrame(this.rafId);
         this.rafId = requestAnimationFrame(() => this.updatePaths());
       };
-      scrollables.forEach(el => el.addEventListener('scroll', this._scrollHandler, { passive: true }));
+      scrollables.forEach(el =>
+        el.addEventListener('scroll', this._scrollHandler, { passive: true })
+      );
 
       this._resizeObserver = new ResizeObserver(this._scrollHandler);
-      this._resizeObserver.observe(panel);
+      this._resizeObserver.observe(body);
 
       this.updatePaths();
     },
     cleanupPathListeners() {
       if (this._scrollHandler) {
-        const panel = this.$refs.splitPanel;
-        if (panel) {
-          const scrollables = panel.querySelectorAll('.te-panel-left, .te-panel-right, .xv-table-wrap');
+        const body = this.$refs.modalBody;
+        if (body) {
+          const scrollables = body.querySelectorAll(
+            '.te-preview-panel, .xv-table-wrap, .te-field-picker-scroll, .te-settings-panel'
+          );
           scrollables.forEach(el => el.removeEventListener('scroll', this._scrollHandler));
         }
       }
@@ -628,38 +846,49 @@ export default {
       }
     },
     updatePaths() {
-      const panel = this.$refs.splitPanel;
-      const leftPanel = this.$refs.panelLeft;
-      const rightPanel = this.$refs.panelRight;
-      if (!panel || !leftPanel || !rightPanel) {
+      const body = this.$refs.modalBody;
+      const previewPanel = this.$refs.previewPanel;
+      const settingsPanel = this.$refs.settingsPanel;
+      if (!body || !previewPanel || !settingsPanel) {
         this.pathLines = [];
         return;
       }
 
-      const panelRect = panel.getBoundingClientRect();
-      const leftRect = leftPanel.getBoundingClientRect();
-      const rightRect = rightPanel.getBoundingClientRect();
+      const bodyRect = body.getBoundingClientRect();
+      const previewRect = previewPanel.getBoundingClientRect();
 
-      this.svgWidth = panelRect.width;
-      this.svgHeight = panelRect.height;
+      const pickerScroll = this.$refs.fieldPickerScroll;
+      const pickerRect = pickerScroll ? pickerScroll.getBoundingClientRect() : null;
 
+      this.svgWidth = bodyRect.width;
+      this.svgHeight = bodyRect.height;
+
+      const fadeZone = 30;
       const lines = [];
+
       this.enrichedMappings.forEach((m, i) => {
-        const cellEl = leftPanel.querySelector(`[data-cell-ref="${m.cell_ref}"]`);
-        const chipEl = rightPanel.querySelector(`[data-field-path="${m.field_path}"]`);
+        const cellEl = previewPanel.querySelector(`[data-cell-ref="${m.cell_ref}"]`);
+        const chipEl = settingsPanel.querySelector(`[data-field-path="${m.field_path}"]`);
         if (!cellEl || !chipEl) return;
 
         const cellRect = cellEl.getBoundingClientRect();
         const chipRect = chipEl.getBoundingClientRect();
 
-        const cellVisible = cellRect.top >= leftRect.top - 2 && cellRect.bottom <= leftRect.bottom + 2;
-        const chipVisible = chipRect.top >= rightRect.top - 2 && chipRect.bottom <= rightRect.bottom + 2;
-        if (!cellVisible || !chipVisible) return;
+        const cellDistTop = cellRect.top - previewRect.top;
+        const cellDistBot = previewRect.bottom - cellRect.bottom;
+        const chipDistTop = pickerRect ? chipRect.top - pickerRect.top : 100;
+        const chipDistBot = pickerRect ? pickerRect.bottom - chipRect.bottom : 100;
 
-        const x1 = chipRect.left - panelRect.left;
-        const y1 = chipRect.top + chipRect.height / 2 - panelRect.top;
-        const x2 = cellRect.right - panelRect.left;
-        const y2 = cellRect.top + cellRect.height / 2 - panelRect.top;
+        const minDist = Math.min(cellDistTop, cellDistBot, chipDistTop, chipDistBot);
+        if (minDist < -5) return;
+
+        let opacity = 0.6;
+        if (minDist < fadeZone) opacity = Math.max(0.05, 0.6 * (minDist / fadeZone));
+
+        const x1 = chipRect.left - bodyRect.left;
+        const y1 = chipRect.top + chipRect.height / 2 - bodyRect.top;
+        const x2 = cellRect.right - bodyRect.left;
+        const y2 = cellRect.top + cellRect.height / 2 - bodyRect.top;
 
         const dx = Math.abs(x1 - x2) * 0.4;
         const d = `M${x1},${y1} C${x1 - dx},${y1} ${x2 + dx},${y2} ${x2},${y2}`;
@@ -667,8 +896,10 @@ export default {
         lines.push({
           id: m.field_path + '-' + m.cell_ref,
           fieldPath: m.field_path,
+          cellRef: m.cell_ref,
           d,
           x1, y1, x2, y2,
+          opacity,
           color: PATH_COLORS[i % PATH_COLORS.length],
         });
       });
@@ -680,63 +911,148 @@ export default {
 </script>
 
 <style scoped>
+/* ---- Layout ---- */
 .te-modal-body {
   display: flex;
+  position: relative;
+  height: calc(85vh - 120px);
+  min-height: 300px;
+}
+
+.te-preview-panel {
+  flex: 1;
+  min-width: 0;
+  overflow: auto;
+  border-right: 1px solid var(--color-border);
+}
+
+.te-preview-panel :deep(.xlsx-viewer) {
+  border: none;
+  border-radius: 0;
+  min-height: 100%;
+}
+
+.te-preview-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--color-text-muted);
+  font-size: 14px;
+}
+
+.te-settings-panel {
+  width: 360px;
+  flex-shrink: 0;
+  overflow-y: auto;
+  padding: 12px;
+  display: flex;
   flex-direction: column;
-  gap: 16px;
-  min-height: 0;
+  gap: 10px;
 }
 
-/* Секция с рамкой */
-.te-section {
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  padding: 16px;
-  background: #fff;
-}
-
-/* Toolbar */
-.te-toolbar {
+/* ---- Rebind banner ---- */
+.te-rebind-banner {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 25;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  flex-wrap: wrap;
   gap: 12px;
+  padding: 8px 16px;
+  background: #fff3cd;
+  border-bottom: 1px solid #ffc107;
+  font-size: 13px;
+  color: #856404;
 }
 
-.te-toolbar-left {
-  display: flex;
-  align-items: center;
-  gap: 12px;
+/* ---- SVG paths ---- */
+.te-path-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 15;
+  overflow: visible;
 }
 
-.te-toolbar-right {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
+.te-path-line {
+  fill: none;
+  stroke-width: 1.5;
+  pointer-events: stroke;
+  cursor: pointer;
+  transition: opacity 0.25s ease, stroke-width 0.25s ease;
 }
 
-.te-toggle {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 14px;
+.te-path-line:hover {
+  stroke-width: 3;
+}
+
+.te-path-line.te-path-highlighted {
+  stroke-width: 2.5;
+}
+
+.te-path-line.te-path-dimmed {
+  opacity: 0 !important;
+}
+
+.te-path-dot {
+  transition: opacity 0.25s ease;
+}
+
+.te-path-dot.te-path-dimmed {
+  opacity: 0 !important;
+}
+
+.te-path-delete-btn {
+  display: block;
+  width: 100%;
+  padding: 4px 8px;
+  background: var(--color-danger);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  font-size: 11px;
   font-weight: 500;
   cursor: pointer;
-  color: var(--color-text);
+  text-align: center;
 }
 
-.te-toggle input[type="checkbox"] {
-  width: 16px;
-  height: 16px;
-  accent-color: var(--color-primary);
+.te-path-delete-btn:hover {
+  background: #c82333;
+}
+
+/* ---- Sections ---- */
+.te-section {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 10px 12px;
+  background: #fff;
+}
+
+.te-section--compact {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* ---- File block ---- */
+.te-file-block {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .te-file-info {
   display: flex;
   align-items: center;
   gap: 8px;
+  flex-wrap: wrap;
 }
 
 .te-file-name {
@@ -746,88 +1062,131 @@ export default {
 }
 
 .te-file-meta {
-  font-size: 12px;
+  font-size: 11px;
   color: var(--color-text-muted);
   background: var(--color-bg-secondary);
-  padding: 2px 8px;
-  border-radius: var(--radius-sm);
+  padding: 2px 6px;
+  border-radius: 4px;
 }
 
-/* Upload area */
+.te-file-actions {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+/* ---- Drag & Drop ---- */
 .te-upload-area {
-  margin-top: 14px;
-  padding-top: 14px;
-  border-top: 1px solid var(--color-border);
-}
-
-.te-upload-form {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 10px;
 }
 
-.te-upload-file input[type="file"] {
+.te-dropzone {
+  border: 2px dashed var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 16px;
+  text-align: center;
+  transition: all 0.2s ease;
+  background: #fff;
+}
+
+.te-dropzone--active {
+  border-color: var(--color-primary);
+  background: #f0f4ff;
+}
+
+.te-dropzone--has-file {
+  border-style: solid;
+  border-color: var(--color-success);
+  background: #f0fdf4;
+}
+
+.te-dropzone__file {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+.te-dropzone__filename {
   font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text);
+}
+
+.te-dropzone__clear {
+  background: none;
+  border: none;
+  color: var(--color-danger);
+  font-size: 18px;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.te-dropzone__placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.te-dropzone__hint {
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
+.te-dropzone__or {
+  font-size: 11px;
+  color: #bbb;
+}
+
+.te-dropzone__browse {
+  cursor: pointer;
 }
 
 .te-upload-fields {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 10px;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 6px;
 }
 
 .te-form-field {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 2px;
 }
 
 .te-form-field label {
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 500;
-  color: #666;
+  color: #888;
+}
+
+.te-compact-input {
+  padding: 5px 8px !important;
+  font-size: 12px !important;
 }
 
 .te-upload-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
+  gap: 6px;
 }
 
-/* Filters bar */
-.te-filters {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  flex-wrap: wrap;
-  padding: 10px 14px;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  background: #fff;
-}
-
-.te-search-wrap {
-  flex: 0 0 220px;
-}
-
-.te-search-input {
-  padding: 6px 12px !important;
-  font-size: 13px !important;
-}
-
+/* ---- Filters ---- */
 .te-category-filter {
   display: flex;
   gap: 4px;
   flex-wrap: wrap;
-  flex: 1;
 }
 
 .te-cat-btn {
-  padding: 4px 12px;
+  padding: 3px 10px;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-pill);
   background: #fff;
-  font-size: 12px;
+  font-size: 11px;
   cursor: pointer;
   transition: all 0.15s;
   color: var(--color-text);
@@ -845,87 +1204,7 @@ export default {
   border-color: var(--color-primary);
 }
 
-.te-paths-toggle {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 13px;
-  cursor: pointer;
-  white-space: nowrap;
-  margin-left: auto;
-  color: var(--color-text);
-}
-
-.te-paths-toggle input[type="checkbox"] {
-  accent-color: var(--color-primary);
-}
-
-/* Split panel */
-.te-split-panel {
-  display: grid;
-  grid-template-columns: 1fr 340px;
-  gap: 16px;
-  position: relative;
-  flex: 1;
-  min-height: 0;
-  height: calc(60vh - 80px);
-}
-
-.te-path-overlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  pointer-events: none;
-  z-index: 10;
-  overflow: visible;
-}
-
-.te-path-line {
-  fill: none;
-  stroke-width: 1.5;
-  opacity: 0.6;
-  transition: opacity 0.25s ease, stroke-width 0.25s ease;
-}
-
-.te-path-line.te-path-highlighted {
-  opacity: 0.85;
-  stroke-width: 2.5;
-}
-
-.te-path-line.te-path-dimmed {
-  opacity: 0;
-}
-
-.te-path-dot {
-  transition: opacity 0.25s ease;
-}
-
-.te-path-dot.te-path-dimmed {
-  opacity: 0;
-}
-
-.te-panel-left {
-  min-width: 0;
-  overflow: auto;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-}
-
-.te-panel-left :deep(.xlsx-viewer) {
-  border: none;
-  border-radius: 0;
-}
-
-.te-panel-right {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  min-height: 0;
-}
-
-/* Field picker */
+/* ---- Field picker ---- */
 .te-field-picker {
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
@@ -940,14 +1219,14 @@ export default {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 10px 12px;
+  padding: 8px 12px;
   border-bottom: 1px solid var(--color-border);
   flex-shrink: 0;
 }
 
 .te-picker-header h4 {
   margin: 0;
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 600;
   color: var(--color-text);
 }
@@ -966,13 +1245,13 @@ export default {
 
 .te-field-picker-scroll {
   overflow-y: auto;
-  padding: 10px 12px;
+  padding: 8px 10px;
   flex: 1;
   min-height: 0;
 }
 
 .te-field-group {
-  margin-bottom: 10px;
+  margin-bottom: 8px;
 }
 
 .te-field-group:last-child {
@@ -983,7 +1262,7 @@ export default {
   display: block;
   font-size: 10px;
   color: var(--color-text-muted);
-  margin-bottom: 4px;
+  margin-bottom: 3px;
   text-transform: uppercase;
   letter-spacing: 0.5px;
   font-weight: 600;
@@ -992,17 +1271,17 @@ export default {
 .te-field-chips {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: 3px;
 }
 
 .te-field-chip {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  padding: 4px 10px;
+  gap: 3px;
+  padding: 3px 8px;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-pill);
-  font-size: 12px;
+  font-size: 11px;
   background: #fff;
   cursor: pointer;
   transition: all 0.15s;
@@ -1035,7 +1314,7 @@ export default {
 }
 
 .te-chip-ref {
-  font-size: 10px;
+  font-size: 9px;
   opacity: 0.7;
   font-weight: 600;
 }
@@ -1044,14 +1323,13 @@ export default {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
   border-radius: 50%;
-  font-size: 14px;
+  font-size: 13px;
   line-height: 1;
   color: var(--color-danger);
   background: rgba(220, 53, 69, 0.1);
-  margin-left: 2px;
   transition: all 0.15s;
 }
 
@@ -1067,61 +1345,72 @@ export default {
   padding: 12px;
 }
 
-/* Mappings */
+/* ---- Mappings (collapsible) ---- */
 .te-mappings-section {
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
-  padding: 12px;
   background: #fff;
   flex-shrink: 0;
-  max-height: 200px;
-  display: flex;
-  flex-direction: column;
 }
 
-.te-section-header {
+.te-section-toggle {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-bottom: 8px;
-  flex-shrink: 0;
+  gap: 6px;
+  width: 100%;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 8px 12px;
 }
 
-.te-section-header h4 {
+.te-section-toggle h4 {
   margin: 0;
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 600;
   color: var(--color-text);
 }
 
 .te-mappings-count {
-  font-size: 11px;
+  font-size: 10px;
   background: var(--color-primary);
   color: #fff;
-  padding: 1px 7px;
+  padding: 1px 6px;
   border-radius: var(--radius-pill);
   font-weight: 600;
 }
 
-.te-empty-state {
-  font-size: 12px;
+.te-chevron {
+  margin-left: auto;
+  transition: transform 0.2s;
+  font-size: 11px;
   color: var(--color-text-muted);
-  text-align: center;
-  padding: 12px 0;
 }
 
-.te-mappings-list {
-  flex: 1;
+.te-chevron.open {
+  transform: rotate(90deg);
+}
+
+.te-mappings-body {
+  padding: 0 10px 8px;
+  max-height: 180px;
   overflow-y: auto;
+}
+
+.te-empty-state {
+  font-size: 11px;
+  color: var(--color-text-muted);
+  text-align: center;
+  padding: 8px 0;
 }
 
 .te-mapping-row {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 5px 8px;
-  border-radius: 6px;
-  font-size: 12px;
+  gap: 6px;
+  padding: 4px 6px;
+  border-radius: 4px;
+  font-size: 11px;
   transition: background 0.1s;
 }
 
@@ -1135,7 +1424,7 @@ export default {
 
 .te-mapping-cell {
   font-weight: 600;
-  min-width: 36px;
+  min-width: 30px;
   color: var(--color-primary);
 }
 
@@ -1148,10 +1437,10 @@ export default {
 }
 
 .te-list-badge {
-  font-size: 10px;
+  font-size: 9px;
   background: #e3f2fd;
   color: #1565c0;
-  padding: 2px 6px;
+  padding: 1px 5px;
   border-radius: var(--radius-pill);
   font-weight: 500;
 }
@@ -1160,13 +1449,13 @@ export default {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 22px;
-  height: 22px;
+  width: 20px;
+  height: 20px;
   border-radius: 50%;
   border: none;
   background: none;
   color: var(--color-text-muted);
-  font-size: 16px;
+  font-size: 14px;
   cursor: pointer;
   transition: all 0.15s;
   flex-shrink: 0;
@@ -1177,33 +1466,32 @@ export default {
   color: var(--color-danger);
 }
 
-/* Button sizes */
-.te-btn-sm {
-  padding: 6px 14px !important;
-  font-size: 12px !important;
+/* ---- Save ---- */
+.te-save-area {
+  flex-shrink: 0;
 }
 
-/* Responsive */
+/* ---- Button sizes ---- */
+.te-btn-sm {
+  padding: 5px 12px !important;
+  font-size: 11px !important;
+}
+
+/* ---- Responsive ---- */
 @media (max-width: 900px) {
-  .te-split-panel {
-    grid-template-columns: 1fr;
+  .te-modal-body {
+    flex-direction: column;
     height: auto;
   }
 
-  .te-panel-left {
+  .te-preview-panel {
     max-height: 50vh;
+    border-right: none;
+    border-bottom: 1px solid var(--color-border);
   }
 
-  .te-panel-right {
-    max-height: none;
-  }
-
-  .te-upload-fields {
-    grid-template-columns: 1fr;
-  }
-
-  .te-search-wrap {
-    flex: 1 1 100%;
+  .te-settings-panel {
+    width: 100%;
   }
 }
 </style>

--- a/frontend/src/components/admin/XlsxViewer.vue
+++ b/frontend/src/components/admin/XlsxViewer.vue
@@ -72,13 +72,14 @@
                 v-show="!cell.hidden"
                 :key="cell.ref"
                 :data-cell-ref="cell.ref"
+                :data-tooltip="cell.ref"
                 class="xv-cell"
                 :class="{
                   selected: selectedCell === cell.ref,
                   mapped: mappedCells.has(cell.ref),
                   'has-value': cell.value,
                 }"
-                :style="cell.style"
+                :style="cellStyle(cell)"
                 :colspan="cell.colspan || 1"
                 :rowspan="cell.rowspan || 1"
                 @click="onCellClick(cell)"
@@ -127,6 +128,7 @@ export default {
     fileBuffer: { type: ArrayBuffer, default: null },
     mappings: { type: Array, default: () => [] },
     selectedCell: { type: String, default: '' },
+    cellColors: { type: Map, default: () => new Map() },
   },
   emits: ['cell-click'],
   data() {
@@ -386,6 +388,15 @@ export default {
 
       return style;
     },
+    cellStyle(cell) {
+      const base = { ...cell.style };
+      const color = this.cellColors.get(cell.ref);
+      if (color) {
+        base.outline = `2px solid ${color}`;
+        base.outlineOffset = '-2px';
+      }
+      return base;
+    },
     onCellClick(cell) {
       if (cell.hidden) return;
       this.$emit('cell-click', cell.ref);
@@ -512,6 +523,32 @@ export default {
   cursor: pointer;
   position: relative;
   transition: background-color 0.1s;
+}
+
+.xv-cell::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 4px);
+  left: 50%;
+  transform: translateX(-50%) scale(0.9);
+  background: #1a1a1a;
+  color: #fff;
+  padding: 3px 7px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  z-index: 20;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+  transition-delay: 0s;
+}
+
+.xv-cell:hover::after {
+  opacity: 1;
+  transform: translateX(-50%) scale(1);
+  transition-delay: 0.5s;
 }
 
 .xv-cell:hover {

--- a/frontend/src/components/ui/ToggleSwitch.vue
+++ b/frontend/src/components/ui/ToggleSwitch.vue
@@ -1,0 +1,91 @@
+<template>
+  <label
+    class="toggle-switch"
+    :class="{ checked: modelValue, disabled }"
+  >
+    <input
+      type="checkbox"
+      :checked="modelValue"
+      :disabled="disabled"
+      @change="$emit('update:modelValue', $event.target.checked)"
+    >
+    <span class="toggle-switch__track">
+      <span class="toggle-switch__thumb" />
+    </span>
+    <span
+      v-if="$slots.default"
+      class="toggle-switch__label"
+    >
+      <slot />
+    </span>
+  </label>
+</template>
+
+<script>
+export default {
+  name: 'ToggleSwitch',
+  props: {
+    modelValue: { type: Boolean, default: false },
+    disabled: { type: Boolean, default: false },
+  },
+  emits: ['update:modelValue'],
+};
+</script>
+
+<style scoped>
+.toggle-switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.toggle-switch.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.toggle-switch input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.toggle-switch__track {
+  position: relative;
+  width: 36px;
+  height: 20px;
+  border-radius: 10px;
+  background: #ccc;
+  transition: background 0.2s ease;
+  flex-shrink: 0;
+}
+
+.toggle-switch.checked .toggle-switch__track {
+  background: var(--color-primary);
+}
+
+.toggle-switch__thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  transition: transform 0.2s ease;
+}
+
+.toggle-switch.checked .toggle-switch__thumb {
+  transform: translateX(16px);
+}
+
+.toggle-switch__label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text);
+}
+</style>


### PR DESCRIPTION
## Summary

Полная переработка UX модального окна Excel-редактора бланков по 17 пунктам:

**Layout:**
- Документ слева на всю высоту модалки, настройки справа (360px)
- Таблица xlsx по ширине документа (без пустого места)
- Компактные секции с gap

**Компоненты:**
- ToggleSwitch вместо чекбоксов (генерация, показать пути)
- Drag&Drop загрузка xlsx (drag zone + browse) + кнопка скачивания
- Collapsible "Привязки" (изначально скрыты)
- CSS tooltip с адресом ячейки при hover (0.5s задержка)

**Маппинг:**
- Одно поле -> несколько ячеек
- Нельзя несколько полей на одну ячейку (валидация + сообщение)
- Перепривязка: клик на привязанную ячейку начинает режим перепривязки (баннер + блокировка других действий)

**Пути (SVG):**
- Пути только от field chips (не из блока Привязки)
- Кликабельные пути: hover выделяет, click показывает кнопку "Удалить"
- Плавное затухание при скролле (fadeZone 30px вместо бинарного hide)
- Фикс бага: пути обновляются при скролле field-picker
- Цветные границы полей (border) и ячеек (outline) при "Показать пути"

**UX:**
- Повторный клик на фильтр категории снимает его

## Test plan

- [ ] Layout: документ слева, настройки справа
- [ ] ToggleSwitch: генерация бланка и показать пути
- [ ] Drag&Drop: перетащить xlsx, выбрать через кнопку
- [ ] Скачать текущий шаблон
- [ ] Tooltip ячейки через 0.5 сек при hover
- [ ] Привязать одно поле к нескольким ячейкам
- [ ] Попытка привязать второе поле к занятой ячейке - ошибка
- [ ] Клик на привязанную ячейку - режим перепривязки
- [ ] Отмена перепривязки
- [ ] Привязки: свернуть/развернуть
- [ ] Показать пути: цветные границы на chips и ячейках
- [ ] Hover на chip - остается только его путь
- [ ] Клик на путь - кнопка удаления
- [ ] Скролл xlsx - пути плавно затухают
- [ ] Скролл field-picker - пути обновляются корректно
- [ ] Повторный клик на фильтр снимает его