### PR TITLE
fix: настоящий номер заявки и колонка в PeopleTable (#345)

### DIFF
--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -252,7 +252,7 @@
                   v-if="isFieldVisible('application_id')"
                   class="col application-col"
                 >
-                  {{ item.applicationId || '-' }}
+                  {{ item.applicationNumber || '-' }}
                 </div>
                 <div
                   v-if="isFieldVisible('unload_place')"
@@ -596,6 +596,7 @@ export default {
             entry_time: null,
             exit_time: null,
             applicationId: car.application_id,
+            applicationNumber: car.application_number,
             territory_status: car.territory_status || 0,
             plateNumber: car.car_number,
             mark: car.car_brand,

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -165,6 +165,20 @@
             >
           </div>
           <div
+            v-if="isFieldVisible('application_id')"
+            class="col application-col"
+            @click="sortBy('application_id')"
+          >
+            <p :class="{ 'active-sort': sortField === 'application_id' }">
+              Номер заявки
+            </p>
+            <img
+              src="@/assets/icons/sort.png"
+              class="sort-icon"
+              :class="{ 'sorted': sortField === 'application_id', 'desc': sortField === 'application_id' && sortDirection === 'desc' }"
+            >
+          </div>
+          <div
             class="col status-col"
             @click="sortBy('status')"
           >
@@ -285,6 +299,12 @@
                   class="col time-col"
                 >
                   {{ formatPassTime(item.pass_time) }}
+                </div>
+                <div
+                  v-if="isFieldVisible('application_id')"
+                  class="col application-col"
+                >
+                  {{ item.applicationNumber || '-' }}
                 </div>
                 <div class="col status-col">
                   <StatusBadge :status="item.status" />
@@ -629,6 +649,7 @@ export default {
           pass_places: emp.pass_places || '',
             status: 'Активен',
             applicationId: emp.application_id,
+            applicationNumber: emp.application_number,
             target_tables: emp.target_tables || [],
             passport_series_number: emp.passport_series_number,
             patent_number: emp.patent_number,
@@ -983,6 +1004,7 @@ export default {
 .company-col { flex: 11 0 0; }
 .date-col { flex: 11 0 0; }
 .time-col { flex: 13 0 0; }
+.application-col { flex: 11 0 0; }
 .status-col { flex: 8 0 0; }
 .actions-col { flex: 2 0 0; padding-right: 0; }
 

--- a/internal/services/car_query_service.go
+++ b/internal/services/car_query_service.go
@@ -28,6 +28,7 @@ type tableCarRow struct {
 	EntryTimeTo        *string
 	Status             *int
 	ApplicationID      *int
+	ApplicationNumber  *string
 }
 
 // GetActiveCarsForTables возвращает активные автомобили для всех таблиц (без «по факту»).
@@ -40,7 +41,7 @@ func (s *carService) GetActiveCarsForTables(ctx context.Context) ([]TableCarResp
 			o.name AS organization, o.id AS organization_id,
 			c2.name AS company, c2.id AS company_id,
 			c.entry_date_to, c.entry_time_from, c.entry_time_to,
-			c.status, app.id AS application_id`).
+			c.status, app.id AS application_id, app.application_number AS application_number`).
 		Joins("JOIN attachments a ON c.attachment_id = a.id").
 		Joins("JOIN applications app ON a.application_id = app.id").
 		Joins("LEFT JOIN organizations o ON app.organization_id = o.id").
@@ -70,7 +71,7 @@ func (s *carService) GetFactCarsForTables(ctx context.Context) ([]TableCarRespon
 				o.name AS organization, o.id AS organization_id,
 				c2.name AS company, c2.id AS company_id,
 				c.entry_date_to, c.entry_time_from, c.entry_time_to,
-				c.status, app.id AS application_id`).
+				c.status, app.id AS application_id, app.application_number AS application_number`).
 			Joins("JOIN attachments a ON c.attachment_id = a.id").
 			Joins("JOIN applications app ON a.application_id = app.id").
 			Joins("LEFT JOIN organizations o ON app.organization_id = o.id").
@@ -163,6 +164,7 @@ func (s *carService) enrichTableCars(ctx context.Context, rows []tableCarRow) ([
 			EntryTimeTo:        row.EntryTimeTo,
 			Status:             status,
 			ApplicationID:      row.ApplicationID,
+			ApplicationNumber:  row.ApplicationNumber,
 			TerritoryStatus:    row.TerritoryStatus,
 			TerritoryEntryTime: territoryEntryTimeStr,
 		})

--- a/internal/services/car_service.go
+++ b/internal/services/car_service.go
@@ -151,6 +151,7 @@ type TableCarResponse struct {
 	EntryTimeTo        *string   `json:"entry_time_to"`
 	Status             int       `json:"status"`
 	ApplicationID      *int      `json:"application_id"`
+	ApplicationNumber  *string   `json:"application_number"`
 	TerritoryStatus    *int      `json:"territory_status"`
 	TerritoryEntryTime *string   `json:"territory_entry_time"`
 }

--- a/internal/services/employee_service.go
+++ b/internal/services/employee_service.go
@@ -76,18 +76,20 @@ type CreateEmployeeResponse struct {
 // CitizenshipName / Position / Company / PassPlaces добавлены для отображения
 // соответствующих колонок в PeopleTable.vue (#116 пункт 10).
 type TableEmployeeResponse struct {
-	ID              int     `json:"id"`
-	LastName        string  `json:"last_name"`
-	FirstName       string  `json:"first_name"`
-	MiddleName      *string `json:"middle_name"`
-	Organization    *string `json:"organization"`
-	Company         *string `json:"company"`
-	CitizenshipName *string `json:"citizenship_name"`
-	Position        *string `json:"position"`
-	PassPlaces      *string `json:"pass_places"`
-	EntryDateTo     *string `json:"entry_date_to"`
-	PassTime        *string `json:"pass_time"`
-	Status          int     `json:"status"`
+	ID                int     `json:"id"`
+	LastName          string  `json:"last_name"`
+	FirstName         string  `json:"first_name"`
+	MiddleName        *string `json:"middle_name"`
+	Organization      *string `json:"organization"`
+	Company           *string `json:"company"`
+	CitizenshipName   *string `json:"citizenship_name"`
+	Position          *string `json:"position"`
+	PassPlaces        *string `json:"pass_places"`
+	EntryDateTo       *string `json:"entry_date_to"`
+	PassTime          *string `json:"pass_time"`
+	Status            int     `json:"status"`
+	ApplicationID     *int    `json:"application_id"`
+	ApplicationNumber *string `json:"application_number"`
 }
 
 // --- Реализация ---
@@ -156,18 +158,20 @@ func (s *employeeService) CreateEmployee(ctx context.Context, req CreateEmployee
 // PeopleTable.vue мог отрисовать соответствующие колонки.
 func (s *employeeService) GetActiveEmployeesForTable(ctx context.Context, tableID int) ([]TableEmployeeResponse, error) {
 	type employeeRow struct {
-		ID              int
-		LastName        string
-		FirstName       string
-		MiddleName      *string
-		Organization    *string
-		Company         *string
-		CitizenshipName *string
-		Position        *string
-		PassPlaces      *string
-		EntryDateTo     *string
-		PassTime        *string
-		Status          *int
+		ID                int
+		LastName          string
+		FirstName         string
+		MiddleName        *string
+		Organization      *string
+		Company           *string
+		CitizenshipName   *string
+		Position          *string
+		PassPlaces        *string
+		EntryDateTo       *string
+		PassTime          *string
+		Status            *int
+		ApplicationID     *int
+		ApplicationNumber *string
 	}
 
 	rows := make([]employeeRow, 0)
@@ -189,7 +193,9 @@ func (s *employeeService) GetActiveEmployeesForTable(ctx context.Context, tableI
 			) AS pass_places,
 			a.entry_date_to,
 			CONCAT(a.entry_time_from, ' - ', a.entry_time_to) AS pass_time,
-			e.status
+			e.status,
+			app.id AS application_id,
+			app.application_number AS application_number
 		FROM employees e
 		JOIN employee_target_tables ett ON e.id = ett.employee_id
 		JOIN attachments a ON e.attachment_id = a.id
@@ -205,7 +211,7 @@ func (s *employeeService) GetActiveEmployeesForTable(ctx context.Context, tableI
 		GROUP BY e.id, e.last_name, e.first_name, e.middle_name,
 				 o.name, co.name, c.name, e.position,
 				 a.entry_date_to, a.entry_time_from,
-				 a.entry_time_to, e.status
+				 a.entry_time_to, e.status, app.id, app.application_number
 		ORDER BY e.last_name, e.first_name
 	`, tableID, models.ConfirmationApproved, models.StatusInWork, models.StatusCompleted).Scan(&rows).Error
 	if err != nil {
@@ -219,18 +225,20 @@ func (s *employeeService) GetActiveEmployeesForTable(ctx context.Context, tableI
 			status = *r.Status
 		}
 		employees = append(employees, TableEmployeeResponse{
-			ID:              r.ID,
-			LastName:        r.LastName,
-			FirstName:       r.FirstName,
-			MiddleName:      r.MiddleName,
-			Organization:    r.Organization,
-			Company:         r.Company,
-			CitizenshipName: r.CitizenshipName,
-			Position:        r.Position,
-			PassPlaces:      r.PassPlaces,
-			EntryDateTo:     r.EntryDateTo,
-			PassTime:        r.PassTime,
-			Status:          status,
+			ID:                r.ID,
+			LastName:          r.LastName,
+			FirstName:         r.FirstName,
+			MiddleName:        r.MiddleName,
+			Organization:      r.Organization,
+			Company:           r.Company,
+			CitizenshipName:   r.CitizenshipName,
+			Position:          r.Position,
+			PassPlaces:        r.PassPlaces,
+			EntryDateTo:       r.EntryDateTo,
+			PassTime:          r.PassTime,
+			Status:            status,
+			ApplicationID:     r.ApplicationID,
+			ApplicationNumber: r.ApplicationNumber,
 		})
 	}
 	return employees, nil

--- a/internal/services/system_table_service.go
+++ b/internal/services/system_table_service.go
@@ -268,6 +268,7 @@ func getDefaultFields(tableType string) []defaultField {
 			{"position", "text", false},
 			{"citizenship_name", "text", false},
 			{"company", "text", false},
+			{"application_id", "text", false},
 		}
 	default:
 		return nil


### PR DESCRIPTION
Доработка по фидбеку #345:
1. **Cars показывал просто ID (33)** вместо человеческого номера заявки (формат "20260530/00148"). Добавил ` + '`app.application_number`' + ` в SELECT и в TableCarResponse, фронт теперь рендерит ` + '`item.applicationNumber`' + `.
2. **В people не было поля "Номер заявки"** - добавил ` + '`application_id`' + ` в people-defaults (по умолчанию скрыт), TableEmployeeResponse теперь возвращает ` + '`application_id`' + ` и ` + '`application_number`' + `, PeopleTable рендерит колонку.

SeedMissingFields подсетит новое поле в существующие people-таблицы при старте бэка. Сценарий: после деплоя надо один раз перезайти в Конструктор - в people-таблицах появится новый чекбокс "Номер заявки".

## Тесты
- Go: все тесты handlers зелёные.
- Vitest: 294/294 зелёные.