### PR TITLE
fix: третья порция багов #316 - UI, данные модалок, debounce

### DIFF
--- a/frontend/src/components/CreateApplication/EmployeeForm.vue
+++ b/frontend/src/components/CreateApplication/EmployeeForm.vue
@@ -454,7 +454,7 @@ export default {
             attachedPassageTables: [],
             selectedPassageTables: [],
             loadingPassageTables: false,
-            autoPlacesNotified: false,
+            autoPlacesNotified: sessionStorage.getItem('autoPlacesNotified') === 'true',
             
             errors: {
                 passageTables: ''
@@ -633,6 +633,7 @@ export default {
                 this.selectedPassageTables = activeAttachedTables.map(table => table.table.id);
                 if (this.selectedPassageTables.length > 0 && !this.autoPlacesNotified) {
                     this.autoPlacesNotified = true;
+                    sessionStorage.setItem('autoPlacesNotified', 'true');
                     this.toast.success('Места прохода выбраны автоматически для вашей организации');
                 }
             }
@@ -673,6 +674,7 @@ export default {
                 this.selectedPassageTables = activeAttachedTables.map(table => table.table.id);
                 if (this.selectedPassageTables.length > 0 && !this.autoPlacesNotified) {
                     this.autoPlacesNotified = true;
+                    sessionStorage.setItem('autoPlacesNotified', 'true');
                     this.toast.success('Места прохода выбраны автоматически для вашей компании');
                 }
             }

--- a/frontend/src/components/CreateApplication/EmployeesList.vue
+++ b/frontend/src/components/CreateApplication/EmployeesList.vue
@@ -372,7 +372,7 @@ export default {
 }
 
 .details-btn .details-icon {
-    color: #a2a2a2;
+    color: #8c8c8c;
 }
 
 .details-btn:hover .details-icon {

--- a/frontend/src/components/CreateApplication/VehiclesList.vue
+++ b/frontend/src/components/CreateApplication/VehiclesList.vue
@@ -375,7 +375,7 @@ export default {
 }
 
 .details-btn .details-icon {
-    color: #1976d2;
+    color: #8c8c8c;
 }
 
 .details-btn:hover .details-icon {

--- a/frontend/src/components/FactTable.vue
+++ b/frontend/src/components/FactTable.vue
@@ -139,7 +139,13 @@
       <!-- Тело таблицы -->
       <div class="fact-container">
         <div
-          v-if="filteredData.length > 0"
+          v-if="loading"
+          class="loading-message"
+        >
+          <LoaderSpinner :label="tableType === 'cars' ? 'Загрузка машин...' : 'Загрузка...'" />
+        </div>
+        <div
+          v-else-if="filteredData.length > 0"
           class="fact-body"
         >
           <transition-group
@@ -266,12 +272,14 @@
 <script>
 import { apiRequest } from '@/api/client'
 import RefreshButton from './RefreshButton.vue';
+import LoaderSpinner from '@/components/ui/LoaderSpinner.vue';
 import VehicleDetailsModal from './CreateApplication/VehicleDetailsModal.vue';
 
 export default {
   name: 'FactTable',
   components: {
     RefreshButton,
+    LoaderSpinner,
     VehicleDetailsModal
   },
   props: {
@@ -1067,5 +1075,17 @@ export default {
     height: 28px;
     font-size: 11px;
   }
+}
+
+.loading-message {
+  text-align: center;
+  color: #a2a2a2;
+  padding: 40px 20px;
+  font-size: 14px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
 }
 </style>

--- a/frontend/src/components/RefreshButton.vue
+++ b/frontend/src/components/RefreshButton.vue
@@ -2,7 +2,7 @@
   <button
     class="refresh-btn"
     :class="{ 'refresh-btn--loading': loading }"
-    :disabled="loading"
+    :disabled="loading || cooldown"
     type="button"
     @click="handleRefresh"
   >
@@ -23,10 +23,15 @@ export default {
     loading: { type: Boolean, default: false },
   },
   emits: ['refresh'],
+  data() {
+    return { cooldown: false };
+  },
   methods: {
     handleRefresh() {
-      if (this.loading) return;
+      if (this.loading || this.cooldown) return;
+      this.cooldown = true;
       this.$emit('refresh');
+      setTimeout(() => { this.cooldown = false; }, 2000);
     }
   }
 }

--- a/frontend/src/components/TheHeader/TheHeader.vue
+++ b/frontend/src/components/TheHeader/TheHeader.vue
@@ -54,6 +54,7 @@
       </p>
       <div
         class="user__notifications"
+        :class="{ 'user__notifications--active': showNotifications }"
         @click.stop="showNotifications = !showNotifications"
       >
         <img
@@ -74,7 +75,6 @@
         <button
           class="appl-btn"
           data-testid="header-button-submit-app"
-          :class="{ 'appl-btn--fixed': isHeaderHidden }"
           @click="navigateToSubmit"
         >
           Подать заявку
@@ -381,6 +381,11 @@ h3 {
   box-shadow: 0 2px 2px rgba(0,0,0,0.05);
   position: relative;
   cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.user__notifications--active {
+  background-color: #e6e6e6;
 }
 
 .notifications__badge {

--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -572,7 +572,7 @@ export default {
         },
 
         unreadCount() {
-            return this.applications.filter(app => app.status === 'Непрочитано').length;
+            return this.applications.filter(app => !app.is_read).length;
         }
     },
     watch: {
@@ -1014,7 +1014,7 @@ export default {
                         this.shouldShake = false;
                     }, 600);
                 }
-            }, 60000);
+            }, 10000);
         }
     }
 }
