### PR TITLE
fix: скрытие кнопки Скачать при деактивации, dropdown #000, анимация переключения (#183)

### DIFF
--- a/frontend/src/components/admin/AttachmentTemplateEditor.vue
+++ b/frontend/src/components/admin/AttachmentTemplateEditor.vue
@@ -728,6 +728,7 @@ export default {
     },
     async loadTemplate() {
       this.loadingTemplate = true;
+      this.templateFileBuffer = null;
       try {
         const data = await getTemplate(this.uniqueAttachmentId);
         this.template = data;
@@ -826,13 +827,18 @@ export default {
     },
     async switchTemplate(tmpl) {
       if (tmpl.id === this.template?.id) return;
+      this.loadingTemplate = true;
+      this.loadingFields = true;
+      this.templateFileBuffer = null;
       try {
         await setActiveTemplate(this.uniqueAttachmentId, tmpl.id);
         useUiStore().success('Шаблон активирован');
         this.resetState();
-        await this.loadTemplate();
+        await Promise.all([this.loadTemplate(), this.loadFields()]);
       } catch {
         useUiStore().error('Не удалось переключить шаблон');
+        this.loadingTemplate = false;
+        this.loadingFields = false;
       }
     },
     async deleteSpecificTemplate(tmpl) {
@@ -2121,13 +2127,13 @@ export default {
 
 .te-dropdown-item.active {
   background: #e8f4fd;
-  color: var(--color-primary);
+  color: #000;
   font-weight: 500;
 }
 
 .te-dropdown-add {
   border-top: 1px solid var(--color-border);
-  color: var(--color-primary);
+  color: #000;
   font-weight: 500;
 }
 

--- a/internal/services/application_service.go
+++ b/internal/services/application_service.go
@@ -493,7 +493,7 @@ func (s *applicationService) GetApplications(ctx context.Context, username strin
 			format_short_name(u.last_name, u.first_name, u.middle_name) as sender_name,
 			format_full_name(ru.last_name, ru.first_name, ru.middle_name) as responsible_full_name,
 			format_short_name(ru.last_name, ru.first_name, ru.middle_name) as responsible_name,
-			EXISTS (SELECT 1 FROM attachments att JOIN attachment_templates at2 ON at2.unique_attachment_id = att.unique_attachment_id WHERE att.application_id = a.id) as has_blank_template
+			EXISTS (SELECT 1 FROM attachments att JOIN attachment_templates at2 ON at2.unique_attachment_id = att.unique_attachment_id AND at2.is_active = true WHERE att.application_id = a.id) as has_blank_template
 		`).
 		Joins("LEFT JOIN organizations o ON a.organization_id = o.id").
 		Joins("LEFT JOIN companies c ON a.company_id = c.id").
@@ -556,7 +556,7 @@ func (s *applicationService) GetApplicationsPaginated(ctx context.Context, usern
 			format_short_name(u.last_name, u.first_name, u.middle_name) as sender_name,
 			format_full_name(ru.last_name, ru.first_name, ru.middle_name) as responsible_full_name,
 			format_short_name(ru.last_name, ru.first_name, ru.middle_name) as responsible_name,
-			EXISTS (SELECT 1 FROM attachments att JOIN attachment_templates at2 ON at2.unique_attachment_id = att.unique_attachment_id WHERE att.application_id = a.id) as has_blank_template
+			EXISTS (SELECT 1 FROM attachments att JOIN attachment_templates at2 ON at2.unique_attachment_id = att.unique_attachment_id AND at2.is_active = true WHERE att.application_id = a.id) as has_blank_template
 		`).
 		Order("a.sending_datetime DESC").
 		Offset(offset).
@@ -586,7 +586,7 @@ func (s *applicationService) GetUserApplications(ctx context.Context, username s
 			format_short_name(u.last_name, u.first_name, u.middle_name) as sender_name,
 			format_full_name(ru.last_name, ru.first_name, ru.middle_name) as responsible_full_name,
 			format_short_name(ru.last_name, ru.first_name, ru.middle_name) as responsible_name,
-			EXISTS (SELECT 1 FROM attachments att JOIN attachment_templates at2 ON at2.unique_attachment_id = att.unique_attachment_id WHERE att.application_id = a.id) as has_blank_template
+			EXISTS (SELECT 1 FROM attachments att JOIN attachment_templates at2 ON at2.unique_attachment_id = att.unique_attachment_id AND at2.is_active = true WHERE att.application_id = a.id) as has_blank_template
 		`).
 		Joins("LEFT JOIN organizations o ON a.organization_id = o.id").
 		Joins("LEFT JOIN companies c ON a.company_id = c.id").


### PR DESCRIPTION
## Summary
- Кнопка "Скачать" в списке заявок скрывается при деактивации шаблона: SQL-подзапрос has_blank_template теперь фильтрует по is_active = true (3 места)
- Весь текст dropdown шаблонов теперь #000 (active item, "Добавить файл.." - убран var(--color-primary))
- Анимация загрузки при переключении шаблонов: templateFileBuffer обнуляется, loadingTemplate/loadingFields ставятся сразу, поля перезагружаются параллельно

## Test plan
- [ ] Деактивировать шаблон через toggle -> в списке заявок кнопка "Скачать" не показывается
- [ ] Активировать обратно -> кнопка "Скачать" появляется
- [ ] Открыть dropdown шаблонов -> все элементы черного цвета (#000)
- [ ] Переключить шаблон в dropdown -> spinner пока грузится предпросмотр и поля