### PR TITLE
feat: видимость столбцов в админ-вкладке "Колонки" (#345)

### DIFF
--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -43,6 +43,7 @@
             Выезд
           </div>
           <div
+            v-if="isFieldVisible('car_number')"
             class="col number-col"
             @click="sortBy('car_number')"
           >
@@ -56,6 +57,7 @@
             >
           </div>
           <div
+            v-if="isFieldVisible('car_brand')"
             class="col brand-col"
             @click="sortBy('car_brand')"
           >
@@ -69,6 +71,7 @@
             >
           </div>
           <div
+            v-if="isFieldVisible('organization')"
             class="col organization-col"
             @click="sortBy('organization')"
           >
@@ -87,6 +90,7 @@
             style="display: none;"
           />
           <div
+            v-if="isFieldVisible('unload_place')"
             class="col place-col"
             @click="sortBy('unload_place')"
           >
@@ -100,6 +104,7 @@
             >
           </div>
           <div
+            v-if="isFieldVisible('valid_until')"
             class="col date-col"
             @click="sortBy('entry_date_to')"
           >
@@ -113,6 +118,7 @@
             >
           </div>
           <div
+            v-if="isFieldVisible('time_range')"
             class="col time-col"
             @click="sortBy('entry_time')"
           >
@@ -126,6 +132,7 @@
             >
           </div>
           <div
+            v-if="isFieldVisible('status')"
             class="col status-col"
             @click="sortBy('status')"
           >
@@ -194,13 +201,22 @@
                     Выезд
                   </button>
                 </div>
-                <div class="col number-col">
+                <div
+                  v-if="isFieldVisible('car_number')"
+                  class="col number-col"
+                >
                   {{ item.car_number }}
                 </div>
-                <div class="col brand-col">
+                <div
+                  v-if="isFieldVisible('car_brand')"
+                  class="col brand-col"
+                >
                   {{ item.car_brand }}
                 </div>
-                <div class="col organization-col">
+                <div
+                  v-if="isFieldVisible('organization')"
+                  class="col organization-col"
+                >
                   {{ item.organization_name }}
                 </div>
                 <!-- Компания скрыта -->
@@ -208,16 +224,28 @@
                   class="col company-col"
                   style="display: none;"
                 />
-                <div class="col place-col">
+                <div
+                  v-if="isFieldVisible('unload_place')"
+                  class="col place-col"
+                >
                   {{ formatUnloadPlaces(item) }}
                 </div>
-                <div class="col date-col">
+                <div
+                  v-if="isFieldVisible('valid_until')"
+                  class="col date-col"
+                >
                   {{ formatDate(item.entry_date_to) }}
                 </div>
-                <div class="col time-col">
+                <div
+                  v-if="isFieldVisible('time_range')"
+                  class="col time-col"
+                >
                   {{ formatTimeRange(item.entry_time_from, item.entry_time_to) }}
                 </div>
-                <div class="col status-col">
+                <div
+                  v-if="isFieldVisible('status')"
+                  class="col status-col"
+                >
                   <StatusBadge :status="item.status" />
                 </div>
                 <div
@@ -325,7 +353,8 @@ export default {
       selectedVehicle: null,
       showCarsTableHistory: false,
       pollingInterval: null,
-      enlarged: false
+      enlarged: false,
+      fieldsVisibility: {}
     };
   },
   computed: {
@@ -426,8 +455,11 @@ export default {
     },
     tableId: {
       immediate: true,
-      handler() {
+      handler(newVal) {
         this.loadEnlargedFromStorage();
+        if (newVal) {
+          this.fetchFieldsVisibility();
+        }
       }
     },
     enlarged(value) {
@@ -814,6 +846,26 @@ export default {
         localStorage.setItem(this.enlargedStorageKey(), value ? '1' : '0');
       } catch {
         /* localStorage недоступен - игнорируем */
+      }
+    },
+
+    isFieldVisible(fieldName) {
+      // Пока конфиг не загружен - показываем всё (предотвращает мигание при инициализации).
+      const v = this.fieldsVisibility[fieldName];
+      return v === undefined ? true : v;
+    },
+
+    async fetchFieldsVisibility() {
+      if (!this.tableId) return;
+      try {
+        const response = await apiRequest(`/system-tables/${this.tableId}`, {});
+        if (!response.ok) return;
+        const data = await response.json();
+        const next = {};
+        (data.fields || []).forEach(f => { next[f.field_name] = f.is_visible !== false; });
+        this.fieldsVisibility = next;
+      } catch (error) {
+        console.error('Ошибка загрузки настроек столбцов:', error);
       }
     }
   }

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -39,6 +39,7 @@
             Выход
           </div>
           <div
+            v-if="isFieldVisible('last_name')"
             class="col last-name-col"
             @click="sortBy('last_name')"
           >
@@ -52,6 +53,7 @@
             >
           </div>
           <div
+            v-if="isFieldVisible('first_name')"
             class="col first-name-col"
             @click="sortBy('first_name')"
           >
@@ -65,6 +67,7 @@
             >
           </div>
           <div
+            v-if="isFieldVisible('middle_name')"
             class="col middle-name-col"
             @click="sortBy('middle_name')"
           >
@@ -78,6 +81,7 @@
             >
           </div>
           <div
+            v-if="isFieldVisible('organization')"
             class="col organization-col"
             @click="sortBy('organization')"
           >
@@ -91,6 +95,7 @@
             >
           </div>
           <div
+            v-if="isFieldVisible('valid_until')"
             class="col date-col"
             @click="sortBy('entry_date_to')"
           >
@@ -104,6 +109,7 @@
             >
           </div>
           <div
+            v-if="isFieldVisible('pass_time')"
             class="col time-col"
             @click="sortBy('pass_time')"
           >
@@ -184,22 +190,40 @@
                     Выход
                   </button>
                 </div>
-                <div class="col last-name-col">
+                <div
+                  v-if="isFieldVisible('last_name')"
+                  class="col last-name-col"
+                >
                   {{ item.last_name }}
                 </div>
-                <div class="col first-name-col">
+                <div
+                  v-if="isFieldVisible('first_name')"
+                  class="col first-name-col"
+                >
                   {{ item.first_name }}
                 </div>
-                <div class="col middle-name-col">
+                <div
+                  v-if="isFieldVisible('middle_name')"
+                  class="col middle-name-col"
+                >
                   {{ item.middle_name || '-' }}
                 </div>
-                <div class="col organization-col">
+                <div
+                  v-if="isFieldVisible('organization')"
+                  class="col organization-col"
+                >
                   {{ item.organization_name }}
                 </div>
-                <div class="col date-col">
+                <div
+                  v-if="isFieldVisible('valid_until')"
+                  class="col date-col"
+                >
                   {{ formatDate(item.entry_date_to) }}
                 </div>
-                <div class="col time-col">
+                <div
+                  v-if="isFieldVisible('pass_time')"
+                  class="col time-col"
+                >
                   {{ formatPassTime(item.pass_time) }}
                 </div>
                 <div class="col status-col">
@@ -332,7 +356,8 @@ export default {
       selectedEmployee: null,
       showEmployeesHistory: false,
       pollingInterval: null,
-      enlarged: false
+      enlarged: false,
+      fieldsVisibility: {}
     };
   },
   computed: {
@@ -512,6 +537,13 @@ export default {
         const responseData = await tableRes.json();
         const table = responseData.table;
         this.currentTableId = table.id;
+
+        // Подтягиваем конфиг видимости столбцов из того же ответа.
+        const nextVisibility = {};
+        (responseData.fields || []).forEach(f => {
+          nextVisibility[f.field_name] = f.is_visible !== false;
+        });
+        this.fieldsVisibility = nextVisibility;
 
         const employeesRes = await apiRequest(`/employees/active-for-table/${table.id}`, { method: "GET" });
         if (!employeesRes.ok) return;
@@ -759,6 +791,12 @@ export default {
       } catch {
         /* localStorage недоступен - игнорируем */
       }
+    },
+
+    isFieldVisible(fieldName) {
+      // Пока конфиг не загружен - показываем всё (предотвращает мигание при инициализации).
+      const v = this.fieldsVisibility[fieldName];
+      return v === undefined ? true : v;
     }
   }
 };

