### PR TITLE
test: покрытие #186 - корзина, уведомления, история (бэк + фронт + E2E)

### DIFF
--- a/frontend/e2e/pages/TrashPage.cjs
+++ b/frontend/e2e/pages/TrashPage.cjs
@@ -1,0 +1,39 @@
+const { expect } = require('@playwright/test');
+
+// POM страницы корзины таблицы (#186): /table/:tableName/trash.
+class TrashPage {
+  constructor(page) {
+    this.page = page;
+    this.root = page.locator('.trash-view');
+    this.title = page.locator('.trash-title');
+    this.backBtn = page.getByTestId('trash-back');
+    this.exportBtn = page.getByTestId('trash-export');
+    this.clearBtn = page.getByTestId('trash-clear');
+    this.restoreBtn = page.getByTestId('trash-restore-selected');
+    this.historyBtn = page.getByTestId('trash-history');
+    this.historyModal = page.locator('.trash-history-modal');
+    this.historyClose = page.getByTestId('trash-history-close');
+  }
+
+  async goto(tableName) {
+    await this.page.goto(`/table/${tableName}/trash`);
+  }
+
+  async expectLoaded() {
+    await expect(this.root).toBeVisible();
+    await expect(this.title).toContainText('Корзина');
+    await expect(this.historyBtn).toBeVisible();
+  }
+
+  async openHistory() {
+    await this.historyBtn.click();
+    await expect(this.historyModal).toBeVisible();
+  }
+
+  async closeHistory() {
+    await this.historyClose.click();
+    await expect(this.historyModal).toBeHidden();
+  }
+}
+
+module.exports = { TrashPage };

--- a/frontend/e2e/tests/trash.spec.cjs
+++ b/frontend/e2e/tests/trash.spec.cjs
@@ -1,0 +1,54 @@
+const { test, expect } = require('@playwright/test');
+const { loginAsSuperAdmin } = require('../helpers/permissions');
+const { loginAsSuperAdminUI } = require('../helpers/auth');
+const { TrashPage } = require('../pages/TrashPage');
+
+const API_BASE = process.env.E2E_API_BASE_URL || '/api';
+
+// Находит первую таблицу типа cars/people - только они поддерживают корзину.
+async function firstTrashableTable(request, token) {
+  const res = await request.get(`${API_BASE}/system-tables`, {
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+  });
+  if (!res.ok()) return null;
+  const data = (await res.json()).data || [];
+  return data.find((t) => t.table_type === 'cars' || t.table_type === 'people') || null;
+}
+
+test.describe('Корзина таблицы (#186)', () => {
+  test('страница корзины рендерится, модалка истории открывается и закрывается', async ({ page, request }) => {
+    const token = await loginAsSuperAdmin(request);
+    const table = await firstTrashableTable(request, token);
+    test.skip(!table, 'нет таблицы типа cars/people в seed-данных');
+
+    await loginAsSuperAdminUI(page);
+
+    const trash = new TrashPage(page);
+    await trash.goto(table.name);
+
+    // Страница корзины загрузилась с базовыми контролами.
+    await trash.expectLoaded();
+    await expect(trash.exportBtn).toBeVisible();
+    await expect(trash.clearBtn).toBeVisible();
+
+    // Модалка истории корзины открывается и закрывается.
+    await trash.openHistory();
+    await expect(trash.historyModal).toContainText('История корзины');
+    await trash.closeHistory();
+  });
+
+  test('ссылка "Назад" возвращает на страницу таблицы', async ({ page, request }) => {
+    const token = await loginAsSuperAdmin(request);
+    const table = await firstTrashableTable(request, token);
+    test.skip(!table, 'нет таблицы типа cars/people в seed-данных');
+
+    await loginAsSuperAdminUI(page);
+
+    const trash = new TrashPage(page);
+    await trash.goto(table.name);
+    await trash.expectLoaded();
+
+    await trash.backBtn.click();
+    await expect(page).toHaveURL(new RegExp(`/table/${table.name}(\\?|$|/)`));
+  });
+});

