### PR TITLE
fix: мерцание удаляемой строки, позиция Истории, border фильтра (#186)

### DIFF
--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -303,6 +303,7 @@ export default {
       sortField: null,
       sortDirection: 'desc',
       itemsData: [],
+      pendingDeleteIds: [],
       isLoading: false,
       organizationsMap: {},
       carUnloadPlacesMap: {},
@@ -316,7 +317,7 @@ export default {
   },
   computed: {
     displayItems() {
-      let filtered = [...this.itemsData];
+      let filtered = this.itemsData.filter(i => !this.pendingDeleteIds.includes(i.id));
       if (this.searchQuery) {
         const query = this.searchQuery.toLowerCase().trim();
         filtered = filtered.filter(item => {
@@ -677,29 +678,26 @@ export default {
 
     removeItemWithNotification(item) {
       if (this.isLoading) return;
-      const originalItem = { ...item };
-      const itemIndex = this.itemsData.findIndex(i => i.id === item.id);
-      if (itemIndex === -1) return;
-      // Оптимистично убираем строку, удаление подтверждается по таймеру (с возможностью отмены).
-      this.itemsData.splice(itemIndex, 1);
+      if (this.pendingDeleteIds.includes(item.id)) return;
       const carId = item.id;
       const tableId = this.tableId;
       const userId = this.currentUserId;
+      // Прячем строку через displayItems-фильтр (устойчиво к polling), пока идёт окно отмены.
+      this.pendingDeleteIds.push(carId);
       useDeletionsStore().enqueue({
         prefix: 'Машина ',
         bold: item.car_number,
         suffix: ' удалена',
-        onConfirm: () => this.commitDelete(carId, tableId, userId, originalItem, itemIndex),
-        onUndo: () => this.reinsertItem(originalItem, itemIndex),
+        onConfirm: () => this.commitDelete(carId, tableId, userId),
+        onUndo: () => this.unhidePending(carId),
       });
     },
 
-    reinsertItem(originalItem, itemIndex) {
-      if (this.itemsData.some(i => i.id === originalItem.id)) return;
-      this.itemsData.splice(Math.min(itemIndex, this.itemsData.length), 0, originalItem);
+    unhidePending(carId) {
+      this.pendingDeleteIds = this.pendingDeleteIds.filter(id => id !== carId);
     },
 
-    async commitDelete(carId, tableId, userId, originalItem, itemIndex) {
+    async commitDelete(carId, tableId, userId) {
       try {
         const response = await apiRequest(`/cars/${carId}/deactivate`, {
           method: "PUT",
@@ -707,11 +705,14 @@ export default {
         });
         if (!response.ok) {
           console.error("Ошибка при удалении");
-          this.reinsertItem(originalItem, itemIndex);
+          this.unhidePending(carId);
+          return;
         }
+        await this._loadData(true);
+        this.unhidePending(carId);
       } catch (error) {
         console.error("Ошибка сети при удалении:", error);
-        this.reinsertItem(originalItem, itemIndex);
+        this.unhidePending(carId);
       }
     },
 

--- a/frontend/src/components/DeleteNotifications.vue
+++ b/frontend/src/components/DeleteNotifications.vue
@@ -46,13 +46,13 @@ function colorFor(progress) {
 <style scoped>
 .del-stack {
   position: fixed;
-  top: 20px;
+  top: 15px;
   right: 20px;
   z-index: 11000;
   display: flex;
   flex-direction: column;
+  align-items: flex-end;
   gap: 10px;
-  width: 320px;
   max-width: calc(100vw - 40px);
 }
 
@@ -63,18 +63,22 @@ function colorFor(progress) {
   padding: 14px 16px;
   box-shadow: 0 3px 10px rgba(0, 0, 0, 0.1);
   font-family: 'Montserrat', sans-serif;
+  width: max-content;
+  min-width: 300px;
+  max-width: calc(100vw - 40px);
 }
 
 .del-row {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 16px;
 }
 
 .del-text {
   flex: 1;
   font-size: 14px;
   color: #000;
+  white-space: nowrap;
 }
 
 .del-text :deep(strong) {

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -324,6 +324,7 @@ export default {
       sortField: null,
       sortDirection: 'desc',
       itemsData: [],
+      pendingDeleteIds: [],
       isLoading: false,
       currentTableId: null,
       organizationsMap: {},
@@ -336,8 +337,8 @@ export default {
   },
   computed: {
     displayItems() {
-      let filtered = [...this.itemsData];
-      
+      let filtered = this.itemsData.filter(i => !this.pendingDeleteIds.includes(i.id));
+
       if (this.searchQuery) {
         const query = this.searchQuery.toLowerCase().trim();
         filtered = filtered.filter(item => {
@@ -637,29 +638,26 @@ export default {
 
     removeItemWithNotification(item) {
       if (this.isLoading) return;
-      const originalItem = { ...item };
-      const itemIndex = this.itemsData.findIndex(i => i.id === item.id);
-      if (itemIndex === -1) return;
-      this.itemsData.splice(itemIndex, 1);
+      if (this.pendingDeleteIds.includes(item.id)) return;
       const empId = item.id;
       const tableId = this.currentTableId;
       const userId = this.currentUserId;
       const fullName = [item.last_name, item.first_name, item.middle_name].filter(Boolean).join(' ') || String(item.last_name || '');
+      this.pendingDeleteIds.push(empId);
       useDeletionsStore().enqueue({
         prefix: 'Сотрудник ',
         bold: fullName,
         suffix: ' удалён',
-        onConfirm: () => this.commitDelete(empId, tableId, userId, originalItem, itemIndex),
-        onUndo: () => this.reinsertItem(originalItem, itemIndex),
+        onConfirm: () => this.commitDelete(empId, tableId, userId),
+        onUndo: () => this.unhidePending(empId),
       });
     },
 
-    reinsertItem(originalItem, itemIndex) {
-      if (this.itemsData.some(i => i.id === originalItem.id)) return;
-      this.itemsData.splice(Math.min(itemIndex, this.itemsData.length), 0, originalItem);
+    unhidePending(empId) {
+      this.pendingDeleteIds = this.pendingDeleteIds.filter(id => id !== empId);
     },
 
-    async commitDelete(empId, tableId, userId, originalItem, itemIndex) {
+    async commitDelete(empId, tableId, userId) {
       try {
         const response = await apiRequest(`/employees/${empId}/deactivate`, {
           method: "PUT",
@@ -667,11 +665,14 @@ export default {
         });
         if (!response.ok) {
           console.error("Ошибка при удалении");
-          this.reinsertItem(originalItem, itemIndex);
+          this.unhidePending(empId);
+          return;
         }
+        await this._loadData(true);
+        this.unhidePending(empId);
       } catch (error) {
         console.error("Ошибка сети при удалении:", error);
-        this.reinsertItem(originalItem, itemIndex);
+        this.unhidePending(empId);
       }
     },
 

--- a/frontend/src/views/TrashView.vue
+++ b/frontend/src/views/TrashView.vue
@@ -1098,8 +1098,8 @@ export default {
 .trash-badge {
   display: inline-flex;
   align-items: center;
-  padding: 4px 8px;
-  border-radius: 8px;
+  padding: 4px 12px;
+  border-radius: 50px;
   font-size: 11px;
   font-weight: 500;
   white-space: nowrap;

--- a/frontend/src/views/TrashView.vue
+++ b/frontend/src/views/TrashView.vue
@@ -97,13 +97,6 @@
         <h3 class="trash-card__title">
           {{ tableType === 'cars' ? 'Удаленные автомобили' : 'Удаленные сотрудники' }}
         </h3>
-        <button
-          class="trash-history-btn"
-          data-testid="trash-history"
-          @click="openHistory"
-        >
-          История
-        </button>
 
         <div class="trash-card__spacer" />
 
@@ -120,6 +113,13 @@
           @click="onRestoreSelected"
         >
           Восстановить
+        </button>
+        <button
+          class="trash-history-btn"
+          data-testid="trash-history"
+          @click="openHistory"
+        >
+          История
         </button>
         <RefreshButton
           :loading="isLoading"
@@ -833,7 +833,18 @@ export default {
 }
 
 .trash-filters :deep(.field) {
+  width: 200px;
+  height: 35px;
+  background-color: #fff;
+  border: 1px solid #e6e6e6;
   border-radius: 15px;
+  padding: 0 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  box-sizing: border-box;
+  cursor: pointer;
 }
 
 .trash-tool-btn {


### PR DESCRIPTION
Догоняющие фиксы по итогам проверки на staging:
- Таблица опрашивает сервер каждые 10с и на время окна отмены возвращала удалённую строку обратно (мерцание). Теперь строка стабильно скрыта весь период отмены через фильтр pending-удалений в displayItems (устойчиво к polling); применено для машин и людей.
- Кнопка «История» перенесена между «Восстановить» и «Обновить».
- Фильтру «Организация» вернул border/бокс (поле берёт оформление от родителя `.field`, было упрощено).