--- a/frontend/src/components/SystemTableColumnsTab.vue
+++ b/frontend/src/components/SystemTableColumnsTab.vue
@@ -1,0 +1,322 @@
+<template>
+  <div class="columns-tab">
+    <div class="columns-tab__header">
+      <h4 class="columns-tab__title">
+        Видимые столбцы
+      </h4>
+      <p class="columns-tab__hint">
+        Отключите столбцы, которые не нужны в этой таблице. Скрытые столбцы не отображаются и не учитываются в фильтрах.
+      </p>
+    </div>
+
+    <div
+      v-if="!visibleFields.length"
+      class="columns-tab__empty"
+    >
+      У этой таблицы пока нет настраиваемых столбцов.
+    </div>
+
+    <ul
+      v-else
+      class="columns-tab__list"
+    >
+      <li
+        v-for="field in localFields"
+        :key="field.field_name"
+        class="columns-tab__item"
+        :class="{ 'columns-tab__item--off': !field.is_visible }"
+      >
+        <label class="columns-tab__row">
+          <input
+            v-model="field.is_visible"
+            type="checkbox"
+            class="columns-tab__checkbox"
+            :data-field="field.field_name"
+          >
+          <span class="columns-tab__label">{{ humanLabel(field.field_name) }}</span>
+          <span class="columns-tab__field-name">{{ field.field_name }}</span>
+        </label>
+      </li>
+    </ul>
+
+    <div class="columns-tab__actions">
+      <button
+        class="columns-tab__btn columns-tab__btn--secondary"
+        :disabled="!isDirty || saving"
+        @click="reset"
+      >
+        Отменить
+      </button>
+      <button
+        class="columns-tab__btn columns-tab__btn--primary"
+        :disabled="!isDirty || saving"
+        @click="save"
+      >
+        {{ saving ? 'Сохраняем...' : 'Сохранить' }}
+      </button>
+    </div>
+
+    <p
+      v-if="statusMessage"
+      class="columns-tab__status"
+      :class="{ 'columns-tab__status--error': statusError }"
+    >
+      {{ statusMessage }}
+    </p>
+  </div>
+</template>
+
+<script>
+import { apiRequest } from '@/api/client';
+
+/**
+ * Маппинг внутреннего имени поля -> человеческое название столбца.
+ * Используется и в админ-вкладке "Колонки", и в реальных таблицах для совпадения подписей.
+ */
+const FIELD_LABELS = {
+  car_number: 'Номер Т/С',
+  car_brand: 'Марка',
+  organization: 'Организация',
+  unload_place: 'Место разгрузки',
+  valid_until: 'Действует до',
+  time_range: 'Время',
+  status: 'Статус',
+  last_name: 'Фамилия',
+  first_name: 'Имя',
+  middle_name: 'Отчество',
+  pass_time: 'Время прохода',
+};
+
+export default {
+  name: 'SystemTableColumnsTab',
+  props: {
+    tableId: { type: Number, required: true },
+    fields: { type: Array, required: true },
+  },
+  emits: ['update'],
+  data() {
+    return {
+      localFields: [],
+      original: {},
+      saving: false,
+      statusMessage: '',
+      statusError: false,
+    };
+  },
+  computed: {
+    visibleFields() {
+      return this.localFields;
+    },
+    isDirty() {
+      return this.localFields.some(f => this.original[f.field_name] !== f.is_visible);
+    },
+  },
+  watch: {
+    fields: {
+      handler() {
+        this.reset();
+      },
+      immediate: true,
+    },
+  },
+  methods: {
+    humanLabel(name) {
+      return FIELD_LABELS[name] || name;
+    },
+    reset() {
+      this.localFields = (this.fields || []).map(f => ({
+        field_name: f.field_name,
+        is_visible: f.is_visible !== false,
+      }));
+      this.original = Object.fromEntries(
+        this.localFields.map(f => [f.field_name, f.is_visible]),
+      );
+      this.statusMessage = '';
+      this.statusError = false;
+    },
+    async save() {
+      if (!this.isDirty || this.saving) return;
+      this.saving = true;
+      this.statusMessage = '';
+      this.statusError = false;
+
+      try {
+        const response = await apiRequest(`/system-tables/${this.tableId}/fields`, {
+          method: 'PUT',
+          body: JSON.stringify({
+            fields: this.localFields.map(f => ({
+              field_name: f.field_name,
+              is_visible: f.is_visible,
+            })),
+          }),
+        });
+        if (!response.ok) {
+          const err = await response.json().catch(() => ({}));
+          throw new Error(err.message || `HTTP ${response.status}`);
+        }
+        this.statusMessage = 'Видимость столбцов сохранена';
+        this.original = Object.fromEntries(
+          this.localFields.map(f => [f.field_name, f.is_visible]),
+        );
+        this.$emit('update');
+      } catch (e) {
+        this.statusError = true;
+        this.statusMessage = `Ошибка сохранения: ${e.message}`;
+      } finally {
+        this.saving = false;
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.columns-tab {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.columns-tab__header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.columns-tab__title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: #000;
+}
+
+.columns-tab__hint {
+  margin: 0;
+  font-size: 13px;
+  color: #6b7280;
+  line-height: 1.4;
+}
+
+.columns-tab__empty {
+  padding: 24px;
+  text-align: center;
+  color: #a2a2a2;
+  background: #f9fafb;
+  border-radius: 12px;
+}
+
+.columns-tab__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.columns-tab__item {
+  border: 1px solid #e6e6e6;
+  border-radius: 12px;
+  transition: background-color 0.2s ease;
+}
+
+.columns-tab__item:hover {
+  background: #f9fafb;
+}
+
+.columns-tab__item--off {
+  background: #fafafa;
+  border-color: #ececec;
+}
+
+.columns-tab__row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.columns-tab__checkbox {
+  width: 18px;
+  height: 18px;
+  accent-color: #4F5BDF;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.columns-tab__label {
+  font-size: 14px;
+  font-weight: 500;
+  color: #000;
+  flex: 1;
+}
+
+.columns-tab__item--off .columns-tab__label {
+  color: #a2a2a2;
+}
+
+.columns-tab__field-name {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  color: #a2a2a2;
+}
+
+.columns-tab__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  border-top: 1px solid #f0f0f0;
+  padding-top: 12px;
+}
+
+.columns-tab__btn {
+  padding: 8px 18px;
+  border-radius: 14px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border: 1px solid transparent;
+}
+
+.columns-tab__btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.columns-tab__btn--secondary {
+  background: #fff;
+  border-color: #e6e6e6;
+  color: #333;
+}
+
+.columns-tab__btn--secondary:hover:not(:disabled) {
+  background: #f5f5f5;
+  border-color: #c0c0c0;
+}
+
+.columns-tab__btn--primary {
+  background: #4F5BDF;
+  color: #fff;
+  border-color: #4F5BDF;
+}
+
+.columns-tab__btn--primary:hover:not(:disabled) {
+  background: #3b48c4;
+  border-color: #3b48c4;
+}
+
+.columns-tab__status {
+  margin: 0;
+  font-size: 13px;
+  color: #079D1D;
+  text-align: right;
+}
+
+.columns-tab__status--error {
+  color: #c62828;
+}
+</style>

--- a/frontend/src/components/TableConstructor.vue
+++ b/frontend/src/components/TableConstructor.vue
@@ -147,12 +147,19 @@
           >
             Расписание
           </button>
-          <button 
-            class="tab-btn" 
+          <button
+            class="tab-btn"
             :class="{ 'active': activeTab === 'location' }"
             @click="activeTab = 'location'"
           >
             Местоположение
+          </button>
+          <button
+            class="tab-btn"
+            :class="{ 'active': activeTab === 'columns' }"
+            @click="activeTab = 'columns'"
+          >
+            Колонки
           </button>
         </div>
 
@@ -451,8 +458,20 @@
             @photos-changed="refreshSelectedTable"
           />
         </div>
+
+        <!-- Вкладка Колонки (#345) -->
+        <div
+          v-if="activeTab === 'columns'"
+          class="tab-content"
+        >
+          <SystemTableColumnsTab
+            :table-id="selectedTable.table.id"
+            :fields="selectedTable.fields || []"
+            @update="refreshSelectedTable"
+          />
+        </div>
       </div>
-      
+
       <div
         v-else
         class="no-selection-message"
@@ -495,6 +514,7 @@ import RefreshButton from './RefreshButton.vue';
 import SearchComponent from './SearchComponent.vue';
 import TextConstructor from './TextConstructor.vue';
 import SystemTableScheduleTab from './SystemTableScheduleTab.vue';
+import SystemTableColumnsTab from './SystemTableColumnsTab.vue';
 import TableConstructorCreateModal from './TableConstructorCreateModal.vue';
 import TableConstructorPhotoSection from './TableConstructorPhotoSection.vue';
 
@@ -505,6 +525,7 @@ export default {
     RefreshButton,
     TextConstructor,
     SystemTableScheduleTab,
+    SystemTableColumnsTab,
     TableConstructorCreateModal,
     TableConstructorPhotoSection
   },

--- a/internal/handlers/system_tables.go
+++ b/internal/handlers/system_tables.go
@@ -162,6 +162,35 @@ func (h *SystemTableHandler) Delete(c echo.Context) error {
 	return RespondMessage(c, "Системная таблица успешно удалена")
 }
 
+// UpdateFields godoc
+// @Summary      Bulk-обновление видимости столбцов таблицы (#345)
+// @Description  Обновляет is_visible для перечисленных field_name. Поля не из БД игнорируются.
+// @Tags         system-tables
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID таблицы"
+// @Param        request body models.UpdateFieldsRequest true "Список столбцов с новой видимостью"
+// @Success      200 {string} string "Видимость столбцов обновлена"
+// @Failure      400 {object} models.HTTPError
+// @Failure      401 {object} models.HTTPError
+// @Failure      404 {object} models.HTTPError
+// @Router       /system-tables/{id}/fields [put]
+func (h *SystemTableHandler) UpdateFields(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	var req models.UpdateFieldsRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	if err := h.service.UpdateFields(c.Request().Context(), id, req); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Видимость столбцов обновлена")
+}
+
 // --- Временные слоты ---
 
 // GetTimeSlots godoc

--- a/internal/handlers/system_tables_test.go
+++ b/internal/handlers/system_tables_test.go
@@ -258,3 +258,60 @@ func TestSystemTables_ResponseStructure(t *testing.T) {
 	assert.Contains(t, details, "photos")
 	assert.Contains(t, details, "current_status")
 }
+
+func TestSystemTables_UpdateFields_TogglesVisibility(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	rec := testutil.POST(t, e, "/system-tables",
+		`{"name":"fields_test","display_name":"FT","table_type":"cars"}`, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	tableID := int(testutil.ParseMap(t, rec)["id"].(float64))
+
+	// PUT /system-tables/:id/fields - скрываем status и unload_place
+	body := `{"fields":[{"field_name":"status","is_visible":false},{"field_name":"unload_place","is_visible":false}]}`
+	rec = testutil.PUT(t, e, fmt.Sprintf("/system-tables/%d/fields", tableID), body, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Re-fetch и проверяем, что is_visible поменялся ровно для двух полей
+	rec = testutil.GET(t, e, fmt.Sprintf("/system-tables/%d", tableID), h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	fields := testutil.ParseMap(t, rec)["fields"].([]interface{})
+
+	visibility := map[string]bool{}
+	for _, f := range fields {
+		fm := f.(map[string]interface{})
+		visibility[fm["field_name"].(string)] = fm["is_visible"].(bool)
+	}
+	assert.False(t, visibility["status"], "status должен быть скрыт")
+	assert.False(t, visibility["unload_place"], "unload_place должен быть скрыт")
+	assert.True(t, visibility["car_number"], "car_number должен остаться видимым")
+	assert.True(t, visibility["car_brand"], "car_brand должен остаться видимым")
+}
+
+func TestSystemTables_UpdateFields_UnknownTable_404(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	body := `{"fields":[{"field_name":"car_number","is_visible":false}]}`
+	rec := testutil.PUT(t, e, "/system-tables/999999/fields", body, h)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestSystemTables_UpdateFields_Unauthorized(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	body := `{"fields":[{"field_name":"car_number","is_visible":false}]}`
+	rec := testutil.PUT(t, e, "/system-tables/1/fields", body, nil)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}

--- a/internal/models/system_table.go
+++ b/internal/models/system_table.go
@@ -131,3 +131,14 @@ type UpdateTimeSlotRequest struct {
 	IsNextDay *bool   `json:"is_next_day"`
 	IsActive  *bool   `json:"is_active"`
 }
+
+// FieldVisibilityUpdate -- одиночное обновление видимости столбца таблицы (#345).
+type FieldVisibilityUpdate struct {
+	FieldName string `json:"field_name" validate:"required"`
+	IsVisible bool   `json:"is_visible"`
+}
+
+// UpdateFieldsRequest -- bulk-обновление видимости столбцов системной таблицы.
+type UpdateFieldsRequest struct {
+	Fields []FieldVisibilityUpdate `json:"fields" validate:"required"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -309,6 +309,9 @@ func Setup(e *echo.Echo, d Dependencies) {
 	stg.DELETE("/:table_id/photos/:photo_id", st.DeletePhoto)
 	stg.POST("/:table_id/photos/:photo_id/main", st.SetMainPhoto)
 
+	// Столбцы таблицы (#345)
+	stg.PUT("/:id/fields", st.UpdateFields)
+
 	// Корзина таблицы (#186) - удалённые элементы с возможностью восстановить
 	// или окончательно удалить. Тип элементов определяется по table_type
 	// системной таблицы (cars или people).

--- a/internal/services/system_table_service.go
+++ b/internal/services/system_table_service.go
@@ -41,6 +41,9 @@ type SystemTableService interface {
 	UploadPhoto(ctx context.Context, tableID int, username string, file *multipart.FileHeader) (int, error)
 	DeletePhoto(ctx context.Context, tableID, photoID int) error
 	SetMainPhoto(ctx context.Context, tableID, photoID int) error
+
+	// Столбцы таблицы (#345): bulk-обновление видимости.
+	UpdateFields(ctx context.Context, tableID int, req models.UpdateFieldsRequest) error
 }
 
 type systemTableService struct {
@@ -450,3 +453,30 @@ func (s *systemTableService) Delete(ctx context.Context, id int) error {
 	return nil
 }
 
+
+
+// UpdateFields bulk-обновляет видимость столбцов таблицы по field_name.
+// Поля, отсутствующие в БД, игнорируются.
+func (s *systemTableService) UpdateFields(ctx context.Context, tableID int, req models.UpdateFieldsRequest) error {
+	var table models.SystemTable
+	if err := s.db.WithContext(ctx).Where("id = ?", tableID).First(&table).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return echo.NewHTTPError(http.StatusNotFound, "Системная таблица не найдена")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Error fetching system table")
+	}
+
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		for _, f := range req.Fields {
+			result := tx.Model(&models.TableField{}).
+				Where("table_id = ? AND field_name = ?", tableID, f.FieldName).
+				Update("is_visible", f.IsVisible)
+			if result.Error != nil {
+				slog.Error("не удалось обновить видимость столбца",
+					"table_id", tableID, "field", f.FieldName, "error", result.Error)
+				return echo.NewHTTPError(http.StatusInternalServerError, "Error updating field visibility")
+			}
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
Первая фаза #345 (Phase 1A): можно скрыть/показать столбцы в каждой системной таблице индивидуально.

## Что вошло

### Backend
- ` + '`PUT /system-tables/:id/fields`' + ` - bulk-апдейт ` + '`is_visible`' + ` для перечисленных field_name. Игнорирует поля, отсутствующие в БД.
- ` + '`models.UpdateFieldsRequest`' + ` + ` + '`FieldVisibilityUpdate`' + `.
- ` + '`SystemTableService.UpdateFields`' + ` - транзакционно апдейтит ` + '`table_fields.is_visible`' + `.

### Admin UI
- Новая вкладка "Колонки" в TableConstructor (после "Местоположение").
- Компонент ` + '`SystemTableColumnsTab.vue`' + `:
  - Список всех полей таблицы с чекбоксом is_visible.
  - Человеческие подписи (Номер Т/С, Фамилия и т.д.) + технический field_name справа.
  - Кнопки "Отменить" / "Сохранить" с tracking dirty-state.
  - Сообщение об успехе/ошибке.

### Реальные таблицы (CarsTable / PeopleTable)
- Каждый столбец-поле обёрнут в ` + '`v-if="isFieldVisible(name)"`' + `.
- CarsTable фетчит конфиг через ` + '`GET /system-tables/:id`' + ` (watch tableId).
- PeopleTable забирает ` + '`fields`' + ` из уже существующего ` + '`GET /system-tables/name/:name`' + `.
- Дефолт: показывать всё (предотвращает мигание при инициализации).

## Что НЕ вошло (следующие фазы)
- Порядок столбцов (display_order) - только хранится, не применяется к рендеру.
- Ширина столбцов, шрифт и размер, плотность строк (Phase 1B, 1C, 1D).
- Портретный режим, "Увеличенный режим" - уже сделано отдельными PR.

## Тесты
- Go: 3 новых теста (TogglesVisibility, UnknownTable_404, Unauthorized).
- Vitest: 294/294 зелёные (не задето).

## Проверка
- [ ] В личном кабинете -> Управление системой -> Таблицы выбрать таблицу.
- [ ] Перейти на вкладку "Колонки" - видны все поля с тогглами.
- [ ] Снять галочку с любого столбца -> Сохранить.
- [ ] Открыть саму таблицу (Таблицы -> ПОСТ N72 или КПП N4) - выбранный столбец скрыт.
- [ ] Сделать обратно - столбец появляется.