@@ -1096,6 +1096,7 @@ export default {
     display: flex;
     flex-direction: column;
     gap: 8px;
+    justify-content: flex-end;
 }
 
 .table-toolbar {
@@ -1447,7 +1448,7 @@ export default {
 }
 
 .application-item.unread {
-    background-color: #fffeda;
+    background-color: #fff5e0;
 }
 
 .application-row {

--- a/frontend/src/views/CarsView.vue
+++ b/frontend/src/views/CarsView.vue
@@ -758,12 +758,16 @@ export default {
                 plateNumber: car.number,
                 mark: car.mark,
                 formatId: car.format_id || null,
-                organization: car.organization_name || null,
+                organization: car.active_app_org_name || car.organization_name || null,
                 organizationId: car.organization_id || null,
-                company: car.company_name || null,
+                company: car.active_app_company_name || car.company_name || null,
                 companyId: car.company_id || null,
                 isExisting: true,
                 unloadPlaces: [],
+                entry_date_to: car.active_entry_date_to,
+                entry_time_from: car.active_entry_time_from,
+                entry_time_to: car.active_entry_time_to,
+                isActive: car.status,
             };
             this.showDetailsViewModal = true;
         },

--- a/frontend/src/views/EmployeeView.vue
+++ b/frontend/src/views/EmployeeView.vue
@@ -555,8 +555,11 @@ export default {
                 passport_series_number: employee.passport_series_number,
                 patent_number: employee.patent_number,
                 other_permission: employee.other_permission,
-                organization: employee.organization_name,
-                company: employee.company_name,
+                organization: employee.active_app_org_name || employee.organization_name,
+                company: employee.active_app_company_name || employee.company_name,
+                entry_date_to: employee.active_entry_date_to,
+                pass_time: employee.active_pass_time,
+                isActive: employee.status,
                 target_tables: []
             };
             this.showDetailsModal = true;

--- a/internal/services/unique_car_service.go
+++ b/internal/services/unique_car_service.go
@@ -54,12 +54,17 @@ type UniqueCarWithRelations struct {
 	CompanyID        *int       `json:"company_id"`
 	FormatID         *int       `json:"format_id"`
 	UserID           *int       `json:"user_id"`
-	Status           bool       `json:"status"`
-	CreatedAt        *time.Time `json:"created_at"`
-	OrganizationName *string    `json:"organization_name"`
-	CompanyName      *string    `json:"company_name"`
-	FormatName       *string    `json:"format_name"`
-	UserName         *string    `json:"user_name"`
+	Status               bool       `json:"status"`
+	CreatedAt            *time.Time `json:"created_at"`
+	OrganizationName     *string    `json:"organization_name"`
+	CompanyName          *string    `json:"company_name"`
+	FormatName           *string    `json:"format_name"`
+	UserName             *string    `json:"user_name"`
+	ActiveEntryDateTo    *string    `json:"active_entry_date_to"`
+	ActiveEntryTimeFrom  *string    `json:"active_entry_time_from"`
+	ActiveEntryTimeTo    *string    `json:"active_entry_time_to"`
+	ActiveAppOrgName     *string    `json:"active_app_org_name"`
+	ActiveAppCompanyName *string    `json:"active_app_company_name"`
 }
 
 // NewUniqueCarRequest -- тело запроса на создание/обновление машины.
@@ -196,7 +201,49 @@ func (s *uniqueCarService) GetAll(ctx context.Context, username string, filterTy
 				AND app.status IN ('В работе', 'Завершено')
 				AND CURRENT_DATE <= a.entry_date_to::date
 				LIMIT 1
-			), false) as status`).
+			), false) as status,
+			(SELECT a.entry_date_to FROM cars cr
+				JOIN attachments a ON cr.attachment_id = a.id
+				JOIN applications app ON a.application_id = app.id
+				WHERE LOWER(TRIM(cr.car_number)) = LOWER(TRIM(uc.number))
+				AND cr.status = 1 AND app.status IN ('В работе', 'Завершено')
+				AND CURRENT_DATE <= a.entry_date_to::date
+				ORDER BY a.entry_date_to DESC LIMIT 1
+			) as active_entry_date_to,
+			(SELECT a.entry_time_from FROM cars cr
+				JOIN attachments a ON cr.attachment_id = a.id
+				JOIN applications app ON a.application_id = app.id
+				WHERE LOWER(TRIM(cr.car_number)) = LOWER(TRIM(uc.number))
+				AND cr.status = 1 AND app.status IN ('В работе', 'Завершено')
+				AND CURRENT_DATE <= a.entry_date_to::date
+				ORDER BY a.entry_date_to DESC LIMIT 1
+			) as active_entry_time_from,
+			(SELECT a.entry_time_to FROM cars cr
+				JOIN attachments a ON cr.attachment_id = a.id
+				JOIN applications app ON a.application_id = app.id
+				WHERE LOWER(TRIM(cr.car_number)) = LOWER(TRIM(uc.number))
+				AND cr.status = 1 AND app.status IN ('В работе', 'Завершено')
+				AND CURRENT_DATE <= a.entry_date_to::date
+				ORDER BY a.entry_date_to DESC LIMIT 1
+			) as active_entry_time_to,
+			(SELECT ao.name FROM cars cr
+				JOIN attachments a ON cr.attachment_id = a.id
+				JOIN applications app ON a.application_id = app.id
+				LEFT JOIN organizations ao ON app.organization_id = ao.id
+				WHERE LOWER(TRIM(cr.car_number)) = LOWER(TRIM(uc.number))
+				AND cr.status = 1 AND app.status IN ('В работе', 'Завершено')
+				AND CURRENT_DATE <= a.entry_date_to::date
+				ORDER BY a.entry_date_to DESC LIMIT 1
+			) as active_app_org_name,
+			(SELECT ac.name FROM cars cr
+				JOIN attachments a ON cr.attachment_id = a.id
+				JOIN applications app ON a.application_id = app.id
+				LEFT JOIN companies ac ON app.company_id = ac.id
+				WHERE LOWER(TRIM(cr.car_number)) = LOWER(TRIM(uc.number))
+				AND cr.status = 1 AND app.status IN ('В работе', 'Завершено')
+				AND CURRENT_DATE <= a.entry_date_to::date
+				ORDER BY a.entry_date_to DESC LIMIT 1
+			) as active_app_company_name`).
 		Joins("LEFT JOIN organizations o ON uc.organization_id = o.id").
 		Joins("LEFT JOIN companies c ON uc.company_id = c.id").
 		Joins("LEFT JOIN license_plate_formats lpf ON uc.format_id = lpf.id").

