### PR TITLE
feat: тоггл "Увеличенный режим" в CarsTable/PeopleTable (#346)

### DIFF
--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     class="selected-table-card"
+    :class="{ 'enlarged': enlarged }"
     data-testid="cars-table"
   >
     <div class="card-header">
@@ -19,6 +20,10 @@
             История
           </button>
         </span>
+        <EnlargedToggle
+          v-model="enlarged"
+          data-testid="enlarged-toggle"
+        />
         <RefreshButton
           :loading="refreshing"
           @refresh="loadData"
@@ -278,6 +283,9 @@ import VehicleDetailsModal from './CreateApplication/VehicleDetailsModal.vue';
 import CarsTableHistoryModal from './CarsTableHistoryModal.vue';
 import LoaderSpinner from '@/components/ui/LoaderSpinner.vue';
 import StatusBadge from '@/components/ui/StatusBadge.vue';
+import EnlargedToggle from '@/components/ui/EnlargedToggle.vue';
+
+const ENLARGED_KEY_PREFIX = 'enlarged-mode:cars:';
 
 export default {
   name: 'CarsTable',
@@ -286,7 +294,8 @@ export default {
     VehicleDetailsModal,
     CarsTableHistoryModal,
     LoaderSpinner,
-    StatusBadge
+    StatusBadge,
+    EnlargedToggle
   },
   props: {
     tableName: { type: String, default: '' },
@@ -315,7 +324,8 @@ export default {
       showVehicleDetails: false,
       selectedVehicle: null,
       showCarsTableHistory: false,
-      pollingInterval: null
+      pollingInterval: null,
+      enlarged: false
     };
   },
   computed: {
@@ -413,10 +423,20 @@ export default {
           this.startPolling();
         }
       }
+    },
+    tableId: {
+      immediate: true,
+      handler() {
+        this.loadEnlargedFromStorage();
+      }
+    },
+    enlarged(value) {
+      this.saveEnlargedToStorage(value);
     }
   },
   mounted() {
     this.startPolling();
+    this.loadEnlargedFromStorage();
     // Подгружаем настроенные длительности уведомлений после авторизации
     // (на холодном старте App.vue запрос мог уйти до получения токена).
     useDeletionsStore().loadDurations();
@@ -775,6 +795,26 @@ export default {
         clearInterval(this.pollingInterval);
         this.pollingInterval = null;
       }
+    },
+
+    enlargedStorageKey() {
+      return `${ENLARGED_KEY_PREFIX}${this.tableId ?? 'default'}`;
+    },
+
+    loadEnlargedFromStorage() {
+      try {
+        this.enlarged = localStorage.getItem(this.enlargedStorageKey()) === '1';
+      } catch {
+        this.enlarged = false;
+      }
+    },
+
+    saveEnlargedToStorage(value) {
+      try {
+        localStorage.setItem(this.enlargedStorageKey(), value ? '1' : '0');
+      } catch {
+        /* localStorage недоступен - игнорируем */
+      }
     }
   }
 };
