### PR TITLE
fix: номер заявки и время в корзине (#186)

### DIFF
--- a/frontend/src/views/TrashView.vue
+++ b/frontend/src/views/TrashView.vue
@@ -543,8 +543,9 @@ export default {
       }
     },
     formatTimeRange(item) {
-      const from = item.entry_time_from || item.time_from;
-      const to = item.entry_time_to || item.time_to;
+      const hhmm = (v) => (typeof v === 'string' && v.length >= 5 ? v.slice(0, 5) : v);
+      const from = hhmm(item.entry_time_from || item.time_from);
+      const to = hhmm(item.entry_time_to || item.time_to);
       if (from && to) return `${from} - ${to}`;
       if (from) return from;
       if (to) return to;

--- a/internal/models/system_table_trash_history.go
+++ b/internal/models/system_table_trash_history.go
@@ -17,31 +17,31 @@ type SystemTableTrashHistory struct {
 
 // TrashActionType - константы для SystemTableTrashHistory.ActionType.
 const (
-	TrashActionCleared       = "cleared"
-	TrashActionBulkRestored  = "bulk_restored"
-	TrashActionPurgedOne     = "purged_one"
+	TrashActionCleared      = "cleared"
+	TrashActionBulkRestored = "bulk_restored"
+	TrashActionPurgedOne    = "purged_one"
 )
 
 // TrashItem - универсальный элемент корзины для API (car или employee).
 // Type определяет какие поля заполнены (для cars: car_number, mark_name;
 // для employees: last_name, first_name, middle_name).
 type TrashItem struct {
-	ID              int        `json:"id"`
-	Type            string     `json:"type"` // car | employee
-	ApplicationNum  *string    `json:"application_number,omitempty"`
-	DeletedAt       *time.Time `json:"deleted_at,omitempty"`
-	DeletedByName   string     `json:"deleted_by_name,omitempty"`
+	ID                int        `json:"id"`
+	Type              string     `json:"type"` // car | employee
+	ApplicationNumber *string    `json:"application_number,omitempty"`
+	DeletedAt         *time.Time `json:"deleted_at,omitempty"`
+	DeletedByName     string     `json:"deleted_by_name,omitempty"`
 	// Cars-only
-	CarNumber       *string    `json:"car_number,omitempty"`
-	MarkName        *string    `json:"mark_name,omitempty"`
-	Organization    string     `json:"organization,omitempty"`
-	EntryDateTo     *string    `json:"entry_date_to,omitempty"`
-	EntryTimeFrom   *string    `json:"entry_time_from,omitempty"`
-	EntryTimeTo     *string    `json:"entry_time_to,omitempty"`
+	CarNumber     *string `json:"car_number,omitempty"`
+	MarkName      *string `json:"mark_name,omitempty"`
+	Organization  string  `json:"organization,omitempty"`
+	EntryDateTo   *string `json:"entry_date_to,omitempty"`
+	EntryTimeFrom *string `json:"entry_time_from,omitempty"`
+	EntryTimeTo   *string `json:"entry_time_to,omitempty"`
 	// Employees-only
-	LastName        *string    `json:"last_name,omitempty"`
-	FirstName       *string    `json:"first_name,omitempty"`
-	MiddleName      *string    `json:"middle_name,omitempty"`
+	LastName   *string `json:"last_name,omitempty"`
+	FirstName  *string `json:"first_name,omitempty"`
+	MiddleName *string `json:"middle_name,omitempty"`
 }
 
 // TrashHistoryItem - запись лога корзины с именем пользователя для API.


### PR DESCRIPTION
Догоняющий фикс к #328 после ручной проверки на staging.

- **Номер заявки в корзине** показывался как прочерк: поле DTO `ApplicationNum` маппилось gorm в колонку `application_num`, а SQL отдаёт `application_number`. Переименовано в `ApplicationNumber` (колонка `application_number`).
- **Время** в таблице корзины показывалось с секундами (`09:00:00 - 18:00:00`); приведено к `HH:MM` как в основной таблице.

Проверено на staging: после фикса номер заявки заполняется, остальные столбцы и «кто удалил» уже работали.