### PR TITLE
fix: grid дат, бейджи, open-application, скачивание (#316)

### DIFF
--- a/frontend/src/components/ApplicationDetail/ApplicationAttachmentDetail.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationAttachmentDetail.vue
@@ -317,10 +317,9 @@ export default {
 .attachment-header-section {
     padding: 15px;
     border-bottom: 1px solid #e6e6e6;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 10px 20px;
-    align-items: baseline;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    gap: 12px 24px;
 }
 
 .attachment-details h4 {
@@ -328,7 +327,7 @@ export default {
     color: #4F5BDF;
     font-weight: 700;
     margin: 0;
-    width: 100%;
+    grid-column: 1 / -1;
 }
 
 .date-range, .time-range {
@@ -358,9 +357,9 @@ export default {
 .custom-values-section {
     padding: 15px;
     border-bottom: 1px solid #e6e6e6;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 6px 20px;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    gap: 12px 24px;
 }
 
 .custom-value-row {

--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -272,6 +272,7 @@
       :show-car-features="true"
       :source="'carstable'"
       @close="closeVehicleDetails"
+      @open-application="$emit('open-application', $event)"
     />
 
     <!-- Модальное окно истории всех машин -->

--- a/frontend/src/components/applications/DownloadBlanksModal.vue
+++ b/frontend/src/components/applications/DownloadBlanksModal.vue
@@ -164,7 +164,7 @@ export default {
       this.downloadingAll = true;
       try {
         for (let i = 0; i < this.selectedIds.length; i++) {
-          if (i > 0) await new Promise(r => setTimeout(r, 500));
+          if (i > 0) await new Promise(r => setTimeout(r, 1000));
           await this.downloadOne({ id: this.selectedIds[i] });
         }
         useUiStore().success(`Скачано: ${this.selectedIds.length}`);

--- a/frontend/src/components/ui/StatusBadge.vue
+++ b/frontend/src/components/ui/StatusBadge.vue
@@ -61,22 +61,22 @@ export default {
 }
 
 /* Green */
-.status-badge--green { background: #dcfce7; color: #166534; }
+.status-badge--green { background: #dcfce7; color: #166534; border: 1px solid #bbf7d0; }
 .status-badge--green .status-badge__dot { background: #22c55e; }
 
 /* Gray */
-.status-badge--gray { background: #e5e7eb; color: #374151; }
+.status-badge--gray { background: #e5e7eb; color: #374151; border: 1px solid #d1d5db; }
 .status-badge--gray .status-badge__dot { background: #9ca3af; }
 
 /* Yellow */
-.status-badge--yellow { background: #fef3c7; color: #92400e; }
+.status-badge--yellow { background: #fef3c7; color: #92400e; border: 1px solid #fde68a; }
 .status-badge--yellow .status-badge__dot { background: #f59e0b; }
 
 /* Red */
-.status-badge--red { background: #fee2e2; color: #991b1b; }
+.status-badge--red { background: #fee2e2; color: #991b1b; border: 1px solid #fecaca; }
 .status-badge--red .status-badge__dot { background: #ef4444; }
 
 /* Blue */
-.status-badge--blue { background: #dbeafe; color: #1e40af; }
+.status-badge--blue { background: #dbeafe; color: #1e40af; border: 1px solid #bfdbfe; }
 .status-badge--blue .status-badge__dot { background: #3b82f6; }
 </style>


### PR DESCRIPTION
## Summary

Пятая (финальная) порция фиксов из #316.

### Изменения
- **ApplicationAttachmentDetail**: CSS grid вместо flex-wrap для дат/времени/доп.полей - равномерные колонки
- **StatusBadge**: добавлен border для всех цветовых вариантов (как в ApplicationsCenter)
- **CarsTable**: пробросил @open-application emit для VehicleDetailsModal -> TablesComponent
- **DownloadBlanksModal**: увеличена задержка между скачиваниями до 1 сек

Closes #316

## Test plan
- [ ] Даты/время в деталях заявки - равномерная сетка
- [ ] Бейджи статусов с бордером (сотрудники, машины, таблицы)
- [ ] "Открыть заявку" из модалки машины в CarsTable открывает ApplicationDetail