### PR TITLE
fix: фильтр организации, столбцы людей, уведомления, поля модалок (#186)

### DIFF
--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -20,7 +20,7 @@
           </button>
         </span>
         <RefreshButton
-          :disabled="isLoading"
+          :loading="refreshing"
           @refresh="loadData"
         />
       </div>
@@ -305,6 +305,7 @@ export default {
       itemsData: [],
       pendingDeleteIds: [],
       isLoading: false,
+      refreshing: false,
       organizationsMap: {},
       carUnloadPlacesMap: {},
       allUnloadingPlaces: [],
@@ -436,9 +437,14 @@ export default {
       }
     },
 
-    // Для внешнего вызова (кнопка Refresh)
+    // Для внешнего вызова (кнопка Refresh) - тихо, без скачка высоты таблицы.
     async loadData() {
-      await this._loadData(false);
+      this.refreshing = true;
+      try {
+        await this._loadData(true);
+      } finally {
+        this.refreshing = false;
+      }
     },
 
     // Для тихого обновления по таймеру

--- a/frontend/src/components/DeleteNotifications.vue
+++ b/frontend/src/components/DeleteNotifications.vue
@@ -11,6 +11,7 @@
             {{ item.prefix }}<strong>{{ item.bold }}</strong>{{ item.suffix }}
           </span>
           <button
+            v-if="item.showUndo"
             class="del-undo"
             @click="store.undo(item.id)"
           >
@@ -105,7 +106,7 @@ function colorFor(progress) {
 
 .del-track {
   margin-top: 10px;
-  height: 15px;
+  height: 10px;
   border: 1px solid #e6e6e6;
   border-radius: 50px;
   overflow: hidden;
@@ -127,5 +128,15 @@ function colorFor(progress) {
 .del-leave-to {
   transform: translateX(20px);
   opacity: 0;
+}
+
+/* Плавный сдвиг оставшихся карточек при удалении одной из стека. */
+.del-move {
+  transition: transform 0.3s ease;
+}
+
+.del-leave-active {
+  position: absolute;
+  right: 0;
 }
 </style>

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -15,7 +15,7 @@
           >История</button>
         </span>
         <RefreshButton
-          :disabled="isLoading"
+          :loading="refreshing"
           @refresh="loadData"
         />
       </div>
@@ -326,6 +326,7 @@ export default {
       itemsData: [],
       pendingDeleteIds: [],
       isLoading: false,
+      refreshing: false,
       currentTableId: null,
       organizationsMap: {},
       allTables: [],
@@ -460,7 +461,12 @@ export default {
     },
 
     async loadData() {
-      await this._loadData(false);
+      this.refreshing = true;
+      try {
+        await this._loadData(true);
+      } finally {
+        this.refreshing = false;
+      }
     },
 
     async silentRefresh() {
@@ -834,18 +840,16 @@ export default {
   white-space: nowrap;
 }
 
-.entry-col { width: 6%; }
-.exit-col { width: 6%; }
-.last-name-col { width: 9%; }
-.first-name-col { width: 8%; }
-.middle-name-col { width: 8%; }
-.position-col { width: 9%; }
-.citizenship-col { width: 8%; }
-.organization-col { width: 11%; }
-.pass-places-col { width: 10%; }
-.date-col { width: 8%; }
-.time-col { width: 8%; }
-.status-col { width: 7%; }
+.entry-col { width: 7%; }
+.exit-col { width: 7%; }
+.last-name-col { width: 11%; }
+.first-name-col { width: 10%; }
+.middle-name-col { width: 10%; }
+.position-col { width: 11%; }
+.organization-col { width: 14%; }
+.date-col { width: 10%; }
+.time-col { width: 10%; }
+.status-col { width: 8%; }
 .actions-col { width: 2%; }
 
 .header-row .col {
@@ -1107,8 +1111,7 @@ export default {
 
   .col.last-name-col,
   .col.first-name-col,
-  .col.organization-col,
-  .col.pass-places-col {
+  .col.organization-col {
     min-width: 110px !important;
   }
 

--- a/frontend/src/components/TrashHistoryModal.vue
+++ b/frontend/src/components/TrashHistoryModal.vue
@@ -1,122 +1,129 @@
 <template>
   <Teleport to="body">
-    <div
-      class="modal-overlay"
-      @click.self="$emit('close')"
+    <transition
+      name="trash-modal-fade"
+      appear
+      @after-leave="$emit('close')"
     >
-      <div class="trash-history-modal">
-        <div class="modal-header">
-          <h3>История корзины — {{ tableDisplayName }}</h3>
-          <div class="header-actions">
+      <div
+        v-if="show"
+        class="modal-overlay"
+        @click.self="close"
+      >
+        <div class="trash-history-modal">
+          <div class="modal-header">
+            <h3>История корзины — {{ tableDisplayName }}</h3>
+            <div class="header-actions">
+              <button
+                class="export-btn"
+                data-testid="trash-history-export"
+                :disabled="filteredHistory.length === 0 || isExporting"
+                @click="exportToExcel"
+              >
+                <img
+                  v-if="!isExporting"
+                  src="@/assets/icons/export.png"
+                  class="export-icon"
+                >
+                <span v-if="!isExporting">Экспорт</span>
+                <div
+                  v-else
+                  class="export-loader"
+                />
+              </button>
+              <button
+                class="close-btn"
+                data-testid="trash-history-close"
+                @click="close"
+              >
+                ×
+              </button>
+            </div>
+          </div>
+
+          <div
+            v-if="history.length"
+            class="history-filters"
+          >
+            <input
+              v-model="searchQuery"
+              type="text"
+              class="hf-input"
+              placeholder="Поиск по действию или пользователю..."
+            >
+            <select
+              v-model="selectedUser"
+              class="hf-select"
+            >
+              <option :value="null">
+                Все пользователи
+              </option>
+              <option
+                v-for="u in uniqueUsers"
+                :key="u"
+                :value="u"
+              >
+                {{ u }}
+              </option>
+            </select>
             <button
-              class="export-btn"
-              data-testid="trash-history-export"
-              :disabled="filteredHistory.length === 0 || isExporting"
-              @click="exportToExcel"
+              class="hf-sort"
+              @click="sortOrder = sortOrder === 'desc' ? 'asc' : 'desc'"
             >
               <img
-                v-if="!isExporting"
-                src="@/assets/icons/export.png"
-                class="export-icon"
+                src="@/assets/icons/sort.png"
+                class="hf-sort-icon"
+                :class="{ 'hf-sort-icon--asc': sortOrder === 'asc' }"
               >
-              <span v-if="!isExporting">Экспорт</span>
-              <div
-                v-else
-                class="export-loader"
-              />
-            </button>
-            <button
-              class="close-btn"
-              data-testid="trash-history-close"
-              @click="$emit('close')"
-            >
-              ×
+              <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
             </button>
           </div>
-        </div>
 
-        <div
-          v-if="history.length"
-          class="history-filters"
-        >
-          <input
-            v-model="searchQuery"
-            type="text"
-            class="hf-input"
-            placeholder="Поиск по действию или пользователю..."
-          >
-          <select
-            v-model="selectedUser"
-            class="hf-select"
-          >
-            <option :value="null">
-              Все пользователи
-            </option>
-            <option
-              v-for="u in uniqueUsers"
-              :key="u"
-              :value="u"
-            >
-              {{ u }}
-            </option>
-          </select>
-          <button
-            class="hf-sort"
-            @click="sortOrder = sortOrder === 'desc' ? 'asc' : 'desc'"
-          >
-            <img
-              src="@/assets/icons/sort.png"
-              class="hf-sort-icon"
-              :class="{ 'hf-sort-icon--asc': sortOrder === 'asc' }"
-            >
-            <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
-          </button>
-        </div>
-
-        <div class="modal-content">
-          <div
-            v-if="loading"
-            class="history-empty"
-          >
-            <div class="loader" />
-          </div>
-          <div
-            v-else-if="filteredHistory.length === 0"
-            class="history-empty"
-          >
-            {{ history.length ? 'Ничего не найдено' : 'История пуста' }}
-          </div>
-          <div
-            v-else
-            class="history-timeline"
-          >
+          <div class="modal-content">
             <div
-              v-for="(item, index) in filteredHistory"
-              :key="item.id"
-              class="history-item"
+              v-if="loading"
+              class="history-empty"
+            >
+              <div class="loader" />
+            </div>
+            <div
+              v-else-if="filteredHistory.length === 0"
+              class="history-empty"
+            >
+              {{ history.length ? 'Ничего не найдено' : 'История пуста' }}
+            </div>
+            <div
+              v-else
+              class="history-timeline"
             >
               <div
-                class="timeline-dot"
-                :class="getActionClass(item.action_type)"
-              />
-              <div
-                v-if="index < filteredHistory.length - 1"
-                class="timeline-line"
-              />
-              <div class="history-content">
-                <div class="history-header">
-                  <span class="action-title">{{ getActionText(item) }}</span>
-                  <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
-                </div>
-                <div class="action-user">
-                  {{ item.user_name || 'Система' }}
+                v-for="(item, index) in filteredHistory"
+                :key="item.id"
+                class="history-item"
+              >
+                <div
+                  class="timeline-dot"
+                  :class="getActionClass(item.action_type)"
+                />
+                <div
+                  v-if="index < filteredHistory.length - 1"
+                  class="timeline-line"
+                />
+                <div class="history-content">
+                  <div class="history-header">
+                    <span class="action-title">{{ getActionText(item) }}</span>
+                    <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                  </div>
+                  <div class="action-user">
+                    {{ item.user_name || 'Система' }}
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    </transition>
   </Teleport>
 </template>
 
@@ -134,6 +141,7 @@ export default {
   emits: ['close'],
   data() {
     return {
+      show: false,
       history: [],
       loading: false,
       isExporting: false,
@@ -178,9 +186,13 @@ export default {
     },
   },
   mounted() {
+    this.show = true;
     this.loadHistory();
   },
   methods: {
+    close() {
+      this.show = false;
+    },
     async loadHistory() {
       this.loading = true;
       try {
@@ -548,5 +560,15 @@ export default {
 .action-user {
   font-size: 13px;
   color: #555;
+}
+
+.trash-modal-fade-enter-active,
+.trash-modal-fade-leave-active {
+  transition: opacity 0.25s ease;
+}
+
+.trash-modal-fade-enter-from,
+.trash-modal-fade-leave-to {
+  opacity: 0;
 }
 </style>

--- a/frontend/src/stores/deletions.js
+++ b/frontend/src/stores/deletions.js
@@ -15,14 +15,19 @@ const TICK_MS = 100;
 export const useDeletionsStore = defineStore('deletions', () => {
   const items = ref([]);
 
-  function enqueue({ prefix = '', bold = '', suffix = '', onConfirm, onUndo, duration = 10000 }) {
+  function enqueue({ prefix = '', bold = '', suffix = '', onConfirm, onUndo, showUndo = true, duration = 10000 }) {
     const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
-    items.value.push({ id, prefix, bold, suffix, progress: 100 });
+    items.value.push({ id, prefix, bold, suffix, progress: 100, showUndo });
     callbacks.set(id, { onConfirm, onUndo });
-    const step = 100 / (duration / TICK_MS);
+    const step = 100 / (Math.max(duration, TICK_MS) / TICK_MS);
     const timer = setInterval(() => tick(id, step), TICK_MS);
     timers.set(id, timer);
     return id;
+  }
+
+  // Информационное уведомление в том же стиле (без отмены), напр. о восстановлении.
+  function notify({ prefix = '', bold = '', suffix = '', duration = 5000 }) {
+    return enqueue({ prefix, bold, suffix, showUndo: false, duration });
   }
 
   function tick(id, step) {
@@ -62,5 +67,5 @@ export const useDeletionsStore = defineStore('deletions', () => {
     callbacks.delete(id);
   }
 
-  return { items, enqueue, undo };
+  return { items, enqueue, notify, undo };
 });

--- a/frontend/src/views/TrashView.vue
+++ b/frontend/src/views/TrashView.vue
@@ -46,7 +46,7 @@
           />
           <OrganizationFilter
             ref="organizationFilter"
-            v-model="filters.organizationId"
+            :value="filters.organizationId"
             :organizations="organizations"
             @change="onOrganizationChange"
           />
@@ -283,7 +283,7 @@
       v-if="tableType === 'people' && showDetails"
       :show="showDetails"
       :employee="selectedDetail"
-      :all-tables="[]"
+      :all-tables="detailPlaces"
       :source="'trash'"
       @close="closeDetails"
       @open-application="() => {}"
@@ -304,6 +304,7 @@
 import ExcelJS from 'exceljs';
 import { apiRequest } from '@/api/client';
 import { useUiStore } from '@/stores/ui';
+import { useDeletionsStore } from '@/stores/deletions';
 import { listTrash, restoreItems, purgeItem, clearTrash } from '@/api/trash';
 import SearchComponent from '@/components/SearchComponent.vue';
 import OrganizationFilter from '@/components/OrganizationFilter.vue';
@@ -486,7 +487,8 @@ export default {
       clearTimeout(this.searchTimer);
       this.searchTimer = setTimeout(() => this.reload(), 300);
     },
-    onOrganizationChange() {
+    onOrganizationChange(payload) {
+      this.filters.organizationId = payload && payload.id ? payload.id : null;
       this.reload();
     },
     onDateClear() {
@@ -566,6 +568,8 @@ export default {
           deletedAtText,
         };
       } else {
+        const places = Array.isArray(item.pass_places) ? item.pass_places : [];
+        this.detailPlaces = places;
         this.selectedDetail = {
           id: item.id,
           last_name: item.last_name,
@@ -582,7 +586,7 @@ export default {
           companyId: null,
           entry_date_to: item.entry_date_to,
           pass_time: this.formatTimeRange(item),
-          target_tables: [],
+          target_tables: places.map(p => p.id),
           territory_status: null,
           applicationId: null,
           deletedByName: item.deleted_by_name,
@@ -597,18 +601,39 @@ export default {
     },
     async onRestoreSelected() {
       if (!this.selectedIds.length) return;
+      const firstItem = this.items.find(i => i.id === this.selectedIds[0]);
       try {
         const result = await restoreItems(this.tableID, this.selectedIds);
         const r = (result && result.restored) || 0;
         const req = (result && result.requested) || this.selectedIds.length;
+        if (r >= 1) {
+          this.notifyRestored(r, firstItem);
+        }
         if (r < req) {
           useUiStore().warning(`Восстановлено ${r} из ${req}. У остальных нет активной согласованной заявки.`);
-        } else {
-          useUiStore().success(`Восстановлено: ${r}`);
         }
         await this.reload();
       } catch {
         useUiStore().error('Не удалось восстановить');
+      }
+    },
+    notifyRestored(count, firstItem) {
+      const isCars = this.tableType === 'cars';
+      if (count === 1 && firstItem) {
+        const name = isCars
+          ? firstItem.car_number
+          : [firstItem.last_name, firstItem.first_name, firstItem.middle_name].filter(Boolean).join(' ');
+        useDeletionsStore().notify({
+          prefix: isCars ? 'Машина ' : 'Сотрудник ',
+          bold: name || '',
+          suffix: isCars ? ' восстановлена' : ' восстановлен',
+        });
+      } else {
+        useDeletionsStore().notify({
+          prefix: 'Восстановлено ',
+          bold: String(count),
+          suffix: ' элемент(ов)',
+        });
       }
     },
     async onPurgeOne(id) {
@@ -688,7 +713,7 @@ export default {
         // Авто-ширина по содержимому (через getColumn - применяется после addRow).
         headers.forEach((h, i) => {
           const maxLen = Math.max(h.length, ...dataRows.map(row => String(row[i] ?? '').length));
-          worksheet.getColumn(i + 1).width = Math.min(Math.max(maxLen + 4, 14), 60);
+          worksheet.getColumn(i + 1).width = Math.min(Math.max(maxLen + 6, 16), 80);
         });
         // Первый столбец должен вмещать подписи футера.
         worksheet.getColumn(1).width = Math.max(worksheet.getColumn(1).width || 0, 22);

--- a/internal/models/system_table_trash_history.go
+++ b/internal/models/system_table_trash_history.go
@@ -44,11 +44,12 @@ type TrashItem struct {
 	MarkName     *string         `json:"mark_name,omitempty"`
 	UnloadPlaces json.RawMessage `json:"unload_places,omitempty" gorm:"type:jsonb" swaggerignore:"true"`
 	// Employees-only
-	LastName        *string `json:"last_name,omitempty"`
-	FirstName       *string `json:"first_name,omitempty"`
-	MiddleName      *string `json:"middle_name,omitempty"`
-	Position        *string `json:"position,omitempty"`
-	CitizenshipName string  `json:"citizenship_name,omitempty"`
+	LastName        *string         `json:"last_name,omitempty"`
+	FirstName       *string         `json:"first_name,omitempty"`
+	MiddleName      *string         `json:"middle_name,omitempty"`
+	Position        *string         `json:"position,omitempty"`
+	CitizenshipName string          `json:"citizenship_name,omitempty"`
+	PassPlaces      json.RawMessage `json:"pass_places,omitempty" gorm:"type:jsonb" swaggerignore:"true"`
 }
 
 // TrashHistoryItem - запись лога корзины с именем пользователя для API.

--- a/internal/services/trash_service.go
+++ b/internal/services/trash_service.go
@@ -112,6 +112,11 @@ func (s *trashService) ListEmployeesTrash(ctx context.Context, systemTableID int
 			COALESCE(org.name, '') AS organization,
 			COALESCE(comp.name, '') AS company,
 			COALESCE(cit.name, '') AS citizenship_name,
+			COALESCE((
+				SELECT json_agg(json_build_object('id', st.id, 'display_name', st.display_name))
+				FROM employee_target_tables ett2 JOIN system_tables st ON st.id = ett2.table_id
+				WHERE ett2.employee_id = e.id
+			), '[]') AS pass_places,
 			att.entry_date_to, att.entry_time_from, att.entry_time_to,
 			e.date_deleted AS deleted_at,
 			COALESCE((


### PR DESCRIPTION
Часть правок по ревью (крупные «детали истории» и «настройка длительности уведомлений» — следующим PR).

- **Фильтр «Организация» в корзине** теперь фильтрует (ловим id из @change, OrganizationFilter — Vue2-стиль value/input).
- **PeopleTable**: убраны неиспользуемые колонки «Гражданство»/«Места прохода», ширины перераспределены на 100% (пустота справа убрана).
- **Уведомления удаления**: прогресс-бар 10px; плавный сдвиг стека при закрытии карточки (transition-group move); уведомление о **восстановлении** в том же стиле (без «Отменить», авто-скрытие).
- **CarsTable/PeopleTable**: «Обновить» больше не схлопывает таблицу (тихий refresh + спиннер на кнопке).
- **История корзины**: плавное закрытие модалки.
- **Экспорт корзины**: увеличена авто-ширина колонок.
- **Детальные модалки в корзине**: у сотрудника показываются «Места прохода» (backend отдаёт pass_places).

Проверено: go build/test, eslint 0 ошибок, npm build.