### PR TITLE
fix: 500 при загрузке второго xlsx, персистенция toggle, цвет dropdown (#183)

### DIFF
--- a/frontend/src/api/attachment-templates.js
+++ b/frontend/src/api/attachment-templates.js
@@ -23,6 +23,13 @@ export async function setActiveTemplate(uniqueAttachmentID, templateID) {
   return res.json();
 }
 
+export async function deactivateAllTemplates(uniqueAttachmentID) {
+  const res = await apiRequest(`/attachments/${uniqueAttachmentID}/template/deactivate`, {
+    method: 'PUT',
+  });
+  return res.json();
+}
+
 export async function deleteTemplateByID(uniqueAttachmentID, templateID) {
   const res = await apiRequest(`/attachments/${uniqueAttachmentID}/template/${templateID}`, {
     method: 'DELETE',

--- a/frontend/src/components/admin/AttachmentTemplateEditor.vue
+++ b/frontend/src/components/admin/AttachmentTemplateEditor.vue
@@ -534,6 +534,7 @@ import {
   getTemplate, uploadTemplate, updateMappings, deleteTemplate,
   getTemplateFields, getTemplateFile, saveBlobAs,
   listTemplates, setActiveTemplate, deleteTemplateByID, getTemplateFileByID,
+  deactivateAllTemplates,
 } from '@/api/attachment-templates';
 import BaseModal from '@/components/ui/BaseModal.vue';
 import ToggleSwitch from '@/components/ui/ToggleSwitch.vue';
@@ -774,8 +775,20 @@ export default {
         this.loadingFields = false;
       }
     },
-    onToggleEnabled(val) {
+    async onToggleEnabled(val) {
       this.enabled = val;
+      try {
+        if (!val) {
+          await deactivateAllTemplates(this.uniqueAttachmentId);
+        } else if (this.allTemplates.length > 0) {
+          const latest = this.allTemplates[0];
+          await setActiveTemplate(this.uniqueAttachmentId, latest.id);
+          await this.loadTemplate();
+        }
+      } catch {
+        this.enabled = !val;
+        useUiStore().error('Не удалось переключить генерацию бланка');
+      }
     },
     onFileChange(e) {
       this.form.file = e.target.files[0] || null;
@@ -1438,105 +1451,6 @@ export default {
   gap: 8px;
 }
 
-.te-template-dropdown-wrap {
-  position: relative;
-}
-
-.te-template-dropdown-trigger {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  width: 100%;
-  padding: 6px 12px;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-pill);
-  font-size: 12px;
-  background: #fff;
-  cursor: pointer;
-  transition: border-color 0.15s;
-  color: var(--color-text);
-}
-
-.te-template-dropdown-trigger:hover {
-  border-color: var(--color-primary);
-}
-
-.te-dropdown-filename {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.te-dropdown-arrow {
-  font-size: 10px;
-  color: var(--color-text-muted);
-  transition: transform 0.2s;
-  flex-shrink: 0;
-}
-
-.te-dropdown-arrow.open {
-  transform: rotate(180deg);
-}
-
-.te-template-dropdown {
-  position: absolute;
-  top: calc(100% + 4px);
-  left: 0;
-  right: 0;
-  background: #fff;
-  border: 1px solid var(--color-border);
-  border-radius: 20px;
-  box-shadow: var(--shadow-md);
-  z-index: 30;
-  overflow: hidden;
-}
-
-.te-dropdown-item {
-  display: block;
-  width: 100%;
-  padding: 7px 12px;
-  border: none;
-  background: none;
-  font-size: 12px;
-  text-align: left;
-  cursor: pointer;
-  color: #000;
-  transition: background 0.1s;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.te-dropdown-item:hover {
-  background: var(--color-bg-secondary);
-}
-
-.te-dropdown-item.active {
-  background: #e8f4fd;
-  color: var(--color-primary);
-  font-weight: 500;
-}
-
-.te-dropdown-add {
-  border-top: 1px solid var(--color-border);
-  color: var(--color-primary);
-  font-weight: 500;
-}
-
-.te-dropdown-fade-enter-active {
-  transition: opacity 0.15s ease, transform 0.15s ease;
-}
-
-.te-dropdown-fade-leave-active {
-  transition: opacity 0.1s ease, transform 0.1s ease;
-}
-
-.te-dropdown-fade-enter-from,
-.te-dropdown-fade-leave-to {
-  opacity: 0;
-  transform: translateY(-4px);
-}
 
 /* ---- Separator ---- */
 .te-separator-block {
@@ -2129,5 +2043,105 @@ export default {
   .te-modal-rounded.base-modal {
     border-radius: 16px 16px 0 0;
   }
+}
+
+.te-template-dropdown-wrap {
+  position: relative;
+}
+
+.te-template-dropdown-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 12px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-pill);
+  font-size: 12px;
+  background: #fff;
+  cursor: pointer;
+  transition: border-color 0.15s;
+  color: var(--color-text);
+}
+
+.te-template-dropdown-trigger:hover {
+  border-color: var(--color-primary);
+}
+
+.te-dropdown-filename {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.te-dropdown-arrow {
+  font-size: 10px;
+  color: var(--color-text-muted);
+  transition: transform 0.2s;
+  flex-shrink: 0;
+}
+
+.te-dropdown-arrow.open {
+  transform: rotate(180deg);
+}
+
+.te-template-dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  background: #fff;
+  border: 1px solid var(--color-border);
+  border-radius: 20px;
+  box-shadow: var(--shadow-md);
+  z-index: 30;
+  overflow: hidden;
+}
+
+.te-dropdown-item {
+  display: block;
+  width: 100%;
+  padding: 7px 12px;
+  border: none;
+  background: none;
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+  color: #000;
+  transition: background 0.1s;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.te-dropdown-item:hover {
+  background: var(--color-bg-secondary);
+}
+
+.te-dropdown-item.active {
+  background: #e8f4fd;
+  color: var(--color-primary);
+  font-weight: 500;
+}
+
+.te-dropdown-add {
+  border-top: 1px solid var(--color-border);
+  color: var(--color-primary);
+  font-weight: 500;
+}
+
+.te-dropdown-fade-enter-active {
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.te-dropdown-fade-leave-active {
+  transition: opacity 0.1s ease, transform 0.1s ease;
+}
+
+.te-dropdown-fade-enter-from,
+.te-dropdown-fade-leave-to {
+  opacity: 0;
+  transform: translateY(-4px);
 }
 </style>

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -133,6 +133,9 @@ func AutoMigrate(db *gorm.DB) error {
 	if err := db.AutoMigrate(AllModels()...); err != nil {
 		return err
 	}
+	if err := fixAttachmentTemplateIndex(db); err != nil {
+		return err
+	}
 	if err := installSQLFunctions(db); err != nil {
 		return err
 	}
@@ -160,6 +163,27 @@ func backfillSuperAdmin(db *gorm.DB) error {
 		slog.Info("super-admin backfilled", "users_updated", res.RowsAffected)
 	}
 	return nil
+}
+
+// fixAttachmentTemplateIndex заменяет UNIQUE индекс на обычный, если GORM
+// создал его при AutoMigrate для belongs-to связи. Несколько шаблонов на
+// одно вложение - штатный сценарий (#183).
+func fixAttachmentTemplateIndex(db *gorm.DB) error {
+	return db.Exec(`
+		DO $$
+		BEGIN
+			IF EXISTS (
+				SELECT 1 FROM pg_indexes
+				WHERE tablename = 'attachment_templates'
+				  AND indexname = 'idx_attachment_templates_unique_attachment_id'
+				  AND indexdef LIKE '%UNIQUE%'
+			) THEN
+				DROP INDEX idx_attachment_templates_unique_attachment_id;
+				CREATE INDEX idx_attachment_templates_unique_attachment_id
+					ON attachment_templates(unique_attachment_id);
+			END IF;
+		END $$;
+	`).Error
 }
 
 // installSQLFunctions создаёт пользовательские SQL-функции, переиспользуемые

--- a/internal/handlers/attachment_templates.go
+++ b/internal/handlers/attachment_templates.go
@@ -68,6 +68,17 @@ func (h *AttachmentTemplateHandler) SetActive(c echo.Context) error {
 	return RespondMessage(c, "Шаблон активирован")
 }
 
+func (h *AttachmentTemplateHandler) DeactivateAll(c echo.Context) error {
+	uaID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	if err := h.service.DeactivateAll(c.Request().Context(), uaID); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Шаблоны деактивированы")
+}
+
 func (h *AttachmentTemplateHandler) DeleteByID(c echo.Context) error {
 	tid, err := strconv.Atoi(c.Param("tid"))
 	if err != nil {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -197,6 +197,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	attRoot.GET("/:id/template/:tid/file", attachmentTemplates.DownloadFileByID)
 	attRoot.PUT("/:id/template/mappings", attachmentTemplates.UpdateMappings)
 	attRoot.PUT("/:id/template/:tid/activate", attachmentTemplates.SetActive)
+	attRoot.PUT("/:id/template/deactivate", attachmentTemplates.DeactivateAll)
 	attRoot.DELETE("/:id/template", attachmentTemplates.Delete)
 	attRoot.DELETE("/:id/template/:tid", attachmentTemplates.DeleteByID)
 	attRoot.GET("/:id/template-fields", attachmentTemplates.GetFields)

--- a/internal/services/attachment_template_service.go
+++ b/internal/services/attachment_template_service.go
@@ -28,6 +28,7 @@ type AttachmentTemplateService interface {
 	Delete(ctx context.Context, uniqueAttachmentID int) error
 	DeleteByID(ctx context.Context, templateID int) error
 	SetActive(ctx context.Context, uniqueAttachmentID int, templateID int) error
+	DeactivateAll(ctx context.Context, uniqueAttachmentID int) error
 	GetByID(ctx context.Context, templateID int) (*models.AttachmentTemplate, error)
 	// Custom fields
 	ListCustomFields(ctx context.Context, uniqueAttachmentID int) ([]models.AttachmentCustomField, error)
@@ -220,6 +221,16 @@ func (s *attachmentTemplateService) deleteTemplate(ctx context.Context, t *model
 		}
 		return tx.Delete(t).Error
 	})
+}
+
+func (s *attachmentTemplateService) DeactivateAll(ctx context.Context, uaID int) error {
+	res := s.db.WithContext(ctx).Model(&models.AttachmentTemplate{}).
+		Where("unique_attachment_id = ? AND is_active = ?", uaID, true).
+		Update("is_active", false)
+	if res.Error != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Не удалось деактивировать шаблоны")
+	}
+	return nil
 }
 
 func (s *attachmentTemplateService) SetActive(ctx context.Context, uaID int, templateID int) error {


### PR DESCRIPTION
## Summary
- Исправлен 500 при загрузке второго xlsx: миграция заменяет UNIQUE индекс на unique_attachment_id обычным (несколько шаблонов на вложение - штатный сценарий)
- Toggle "Генерация бланка" теперь персистит: добавлен эндпоинт PUT /deactivate, при выключении деактивируются все шаблоны, при включении активируется последний
- Цвет текста dropdown теперь корректно #000: стили перенесены из scoped в unscoped блок (teleport ломал scoped-селекторы)

## Test plan
- [ ] Загрузить второй xlsx через "Добавить файл.." - не должно быть 500
- [ ] Выключить toggle -> закрыть -> открыть -> toggle должен быть выключен
- [ ] Включить toggle обратно -> шаблон активируется
- [ ] Текст dropdown шаблонов должен быть черным (#000), не синим