### PR TITLE
fix: уведомления удаления, поля и стили корзины (#186)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -36,6 +36,7 @@
     </div>
     <ToastContainer />
     <ConfirmDialog />
+    <DeleteNotifications />
   </div>
 </template>
 
@@ -48,6 +49,7 @@ import TheHeader from './components/TheHeader/TheHeader.vue';
 import ScrollTopButton from './components/ScrollTopButton.vue';
 import ToastContainer from './components/ToastContainer.vue';
 import ConfirmDialog from './components/ConfirmDialog.vue';
+import DeleteNotifications from './components/DeleteNotifications.vue';
 
 export default {
   name: "App",
@@ -57,6 +59,7 @@ export default {
     ScrollTopButton,
     ToastContainer,
     ConfirmDialog,
+    DeleteNotifications,
   },
   computed: {
     isAuthenticated() {

--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -3,22 +3,6 @@
     class="selected-table-card"
     data-testid="cars-table"
   >
-    <transition name="slide-down">
-      <div
-        v-if="notification.message"
-        class="notification"
-      >
-        <span>{{ notification.message }}</span>
-        <button @click="undoDelete">
-          Отменить
-        </button>
-        <div
-          class="progress-bar"
-          :style="{ width: `${progress}%` }"
-        />
-      </div>
-    </transition>
-
     <div class="card-header">
       <div class="card-header__title">
         <h3 class="card-title">
@@ -288,6 +272,7 @@
 
 <script>
 import { apiRequest } from '@/api/client'
+import { useDeletionsStore } from '@/stores/deletions';
 import RefreshButton from './RefreshButton.vue';
 import VehicleDetailsModal from './CreateApplication/VehicleDetailsModal.vue';
 import CarsTableHistoryModal from './CarsTableHistoryModal.vue';
@@ -318,9 +303,6 @@ export default {
       sortField: null,
       sortDirection: 'desc',
       itemsData: [],
-      notification: { message: null, item: null },
-      progress: 100,
-      progressInterval: null,
       isLoading: false,
       organizationsMap: {},
       carUnloadPlacesMap: {},
@@ -434,7 +416,6 @@ export default {
   },
   beforeUnmount() {
     this.stopPolling();
-    if (this.progressInterval) clearInterval(this.progressInterval);
   },
   methods: {
     // Основной метод загрузки данных с флагом silent (без показа лоадера)
@@ -698,52 +679,40 @@ export default {
       if (this.isLoading) return;
       const originalItem = { ...item };
       const itemIndex = this.itemsData.findIndex(i => i.id === item.id);
-      if (this.notification.message) clearInterval(this.progressInterval);
-      this.notification = { 
-        message: `Машина ${item.car_number} удалена.`, 
-        item,
-        originalItem,
-        itemIndex,
-        undoFunction: () => {
-          if (itemIndex !== -1) this.itemsData.splice(itemIndex, 1, { ...originalItem });
-        }
-      };
-      item.status = 'Удален';
-      item.checked = false;
-      this.progress = 100;
-      clearInterval(this.progressInterval);
-      this.progressInterval = setInterval(() => {
-        this.progress -= 1;
-        if (this.progress <= 0) {
-          clearInterval(this.progressInterval);
-          this.actuallyDeleteItem(item, originalItem, itemIndex);
-          if (this.notification.item?.id === item.id) this.notification = { message: null, item: null };
-        }
-      }, 100);
+      if (itemIndex === -1) return;
+      // Оптимистично убираем строку, удаление подтверждается по таймеру (с возможностью отмены).
+      this.itemsData.splice(itemIndex, 1);
+      const carId = item.id;
+      const tableId = this.tableId;
+      const userId = this.currentUserId;
+      useDeletionsStore().enqueue({
+        prefix: 'Машина ',
+        bold: item.car_number,
+        suffix: ' удалена',
+        onConfirm: () => this.commitDelete(carId, tableId, userId, originalItem, itemIndex),
+        onUndo: () => this.reinsertItem(originalItem, itemIndex),
+      });
     },
 
-    async actuallyDeleteItem(item, originalItem, itemIndex) {
+    reinsertItem(originalItem, itemIndex) {
+      if (this.itemsData.some(i => i.id === originalItem.id)) return;
+      this.itemsData.splice(Math.min(itemIndex, this.itemsData.length), 0, originalItem);
+    },
+
+    async commitDelete(carId, tableId, userId, originalItem, itemIndex) {
       try {
-        const response = await apiRequest(`/cars/${item.id}/deactivate`, {
+        const response = await apiRequest(`/cars/${carId}/deactivate`, {
           method: "PUT",
-          body: JSON.stringify({ status: 0, user_id: this.currentUserId, table_id: this.tableId })
+          body: JSON.stringify({ status: 0, user_id: userId, table_id: tableId })
         });
         if (!response.ok) {
           console.error("Ошибка при удалении");
-          if (itemIndex !== -1) this.itemsData.splice(itemIndex, 1, { ...originalItem });
-          return;
+          this.reinsertItem(originalItem, itemIndex);
         }
-        if (itemIndex !== -1) this.itemsData.splice(itemIndex, 1);
       } catch (error) {
         console.error("Ошибка сети при удалении:", error);
-        if (itemIndex !== -1) this.itemsData.splice(itemIndex, 1, { ...originalItem });
+        this.reinsertItem(originalItem, itemIndex);
       }
-    },
-
-    undoDelete() {
-      clearInterval(this.progressInterval);
-      if (this.notification.undoFunction) this.notification.undoFunction();
-      this.notification = { message: null, item: null };
     },
 
     openVehicleDetails(item) {
@@ -1133,69 +1102,6 @@ export default {
   transition: transform 0.3s ease;
 }
 
-.notification {
-  position: fixed;
-  top: 20px;
-  right: 20px;
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  background: #fff;
-  border: 1px solid #e6e6e6;
-  border-left: 4px solid #FF6668;
-  border-radius: 15px;
-  padding: 14px 18px;
-  box-shadow: 0 3px 10px rgba(0,0,0,0.1);
-  z-index: 1000;
-  min-width: 280px;
-  overflow: hidden;
-  font-family: 'Montserrat', sans-serif;
-  font-size: 14px;
-  color: #000;
-}
-
-.notification button {
-  margin-left: auto;
-  background: #4F5BDF;
-  color: white;
-  border: none;
-  padding: 6px 16px;
-  border-radius: 50px;
-  font-family: 'Montserrat', sans-serif;
-  font-size: 13px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-
-.notification button:hover {
-  background: #3a46d2;
-}
-
-.progress-bar {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  height: 3px;
-  background: #FF6668;
-  transition: width 0.1s linear;
-}
-
-.slide-down-enter-active,
-.slide-down-leave-active {
-  transition: all 0.3s ease;
-}
-
-.slide-down-enter-from {
-  transform: translateY(-100%);
-  opacity: 0;
-}
-
-.slide-down-leave-to {
-  transform: translateY(-100%);
-  opacity: 0;
-}
-
 @media (max-width: 768px) {
   .selected-table-card {
     max-height: none;
@@ -1256,12 +1162,6 @@ export default {
   .card-header__settings {
     width: 100%;
     justify-content: flex-end;
-  }
-
-  .notification {
-    left: 20px;
-    right: 20px;
-    min-width: auto;
   }
 
   .action-btn {

--- a/frontend/src/components/DeleteNotifications.vue
+++ b/frontend/src/components/DeleteNotifications.vue
@@ -1,0 +1,127 @@
+<template>
+  <div class="del-stack">
+    <transition-group name="del">
+      <div
+        v-for="item in store.items"
+        :key="item.id"
+        class="del-card"
+      >
+        <div class="del-row">
+          <span class="del-text">
+            {{ item.prefix }}<strong>{{ item.bold }}</strong>{{ item.suffix }}
+          </span>
+          <button
+            class="del-undo"
+            @click="store.undo(item.id)"
+          >
+            Отменить
+          </button>
+        </div>
+        <div class="del-track">
+          <div
+            class="del-fill"
+            :style="{ width: item.progress + '%', background: colorFor(item.progress) }"
+          />
+        </div>
+      </div>
+    </transition-group>
+  </div>
+</template>
+
+<script setup>
+import { useDeletionsStore } from '@/stores/deletions';
+
+const store = useDeletionsStore();
+
+// Цвет прогресс-бара: 100% (только удалили) - зелёный, 0% (вот-вот исчезнет) - красный.
+function colorFor(progress) {
+  const t = Math.min(1, Math.max(0, (100 - progress) / 100));
+  const green = [52, 199, 89];
+  const red = [255, 102, 104];
+  const c = green.map((g, i) => Math.round(g + (red[i] - g) * t));
+  return `rgb(${c[0]}, ${c[1]}, ${c[2]})`;
+}
+</script>
+
+<style scoped>
+.del-stack {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  z-index: 11000;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 320px;
+  max-width: calc(100vw - 40px);
+}
+
+.del-card {
+  background: #fff;
+  border: 1px solid #e6e6e6;
+  border-radius: 15px;
+  padding: 14px 16px;
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.1);
+  font-family: 'Montserrat', sans-serif;
+}
+
+.del-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.del-text {
+  flex: 1;
+  font-size: 14px;
+  color: #000;
+}
+
+.del-text :deep(strong) {
+  font-weight: 700;
+}
+
+.del-undo {
+  flex-shrink: 0;
+  background: #4F5BDF;
+  color: #fff;
+  border: none;
+  padding: 6px 16px;
+  border-radius: 50px;
+  font-family: 'Montserrat', sans-serif;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.del-undo:hover {
+  background: #3a45b2;
+}
+
+.del-track {
+  margin-top: 10px;
+  height: 15px;
+  border: 1px solid #e6e6e6;
+  border-radius: 50px;
+  overflow: hidden;
+  background: #f5f5f5;
+}
+
+.del-fill {
+  height: 100%;
+  border-radius: 50px;
+  transition: width 0.1s linear, background 0.1s linear;
+}
+
+.del-enter-active,
+.del-leave-active {
+  transition: all 0.3s ease;
+}
+
+.del-enter-from,
+.del-leave-to {
+  transform: translateX(20px);
+  opacity: 0;
+}
+</style>

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -1,21 +1,5 @@
 <template>
   <div class="selected-table-card">
-    <transition name="slide-down">
-      <div
-        v-if="notification.message"
-        class="notification"
-      >
-        <span>{{ notification.message }}</span>
-        <button @click="undoDelete">
-          Отменить
-        </button>
-        <div
-          class="progress-bar"
-          :style="{ width: `${progress}%` }"
-        />
-      </div>
-    </transition>
-
     <div class="card-header">
       <div class="card-header__title">
         <h3 class="card-title">
@@ -284,6 +268,7 @@
 
 <script>
 import { apiRequest } from '@/api/client';
+import { useDeletionsStore } from '@/stores/deletions';
 import RefreshButton from './RefreshButton.vue';
 import EmployeeDetailsModal from './CreateApplication/EmployeeDetailsModal.vue';
 import EmployeesTableHistoryModal from './CreateApplication/EmployeesTableHistoryModal.vue';
@@ -339,9 +324,6 @@ export default {
       sortField: null,
       sortDirection: 'desc',
       itemsData: [],
-      notification: { message: null, item: null },
-      progress: 100,
-      progressInterval: null,
       isLoading: false,
       currentTableId: null,
       organizationsMap: {},
@@ -459,7 +441,6 @@ export default {
   },
   beforeUnmount() {
     this.stopPolling();
-    if (this.progressInterval) clearInterval(this.progressInterval);
   },
   methods: {
     async _loadData(silent = false) {
@@ -658,55 +639,40 @@ export default {
       if (this.isLoading) return;
       const originalItem = { ...item };
       const itemIndex = this.itemsData.findIndex(i => i.id === item.id);
-      if (this.notification.message) clearInterval(this.progressInterval);
-      this.notification = { 
-        message: `Сотрудник ${item.last_name} удален.`, 
-        item,
-        originalItem,
-        itemIndex,
-        undoFunction: () => {
-          if (itemIndex !== -1) {
-            this.itemsData[itemIndex] = { ...originalItem };
-          }
-        }
-      };
-      item.status = 'Удален';
-      this.progress = 100;
-      clearInterval(this.progressInterval);
-      this.progressInterval = setInterval(() => {
-        this.progress -= 1;
-        if (this.progress <= 0) {
-          clearInterval(this.progressInterval);
-          this.actuallyDeleteItem(item, originalItem, itemIndex);
-          if (this.notification.item?.id === item.id) {
-            this.notification = { message: null, item: null };
-          }
-        }
-      }, 100);
+      if (itemIndex === -1) return;
+      this.itemsData.splice(itemIndex, 1);
+      const empId = item.id;
+      const tableId = this.currentTableId;
+      const userId = this.currentUserId;
+      const fullName = [item.last_name, item.first_name, item.middle_name].filter(Boolean).join(' ') || String(item.last_name || '');
+      useDeletionsStore().enqueue({
+        prefix: 'Сотрудник ',
+        bold: fullName,
+        suffix: ' удалён',
+        onConfirm: () => this.commitDelete(empId, tableId, userId, originalItem, itemIndex),
+        onUndo: () => this.reinsertItem(originalItem, itemIndex),
+      });
     },
 
-    async actuallyDeleteItem(item, originalItem, itemIndex) {
+    reinsertItem(originalItem, itemIndex) {
+      if (this.itemsData.some(i => i.id === originalItem.id)) return;
+      this.itemsData.splice(Math.min(itemIndex, this.itemsData.length), 0, originalItem);
+    },
+
+    async commitDelete(empId, tableId, userId, originalItem, itemIndex) {
       try {
-        const response = await apiRequest(`/employees/${item.id}/deactivate`, {
+        const response = await apiRequest(`/employees/${empId}/deactivate`, {
           method: "PUT",
-          body: JSON.stringify({ status: 0, user_id: this.currentUserId, table_id: this.currentTableId })
+          body: JSON.stringify({ status: 0, user_id: userId, table_id: tableId })
         });
-        if (response.ok) {
-          this.itemsData.splice(itemIndex, 1);
-        } else {
+        if (!response.ok) {
           console.error("Ошибка при удалении");
-          if (itemIndex !== -1) this.itemsData[itemIndex] = { ...originalItem };
+          this.reinsertItem(originalItem, itemIndex);
         }
       } catch (error) {
         console.error("Ошибка сети при удалении:", error);
-        if (itemIndex !== -1) this.itemsData[itemIndex] = { ...originalItem };
+        this.reinsertItem(originalItem, itemIndex);
       }
-    },
-
-    undoDelete() {
-      clearInterval(this.progressInterval);
-      if (this.notification.undoFunction) this.notification.undoFunction();
-      this.notification = { message: null, item: null };
     },
 
     openEmployeeDetails(item) {
@@ -1100,69 +1066,6 @@ export default {
   transition: transform 0.3s ease;
 }
 
-.notification {
-  position: fixed;
-  top: 20px;
-  right: 20px;
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  background: #fff;
-  border: 1px solid #e6e6e6;
-  border-left: 4px solid #FF6668;
-  border-radius: 15px;
-  padding: 14px 18px;
-  box-shadow: 0 3px 10px rgba(0,0,0,0.1);
-  z-index: 1000;
-  min-width: 280px;
-  overflow: hidden;
-  font-family: 'Montserrat', sans-serif;
-  font-size: 14px;
-  color: #000;
-}
-
-.notification button {
-  margin-left: auto;
-  background: #4F5BDF;
-  color: white;
-  border: none;
-  padding: 6px 16px;
-  border-radius: 50px;
-  font-family: 'Montserrat', sans-serif;
-  font-size: 13px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-
-.notification button:hover {
-  background: #3a46d2;
-}
-
-.progress-bar {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  height: 3px;
-  background: #FF6668;
-  transition: width 0.1s linear;
-}
-
-.slide-down-enter-active,
-.slide-down-leave-active {
-  transition: all 0.3s ease;
-}
-
-.slide-down-enter-from {
-  transform: translateY(-100%);
-  opacity: 0;
-}
-
-.slide-down-leave-to {
-  transform: translateY(-100%);
-  opacity: 0;
-}
-
 @media (max-width: 768px) {
   .selected-table-card {
     max-height: none;
@@ -1225,12 +1128,6 @@ export default {
   .card-header__settings {
     width: 100%;
     justify-content: flex-end;
-  }
-
-  .notification {
-    left: 20px;
-    right: 20px;
-    min-width: auto;
   }
 
   .action-btn {

--- a/frontend/src/components/TrashHistoryModal.vue
+++ b/frontend/src/components/TrashHistoryModal.vue
@@ -11,7 +11,7 @@
             <button
               class="export-btn"
               data-testid="trash-history-export"
-              :disabled="history.length === 0 || isExporting"
+              :disabled="filteredHistory.length === 0 || isExporting"
               @click="exportToExcel"
             >
               <img
@@ -35,6 +35,44 @@
           </div>
         </div>
 
+        <div
+          v-if="history.length"
+          class="history-filters"
+        >
+          <input
+            v-model="searchQuery"
+            type="text"
+            class="hf-input"
+            placeholder="Поиск по действию или пользователю..."
+          >
+          <select
+            v-model="selectedUser"
+            class="hf-select"
+          >
+            <option :value="null">
+              Все пользователи
+            </option>
+            <option
+              v-for="u in uniqueUsers"
+              :key="u"
+              :value="u"
+            >
+              {{ u }}
+            </option>
+          </select>
+          <button
+            class="hf-sort"
+            @click="sortOrder = sortOrder === 'desc' ? 'asc' : 'desc'"
+          >
+            <img
+              src="@/assets/icons/sort.png"
+              class="hf-sort-icon"
+              :class="{ 'hf-sort-icon--asc': sortOrder === 'asc' }"
+            >
+            <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
+          </button>
+        </div>
+
         <div class="modal-content">
           <div
             v-if="loading"
@@ -43,17 +81,17 @@
             <div class="loader" />
           </div>
           <div
-            v-else-if="history.length === 0"
+            v-else-if="filteredHistory.length === 0"
             class="history-empty"
           >
-            История пуста
+            {{ history.length ? 'Ничего не найдено' : 'История пуста' }}
           </div>
           <div
             v-else
             class="history-timeline"
           >
             <div
-              v-for="(item, index) in history"
+              v-for="(item, index) in filteredHistory"
               :key="item.id"
               class="history-item"
             >
@@ -62,7 +100,7 @@
                 :class="getActionClass(item.action_type)"
               />
               <div
-                v-if="index < history.length - 1"
+                v-if="index < filteredHistory.length - 1"
                 class="timeline-line"
               />
               <div class="history-content">
@@ -99,9 +137,34 @@ export default {
       history: [],
       loading: false,
       isExporting: false,
+      searchQuery: '',
+      selectedUser: null,
+      sortOrder: 'desc',
     };
   },
   computed: {
+    uniqueUsers() {
+      return [...new Set(this.history.map(h => h.user_name || 'Система'))];
+    },
+    filteredHistory() {
+      let arr = [...this.history];
+      if (this.selectedUser) {
+        arr = arr.filter(h => (h.user_name || 'Система') === this.selectedUser);
+      }
+      if (this.searchQuery) {
+        const q = this.searchQuery.toLowerCase();
+        arr = arr.filter(h =>
+          this.getActionText(h).toLowerCase().includes(q)
+          || (h.user_name || 'Система').toLowerCase().includes(q),
+        );
+      }
+      arr.sort((a, b) => {
+        const da = new Date(a.created_at).getTime();
+        const db = new Date(b.created_at).getTime();
+        return this.sortOrder === 'asc' ? da - db : db - da;
+      });
+      return arr;
+    },
     formattedCurrentDateTime() {
       return new Date().toLocaleString('ru-RU', {
         day: '2-digit', month: '2-digit', year: 'numeric',
@@ -149,7 +212,7 @@ export default {
       }).replace(',', '');
     },
     async exportToExcel() {
-      if (this.history.length === 0) return;
+      if (this.filteredHistory.length === 0) return;
       this.isExporting = true;
       try {
         const workbook = new ExcelJS.Workbook();
@@ -164,7 +227,7 @@ export default {
           cell.alignment = { vertical: 'middle', horizontal: 'center' };
         });
 
-        this.history.forEach((item, index) => {
+        this.filteredHistory.forEach((item, index) => {
           const row = worksheet.addRow([
             this.formatDateTime(item.created_at),
             this.getActionText(item),
@@ -324,6 +387,73 @@ export default {
 .close-btn:hover {
   background: #f5f5f5;
   color: #333;
+}
+
+.history-filters {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding: 12px 25px;
+  border-bottom: 1px solid #e6e6e6;
+  background: #fafafa;
+}
+
+.hf-input {
+  flex: 1 1 220px;
+  height: 32px;
+  border: 1px solid #e6e6e6;
+  border-radius: 15px;
+  padding: 0 12px;
+  font-family: 'Montserrat', sans-serif;
+  font-size: 13px;
+  outline: none;
+}
+
+.hf-input:focus {
+  border-color: #4F5BDF;
+}
+
+.hf-select {
+  height: 32px;
+  border: 1px solid #e6e6e6;
+  border-radius: 15px;
+  padding: 0 10px;
+  font-family: 'Montserrat', sans-serif;
+  font-size: 13px;
+  background: #fff;
+  cursor: pointer;
+  outline: none;
+}
+
+.hf-sort {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 32px;
+  padding: 0 14px;
+  background: #fff;
+  border: 1px solid #e6e6e6;
+  border-radius: 15px;
+  font-family: 'Montserrat', sans-serif;
+  font-size: 13px;
+  color: #333;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.hf-sort:hover {
+  border-color: #4F5BDF;
+}
+
+.hf-sort-icon {
+  width: 12px;
+  height: 12px;
+  transition: transform 0.2s ease;
+}
+
+.hf-sort-icon--asc {
+  transform: rotate(180deg);
 }
 
 .modal-content {

--- a/frontend/src/stores/deletions.js
+++ b/frontend/src/stores/deletions.js
@@ -1,0 +1,66 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+
+/**
+ * Стек уведомлений об удалении с отменой (#186).
+ * Таймер и колбэки живут в сторе (вне жизненного цикла компонентов), поэтому
+ * удаление доводится до конца даже при переходе на другую вкладку, а уведомления
+ * накапливаются и не перекрывают друг друга.
+ */
+
+const timers = new Map();
+const callbacks = new Map();
+const TICK_MS = 100;
+
+export const useDeletionsStore = defineStore('deletions', () => {
+  const items = ref([]);
+
+  function enqueue({ prefix = '', bold = '', suffix = '', onConfirm, onUndo, duration = 10000 }) {
+    const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    items.value.push({ id, prefix, bold, suffix, progress: 100 });
+    callbacks.set(id, { onConfirm, onUndo });
+    const step = 100 / (duration / TICK_MS);
+    const timer = setInterval(() => tick(id, step), TICK_MS);
+    timers.set(id, timer);
+    return id;
+  }
+
+  function tick(id, step) {
+    const it = items.value.find(i => i.id === id);
+    if (!it) {
+      stopTimer(id);
+      return;
+    }
+    it.progress = Math.max(0, it.progress - step);
+    if (it.progress <= 0) confirm(id);
+  }
+
+  function confirm(id) {
+    stopTimer(id);
+    const cb = callbacks.get(id);
+    remove(id);
+    if (cb && cb.onConfirm) cb.onConfirm();
+  }
+
+  function undo(id) {
+    stopTimer(id);
+    const cb = callbacks.get(id);
+    remove(id);
+    if (cb && cb.onUndo) cb.onUndo();
+  }
+
+  function stopTimer(id) {
+    const t = timers.get(id);
+    if (t) {
+      clearInterval(t);
+      timers.delete(id);
+    }
+  }
+
+  function remove(id) {
+    items.value = items.value.filter(i => i.id !== id);
+    callbacks.delete(id);
+  }
+
+  return { items, enqueue, undo };
+});

--- a/frontend/src/views/TrashView.vue
+++ b/frontend/src/views/TrashView.vue
@@ -47,6 +47,7 @@
           <OrganizationFilter
             ref="organizationFilter"
             v-model="filters.organizationId"
+            :organizations="organizations"
             @change="onOrganizationChange"
           />
           <DateFilter
@@ -61,13 +62,6 @@
           />
         </div>
         <div class="trash-filters__group trash-filters__group--right">
-          <button
-            class="trash-tool-btn"
-            data-testid="trash-history"
-            @click="openHistory"
-          >
-            История
-          </button>
           <button
             class="trash-tool-btn"
             data-testid="trash-export"
@@ -103,6 +97,13 @@
         <h3 class="trash-card__title">
           {{ tableType === 'cars' ? 'Удаленные автомобили' : 'Удаленные сотрудники' }}
         </h3>
+        <button
+          class="trash-history-btn"
+          data-testid="trash-history"
+          @click="openHistory"
+        >
+          История
+        </button>
 
         <div class="trash-card__spacer" />
 
@@ -126,28 +127,31 @@
         />
       </div>
 
-      <div class="trash-card__body">
+      <div
+        ref="cardBody"
+        class="trash-card__body"
+        :style="bodyStyle"
+      >
         <div
           v-if="isLoading"
-          class="trash-state"
+          class="trash-overlay"
         >
           <span class="trash-spinner" />
-          Загрузка...
         </div>
         <div
-          v-else-if="error"
+          v-if="error"
           class="trash-state trash-state--error"
         >
           {{ error }}
         </div>
         <div
-          v-else-if="!items.length"
+          v-else-if="!items.length && !isLoading"
           class="trash-state"
         >
           Корзина пуста
         </div>
         <table
-          v-else
+          v-else-if="items.length"
           class="trash-table"
           data-testid="trash-table"
         >
@@ -170,10 +174,13 @@
               >
                 <span>{{ col.label }}</span>
                 <img
-                  v-if="col.sortable && sortField === col.key"
+                  v-if="col.sortable"
                   src="@/assets/icons/sort.png"
                   class="trash-table__sort"
-                  :class="{ 'trash-table__sort--desc': sortDir === 'desc' }"
+                  :class="{
+                    'trash-table__sort--sorted': sortField === col.key,
+                    'trash-table__sort--desc': sortField === col.key && sortDir === 'desc',
+                  }"
                   alt=""
                 >
               </th>
@@ -266,7 +273,7 @@
       v-if="tableType === 'cars' && showDetails"
       :show="showDetails"
       :vehicle="selectedDetail"
-      :all-unloading-places="[]"
+      :all-unloading-places="detailPlaces"
       :license-plate-formats="[]"
       :show-car-features="false"
       :source="'trash'"
@@ -335,7 +342,10 @@ export default {
       sortDir: 'desc',
       showDetails: false,
       selectedDetail: null,
+      detailPlaces: [],
       showHistory: false,
+      organizations: [],
+      lastHeight: 0,
     };
   },
   computed: {
@@ -393,6 +403,9 @@ export default {
         hour: '2-digit', minute: '2-digit', second: '2-digit',
       }).replace(',', '');
     },
+    bodyStyle() {
+      return this.isLoading ? { minHeight: `${this.lastHeight || 200}px` } : {};
+    },
   },
   watch: {
     '$route.params.tableName'() {
@@ -401,6 +414,7 @@ export default {
   },
   async mounted() {
     this.fetchCurrentUser();
+    this.fetchOrganizations();
     await this.fetchTable();
     if (this.tableID) await this.reload();
   },
@@ -413,6 +427,15 @@ export default {
         this.currentUserName = parts.join(' ') || data.username || '';
       } catch {
         this.currentUserName = '';
+      }
+    },
+    async fetchOrganizations() {
+      try {
+        const res = await apiRequest('/organizations');
+        const data = await res.json();
+        this.organizations = Array.isArray(data) ? data : [];
+      } catch {
+        this.organizations = [];
       }
     },
     async fetchTable() {
@@ -437,6 +460,9 @@ export default {
     },
     async reload() {
       if (!this.tableID || this.error) return;
+      if (this.$refs.cardBody && this.$refs.cardBody.offsetHeight) {
+        this.lastHeight = this.$refs.cardBody.offsetHeight;
+      }
       this.isLoading = true;
       this.selectedIds = [];
       try {
@@ -520,16 +546,18 @@ export default {
     onRowClick(item) {
       const deletedAtText = this.formatDateTime(item.deleted_at);
       if (this.tableType === 'cars') {
+        const places = Array.isArray(item.unload_places) ? item.unload_places : [];
+        this.detailPlaces = places;
         this.selectedDetail = {
           plateNumber: item.car_number,
           mark: item.mark_name,
           formatId: null,
           organization: item.organization,
           organizationId: null,
-          company: '',
+          company: item.company || '',
           companyId: null,
           isExisting: true,
-          unloadPlaces: [],
+          unloadPlaces: places.map(p => p.id),
           entry_date_to: item.entry_date_to,
           entry_time_from: item.entry_time_from,
           entry_time_to: item.entry_time_to,
@@ -543,14 +571,14 @@ export default {
           last_name: item.last_name,
           first_name: item.first_name,
           middle_name: item.middle_name,
-          position: '',
-          citizenshipName: '',
+          position: item.position || '',
+          citizenshipName: item.citizenship_name || '',
           passport_series_number: '',
           patent_number: '',
           other_permission: '',
           organization: item.organization,
           organizationId: null,
-          company: '',
+          company: item.company || '',
           companyId: null,
           entry_date_to: item.entry_date_to,
           pass_time: this.formatTimeRange(item),
@@ -657,11 +685,13 @@ export default {
           });
         });
 
-        // Авто-ширина по содержимому.
-        worksheet.columns = headers.map((h, i) => {
+        // Авто-ширина по содержимому (через getColumn - применяется после addRow).
+        headers.forEach((h, i) => {
           const maxLen = Math.max(h.length, ...dataRows.map(row => String(row[i] ?? '').length));
-          return { width: Math.min(Math.max(maxLen + 4, 12), 50) };
+          worksheet.getColumn(i + 1).width = Math.min(Math.max(maxLen + 4, 14), 60);
         });
+        // Первый столбец должен вмещать подписи футера.
+        worksheet.getColumn(1).width = Math.max(worksheet.getColumn(1).width || 0, 22);
 
         worksheet.addRow([]);
         const infoRow1 = worksheet.addRow(['Отчёт сформировал:', this.currentUserDisplayName]);
@@ -869,6 +899,23 @@ export default {
   color: #000000;
 }
 
+.trash-history-btn {
+  padding: 4px 12px;
+  background: #fff;
+  border: 1px solid #e6e6e6;
+  border-radius: 15px;
+  font-family: 'Montserrat', sans-serif;
+  font-size: 12px;
+  color: #333;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.trash-history-btn:hover {
+  background: #f5f5f5;
+  border-color: #4F5BDF;
+}
+
 .trash-card__spacer {
   flex: 1;
 }
@@ -905,6 +952,17 @@ export default {
   padding: 0;
   flex-grow: 1;
   overflow-y: auto;
+  position: relative;
+}
+
+.trash-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.6);
+  z-index: 2;
 }
 
 .trash-state {
@@ -969,8 +1027,12 @@ export default {
   color: #333;
 }
 
+.trash-table__th--sortable:hover .trash-table__sort {
+  filter: brightness(0);
+}
+
 .trash-table__th--active {
-  color: #4F5BDF;
+  color: #333;
 }
 
 .trash-table__sort {
@@ -978,8 +1040,13 @@ export default {
   height: 12px;
   margin-left: 6px;
   vertical-align: middle;
-  opacity: 1;
+  opacity: 0.7;
   transition: transform 0.2s ease;
+}
+
+.trash-table__sort--sorted {
+  filter: brightness(0);
+  opacity: 1;
 }
 
 .trash-table__sort--desc {
@@ -1020,16 +1087,18 @@ export default {
 .trash-badge {
   display: inline-flex;
   align-items: center;
-  padding: 3px 12px;
-  border-radius: 50px;
-  font-size: 12px;
+  padding: 4px 8px;
+  border-radius: 8px;
+  font-size: 11px;
   font-weight: 500;
   white-space: nowrap;
+  border: 1px solid;
 }
 
 .trash-badge--deleted {
-  background: #FFECEC;
-  color: #FF6668;
+  background-color: #ffebee;
+  color: #c62828;
+  border-color: #ffcdd2;
 }
 
 .trash-check {

--- a/internal/models/system_table_trash_history.go
+++ b/internal/models/system_table_trash_history.go
@@ -1,6 +1,9 @@
 package models
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 // SystemTableTrashHistory логирует массовые действия с корзиной таблицы (#186):
 // очистка (cleared) и массовое восстановление (bulk_restored). Действия с
@@ -31,17 +34,21 @@ type TrashItem struct {
 	ApplicationNumber *string    `json:"application_number,omitempty"`
 	DeletedAt         *time.Time `json:"deleted_at,omitempty"`
 	DeletedByName     string     `json:"deleted_by_name,omitempty"`
-	// Cars-only
-	CarNumber     *string `json:"car_number,omitempty"`
-	MarkName      *string `json:"mark_name,omitempty"`
 	Organization  string  `json:"organization,omitempty"`
+	Company       string  `json:"company,omitempty"`
 	EntryDateTo   *string `json:"entry_date_to,omitempty"`
 	EntryTimeFrom *string `json:"entry_time_from,omitempty"`
 	EntryTimeTo   *string `json:"entry_time_to,omitempty"`
+	// Cars-only
+	CarNumber    *string         `json:"car_number,omitempty"`
+	MarkName     *string         `json:"mark_name,omitempty"`
+	UnloadPlaces json.RawMessage `json:"unload_places,omitempty" gorm:"type:jsonb"`
 	// Employees-only
-	LastName   *string `json:"last_name,omitempty"`
-	FirstName  *string `json:"first_name,omitempty"`
-	MiddleName *string `json:"middle_name,omitempty"`
+	LastName        *string `json:"last_name,omitempty"`
+	FirstName       *string `json:"first_name,omitempty"`
+	MiddleName      *string `json:"middle_name,omitempty"`
+	Position        *string `json:"position,omitempty"`
+	CitizenshipName string  `json:"citizenship_name,omitempty"`
 }
 
 // TrashHistoryItem - запись лога корзины с именем пользователя для API.

--- a/internal/models/system_table_trash_history.go
+++ b/internal/models/system_table_trash_history.go
@@ -42,7 +42,7 @@ type TrashItem struct {
 	// Cars-only
 	CarNumber    *string         `json:"car_number,omitempty"`
 	MarkName     *string         `json:"mark_name,omitempty"`
-	UnloadPlaces json.RawMessage `json:"unload_places,omitempty" gorm:"type:jsonb"`
+	UnloadPlaces json.RawMessage `json:"unload_places,omitempty" gorm:"type:jsonb" swaggerignore:"true"`
 	// Employees-only
 	LastName        *string `json:"last_name,omitempty"`
 	FirstName       *string `json:"first_name,omitempty"`

--- a/internal/services/car_status_service.go
+++ b/internal/services/car_status_service.go
@@ -130,10 +130,9 @@ func (s *carService) DeactivateCar(ctx context.Context, carID int, req Deactivat
 		}
 
 		now := time.Now().UTC()
-		today := now.Format("2006-01-02")
 		if err := tx.Model(&models.Car{}).Where("id = ?", carID).Updates(map[string]interface{}{
 			"status":       req.Status,
-			"date_removed": today,
+			"date_removed": now,
 			"updated_at":   now,
 		}).Error; err != nil {
 			slog.Error("не удалось деактивировать автомобиль", "car_id", carID, "error", err)

--- a/internal/services/trash_service.go
+++ b/internal/services/trash_service.go
@@ -50,6 +50,12 @@ func (s *trashService) ListCarsTrash(ctx context.Context, systemTableID int, fil
 			c.entry_date_to, c.entry_time_from, c.entry_time_to,
 			COALESCE(c.mark_name, c.car_brand) AS mark_name, c.car_number,
 			COALESCE(org.name, '') AS organization,
+			COALESCE(comp.name, '') AS company,
+			COALESCE((
+				SELECT json_agg(json_build_object('id', up.id, 'name', up.name))
+				FROM car_unload_places cup JOIN unload_places up ON up.id = cup.unload_place_id
+				WHERE cup.car_id = c.id
+			), '[]') AS unload_places,
 			c.date_removed AS deleted_at,
 			COALESCE((
 				SELECT format_short_name(u.last_name, u.first_name, u.middle_name)
@@ -61,6 +67,7 @@ func (s *trashService) ListCarsTrash(ctx context.Context, systemTableID int, fil
 		JOIN attachments att ON att.id = c.attachment_id
 		JOIN applications a ON a.id = att.application_id
 		LEFT JOIN organizations org ON org.id = a.organization_id
+		LEFT JOIN companies comp ON comp.id = a.company_id
 		WHERE c.status = 0 AND c.date_removed IS NOT NULL AND c.is_purged = false
 			AND EXISTS (
 				SELECT 1 FROM cars_history ch
@@ -101,7 +108,10 @@ func (s *trashService) ListEmployeesTrash(ctx context.Context, systemTableID int
 		SELECT e.id, 'employee' AS type,
 			a.application_number,
 			e.last_name, e.first_name, e.middle_name,
+			e.position,
 			COALESCE(org.name, '') AS organization,
+			COALESCE(comp.name, '') AS company,
+			COALESCE(cit.name, '') AS citizenship_name,
 			att.entry_date_to, att.entry_time_from, att.entry_time_to,
 			e.date_deleted AS deleted_at,
 			COALESCE((
@@ -114,6 +124,8 @@ func (s *trashService) ListEmployeesTrash(ctx context.Context, systemTableID int
 		JOIN attachments att ON att.id = e.attachment_id
 		JOIN applications a ON a.id = att.application_id
 		LEFT JOIN organizations org ON org.id = a.organization_id
+		LEFT JOIN companies comp ON comp.id = a.company_id
+		LEFT JOIN citizenships cit ON cit.id = e.citizenship_id
 		WHERE e.status = 0 AND e.date_deleted IS NOT NULL AND e.is_purged = false
 			AND EXISTS (
 				SELECT 1 FROM employees_history eh


### PR DESCRIPTION
Второй раунд правок корзины по ревью.

### Уведомления удаления (CarsTable/PeopleTable)
- Вынесены в глобальный стор `useDeletionsStore` + компонент `DeleteNotifications` (в App.vue): стек сверху вниз, не перекрываются, каждое отменяемо, таймер не сбрасывается при переходе на другую вкладку (удаление доводится до конца через стор).
- Номер/ФИО жирным; прогресс-бар внутри карточки под текстом (15px, border 1px #e6e6e6), цвет зелёный->красный за 10с; убран вылезающий красный прямоугольник.

### TrashView
- Фильтр «Организация» починен (передаётся `:organizations`, грузится `/organizations`).
- Бейдж статуса в цветах как «Отказано» в Центре заявок (`#ffebee/#c62828`).
- Иконка сортировки видна всегда; при активной - затемняется (#333) и переворачивается (как в CarsTable); стартовая сортировка без подсветки заголовка.
- Экспорт: авто-ширина колонок через `getColumn().width`.
- «Обновить» больше не дёргает таблицу: overlay-лоадер с запоминанием высоты.
- Кнопка «История» перенесена в header карточки, дизайн как `history-btn` в CarsTable.

### История корзины
- Добавлены поиск, фильтр по пользователю, переключатель сортировки.

### Детальные модалки в корзине
- Backend: trash-список отдаёт company + места разгрузки (cars), должность + гражданство (employees).
- VehicleDetailsModal/EmployeeDetailsModal в корзине показывают компанию, места разгрузки, должность, гражданство.

### Прочее
- Время удаления машины фиксировалось как 03:00:00 (хранилась только дата) - теперь полный timestamp.

Проверено: eslint 0 ошибок, `npm run build`, `go build`, trash-тесты зелёные.