--- a/internal/services/unique_employee_service.go
+++ b/internal/services/unique_employee_service.go
@@ -227,7 +227,7 @@ func (s *uniqueEmployeeService) GetAll(ctx context.Context, username string, fil
 				AND CURRENT_DATE <= a.entry_date_to::date
 				ORDER BY a.entry_date_to DESC LIMIT 1
 			) as active_entry_date_to,
-			(SELECT e.pass_time FROM employees e
+			(SELECT CONCAT(a.entry_time_from, ' - ', a.entry_time_to) FROM employees e
 				JOIN attachments a ON e.attachment_id = a.id
 				JOIN applications app ON a.application_id = app.id
 				WHERE e.passport_series_number_hmac = ue.passport_series_number_hmac

--- a/internal/services/unique_employee_service.go
+++ b/internal/services/unique_employee_service.go
@@ -83,6 +83,10 @@ type UniqueEmployeeWithRelations struct {
 	OrganizationName     *string    `json:"organization_name"`
 	CompanyName          *string    `json:"company_name"`
 	CitizenshipName      *string    `json:"citizenship_name"`
+	ActiveEntryDateTo    *string    `json:"active_entry_date_to"`
+	ActivePassTime       *string    `json:"active_pass_time"`
+	ActiveAppOrgName     *string    `json:"active_app_org_name"`
+	ActiveAppCompanyName *string    `json:"active_app_company_name"`
 }
 
 // NewUniqueEmployeeRequest -- тело запроса на создание/обновление сотрудника.
@@ -214,7 +218,41 @@ func (s *uniqueEmployeeService) GetAll(ctx context.Context, username string, fil
 				AND app.status IN ('В работе', 'Завершено')
 				AND CURRENT_DATE <= a.entry_date_to::date
 				LIMIT 1
-			), false) as status`).
+			), false) as status,
+			(SELECT a.entry_date_to FROM employees e
+				JOIN attachments a ON e.attachment_id = a.id
+				JOIN applications app ON a.application_id = app.id
+				WHERE e.passport_series_number_hmac = ue.passport_series_number_hmac
+				AND e.status = 1 AND app.status IN ('В работе', 'Завершено')
+				AND CURRENT_DATE <= a.entry_date_to::date
+				ORDER BY a.entry_date_to DESC LIMIT 1
+			) as active_entry_date_to,
+			(SELECT e.pass_time FROM employees e
+				JOIN attachments a ON e.attachment_id = a.id
+				JOIN applications app ON a.application_id = app.id
+				WHERE e.passport_series_number_hmac = ue.passport_series_number_hmac
+				AND e.status = 1 AND app.status IN ('В работе', 'Завершено')
+				AND CURRENT_DATE <= a.entry_date_to::date
+				ORDER BY a.entry_date_to DESC LIMIT 1
+			) as active_pass_time,
+			(SELECT ao.name FROM employees e
+				JOIN attachments a ON e.attachment_id = a.id
+				JOIN applications app ON a.application_id = app.id
+				LEFT JOIN organizations ao ON app.organization_id = ao.id
+				WHERE e.passport_series_number_hmac = ue.passport_series_number_hmac
+				AND e.status = 1 AND app.status IN ('В работе', 'Завершено')
+				AND CURRENT_DATE <= a.entry_date_to::date
+				ORDER BY a.entry_date_to DESC LIMIT 1
+			) as active_app_org_name,
+			(SELECT ac.name FROM employees e
+				JOIN attachments a ON e.attachment_id = a.id
+				JOIN applications app ON a.application_id = app.id
+				LEFT JOIN companies ac ON app.company_id = ac.id
+				WHERE e.passport_series_number_hmac = ue.passport_series_number_hmac
+				AND e.status = 1 AND app.status IN ('В работе', 'Завершено')
+				AND CURRENT_DATE <= a.entry_date_to::date
+				ORDER BY a.entry_date_to DESC LIMIT 1
+			) as active_app_company_name`).
 		Joins("LEFT JOIN organizations o ON ue.organization_id = o.id").
 		Joins("LEFT JOIN companies c ON ue.company_id = c.id").
 		Joins("LEFT JOIN citizenships cit ON ue.citizenship_id = cit.id")


