### PR TITLE
fix: в архив заявок попадают завершённые, отклонённые и не согласованные

### DIFF
--- a/internal/handlers/application_reads_test.go
+++ b/internal/handlers/application_reads_test.go
@@ -204,6 +204,56 @@ func TestGetApplications_ArchiveTrue_ShowsOnlyArchived(t *testing.T) {
 	assert.Equal(t, float64(appID), apps[0]["id"])
 }
 
+// Архив должен включать все закрытые статусы (Завершено, Отказано), а не только
+// Завершено. Заявка "В работе" с истёкшим вложением остаётся активной.
+func TestGetApplications_Archive_IncludesRefused_ExcludesInWork(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	makeApprover(t, db, "testadmin")
+
+	archive := func(name string, status string) int {
+		uaID := seedUniqueAttachment(t, db, "cars", "tmpl_"+name, "Disp_"+name)
+		appID := submitCompleteApplication(t, e, token, "Test Organization", uaID)
+		db.Model(&models.Application{}).Where("id = ?", appID).Update("status", status)
+		db.Model(&models.Attachment{}).Where("application_id = ?", appID).Update("entry_date_to", "2025-01-01")
+		return appID
+	}
+
+	completedID := archive("done", models.StatusCompleted)
+	refusedID := archive("refused", models.StatusRefused)
+	inWorkID := archive("inwork", models.StatusInWork)
+
+	ids := func(apps []map[string]interface{}) []float64 {
+		out := make([]float64, 0, len(apps))
+		for _, a := range apps {
+			if id, ok := a["id"].(float64); ok {
+				out = append(out, id)
+			}
+		}
+		return out
+	}
+
+	// archive=true: закрытые (Завершено, Отказано), но не "В работе".
+	rec := testutil.GET(t, e, "/applications?archive=true", testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	archived := ids(testutil.ParseSlice(t, rec))
+	assert.Contains(t, archived, float64(completedID))
+	assert.Contains(t, archived, float64(refusedID))
+	assert.NotContains(t, archived, float64(inWorkID))
+
+	// Активные (по умолчанию): "В работе" есть, закрытые исключены.
+	recActive := testutil.GET(t, e, "/applications", testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusOK, recActive.Code)
+	active := ids(testutil.ParseSlice(t, recActive))
+	assert.Contains(t, active, float64(inWorkID))
+	assert.NotContains(t, active, float64(completedID))
+	assert.NotContains(t, active, float64(refusedID))
+}
+
 // --- Part 3: Active today ---
 
 func TestGetApplications_ActiveToday_FiltersByAttachmentPeriod(t *testing.T) {

--- a/internal/models/status.go
+++ b/internal/models/status.go
@@ -12,6 +12,12 @@ const (
 	StatusRefused    = "Отказано"
 )
 
+// ArchivableStatuses — статусы заявки, при которых она считается закрытой и
+// подлежит переносу в архив (после того как срок действия вложений истёк
+// более месяца назад). Заявки "В работе"/"В обработке"/"Непрочитано" остаются
+// активными независимо от срока - они ещё действуют либо не обработаны.
+var ArchivableStatuses = []string{StatusCompleted, StatusRejected, StatusRefused}
+
 // Application confirmations
 const (
 	ConfirmationPending  = "Согласование"

--- a/internal/services/application_helpers.go
+++ b/internal/services/application_helpers.go
@@ -247,16 +247,16 @@ func applyApplicationFilters(query *gorm.DB, filter ApplicationFilter, includeUs
 
 	// Archive filter: by default exclude archived, archive=true shows only archived
 	archiveCondition := `
-		(a.status IN (?, ?) AND EXISTS(
+		(a.status IN ? AND EXISTS(
 			SELECT 1 FROM attachments att WHERE att.application_id = a.id
 			AND att.entry_date_to IS NOT NULL
 			AND CAST(att.entry_date_to AS DATE) + INTERVAL '1 month' < NOW()
 		))
 	`
 	if filter.Archive != nil && *filter.Archive {
-		query = query.Where(archiveCondition, models.StatusCompleted, models.StatusRejected)
+		query = query.Where(archiveCondition, models.ArchivableStatuses)
 	} else {
-		query = query.Where("NOT "+archiveCondition, models.StatusCompleted, models.StatusRejected)
+		query = query.Where("NOT "+archiveCondition, models.ArchivableStatuses)
 	}
 
 	// Active today: заявка активна сегодня, если период действия хотя бы одного

--- a/internal/services/application_read_service.go
+++ b/internal/services/application_read_service.go
@@ -17,7 +17,7 @@ func (s *applicationService) isArchived(ctx context.Context, applicationID int) 
 		Table("applications app").
 		Joins("JOIN attachments a ON a.application_id = app.id").
 		Where("app.id = ?", applicationID).
-		Where("app.status IN ?", []string{models.StatusCompleted, models.StatusRejected}).
+		Where("app.status IN ?", models.ArchivableStatuses).
 		Where("CAST(a.entry_date_to AS DATE) + INTERVAL '1 month' < NOW()").
 		Count(&count).Error
 	if err != nil {
@@ -102,7 +102,7 @@ func (s *applicationService) GetUnreadCount(ctx context.Context, username string
 	// Непрочитанные = нет записи в application_reads для пользователя + не архивные.
 	archiveExclude := `
 		NOT (
-			a.status IN (?, ?) AND EXISTS(
+			a.status IN ? AND EXISTS(
 				SELECT 1 FROM attachments att WHERE att.application_id = a.id
 				AND att.entry_date_to IS NOT NULL
 				AND CAST(att.entry_date_to AS DATE) + INTERVAL '1 month' < NOW()
@@ -112,7 +112,7 @@ func (s *applicationService) GetUnreadCount(ctx context.Context, username string
 	query := s.db.WithContext(ctx).
 		Table("applications a").
 		Where("NOT EXISTS (SELECT 1 FROM application_reads ar WHERE ar.application_id = a.id AND ar.user_id = ?)", user.ID).
-		Where(archiveExclude, models.StatusCompleted, models.StatusRejected)
+		Where(archiveExclude, models.ArchivableStatuses)
 
 	// Permission filter: совпадает с GetApplications (см. application_service.go).
 	// Если юзер не approver, видит только заявки, где он responsible или viewer.


### PR DESCRIPTION
## Проблема
Фильтр архива в Центре заявок ссылался на пару статусов `StatusCompleted ("Завершено")` + `StatusRejected ("Не согласовано")`. Но `"Не согласовано"` заявке как *статус* нигде не присваивается - это значение поля *confirmation* (согласование). Реальный статус отклонённой заявки - `StatusRefused ("Отказано")` (ставит action `reject`).

Следствие: отклонённые ("Отказано") заявки никогда не попадали в архив - оставались в "Активных" навсегда. В архив фактически уходили только "Завершено".

## Что сделано
- `models/status.go`: добавлен общий список `ArchivableStatuses = {Завершено, Не согласовано, Отказано}` - статусы, при которых заявка считается закрытой и подлежит архивации (после истечения срока вложений > 1 месяца).
- `application_helpers.go` (фильтр архива в `GetApplications`) и `application_read_service.go` (`isArchived`, `GetUnreadCount`) переведены на `ArchivableStatuses` вместо хардкода пары.
- Условие "срок вложения истёк > 1 месяца назад" не тронуто - заявка "В работе" (напр. 3-месячная действующая) в архив не уходит.

## Тесты
- Новый `TestGetApplications_Archive_IncludesRefused_ExcludesInWork`: "Отказано" и "Завершено" с истёкшим вложением -> в архиве; "В работе" с истёкшим -> остаётся активной.
- Полный прогон `internal/handlers` + `internal/services` - зелёный.