### PR TITLE
fix: опустил стек уведомлений удаления (top 75px) (#186)

### DIFF
--- a/frontend/src/components/DeleteNotifications.vue
+++ b/frontend/src/components/DeleteNotifications.vue
@@ -50,7 +50,7 @@ function colorFor(progress) {
 <style scoped>
 .del-stack {
   position: fixed;
-  top: 15px;
+  top: 75px;
   right: 20px;
   z-index: 11000;
   display: flex;


### PR DESCRIPTION
Сместил .del-stack с top:15px на 75px, чтобы плашки удаления не наезжали на верхнюю панель.