### PR TITLE
fix: убрал Должность из PeopleTable, заголовки не увеличиваются в enlarged

### DIFF
--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -1154,10 +1154,9 @@ export default {
   transition: transform 0.3s ease;
 }
 
-/* "Увеличенный режим": крупный шрифт строк, bold номера, скрытый статус.
-   Освободившуюся ширину забирает organization-col через flex-grow. */
-.selected-table-card.enlarged .items-body .col,
-.selected-table-card.enlarged .header-row .col {
+/* "Увеличенный режим": крупный шрифт только данных строк (заголовки не трогаем),
+   bold номера, скрытый статус. Освободившуюся ширину забирает organization-col. */
+.selected-table-card.enlarged .items-body .col {
   font-size: 18px;
 }
 

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -78,19 +78,6 @@
             >
           </div>
           <div
-            class="col position-col"
-            @click="sortBy('position')"
-          >
-            <p :class="{ 'active-sort': sortField === 'position' }">
-              Должность
-            </p>
-            <img
-              src="@/assets/icons/sort.png"
-              class="sort-icon"
-              :class="{ 'sorted': sortField === 'position', 'desc': sortField === 'position' && sortDirection === 'desc' }"
-            >
-          </div>
-          <div
             class="col organization-col"
             @click="sortBy('organization')"
           >
@@ -205,9 +192,6 @@
                 </div>
                 <div class="col middle-name-col">
                   {{ item.middle_name || '-' }}
-                </div>
-                <div class="col position-col">
-                  {{ item.position || '-' }}
                 </div>
                 <div class="col organization-col">
                   {{ item.organization_name }}
@@ -397,7 +381,6 @@ export default {
             case 'middle_name':
             case 'organization':
             case 'status':
-            case 'position':
             case 'pass_places':
               valueA = (a[this.sortField] || '').toString().toLowerCase();
               valueB = (b[this.sortField] || '').toString().toLowerCase();
@@ -886,13 +869,12 @@ export default {
 
 .entry-col { width: 6%; }
 .exit-col { width: 6%; }
-.last-name-col { width: 11%; }
+.last-name-col { width: 14%; }
 .first-name-col { width: 9%; }
-.middle-name-col { width: 9%; }
-.position-col { width: 9.5%; }
-.organization-col { width: 13.5%; }
-.date-col { width: 9%; }
-.time-col { width: 12%; }
+.middle-name-col { width: 11%; }
+.organization-col { width: 16%; }
+.date-col { width: 11%; }
+.time-col { width: 13%; }
 .status-col { width: 8%; }
 .actions-col { width: 2%; padding-right: 0; }
 
@@ -1115,10 +1097,9 @@ export default {
   transition: transform 0.3s ease;
 }
 
-/* "Увеличенный режим": крупный шрифт строк, bold фамилии, скрытый статус.
-   Освободившуюся ширину забирает organization-col через flex-grow. */
-.selected-table-card.enlarged .items-body .col,
-.selected-table-card.enlarged .header-row .col {
+/* "Увеличенный режим": крупный шрифт только данных строк (заголовки не трогаем),
+   bold фамилии, скрытый статус. Освободившуюся ширину забирает organization-col. */
+.selected-table-card.enlarged .items-body .col {
   font-size: 18px;
 }
 


### PR DESCRIPTION
Две мелкие правки в одном PR (обе доделки к #346 / #345).

## 1. Убрал столбец "Должность" из PeopleTable
Пропустил эту просьбу в полировке #344. Удалил header-ячейку, data-ячейку, case в sortBy. Пересчитал ширины колонок (бывшие 9.5% Должности перераспределил по Фамилия/Отчество/Организация/Действует до/Время прохода - в enlarged они становятся тесными иначе).

## 2. Заголовки таблиц не увеличиваются в "Увеличенном режиме"
Раньше CSS-правило ` + '`.selected-table-card.enlarged .header-row .col`' + ` тоже задавало font-size: 18px - заголовки раздувались вместе с данными. Убрал ` + '`.header-row .col`' + ` из селектора - увеличиваются только ` + '`.items-body .col`' + `.

## Проверка
- Vitest: 13/13 enlarged-тестов зелёные (логика не задета).
- На стейдже после деплоя: заголовки 14px (как обычно), данные 18px, layout PeopleTable не переполняется.