### PR TITLE
fix: UX путей, расширение полей, совмещение полей xlsx-редактора (#183)

### DIFF
--- a/frontend/src/components/admin/AttachmentTemplateEditor.vue
+++ b/frontend/src/components/admin/AttachmentTemplateEditor.vue
@@ -16,13 +16,13 @@
             :model-value="enabled"
             @update:model-value="onToggleEnabled"
           >
-            Генерация
+            Генерация бланка
           </ToggleSwitch>
           <ToggleSwitch
             v-if="enabled && template && template.file_path"
             v-model="showPaths"
           >
-            Пути
+            Отображать пути
           </ToggleSwitch>
         </div>
       </div>
@@ -82,36 +82,33 @@
           @click="onPathClick(line, $event)"
         />
         <path
-          v-for="line in pathLines"
+          v-for="(line, idx) in pathLines"
           :key="line.id"
           :d="line.d"
           class="te-path-line"
-          :class="{
-            'te-path-dimmed': hoveredFieldPath && line.fieldPath !== hoveredFieldPath,
-            'te-path-highlighted': hoveredFieldPath === line.fieldPath,
-          }"
+          :class="pathLineClasses(line, idx)"
           :style="{ stroke: line.color, opacity: line.opacity }"
         />
         <circle
-          v-for="line in pathLines"
+          v-for="(line, idx) in pathLines"
           :key="line.id + '-dot-l'"
           :cx="line.x2"
           :cy="line.y2"
           r="3"
           :fill="line.color"
           class="te-path-dot"
-          :class="{ 'te-path-dimmed': hoveredFieldPath && line.fieldPath !== hoveredFieldPath }"
+          :class="pathDotClasses(line, idx)"
           :style="{ opacity: line.opacity }"
         />
         <circle
-          v-for="line in pathLines"
+          v-for="(line, idx) in pathLines"
           :key="line.id + '-dot-r'"
           :cx="line.x1"
           :cy="line.y1"
           r="3"
           :fill="line.color"
           class="te-path-dot"
-          :class="{ 'te-path-dimmed': hoveredFieldPath && line.fieldPath !== hoveredFieldPath }"
+          :class="pathDotClasses(line, idx)"
           :style="{ opacity: line.opacity }"
         />
         <!-- Кнопка удаления на пути -->
@@ -155,7 +152,7 @@
           v-else
           class="te-preview-empty"
         >
-          <span>Загрузите .xlsx файл для предпросмотра</span>
+          <span>Загрузите шаблон .xlsx для настройки генерации бланка</span>
         </div>
       </div>
 
@@ -171,7 +168,7 @@
           class="te-field-picker"
         >
           <div class="te-picker-header">
-            <h4>Поля</h4>
+            <h4>Привязка полей системы</h4>
             <input
               v-model="searchQuery"
               type="text"
