### PR TITLE
fix: пробелы в заголовке корзины и выравнивание чекбоксов (#186)

### DIFF
--- a/frontend/src/views/TrashView.vue
+++ b/frontend/src/views/TrashView.vue
@@ -729,6 +729,14 @@ export default {
   transition: color 0.2s ease;
 }
 
+.trash-title__prefix {
+  margin-right: 0.35em;
+}
+
+.trash-title__sep {
+  margin-left: 0.35em;
+}
+
 .trash-title__link:hover .trash-title__prefix {
   color: #000;
 }
@@ -945,8 +953,8 @@ export default {
   user-select: none;
 }
 
-.trash-table__th-check,
-.trash-table__td-check {
+.trash-table__th.trash-table__th-check,
+.trash-table__td.trash-table__td-check {
   width: 44px;
   padding: 0 0 0 20px;
   text-align: left;


### PR DESCRIPTION
Мелкие визуальные фиксы по итогам проверки на staging:
- В заголовке схлопывались пробелы: было "ТаблицаКПП №4/ Корзина" -> добавлены отступы, стало "Таблица КПП №4 / Корзина".
- Чекбокс строки был сдвинут относительно чекбокса в шапке (`.trash-table__td` перебивал padding) -> повышена специфичность селектора ячеек-чекбоксов.