@@ -1112,6 +1152,30 @@ export default {
 
 .fade-list-move {
   transition: transform 0.3s ease;
+}
+
+/* "Увеличенный режим": крупный шрифт строк, bold номера, скрытый статус.
+   Освободившуюся ширину забирает organization-col через flex-grow. */
+.selected-table-card.enlarged .items-body .col,
+.selected-table-card.enlarged .header-row .col {
+  font-size: 18px;
+}
+
+.selected-table-card.enlarged .items-body .number-col {
+  font-weight: 700;
+}
+
+.selected-table-card.enlarged .status-col {
+  display: none;
+}
+
+.selected-table-card.enlarged .organization-col {
+  flex-grow: 1;
+}
+
+.selected-table-card.enlarged .item-data,
+.selected-table-card.enlarged .header-row {
+  min-height: 36px;
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="selected-table-card">
+  <div
+    class="selected-table-card"
+    :class="{ 'enlarged': enlarged }"
+    data-testid="people-table"
+  >
     <div class="card-header">
       <div class="card-header__title">
         <h3 class="card-title">
@@ -14,6 +18,10 @@
             @click="openEmployeesHistory"
           >История</button>
         </span>
+        <EnlargedToggle
+          v-model="enlarged"
+          data-testid="enlarged-toggle"
+        />
         <RefreshButton
           :loading="refreshing"
           @refresh="loadData"
@@ -273,6 +281,9 @@ import RefreshButton from './RefreshButton.vue';
 import EmployeeDetailsModal from './CreateApplication/EmployeeDetailsModal.vue';
 import EmployeesTableHistoryModal from './CreateApplication/EmployeesTableHistoryModal.vue';
 import StatusBadge from './ui/StatusBadge.vue';
+import EnlargedToggle from './ui/EnlargedToggle.vue';
+
+const ENLARGED_KEY_PREFIX = 'enlarged-mode:people:';
 
 export default {
   name: 'PeopleTable',
@@ -280,7 +291,8 @@ export default {
     RefreshButton,
     EmployeeDetailsModal,
     EmployeesTableHistoryModal,
-    StatusBadge
+    StatusBadge,
+    EnlargedToggle
   },
   props: {
     tableName: {
@@ -335,7 +347,8 @@ export default {
       showDetailsModal: false,
       selectedEmployee: null,
       showEmployeesHistory: false,
-      pollingInterval: null
+      pollingInterval: null,
+      enlarged: false
     };
   },
   computed: {
@@ -436,12 +449,17 @@ export default {
       handler() {
         this.stopPolling();
         this.startPolling();
+        this.loadEnlargedFromStorage();
       },
       immediate: true
+    },
+    enlarged(value) {
+      this.saveEnlargedToStorage(value);
     }
   },
   mounted() {
     this.startPolling();
+    this.loadEnlargedFromStorage();
     // Подгружаем настроенные длительности уведомлений после авторизации
     // (на холодном старте App.vue запрос мог уйти до получения токена).
     useDeletionsStore().loadDurations();
@@ -737,6 +755,26 @@ export default {
       if (this.pollingInterval) {
         clearInterval(this.pollingInterval);
         this.pollingInterval = null;
+      }
+    },
+
+    enlargedStorageKey() {
+      return `${ENLARGED_KEY_PREFIX}${this.tableName || 'default'}`;
+    },
+
+    loadEnlargedFromStorage() {
+      try {
+        this.enlarged = localStorage.getItem(this.enlargedStorageKey()) === '1';
+      } catch {
+        this.enlarged = false;
+      }
+    },
+
+    saveEnlargedToStorage(value) {
+      try {
+        localStorage.setItem(this.enlargedStorageKey(), value ? '1' : '0');
+      } catch {
+        /* localStorage недоступен - игнорируем */
       }
     }
   }
@@ -1075,6 +1113,30 @@ export default {
 
 .fade-list-move {
   transition: transform 0.3s ease;
+}
+
+/* "Увеличенный режим": крупный шрифт строк, bold фамилии, скрытый статус.
+   Освободившуюся ширину забирает organization-col через flex-grow. */
+.selected-table-card.enlarged .items-body .col,
+.selected-table-card.enlarged .header-row .col {
+  font-size: 18px;
+}
+
+.selected-table-card.enlarged .items-body .last-name-col {
+  font-weight: 700;
+}
+
+.selected-table-card.enlarged .status-col {
+  display: none;
+}
+
+.selected-table-card.enlarged .organization-col {
+  flex-grow: 1;
+}
+
+.selected-table-card.enlarged .item-data,
+.selected-table-card.enlarged .header-row {
+  min-height: 36px;
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/components/__tests__/CarsTable.enlarged.spec.js
+++ b/frontend/src/components/__tests__/CarsTable.enlarged.spec.js
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+
+const apiRequest = vi.fn();
+vi.mock('@/api/client', () => ({
+  apiRequest: (...args) => apiRequest(...args),
+}));
+
+import CarsTable from '../CarsTable.vue';
+
+function okResponse(data) {
+  return { ok: true, json: async () => data };
+}
+
+function mountTable(props = {}) {
+  return mount(CarsTable, {
+    props: {
+      tableName: 'КПП 1',
+      tableId: 42,
+      currentUserId: 1,
+      currentUserName: 'Тест',
+      ...props,
+    },
+    global: {
+      stubs: { teleport: true, transition: false, 'transition-group': false },
+    },
+  });
+}
+
+describe('CarsTable - Увеличенный режим', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    localStorage.clear();
+    apiRequest.mockReset();
+    // Минимальные ответы, чтобы _loadData не падал.
+    apiRequest.mockImplementation((url) => {
+      if (url.startsWith('/unload-places')) return okResponse([]);
+      if (url.startsWith('/license-plate-formats')) return okResponse([]);
+      if (url.startsWith('/cars/active-for-tables')) return okResponse([]);
+      if (url.startsWith('/cars/unload-places')) return okResponse([]);
+      if (url.startsWith('/cars/history/current-status')) return okResponse([]);
+      if (url.startsWith('/organizations')) return okResponse([]);
+      if (url.startsWith('/notifications/deletion-settings')) return okResponse({});
+      return okResponse({});
+    });
+  });
+
+  it('по умолчанию режим выключен, класс .enlarged отсутствует', async () => {
+    const wrapper = mountTable();
+    await flushPromises();
+    expect(wrapper.get('[data-testid=cars-table]').classes()).not.toContain('enlarged');
+  });
+
+  it('включение тоггла добавляет .enlarged и сохраняет в localStorage', async () => {
+    const wrapper = mountTable();
+    await flushPromises();
+    await wrapper.setData({ enlarged: true });
+    expect(wrapper.get('[data-testid=cars-table]').classes()).toContain('enlarged');
+    expect(localStorage.getItem('enlarged-mode:cars:42')).toBe('1');
+  });
+
+  it('состояние восстанавливается из localStorage при монтировании', async () => {
+    localStorage.setItem('enlarged-mode:cars:42', '1');
+    const wrapper = mountTable();
+    await flushPromises();
+    expect(wrapper.vm.enlarged).toBe(true);
+    expect(wrapper.get('[data-testid=cars-table]').classes()).toContain('enlarged');
+  });
+
+  it('состояние хранится отдельно по tableId', async () => {
+    localStorage.setItem('enlarged-mode:cars:42', '1');
+    localStorage.setItem('enlarged-mode:cars:43', '0');
+    const wrapper = mountTable({ tableId: 43 });
+    await flushPromises();
+    expect(wrapper.vm.enlarged).toBe(false);
+  });
+});

--- a/frontend/src/components/__tests__/PeopleTable.enlarged.spec.js
+++ b/frontend/src/components/__tests__/PeopleTable.enlarged.spec.js
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+
+const apiRequest = vi.fn();
+vi.mock('@/api/client', () => ({
+  apiRequest: (...args) => apiRequest(...args),
+}));
+
+import PeopleTable from '../PeopleTable.vue';
+
+function okResponse(data) {
+  return { ok: true, json: async () => data };
+}
+
+function mountTable(props = {}) {
+  return mount(PeopleTable, {
+    props: {
+      tableName: 'КПП-72',
+      currentUserId: 1,
+      currentUserName: 'Тест',
+      ...props,
+    },
+    global: {
+      stubs: { teleport: true, transition: false, 'transition-group': false },
+    },
+  });
+}
+
+describe('PeopleTable - Увеличенный режим', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    localStorage.clear();
+    apiRequest.mockReset();
+    apiRequest.mockImplementation((url) => {
+      if (url.startsWith('/system-tables/name/')) {
+        return okResponse({ table: { id: 7 } });
+      }
+      if (url.startsWith('/system-tables')) return okResponse([]);
+      if (url.startsWith('/organizations')) return okResponse([]);
+      if (url.startsWith('/employees/active-for-table/')) return okResponse([]);
+      if (url.startsWith('/employees/history/current-status')) return okResponse([]);
+      if (url.startsWith('/notifications/deletion-settings')) return okResponse({});
+      return okResponse({});
+    });
+  });
+
+  it('по умолчанию режим выключен, класс .enlarged отсутствует', async () => {
+    const wrapper = mountTable();
+    await flushPromises();
+    expect(wrapper.get('[data-testid=people-table]').classes()).not.toContain('enlarged');
+  });
+
+  it('включение тоггла добавляет .enlarged и сохраняет в localStorage', async () => {
+    const wrapper = mountTable();
+    await flushPromises();
+    await wrapper.setData({ enlarged: true });
+    expect(wrapper.get('[data-testid=people-table]').classes()).toContain('enlarged');
+    expect(localStorage.getItem('enlarged-mode:people:КПП-72')).toBe('1');
+  });
+
+  it('состояние восстанавливается из localStorage при монтировании', async () => {
+    localStorage.setItem('enlarged-mode:people:КПП-72', '1');
+    const wrapper = mountTable();
+    await flushPromises();
+    expect(wrapper.vm.enlarged).toBe(true);
+    expect(wrapper.get('[data-testid=people-table]').classes()).toContain('enlarged');
+  });
+
+  it('состояние хранится отдельно по tableName', async () => {
+    localStorage.setItem('enlarged-mode:people:КПП-72', '1');
+    localStorage.setItem('enlarged-mode:people:КПП-27', '0');
+    const wrapper = mountTable({ tableName: 'КПП-27' });
+    await flushPromises();
+    expect(wrapper.vm.enlarged).toBe(false);
+  });
+});

