### PR TITLE
feat: детали истории корзины + настройка длительности уведомлений (#186)

### DIFF
--- a/frontend/src/components/DeleteNotifications.vue
+++ b/frontend/src/components/DeleteNotifications.vue
@@ -30,9 +30,12 @@
 </template>
 
 <script setup>
+import { onMounted } from 'vue';
 import { useDeletionsStore } from '@/stores/deletions';
 
 const store = useDeletionsStore();
+
+onMounted(() => store.loadDurations());
 
 // Цвет прогресс-бара: 100% (только удалили) - зелёный, 0% (вот-вот исчезнет) - красный.
 function colorFor(progress) {

--- a/frontend/src/components/TrashHistoryModal.vue
+++ b/frontend/src/components/TrashHistoryModal.vue
@@ -111,12 +111,38 @@
                 />
                 <div class="history-content">
                   <div class="history-header">
-                    <span class="action-title">{{ getActionText(item) }}</span>
+                    <span class="action-title">{{ actionTitle(item) }}</span>
                     <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
                   </div>
                   <div class="action-user">
                     {{ item.user_name || 'Система' }}
                   </div>
+                  <template v-if="itemDetails(item).length > 1">
+                    <button
+                      class="detail-toggle"
+                      @click="toggleExpand(item.id)"
+                    >
+                      {{ expanded[item.id] ? 'Свернуть' : `Раскрыть (${itemDetails(item).length})` }}
+                    </button>
+                    <ul
+                      v-if="expanded[item.id]"
+                      class="detail-list"
+                    >
+                      <li
+                        v-for="(d, i) in visibleDetails(item)"
+                        :key="i"
+                      >
+                        {{ d.label || ('ID ' + d.id) }}
+                      </li>
+                    </ul>
+                    <button
+                      v-if="expanded[item.id] && visibleDetails(item).length < filteredDetails(item).length"
+                      class="detail-more"
+                      @click="showMore(item.id)"
+                    >
+                      Показать ещё
+                    </button>
+                  </template>
                 </div>
               </div>
             </div>
@@ -148,6 +174,8 @@ export default {
       searchQuery: '',
       selectedUser: null,
       sortOrder: 'desc',
+      expanded: {},
+      shown: {},
     };
   },
   computed: {
@@ -163,7 +191,8 @@ export default {
         const q = this.searchQuery.toLowerCase();
         arr = arr.filter(h =>
           this.getActionText(h).toLowerCase().includes(q)
-          || (h.user_name || 'Система').toLowerCase().includes(q),
+          || (h.user_name || 'Система').toLowerCase().includes(q)
+          || this.itemDetails(h).some(d => (d.label || '').toLowerCase().includes(q)),
         );
       }
       arr.sort((a, b) => {
@@ -215,6 +244,39 @@ export default {
     },
     getActionClass(actionType) {
       return actionType === 'bulk_restored' ? 'dot-restore' : 'dot-clear';
+    },
+    itemDetails(item) {
+      return Array.isArray(item.details) ? item.details : [];
+    },
+    actionVerb(item) {
+      return item.action_type === 'bulk_restored' ? 'Восстановлено' : 'Удалено';
+    },
+    actionTitle(item) {
+      const d = this.itemDetails(item);
+      if (d.length === 1) {
+        return `${this.actionVerb(item)}: ${d[0].label || ('ID ' + d[0].id)}`;
+      }
+      if (d.length > 1) {
+        return `${this.actionVerb(item)} ${item.affected_count} элемент(ов)`;
+      }
+      return this.getActionText(item);
+    },
+    filteredDetails(item) {
+      const d = this.itemDetails(item);
+      if (!this.searchQuery) return d;
+      const q = this.searchQuery.toLowerCase();
+      const matched = d.filter(x => (x.label || '').toLowerCase().includes(q));
+      return matched.length ? matched : d;
+    },
+    visibleDetails(item) {
+      return this.filteredDetails(item).slice(0, this.shown[item.id] || 10);
+    },
+    toggleExpand(id) {
+      if (!this.shown[id]) this.shown[id] = 10;
+      this.expanded[id] = !this.expanded[id];
+    },
+    showMore(id) {
+      this.shown[id] = (this.shown[id] || 10) + 10;
     },
     formatDateTime(s) {
       if (!s) return '';
@@ -560,6 +622,41 @@ export default {
 .action-user {
   font-size: 13px;
   color: #555;
+}
+
+.detail-toggle,
+.detail-more {
+  margin-top: 6px;
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: 'Montserrat', sans-serif;
+  font-size: 12px;
+  font-weight: 500;
+  color: #4F5BDF;
+  cursor: pointer;
+}
+
+.detail-toggle:hover,
+.detail-more:hover {
+  text-decoration: underline;
+}
+
+.detail-list {
+  list-style: none;
+  margin: 6px 0 0;
+  padding: 8px 12px;
+  background: #f7f8ff;
+  border: 1px solid #e6e6e6;
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.detail-list li {
+  font-size: 13px;
+  color: #333;
 }
 
 .trash-modal-fade-enter-active,

--- a/frontend/src/stores/deletions.js
+++ b/frontend/src/stores/deletions.js
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
+import { apiRequest } from '@/api/client';
 
 /**
  * Стек уведомлений об удалении с отменой (#186).
@@ -14,20 +15,38 @@ const TICK_MS = 100;
 
 export const useDeletionsStore = defineStore('deletions', () => {
   const items = ref([]);
+  // Длительности (мс), настраиваются в Админка->Настройки.
+  const deleteDuration = ref(10000);
+  const restoreDuration = ref(5000);
+  let durationsLoaded = false;
 
-  function enqueue({ prefix = '', bold = '', suffix = '', onConfirm, onUndo, showUndo = true, duration = 10000 }) {
+  async function loadDurations() {
+    if (durationsLoaded) return;
+    durationsLoaded = true;
+    try {
+      const res = await apiRequest('/settings/notifications');
+      const data = await res.json();
+      if (data && Number(data.delete_duration) > 0) deleteDuration.value = Number(data.delete_duration) * 1000;
+      if (data && Number(data.restore_duration) > 0) restoreDuration.value = Number(data.restore_duration) * 1000;
+    } catch {
+      durationsLoaded = false;
+    }
+  }
+
+  function enqueue({ prefix = '', bold = '', suffix = '', onConfirm, onUndo, showUndo = true, duration }) {
     const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const ms = duration || deleteDuration.value;
     items.value.push({ id, prefix, bold, suffix, progress: 100, showUndo });
     callbacks.set(id, { onConfirm, onUndo });
-    const step = 100 / (Math.max(duration, TICK_MS) / TICK_MS);
+    const step = 100 / (Math.max(ms, TICK_MS) / TICK_MS);
     const timer = setInterval(() => tick(id, step), TICK_MS);
     timers.set(id, timer);
     return id;
   }
 
   // Информационное уведомление в том же стиле (без отмены), напр. о восстановлении.
-  function notify({ prefix = '', bold = '', suffix = '', duration = 5000 }) {
-    return enqueue({ prefix, bold, suffix, showUndo: false, duration });
+  function notify({ prefix = '', bold = '', suffix = '', duration }) {
+    return enqueue({ prefix, bold, suffix, showUndo: false, duration: duration || restoreDuration.value });
   }
 
   function tick(id, step) {
@@ -67,5 +86,5 @@ export const useDeletionsStore = defineStore('deletions', () => {
     callbacks.delete(id);
   }
 
-  return { items, enqueue, notify, undo };
+  return { items, enqueue, notify, undo, loadDurations };
 });

--- a/frontend/src/views/AdminSettings.vue
+++ b/frontend/src/views/AdminSettings.vue
@@ -247,6 +247,42 @@
               <span class="form-hint">От 10 до 120 секунд</span>
             </div>
 
+            <div class="form-group">
+              <label
+                class="form-label"
+                for="del-duration"
+              >
+                Длительность уведомления об удалении (секунды)
+              </label>
+              <input
+                id="del-duration"
+                v-model.number="settings.notifications_delete_duration"
+                type="number"
+                class="form-input"
+                :min="3"
+                :max="60"
+              >
+              <span class="form-hint">От 3 до 60 секунд (машины и люди)</span>
+            </div>
+
+            <div class="form-group">
+              <label
+                class="form-label"
+                for="res-duration"
+              >
+                Длительность уведомления о восстановлении (секунды)
+              </label>
+              <input
+                id="res-duration"
+                v-model.number="settings.notifications_restore_duration"
+                type="number"
+                class="form-input"
+                :min="3"
+                :max="60"
+              >
+              <span class="form-hint">От 3 до 60 секунд (машины и люди)</span>
+            </div>
+
             <button
               class="btn btn--primary"
               :disabled="saving"
@@ -296,6 +332,8 @@ export default {
         max_per_page: 50,
         notifications_enabled: false,
         notifications_poll_interval: 30,
+        notifications_delete_duration: 10,
+        notifications_restore_duration: 5,
       },
       availableImageTypes: ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/svg+xml'],
       availableDocTypes: ['application/pdf', 'application/msword', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', 'text/plain'],
@@ -375,6 +413,12 @@ export default {
           case 'notifications.poll_interval':
             this.settings.notifications_poll_interval = Number(item.value) || 30;
             break;
+          case 'notifications.delete_duration':
+            this.settings.notifications_delete_duration = Number(item.value) || 10;
+            break;
+          case 'notifications.restore_duration':
+            this.settings.notifications_restore_duration = Number(item.value) || 5;
+            break;
         }
       }
     },
@@ -440,10 +484,18 @@ export default {
         this.showToast('Интервал должен быть от 10 до 120 секунд', 'error');
         return;
       }
+      const del = this.settings.notifications_delete_duration;
+      const res = this.settings.notifications_restore_duration;
+      if (del < 3 || del > 60 || res < 3 || res > 60) {
+        this.showToast('Длительность уведомлений: от 3 до 60 секунд', 'error');
+        return;
+      }
       this.saving = true;
       try {
         await updateSetting('notifications.enabled', String(this.settings.notifications_enabled));
         await updateSetting('notifications.poll_interval', String(interval));
+        await updateSetting('notifications.delete_duration', String(del));
+        await updateSetting('notifications.restore_duration', String(res));
         this.showToast('Настройки уведомлений сохранены', 'success');
       } catch (error) {
         console.error('Ошибка сохранения:', error);

--- a/internal/handlers/settings.go
+++ b/internal/handlers/settings.go
@@ -47,3 +47,12 @@ func (h *SettingsHandler) GetUploadSettings(c echo.Context) error {
 	}
 	return RespondSuccess(c, result)
 }
+
+// GetNotificationSettings возвращает длительности уведомлений удаления/восстановления.
+func (h *SettingsHandler) GetNotificationSettings(c echo.Context) error {
+	result, err := h.service.GetNotificationSettings(c.Request().Context())
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, result)
+}

--- a/internal/models/system_table_trash_history.go
+++ b/internal/models/system_table_trash_history.go
@@ -9,12 +9,13 @@ import (
 // очистка (cleared) и массовое восстановление (bulk_restored). Действия с
 // отдельными элементами логируются в cars_history/employees_history.
 type SystemTableTrashHistory struct {
-	ID            int       `json:"id"`
-	SystemTableID int       `gorm:"index" json:"system_table_id"`
-	ActionType    string    `gorm:"size:30;index" json:"action_type"` // cleared | bulk_restored | purged_one
-	AffectedCount int       `json:"affected_count"`
-	UserID        *int      `gorm:"index" json:"user_id,omitempty"`
-	User          *User     `gorm:"foreignKey:UserID" json:"-"`
+	ID            int             `json:"id"`
+	SystemTableID int             `gorm:"index" json:"system_table_id"`
+	ActionType    string          `gorm:"size:30;index" json:"action_type"` // cleared | bulk_restored | purged_one
+	AffectedCount int             `json:"affected_count"`
+	Details       json.RawMessage `gorm:"type:jsonb" json:"details,omitempty"` // [{id,label}] затронутых элементов
+	UserID        *int            `gorm:"index" json:"user_id,omitempty"`
+	User          *User           `gorm:"foreignKey:UserID" json:"-"`
 	CreatedAt     time.Time `json:"created_at"`
 }
 
@@ -54,11 +55,18 @@ type TrashItem struct {
 
 // TrashHistoryItem - запись лога корзины с именем пользователя для API.
 type TrashHistoryItem struct {
-	ID            int       `json:"id"`
-	ActionType    string    `json:"action_type"`
-	AffectedCount int       `json:"affected_count"`
-	UserName      string    `json:"user_name,omitempty"`
-	CreatedAt     time.Time `json:"created_at"`
+	ID            int             `json:"id"`
+	ActionType    string          `json:"action_type"`
+	AffectedCount int             `json:"affected_count"`
+	Details       json.RawMessage `json:"details,omitempty" swaggerignore:"true"`
+	UserName      string          `json:"user_name,omitempty"`
+	CreatedAt     time.Time       `json:"created_at"`
+}
+
+// TrashDetail - затронутый элемент в логе корзины (для деталей восстановления/очистки).
+type TrashDetail struct {
+	ID    int    `json:"id"`
+	Label string `json:"label"`
 }
 
 // RestoreTrashRequest - тело запроса POST /system-tables/:id/trash/restore.

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -445,6 +445,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	// Настройки системы
 	protected.GET("/settings", settings.GetAll)
 	protected.GET("/settings/upload", settings.GetUploadSettings)
+	protected.GET("/settings/notifications", settings.GetNotificationSettings)
 	protected.PUT("/settings/:key", settings.Update)
 
 	// Новости

--- a/internal/services/settings_service.go
+++ b/internal/services/settings_service.go
@@ -19,15 +19,18 @@ type SettingsService interface {
 	GetAll(ctx context.Context, isSuperAdmin bool) ([]models.SystemSetting, error)
 	Update(ctx context.Context, isSuperAdmin bool, key string, value string) (*models.SystemSetting, error)
 	GetUploadSettings(ctx context.Context) (map[string]interface{}, error)
+	GetNotificationSettings(ctx context.Context) (map[string]interface{}, error)
 }
 
 var knownKeys = map[string]string{
-	"upload.max_file_size":        "int",
-	"upload.allowed_image_types":  "json",
-	"upload.allowed_doc_types":    "json",
-	"pagination.max_per_page":     "int",
-	"notifications.enabled":       "bool",
-	"notifications.poll_interval": "int",
+	"upload.max_file_size":            "int",
+	"upload.allowed_image_types":      "json",
+	"upload.allowed_doc_types":        "json",
+	"pagination.max_per_page":         "int",
+	"notifications.enabled":           "bool",
+	"notifications.poll_interval":     "int",
+	"notifications.delete_duration":   "int",
+	"notifications.restore_duration":  "int",
 }
 
 type settingsService struct {
@@ -44,8 +47,10 @@ func NewSettingsService(db *gorm.DB, cfg *config.Config) SettingsService {
 		"upload.allowed_image_types":  {Key: "upload.allowed_image_types", Value: mustJSON(cfg.UploadAllowedImageTypes), Type: "json"},
 		"upload.allowed_doc_types":    {Key: "upload.allowed_doc_types", Value: mustJSON(cfg.UploadAllowedDocTypes), Type: "json"},
 		"pagination.max_per_page":     {Key: "pagination.max_per_page", Value: strconv.Itoa(cfg.PaginationMaxLimit), Type: "int"},
-		"notifications.enabled":       {Key: "notifications.enabled", Value: "true", Type: "bool"},
-		"notifications.poll_interval": {Key: "notifications.poll_interval", Value: "30", Type: "int"},
+		"notifications.enabled":         {Key: "notifications.enabled", Value: "true", Type: "bool"},
+		"notifications.poll_interval":    {Key: "notifications.poll_interval", Value: "30", Type: "int"},
+		"notifications.delete_duration":  {Key: "notifications.delete_duration", Value: "10", Type: "int"},
+		"notifications.restore_duration": {Key: "notifications.restore_duration", Value: "5", Type: "int"},
 	}
 
 	s := &settingsService{db: db, defaults: defaults, cache: make(map[string]models.SystemSetting)}
@@ -148,6 +153,25 @@ func (s *settingsService) GetUploadSettings(ctx context.Context) (map[string]int
 	}, nil
 }
 
+// GetNotificationSettings возвращает длительности уведомлений удаления/восстановления (сек).
+func (s *settingsService) GetNotificationSettings(ctx context.Context) (map[string]interface{}, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	del, _ := strconv.Atoi(s.cache["notifications.delete_duration"].Value)
+	res, _ := strconv.Atoi(s.cache["notifications.restore_duration"].Value)
+	if del <= 0 {
+		del = 10
+	}
+	if res <= 0 {
+		res = 5
+	}
+	return map[string]interface{}{
+		"delete_duration":  del,
+		"restore_duration": res,
+	}, nil
+}
+
 func validateSettingValue(key, value string) error {
 	switch key {
 	case "upload.max_file_size":
@@ -164,6 +188,11 @@ func validateSettingValue(key, value string) error {
 		v, err := strconv.Atoi(value)
 		if err != nil || v < 10 || v > 120 {
 			return fmt.Errorf("notifications.poll_interval: 10-120 сек (получено %s)", value)
+		}
+	case "notifications.delete_duration", "notifications.restore_duration":
+		v, err := strconv.Atoi(value)
+		if err != nil || v < 3 || v > 60 {
+			return fmt.Errorf("%s: 3-60 сек (получено %s)", key, value)
 		}
 	case "notifications.enabled":
 		if value != "true" && value != "false" {

--- a/internal/services/trash_service.go
+++ b/internal/services/trash_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"time"
@@ -200,7 +201,7 @@ func (s *trashService) CanRestoreEmployee(ctx context.Context, id int) (bool, st
 }
 
 func (s *trashService) RestoreCars(ctx context.Context, systemTableID int, ids []int, userID int) (int, error) {
-	restored := 0
+	restoredIDs := make([]int, 0, len(ids))
 	for _, id := range ids {
 		ok, _ := s.CanRestoreCar(ctx, id)
 		if !ok {
@@ -221,17 +222,17 @@ func (s *trashService) RestoreCars(ctx context.Context, systemTableID int, ids [
 			}).Error
 		})
 		if err == nil {
-			restored++
+			restoredIDs = append(restoredIDs, id)
 		}
 	}
-	if restored >= 1 {
-		s.logTrashAction(ctx, systemTableID, models.TrashActionBulkRestored, restored, userID)
+	if len(restoredIDs) >= 1 {
+		s.logTrashAction(ctx, systemTableID, models.TrashActionBulkRestored, len(restoredIDs), userID, s.carDetails(ctx, restoredIDs))
 	}
-	return restored, nil
+	return len(restoredIDs), nil
 }
 
 func (s *trashService) RestoreEmployees(ctx context.Context, systemTableID int, ids []int, userID int) (int, error) {
-	restored := 0
+	restoredIDs := make([]int, 0, len(ids))
 	for _, id := range ids {
 		ok, _ := s.CanRestoreEmployee(ctx, id)
 		if !ok {
@@ -252,13 +253,13 @@ func (s *trashService) RestoreEmployees(ctx context.Context, systemTableID int, 
 			}).Error
 		})
 		if err == nil {
-			restored++
+			restoredIDs = append(restoredIDs, id)
 		}
 	}
-	if restored >= 1 {
-		s.logTrashAction(ctx, systemTableID, models.TrashActionBulkRestored, restored, userID)
+	if len(restoredIDs) >= 1 {
+		s.logTrashAction(ctx, systemTableID, models.TrashActionBulkRestored, len(restoredIDs), userID, s.employeeDetails(ctx, restoredIDs))
 	}
-	return restored, nil
+	return len(restoredIDs), nil
 }
 
 func (s *trashService) PurgeCar(ctx context.Context, systemTableID, id, userID int) error {
@@ -314,34 +315,47 @@ func (s *trashService) PurgeEmployee(ctx context.Context, systemTableID, id, use
 // ClearCarsTrash покрывает все cars в корзине этой таблицы (через cars_history.table_id).
 func (s *trashService) ClearCarsTrash(ctx context.Context, systemTableID, userID int) (int, error) {
 	now := time.Now().UTC()
-	subq := s.db.Table("cars_history").
-		Select("DISTINCT car_id").
-		Where("action_type = 'delete' AND table_id = ?", systemTableID)
+	subqIDs := func() *gorm.DB {
+		return s.db.Table("cars_history").Select("DISTINCT car_id").
+			Where("action_type = 'delete' AND table_id = ?", systemTableID)
+	}
+	// Детали очищаемых машин собираем до purge.
+	purgeIDs := make([]int, 0)
+	s.db.WithContext(ctx).Model(&models.Car{}).
+		Where("status = 0 AND is_purged = false AND id IN (?)", subqIDs()).
+		Pluck("id", &purgeIDs)
+	details := s.carDetails(ctx, purgeIDs)
 	res := s.db.WithContext(ctx).Model(&models.Car{}).
-		Where("status = 0 AND is_purged = false AND id IN (?)", subq).
+		Where("status = 0 AND is_purged = false AND id IN (?)", subqIDs()).
 		Updates(map[string]any{"is_purged": true, "purged_at": now, "purged_by_user_id": userID})
 	if res.Error != nil {
 		return 0, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка очистки")
 	}
 	if res.RowsAffected > 0 {
-		s.logTrashAction(ctx, systemTableID, models.TrashActionCleared, int(res.RowsAffected), userID)
+		s.logTrashAction(ctx, systemTableID, models.TrashActionCleared, int(res.RowsAffected), userID, details)
 	}
 	return int(res.RowsAffected), nil
 }
 
 func (s *trashService) ClearEmployeesTrash(ctx context.Context, systemTableID, userID int) (int, error) {
 	now := time.Now().UTC()
-	subq := s.db.Table("employees_history").
-		Select("DISTINCT employee_id").
-		Where("action_type = 'delete' AND table_id = ?", systemTableID)
+	subqIDs := func() *gorm.DB {
+		return s.db.Table("employees_history").Select("DISTINCT employee_id").
+			Where("action_type = 'delete' AND table_id = ?", systemTableID)
+	}
+	purgeIDs := make([]int, 0)
+	s.db.WithContext(ctx).Model(&models.Employee{}).
+		Where("status = 0 AND is_purged = false AND id IN (?)", subqIDs()).
+		Pluck("id", &purgeIDs)
+	details := s.employeeDetails(ctx, purgeIDs)
 	res := s.db.WithContext(ctx).Model(&models.Employee{}).
-		Where("status = 0 AND is_purged = false AND id IN (?)", subq).
+		Where("status = 0 AND is_purged = false AND id IN (?)", subqIDs()).
 		Updates(map[string]any{"is_purged": true, "purged_at": now, "purged_by_user_id": userID})
 	if res.Error != nil {
 		return 0, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка очистки")
 	}
 	if res.RowsAffected > 0 {
-		s.logTrashAction(ctx, systemTableID, models.TrashActionCleared, int(res.RowsAffected), userID)
+		s.logTrashAction(ctx, systemTableID, models.TrashActionCleared, int(res.RowsAffected), userID, details)
 	}
 	return int(res.RowsAffected), nil
 }
@@ -349,7 +363,7 @@ func (s *trashService) ClearEmployeesTrash(ctx context.Context, systemTableID, u
 // ListTrashHistory возвращает лог массовых действий с корзиной таблицы.
 func (s *trashService) ListTrashHistory(ctx context.Context, systemTableID int) ([]models.TrashHistoryItem, error) {
 	sql := `
-		SELECT h.id, h.action_type, h.affected_count,
+		SELECT h.id, h.action_type, h.affected_count, h.details,
 			COALESCE(format_short_name(u.last_name, u.first_name, u.middle_name), '') AS user_name,
 			h.created_at
 		FROM system_table_trash_histories h
@@ -364,12 +378,42 @@ func (s *trashService) ListTrashHistory(ctx context.Context, systemTableID int) 
 }
 
 // logTrashAction пишет запись в лог корзины. Ошибка не прерывает основную операцию.
-func (s *trashService) logTrashAction(ctx context.Context, systemTableID int, action string, count, userID int) {
+func (s *trashService) logTrashAction(ctx context.Context, systemTableID int, action string, count, userID int, details []models.TrashDetail) {
 	uid := userID
-	_ = s.db.WithContext(ctx).Create(&models.SystemTableTrashHistory{
+	rec := models.SystemTableTrashHistory{
 		SystemTableID: systemTableID,
 		ActionType:    action,
 		AffectedCount: count,
 		UserID:        &uid,
-	}).Error
+	}
+	if len(details) > 0 {
+		if b, err := json.Marshal(details); err == nil {
+			rec.Details = b
+		}
+	}
+	_ = s.db.WithContext(ctx).Create(&rec).Error
+}
+
+// carDetails возвращает [{id,label}] машин для лога корзины (номер + марка).
+func (s *trashService) carDetails(ctx context.Context, ids []int) []models.TrashDetail {
+	if len(ids) == 0 {
+		return nil
+	}
+	rows := make([]models.TrashDetail, 0)
+	s.db.WithContext(ctx).Table("cars").
+		Select("id, TRIM(COALESCE(car_number, '') || ' ' || COALESCE(mark_name, car_brand, '')) AS label").
+		Where("id IN ?", ids).Scan(&rows)
+	return rows
+}
+
+// employeeDetails возвращает [{id,label}] сотрудников для лога корзины (ФИО).
+func (s *trashService) employeeDetails(ctx context.Context, ids []int) []models.TrashDetail {
+	if len(ids) == 0 {
+		return nil
+	}
+	rows := make([]models.TrashDetail, 0)
+	s.db.WithContext(ctx).Table("employees").
+		Select("id, TRIM(CONCAT_WS(' ', last_name, first_name, middle_name)) AS label").
+		Where("id IN ?", ids).Scan(&rows)
+	return rows
 }


### PR DESCRIPTION
- История корзины: вместо «Восстановлено N» — конкретика (номер/марка/ФИО). 1 элемент — сразу; несколько — счётчик + «Раскрыть» + «Показать ещё»; поиск работает по элементам. Backend хранит details (jsonb).
- Админка→Настройки→Уведомления: раздельная настройка длительности уведомлений удаления и восстановления (3-60с). Backend settings + публичный GET /settings/notifications; стор уведомлений читает значения.