### PR TITLE
feat: плавная анимация переключения "Увеличенного режима"

### DIFF
--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -1155,7 +1155,22 @@ export default {
 }
 
 /* "Увеличенный режим": крупный шрифт только данных строк (заголовки не трогаем),
-   bold номера, скрытый статус. Освободившуюся ширину забирает organization-col. */
+   bold номера, скрытый статус. Освободившуюся ширину забирает organization-col.
+   Переключение анимируем через transition на font-size, min-height, max-width/opacity. */
+.selected-table-card .items-body .col {
+  transition: font-size 0.25s ease;
+}
+
+.selected-table-card .item-data {
+  transition: min-height 0.25s ease;
+}
+
+.selected-table-card .status-col {
+  transition: max-width 0.25s ease, opacity 0.2s ease, padding-right 0.25s ease;
+  max-width: 100%;
+  overflow: hidden;
+}
+
 .selected-table-card.enlarged .items-body .col {
   font-size: 18px;
 }
@@ -1165,7 +1180,10 @@ export default {
 }
 
 .selected-table-card.enlarged .status-col {
-  display: none;
+  max-width: 0;
+  opacity: 0;
+  padding-right: 0;
+  pointer-events: none;
 }
 
 .selected-table-card.enlarged .organization-col {

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -1098,7 +1098,22 @@ export default {
 }
 
 /* "Увеличенный режим": крупный шрифт только данных строк (заголовки не трогаем),
-   bold фамилии, скрытый статус. Освободившуюся ширину забирает organization-col. */
+   bold фамилии, скрытый статус. Освободившуюся ширину забирает organization-col.
+   Переключение анимируем через transition на font-size, min-height, max-width/opacity. */
+.selected-table-card .items-body .col {
+  transition: font-size 0.25s ease;
+}
+
+.selected-table-card .item-data {
+  transition: min-height 0.25s ease;
+}
+
+.selected-table-card .status-col {
+  transition: max-width 0.25s ease, opacity 0.2s ease, padding-right 0.25s ease;
+  max-width: 100%;
+  overflow: hidden;
+}
+
 .selected-table-card.enlarged .items-body .col {
   font-size: 18px;
 }
@@ -1108,7 +1123,10 @@ export default {
 }
 
 .selected-table-card.enlarged .status-col {
-  display: none;
+  max-width: 0;
+  opacity: 0;
+  padding-right: 0;
+  pointer-events: none;
 }
 
 .selected-table-card.enlarged .organization-col {


### PR DESCRIPTION
Добавил CSS-переходы (250ms ease) на ключевые свойства, которые меняются при включении/выключении enlarged:

- ` + '`font-size`' + ` на ` + '`.items-body .col`' + ` - данные строк плавно растут до 18px.
- ` + '`min-height`' + ` на ` + '`.item-data`' + ` - высота строки плавно увеличивается до 36px.
- ` + '`max-width / opacity / padding-right`' + ` на ` + '`.status-col`' + ` - столбец Статус плавно схлопывается (заменил ` + '`display: none`' + ` на эту тройку, иначе анимация не работала бы).

Применено к обеим таблицам (CarsTable и PeopleTable). Все 13 enlarged-тестов зелёные (логика не задета).