### PR TITLE
feat: доделал корзину таблиц (#186)

### DIFF
--- a/frontend/src/api/trash.js
+++ b/frontend/src/api/trash.js
@@ -37,3 +37,8 @@ export async function clearTrash(systemTableID) {
   });
   return res.json();
 }
+
+export async function getTrashHistory(systemTableID) {
+  const res = await apiRequest(`/system-tables/${systemTableID}/trash/history`);
+  return res.json();
+}

--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -303,6 +303,7 @@ export default {
   },
   props: {
     tableName: { type: String, default: '' },
+    tableId: { type: Number, default: null },
     searchQuery: { type: String, default: '' },
     selectedOrganizationId: { type: [Number, String], default: null },
     selectedUnloadingPlaceId: { type: [Number, String], default: null },
@@ -725,7 +726,7 @@ export default {
       try {
         const response = await apiRequest(`/cars/${item.id}/deactivate`, {
           method: "PUT",
-          body: JSON.stringify({ status: 0, user_id: this.currentUserId })
+          body: JSON.stringify({ status: 0, user_id: this.currentUserId, table_id: this.tableId })
         });
         if (!response.ok) {
           console.error("Ошибка при удалении");

--- a/frontend/src/components/CarsTableHistoryModal.vue
+++ b/frontend/src/components/CarsTableHistoryModal.vue
@@ -425,6 +425,12 @@ export default {
         return 'Отметил о прибытии';
       } else if (item.action_type === 'exit') {
         return 'Машина уехала';
+      } else if (item.action_type === 'delete') {
+        return 'Удаление из таблицы';
+      } else if (item.action_type === 'restore') {
+        return 'Восстановление в таблице';
+      } else if (item.action_type === 'purge') {
+        return 'Безвозвратное удаление';
       }
       return item.action_type;
     },
@@ -455,7 +461,8 @@ export default {
     },
 
     getActionClass(actionType) {
-      return actionType === 'entry' ? 'dot-entry' : 'dot-exit';
+      if (actionType === 'entry' || actionType === 'restore') return 'dot-entry';
+      return 'dot-exit';
     },
 
     formatDateTime(dateTimeString) {

--- a/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
@@ -57,6 +57,30 @@
                 v-if="employee"
                 class="employee-details"
               >
+                <!-- Секция Удаление (только корзина) -->
+                <div
+                  v-if="source === 'trash' && (employee.deletedByName || employee.deletedAtText)"
+                  class="details-section"
+                >
+                  <div class="section-header">
+                    <h4 class="section-title">
+                      Удаление
+                    </h4>
+                  </div>
+                  <div class="section-body">
+                    <div class="details-grid two-columns">
+                      <div class="detail-item">
+                        <span class="detail-label">Дата и время удаления:</span>
+                        <span class="detail-value">{{ employee.deletedAtText || '-' }}</span>
+                      </div>
+                      <div class="detail-item">
+                        <span class="detail-label">Кто удалил:</span>
+                        <span class="detail-value">{{ employee.deletedByName || '-' }}</span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
                 <!-- Основная информация -->
                 <div class="details-section">
                   <div class="section-header">

--- a/frontend/src/components/CreateApplication/EmployeesTableHistoryModal.vue
+++ b/frontend/src/components/CreateApplication/EmployeesTableHistoryModal.vue
@@ -403,7 +403,8 @@ export default {
     },
 
     getActionClass(actionType) {
-      return actionType === 'entry' ? 'dot-entry' : 'dot-exit';
+      if (actionType === 'entry' || actionType === 'restore') return 'dot-entry';
+      return 'dot-exit';
     },
 
     getActionText(item) {
@@ -411,6 +412,12 @@ export default {
         return 'Проход на территорию';
       } else if (item.action_type === 'exit') {
         return 'Выход с территории';
+      } else if (item.action_type === 'delete') {
+        return 'Удаление из таблицы';
+      } else if (item.action_type === 'restore') {
+        return 'Восстановление в таблице';
+      } else if (item.action_type === 'purge') {
+        return 'Безвозвратное удаление';
       }
       return item.action_type;
     },

--- a/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
@@ -81,6 +81,30 @@
                 v-if="vehicle"
                 class="vehicle-details"
               >
+                <!-- Секция Удаление (только корзина) -->
+                <div
+                  v-if="source === 'trash' && (vehicle.deletedByName || vehicle.deletedAtText)"
+                  class="details-section"
+                >
+                  <div class="section-header">
+                    <h4 class="section-title">
+                      Удаление
+                    </h4>
+                  </div>
+                  <div class="section-body">
+                    <div class="details-grid two-columns">
+                      <div class="detail-item">
+                        <span class="detail-label">Дата и время удаления:</span>
+                        <span class="detail-value">{{ vehicle.deletedAtText || '-' }}</span>
+                      </div>
+                      <div class="detail-item">
+                        <span class="detail-label">Кто удалил:</span>
+                        <span class="detail-value">{{ vehicle.deletedByName || '-' }}</span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
                 <!-- Секция Основная информация -->
                 <div class="details-section">
                   <div class="section-header">

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -689,7 +689,7 @@ export default {
       try {
         const response = await apiRequest(`/employees/${item.id}/deactivate`, {
           method: "PUT",
-          body: JSON.stringify({ status: 0, user_id: this.currentUserId })
+          body: JSON.stringify({ status: 0, user_id: this.currentUserId, table_id: this.currentTableId })
         });
         if (response.ok) {
           this.itemsData.splice(itemIndex, 1);

--- a/frontend/src/views/TrashView.vue
+++ b/frontend/src/views/TrashView.vue
@@ -3,7 +3,14 @@
     <header class="trash-header">
       <div class="trash-titlebar">
         <h2 class="trash-title">
-          Таблица <RouterLink :to="`/table/${tableName}`" class="trash-title__name">{{ displayName }}</RouterLink> / Корзина
+          Таблица
+          <RouterLink
+            :to="`/table/${tableName}`"
+            class="trash-title__name"
+          >
+            {{ displayName }}
+          </RouterLink>
+          / Корзина
         </h2>
         <RouterLink
           :to="`/table/${tableName}`"
@@ -46,15 +53,15 @@
         <div class="trash-filters__group trash-filters__group--right">
           <button
             class="trash-btn trash-btn--ghost"
-            data-testid="trash-clear-filters"
-            @click="clearFilters"
+            data-testid="trash-history"
+            @click="openHistory"
           >
-            Очистить
+            История
           </button>
           <button
             class="trash-btn trash-btn--ghost"
             data-testid="trash-export"
-            :disabled="!items.length"
+            :disabled="!items.length || isExporting"
             @click="onExport"
           >
             <img
@@ -65,6 +72,14 @@
             Экспорт
           </button>
           <button
+            class="trash-btn trash-btn--ghost"
+            data-testid="trash-clear"
+            :disabled="!items.length"
+            @click="onClearAll"
+          >
+            Очистить
+          </button>
+          <button
             class="trash-btn trash-btn--refresh"
             data-testid="trash-refresh"
             :disabled="isLoading"
@@ -73,6 +88,7 @@
             <img
               src="@/assets/icons/refresh.png"
               class="trash-btn__icon"
+              :class="{ 'trash-btn__icon--spin': isLoading }"
               alt=""
             >
             Обновить
@@ -86,17 +102,15 @@
         <h3 class="trash-card__title">
           {{ tableType === 'cars' ? 'Удаленные автомобили' : 'Удаленные сотрудники' }}
         </h3>
-        <button
-          class="trash-card__link"
-          data-testid="trash-restore-all-link"
-          :disabled="!items.length"
-          @click="onRestoreAll"
-        >
-          Восстановить
-        </button>
 
         <div class="trash-card__spacer" />
 
+        <span
+          v-if="selectedIds.length"
+          class="trash-card__selected"
+        >
+          Выбрано: {{ selectedIds.length }}
+        </span>
         <button
           class="trash-btn trash-btn--primary"
           data-testid="trash-restore-selected"
@@ -112,6 +126,7 @@
           v-if="isLoading"
           class="trash-state"
         >
+          <span class="trash-spinner" />
           Загрузка...
         </div>
         <div
@@ -133,6 +148,15 @@
         >
           <thead>
             <tr>
+              <th class="trash-table__th trash-table__th-check">
+                <input
+                  type="checkbox"
+                  class="trash-check"
+                  :checked="allSelected"
+                  data-testid="trash-select-all"
+                  @change="toggleSelectAll"
+                >
+              </th>
               <th
                 v-for="col in columns"
                 :key="col.key"
@@ -155,8 +179,22 @@
             <tr
               v-for="item in sortedItems"
               :key="item.id"
+              class="trash-table__row"
               data-testid="trash-row"
+              @click="onRowClick(item)"
             >
+              <td
+                class="trash-table__td trash-table__td-check"
+                @click.stop
+              >
+                <input
+                  type="checkbox"
+                  class="trash-check"
+                  :checked="isSelected(item.id)"
+                  data-testid="trash-row-check"
+                  @change="toggleSelect(item.id)"
+                >
+              </td>
               <td class="trash-table__td trash-table__td--muted">
                 {{ item.application_number || '—' }}
               </td>
@@ -178,6 +216,9 @@
                 <td class="trash-table__td">
                   {{ item.first_name || '—' }}
                 </td>
+                <td class="trash-table__td">
+                  {{ item.middle_name || '—' }}
+                </td>
               </template>
               <td class="trash-table__td">
                 {{ item.organization || '—' }}
@@ -191,7 +232,10 @@
               <td class="trash-table__td trash-table__td--danger">
                 {{ tableType === 'cars' ? 'Удалена' : 'Удалён' }}
               </td>
-              <td class="trash-table__td trash-table__td--actions">
+              <td
+                class="trash-table__td trash-table__td--actions"
+                @click.stop
+              >
                 <button
                   class="trash-icon-btn"
                   title="Удалить безвозвратно"
@@ -209,20 +253,120 @@
         </table>
       </div>
     </article>
+
+    <!-- Детальная модалка -->
+    <VehicleDetailsModal
+      v-if="tableType === 'cars' && showDetails"
+      :show="showDetails"
+      :vehicle="selectedDetail"
+      :all-unloading-places="[]"
+      :license-plate-formats="[]"
+      :show-car-features="false"
+      :source="'trash'"
+      @close="closeDetails"
+    />
+    <EmployeeDetailsModal
+      v-if="tableType === 'people' && showDetails"
+      :show="showDetails"
+      :employee="selectedDetail"
+      :all-tables="[]"
+      :source="'trash'"
+      @close="closeDetails"
+      @open-application="() => {}"
+    />
+
+    <!-- Модалка истории корзины -->
+    <Teleport to="body">
+      <transition name="modal-fade">
+        <div
+          v-if="showHistory"
+          class="trash-modal-overlay"
+          @click.self="closeHistory"
+        >
+          <div class="trash-modal">
+            <div class="trash-modal__header">
+              <h3 class="trash-modal__title">
+                История корзины
+              </h3>
+              <button
+                class="trash-modal__close"
+                data-testid="trash-history-close"
+                @click="closeHistory"
+              >
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 14 14"
+                  fill="none"
+                >
+                  <path
+                    d="M13 1L1 13M1 1L13 13"
+                    stroke="#666"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                  />
+                </svg>
+              </button>
+            </div>
+            <div class="trash-modal__body">
+              <div
+                v-if="historyLoading"
+                class="trash-state"
+              >
+                <span class="trash-spinner" />
+                Загрузка...
+              </div>
+              <div
+                v-else-if="!historyItems.length"
+                class="trash-state"
+              >
+                История пуста
+              </div>
+              <ul
+                v-else
+                class="trash-log"
+              >
+                <li
+                  v-for="h in historyItems"
+                  :key="h.id"
+                  class="trash-log__item"
+                >
+                  <span
+                    class="trash-log__dot"
+                    :class="h.action_type === 'bulk_restored' ? 'trash-log__dot--restore' : 'trash-log__dot--clear'"
+                  />
+                  <div class="trash-log__content">
+                    <p class="trash-log__text">
+                      {{ historyActionText(h) }}
+                    </p>
+                    <p class="trash-log__meta">
+                      {{ h.user_name || 'Система' }} · {{ formatDateTime(h.created_at) }}
+                    </p>
+                  </div>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </transition>
+    </Teleport>
   </section>
 </template>
 
 <script>
+import ExcelJS from 'exceljs';
 import { apiRequest } from '@/api/client';
 import { useUiStore } from '@/stores/ui';
-import { listTrash, restoreItems, purgeItem, clearTrash } from '@/api/trash';
+import { listTrash, restoreItems, purgeItem, clearTrash, getTrashHistory } from '@/api/trash';
 import SearchComponent from '@/components/SearchComponent.vue';
 import OrganizationFilter from '@/components/OrganizationFilter.vue';
 import DateFilter from '@/components/DateFilter.vue';
+import VehicleDetailsModal from '@/components/CreateApplication/VehicleDetailsModal.vue';
+import EmployeeDetailsModal from '@/components/CreateApplication/EmployeeDetailsModal.vue';
 
 export default {
   name: 'TrashView',
-  components: { SearchComponent, OrganizationFilter, DateFilter },
+  components: { SearchComponent, OrganizationFilter, DateFilter, VehicleDetailsModal, EmployeeDetailsModal },
   data() {
     return {
       tableID: 0,
@@ -231,6 +375,7 @@ export default {
       items: [],
       selectedIds: [],
       isLoading: false,
+      isExporting: false,
       error: '',
       filters: {
         search: '',
@@ -242,6 +387,11 @@ export default {
       searchTimer: null,
       sortField: 'deleted_at',
       sortDir: 'desc',
+      showDetails: false,
+      selectedDetail: null,
+      showHistory: false,
+      historyItems: [],
+      historyLoading: false,
     };
   },
   computed: {
@@ -261,6 +411,7 @@ export default {
         : [
             { key: 'last_name', label: 'Фамилия', sortable: true },
             { key: 'first_name', label: 'Имя', sortable: true },
+            { key: 'middle_name', label: 'Отчество', sortable: true },
           ];
       return [
         ...base,
@@ -268,7 +419,7 @@ export default {
         { key: 'organization', label: 'Организация', sortable: true },
         { key: 'entry_date_to', label: 'Действует до', sortable: true },
         { key: 'time', label: 'Время', sortable: false },
-        { key: 'status', label: 'Статус', sortable: true },
+        { key: 'status', label: 'Статус', sortable: false },
       ];
     },
     sortedItems() {
@@ -283,6 +434,9 @@ export default {
         return 0;
       });
       return arr;
+    },
+    allSelected() {
+      return this.items.length > 0 && this.selectedIds.length === this.items.length;
     },
   },
   watch: {
@@ -349,15 +503,6 @@ export default {
       this.filters.dateTo = null;
       this.reload();
     },
-    clearFilters() {
-      this.filters.search = '';
-      this.filters.organizationId = null;
-      this.filters.selectedDate = null;
-      this.filters.dateFrom = null;
-      this.filters.dateTo = null;
-      if (this.$refs.organizationFilter?.reset) this.$refs.organizationFilter.reset();
-      this.reload();
-    },
     sortBy(field) {
       if (this.sortField === field) {
         this.sortDir = this.sortDir === 'asc' ? 'desc' : 'asc';
@@ -365,6 +510,18 @@ export default {
         this.sortField = field;
         this.sortDir = 'desc';
       }
+    },
+    isSelected(id) {
+      return this.selectedIds.includes(id);
+    },
+    toggleSelect(id) {
+      const i = this.selectedIds.indexOf(id);
+      if (i === -1) this.selectedIds.push(id);
+      else this.selectedIds.splice(i, 1);
+    },
+    toggleSelectAll() {
+      if (this.allSelected) this.selectedIds = [];
+      else this.selectedIds = this.items.map(i => i.id);
     },
     formatDateTime(s) {
       if (!s) return '—';
@@ -390,7 +547,58 @@ export default {
       const to = item.entry_time_to || item.time_to;
       if (from && to) return `${from} - ${to}`;
       if (from) return from;
+      if (to) return to;
       return '—';
+    },
+    onRowClick(item) {
+      const deletedAtText = this.formatDateTime(item.deleted_at);
+      if (this.tableType === 'cars') {
+        this.selectedDetail = {
+          plateNumber: item.car_number,
+          mark: item.mark_name,
+          formatId: null,
+          organization: item.organization,
+          organizationId: null,
+          company: '',
+          companyId: null,
+          isExisting: true,
+          unloadPlaces: [],
+          entry_date_to: item.entry_date_to,
+          entry_time_from: item.entry_time_from,
+          entry_time_to: item.entry_time_to,
+          applicationId: null,
+          deletedByName: item.deleted_by_name,
+          deletedAtText,
+        };
+      } else {
+        this.selectedDetail = {
+          id: item.id,
+          last_name: item.last_name,
+          first_name: item.first_name,
+          middle_name: item.middle_name,
+          position: '',
+          citizenshipName: '',
+          passport_series_number: '',
+          patent_number: '',
+          other_permission: '',
+          organization: item.organization,
+          organizationId: null,
+          company: '',
+          companyId: null,
+          entry_date_to: item.entry_date_to,
+          pass_time: this.formatTimeRange(item),
+          target_tables: [],
+          territory_status: null,
+          applicationId: null,
+          deletedByName: item.deleted_by_name,
+          deletedAtText,
+        };
+      }
+      this.showDetails = true;
+    },
+    closeDetails() {
+      this.showDetails = false;
+      this.selectedDetail = null;
     },
     async onRestoreSelected() {
       if (!this.selectedIds.length) return;
@@ -403,18 +611,6 @@ export default {
         } else {
           useUiStore().success(`Восстановлено: ${r}`);
         }
-        await this.reload();
-      } catch {
-        useUiStore().error('Не удалось восстановить');
-      }
-    },
-    async onRestoreAll() {
-      if (!this.items.length) return;
-      const ids = this.items.map(i => i.id);
-      try {
-        const result = await restoreItems(this.tableID, ids);
-        const r = (result && result.restored) || 0;
-        useUiStore().success(`Восстановлено: ${r}`);
         await this.reload();
       } catch {
         useUiStore().error('Не удалось восстановить');
@@ -452,8 +648,82 @@ export default {
         useUiStore().error('Не удалось очистить');
       }
     },
-    onExport() {
-      useUiStore().info('Экспорт корзины - скоро');
+    async openHistory() {
+      this.showHistory = true;
+      this.historyLoading = true;
+      try {
+        const data = await getTrashHistory(this.tableID);
+        this.historyItems = Array.isArray(data) ? data : [];
+      } catch {
+        useUiStore().error('Не удалось загрузить историю');
+        this.historyItems = [];
+      } finally {
+        this.historyLoading = false;
+      }
+    },
+    closeHistory() {
+      this.showHistory = false;
+    },
+    historyActionText(h) {
+      if (h.action_type === 'cleared') {
+        return `Корзина очищена (${h.affected_count} запис.)`;
+      }
+      if (h.action_type === 'bulk_restored') {
+        return `Восстановлено ${h.affected_count} элемент(ов)`;
+      }
+      return h.action_type;
+    },
+    async onExport() {
+      if (!this.items.length) return;
+      this.isExporting = true;
+      try {
+        const isCars = this.tableType === 'cars';
+        const headers = isCars
+          ? ['Номер заявки', 'Дата и время удаления', 'Номер Т/С', 'Марка', 'Организация', 'Действует до', 'Время', 'Статус', 'Кто удалил']
+          : ['Номер заявки', 'Дата и время удаления', 'Фамилия', 'Имя', 'Отчество', 'Организация', 'Действует до', 'Время', 'Статус', 'Кто удалил'];
+
+        const workbook = new ExcelJS.Workbook();
+        const worksheet = workbook.addWorksheet('Korzina');
+
+        const headerRow = worksheet.addRow(headers);
+        headerRow.height = 25;
+        headerRow.eachCell((cell) => {
+          cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FF4F5BDF' } };
+          cell.font = { name: 'Verdana', size: 11, bold: true, color: { argb: 'FFFFFFFF' } };
+          cell.alignment = { vertical: 'middle', horizontal: 'center' };
+        });
+
+        this.sortedItems.forEach((item, index) => {
+          const status = isCars ? 'Удалена' : 'Удалён';
+          const row = isCars
+            ? [item.application_number || '', this.formatDateTime(item.deleted_at), item.car_number || '', item.mark_name || '', item.organization || '', this.formatDate(item.entry_date_to), this.formatTimeRange(item), status, item.deleted_by_name || '']
+            : [item.application_number || '', this.formatDateTime(item.deleted_at), item.last_name || '', item.first_name || '', item.middle_name || '', item.organization || '', this.formatDate(item.entry_date_to), this.formatTimeRange(item), status, item.deleted_by_name || ''];
+          const r = worksheet.addRow(row);
+          r.height = 20;
+          const fillColor = index % 2 === 0 ? 'FFF0F5FF' : 'FFE0E9FF';
+          r.eachCell((cell) => {
+            cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: fillColor } };
+            cell.font = { name: 'Verdana', size: 9, color: { argb: 'FF333333' } };
+            cell.alignment = { vertical: 'middle' };
+          });
+        });
+
+        worksheet.columns = headers.map(() => ({ width: 22 }));
+
+        const buffer = await workbook.xlsx.writeBuffer();
+        const blob = new Blob([buffer], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.download = `korzina_${this.displayName}_${new Date().toISOString().slice(0, 10)}.xlsx`;
+        a.href = url;
+        a.click();
+        window.URL.revokeObjectURL(url);
+      } catch (e) {
+        console.error('Ошибка экспорта корзины', e);
+        useUiStore().error('Ошибка при экспорте');
+      } finally {
+        this.isExporting = false;
+      }
     },
   },
 };
@@ -620,6 +890,10 @@ export default {
   height: 15px;
 }
 
+.trash-btn__icon--spin {
+  animation: trash-spin 0.8s linear infinite;
+}
+
 .trash-btn--refresh {
   border-radius: 50px;
   color: #4F5BDF;
@@ -665,29 +939,13 @@ export default {
   color: #000000;
 }
 
-.trash-card__link {
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 0;
-  font-family: 'Montserrat', sans-serif;
-  font-weight: 500;
-  font-size: 12px;
-  line-height: 15px;
-  color: #A2A2A2;
-}
-
-.trash-card__link:hover:not(:disabled) {
-  color: #4F5BDF;
-}
-
-.trash-card__link:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
 .trash-card__spacer {
   flex: 1;
+}
+
+.trash-card__selected {
+  font-size: 13px;
+  color: #A2A2A2;
 }
 
 .trash-card__body {
@@ -702,10 +960,27 @@ export default {
   font-family: 'Montserrat', sans-serif;
   color: #A2A2A2;
   font-size: 14px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
 }
 
 .trash-state--error {
   color: #FF6668;
+}
+
+.trash-spinner {
+  width: 28px;
+  height: 28px;
+  border: 3px solid #E6E6E6;
+  border-top-color: #4F5BDF;
+  border-radius: 50%;
+  animation: trash-spin 0.8s linear infinite;
+}
+
+@keyframes trash-spin {
+  to { transform: rotate(360deg); }
 }
 
 .trash-table {
@@ -725,8 +1000,11 @@ export default {
   user-select: none;
 }
 
-.trash-table__th:first-child {
+.trash-table__th-check,
+.trash-table__td-check {
+  width: 44px;
   padding-left: 20px;
+  padding-right: 0;
 }
 
 .trash-table__th--sortable {
@@ -762,6 +1040,15 @@ export default {
   width: 60px;
 }
 
+.trash-table__row {
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.trash-table__row:hover {
+  background: #f8f9ff;
+}
+
 .trash-table__td {
   padding: 12px;
   font-weight: 400;
@@ -769,10 +1056,6 @@ export default {
   line-height: 17px;
   color: #000000;
   border-top: 1px solid #F0F0F0;
-}
-
-.trash-table__td:first-child {
-  padding-left: 20px;
 }
 
 .trash-table__td--muted {
@@ -786,6 +1069,13 @@ export default {
 .trash-table__td--actions {
   text-align: right;
   padding-right: 20px;
+}
+
+.trash-check {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+  accent-color: #4F5BDF;
 }
 
 .trash-icon-btn {
@@ -809,6 +1099,109 @@ export default {
   height: 20px;
 }
 
+/* История корзины */
+.trash-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.trash-modal {
+  background: #FFFFFF;
+  border-radius: 30px;
+  width: 480px;
+  max-width: calc(100vw - 40px);
+  max-height: 70vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  font-family: 'Montserrat', sans-serif;
+}
+
+.trash-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 24px;
+  border-bottom: 1px solid #E6E6E6;
+}
+
+.trash-modal__title {
+  margin: 0;
+  font-weight: 600;
+  font-size: 16px;
+  color: #000;
+}
+
+.trash-modal__close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+}
+
+.trash-modal__body {
+  padding: 12px 24px 24px;
+  overflow-y: auto;
+}
+
+.trash-log {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.trash-log__item {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.trash-log__dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  margin-top: 5px;
+  flex-shrink: 0;
+}
+
+.trash-log__dot--restore {
+  background: #34C759;
+}
+
+.trash-log__dot--clear {
+  background: #FF6668;
+}
+
+.trash-log__text {
+  margin: 0;
+  font-size: 14px;
+  color: #000;
+}
+
+.trash-log__meta {
+  margin: 2px 0 0;
+  font-size: 12px;
+  color: #A2A2A2;
+}
+
+.modal-fade-enter-active,
+.modal-fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+  opacity: 0;
+}
+
 @media (max-width: 1100px) {
   .trash-filters {
     flex-direction: column;
@@ -825,10 +1218,6 @@ export default {
   }
   .trash-title {
     font-size: 16px;
-  }
-  .trash-table th:nth-child(n+5),
-  .trash-table td:nth-child(n+5) {
-    display: none;
   }
 }
 </style>

--- a/internal/handlers/trash.go
+++ b/internal/handlers/trash.go
@@ -138,9 +138,9 @@ func (h *TrashHandler) PurgeOne(c echo.Context) error {
 	userID, _ := c.Get("user_id").(int)
 	switch tableType {
 	case "cars":
-		err = h.service.PurgeCar(c.Request().Context(), itemID, userID)
+		err = h.service.PurgeCar(c.Request().Context(), tableID, itemID, userID)
 	case "people":
-		err = h.service.PurgeEmployee(c.Request().Context(), itemID, userID)
+		err = h.service.PurgeEmployee(c.Request().Context(), tableID, itemID, userID)
 	default:
 		return echo.NewHTTPError(http.StatusBadRequest, "Тип таблицы не поддерживает корзину")
 	}
@@ -148,6 +148,26 @@ func (h *TrashHandler) PurgeOne(c echo.Context) error {
 		return err
 	}
 	return RespondMessage(c, "Удалено безвозвратно")
+}
+
+// History godoc
+// @Summary      Лог массовых действий с корзиной таблицы
+// @Tags         trash
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID SystemTable"
+// @Success      200 {array} models.TrashHistoryItem
+// @Router       /system-tables/{id}/trash/history [get]
+func (h *TrashHandler) History(c echo.Context) error {
+	tableID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid table id")
+	}
+	items, err := h.service.ListTrashHistory(c.Request().Context(), tableID)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, items)
 }
 
 // ClearAll godoc

--- a/internal/handlers/trash_test.go
+++ b/internal/handlers/trash_test.go
@@ -1,0 +1,152 @@
+package handlers_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"systemburo/internal/models"
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrash_CarFlowListScopingRestoreHistory(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "trashcar1", "pass123", 1, td.OrgID, td.CompanyID)
+
+	// Имя пользователю -> deleted_by_name не пустой.
+	var u models.User
+	require.NoError(t, db.Where("username = ?", "trashcar1").First(&u).Error)
+	require.NoError(t, db.Model(&models.User{}).Where("id = ?", u.ID).Updates(map[string]any{
+		"last_name": "Иванов", "first_name": "Иван", "middle_name": "Иванович",
+	}).Error)
+
+	// Две cars-таблицы для проверки скоупинга.
+	dn1, dn2 := "Корзина КПП 1", "Корзина КПП 2"
+	t1 := models.SystemTable{Name: "trash_cars_t1", DisplayName: &dn1, TableType: "cars", IsActive: true}
+	t2 := models.SystemTable{Name: "trash_cars_t2", DisplayName: &dn2, TableType: "cars", IsActive: true}
+	require.NoError(t, db.Create(&t1).Error)
+	require.NoError(t, db.Create(&t2).Error)
+
+	appID, _, carID := seedCarViaCompleteApp(t, e, db, token, "Test Organization")
+	activateCarViaApp(t, e, db, appID, td)
+
+	// Удаление из таблицы t1 с указанием table_id.
+	rec := testutil.PUT(t, e, fmt.Sprintf("/cars/%d/deactivate", carID),
+		fmt.Sprintf(`{"status":0,"user_id":%d,"table_id":%d}`, u.ID, t1.ID), testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	// Корзина t1: ровно 1 элемент с заполненными полями.
+	rec = testutil.GET(t, e, fmt.Sprintf("/system-tables/%d/trash", t1.ID), testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+	items := testutil.ParseSlice(t, rec)
+	require.Len(t, items, 1)
+	assert.Equal(t, float64(carID), items[0]["id"])
+	assert.Equal(t, "B002BB799", items[0]["car_number"])
+	assert.Equal(t, "Test Organization", items[0]["organization"])
+	assert.NotEmpty(t, items[0]["deleted_by_name"], "deleted_by_name должен заполняться")
+	assert.NotEmpty(t, items[0]["entry_date_to"], "Действует до должно заполняться")
+	assert.NotEmpty(t, items[0]["deleted_at"])
+
+	// Скоупинг: корзина t2 пуста.
+	rec = testutil.GET(t, e, fmt.Sprintf("/system-tables/%d/trash", t2.ID), testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Empty(t, testutil.ParseSlice(t, rec), "удалённое из t1 не должно показываться в t2")
+
+	// Восстановление.
+	rec = testutil.POST(t, e, fmt.Sprintf("/system-tables/%d/trash/restore", t1.ID),
+		fmt.Sprintf(`{"ids":[%d]}`, carID), testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	restoreResp := testutil.ParseMap(t, rec)
+	assert.Equal(t, float64(1), restoreResp["restored"])
+
+	// Машина снова активна и пропала из корзины.
+	var car models.Car
+	require.NoError(t, db.First(&car, carID).Error)
+	require.NotNil(t, car.Status)
+	assert.Equal(t, 1, *car.Status)
+	rec = testutil.GET(t, e, fmt.Sprintf("/system-tables/%d/trash", t1.ID), testutil.AuthHeader(token))
+	assert.Empty(t, testutil.ParseSlice(t, rec))
+
+	// История корзины: запись bulk_restored.
+	rec = testutil.GET(t, e, fmt.Sprintf("/system-tables/%d/trash/history", t1.ID), testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+	history := testutil.ParseSlice(t, rec)
+	require.NotEmpty(t, history)
+	assert.Equal(t, "bulk_restored", history[0]["action_type"])
+	assert.Equal(t, float64(1), history[0]["affected_count"])
+}
+
+func TestTrash_RestoreBlockedWithoutApprovedApplication(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "trashcar2", "pass123", 1, td.OrgID, td.CompanyID)
+	var u models.User
+	require.NoError(t, db.Where("username = ?", "trashcar2").First(&u).Error)
+
+	dn := "Корзина КПП"
+	tbl := models.SystemTable{Name: "trash_cars_blocked", DisplayName: &dn, TableType: "cars", IsActive: true}
+	require.NoError(t, db.Create(&tbl).Error)
+
+	// Машина без согласованной заявки (не активируем).
+	_, _, carID := seedCarViaCompleteApp(t, e, db, token, "Test Organization")
+	rec := testutil.PUT(t, e, fmt.Sprintf("/cars/%d/deactivate", carID),
+		fmt.Sprintf(`{"status":0,"user_id":%d,"table_id":%d}`, u.ID, tbl.ID), testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// В корзине есть, но восстановление запрещено.
+	rec = testutil.GET(t, e, fmt.Sprintf("/system-tables/%d/trash", tbl.ID), testutil.AuthHeader(token))
+	require.Len(t, testutil.ParseSlice(t, rec), 1)
+
+	rec = testutil.POST(t, e, fmt.Sprintf("/system-tables/%d/trash/restore", tbl.ID),
+		fmt.Sprintf(`{"ids":[%d]}`, carID), testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	resp := testutil.ParseMap(t, rec)
+	assert.Equal(t, float64(0), resp["restored"], "без согласованной заявки восстановление невозможно")
+}
+
+func TestTrash_PurgeOneRemovesFromTrash(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "trashcar3", "pass123", 1, td.OrgID, td.CompanyID)
+	var u models.User
+	require.NoError(t, db.Where("username = ?", "trashcar3").First(&u).Error)
+
+	dn := "Корзина КПП"
+	tbl := models.SystemTable{Name: "trash_cars_purge", DisplayName: &dn, TableType: "cars", IsActive: true}
+	require.NoError(t, db.Create(&tbl).Error)
+
+	appID, _, carID := seedCarViaCompleteApp(t, e, db, token, "Test Organization")
+	activateCarViaApp(t, e, db, appID, td)
+	rec := testutil.PUT(t, e, fmt.Sprintf("/cars/%d/deactivate", carID),
+		fmt.Sprintf(`{"status":0,"user_id":%d,"table_id":%d}`, u.ID, tbl.ID), testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Окончательное удаление.
+	rec = testutil.DELETE(t, e, fmt.Sprintf("/system-tables/%d/trash/%d", tbl.ID, carID), testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	// Пропала из корзины, is_purged=true, есть history purge.
+	rec = testutil.GET(t, e, fmt.Sprintf("/system-tables/%d/trash", tbl.ID), testutil.AuthHeader(token))
+	assert.Empty(t, testutil.ParseSlice(t, rec))
+
+	var car models.Car
+	require.NoError(t, db.First(&car, carID).Error)
+	assert.True(t, car.IsPurged)
+
+	var purgeCount int64
+	db.Model(&models.CarHistory{}).Where("car_id = ? AND action_type = 'purge'", carID).Count(&purgeCount)
+	assert.Equal(t, int64(1), purgeCount)
+}

--- a/internal/models/system_table_trash_history.go
+++ b/internal/models/system_table_trash_history.go
@@ -36,11 +36,21 @@ type TrashItem struct {
 	MarkName        *string    `json:"mark_name,omitempty"`
 	Organization    string     `json:"organization,omitempty"`
 	EntryDateTo     *string    `json:"entry_date_to,omitempty"`
+	EntryTimeFrom   *string    `json:"entry_time_from,omitempty"`
 	EntryTimeTo     *string    `json:"entry_time_to,omitempty"`
 	// Employees-only
 	LastName        *string    `json:"last_name,omitempty"`
 	FirstName       *string    `json:"first_name,omitempty"`
 	MiddleName      *string    `json:"middle_name,omitempty"`
+}
+
+// TrashHistoryItem - запись лога корзины с именем пользователя для API.
+type TrashHistoryItem struct {
+	ID            int       `json:"id"`
+	ActionType    string    `json:"action_type"`
+	AffectedCount int       `json:"affected_count"`
+	UserName      string    `json:"user_name,omitempty"`
+	CreatedAt     time.Time `json:"created_at"`
 }
 
 // RestoreTrashRequest - тело запроса POST /system-tables/:id/trash/restore.

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -313,6 +313,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	// или окончательно удалить. Тип элементов определяется по table_type
 	// системной таблицы (cars или people).
 	stg.GET("/:id/trash", trash.List)
+	stg.GET("/:id/trash/history", trash.History)
 	stg.POST("/:id/trash/restore", trash.Restore)
 	stg.DELETE("/:id/trash/:item_id", trash.PurgeOne)
 	stg.DELETE("/:id/trash", trash.ClearAll)

--- a/internal/services/car_service.go
+++ b/internal/services/car_service.go
@@ -110,8 +110,9 @@ type UpdateTerritoryStatusRequest struct {
 
 // DeactivateCarRequest -- тело запроса деактивации автомобиля.
 type DeactivateCarRequest struct {
-	Status int  `json:"status"`
-	UserID *int `json:"user_id"`
+	Status  int  `json:"status"`
+	UserID  *int `json:"user_id"`
+	TableID *int `json:"table_id"`
 }
 
 // ActivateCarRequest -- тело запроса активации автомобиля.

--- a/internal/services/car_status_service.go
+++ b/internal/services/car_status_service.go
@@ -156,6 +156,7 @@ func (s *carService) DeactivateCar(ctx context.Context, carID int, req Deactivat
 			ActionType: actionType,
 			Comment:    &comment,
 			CreatedAt:  now,
+			TableID:    req.TableID,
 		}
 		if err := tx.Create(&history).Error; err != nil {
 			slog.Error("не удалось добавить запись в историю автомобиля", "car_id", carID, "action_type", actionType, "error", err)

--- a/internal/services/employee_service.go
+++ b/internal/services/employee_service.go
@@ -33,8 +33,9 @@ type EmployeeService interface {
 
 // DeactivateEmployeeRequest -- тело запроса деактивации сотрудника.
 type DeactivateEmployeeRequest struct {
-	Status int  `json:"status"`
-	UserID *int `json:"user_id"`
+	Status  int  `json:"status"`
+	UserID  *int `json:"user_id"`
+	TableID *int `json:"table_id"`
 }
 
 // ActivateEmployeeRequest -- тело запроса активации сотрудника.
@@ -332,6 +333,7 @@ func (s *employeeService) DeactivateEmployee(ctx context.Context, employeeID int
 			ActionType: actionType,
 			Comment:    &comment,
 			CreatedAt:  now,
+			TableID:    req.TableID,
 		}
 		if err := tx.Create(&history).Error; err != nil {
 			slog.Error("не удалось добавить запись в историю сотрудника", "employee_id", employeeID, "action_type", actionType, "error", err)

--- a/internal/services/trash_service.go
+++ b/internal/services/trash_service.go
@@ -3,7 +3,6 @@ package services
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -15,19 +14,21 @@ import (
 
 // TrashService - корзина для cars/employees (#186). Использует существующий
 // soft-delete (status=0, date_removed/date_deleted) и новое поле is_purged
-// для финального удаления. Восстановление разрешено только при наличии
-// действующей согласованной заявки на эту запись.
+// для финального удаления. Привязка элемента к таблице идёт через запись
+// action_type='delete' в cars_history/employees_history с проставленным table_id.
+// Восстановление разрешено только при наличии действующей согласованной заявки.
 type TrashService interface {
 	ListCarsTrash(ctx context.Context, systemTableID int, filter models.TrashFilter) ([]models.TrashItem, error)
 	ListEmployeesTrash(ctx context.Context, systemTableID int, filter models.TrashFilter) ([]models.TrashItem, error)
 	RestoreCars(ctx context.Context, systemTableID int, ids []int, userID int) (int, error)
 	RestoreEmployees(ctx context.Context, systemTableID int, ids []int, userID int) (int, error)
-	PurgeCar(ctx context.Context, id, userID int) error
-	PurgeEmployee(ctx context.Context, id, userID int) error
+	PurgeCar(ctx context.Context, systemTableID, id, userID int) error
+	PurgeEmployee(ctx context.Context, systemTableID, id, userID int) error
 	ClearCarsTrash(ctx context.Context, systemTableID, userID int) (int, error)
 	ClearEmployeesTrash(ctx context.Context, systemTableID, userID int) (int, error)
 	CanRestoreCar(ctx context.Context, id int) (bool, string)
 	CanRestoreEmployee(ctx context.Context, id int) (bool, string)
+	ListTrashHistory(ctx context.Context, systemTableID int) ([]models.TrashHistoryItem, error)
 }
 
 type trashService struct {
@@ -39,83 +40,108 @@ func NewTrashService(db *gorm.DB) TrashService {
 	return &trashService{db: db}
 }
 
-// ListCarsTrash возвращает удалённые машины таблицы. Привязка car → system_table
-// идёт через attachment → application_responsible_users или через cars_history.table_id.
-// Используем cars_history.table_id - проще и надёжней.
+// ListCarsTrash возвращает удалённые из этой таблицы машины. Скоуп определяется
+// записью cars_history(action_type='delete', table_id) - именно она создаётся
+// при удалении машины из конкретной таблицы.
 func (s *trashService) ListCarsTrash(ctx context.Context, systemTableID int, filter models.TrashFilter) ([]models.TrashItem, error) {
-	rows, err := s.queryCarsTrash(ctx, systemTableID, filter)
-	if err != nil {
+	sql := `
+		SELECT c.id, 'car' AS type,
+			a.application_number,
+			c.entry_date_to, c.entry_time_from, c.entry_time_to,
+			COALESCE(c.mark_name, c.car_brand) AS mark_name, c.car_number,
+			COALESCE(org.name, '') AS organization,
+			c.date_removed AS deleted_at,
+			COALESCE((
+				SELECT format_short_name(u.last_name, u.first_name, u.middle_name)
+				FROM cars_history ch JOIN users u ON u.id = ch.user_id
+				WHERE ch.car_id = c.id AND ch.action_type = 'delete' AND ch.table_id = ?
+				ORDER BY ch.created_at DESC LIMIT 1
+			), '') AS deleted_by_name
+		FROM cars c
+		JOIN attachments att ON att.id = c.attachment_id
+		JOIN applications a ON a.id = att.application_id
+		LEFT JOIN organizations org ON org.id = a.organization_id
+		WHERE c.status = 0 AND c.date_removed IS NOT NULL AND c.is_purged = false
+			AND EXISTS (
+				SELECT 1 FROM cars_history ch
+				WHERE ch.car_id = c.id AND ch.action_type = 'delete' AND ch.table_id = ?
+			)`
+	args := []any{systemTableID, systemTableID}
+
+	if filter.Search != "" {
+		sql += ` AND (c.car_number ILIKE ? OR COALESCE(c.mark_name, c.car_brand) ILIKE ?)`
+		like := "%" + filter.Search + "%"
+		args = append(args, like, like)
+	}
+	if filter.OrganizationID > 0 {
+		sql += ` AND a.organization_id = ?`
+		args = append(args, filter.OrganizationID)
+	}
+	if filter.DateFrom != "" {
+		sql += ` AND c.date_removed >= ?`
+		args = append(args, filter.DateFrom)
+	}
+	if filter.DateTo != "" {
+		sql += ` AND c.date_removed <= ?`
+		args = append(args, filter.DateTo+" 23:59:59")
+	}
+	sql += ` ORDER BY c.date_removed DESC`
+
+	rows := make([]models.TrashItem, 0)
+	if err := s.db.WithContext(ctx).Raw(sql, args...).Scan(&rows).Error; err != nil {
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения корзины")
 	}
 	return rows, nil
 }
 
-func (s *trashService) queryCarsTrash(ctx context.Context, tableID int, f models.TrashFilter) ([]models.TrashItem, error) {
-	q := s.db.WithContext(ctx).
-		Table("cars c").
-		Select(`c.id, 'car' AS type,
-			a.application_number, c.entry_date_to, c.entry_time_to,
-			COALESCE(c.mark_name, c.car_brand) AS mark_name, c.car_number,
-			COALESCE(org.name, '') AS organization,
-			c.date_removed AS deleted_at,
-			COALESCE(format_short_name(u.last_name, u.first_name, u.middle_name), '') AS deleted_by_name`).
-		Joins(`JOIN attachments att ON att.id = c.attachment_id`).
-		Joins(`JOIN applications a ON a.id = att.application_id`).
-		Joins(`LEFT JOIN organizations org ON org.id = a.organization_id`).
-		Joins(`LEFT JOIN cars_history ch ON ch.car_id = c.id AND ch.action_type = 'delete' AND ch.table_id = ?`, tableID).
-		Joins(`LEFT JOIN users u ON u.id = ch.user_id`).
-		Where("c.status = 0 AND c.date_removed IS NOT NULL AND c.is_purged = false")
-	if f.Search != "" {
-		q = q.Where("(c.car_number ILIKE ? OR COALESCE(c.mark_name, c.car_brand) ILIKE ?)", "%"+f.Search+"%", "%"+f.Search+"%")
-	}
-	if f.OrganizationID > 0 {
-		q = q.Where("a.organization_id = ?", f.OrganizationID)
-	}
-	if f.DateFrom != "" {
-		q = q.Where("c.date_removed >= ?", f.DateFrom)
-	}
-	if f.DateTo != "" {
-		q = q.Where("c.date_removed <= ?", f.DateTo+" 23:59:59")
-	}
-	q = q.Order("c.date_removed DESC")
-
-	rows := make([]models.TrashItem, 0)
-	if err := q.Scan(&rows).Error; err != nil {
-		return nil, err
-	}
-	return rows, nil
-}
-
+// ListEmployeesTrash возвращает удалённых из этой таблицы сотрудников. Скоуп -
+// запись employees_history(action_type='delete', table_id).
 func (s *trashService) ListEmployeesTrash(ctx context.Context, systemTableID int, filter models.TrashFilter) ([]models.TrashItem, error) {
-	q := s.db.WithContext(ctx).
-		Table("employees e").
-		Select(`e.id, 'employee' AS type,
-			a.application_number, e.last_name, e.first_name, e.middle_name,
+	sql := `
+		SELECT e.id, 'employee' AS type,
+			a.application_number,
+			e.last_name, e.first_name, e.middle_name,
 			COALESCE(org.name, '') AS organization,
+			att.entry_date_to, att.entry_time_from, att.entry_time_to,
 			e.date_deleted AS deleted_at,
-			COALESCE(format_short_name(u.last_name, u.first_name, u.middle_name), '') AS deleted_by_name`).
-		Joins(`JOIN attachments att ON att.id = e.attachment_id`).
-		Joins(`JOIN applications a ON a.id = att.application_id`).
-		Joins(`LEFT JOIN organizations org ON org.id = a.organization_id`).
-		Joins(`LEFT JOIN employees_history eh ON eh.employee_id = e.id AND eh.action_type = 'delete' AND eh.table_id = ?`, systemTableID).
-		Joins(`LEFT JOIN users u ON u.id = eh.user_id`).
-		Where("e.status = 0 AND e.date_deleted IS NOT NULL AND e.is_purged = false")
+			COALESCE((
+				SELECT format_short_name(u.last_name, u.first_name, u.middle_name)
+				FROM employees_history eh JOIN users u ON u.id = eh.user_id
+				WHERE eh.employee_id = e.id AND eh.action_type = 'delete' AND eh.table_id = ?
+				ORDER BY eh.created_at DESC LIMIT 1
+			), '') AS deleted_by_name
+		FROM employees e
+		JOIN attachments att ON att.id = e.attachment_id
+		JOIN applications a ON a.id = att.application_id
+		LEFT JOIN organizations org ON org.id = a.organization_id
+		WHERE e.status = 0 AND e.date_deleted IS NOT NULL AND e.is_purged = false
+			AND EXISTS (
+				SELECT 1 FROM employees_history eh
+				WHERE eh.employee_id = e.id AND eh.action_type = 'delete' AND eh.table_id = ?
+			)`
+	args := []any{systemTableID, systemTableID}
+
 	if filter.Search != "" {
-		q = q.Where("(e.last_name ILIKE ? OR e.first_name ILIKE ?)", "%"+filter.Search+"%", "%"+filter.Search+"%")
+		sql += ` AND (e.last_name ILIKE ? OR e.first_name ILIKE ? OR e.middle_name ILIKE ?)`
+		like := "%" + filter.Search + "%"
+		args = append(args, like, like, like)
 	}
 	if filter.OrganizationID > 0 {
-		q = q.Where("a.organization_id = ?", filter.OrganizationID)
+		sql += ` AND a.organization_id = ?`
+		args = append(args, filter.OrganizationID)
 	}
 	if filter.DateFrom != "" {
-		q = q.Where("e.date_deleted >= ?", filter.DateFrom)
+		sql += ` AND e.date_deleted >= ?`
+		args = append(args, filter.DateFrom)
 	}
 	if filter.DateTo != "" {
-		q = q.Where("e.date_deleted <= ?", filter.DateTo+" 23:59:59")
+		sql += ` AND e.date_deleted <= ?`
+		args = append(args, filter.DateTo+" 23:59:59")
 	}
-	q = q.Order("e.date_deleted DESC")
+	sql += ` ORDER BY e.date_deleted DESC`
 
 	rows := make([]models.TrashItem, 0)
-	if err := q.Scan(&rows).Error; err != nil {
+	if err := s.db.WithContext(ctx).Raw(sql, args...).Scan(&rows).Error; err != nil {
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения корзины")
 	}
 	return rows, nil
@@ -131,7 +157,7 @@ func (s *trashService) CanRestoreCar(ctx context.Context, id int) (bool, string)
 		Where("c.id = ?", id).
 		Where("app.confirmation = ?", models.ConfirmationApproved).
 		Where("app.status NOT IN ?", []string{models.StatusCompleted, models.StatusRefused}).
-		Where("a.entry_date_to IS NULL OR a.entry_date_to::date >= CURRENT_DATE").
+		Where("(a.entry_date_to IS NULL OR a.entry_date_to::date >= CURRENT_DATE)").
 		Count(&cnt).Error
 	if err != nil || cnt == 0 {
 		return false, "Нет активной согласованной заявки - восстановление невозможно"
@@ -148,7 +174,7 @@ func (s *trashService) CanRestoreEmployee(ctx context.Context, id int) (bool, st
 		Where("e.id = ?", id).
 		Where("app.confirmation = ?", models.ConfirmationApproved).
 		Where("app.status NOT IN ?", []string{models.StatusCompleted, models.StatusRefused}).
-		Where("a.entry_date_to IS NULL OR a.entry_date_to::date >= CURRENT_DATE").
+		Where("(a.entry_date_to IS NULL OR a.entry_date_to::date >= CURRENT_DATE)").
 		Count(&cnt).Error
 	if err != nil || cnt == 0 {
 		return false, "Нет активной согласованной заявки - восстановление невозможно"
@@ -181,12 +207,8 @@ func (s *trashService) RestoreCars(ctx context.Context, systemTableID int, ids [
 			restored++
 		}
 	}
-	if restored > 1 {
-		tid := systemTableID
-		s.db.WithContext(ctx).Create(&models.SystemTableTrashHistory{
-			SystemTableID: tid, ActionType: models.TrashActionBulkRestored,
-			AffectedCount: restored, UserID: &userID,
-		})
+	if restored >= 1 {
+		s.logTrashAction(ctx, systemTableID, models.TrashActionBulkRestored, restored, userID)
 	}
 	return restored, nil
 }
@@ -216,47 +238,65 @@ func (s *trashService) RestoreEmployees(ctx context.Context, systemTableID int, 
 			restored++
 		}
 	}
-	if restored > 1 {
-		s.db.WithContext(ctx).Create(&models.SystemTableTrashHistory{
-			SystemTableID: systemTableID, ActionType: models.TrashActionBulkRestored,
-			AffectedCount: restored, UserID: &userID,
-		})
+	if restored >= 1 {
+		s.logTrashAction(ctx, systemTableID, models.TrashActionBulkRestored, restored, userID)
 	}
 	return restored, nil
 }
 
-func (s *trashService) PurgeCar(ctx context.Context, id, userID int) error {
+func (s *trashService) PurgeCar(ctx context.Context, systemTableID, id, userID int) error {
 	now := time.Now().UTC()
-	res := s.db.WithContext(ctx).Model(&models.Car{}).
-		Where("id = ? AND status = 0 AND is_purged = false", id).
-		Updates(map[string]any{"is_purged": true, "purged_at": now, "purged_by_user_id": userID})
-	if res.Error != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка удаления")
-	}
-	if res.RowsAffected == 0 {
-		return echo.NewHTTPError(http.StatusNotFound, "Запись не в корзине")
-	}
-	return nil
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		res := tx.Model(&models.Car{}).
+			Where("id = ? AND status = 0 AND is_purged = false", id).
+			Updates(map[string]any{"is_purged": true, "purged_at": now, "purged_by_user_id": userID})
+		if res.Error != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка удаления")
+		}
+		if res.RowsAffected == 0 {
+			return echo.NewHTTPError(http.StatusNotFound, "Запись не в корзине")
+		}
+		tableID := systemTableID
+		comment := "Безвозвратно удалён из корзины"
+		return tx.Create(&models.CarHistory{
+			CarID:      id,
+			UserID:     &userID,
+			ActionType: "purge",
+			TableID:    &tableID,
+			Comment:    &comment,
+			CreatedAt:  now,
+		}).Error
+	})
 }
 
-func (s *trashService) PurgeEmployee(ctx context.Context, id, userID int) error {
+func (s *trashService) PurgeEmployee(ctx context.Context, systemTableID, id, userID int) error {
 	now := time.Now().UTC()
-	res := s.db.WithContext(ctx).Model(&models.Employee{}).
-		Where("id = ? AND status = 0 AND is_purged = false", id).
-		Updates(map[string]any{"is_purged": true, "purged_at": now, "purged_by_user_id": userID})
-	if res.Error != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка удаления")
-	}
-	if res.RowsAffected == 0 {
-		return echo.NewHTTPError(http.StatusNotFound, "Запись не в корзине")
-	}
-	return nil
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		res := tx.Model(&models.Employee{}).
+			Where("id = ? AND status = 0 AND is_purged = false", id).
+			Updates(map[string]any{"is_purged": true, "purged_at": now, "purged_by_user_id": userID})
+		if res.Error != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка удаления")
+		}
+		if res.RowsAffected == 0 {
+			return echo.NewHTTPError(http.StatusNotFound, "Запись не в корзине")
+		}
+		tableID := systemTableID
+		comment := "Безвозвратно удалён из корзины"
+		return tx.Create(&models.EmployeeHistory{
+			EmployeeID: id,
+			UserID:     &userID,
+			ActionType: "purge",
+			TableID:    &tableID,
+			Comment:    &comment,
+			CreatedAt:  now,
+		}).Error
+	})
 }
 
 // ClearCarsTrash покрывает все cars в корзине этой таблицы (через cars_history.table_id).
 func (s *trashService) ClearCarsTrash(ctx context.Context, systemTableID, userID int) (int, error) {
 	now := time.Now().UTC()
-	// Подзапрос: cars где есть запись 'delete' в cars_history с нужным table_id.
 	subq := s.db.Table("cars_history").
 		Select("DISTINCT car_id").
 		Where("action_type = 'delete' AND table_id = ?", systemTableID)
@@ -264,13 +304,10 @@ func (s *trashService) ClearCarsTrash(ctx context.Context, systemTableID, userID
 		Where("status = 0 AND is_purged = false AND id IN (?)", subq).
 		Updates(map[string]any{"is_purged": true, "purged_at": now, "purged_by_user_id": userID})
 	if res.Error != nil {
-		return 0, echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Ошибка очистки: %v", res.Error))
+		return 0, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка очистки")
 	}
 	if res.RowsAffected > 0 {
-		s.db.WithContext(ctx).Create(&models.SystemTableTrashHistory{
-			SystemTableID: systemTableID, ActionType: models.TrashActionCleared,
-			AffectedCount: int(res.RowsAffected), UserID: &userID,
-		})
+		s.logTrashAction(ctx, systemTableID, models.TrashActionCleared, int(res.RowsAffected), userID)
 	}
 	return int(res.RowsAffected), nil
 }
@@ -287,10 +324,35 @@ func (s *trashService) ClearEmployeesTrash(ctx context.Context, systemTableID, u
 		return 0, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка очистки")
 	}
 	if res.RowsAffected > 0 {
-		s.db.WithContext(ctx).Create(&models.SystemTableTrashHistory{
-			SystemTableID: systemTableID, ActionType: models.TrashActionCleared,
-			AffectedCount: int(res.RowsAffected), UserID: &userID,
-		})
+		s.logTrashAction(ctx, systemTableID, models.TrashActionCleared, int(res.RowsAffected), userID)
 	}
 	return int(res.RowsAffected), nil
+}
+
+// ListTrashHistory возвращает лог массовых действий с корзиной таблицы.
+func (s *trashService) ListTrashHistory(ctx context.Context, systemTableID int) ([]models.TrashHistoryItem, error) {
+	sql := `
+		SELECT h.id, h.action_type, h.affected_count,
+			COALESCE(format_short_name(u.last_name, u.first_name, u.middle_name), '') AS user_name,
+			h.created_at
+		FROM system_table_trash_histories h
+		LEFT JOIN users u ON u.id = h.user_id
+		WHERE h.system_table_id = ?
+		ORDER BY h.created_at DESC`
+	rows := make([]models.TrashHistoryItem, 0)
+	if err := s.db.WithContext(ctx).Raw(sql, systemTableID).Scan(&rows).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения истории корзины")
+	}
+	return rows, nil
+}
+
+// logTrashAction пишет запись в лог корзины. Ошибка не прерывает основную операцию.
+func (s *trashService) logTrashAction(ctx context.Context, systemTableID int, action string, count, userID int) {
+	uid := userID
+	_ = s.db.WithContext(ctx).Create(&models.SystemTableTrashHistory{
+		SystemTableID: systemTableID,
+		ActionType:    action,
+		AffectedCount: count,
+		UserID:        &uid,
+	}).Error
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -54,6 +54,7 @@ var tables = []string{
 	"companies_unload_places", "organization_unload_places",
 	"unload_place_time_slots", "unload_place_photos", "unload_places",
 	"table_fields", "companies_tables", "organization_tables",
+	"system_table_trash_histories",
 	"system_table_time_slots", "system_table_photos", "system_tables",
 	"license_plate_format_cells", "license_plate_formats",
 	"citizenships",


### PR DESCRIPTION
## Что сделано

Завершение фичи «Корзина таблиц» (#186). Предыдущие PR (#283/#285/#292) дали каркас, но фича была нерабочей: при удалении не писался `table_id`, из-за чего не работали скоупинг по таблице, атрибуция «кто удалил» и очистка; в UI нельзя было выбрать строки и очистить корзину; не было детальной модалки, экспорта и истории.

### Backend
- При удалении (`DeactivateCar`/`DeactivateEmployee`) теперь пишется `table_id` в `cars_history`/`employees_history` (добавлено поле `TableID` в запросы деактивации).
- Переписаны `ListCarsTrash`/`ListEmployeesTrash`: скоуп по таблице через `EXISTS` по `*_history.table_id` (раньше фильтр был в `JOIN ON` и не фильтровал), `deleted_by_name` через коррелированный подзапрос, для сотрудников добавлены `entry_date_to`/`entry_time_from`/`entry_time_to` (были прочерки).
- `PurgeCar`/`PurgeEmployee` пишут историю `action_type=purge`; восстановление логирует `bulk_restored`.
- Новый эндпоинт `GET /system-tables/:id/trash/history` - лог массовых действий с корзиной.

### Frontend
- Чекбоксы выбора строк + рабочая кнопка «Восстановить».
- Кнопка «Очистить» теперь действительно очищает корзину (раньше сбрасывала фильтры).
- Клик по строке открывает `VehicleDetailsModal`/`EmployeeDetailsModal` с блоком «кто удалил» + дата/время.
- Экспорт в Excel (ExcelJS), столбец «Отчество» для людей, анимация-спиннер на «Обновить», модалка «История корзины».
- В history-модалках добавлены подписи действий delete/restore/purge.

### Тесты
- `internal/handlers/trash_test.go`: список+скоупинг+поля, восстановление+история, блокировка восстановления без согласованной заявки, окончательное удаление.

## Test plan
- [x] go build ./..., go vet ./...
- [x] go test ./internal/handlers -run TestTrash_ (3/3 зелёные)
- [x] frontend eslint + build
- [ ] Ручная проверка на staging: удалить машины/людей, проверить столбцы без прочерков, восстановление/очистка/экспорт, детальная модалка, история