### PR TITLE
fix: фиксированная высота модалки истории корзины (#186)

### DIFF
--- a/frontend/src/components/TrashHistoryModal.vue
+++ b/frontend/src/components/TrashHistoryModal.vue
@@ -533,7 +533,8 @@ export default {
 .modal-content {
   padding: 20px 25px;
   overflow-y: auto;
-  flex: 1;
+  /* Фиксированная высота списка - модалка не меняет размер при поиске/фильтрации. */
+  height: 55vh;
 }
 
 .history-empty {


### PR DESCRIPTION
Список истории (.modal-content) получил фиксированную высоту 55vh вместо flex:1 - модалка больше не меняет размер при поиске/фильтрации.