### PR TITLE
fix: ZIP-имя в UserApplications, иконки 18px (#316)

### DIFF
--- a/frontend/src/components/CreateApplication/EmployeesList.vue
+++ b/frontend/src/components/CreateApplication/EmployeesList.vue
@@ -365,8 +365,8 @@ export default {
 }
 
 .details-icon, .edit-icon, .delete-icon {
-    width: 14px;
-    height: 14px;
+    width: 18px;
+    height: 18px;
     opacity: 0.6;
     transition: opacity 0.2s ease, color 0.2s ease;
 }

--- a/frontend/src/components/CreateApplication/VehiclesList.vue
+++ b/frontend/src/components/CreateApplication/VehiclesList.vue
@@ -368,8 +368,8 @@ export default {
 }
 
 .details-icon, .edit-icon, .delete-icon {
-    width: 14px;
-    height: 14px;
+    width: 18px;
+    height: 18px;
     opacity: 0.6;
     transition: opacity 0.2s ease, color 0.2s ease;
 }

--- a/frontend/src/components/UserApplications.vue
+++ b/frontend/src/components/UserApplications.vue
@@ -223,6 +223,7 @@
       <DownloadBlanksModal
         v-if="showDownloadModal && downloadAppId"
         :application-id="downloadAppId"
+        :application-info="downloadAppInfo"
         @close="showDownloadModal = false"
       />
     </teleport>
@@ -274,7 +275,8 @@ export default {
       currentUserId: null,
       currentUserName: '',
       showDownloadModal: false,
-      downloadAppId: null
+      downloadAppId: null,
+      downloadAppInfo: null
     };
   },
   computed: {
@@ -540,6 +542,7 @@ export default {
 
     downloadApplication(application) {
       this.downloadAppId = application.id;
+      this.downloadAppInfo = application;
       this.showDownloadModal = true;
     },
 


### PR DESCRIPTION
## Summary
- Передал `applicationInfo` в `DownloadBlanksModal` из `UserApplications.vue` - ZIP-архив теперь называется "номер_дата_организация.zip" вместо "11.zip"
- Увеличил иконки деталей с 14px до 18px в списках сотрудников и ТС

## Test plan
- [ ] Скачать бланки из "Мои заявки" - ZIP-имя содержит номер, дату, организацию
- [ ] Иконки глаза в списках сотрудников/ТС стали крупнее