### PR TITLE
fix: колокольчик, ZIP имя, padding, иконки (#316)

### DIFF
--- a/frontend/src/components/CreateApplication/EmployeesList.vue
+++ b/frontend/src/components/CreateApplication/EmployeesList.vue
@@ -372,7 +372,7 @@ export default {
 }
 
 .details-btn .details-icon {
-    color: #6b6b6b;
+    color: #4a4a4a;
 }
 
 .details-btn:hover .details-icon {

--- a/frontend/src/components/CreateApplication/VehiclesList.vue
+++ b/frontend/src/components/CreateApplication/VehiclesList.vue
@@ -375,7 +375,7 @@ export default {
 }
 
 .details-btn .details-icon {
-    color: #6b6b6b;
+    color: #4a4a4a;
 }
 
 .details-btn:hover .details-icon {

--- a/frontend/src/components/TheHeader/TheHeader.vue
+++ b/frontend/src/components/TheHeader/TheHeader.vue
@@ -384,7 +384,8 @@ h3 {
   transition: background-color 0.2s ease;
 }
 
-.user__notifications--active .notifications__icon {
+.user__notifications--active .notifications__icon,
+.user__notifications--active .notifications__icon:hover {
   filter: grayscale(100%) brightness(0.6);
 }
 

--- a/frontend/src/components/UserNotificationsInline.vue
+++ b/frontend/src/components/UserNotificationsInline.vue
@@ -260,7 +260,7 @@ export default {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 8px 20px;
+  padding: 10px 20px;
   flex-shrink: 0;
   background: #fff;
   gap: 12px;
@@ -367,7 +367,7 @@ export default {
 .notification-item {
   display: flex;
   align-items: flex-start;
-  padding: 8px 20px;
+  padding: 10px 20px;
   gap: 10px;
   border-bottom: 1px solid #f5f5f5;
   transition: background-color 0.15s;

--- a/frontend/src/components/applications/DownloadBlanksModal.vue
+++ b/frontend/src/components/applications/DownloadBlanksModal.vue
@@ -113,6 +113,7 @@ export default {
   name: 'DownloadBlanksModal',
   props: {
     applicationId: { type: Number, required: true },
+    applicationInfo: { type: Object, default: null },
   },
   emits: ['close'],
   data() {
@@ -184,7 +185,12 @@ export default {
         }
       }
       const content = await zip.generateAsync({ type: 'blob' });
-      saveBlobAs(content, `blanks_${this.applicationId}.zip`);
+      const info = this.applicationInfo;
+      const num = info?.application_number || this.applicationId;
+      const date = info?.sending_datetime ? new Date(info.sending_datetime).toLocaleDateString('ru-RU') : '';
+      const org = info?.organization_name || '';
+      const parts = [num, date, org].filter(Boolean).join('_').replace(/[/\\:*?"<>|]/g, '_');
+      saveBlobAs(content, `${parts}.zip`);
       useUiStore().success(`Скачано: ${ids.length} файлов в ZIP`);
     },
     async downloadAll() {

--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -348,6 +348,7 @@
     <DownloadBlanksModal
       v-if="showDownloadModal && downloadAppId"
       :application-id="downloadAppId"
+      :application-info="downloadAppInfo"
       @close="showDownloadModal = false"
     />
   </section>
@@ -383,6 +384,7 @@ export default {
         return {
             showDownloadModal: false,
             downloadAppId: 0,
+            downloadAppInfo: null,
             searchQuery: '',
             selectedOrganizationId: null,
             selectedOrganizationName: '',
@@ -914,6 +916,7 @@ export default {
 
         downloadApplication(application) {
             this.downloadAppId = application.id;
+            this.downloadAppInfo = application;
             this.showDownloadModal = true;
         },
 


### PR DESCRIPTION
## Summary

Седьмая порция - правки по третьему раунду тестирования.

### Изменения
1. Колокольчик: иконка серая и при hover, и без hover пока уведомления открыты
2. ZIP имя: "номер_дата_организация.zip" вместо "blanks_ID.zip"
3. Уведомления: padding 10px 20px (было 8px 20px)
4. Иконки деталей: #4a4a4a (ещё темнее)

Relates #316

## Test plan
- [ ] Колокольчик серый пока уведомления открыты (и при hover, и без)
- [ ] ZIP архив: имя содержит номер заявки, дату, организацию
- [ ] Padding уведомлений 10px
- [ ] Иконки деталей заметно темнее