### PR TITLE
fix: плавная анимация данных в enlarged + выравнивание остальных таблиц

### DIFF
--- a/frontend/src/components/CarsFact.vue
+++ b/frontend/src/components/CarsFact.vue
@@ -560,14 +560,18 @@ export default {
   overflow-y: auto;
 }
 
-/* Заголовок таблицы */
+/* cars-header повторяет геометрию cars-body (padding-right + margin-right 4px),
+   чтобы доступная ширина колонок совпала и заголовки выровнялись с данными. */
 .cars-header {
   border-bottom: 1px solid #e6e6e6;
-  padding: 12px 16px;
   flex-shrink: 0;
+  padding-right: 4px;
+  margin-right: 4px;
 }
 
+/* header-row повторяет геометрию car-row: padding 12/16 + flex. */
 .header-row {
+  padding: 12px 16px;
   display: flex;
   width: 100%;
   align-items: center;

--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -1160,9 +1160,11 @@ export default {
 }
 
 /* "Увеличенный режим": плавный переход в обе стороны.
-   Анимируем width status/organization, font-size данных, min-height строки. */
-.selected-table-card .items-body .col {
-  transition: font-size 0.4s ease-in-out;
+   Transition объединён на .col (font-size + width + opacity), чтобы избежать
+   конфликта специфичности (раньше .items-body .col перекрывал отдельные
+   правила .status-col / .organization-col и данные не анимировались). */
+.selected-table-card .col {
+  transition: font-size 0.4s ease-in-out, width 0.4s ease-in-out, opacity 0.3s ease-in-out;
 }
 
 .selected-table-card .item-data {
@@ -1170,12 +1172,7 @@ export default {
 }
 
 .selected-table-card .status-col {
-  transition: width 0.4s ease-in-out, opacity 0.3s ease-in-out;
   overflow: hidden;
-}
-
-.selected-table-card .organization-col {
-  transition: width 0.4s ease-in-out;
 }
 
 .selected-table-card.enlarged .items-body .col {
@@ -1186,7 +1183,8 @@ export default {
   font-weight: 700;
 }
 
-/* Освобождённую ширину status-col (7%) переливаем в organization-col (18% -> 25%). */
+/* Освобождённую ширину status-col (7%) переливаем в organization-col (18% -> 25%).
+   Сумма ширин не меняется - layout идеально сходится в обе стороны. */
 .selected-table-card.enlarged .status-col {
   width: 0;
   opacity: 0;

--- a/frontend/src/components/FactTable.vue
+++ b/frontend/src/components/FactTable.vue
@@ -775,13 +775,18 @@ export default {
   flex-direction: column;
 }
 
+/* fact-header повторяет геометрию fact-body (padding-right + margin-right 4px),
+   чтобы доступная ширина колонок совпала и заголовки выровнялись с данными. */
 .fact-header {
-  padding: 10px 16px;
   border-bottom: 1px solid #e6e6e6;
   flex-shrink: 0;
+  padding-right: 4px;
+  margin-right: 4px;
 }
 
+/* header-row повторяет геометрию fact-row: padding 10/16 + flex + gap 4. */
 .header-row {
+  padding: 10px 16px;
   display: flex;
   width: 100%;
   align-items: center;

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -1103,9 +1103,11 @@ export default {
 }
 
 /* "Увеличенный режим": плавный переход в обе стороны.
-   Анимируем width status/organization, font-size данных, min-height строки. */
-.selected-table-card .items-body .col {
-  transition: font-size 0.4s ease-in-out;
+   Transition объединён на .col (font-size + width + opacity), чтобы избежать
+   конфликта специфичности (раньше .items-body .col перекрывал отдельные
+   правила .status-col / .organization-col и данные не анимировались). */
+.selected-table-card .col {
+  transition: font-size 0.4s ease-in-out, width 0.4s ease-in-out, opacity 0.3s ease-in-out;
 }
 
 .selected-table-card .item-data {
@@ -1113,12 +1115,7 @@ export default {
 }
 
 .selected-table-card .status-col {
-  transition: width 0.4s ease-in-out, opacity 0.3s ease-in-out;
   overflow: hidden;
-}
-
-.selected-table-card .organization-col {
-  transition: width 0.4s ease-in-out;
 }
 
 .selected-table-card.enlarged .items-body .col {
@@ -1129,7 +1126,8 @@ export default {
   font-weight: 700;
 }
 
-/* Освобождённую ширину status-col (8%) переливаем в organization-col (16% -> 24%). */
+/* Освобождённую ширину status-col (8%) переливаем в organization-col (16% -> 24%).
+   Сумма ширин не меняется - layout идеально сходится в обе стороны. */
 .selected-table-card.enlarged .status-col {
   width: 0;
   opacity: 0;

--- a/frontend/src/views/CarsView.vue
+++ b/frontend/src/views/CarsView.vue
@@ -1439,14 +1439,18 @@ export default {
     overflow-y: auto;
 }
 
-/* Заголовок таблицы */
+/* cars-header повторяет геометрию cars-body (padding-right + margin-right 4px),
+   чтобы доступная ширина колонок совпала и заголовки выровнялись с данными. */
 .cars-header {
     border-bottom: 1px solid #e6e6e6;
-    padding: 12px 16px;
     flex-shrink: 0;
+    padding-right: 4px;
+    margin-right: 4px;
 }
 
+/* header-row повторяет геометрию car-row: padding 12/16 + flex. */
 .header-row {
+    padding: 12px 16px;
     display: flex;
     width: 100%;
     align-items: center;

--- a/frontend/src/views/EmployeeView.vue
+++ b/frontend/src/views/EmployeeView.vue
@@ -757,14 +757,18 @@ export default {
     overflow-y: auto;
 }
 
-/* Заголовок таблицы */
+/* employees-header повторяет геометрию employees-body (padding-right + margin-right 4px),
+   чтобы доступная ширина колонок совпала и заголовки выровнялись с данными. */
 .employees-header {
     border-bottom: 1px solid #e6e6e6;
-    padding: 12px 16px;
     flex-shrink: 0;
+    padding-right: 4px;
+    margin-right: 4px;
 }
 
+/* header-row повторяет геометрию employee-row: padding 12/16 + flex. */
 .header-row {
+    padding: 12px 16px;
     display: flex;
     width: 100%;
     align-items: center;


### PR DESCRIPTION
Две связанные правки.

## 1. Данные в enlarged анимируются (width + opacity), не только заголовки
**Причина:** правила ` + '`.items-body .col { transition: font-size }`' + ` (специфичность 0,0,2,0) перекрывали отдельные правила ` + '`.status-col { transition: width, opacity }`' + ` и ` + '`.organization-col { transition: width }`' + ` (специфичность 0,0,1,0). Из-за этого:
- В шапке статус-колонка плавно уезжала вправо и затухала (там нет items-body .col).
- В данных - резко исчезала. Аналогично "Дебаркадер N1", "31.05.2026" телепортировались на новое положение.

**Решение:** объединить все transition на ` + '`.col`' + ` (font-size + width + opacity). Один селектор - никаких конфликтов специфичности.

## 2. Выравнивание заголовков с данными в остальных таблицах
Тот же фикс из PR #351 применён к: FactTable, CarsFact, EmployeeView, CarsView. У всех был одинаковый паттерн:
- header-wrapper с ` + '`padding: 12/16`' + ` (или 10/16)
- body-wrapper с ` + '`padding-right: 4 + margin-right: 4`' + `
- row внутри body с ` + '`padding: 12/16`' + `

Перенёс padding с header-wrapper на header-row, добавил header-wrapper те же ` + '`padding-right: 4 + margin-right: 4`' + `. Доступная ширина для колонок одинакова - заголовки точно над данными.

Что не трогал: ApplicationsCenter, UserApplications, UserControl, OrganizationCompanyManagement, FeedbackPage, TrashView - у них другая структура (нет padding-right: 4 + margin-right: 4 на body, либо table-вёрстка). Если найду рассинхрон при тесте - сделаю отдельным PR.

Тесты vitest 294/294 зелёные.