--- a/frontend/src/components/ui/EnlargedToggle.vue
+++ b/frontend/src/components/ui/EnlargedToggle.vue
@@ -1,0 +1,106 @@
+<template>
+  <label
+    class="enlarged-toggle"
+    :class="{ 'enlarged-toggle--active': modelValue }"
+    :title="title"
+  >
+    <input
+      type="checkbox"
+      class="enlarged-toggle__input"
+      :checked="modelValue"
+      @change="onChange"
+    >
+    <span class="enlarged-toggle__switch">
+      <span class="enlarged-toggle__thumb" />
+    </span>
+    <span class="enlarged-toggle__label">{{ label }}</span>
+  </label>
+</template>
+
+<script>
+/**
+ * Переключатель "Увеличенный режим" для таблиц.
+ * Используется в CarsTable и PeopleTable как v-model.
+ * Сохранение в localStorage делает родитель по своему ключу.
+ */
+export default {
+  name: 'EnlargedToggle',
+  props: {
+    modelValue: { type: Boolean, default: false },
+    label: { type: String, default: 'Увеличенный режим' },
+    title: { type: String, default: 'Увеличить шрифт и скрыть второстепенные столбцы' }
+  },
+  emits: ['update:modelValue'],
+  methods: {
+    onChange(e) {
+      this.$emit('update:modelValue', e.target.checked);
+    }
+  }
+};
+</script>
+
+<style scoped>
+.enlarged-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  user-select: none;
+  font-size: 12px;
+  color: #333;
+}
+
+.enlarged-toggle__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  border: 0;
+}
+
+.enlarged-toggle__switch {
+  position: relative;
+  width: 32px;
+  height: 18px;
+  background: #e6e6e6;
+  border-radius: 50px;
+  transition: background-color 0.2s ease;
+  flex-shrink: 0;
+}
+
+.enlarged-toggle__thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 14px;
+  height: 14px;
+  background: #fff;
+  border-radius: 50%;
+  transition: transform 0.2s ease;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+
+.enlarged-toggle--active .enlarged-toggle__switch {
+  background: #4F5BDF;
+}
+
+.enlarged-toggle--active .enlarged-toggle__thumb {
+  transform: translateX(14px);
+}
+
+.enlarged-toggle__label {
+  white-space: nowrap;
+}
+
+.enlarged-toggle:hover .enlarged-toggle__switch {
+  filter: brightness(0.95);
+}
+
+.enlarged-toggle__input:focus-visible + .enlarged-toggle__switch {
+  outline: 2px solid #4F5BDF;
+  outline-offset: 2px;
+}
+</style>

