### PR TITLE
fix: высота header-row не увеличивается в "Увеличенном режиме"

### DIFF
--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -1172,8 +1172,7 @@ export default {
   flex-grow: 1;
 }
 
-.selected-table-card.enlarged .item-data,
-.selected-table-card.enlarged .header-row {
+.selected-table-card.enlarged .item-data {
   min-height: 36px;
 }
 

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -1115,8 +1115,7 @@ export default {
   flex-grow: 1;
 }
 
-.selected-table-card.enlarged .item-data,
-.selected-table-card.enlarged .header-row {
+.selected-table-card.enlarged .item-data {
   min-height: 36px;
 }
 


### PR DESCRIPTION
Убрал .header-row из правила min-height: 36px - заголовкам это не нужно, они остались на 14px, только данные строк (.item-data) требуют большей высоты под крупный шрифт.