### PR TITLE
fix: выровнял заголовки/колонки по левому краю + плавная анимация enlarged

### DIFF
--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -900,13 +900,18 @@ export default {
   overflow: hidden;
 }
 
+/* items-header повторяет геометрию items-body (padding-right + margin-right 4px),
+   чтобы доступная ширина для колонок совпала и заголовки выровнялись с данными. */
 .items-header {
-  padding: 10px 16px;
   border-bottom: 1px solid #e6e6e6;
   flex-shrink: 0;
+  padding-right: 4px;
+  margin-right: 4px;
 }
 
+/* header-row повторяет геометрию item-data: padding 10/16 + flex + gap 4. */
 .header-row {
+  padding: 10px 16px;
   display: flex;
   width: 100%;
   align-items: center;
@@ -1154,21 +1159,23 @@ export default {
   transition: transform 0.3s ease;
 }
 
-/* "Увеличенный режим": крупный шрифт только данных строк (заголовки не трогаем),
-   bold номера, скрытый статус. Освободившуюся ширину забирает organization-col.
-   Переключение анимируем через transition на font-size, min-height, max-width/opacity. */
+/* "Увеличенный режим": плавный переход в обе стороны.
+   Анимируем width status/organization, font-size данных, min-height строки. */
 .selected-table-card .items-body .col {
-  transition: font-size 0.25s ease;
+  transition: font-size 0.4s ease-in-out;
 }
 
 .selected-table-card .item-data {
-  transition: min-height 0.25s ease;
+  transition: min-height 0.4s ease-in-out;
 }
 
 .selected-table-card .status-col {
-  transition: max-width 0.25s ease, opacity 0.2s ease, padding-right 0.25s ease;
-  max-width: 100%;
+  transition: width 0.4s ease-in-out, opacity 0.3s ease-in-out;
   overflow: hidden;
+}
+
+.selected-table-card .organization-col {
+  transition: width 0.4s ease-in-out;
 }
 
 .selected-table-card.enlarged .items-body .col {
@@ -1179,15 +1186,15 @@ export default {
   font-weight: 700;
 }
 
+/* Освобождённую ширину status-col (7%) переливаем в organization-col (18% -> 25%). */
 .selected-table-card.enlarged .status-col {
-  max-width: 0;
+  width: 0;
   opacity: 0;
-  padding-right: 0;
   pointer-events: none;
 }
 
 .selected-table-card.enlarged .organization-col {
-  flex-grow: 1;
+  width: 25%;
 }
 
 .selected-table-card.enlarged .item-data {

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -843,13 +843,18 @@ export default {
   overflow: hidden;
 }
 
+/* items-header повторяет геометрию items-body (padding-right + margin-right 4px),
+   чтобы доступная ширина для колонок совпала и заголовки выровнялись с данными. */
 .items-header {
-  padding: 10px 16px;
   border-bottom: 1px solid #e6e6e6;
   flex-shrink: 0;
+  padding-right: 4px;
+  margin-right: 4px;
 }
 
+/* header-row повторяет геометрию item-data: padding 10/16 + flex + gap 4. */
 .header-row {
+  padding: 10px 16px;
   display: flex;
   width: 100%;
   align-items: center;
@@ -1097,21 +1102,23 @@ export default {
   transition: transform 0.3s ease;
 }
 
-/* "Увеличенный режим": крупный шрифт только данных строк (заголовки не трогаем),
-   bold фамилии, скрытый статус. Освободившуюся ширину забирает organization-col.
-   Переключение анимируем через transition на font-size, min-height, max-width/opacity. */
+/* "Увеличенный режим": плавный переход в обе стороны.
+   Анимируем width status/organization, font-size данных, min-height строки. */
 .selected-table-card .items-body .col {
-  transition: font-size 0.25s ease;
+  transition: font-size 0.4s ease-in-out;
 }
 
 .selected-table-card .item-data {
-  transition: min-height 0.25s ease;
+  transition: min-height 0.4s ease-in-out;
 }
 
 .selected-table-card .status-col {
-  transition: max-width 0.25s ease, opacity 0.2s ease, padding-right 0.25s ease;
-  max-width: 100%;
+  transition: width 0.4s ease-in-out, opacity 0.3s ease-in-out;
   overflow: hidden;
+}
+
+.selected-table-card .organization-col {
+  transition: width 0.4s ease-in-out;
 }
 
 .selected-table-card.enlarged .items-body .col {
@@ -1122,15 +1129,15 @@ export default {
   font-weight: 700;
 }
 
+/* Освобождённую ширину status-col (8%) переливаем в organization-col (16% -> 24%). */
 .selected-table-card.enlarged .status-col {
-  max-width: 0;
+  width: 0;
   opacity: 0;
-  padding-right: 0;
   pointer-events: none;
 }
 
 .selected-table-card.enlarged .organization-col {
-  flex-grow: 1;
+  width: 24%;
 }
 
 .selected-table-card.enlarged .item-data {


### PR DESCRIPTION
Две правки в таблицах.

## 1. Выравнивание заголовков с данными по левому краю
**Корень:** Колонки заголовка и данных считают проценты от разных ширин:
- ` + '`.items-header`' + ` имеет padding 16/16 (доступно W - 32 для колонок).
- ` + '`.items-body`' + ` имеет padding-right + margin-right по 4px (запас под скроллбар) + item-data padding 16/16 (доступно W - 40 для колонок).
- Разница 8px накапливается слева направо: на правых колонках смещение до 7px (замерил через DOM).

**Решение:** структурно симметризовать.
- ` + '`.items-header`' + ` получает padding-right + margin-right по 4px (как ` + '`.items-body`' + `).
- Внутренний padding 10/16 переезжает с ` + '`.items-header`' + ` на ` + '`.header-row`' + ` (как уже на ` + '`.item-data`' + `).

Теперь колонки заголовка и строки данных идут от одинаковой доступной ширины - выравнивание идеальное.

## 2. Плавная анимация enlarged (в обе стороны)
Раньше:
- duration 250ms, ease - слишком резко.
- ` + '`flex-grow: 1`' + ` на organization-col не анимируется браузером, поэтому колонка прыгала в новый размер.
- ` + '`max-width: 0`' + ` на status-col технически работало, но визуально оставляла 4px от gap.

Стало:
- duration 400ms, ease-in-out - заметно плавнее.
- ` + '`width`' + ` явно меняется: status-col 7%/8% -> 0, organization-col 18% -> 25% (Cars), 16% -> 24% (People). ` + '`width`' + ` транзишен работает и в Chrome, и в Firefox в обе стороны.
- font-size, min-height, opacity синхронно с тем же таймингом.

Сумма ширин не меняется (передаём освобождённые проценты в organization-col), поэтому layout идеально сходится.

Тесты vitest 13/13 зелёные.