### PR TITLE
feat: дополнительные столбцы (Должность, Гражданство, Компания) и фикс ширины (#345)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -157,6 +157,9 @@ func main() {
 	banCheckService := services.NewBanCheckService(db, 30*time.Second)
 	userBanService := services.NewUserBanService(db, permissionResolver, banCheckService)
 	systemTableService := services.NewSystemTableService(db, cfg.UploadPath, cfg.UploadMaxFileSize, permissionService)
+	if err := systemTableService.SeedMissingFields(context.Background()); err != nil {
+		slog.Error("не удалось досидить отсутствующие поля таблиц (#345)", "error", err)
+	}
 	uniqueCarService := services.NewUniqueCarService(db)
 	uniqueEmployeeService := services.NewUniqueEmployeeService(db)
 	feedbackService := services.NewFeedbackService(db)

--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -84,11 +84,34 @@
               :class="{ 'sorted': sortField === 'organization', 'desc': sortField === 'organization' && sortDirection === 'desc' }"
             >
           </div>
-          <!-- Компания скрыта, но класс оставлен для возможного использования -->
           <div
+            v-if="isFieldVisible('company')"
             class="col company-col"
-            style="display: none;"
-          />
+            @click="sortBy('company')"
+          >
+            <p :class="{ 'active-sort': sortField === 'company' }">
+              Компания
+            </p>
+            <img
+              src="@/assets/icons/sort.png"
+              class="sort-icon"
+              :class="{ 'sorted': sortField === 'company', 'desc': sortField === 'company' && sortDirection === 'desc' }"
+            >
+          </div>
+          <div
+            v-if="isFieldVisible('application_id')"
+            class="col application-col"
+            @click="sortBy('application_id')"
+          >
+            <p :class="{ 'active-sort': sortField === 'application_id' }">
+              Номер заявки
+            </p>
+            <img
+              src="@/assets/icons/sort.png"
+              class="sort-icon"
+              :class="{ 'sorted': sortField === 'application_id', 'desc': sortField === 'application_id' && sortDirection === 'desc' }"
+            >
+          </div>
           <div
             v-if="isFieldVisible('unload_place')"
             class="col place-col"
@@ -219,11 +242,18 @@
                 >
                   {{ item.organization_name }}
                 </div>
-                <!-- Компания скрыта -->
                 <div
+                  v-if="isFieldVisible('company')"
                   class="col company-col"
-                  style="display: none;"
-                />
+                >
+                  {{ item.company || '-' }}
+                </div>
+                <div
+                  v-if="isFieldVisible('application_id')"
+                  class="col application-col"
+                >
+                  {{ item.applicationId || '-' }}
+                </div>
                 <div
                   v-if="isFieldVisible('unload_place')"
                   class="col place-col"
@@ -980,17 +1010,21 @@ export default {
   white-space: nowrap;
 }
 
-.entry-col { width: 6.5%; }
-.exit-col { width: 8%; }
-.number-col { width: 10%; }
-.brand-col { width: 8.5%; }
-.organization-col { width: 18%; }
-.company-col { width: 0%; }
-.place-col { width: 15%; }
-.date-col { width: 11.5%; }
-.time-col { width: 10%; }
-.status-col { width: 7%; }
-.actions-col { width: 2%; }
+/* Веса колонок (flex-grow). Браузер делит доступную ширину пропорционально весам
+   видимых колонок. При скрытии любых через v-if остальные автоматически расширяются,
+   занимая освободившееся место. */
+.entry-col { flex: 6.5 0 0; }
+.exit-col { flex: 8 0 0; }
+.number-col { flex: 10 0 0; }
+.brand-col { flex: 8.5 0 0; }
+.organization-col { flex: 18 0 0; }
+.company-col { flex: 10 0 0; }
+.application-col { flex: 8 0 0; }
+.place-col { flex: 15 0 0; }
+.date-col { flex: 11.5 0 0; }
+.time-col { flex: 10 0 0; }
+.status-col { flex: 7 0 0; }
+.actions-col { flex: 2 0 0; }
 
 .header-row .col {
   font-weight: 500;
@@ -1216,7 +1250,7 @@ export default {
    конфликта специфичности (раньше .items-body .col перекрывал отдельные
    правила .status-col / .organization-col и данные не анимировались). */
 .selected-table-card .col {
-  transition: font-size 0.4s ease-in-out, width 0.4s ease-in-out, opacity 0.3s ease-in-out;
+  transition: font-size 0.4s ease-in-out, flex-grow 0.4s ease-in-out, opacity 0.3s ease-in-out;
 }
 
 .selected-table-card .item-data {
@@ -1235,16 +1269,16 @@ export default {
   font-weight: 700;
 }
 
-/* Освобождённую ширину status-col (7%) переливаем в organization-col (18% -> 25%).
-   Сумма ширин не меняется - layout идеально сходится в обе стороны. */
+/* В enlarged переливаем вес status-col (7) в organization-col (18 -> 25).
+   Остальные пропорции сохраняются. */
 .selected-table-card.enlarged .status-col {
-  width: 0;
+  flex-grow: 0;
   opacity: 0;
   pointer-events: none;
 }
 
 .selected-table-card.enlarged .organization-col {
-  width: 25%;
+  flex-grow: 25;
 }
 
 .selected-table-card.enlarged .item-data {

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -81,6 +81,34 @@
             >
           </div>
           <div
+            v-if="isFieldVisible('position')"
+            class="col position-col"
+            @click="sortBy('position')"
+          >
+            <p :class="{ 'active-sort': sortField === 'position' }">
+              Должность
+            </p>
+            <img
+              src="@/assets/icons/sort.png"
+              class="sort-icon"
+              :class="{ 'sorted': sortField === 'position', 'desc': sortField === 'position' && sortDirection === 'desc' }"
+            >
+          </div>
+          <div
+            v-if="isFieldVisible('citizenship_name')"
+            class="col citizenship-col"
+            @click="sortBy('citizenship_name')"
+          >
+            <p :class="{ 'active-sort': sortField === 'citizenship_name' }">
+              Гражданство
+            </p>
+            <img
+              src="@/assets/icons/sort.png"
+              class="sort-icon"
+              :class="{ 'sorted': sortField === 'citizenship_name', 'desc': sortField === 'citizenship_name' && sortDirection === 'desc' }"
+            >
+          </div>
+          <div
             v-if="isFieldVisible('organization')"
             class="col organization-col"
             @click="sortBy('organization')"
@@ -92,6 +120,20 @@
               src="@/assets/icons/sort.png"
               class="sort-icon"
               :class="{ 'sorted': sortField === 'organization', 'desc': sortField === 'organization' && sortDirection === 'desc' }"
+            >
+          </div>
+          <div
+            v-if="isFieldVisible('company')"
+            class="col company-col"
+            @click="sortBy('company')"
+          >
+            <p :class="{ 'active-sort': sortField === 'company' }">
+              Компания
+            </p>
+            <img
+              src="@/assets/icons/sort.png"
+              class="sort-icon"
+              :class="{ 'sorted': sortField === 'company', 'desc': sortField === 'company' && sortDirection === 'desc' }"
             >
           </div>
           <div
@@ -209,10 +251,28 @@
                   {{ item.middle_name || '-' }}
                 </div>
                 <div
+                  v-if="isFieldVisible('position')"
+                  class="col position-col"
+                >
+                  {{ item.position || '-' }}
+                </div>
+                <div
+                  v-if="isFieldVisible('citizenship_name')"
+                  class="col citizenship-col"
+                >
+                  {{ item.citizenshipName || '-' }}
+                </div>
+                <div
                   v-if="isFieldVisible('organization')"
                   class="col organization-col"
                 >
                   {{ item.organization_name }}
+                </div>
+                <div
+                  v-if="isFieldVisible('company')"
+                  class="col company-col"
+                >
+                  {{ item.company || '-' }}
                 </div>
                 <div
                   v-if="isFieldVisible('valid_until')"
@@ -910,16 +970,21 @@ export default {
   padding-right: 8px;
 }
 
-.entry-col { width: 6%; }
-.exit-col { width: 6%; }
-.last-name-col { width: 14%; }
-.first-name-col { width: 9%; }
-.middle-name-col { width: 11%; }
-.organization-col { width: 16%; }
-.date-col { width: 11%; }
-.time-col { width: 13%; }
-.status-col { width: 8%; }
-.actions-col { width: 2%; padding-right: 0; }
+/* Веса колонок (flex-grow). Браузер делит доступную ширину пропорционально весам
+   видимых колонок. При скрытии любых через v-if остальные автоматически расширяются. */
+.entry-col { flex: 6 0 0; }
+.exit-col { flex: 6 0 0; }
+.last-name-col { flex: 14 0 0; }
+.first-name-col { flex: 9 0 0; }
+.middle-name-col { flex: 11 0 0; }
+.position-col { flex: 9 0 0; }
+.citizenship-col { flex: 10 0 0; }
+.organization-col { flex: 16 0 0; }
+.company-col { flex: 11 0 0; }
+.date-col { flex: 11 0 0; }
+.time-col { flex: 13 0 0; }
+.status-col { flex: 8 0 0; }
+.actions-col { flex: 2 0 0; padding-right: 0; }
 
 .header-row .col {
   font-weight: 500;
@@ -1145,7 +1210,7 @@ export default {
    конфликта специфичности (раньше .items-body .col перекрывал отдельные
    правила .status-col / .organization-col и данные не анимировались). */
 .selected-table-card .col {
-  transition: font-size 0.4s ease-in-out, width 0.4s ease-in-out, opacity 0.3s ease-in-out;
+  transition: font-size 0.4s ease-in-out, flex-grow 0.4s ease-in-out, opacity 0.3s ease-in-out;
 }
 
 .selected-table-card .item-data {
@@ -1164,16 +1229,16 @@ export default {
   font-weight: 700;
 }
 
-/* Освобождённую ширину status-col (8%) переливаем в organization-col (16% -> 24%).
-   Сумма ширин не меняется - layout идеально сходится в обе стороны. */
+/* В enlarged переливаем вес status-col (8) в organization-col (16 -> 24).
+   Остальные пропорции сохраняются. */
 .selected-table-card.enlarged .status-col {
-  width: 0;
+  flex-grow: 0;
   opacity: 0;
   pointer-events: none;
 }
 
 .selected-table-card.enlarged .organization-col {
-  width: 24%;
+  flex-grow: 24;
 }
 
 .selected-table-card.enlarged .item-data {

--- a/frontend/src/components/SystemTableColumnsTab.vue
+++ b/frontend/src/components/SystemTableColumnsTab.vue
@@ -81,10 +81,18 @@ const FIELD_LABELS = {
   valid_until: 'Действует до',
   time_range: 'Время',
   status: 'Статус',
+  // Расширенные поля cars (по умолчанию скрыты)
+  application_id: 'Номер заявки',
+  // Базовые поля people
   last_name: 'Фамилия',
   first_name: 'Имя',
   middle_name: 'Отчество',
   pass_time: 'Время прохода',
+  // Расширенные поля people (по умолчанию скрыты)
+  position: 'Должность',
+  citizenship_name: 'Гражданство',
+  // Общие
+  company: 'Компания',
 };
 
 export default {

--- a/internal/services/system_table_service.go
+++ b/internal/services/system_table_service.go
@@ -44,6 +44,10 @@ type SystemTableService interface {
 
 	// Столбцы таблицы (#345): bulk-обновление видимости.
 	UpdateFields(ctx context.Context, tableID int, req models.UpdateFieldsRequest) error
+
+	// SeedMissingFields добавляет default-поля, которых ещё нет у существующих таблиц.
+	// Вызывается один раз при старте сервиса для миграции старых таблиц.
+	SeedMissingFields(ctx context.Context) error
 }
 
 type systemTableService struct {
@@ -225,32 +229,45 @@ func (s *systemTableService) GetByName(ctx context.Context, name string) (*model
 }
 
 // defaultField -- описание поля по умолчанию для нового типа таблицы.
+// IsVisible определяет, включён ли столбец сразу при создании таблицы.
+// "Базовые" столбцы видимы, "дополнительные" - скрыты и включаются админом по необходимости.
 type defaultField struct {
 	Name      string
 	FieldType string
+	IsVisible bool
 }
 
 // getDefaultFields возвращает набор полей по умолчанию для типа таблицы.
+// Видимые сразу после создания таблицы - типовые поля гостевого пропуска.
+// Скрытые - расширенные поля (компания, должность, гражданство и т.п.),
+// которые админ может включить в "Колонки".
 func getDefaultFields(tableType string) []defaultField {
 	switch tableType {
 	case "cars":
 		return []defaultField{
-			{"car_number", "text"},
-			{"car_brand", "text"},
-			{"organization", "text"},
-			{"unload_place", "text"},
-			{"valid_until", "date"},
-			{"time_range", "text"},
-			{"status", "text"},
+			{"car_number", "text", true},
+			{"car_brand", "text", true},
+			{"organization", "text", true},
+			{"unload_place", "text", true},
+			{"valid_until", "date", true},
+			{"time_range", "text", true},
+			{"status", "text", true},
+			// Расширенные (по умолчанию скрытые)
+			{"company", "text", false},
+			{"application_id", "text", false},
 		}
 	case "people":
 		return []defaultField{
-			{"organization", "text"},
-			{"last_name", "text"},
-			{"first_name", "text"},
-			{"middle_name", "text"},
-			{"valid_until", "date"},
-			{"pass_time", "text"},
+			{"organization", "text", true},
+			{"last_name", "text", true},
+			{"first_name", "text", true},
+			{"middle_name", "text", true},
+			{"valid_until", "date", true},
+			{"pass_time", "text", true},
+			// Расширенные (по умолчанию скрытые)
+			{"position", "text", false},
+			{"citizenship_name", "text", false},
+			{"company", "text", false},
 		}
 	default:
 		return nil
@@ -309,7 +326,7 @@ func (s *systemTableService) Create(ctx context.Context, req models.CreateSystem
 				FieldName:    f.Name,
 				FieldType:    &fieldType,
 				DisplayOrder: &order,
-				IsVisible:    true,
+				IsVisible:    f.IsVisible,
 			}
 			if err := tx.Create(&tf).Error; err != nil {
 				slog.Error("не удалось создать поле таблицы", "table_id", table.ID, "field", f.Name, "error", err)
@@ -479,4 +496,69 @@ func (s *systemTableService) UpdateFields(ctx context.Context, tableID int, req 
 		}
 		return nil
 	})
+}
+
+// SeedMissingFields добавляет недостающие default-поля во все существующие таблицы.
+// Уже существующие поля не трогает (сохраняет ранее настроенную видимость).
+// Идемпотентна - повторные вызовы безопасны. Вызывается один раз при старте сервиса.
+func (s *systemTableService) SeedMissingFields(ctx context.Context) error {
+	var tables []models.SystemTable
+	if err := s.db.WithContext(ctx).
+		Where("is_active = ?", true).
+		Find(&tables).Error; err != nil {
+		return fmt.Errorf("load tables: %w", err)
+	}
+
+	added := 0
+	for _, t := range tables {
+		defaults := getDefaultFields(t.TableType)
+		if len(defaults) == 0 {
+			continue
+		}
+
+		var existing []models.TableField
+		if err := s.db.WithContext(ctx).
+			Where("table_id = ?", t.ID).
+			Find(&existing).Error; err != nil {
+			slog.Error("не удалось загрузить существующие поля таблицы",
+				"table_id", t.ID, "error", err)
+			continue
+		}
+
+		existingSet := make(map[string]bool, len(existing))
+		maxOrder := -1
+		for _, f := range existing {
+			existingSet[f.FieldName] = true
+			if f.DisplayOrder != nil && *f.DisplayOrder > maxOrder {
+				maxOrder = *f.DisplayOrder
+			}
+		}
+
+		for _, d := range defaults {
+			if existingSet[d.Name] {
+				continue
+			}
+			maxOrder++
+			order := maxOrder
+			fieldType := d.FieldType
+			tf := models.TableField{
+				TableID:      t.ID,
+				FieldName:    d.Name,
+				FieldType:    &fieldType,
+				DisplayOrder: &order,
+				IsVisible:    d.IsVisible,
+			}
+			if err := s.db.WithContext(ctx).Create(&tf).Error; err != nil {
+				slog.Error("не удалось добавить отсутствующее поле",
+					"table_id", t.ID, "field", d.Name, "error", err)
+				continue
+			}
+			added++
+		}
+	}
+
+	if added > 0 {
+		slog.Info("досидил отсутствующие поля таблиц (#345)", "added", added)
+	}
+	return nil
 }


### PR DESCRIPTION
Доработка Phase 1A #345 по фидбеку: новые столбцы (по умолчанию скрытые) и фикс ширины при скрытии.

## 1. Новые столбцы

### Cars (по умолчанию выключены)
- ` + '`company`' + ` (Компания) - отдельно от Организации.
- ` + '`application_id`' + ` (Номер заявки).

### People (по умолчанию выключены)
- ` + '`position`' + ` (Должность) - явно просили.
- ` + '`citizenship_name`' + ` (Гражданство).
- ` + '`company`' + ` (Компания).

Старые таблицы получают новые поля через ` + '`SeedMissingFields`' + ` при старте бэкенда (идемпотентно). Видимость существующих полей не меняется - сохраняется текущая конфигурация админа.

### Не вошло (нужна доп. логика декриптинга на active-endpoint)
- ` + '`passport_series_number`' + `, ` + '`patent_number`' + ` - данные encrypted, ` + '`/employees/active-for-table/:id`' + ` их не расшифровывает. Сделаю отдельным PR (нужно дёргать crypto.DecryptOptional на сервисе).

## 2. Фикс ширины при скрытии столбцов
**Корень:** колонки имели ` + '`width: X%`' + ` фиксированно. При v-if=false у одной из них остальные оставались на своих % и не растягивались - справа появлялась пустота.

**Решение:** перешёл с ` + '`width: %`' + ` на ` + '`flex: <weight> 0 0`' + `. Браузер делит доступное пространство пропорционально весам видимых колонок. При скрытии любых остальные плавно растягиваются на освободившееся место.

В enlarged-режиме ` + '`width: 0`' + ` -> ` + '`flex-grow: 0`' + `, ` + '`width: 25%`' + ` -> ` + '`flex-grow: 25`' + `. Анимация теперь на ` + '`flex-grow`' + ` (анимируется браузерами, плавно).

## Тесты
- Go: 3 теста UpdateFields зелёные (логика не задета).
- Vitest: 294/294 зелёные.

## Проверка
- [ ] В Конструкторе - Колонки видны новые скрытые поля (Должность и т.д.) - чекбоксы выключены.
- [ ] Включить любое из них -> Сохранить.
- [ ] Открыть таблицу - столбец появился, остальные равномерно сжались.
- [ ] Выключить один из стандартных столбцов -> Сохранить.
- [ ] Остальные плавно растянулись на освободившееся место (без пустоты справа).