### PR TITLE
fix: длительность уведомлений применяется сразу и после логина (#186)

### DIFF
--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -415,6 +415,9 @@ export default {
   },
   mounted() {
     this.startPolling();
+    // Подгружаем настроенные длительности уведомлений после авторизации
+    // (на холодном старте App.vue запрос мог уйти до получения токена).
+    useDeletionsStore().loadDurations();
   },
   beforeUnmount() {
     this.stopPolling();

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -440,6 +440,9 @@ export default {
   },
   mounted() {
     this.startPolling();
+    // Подгружаем настроенные длительности уведомлений после авторизации
+    // (на холодном старте App.vue запрос мог уйти до получения токена).
+    useDeletionsStore().loadDurations();
   },
   beforeUnmount() {
     this.stopPolling();

--- a/frontend/src/stores/__tests__/deletions.spec.js
+++ b/frontend/src/stores/__tests__/deletions.spec.js
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+
+const apiRequest = vi.fn();
+vi.mock('@/api/client', () => ({
+  apiRequest: (...args) => apiRequest(...args),
+}));
+
+import { useDeletionsStore } from '../deletions';
+
+function mockResponse(data) {
+  return { json: async () => data };
+}
+
+// Возвращает мс, после которых уведомление само подтверждается (onConfirm).
+// Так косвенно проверяем применённую длительность, не завязываясь на внутренний ref.
+function confirmDelayMs(store) {
+  const onConfirm = vi.fn();
+  store.enqueue({ onConfirm });
+  let elapsed = 0;
+  while (!onConfirm.mock.calls.length && elapsed < 120000) {
+    vi.advanceTimersByTime(100);
+    elapsed += 100;
+  }
+  return onConfirm.mock.calls.length ? elapsed : -1;
+}
+
+// Декремент progress на каждом тике копит ошибку округления, поэтому
+// подтверждение может прийти на один тик (100мс) позже теоретического.
+function expectDuration(store, ms) {
+  const delay = confirmDelayMs(store);
+  expect(delay).toBeGreaterThanOrEqual(ms);
+  expect(delay).toBeLessThanOrEqual(ms + 200);
+}
+
+describe('deletions store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    apiRequest.mockReset();
+    vi.useFakeTimers();
+  });
+
+  describe('loadDurations', () => {
+    it('применяет длительности из успешного ответа', async () => {
+      apiRequest.mockResolvedValue(mockResponse({ delete_duration: 15, restore_duration: 3 }));
+      const store = useDeletionsStore();
+
+      await store.loadDurations();
+
+      expectDuration(store, 15000);
+    });
+
+    it('не латчит и пробует снова, если ответ без валидных значений (напр. 401 до авторизации)', async () => {
+      // apiRequest разворачивает 401 в {message} - валидных длительностей нет.
+      apiRequest.mockResolvedValueOnce(mockResponse({ message: 'Missing or invalid authorization header' }));
+      const store = useDeletionsStore();
+
+      await store.loadDurations();
+      // Дефолт сохранился (10с), значение из ошибочного ответа не применилось.
+      expectDuration(store, 10000);
+
+      // Второй вызов (после логина) отдаёт валидные значения - они применяются.
+      apiRequest.mockResolvedValueOnce(mockResponse({ delete_duration: 15, restore_duration: 3 }));
+      await store.loadDurations();
+      expect(apiRequest).toHaveBeenCalledTimes(2);
+      expectDuration(store, 15000);
+    });
+
+    it('после успешной загрузки повторный вызов не делает новый запрос', async () => {
+      apiRequest.mockResolvedValue(mockResponse({ delete_duration: 8, restore_duration: 4 }));
+      const store = useDeletionsStore();
+
+      await store.loadDurations();
+      await store.loadDurations();
+
+      expect(apiRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it('не падает, если apiRequest бросает, и позволяет повторить', async () => {
+      apiRequest.mockRejectedValueOnce(new Error('network'));
+      const store = useDeletionsStore();
+
+      await expect(store.loadDurations()).resolves.toBeUndefined();
+
+      // Защёлка не выставлена - повтор отдаёт валидные значения.
+      apiRequest.mockResolvedValueOnce(mockResponse({ delete_duration: 20, restore_duration: 5 }));
+      await store.loadDurations();
+      expectDuration(store, 20000);
+    });
+  });
+
+  describe('setDurations', () => {
+    it('сразу применяет новые длительности без запроса', () => {
+      const store = useDeletionsStore();
+
+      store.setDurations(25, 6);
+
+      expect(apiRequest).not.toHaveBeenCalled();
+      expectDuration(store, 25000);
+    });
+
+    it('латчит загрузку - после setDurations loadDurations не делает запрос', async () => {
+      const store = useDeletionsStore();
+
+      store.setDurations(12, 4);
+      await store.loadDurations();
+
+      expect(apiRequest).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/stores/deletions.js
+++ b/frontend/src/stores/deletions.js
@@ -22,15 +22,37 @@ export const useDeletionsStore = defineStore('deletions', () => {
 
   async function loadDurations() {
     if (durationsLoaded) return;
-    durationsLoaded = true;
     try {
       const res = await apiRequest('/settings/notifications');
       const data = await res.json();
-      if (data && Number(data.delete_duration) > 0) deleteDuration.value = Number(data.delete_duration) * 1000;
-      if (data && Number(data.restore_duration) > 0) restoreDuration.value = Number(data.restore_duration) * 1000;
+      const del = Number(data?.delete_duration);
+      const rest = Number(data?.restore_duration);
+      // Защёлкиваем только при успешном ответе с валидными значениями. До
+      // авторизации запрос отдаёт 401 с JSON-телом (без throw), и значения
+      // остаются дефолтными - в этом случае не латчим, чтобы перечитать после логина.
+      if (del > 0 || rest > 0) {
+        if (del > 0) deleteDuration.value = del * 1000;
+        if (rest > 0) restoreDuration.value = rest * 1000;
+        durationsLoaded = true;
+      }
     } catch {
-      durationsLoaded = false;
+      // оставляем durationsLoaded = false для повторной попытки
     }
+  }
+
+  /**
+   * Принудительно выставить длительности (в секундах).
+   * Вызывается при сохранении настроек, чтобы изменение применилось сразу,
+   * без перезагрузки страницы.
+   * @param {number} deleteSec длительность плашки удаления, сек
+   * @param {number} restoreSec длительность плашки восстановления, сек
+   */
+  function setDurations(deleteSec, restoreSec) {
+    const del = Number(deleteSec);
+    const rest = Number(restoreSec);
+    if (del > 0) deleteDuration.value = del * 1000;
+    if (rest > 0) restoreDuration.value = rest * 1000;
+    durationsLoaded = true;
   }
 
   function enqueue({ prefix = '', bold = '', suffix = '', onConfirm, onUndo, showUndo = true, duration }) {
@@ -86,5 +108,5 @@ export const useDeletionsStore = defineStore('deletions', () => {
     callbacks.delete(id);
   }
 
-  return { items, enqueue, notify, undo, loadDurations };
+  return { items, enqueue, notify, undo, loadDurations, setDurations };
 });

--- a/frontend/src/views/AdminSettings.vue
+++ b/frontend/src/views/AdminSettings.vue
@@ -311,6 +311,7 @@
 <script>
 import { getSettings, updateSetting } from '@/api/settings';
 import { SkeletonTransition, SkeletonLine, SkeletonBlock } from '@/components/ui';
+import { useDeletionsStore } from '@/stores/deletions';
 
 export default {
   name: 'AdminSettings',
@@ -496,6 +497,9 @@ export default {
         await updateSetting('notifications.poll_interval', String(interval));
         await updateSetting('notifications.delete_duration', String(del));
         await updateSetting('notifications.restore_duration', String(res));
+        // Сразу применяем к стору уведомлений, иначе новые длительности
+        // вступят в силу только после полной перезагрузки страницы.
+        useDeletionsStore().setDurations(del, res);
         this.showToast('Настройки уведомлений сохранены', 'success');
       } catch (error) {
         console.error('Ошибка сохранения:', error);

--- a/frontend/src/views/TrashView.vue
+++ b/frontend/src/views/TrashView.vue
@@ -416,6 +416,9 @@ export default {
   async mounted() {
     this.fetchCurrentUser();
     this.fetchOrganizations();
+    // Подгружаем настроенные длительности уведомлений после авторизации
+    // (на холодном старте App.vue запрос мог уйти до получения токена).
+    useDeletionsStore().loadDurations();
     await this.fetchTable();
     if (this.tableID) await this.reload();
   },


### PR DESCRIPTION
## Проблема
Настройка длительности плашек удаления/восстановления (Админка -> Настройки -> Уведомления) сохранялась в БД, но не применялась к самим уведомлениям:
- **В текущей сессии:** после смены значения и сохранения плашка продолжала висеть старую длительность - `loadDurations()` вызывался один раз на маунте `DeleteNotifications` (старт `App.vue`) с вечной защёлкой `durationsLoaded`, и при сохранении настроек стор не перечитывался.
- **На холодном логине:** `loadDurations()` стартует до получения JWT, GET `/settings/notifications` возвращает 401 с JSON-телом `{success:false}`. `res.json()` не бросает, длительности остаются дефолтными, а `durationsLoaded` навсегда `true` (выставлялся до `await`). После логина (SPA, без ремаунта App) стор уже не перечитывал значения -> всю сессию дефолт.

## Что сделано
- `stores/deletions.js`: защёлка `durationsLoaded` выставляется только при успешном ответе с валидными значениями (иначе повторяем после логина). Добавлен `setDurations(deleteSec, restoreSec)` для мгновенного применения.
- `AdminSettings.vue`: после успешного сохранения настроек вызываем `setDurations()` - изменение применяется сразу, без перезагрузки.
- `CarsTable.vue`, `PeopleTable.vue`, `TrashView.vue`: `loadDurations()` в `mounted` - надёжная подгрузка после авторизации (дёшево: латчится после первого успеха).
- Юнит-тесты стора: защёлка только при успехе + повтор, мгновенное применение `setDurations`.

## Тестирование
- [x] `vitest run` - 272 passed
- [x] eslint по изменённым файлам - 0 ошибок
- [ ] Staging: смена настройки в сессии -> удаление применяет новую длительность без перезагрузки
- [ ] Staging: холодный логин -> удаление применяет сохранённую длительность