@@ -461,6 +458,19 @@ import XlsxViewer from './XlsxViewer.vue';
 const PATH_COLORS = [
   '#4F5BDF', '#e85d75', '#2e9e5a', '#e8a317', '#8e44ad',
   '#16a085', '#c0392b', '#2980b9', '#d35400', '#e06090',
+  '#1abc9c', '#6c5ce7', '#00b894', '#e17055', '#0984e3',
+  '#b8255f', '#299438', '#6accbc', '#af38eb', '#ff9933',
+];
+
+function getPathColor(index) {
+  if (index < PATH_COLORS.length) return PATH_COLORS[index];
+  const hue = (index * 137.508) % 360;
+  if (hue > 180 && hue < 240) return `hsl(${(hue + 80) % 360}, 65%, 45%)`;
+  return `hsl(${hue}, 65%, 45%)`;
+}
+
+const GROUP_ORDER = [
+  'application', 'attachment', 'employee', 'car', 'item', 'custom',
 ];
 
 export default {
@@ -497,6 +507,7 @@ export default {
       rebindMapping: null,
       pathLines: [],
       pathsAnimatingOut: false,
+      hoveredPathIndex: null,
       svgWidth: 0,
       svgHeight: 0,
       rafId: null,
@@ -510,7 +521,15 @@ export default {
       }));
     },
     filteredFieldGroups() {
-      let groups = this.fieldGroups;
+      let groups = this.fieldGroups.map(g => ({
+        ...g,
+        fields: [...g.fields].sort((a, b) => a.label.localeCompare(b.label, 'ru')),
+      }));
+      groups.sort((a, b) => {
+        const ai = GROUP_ORDER.indexOf(a.group);
+        const bi = GROUP_ORDER.indexOf(b.group);
+        return (ai === -1 ? 99 : ai) - (bi === -1 ? 99 : bi);
+      });
       if (this.activeCategory) {
         groups = groups.filter(g => g.group === this.activeCategory);
       }
@@ -534,7 +553,7 @@ export default {
       if (!this.showPaths) return new Map();
       const map = new Map();
       this.mappings.forEach((m, i) => {
-        const color = PATH_COLORS[i % PATH_COLORS.length];
+        const color = getPathColor(i);
         map.set(m.cell_ref.toUpperCase(), color);
       });
       return map;
@@ -560,7 +579,7 @@ export default {
           this.pathsAnimatingOut = false;
           this.pathLines = [];
           this.cleanupPathListeners();
-        }, 400);
+        }, 800);
       }
     },
     mappings: {
@@ -587,6 +606,7 @@ export default {
       this.pathPopup = null;
       this.removePopupField = '';
       this.hoveredFieldPath = '';
+      this.hoveredPathIndex = null;
       this.pathLines = [];
       this.pathsAnimatingOut = false;
       this.showPaths = false;
@@ -808,7 +828,7 @@ export default {
     },
     getFieldColor(fieldPath) {
       const idx = this.mappings.findIndex(m => m.field_path === fieldPath);
-      return idx >= 0 ? PATH_COLORS[idx % PATH_COLORS.length] : '';
+      return idx >= 0 ? getPathColor(idx) : '';
     },
     chipStyle(fieldPath) {
       if (!this.showPaths || !this.fieldPathUsed(fieldPath)) return {};
@@ -833,12 +853,50 @@ export default {
       this.hoveredFieldPath = fieldPath;
     },
     onPathHover(line) {
+      const idx = this.pathLines.findIndex(l => l.id === line.id);
+      this.hoveredPathIndex = idx >= 0 ? idx : null;
       this.hoveredFieldPath = line.fieldPath;
     },
     onPathLeave() {
       if (!this.pathPopup) {
+        this.hoveredPathIndex = null;
         this.hoveredFieldPath = '';
       }
+    },
+    pathLineClasses(line, idx) {
+      if (this.pathPopup) {
+        return {
+          'te-path-dimmed': line.fieldPath !== this.pathPopup.fieldPath || line.cellRef !== this.pathPopup.cellRef,
+          'te-path-highlighted': line.fieldPath === this.pathPopup.fieldPath && line.cellRef === this.pathPopup.cellRef,
+        };
+      }
+      if (this.hoveredPathIndex !== null) {
+        return {
+          'te-path-hover-hidden': idx !== this.hoveredPathIndex,
+          'te-path-hover-active': idx === this.hoveredPathIndex,
+        };
+      }
+      if (this.hoveredFieldPath) {
+        return {
+          'te-path-hover-hidden': line.fieldPath !== this.hoveredFieldPath,
+          'te-path-hover-active': line.fieldPath === this.hoveredFieldPath,
+        };
+      }
+      return {};
+    },
+    pathDotClasses(line, idx) {
+      if (this.pathPopup) {
+        return {
+          'te-path-dimmed': line.fieldPath !== this.pathPopup.fieldPath || line.cellRef !== this.pathPopup.cellRef,
+        };
+      }
+      if (this.hoveredPathIndex !== null) {
+        return { 'te-path-hover-hidden': idx !== this.hoveredPathIndex };
+      }
+      if (this.hoveredFieldPath) {
+        return { 'te-path-hover-hidden': line.fieldPath !== this.hoveredFieldPath };
+      }
+      return {};
     },
     onPathClick(line, e) {
       e.stopPropagation();
@@ -951,7 +1009,7 @@ export default {
           d,
           x1, y1, x2, y2,
           opacity,
-          color: PATH_COLORS[i % PATH_COLORS.length],
+          color: getPathColor(i),
         });
       });
 
@@ -1024,6 +1082,12 @@ export default {
   height: 100%;
   color: var(--color-text-muted);
   font-size: 14px;
+  padding: 20px 40px;
+  text-align: center;
+}
+
+:deep(.base-modal) {
+  border-radius: 30px !important;
 }
 
 .te-settings-panel {
@@ -1100,11 +1164,11 @@ export default {
   cursor: pointer;
   transition: opacity 0.25s ease;
   stroke-dasharray: 2000;
-  animation: te-path-draw 0.5s ease forwards;
+  animation: te-path-draw 1s ease forwards;
 }
 
 .te-paths-leaving .te-path-line {
-  animation: te-path-retract 0.4s ease forwards;
+  animation: te-path-retract 0.8s ease forwards;
 }
 
 @keyframes te-path-draw {
@@ -1118,7 +1182,7 @@ export default {
 }
 
 .te-paths-leaving .te-path-dot {
-  animation: te-dot-fade-out 0.3s ease forwards;
+  animation: te-dot-fade-out 0.6s ease forwards;
 }
 
 @keyframes te-dot-fade-out {
@@ -1141,12 +1205,26 @@ export default {
   opacity: 0.15 !important;
 }
 
+.te-path-line.te-path-hover-hidden {
+  opacity: 0 !important;
+  transition: opacity 0.25s ease;
+}
+
+.te-path-line.te-path-hover-active {
+  stroke-width: 3.5 !important;
+  filter: brightness(0.85);
+}
+
 .te-path-dot {
   transition: opacity 0.25s ease;
 }
 
 .te-path-dot.te-path-dimmed {
   opacity: 0.15 !important;
+}
+
+.te-path-dot.te-path-hover-hidden {
+  opacity: 0 !important;
 }
 
 .te-path-delete-btn {
@@ -1413,11 +1491,15 @@ export default {
 }
 
 .te-field-group {
-  margin-bottom: 8px;
+  margin-bottom: 10px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--color-border);
 }
 
 .te-field-group:last-child {
   margin-bottom: 0;
+  padding-bottom: 0;
+  border-bottom: none;
 }
 
 .te-field-group-label {
@@ -1560,9 +1642,10 @@ export default {
 /* ---- Mappings (collapsible) ---- */
 .te-mappings-section {
   border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
+  border-radius: 30px;
   background: #fff;
   flex-shrink: 0;
+  overflow: hidden;
 }
 
 .te-section-toggle {

--- a/frontend/src/components/admin/AttachmentTemplateEditor.vue
+++ b/frontend/src/components/admin/AttachmentTemplateEditor.vue
@@ -724,11 +724,6 @@ export default {
       }
 
       if (this.pendingFieldPath) {
-        const existing = this.mappings.find(m => m.cell_ref === cellRef);
-        if (existing && existing.field_path !== this.pendingFieldPath) {
-          useUiStore().error(`Ячейка ${cellRef} уже привязана к "${this.getFieldLabel(existing.field_path)}"`);
-          return;
-        }
         const duplicate = this.mappings.find(
           m => m.cell_ref === cellRef && m.field_path === this.pendingFieldPath
         );
@@ -768,11 +763,6 @@ export default {
     },
     finishRebind(newCellRef) {
       if (!this.rebindMapping) return;
-      const existing = this.mappings.find(m => m.cell_ref === newCellRef);
-      if (existing && existing.field_path !== this.rebindMapping.field_path) {
-        useUiStore().error(`Ячейка ${newCellRef} уже привязана к "${this.getFieldLabel(existing.field_path)}"`);
-        return;
-      }
       if (this.rebindMapping.index >= 0) {
         this.mappings[this.rebindMapping.index].cell_ref = newCellRef;
       }

--- a/internal/models/attachment_template.go
+++ b/internal/models/attachment_template.go
@@ -14,6 +14,7 @@ type AttachmentTemplate struct {
 	ListStartRow        int                          `json:"list_start_row"`
 	ListEndRow          int                          `json:"list_end_row"`
 	MaxListRows         int                          `json:"max_list_rows"`
+	ConcatSeparator     *string                      `gorm:"size:20" json:"concat_separator,omitempty"`
 	UploadedByUserID    *int                         `json:"uploaded_by_user_id,omitempty"`
 	CreatedAt           time.Time                    `json:"created_at"`
 	UpdatedAt           time.Time                    `json:"updated_at"`

--- a/internal/services/attachment_blank_resolver.go
+++ b/internal/services/attachment_blank_resolver.go
@@ -89,6 +89,30 @@ func resolveApplication(bctx *BlankContext, path string) string {
 		if bctx.Sender != nil {
 			return derefStr(bctx.Sender.FirstName)
 		}
+	case "application.sender.middle_name":
+		if bctx.Sender != nil {
+			return derefStr(bctx.Sender.MiddleName)
+		}
+	case "application.sender.phone":
+		if bctx.Sender != nil {
+			return derefStr(bctx.Sender.Phone)
+		}
+	case "application.sender.email":
+		if bctx.Sender != nil {
+			return derefStr(bctx.Sender.Email)
+		}
+	case "application.sender.position":
+		if bctx.Sender != nil {
+			return derefStr(bctx.Sender.Position)
+		}
+	case "application.confirmation_datetime":
+		if app.ConfirmationDatetime != nil {
+			return app.ConfirmationDatetime.Format("02.01.2006")
+		}
+	case "application.approver_name":
+		return bctx.ApproverName
+	case "application.responsible_comment":
+		return derefStr(app.ResponsibleComment)
 	}
 	return ""
 }
@@ -148,6 +172,10 @@ func resolveCar(c *models.Car, path string, rowIdx int) string {
 		return derefStr(c.EntryDateFrom)
 	case "car.entry_date_to":
 		return derefStr(c.EntryDateTo)
+	case "car.entry_time_from":
+		return formatTime(derefStr(c.EntryTimeFrom))
+	case "car.entry_time_to":
+		return formatTime(derefStr(c.EntryTimeTo))
 	}
 	return ""
 }

--- a/internal/services/attachment_blank_service.go
+++ b/internal/services/attachment_blank_service.go
@@ -89,17 +89,30 @@ func (s *attachmentBlankService) GenerateBlank(ctx context.Context, applicationI
 	defer f.Close()
 	sheet := f.GetSheetName(0)
 
-	// 4. Простые (не list) маппинги - сразу в ячейку.
+	// 4. Простые (не list) маппинги - группировка по cell_ref для совмещения.
 	var listMappings []models.AttachmentTemplateMapping
+	cellValues := make(map[string][]string)
+	cellOrder := make([]string, 0)
 	for _, m := range template.Mappings {
 		if m.IsListField {
 			listMappings = append(listMappings, m)
 			continue
 		}
 		val := resolveValue(bctx, m.FieldPath, 0)
-		if val != "" {
-			_ = f.SetCellValue(sheet, m.CellRef, val)
+		if val == "" {
+			continue
 		}
+		if _, exists := cellValues[m.CellRef]; !exists {
+			cellOrder = append(cellOrder, m.CellRef)
+		}
+		cellValues[m.CellRef] = append(cellValues[m.CellRef], val)
+	}
+	sep := ", "
+	if template.ConcatSeparator != nil && *template.ConcatSeparator != "" {
+		sep = *template.ConcatSeparator
+	}
+	for _, ref := range cellOrder {
+		_ = f.SetCellValue(sheet, ref, strings.Join(cellValues[ref], sep))
 	}
 
 	// 5. List-fields с авторасширением.

--- a/internal/services/attachment_blank_service.go
+++ b/internal/services/attachment_blank_service.go
@@ -29,6 +29,7 @@ type BlankContext struct {
 	Items            []models.Item
 	Citizenships     map[int]string // citizenship_id → name
 	CustomValues     map[int]string // custom_field_id → value
+	ApproverName     string         // ФИО согласовавшего
 }
 
 // AttachmentBlankService - генерация заполненных .xlsx-бланков на основе
@@ -209,6 +210,9 @@ func (s *attachmentBlankService) buildContext(ctx context.Context, appID int, at
 		bctx.Company = &c
 	}
 
+	// ApproverName: ФИО согласовавшего.
+	bctx.ApproverName = s.resolveApproverName(ctx, appID)
+
 	// Cars / employees / items - только для этого attachment.
 	s.db.WithContext(ctx).Where("attachment_id = ?", att.ID).Order("id").Find(&bctx.Cars)
 	s.db.WithContext(ctx).Where("attachment_id = ?", att.ID).Order("id").Find(&bctx.Employees)
@@ -239,4 +243,37 @@ func (s *attachmentBlankService) buildContext(ctx context.Context, appID int, at
 	}
 
 	return bctx, nil
+}
+
+// resolveApproverName определяет ФИО согласовавшего заявку:
+// - если есть обязательные согласующие (required_approval=true) с approval_status='approved',
+//   берется последний по approval_datetime;
+// - иначе берется первый согласовавший (approval_status='approved').
+func (s *attachmentBlankService) resolveApproverName(ctx context.Context, appID int) string {
+	var responsible []models.ApplicationResponsibleUser
+	s.db.WithContext(ctx).
+		Preload("User").
+		Where("application_id = ? AND approval_status = ?", appID, "approved").
+		Order("approval_datetime ASC").
+		Find(&responsible)
+
+	if len(responsible) == 0 {
+		return ""
+	}
+
+	var required []models.ApplicationResponsibleUser
+	for _, r := range responsible {
+		if r.RequiredApproval {
+			required = append(required, r)
+		}
+	}
+
+	var approver *models.User
+	if len(required) > 0 {
+		approver = &required[len(required)-1].User
+	} else {
+		approver = &responsible[0].User
+	}
+
+	return joinFullName(derefStr(approver.LastName), derefStr(approver.FirstName), derefStr(approver.MiddleName))
 }

--- a/internal/services/attachment_template_fields.go
+++ b/internal/services/attachment_template_fields.go
@@ -39,6 +39,13 @@ func BuiltinTemplateFields() []TemplateFieldGroup {
 				{Path: "application.sender.short_name", Label: "Фамилия И.О. отправителя"},
 				{Path: "application.sender.last_name", Label: "Фамилия отправителя"},
 				{Path: "application.sender.first_name", Label: "Имя отправителя"},
+				{Path: "application.sender.middle_name", Label: "Отчество отправителя"},
+				{Path: "application.sender.phone", Label: "Телефон отправителя"},
+				{Path: "application.sender.email", Label: "Email отправителя"},
+				{Path: "application.sender.position", Label: "Должность отправителя"},
+				{Path: "application.confirmation_datetime", Label: "Дата согласования"},
+				{Path: "application.approver_name", Label: "Согласовавший (ФИО)"},
+				{Path: "application.responsible_comment", Label: "Комментарий ответственного"},
 			},
 		},
 		{
@@ -63,6 +70,8 @@ func BuiltinTemplateFields() []TemplateFieldGroup {
 				{Path: "car.unload_place", Label: "Место разгрузки", IsList: true},
 				{Path: "car.entry_date_from", Label: "Дата с", IsList: true},
 				{Path: "car.entry_date_to", Label: "Дата по", IsList: true},
+				{Path: "car.entry_time_from", Label: "Время с", IsList: true},
+				{Path: "car.entry_time_to", Label: "Время по", IsList: true},
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

**UX путей:**
- При наведении на путь остальные скрываются, наведенный жирнеет (+2px)
- При открытом popup "Удалить" остальные бледнеют (как раньше)
- Наведение на непривязанное поле не скрывает пути
- Анимация draw/retract замедлена x2 (1s/0.8s)
- 20 статических цветов + HSL-генератор для >20 (никогда не кончатся, без серых)

**Визуальные правки:**
- "Генерация" -> "Генерация бланка", "Пути" -> "Отображать пути"
- "Поля" -> "Привязка полей системы"
- Текст пустого состояния обновлен + padding
- border-radius 30px на модалке, секции привязок
- Разделители между группами полей

**Сортировка полей:**
- Поля внутри групп сортируются по алфавиту (ru locale)
- Группы в логичном порядке: Заявка -> Вложение -> Сотрудник -> Авто -> Имущество -> Доп.поля

**Расширение полей (backend):**
- Отчество, телефон, email, должность отправителя
- Дата согласования, ФИО согласовавшего (с логикой обязательных/необязательных)
- Комментарий ответственного
- Время с/по для автомобилей

**Совмещение полей:**
- Разрешена привязка нескольких полей к одной ячейке
- При генерации бланка значения конкатенируются через разделитель
- Поле concat_separator в модели шаблона (по умолчанию ", ")

## Test plan

- [ ] Hover на путь скрывает остальные, путь жирнеет
- [ ] Hover на непривязанное поле - пути остаются
- [ ] Popup "Удалить" - остальные бледнеют
- [ ] Анимация draw/retract медленнее
- [ ] Цвета не повторяются при >10 привязках
- [ ] Тексты тумблеров обновлены
- [ ] border-radius модалки и секций 30px
- [ ] Поля отсортированы по алфавиту
- [ ] Новые поля видны в списке: телефон, email, согласовавший
- [ ] Два поля привязываются к одной ячейке без ошибки