--- a/frontend/src/components/__tests__/TrashHistoryModal.spec.js
+++ b/frontend/src/components/__tests__/TrashHistoryModal.spec.js
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+
+const getTrashHistory = vi.fn();
+vi.mock('@/api/trash', () => ({
+  getTrashHistory: (...args) => getTrashHistory(...args),
+}));
+// exceljs тяжёлый и нужен только для экспорта - экспорт здесь не тестируем.
+vi.mock('exceljs', () => ({ default: { Workbook: class {} } }));
+
+import TrashHistoryModal from '../TrashHistoryModal.vue';
+
+async function mountWith(history) {
+  getTrashHistory.mockResolvedValue(history);
+  const wrapper = mount(TrashHistoryModal, {
+    props: { tableId: 1, tableDisplayName: 'КПП №4', currentUserName: 'Иванов Иван' },
+    global: { stubs: { teleport: true } },
+    attachTo: document.body,
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+function entry(over = {}) {
+  return {
+    id: 1,
+    action_type: 'cleared',
+    affected_count: 1,
+    details: [{ id: 10, label: 'М 001 АА 77 Киа' }],
+    user_name: 'Иванов И.И.',
+    created_at: '2026-05-01T10:00:00Z',
+    ...over,
+  };
+}
+
+describe('TrashHistoryModal', () => {
+  beforeEach(() => {
+    getTrashHistory.mockReset();
+    document.body.innerHTML = '';
+  });
+
+  it('одна деталь: заголовок inline "Удалено: <label>" без кнопки Раскрыть', async () => {
+    const wrapper = await mountWith([entry()]);
+
+    expect(wrapper.find('.action-title').text()).toBe('Удалено: М 001 АА 77 Киа');
+    expect(wrapper.find('.detail-toggle').exists()).toBe(false);
+  });
+
+  it('несколько деталей: "Удалено N элемент(ов)" + Раскрыть -> список -> Свернуть', async () => {
+    const wrapper = await mountWith([
+      entry({ affected_count: 2, details: [{ id: 1, label: 'A' }, { id: 2, label: 'B' }] }),
+    ]);
+
+    expect(wrapper.find('.action-title').text()).toBe('Удалено 2 элемент(ов)');
+    const toggle = wrapper.find('.detail-toggle');
+    expect(toggle.text()).toBe('Раскрыть (2)');
+    expect(wrapper.find('.detail-list').exists()).toBe(false);
+
+    await toggle.trigger('click');
+    expect(wrapper.find('.detail-list').exists()).toBe(true);
+    expect(wrapper.findAll('.detail-list li')).toHaveLength(2);
+    expect(wrapper.find('.detail-toggle').text()).toBe('Свернуть');
+
+    await wrapper.find('.detail-toggle').trigger('click');
+    expect(wrapper.find('.detail-list').exists()).toBe(false);
+  });
+
+  it('восстановление использует глагол "Восстановлено"', async () => {
+    const wrapper = await mountWith([
+      entry({ action_type: 'bulk_restored', details: [{ id: 5, label: 'Петров П.П.' }] }),
+    ]);
+
+    expect(wrapper.find('.action-title').text()).toBe('Восстановлено: Петров П.П.');
+  });
+
+  it('поиск фильтрует историю по label детали', async () => {
+    const wrapper = await mountWith([
+      entry({ id: 1, details: [{ id: 1, label: 'В 746 КУ 964 БМВ' }] }),
+      entry({ id: 2, details: [{ id: 2, label: 'М 001 АА 77 Киа' }] }),
+    ]);
+
+    expect(wrapper.findAll('.history-item')).toHaveLength(2);
+
+    await wrapper.find('.hf-input').setValue('бмв');
+    expect(wrapper.findAll('.history-item')).toHaveLength(1);
+    expect(wrapper.find('.action-title').text()).toContain('БМВ');
+  });
+
+  it('>10 деталей: показывается "Показать ещё", по клику список расширяется', async () => {
+    const details = Array.from({ length: 12 }, (_, i) => ({ id: i + 1, label: `Авто ${i + 1}` }));
+    const wrapper = await mountWith([entry({ affected_count: 12, details })]);
+
+    await wrapper.find('.detail-toggle').trigger('click');
+    expect(wrapper.findAll('.detail-list li')).toHaveLength(10);
+    const more = wrapper.find('.detail-more');
+    expect(more.exists()).toBe(true);
+
+    await more.trigger('click');
+    expect(wrapper.findAll('.detail-list li')).toHaveLength(12);
+    expect(wrapper.find('.detail-more').exists()).toBe(false);
+  });
+
+  it('пустая история показывает "История пуста"', async () => {
+    const wrapper = await mountWith([]);
+    expect(wrapper.find('.history-empty').text()).toBe('История пуста');
+  });
+});

--- a/frontend/src/views/__tests__/AdminSettings.notifications.spec.js
+++ b/frontend/src/views/__tests__/AdminSettings.notifications.spec.js
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { shallowMount, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+
+const getSettings = vi.fn();
+const updateSetting = vi.fn();
+vi.mock('@/api/settings', () => ({
+  getSettings: (...a) => getSettings(...a),
+  updateSetting: (...a) => updateSetting(...a),
+}));
+
+import AdminSettings from '../AdminSettings.vue';
+import { useDeletionsStore } from '@/stores/deletions';
+
+async function mountView() {
+  getSettings.mockResolvedValue([]);
+  updateSetting.mockResolvedValue({});
+  const wrapper = shallowMount(AdminSettings);
+  await flushPromises();
+  return wrapper;
+}
+
+function setNotif(vm, { del = 10, res = 5, poll = 30 } = {}) {
+  vm.settings.notifications_enabled = true;
+  vm.settings.notifications_poll_interval = poll;
+  vm.settings.notifications_delete_duration = del;
+  vm.settings.notifications_restore_duration = res;
+}
+
+describe('AdminSettings - уведомления', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    getSettings.mockReset();
+    updateSetting.mockReset();
+  });
+
+  it('валидное сохранение пишет настройки и сразу применяет к стору (setDurations)', async () => {
+    const wrapper = await mountView();
+    const store = useDeletionsStore();
+    const spy = vi.spyOn(store, 'setDurations');
+
+    setNotif(wrapper.vm, { del: 15, res: 3, poll: 30 });
+    await wrapper.vm.saveNotificationSettings();
+
+    expect(updateSetting).toHaveBeenCalledWith('notifications.delete_duration', '15');
+    expect(updateSetting).toHaveBeenCalledWith('notifications.restore_duration', '3');
+    expect(spy).toHaveBeenCalledWith(15, 3);
+  });
+
+  it('длительность вне 3-60 блокирует сохранение (нет запросов и setDurations)', async () => {
+    const wrapper = await mountView();
+    const store = useDeletionsStore();
+    const spy = vi.spyOn(store, 'setDurations');
+
+    setNotif(wrapper.vm, { del: 2, res: 5, poll: 30 });
+    await wrapper.vm.saveNotificationSettings();
+
+    expect(updateSetting).not.toHaveBeenCalled();
+    expect(spy).not.toHaveBeenCalled();
+    expect(wrapper.vm.toast.type).toBe('error');
+  });
+
+  it('интервал опроса вне 10-120 блокирует сохранение', async () => {
+    const wrapper = await mountView();
+    const store = useDeletionsStore();
+    const spy = vi.spyOn(store, 'setDurations');
+
+    setNotif(wrapper.vm, { del: 10, res: 5, poll: 5 });
+    await wrapper.vm.saveNotificationSettings();
+
+    expect(updateSetting).not.toHaveBeenCalled();
+    expect(spy).not.toHaveBeenCalled();
+    expect(wrapper.vm.toast.type).toBe('error');
+  });
+});

--- a/internal/handlers/settings_test.go
+++ b/internal/handlers/settings_test.go
@@ -69,6 +69,53 @@ func TestSettings_Update_InvalidValue(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+func TestSettings_GetNotifications_ReturnsDurations(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	// Доступно любому авторизованному (не только супер-админу).
+	token := testutil.RegisterAndLogin(t, e, "notif_reader", "password123456789012345678901234", 1, td.OrgID, td.CompanyID)
+	rec := testutil.GET(t, e, "/settings/notifications", testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+	resp := testutil.ParseMap(t, rec)
+	assert.Equal(t, float64(10), resp["delete_duration"], "дефолт длительности удаления - 10 сек")
+	assert.Equal(t, float64(5), resp["restore_duration"], "дефолт длительности восстановления - 5 сек")
+}
+
+func TestSettings_UpdateNotificationDuration_ValidPersists(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	rec := testutil.PUT(t, e, "/settings/notifications.delete_duration", `{"value":"15"}`, testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	rec = testutil.PUT(t, e, "/settings/notifications.restore_duration", `{"value":"3"}`, testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	// GET отражает сохранённые значения.
+	rec = testutil.GET(t, e, "/settings/notifications", testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+	resp := testutil.ParseMap(t, rec)
+	assert.Equal(t, float64(15), resp["delete_duration"])
+	assert.Equal(t, float64(3), resp["restore_duration"])
+}
+
+func TestSettings_UpdateNotificationDuration_OutOfRangeRejected(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	for _, v := range []string{"2", "61", "abc"} {
+		rec := testutil.PUT(t, e, "/settings/notifications.delete_duration", `{"value":"`+v+`"}`, testutil.AuthHeader(token))
+		assert.Equal(t, http.StatusBadRequest, rec.Code, "значение %q должно отклоняться (диапазон 3-60)", v)
+	}
+}
+
 func TestSettings_GetUploadSettings_AuthUser(t *testing.T) {
 	e, db, cleanup := testutil.SetupTestApp(t)
 	defer cleanup()

--- a/internal/handlers/trash_test.go
+++ b/internal/handlers/trash_test.go
@@ -150,3 +150,113 @@ func TestTrash_PurgeOneRemovesFromTrash(t *testing.T) {
 	db.Model(&models.CarHistory{}).Where("car_id = ? AND action_type = 'purge'", carID).Count(&purgeCount)
 	assert.Equal(t, int64(1), purgeCount)
 }
+
+func TestTrash_ClearAllCars_PurgesAndLogsDetails(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "trashclear1", "pass123", 1, td.OrgID, td.CompanyID)
+	var u models.User
+	require.NoError(t, db.Where("username = ?", "trashclear1").First(&u).Error)
+
+	dn := "Корзина Очистка"
+	tbl := models.SystemTable{Name: "trash_cars_clear", DisplayName: &dn, TableType: "cars", IsActive: true}
+	require.NoError(t, db.Create(&tbl).Error)
+
+	appID, _, carID := seedCarViaCompleteApp(t, e, db, token, "Test Organization")
+	activateCarViaApp(t, e, db, appID, td)
+	rec := testutil.PUT(t, e, fmt.Sprintf("/cars/%d/deactivate", carID),
+		fmt.Sprintf(`{"status":0,"user_id":%d,"table_id":%d}`, u.ID, tbl.ID), testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = testutil.GET(t, e, fmt.Sprintf("/system-tables/%d/trash", tbl.ID), testutil.AuthHeader(token))
+	require.Len(t, testutil.ParseSlice(t, rec), 1)
+
+	// Очистка корзины (ClearAll).
+	rec = testutil.DELETE(t, e, fmt.Sprintf("/system-tables/%d/trash", tbl.ID), testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	// Корзина пуста, машина окончательно удалена.
+	rec = testutil.GET(t, e, fmt.Sprintf("/system-tables/%d/trash", tbl.ID), testutil.AuthHeader(token))
+	assert.Empty(t, testutil.ParseSlice(t, rec))
+	var car models.Car
+	require.NoError(t, db.First(&car, carID).Error)
+	assert.True(t, car.IsPurged)
+
+	// История: cleared с деталями (id + label заполнены).
+	rec = testutil.GET(t, e, fmt.Sprintf("/system-tables/%d/trash/history", tbl.ID), testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+	history := testutil.ParseSlice(t, rec)
+	require.NotEmpty(t, history)
+	assert.Equal(t, "cleared", history[0]["action_type"])
+	assert.Equal(t, float64(1), history[0]["affected_count"])
+	details, ok := history[0]["details"].([]interface{})
+	require.True(t, ok, "details должен быть массивом, got %v", history[0]["details"])
+	require.Len(t, details, 1)
+	d0 := details[0].(map[string]interface{})
+	assert.Equal(t, float64(carID), d0["id"])
+	assert.NotEmpty(t, d0["label"], "label детали должен заполняться (номер + марка)")
+}
+
+func TestTrash_EmployeeFlow_ScopingRestoreHistoryDetails(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "trashemp1", "pass123", 1, td.OrgID, td.CompanyID)
+	var u models.User
+	require.NoError(t, db.Where("username = ?", "trashemp1").First(&u).Error)
+
+	dn1, dn2 := "Корзина Сотр 1", "Корзина Сотр 2"
+	t1 := models.SystemTable{Name: "trash_emp_t1", DisplayName: &dn1, TableType: "people", IsActive: true}
+	t2 := models.SystemTable{Name: "trash_emp_t2", DisplayName: &dn2, TableType: "people", IsActive: true}
+	require.NoError(t, db.Create(&t1).Error)
+	require.NoError(t, db.Create(&t2).Error)
+
+	appID, _, empID := seedEmployeeViaCompleteApp(t, e, db, token, "Test Organization")
+	activateCarViaApp(t, e, db, appID, td) // согласовать + в работу: нужно для restore
+
+	// Деактивация с table_id -> сотрудник в корзину t1.
+	rec := testutil.PUT(t, e, fmt.Sprintf("/employees/%d/deactivate", empID),
+		fmt.Sprintf(`{"status":0,"user_id":%d,"table_id":%d}`, u.ID, t1.ID), testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	// Корзина t1: 1 сотрудник; скоупинг - t2 пусто.
+	rec = testutil.GET(t, e, fmt.Sprintf("/system-tables/%d/trash", t1.ID), testutil.AuthHeader(token))
+	items := testutil.ParseSlice(t, rec)
+	require.Len(t, items, 1)
+	assert.Equal(t, float64(empID), items[0]["id"])
+	assert.Equal(t, "employee", items[0]["type"])
+	assert.NotEmpty(t, items[0]["last_name"])
+
+	rec = testutil.GET(t, e, fmt.Sprintf("/system-tables/%d/trash", t2.ID), testutil.AuthHeader(token))
+	assert.Empty(t, testutil.ParseSlice(t, rec), "удалённое из t1 не должно показываться в t2")
+
+	// Восстановление.
+	rec = testutil.POST(t, e, fmt.Sprintf("/system-tables/%d/trash/restore", t1.ID),
+		fmt.Sprintf(`{"ids":[%d]}`, empID), testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	assert.Equal(t, float64(1), testutil.ParseMap(t, rec)["restored"])
+
+	var emp models.Employee
+	require.NoError(t, db.First(&emp, empID).Error)
+	require.NotNil(t, emp.Status)
+	assert.Equal(t, 1, *emp.Status)
+	rec = testutil.GET(t, e, fmt.Sprintf("/system-tables/%d/trash", t1.ID), testutil.AuthHeader(token))
+	assert.Empty(t, testutil.ParseSlice(t, rec))
+
+	// История: bulk_restored с деталью (ФИО в label).
+	rec = testutil.GET(t, e, fmt.Sprintf("/system-tables/%d/trash/history", t1.ID), testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+	history := testutil.ParseSlice(t, rec)
+	require.NotEmpty(t, history)
+	assert.Equal(t, "bulk_restored", history[0]["action_type"])
+	assert.Equal(t, float64(1), history[0]["affected_count"])
+	details, ok := history[0]["details"].([]interface{})
+	require.True(t, ok, "details должен быть массивом, got %v", history[0]["details"])
+	require.Len(t, details, 1)
+	assert.NotEmpty(t, details[0].(map[string]interface{})["label"], "label детали - ФИО сотрудника")
+}


### PR DESCRIPTION
## Что добавлено
Фиксация результатов #186 тестами на всех уровнях.

### Backend (Go, internal/handlers)
- `trash_test.go`: `TestTrash_ClearAllCars_PurgesAndLogsDetails` (очистка корзины -> purge + лог cleared с деталями id/label), `TestTrash_EmployeeFlow_ScopingRestoreHistoryDetails` (сотрудники: скоупинг по table_id, восстановление, история bulk_restored с ФИО в деталях).
- `settings_test.go`: GET /settings/notifications (дефолты 10/5), сохранение длительностей (persist), валидация диапазона 3-60.

### Frontend (vitest)
- `TrashHistoryModal.spec.js`: actionTitle (1 деталь inline "Удалено: label" vs N "Удалено N элемент(ов)"), раскрытие/сворачивание, поиск по label детали, "Показать ещё" при >10, пустая история.
- `AdminSettings.notifications.spec.js`: валидное сохранение зовёт `setDurations`; значения вне 3-60 и интервал вне 10-120 блокируют сохранение.

### E2E (Playwright)
- `TrashPage.cjs` POM + `trash.spec.cjs`: рендер страницы корзины (контролы Экспорт/Очистить/История), открытие/закрытие модалки истории, ссылка "Назад". Таблица для теста выбирается из `/system-tables` (cars/people), при отсутствии - graceful skip.

## Проверка
- Go: `internal/handlers` + `internal/services` зелёные локально (Postgres).
- Vitest: 281 тест зелёный локально.
- E2E: валидируется в CI (Playwright job) - локальный dev-стек недоступен.