### PR TITLE
fix: UX правки редактора бланков и модалки скачивания (#183)

### DIFF
--- a/frontend/src/components/admin/AttachmentTemplateEditor.vue
+++ b/frontend/src/components/admin/AttachmentTemplateEditor.vue
@@ -139,8 +139,14 @@
         class="te-preview-panel"
         @click="pathPopup = null; removePopupField = ''"
       >
+        <div
+          v-if="loadingTemplate"
+          class="te-preview-empty"
+        >
+          <span class="te-spinner" />
+        </div>
         <XlsxViewer
-          v-if="enabled && templateFileBuffer"
+          v-else-if="enabled && templateFileBuffer"
           ref="xlsxViewer"
           :file-buffer="templateFileBuffer"
           :mappings="enrichedMappings"
@@ -170,19 +176,33 @@
         >
           <div class="te-picker-header">
             <h4>Привязка полей системы</h4>
-            <input
-              v-model="searchQuery"
-              type="text"
-              class="lk-input te-search-input"
-              placeholder="Поиск..."
-            >
+            <div class="te-search-wrap">
+              <img
+                src="@/assets/icons/search.png"
+                class="te-search-icon"
+                alt=""
+              >
+              <input
+                v-model="searchQuery"
+                type="text"
+                class="lk-input te-search-input"
+                placeholder="Поиск..."
+              >
+            </div>
           </div>
           <div
             ref="fieldPickerScroll"
             class="te-field-picker-scroll"
           >
             <div
+              v-if="loadingFields"
+              class="te-fields-loading"
+            >
+              <span class="te-spinner" />
+            </div>
+            <div
               v-for="g in filteredFieldGroups"
+              v-else
               :key="g.group"
               class="te-field-group"
             >
@@ -253,34 +273,44 @@
           v-if="enabled"
           class="te-section"
         >
-          <!-- Шаблоны: табы + действия -->
+          <!-- Шаблоны: dropdown + действия -->
           <div
             v-if="allTemplates.length > 0 && !showUpload"
             class="te-templates-block"
           >
-            <div class="te-template-tabs">
+            <div class="te-template-dropdown-wrap">
               <button
-                v-for="tmpl in allTemplates"
-                :key="tmpl.id"
-                class="te-template-tab"
-                :class="{ active: tmpl.is_active }"
-                :title="tmpl.original_file_name"
-                @click="switchTemplate(tmpl)"
+                class="te-template-dropdown-trigger"
+                @click="templateDropdownOpen = !templateDropdownOpen"
               >
-                <span class="te-tab-name">{{ tmpl.original_file_name || 'template.xlsx' }}</span>
+                <span class="te-dropdown-filename">{{ template?.original_file_name || 'template.xlsx' }}</span>
                 <span
-                  v-if="allTemplates.length > 1"
-                  class="te-tab-remove"
-                  @click.stop="deleteSpecificTemplate(tmpl)"
-                >&times;</span>
+                  class="te-dropdown-arrow"
+                  :class="{ open: templateDropdownOpen }"
+                >&#9662;</span>
               </button>
-              <button
-                class="te-template-tab te-tab-add"
-                title="Загрузить ещё один шаблон"
-                @click="showUpload = true"
-              >
-                +
-              </button>
+              <transition name="te-dropdown-fade">
+                <div
+                  v-if="templateDropdownOpen"
+                  class="te-template-dropdown"
+                >
+                  <button
+                    v-for="tmpl in allTemplates"
+                    :key="tmpl.id"
+                    class="te-dropdown-item"
+                    :class="{ active: tmpl.id === template?.id }"
+                    @click="onDropdownSelectTemplate(tmpl)"
+                  >
+                    {{ tmpl.original_file_name || 'template.xlsx' }}
+                  </button>
+                  <button
+                    class="te-dropdown-item te-dropdown-add"
+                    @click="showUpload = true; templateDropdownOpen = false"
+                  >
+                    Добавить файл..
+                  </button>
+                </div>
+              </transition>
             </div>
             <div class="te-file-actions">
               <button
@@ -288,6 +318,12 @@
                 @click="downloadCurrentTemplate"
               >
                 Скачать
+              </button>
+              <button
+                class="lk-button lk-button--ghost te-btn-sm"
+                @click="showUpload = true"
+              >
+                Редактировать
               </button>
               <button
                 class="lk-button lk-button--danger te-btn-sm"
@@ -523,6 +559,8 @@ export default {
       uploading: false,
       savingMappings: false,
       concatSeparator: ', ',
+      loadingTemplate: false,
+      loadingFields: false,
       templateFileBuffer: null,
       pendingFieldPath: '',
       pendingFieldLabel: '',
@@ -540,6 +578,7 @@ export default {
       pathsAnimatingOut: false,
       hoveredPathIndex: null,
       hoveredCellRef: '',
+      templateDropdownOpen: false,
       svgWidth: 0,
       svgHeight: 0,
       rafId: null,
@@ -652,6 +691,7 @@ export default {
       this.hoveredFieldPath = '';
       this.hoveredPathIndex = null;
       this.hoveredCellRef = '';
+      this.templateDropdownOpen = false;
       this.pathLines = [];
       this.pathsAnimatingOut = false;
       this.showPaths = false;
@@ -667,6 +707,7 @@ export default {
       await Promise.all([this.loadTemplate(), this.loadFields()]);
     },
     async loadTemplate() {
+      this.loadingTemplate = true;
       try {
         const data = await getTemplate(this.uniqueAttachmentId);
         this.template = data;
@@ -676,12 +717,14 @@ export default {
         this.form.listEndRow = data && data.list_end_row || 1;
         this.form.maxListRows = data && data.max_list_rows || 0;
         this.concatSeparator = data && data.concat_separator || ', ';
-        if (this.enabled) this.loadTemplateFile();
+        if (this.enabled) await this.loadTemplateFile();
       } catch {
         this.template = null;
         this.mappings = [];
         this.enabled = false;
         this.templateFileBuffer = null;
+      } finally {
+        this.loadingTemplate = false;
       }
       try {
         const all = await listTemplates(this.uniqueAttachmentId);
@@ -702,11 +745,14 @@ export default {
       }
     },
     async loadFields() {
+      this.loadingFields = true;
       try {
         const data = await getTemplateFields(this.uniqueAttachmentId);
         this.fieldGroups = Array.isArray(data) ? data : [];
       } catch {
         this.fieldGroups = [];
+      } finally {
+        this.loadingFields = false;
       }
     },
     onToggleEnabled(val) {
@@ -740,6 +786,11 @@ export default {
       } finally {
         this.uploading = false;
       }
+    },
+    async onDropdownSelectTemplate(tmpl) {
+      this.templateDropdownOpen = false;
+      if (tmpl.id === this.template?.id) return;
+      await this.switchTemplate(tmpl);
     },
     async switchTemplate(tmpl) {
       if (tmpl.id === this.template?.id) return;
@@ -938,6 +989,8 @@ export default {
     },
     isPathHighlighted(line, idx) {
       if (this.hoveredPathIndex === idx) return true;
+      if (this.hoveredFieldPath && line.fieldPath === this.hoveredFieldPath) return true;
+      if (this.hoveredCellRef && line.cellRef === this.hoveredCellRef) return true;
       return false;
     },
     isPathHidden(line, idx) {
@@ -1170,7 +1223,7 @@ export default {
 }
 
 :deep(.base-modal) {
-  border-radius: 50px !important;
+  border-radius: 40px !important;
 }
 
 .te-settings-panel {
@@ -1363,78 +1416,111 @@ export default {
 
 /* ---- Templates block ---- */
 .te-templates-block {
-  border: 1px solid var(--color-border);
-  border-radius: 30px;
-  padding: 10px 14px;
+  padding: 0;
   background: #fff;
   display: flex;
   flex-direction: column;
   gap: 8px;
 }
 
-.te-template-tabs {
-  display: flex;
-  gap: 4px;
-  flex-wrap: wrap;
+.te-template-dropdown-wrap {
+  position: relative;
 }
 
-.te-template-tab {
-  display: inline-flex;
+.te-template-dropdown-trigger {
+  display: flex;
   align-items: center;
-  gap: 4px;
-  padding: 4px 10px;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 12px;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-pill);
-  font-size: 11px;
+  font-size: 12px;
   background: #fff;
   cursor: pointer;
-  transition: all 0.15s;
+  transition: border-color 0.15s;
   color: var(--color-text);
 }
 
-.te-template-tab:hover {
+.te-template-dropdown-trigger:hover {
   border-color: var(--color-primary);
 }
 
-.te-template-tab.active {
-  background: var(--color-primary);
-  color: #fff;
-  border-color: var(--color-primary);
-}
-
-.te-tab-name {
-  max-width: 120px;
+.te-dropdown-filename {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.te-tab-remove {
-  font-size: 14px;
-  line-height: 1;
-  opacity: 0.6;
+.te-dropdown-arrow {
+  font-size: 10px;
+  color: var(--color-text-muted);
+  transition: transform 0.2s;
+  flex-shrink: 0;
+}
+
+.te-dropdown-arrow.open {
+  transform: rotate(180deg);
+}
+
+.te-template-dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  background: #fff;
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  box-shadow: var(--shadow-md);
+  z-index: 30;
+  overflow: hidden;
+}
+
+.te-dropdown-item {
+  display: block;
+  width: 100%;
+  padding: 7px 12px;
+  border: none;
+  background: none;
+  font-size: 12px;
+  text-align: left;
   cursor: pointer;
+  color: var(--color-text);
+  transition: background 0.1s;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.te-tab-remove:hover {
-  opacity: 1;
-  color: var(--color-danger);
+.te-dropdown-item:hover {
+  background: var(--color-bg-secondary);
 }
 
-.te-template-tab.active .te-tab-remove:hover {
-  color: #ffc;
-}
-
-.te-tab-add {
-  font-size: 16px;
-  font-weight: 600;
-  padding: 4px 12px;
+.te-dropdown-item.active {
+  background: #e8f4fd;
   color: var(--color-primary);
-  border-style: dashed;
+  font-weight: 500;
 }
 
-.te-tab-add:hover {
-  background: #f0f4ff;
+.te-dropdown-add {
+  border-top: 1px solid var(--color-border);
+  color: var(--color-primary);
+  font-weight: 500;
+}
+
+.te-dropdown-fade-enter-active {
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.te-dropdown-fade-leave-active {
+  transition: opacity 0.1s ease, transform 0.1s ease;
+}
+
+.te-dropdown-fade-enter-from,
+.te-dropdown-fade-leave-to {
+  opacity: 0;
+  transform: translateY(-4px);
 }
 
 /* ---- Separator ---- */
@@ -1641,14 +1727,29 @@ export default {
 
 .te-picker-header h4 {
   margin: 0;
-  font-size: 12px;
+  font-size: 14px;
   font-weight: 600;
   color: var(--color-text);
 }
 
+.te-search-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.te-search-icon {
+  position: absolute;
+  left: 8px;
+  width: 12px;
+  height: 12px;
+  opacity: 0.45;
+  pointer-events: none;
+}
+
 .te-search-input {
   width: 140px;
-  padding: 4px 8px !important;
+  padding: 4px 8px 4px 24px !important;
   font-size: 11px !important;
 }
 
@@ -1666,19 +1767,16 @@ export default {
 
 .te-field-picker-scroll {
   overflow-y: auto;
-  padding: 8px 10px;
+  padding: 0;
   height: 450px;
 }
 
 .te-field-group {
-  margin-bottom: 10px;
-  padding-bottom: 10px;
+  padding: 8px 10px 10px;
   border-bottom: 1px solid var(--color-border);
 }
 
 .te-field-group:last-child {
-  margin-bottom: 0;
-  padding-bottom: 0;
   border-bottom: none;
 }
 
@@ -1950,6 +2048,28 @@ export default {
 .te-btn-sm {
   padding: 5px 12px !important;
   font-size: 11px !important;
+}
+
+/* ---- Spinner ---- */
+.te-spinner {
+  display: block;
+  width: 28px;
+  height: 28px;
+  border: 3px solid var(--color-border);
+  border-top-color: var(--color-primary);
+  border-radius: 50%;
+  animation: te-spin 0.7s linear infinite;
+}
+
+@keyframes te-spin {
+  to { transform: rotate(360deg); }
+}
+
+.te-fields-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px 0;
 }
 
 /* ---- Responsive ---- */

--- a/frontend/src/components/applications/DownloadBlanksModal.vue
+++ b/frontend/src/components/applications/DownloadBlanksModal.vue
@@ -1,24 +1,65 @@
 <template>
-  <div class="modal-overlay" data-testid="download-blanks-modal" @click.self="$emit('close')">
-    <div class="modal-content">
-      <h3 class="modal-title">Скачивание бланков заявки</h3>
+  <div
+    class="dbm-overlay"
+    data-testid="download-blanks-modal"
+    @click.self="$emit('close')"
+  >
+    <div class="dbm-modal">
+      <div class="dbm-header">
+        <h3 class="dbm-title">
+          Скачивание бланков
+        </h3>
+        <button
+          class="dbm-close"
+          @click="$emit('close')"
+        >
+          &times;
+        </button>
+      </div>
 
-      <div v-if="isLoading" class="loader">Загрузка вложений...</div>
-      <div v-else-if="error" class="error">{{ error }}</div>
-      <div v-else-if="!eligibleAttachments.length" class="empty">
+      <div
+        v-if="isLoading"
+        class="dbm-state"
+      >
+        <span class="dbm-spinner" />
+      </div>
+      <div
+        v-else-if="error"
+        class="dbm-state dbm-state--error"
+      >
+        {{ error }}
+      </div>
+      <div
+        v-else-if="!eligibleAttachments.length"
+        class="dbm-state"
+      >
         У заявки нет вложений с настроенным шаблоном бланка.
       </div>
-      <div v-else class="attachments">
-        <label v-for="att in eligibleAttachments" :key="att.id" class="attachment-row">
+      <div
+        v-else
+        class="dbm-list"
+      >
+        <label
+          v-for="att in eligibleAttachments"
+          :key="att.id"
+          class="dbm-item"
+          :class="{ selected: selectedIds.includes(att.id) }"
+        >
           <input
+            v-model="selectedIds"
             type="checkbox"
             :value="att.id"
-            v-model="selectedIds"
+            class="dbm-checkbox"
           >
-          <span class="att-name">{{ att.display_name || att.name }}</span>
-          <span class="att-type">{{ attachmentTypeLabel(att.attachment_type) }}</span>
+          <div class="dbm-item-info">
+            <span class="dbm-item-name">{{ att.display_name || att.name }}</span>
+            <span
+              v-if="attachmentTypeLabel(att.attachment_type)"
+              class="dbm-item-type"
+            >{{ attachmentTypeLabel(att.attachment_type) }}</span>
+          </div>
           <button
-            class="link-btn"
+            class="dbm-item-download"
             :disabled="downloadingId === att.id"
             @click.prevent="downloadOne(att)"
           >
@@ -27,21 +68,29 @@
         </label>
       </div>
 
-      <footer v-if="eligibleAttachments.length" class="modal-actions">
-        <button class="lk-btn lk-btn--ghost" @click="$emit('close')">Закрыть</button>
+      <footer
+        v-if="eligibleAttachments.length"
+        class="dbm-footer"
+      >
         <button
-          class="lk-btn"
-          :disabled="!selectedIds.length || downloadingAll"
-          @click="downloadSelected"
+          class="dbm-btn dbm-btn--ghost"
+          @click="$emit('close')"
         >
-          {{ downloadingAll ? 'Скачивание...' : `Скачать выбранное (${selectedIds.length})` }}
+          Закрыть
         </button>
         <button
-          class="lk-btn lk-btn--ghost"
+          class="dbm-btn dbm-btn--ghost"
           :disabled="downloadingAll"
           @click="downloadAll"
         >
           Скачать все
+        </button>
+        <button
+          class="dbm-btn dbm-btn--primary"
+          :disabled="!selectedIds.length || downloadingAll"
+          @click="downloadSelected"
+        >
+          {{ downloadingAll ? 'Скачивание...' : `Скачать (${selectedIds.length})` }}
         </button>
       </footer>
     </div>
@@ -112,8 +161,6 @@ export default {
     },
     async downloadSelected() {
       if (!this.selectedIds.length) return;
-      // ZIP-выгрузка пока не реализована на бэке - скачиваем по одному.
-      // TODO: backend endpoint /applications/:id/blanks?attachment_ids= → отдельная задача.
       this.downloadingAll = true;
       try {
         for (const id of this.selectedIds) {
@@ -133,101 +180,211 @@ export default {
 </script>
 
 <style scoped>
-.modal-overlay {
+.dbm-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.4);
+  background: rgba(0, 0, 0, 0.35);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 100;
 }
 
-.modal-content {
+.dbm-modal {
   background: #fff;
-  border-radius: 12px;
-  padding: 24px;
-  width: 520px;
+  border-radius: 30px;
+  padding: 0;
+  width: 480px;
   max-width: 92vw;
   max-height: 80vh;
-  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
 }
 
-.modal-title {
-  margin: 0 0 16px;
-  font-size: 18px;
-}
-
-.loader, .empty, .error {
-  text-align: center;
-  color: #888;
-  padding: 24px 0;
-}
-
-.error {
-  color: #d73a3a;
-}
-
-.attachment-row {
+.dbm-header {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 10px 8px;
-  border-bottom: 1px solid var(--color-border);
-  cursor: pointer;
+  justify-content: space-between;
+  padding: 20px 24px 0;
 }
 
-.attachment-row:hover {
+.dbm-title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.dbm-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
   background: var(--color-bg-secondary);
+  border-radius: 50%;
+  font-size: 18px;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: all 0.15s;
+  line-height: 1;
 }
 
-.att-name {
+.dbm-close:hover {
+  background: var(--color-border);
+  color: var(--color-text);
+}
+
+.dbm-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 24px;
+  color: var(--color-text-muted);
+  font-size: 13px;
+}
+
+.dbm-state--error {
+  color: var(--color-danger);
+}
+
+.dbm-spinner {
+  display: block;
+  width: 28px;
+  height: 28px;
+  border: 3px solid var(--color-border);
+  border-top-color: var(--color-primary);
+  border-radius: 50%;
+  animation: dbm-spin 0.7s linear infinite;
+}
+
+@keyframes dbm-spin {
+  to { transform: rotate(360deg); }
+}
+
+.dbm-list {
+  padding: 16px 24px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.dbm-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  transition: all 0.15s;
+  background: #fff;
+}
+
+.dbm-item:hover {
+  border-color: var(--color-primary);
+  background: #f8faff;
+}
+
+.dbm-item.selected {
+  border-color: var(--color-primary);
+  background: #eef4ff;
+}
+
+.dbm-checkbox {
+  accent-color: var(--color-primary);
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+.dbm-item-info {
   flex: 1;
-  font-size: 14px;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 
-.att-type {
-  font-size: 12px;
-  color: #888;
+.dbm-item-name {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.link-btn {
+.dbm-item-type {
+  font-size: 11px;
+  color: var(--color-text-muted);
+}
+
+.dbm-item-download {
+  flex-shrink: 0;
   background: none;
-  border: 0;
+  border: none;
   color: var(--color-primary);
   cursor: pointer;
-  font-size: 13px;
+  font-size: 12px;
+  font-weight: 500;
   padding: 4px 8px;
+  border-radius: var(--radius-pill);
+  transition: all 0.15s;
 }
 
-.link-btn:disabled {
-  opacity: 0.5;
+.dbm-item-download:hover {
+  background: #eef4ff;
 }
 
-.modal-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 10px;
-  margin-top: 16px;
-}
-
-.lk-btn {
-  padding: 8px 16px;
-  border-radius: 8px;
-  border: 0;
-  background: var(--color-primary);
-  color: #fff;
-  cursor: pointer;
-}
-
-.lk-btn:disabled {
+.dbm-item-download:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
 
-.lk-btn--ghost {
+.dbm-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 0 24px 20px;
+}
+
+.dbm-btn {
+  padding: 8px 18px;
+  border-radius: var(--radius-pill);
+  border: none;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.dbm-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.dbm-btn--primary {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.dbm-btn--primary:hover:not(:disabled) {
+  filter: brightness(0.92);
+}
+
+.dbm-btn--ghost {
   background: transparent;
   border: 1px solid var(--color-border);
-  color: #333;
+  color: var(--color-text);
+}
+
+.dbm-btn--ghost:hover:not(:disabled) {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
 }
 </style>


### PR DESCRIPTION
## Summary
- Dropdown выбора xlsx-шаблона вместо табов (выбор, "Добавить файл..", кнопки Скачать/Редактировать/Удалить)
- Иконка поиска в поле фильтра полей
- Спиннеры загрузки при открытии модалки (превью xlsx + список полей)
- border-radius модалки 40px, заголовок полей 14px, убран border te-templates-block
- При наведении на ячейку/поле путь тоже жирнеет на 1px
- Padding перенесён с te-field-picker-scroll на каждую te-field-group
- Редизайн DownloadBlanksModal: скругления 30px, pill-карточки, спиннер, кнопка закрытия

## Test plan
- [ ] Открыть редактор бланков, проверить dropdown шаблонов
- [ ] Проверить иконку поиска в поле фильтра
- [ ] Проверить спиннеры при открытии модалки
- [ ] Навести на ячейку/поле - путь должен жирнеть
- [ ] Открыть модалку скачивания бланков - проверить новый дизайн