--- a/frontend/src/components/ui/__tests__/EnlargedToggle.spec.js
+++ b/frontend/src/components/ui/__tests__/EnlargedToggle.spec.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import EnlargedToggle from '../EnlargedToggle.vue';
+
+describe('EnlargedToggle', () => {
+  it('отражает modelValue=false в неактивном состоянии', () => {
+    const wrapper = mount(EnlargedToggle, {
+      props: { modelValue: false },
+    });
+    expect(wrapper.classes()).not.toContain('enlarged-toggle--active');
+    expect(wrapper.get('input[type=checkbox]').element.checked).toBe(false);
+  });
+
+  it('отражает modelValue=true в активном состоянии', () => {
+    const wrapper = mount(EnlargedToggle, {
+      props: { modelValue: true },
+    });
+    expect(wrapper.classes()).toContain('enlarged-toggle--active');
+    expect(wrapper.get('input[type=checkbox]').element.checked).toBe(true);
+  });
+
+  it('эмитит update:modelValue=true при включении', async () => {
+    const wrapper = mount(EnlargedToggle, {
+      props: { modelValue: false },
+    });
+    await wrapper.get('input[type=checkbox]').setValue(true);
+    expect(wrapper.emitted('update:modelValue')).toEqual([[true]]);
+  });
+
+  it('эмитит update:modelValue=false при выключении', async () => {
+    const wrapper = mount(EnlargedToggle, {
+      props: { modelValue: true },
+    });
+    await wrapper.get('input[type=checkbox]').setValue(false);
+    expect(wrapper.emitted('update:modelValue')).toEqual([[false]]);
+  });
+
+  it('показывает кастомный label через prop', () => {
+    const wrapper = mount(EnlargedToggle, {
+      props: { modelValue: false, label: 'Большой шрифт' },
+    });
+    expect(wrapper.text()).toContain('Большой шрифт');
+  });
+});


