### PR TITLE
fix: оставшиеся баги из #316 - непрочитанные, фильтры, кастомные поля

### DIFF
--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -1018,6 +1018,9 @@ export default {
 
             this.selectAttachment(attachment);
 
+            const uaId = attachment.template_id || attachment.id;
+            this.loadCustomFields(uaId);
+
             this.saveToLocalStorage();
         },
 

--- a/frontend/src/components/FactTable.vue
+++ b/frontend/src/components/FactTable.vue
@@ -859,7 +859,7 @@ export default {
   transition: background-color 0.2s ease;
   opacity: 0;
   transform: translateY(10px);
-  animation: fadeInUp 0.5s ease forwards;
+  animation: fadeInUp 0.3s ease forwards;
   cursor: pointer;
 }
 

--- a/frontend/src/components/applications/DownloadBlanksModal.vue
+++ b/frontend/src/components/applications/DownloadBlanksModal.vue
@@ -163,8 +163,9 @@ export default {
       if (!this.selectedIds.length) return;
       this.downloadingAll = true;
       try {
-        for (const id of this.selectedIds) {
-          await this.downloadOne({ id });
+        for (let i = 0; i < this.selectedIds.length; i++) {
+          if (i > 0) await new Promise(r => setTimeout(r, 500));
+          await this.downloadOne({ id: this.selectedIds[i] });
         }
         useUiStore().success(`Скачано: ${this.selectedIds.length}`);
       } finally {

--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -70,15 +70,6 @@
           </button>
 
           <button
-            class="today-filter-btn"
-            :class="{ 'today-filter-btn--active': activeToday }"
-            data-testid="center-button-today"
-            @click="toggleActiveToday"
-          >
-            Заявки на сегодня
-          </button>
-
-          <button
             class="reset-filters-btn"
             data-testid="center-button-reset-filters"
             :disabled="!hasActiveFilters"
@@ -89,6 +80,18 @@
         </div>
 
         <div class="filters-row filters-row--secondary">
+          <div class="filter-section">
+            <div class="status-buttons">
+              <button
+                class="status-btn"
+                :class="{ 'status-btn--active': activeToday }"
+                data-testid="center-button-today"
+                @click="toggleActiveToday"
+              >
+                Заявки на сегодня
+              </button>
+            </div>
+          </div>
           <div class="filter-section">
             <div class="filter-section__header">
               <span class="filter-label">Подтверждение</span>
@@ -256,7 +259,7 @@
               :key="application.id"
               class="application-item"
               :class="{
-                'unread': application.status === 'Непрочитано',
+                'unread': !application.is_read,
                 'initial-load': isInitialLoad,
                 'filtered': !isInitialLoad
               }"
@@ -915,25 +918,16 @@ export default {
         },
 
         async openApplication(application) {
-            
-            if (application.status === 'Непрочитано') {
+            if (!application.is_read) {
                 try {
-                    const response = await apiRequest(`/applications/${application.id}`, {
-                        method: "PUT",
-                        body: JSON.stringify({
-                            status: "В обработке"
-                        })
+                    const response = await apiRequest(`/applications/${application.id}/read`, {
+                        method: "POST"
                     });
-
                     if (response.ok) {
-                        application.status = 'В обработке';
-                        this.fetchApplications();
-                    } else {
-                        const errorText = await response.text();
-                        console.error("Ошибка при обновлении статуса заявки:", errorText);
+                        application.is_read = true;
                     }
                 } catch (error) {
-                    console.error("Ошибка сети при обновлении статуса заявки:", error);
+                    console.error("Ошибка при отметке прочтения:", error);
                 }
             }
 

--- a/internal/handlers/testdata/applications_list.golden
+++ b/internal/handlers/testdata/applications_list.golden
@@ -7,6 +7,7 @@ data[].confirmation_datetime
 data[].data_approval
 data[].has_blank_template
 data[].id
+data[].is_read
 data[].message
 data[].organization_id
 data[].organization_name

--- a/internal/services/application_service.go
+++ b/internal/services/application_service.go
@@ -289,6 +289,7 @@ type ApplicationWithDetails struct {
 	ResponsibleComment   *string    `json:"responsible_comment"`
 	DataApproval         bool       `json:"data_approval"`
 	HasBlankTemplate     bool       `json:"has_blank_template"`
+	IsRead               bool       `json:"is_read"`
 }
 
 // ApplicationCreateResponse ответ при создании заявки.
@@ -493,8 +494,9 @@ func (s *applicationService) GetApplications(ctx context.Context, username strin
 			format_short_name(u.last_name, u.first_name, u.middle_name) as sender_name,
 			format_full_name(ru.last_name, ru.first_name, ru.middle_name) as responsible_full_name,
 			format_short_name(ru.last_name, ru.first_name, ru.middle_name) as responsible_name,
-			EXISTS (SELECT 1 FROM attachments att JOIN attachment_templates at2 ON at2.unique_attachment_id = att.unique_attachment_id AND at2.is_active = true WHERE att.application_id = a.id) as has_blank_template
-		`).
+			EXISTS (SELECT 1 FROM attachments att JOIN attachment_templates at2 ON at2.unique_attachment_id = att.unique_attachment_id AND at2.is_active = true WHERE att.application_id = a.id) as has_blank_template,
+			EXISTS (SELECT 1 FROM application_reads ar WHERE ar.application_id = a.id AND ar.user_id = ?) as is_read
+		`, user.ID).
 		Joins("LEFT JOIN organizations o ON a.organization_id = o.id").
 		Joins("LEFT JOIN companies c ON a.company_id = c.id").
 		Joins("LEFT JOIN users u ON a.sender_user_id = u.id").
@@ -556,8 +558,9 @@ func (s *applicationService) GetApplicationsPaginated(ctx context.Context, usern
 			format_short_name(u.last_name, u.first_name, u.middle_name) as sender_name,
 			format_full_name(ru.last_name, ru.first_name, ru.middle_name) as responsible_full_name,
 			format_short_name(ru.last_name, ru.first_name, ru.middle_name) as responsible_name,
-			EXISTS (SELECT 1 FROM attachments att JOIN attachment_templates at2 ON at2.unique_attachment_id = att.unique_attachment_id AND at2.is_active = true WHERE att.application_id = a.id) as has_blank_template
-		`).
+			EXISTS (SELECT 1 FROM attachments att JOIN attachment_templates at2 ON at2.unique_attachment_id = att.unique_attachment_id AND at2.is_active = true WHERE att.application_id = a.id) as has_blank_template,
+			EXISTS (SELECT 1 FROM application_reads ar WHERE ar.application_id = a.id AND ar.user_id = ?) as is_read
+		`, user.ID).
 		Order("a.sending_datetime DESC").
 		Offset(offset).
 		Limit(perPage)
@@ -573,7 +576,8 @@ func (s *applicationService) GetApplicationsPaginated(ctx context.Context, usern
 
 // GetUserApplications возвращает заявки текущего пользователя с фильтрацией.
 func (s *applicationService) GetUserApplications(ctx context.Context, username string, filter ApplicationFilter) ([]ApplicationWithDetails, error) {
-	if _, err := s.getUserByUsername(ctx, username); err != nil {
+	user, err := s.getUserByUsername(ctx, username)
+	if err != nil {
 		return nil, err
 	}
 
@@ -586,8 +590,9 @@ func (s *applicationService) GetUserApplications(ctx context.Context, username s
 			format_short_name(u.last_name, u.first_name, u.middle_name) as sender_name,
 			format_full_name(ru.last_name, ru.first_name, ru.middle_name) as responsible_full_name,
 			format_short_name(ru.last_name, ru.first_name, ru.middle_name) as responsible_name,
-			EXISTS (SELECT 1 FROM attachments att JOIN attachment_templates at2 ON at2.unique_attachment_id = att.unique_attachment_id AND at2.is_active = true WHERE att.application_id = a.id) as has_blank_template
-		`).
+			EXISTS (SELECT 1 FROM attachments att JOIN attachment_templates at2 ON at2.unique_attachment_id = att.unique_attachment_id AND at2.is_active = true WHERE att.application_id = a.id) as has_blank_template,
+			EXISTS (SELECT 1 FROM application_reads ar WHERE ar.application_id = a.id AND ar.user_id = ?) as is_read
+		`, user.ID).
 		Joins("LEFT JOIN organizations o ON a.organization_id = o.id").
 		Joins("LEFT JOIN companies c ON a.company_id = c.id").
 		Joins("LEFT JOIN users u ON a.sender_user_id = u.id").


### PR DESCRIPTION
## Summary

Вторая порция фиксов из сбора багов #316.

### Backend (Go)
- Добавлен `is_read` флаг в `ApplicationWithDetails` - per-user прочтение заявок через `application_reads`
- Подзапрос `is_read` добавлен во все три метода: GetApplications, GetApplicationsPaginated, GetUserApplications

### Frontend
- Непрочитанные заявки: желтый фон по `!is_read` вместо `status === 'Непрочитано'`, вызов POST /applications/{id}/read при открытии
- Кнопка "Заявки на сегодня" перенесена из основного ряда фильтров в secondary (рядом с подтверждением и статусом)
- Анимация FactTable: 0.5s -> 0.3s (унификация с PeopleTable и CarsTable)
- Кастомные поля: вызов loadCustomFields при добавлении нового вложения (ранее поля не появлялись до перезагрузки)
- Скачивание бланков: задержка 500ms между файлами для предотвращения блокировки браузером

Relates #316

## Test plan
- [ ] Центр заявок: непрочитанные заявки выделены желтым
- [ ] При открытии заявки желтый фон пропадает (помечается как прочитанная)
- [ ] Кнопка "Заявки на сегодня" в нижнем ряду фильтров
- [ ] Анимация обновления одинакова для всех таблиц
- [ ] Кастомные поля появляются сразу при создании вложения
- [ ] Скачивание нескольких бланков - файлы скачиваются по отдельности