### PR TITLE
fix: полные детали машины/сотрудника в корзине + Открыть заявку (#186)

### DIFF
--- a/frontend/src/views/TrashView.vue
+++ b/frontend/src/views/TrashView.vue
@@ -275,9 +275,10 @@
       :vehicle="selectedDetail"
       :all-unloading-places="detailPlaces"
       :license-plate-formats="[]"
-      :show-car-features="false"
+      :show-car-features="true"
       :source="'trash'"
       @close="closeDetails"
+      @open-application="handleOpenApplication"
     />
     <EmployeeDetailsModal
       v-if="tableType === 'people' && showDetails"
@@ -286,7 +287,7 @@
       :all-tables="detailPlaces"
       :source="'trash'"
       @close="closeDetails"
-      @open-application="() => {}"
+      @open-application="handleOpenApplication"
     />
 
     <!-- История корзины -->
@@ -308,6 +309,15 @@
       @confirm="onConfirmModal"
       @cancel="cancelConfirm"
     />
+
+    <!-- Детали заявки (открывается поверх деталей машины/сотрудника) -->
+    <ApplicationDetail
+      v-if="showApplicationDetail && selectedApplication"
+      :application="selectedApplication"
+      :current-user-name="currentUserName"
+      :mode="'center'"
+      @close="closeApplicationDetail"
+    />
   </section>
 </template>
 
@@ -325,12 +335,14 @@ import VehicleDetailsModal from '@/components/CreateApplication/VehicleDetailsMo
 import EmployeeDetailsModal from '@/components/CreateApplication/EmployeeDetailsModal.vue';
 import TrashHistoryModal from '@/components/TrashHistoryModal.vue';
 import ConfirmationModal from '@/components/ConfirmationModal.vue';
+import ApplicationDetail from '@/components/ApplicationDetail/ApplicationDetail.vue';
 
 export default {
   name: 'TrashView',
   components: {
     SearchComponent, OrganizationFilter, DateFilter, RefreshButton,
     VehicleDetailsModal, EmployeeDetailsModal, TrashHistoryModal, ConfirmationModal,
+    ApplicationDetail,
   },
   data() {
     return {
@@ -360,6 +372,8 @@ export default {
       organizations: [],
       lastHeight: 0,
       confirmModal: { show: false, message: '', confirmText: 'Удалить', action: null, itemId: null },
+      showApplicationDetail: false,
+      selectedApplication: null,
     };
   },
   computed: {
@@ -567,6 +581,7 @@ export default {
         const places = Array.isArray(item.unload_places) ? item.unload_places : [];
         this.detailPlaces = places;
         this.selectedDetail = {
+          id: item.id,
           plateNumber: item.car_number,
           mark: item.mark_name,
           formatId: null,
@@ -579,7 +594,7 @@ export default {
           entry_date_to: item.entry_date_to,
           entry_time_from: item.entry_time_from,
           entry_time_to: item.entry_time_to,
-          applicationId: null,
+          applicationId: item.application_id || null,
           deletedByName: item.deleted_by_name,
           deletedAtText,
         };
@@ -604,7 +619,7 @@ export default {
           pass_time: this.formatTimeRange(item),
           target_tables: places.map(p => p.id),
           territory_status: null,
-          applicationId: null,
+          applicationId: item.application_id || null,
           deletedByName: item.deleted_by_name,
           deletedAtText,
         };
@@ -614,6 +629,24 @@ export default {
     closeDetails() {
       this.showDetails = false;
       this.selectedDetail = null;
+    },
+    async handleOpenApplication(applicationId) {
+      if (!applicationId) return;
+      try {
+        const response = await apiRequest(`/applications/${applicationId}/details`, {});
+        if (!response.ok) {
+          useUiStore().error('Не удалось загрузить заявку');
+          return;
+        }
+        this.selectedApplication = await response.json();
+        this.showApplicationDetail = true;
+      } catch {
+        useUiStore().error('Не удалось загрузить заявку');
+      }
+    },
+    closeApplicationDetail() {
+      this.showApplicationDetail = false;
+      this.selectedApplication = null;
     },
     async onRestoreSelected() {
       if (!this.selectedIds.length) return;

--- a/internal/handlers/trash_test.go
+++ b/internal/handlers/trash_test.go
@@ -50,6 +50,8 @@ func TestTrash_CarFlowListScopingRestoreHistory(t *testing.T) {
 	assert.Equal(t, float64(carID), items[0]["id"])
 	assert.Equal(t, "B002BB799", items[0]["car_number"])
 	assert.Equal(t, "Test Organization", items[0]["organization"])
+	assert.NotNil(t, items[0]["application_id"], "application_id нужен для кнопки 'Открыть заявку'")
+	assert.Greater(t, items[0]["application_id"], float64(0))
 	assert.NotEmpty(t, items[0]["deleted_by_name"], "deleted_by_name должен заполняться")
 	assert.NotEmpty(t, items[0]["entry_date_to"], "Действует до должно заполняться")
 	assert.NotEmpty(t, items[0]["deleted_at"])

--- a/internal/models/system_table_trash_history.go
+++ b/internal/models/system_table_trash_history.go
@@ -33,6 +33,7 @@ type TrashItem struct {
 	ID                int        `json:"id"`
 	Type              string     `json:"type"` // car | employee
 	ApplicationNumber *string    `json:"application_number,omitempty"`
+	ApplicationID     *int       `json:"application_id,omitempty"`
 	DeletedAt         *time.Time `json:"deleted_at,omitempty"`
 	DeletedByName     string     `json:"deleted_by_name,omitempty"`
 	Organization  string  `json:"organization,omitempty"`

--- a/internal/services/trash_service.go
+++ b/internal/services/trash_service.go
@@ -47,7 +47,7 @@ func NewTrashService(db *gorm.DB) TrashService {
 func (s *trashService) ListCarsTrash(ctx context.Context, systemTableID int, filter models.TrashFilter) ([]models.TrashItem, error) {
 	sql := `
 		SELECT c.id, 'car' AS type,
-			a.application_number,
+			a.application_number, a.id AS application_id,
 			c.entry_date_to, c.entry_time_from, c.entry_time_to,
 			COALESCE(c.mark_name, c.car_brand) AS mark_name, c.car_number,
 			COALESCE(org.name, '') AS organization,
@@ -107,7 +107,7 @@ func (s *trashService) ListCarsTrash(ctx context.Context, systemTableID int, fil
 func (s *trashService) ListEmployeesTrash(ctx context.Context, systemTableID int, filter models.TrashFilter) ([]models.TrashItem, error) {
 	sql := `
 		SELECT e.id, 'employee' AS type,
-			a.application_number,
+			a.application_number, a.id AS application_id,
 			e.last_name, e.first_name, e.middle_name,
 			e.position,
 			COALESCE(org.name, '') AS organization,


### PR DESCRIPTION
## Проблема
В модалках деталей корзины (VehicleDetails/EmployeeDetails) не хватало половины элементов: «Полная история», «Открыть заявку», «Статус», «История въездов/выездов» (машина показывалась с show-car-features=false), а кнопка «Открыть заявку» была неактивна (applicationId не пробрасывался, обработчик был no-op).

## Что сделано
- Backend (`trash_service.go`, `TrashItem`): добавлен `application_id` в trash-элементы машин и сотрудников (нужен для «Открыть заявку»). company/unload_places/pass_places/position/citizenship уже отдавались.
- `TrashView`:
  - машина: `show-car-features="true"` + проброс `id` и `applicationId` -> вернулись «Полная история», «Статус», «История въездов/выездов».
  - сотрудник: проброс `applicationId`.
  - обе модалки: `@open-application` -> `handleOpenApplication` грузит `/applications/:id/details` и открывает `ApplicationDetail` поверх (как в кабинете).

## Не входит (отдельно при необходимости)
- Паспорт/патент сотрудника в корзине (поля шифрованные, требуют расшифровки в trash-сервисе).

## Тесты
- Go: `TestTrash_CarFlow...` проверяет наличие `application_id`; пакет handlers зелёный.
- Vitest: 281 тест зелёный. E2E корзины в CI.