### PR DESCRIPTION
## Summary

Третья порция фиксов из #316 по результатам ручного тестирования.

### UI/UX
- Колокольчик уведомлений серый при открытых уведомлениях
- Кнопка "Подать заявку" всегда в хедере (убрана плавающая позиция)
- Жёлтый цвет непрочитанных - теплый (#fff5e0 вместо кислотного #fffeda)
- Счётчик "Новые: N" синхронизирован с is_read (был баг - считал по status)
- Тряска бейджа "Новые: N" каждые 10 секунд
- Кнопка "Заявки на сегодня" прибита к низу фильтров
- Иконки "Детали" в EmployeesList/VehiclesList - единый серый (#8c8c8c)
- FactTable: LoaderSpinner вместо cursor:progress при обновлении
- RefreshButton: cooldown 2 сек между нажатиями (защита от rate limit)

### Тост "Места прохода"
- Флаг через sessionStorage - не сбрасывается при перемонтировании компонента

### Backend (Go)
- unique_employee_service: подзапросы active_entry_date_to, active_pass_time, active_app_org_name, active_app_company_name
- unique_car_service: подзапросы active_entry_date_to, active_entry_time_from/to, active_app_org_name, active_app_company_name

### Frontend модалки
- EmployeeView: передает org/company/dates из активной заявки в EmployeeDetailsModal
- CarsView: передает org/company/dates/times из активной заявки в VehicleDetailsModal

Relates #316

## Test plan
- [ ] Колокольчик серый при открытых уведомлениях
- [ ] Кнопка "Подать заявку" не плавает
- [ ] Счётчик "Новые" совпадает с желтыми строками
- [ ] Бейдж трясется каждые 10 секунд
- [ ] RefreshButton не даёт спамить (cooldown 2 сек)
- [ ] Модалка сотрудника показывает организацию, компанию, "Действует до"
- [ ] Модалка машины показывает организацию, компанию, даты
- [ ] Тост про места прохода - один раз за сессию