### PR DESCRIPTION
Closes #346 (подзадача #345).

## Что
Тоггл "Увеличенный режим" в шапке CarsTable и PeopleTable. Делает таблицу удобной для просмотра охранником на расстоянии.

## Поведение
- Шрифт строк увеличивается до 18px (default 14).
- CarsTable: столбец "Номер Т/С" становится bold.
- PeopleTable: столбец "Фамилия" становится bold.
- Столбец "Статус" скрывается (` + '`display: none`' + ` через CSS-класс).
- Освободившуюся ширину забирает organization-col (` + '`flex-grow: 1`' + `) - layout не ломается.
- Состояние сохраняется в localStorage по ключу ` + '`enlarged-mode:cars:<tableId>`' + ` / ` + '`enlarged-mode:people:<tableName>`' + ` - каждая таблица помнит свой режим.

## Файлы
- ` + '`frontend/src/components/ui/EnlargedToggle.vue`' + ` - переиспользуемый компонент-переключатель (v-model).
- ` + '`frontend/src/components/CarsTable.vue`' + ` - интеграция + CSS ` + '`.enlarged`' + `.
- ` + '`frontend/src/components/PeopleTable.vue`' + ` - интеграция + CSS ` + '`.enlarged`' + `.

## Тесты
- ` + '`EnlargedToggle.spec.js`' + ` - 5 тестов: v-model, классы, label.
- ` + '`CarsTable.enlarged.spec.js`' + ` - 4 теста: дефолт, save, restore, scoping по tableId.
- ` + '`PeopleTable.enlarged.spec.js`' + ` - 4 теста: то же по tableName.
- Локально: 294/294 vitest зелёные.

## Связь с #345
Это упрощённая преднастройка до большой работы. Когда #345 будет готов, тоггл остаётся как быстрый шорткат, а конкретные параметры (размер шрифта, какие столбцы bold, какие скрыты) перейдут в индивидуальные настройки таблицы.

## Проверка
- [ ] Тоггл виден в шапке обеих таблиц.
- [ ] Включение/выключение работает, состояние сохраняется при F5.
- [ ] Layout не ломается, горизонтальный скролл не появляется.
- [ ] Разные таблицы (разные tableId/tableName) помнят свой режим независимо.