### PR TITLE
feat: порядок столбцов в админ-вкладке "Колонки" (#345)

### DIFF
--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -35,16 +35,23 @@
       <div class="items-header">
         <div class="header-row">
           <!-- Въезд - отдельная колонка -->
-          <div class="col entry-col">
+          <div
+            class="col entry-col"
+            style="order: 0;"
+          >
             Въезд
           </div>
           <!-- Выезд - отдельная колонка -->
-          <div class="col exit-col">
+          <div
+            class="col exit-col"
+            style="order: 1;"
+          >
             Выезд
           </div>
           <div
             v-if="isFieldVisible('car_number')"
             class="col number-col"
+            :style="getColStyle('car_number')"
             @click="sortBy('car_number')"
           >
             <p :class="{ 'active-sort': sortField === 'car_number' }">
@@ -59,6 +66,7 @@
           <div
             v-if="isFieldVisible('car_brand')"
             class="col brand-col"
+            :style="getColStyle('car_brand')"
             @click="sortBy('car_brand')"
           >
             <p :class="{ 'active-sort': sortField === 'car_brand' }">
@@ -73,6 +81,7 @@
           <div
             v-if="isFieldVisible('organization')"
             class="col organization-col"
+            :style="getColStyle('organization')"
             @click="sortBy('organization')"
           >
             <p :class="{ 'active-sort': sortField === 'organization' }">
@@ -87,6 +96,7 @@
           <div
             v-if="isFieldVisible('company')"
             class="col company-col"
+            :style="getColStyle('company')"
             @click="sortBy('company')"
           >
             <p :class="{ 'active-sort': sortField === 'company' }">
@@ -101,6 +111,7 @@
           <div
             v-if="isFieldVisible('application_id')"
             class="col application-col"
+            :style="getColStyle('application_id')"
             @click="sortBy('application_id')"
           >
             <p :class="{ 'active-sort': sortField === 'application_id' }">
@@ -115,6 +126,7 @@
           <div
             v-if="isFieldVisible('unload_place')"
             class="col place-col"
+            :style="getColStyle('unload_place')"
             @click="sortBy('unload_place')"
           >
             <p :class="{ 'active-sort': sortField === 'unload_place' }">
@@ -129,6 +141,7 @@
           <div
             v-if="isFieldVisible('valid_until')"
             class="col date-col"
+            :style="getColStyle('valid_until')"
             @click="sortBy('entry_date_to')"
           >
             <p :class="{ 'active-sort': sortField === 'entry_date_to' }">
@@ -143,6 +156,7 @@
           <div
             v-if="isFieldVisible('time_range')"
             class="col time-col"
+            :style="getColStyle('time_range')"
             @click="sortBy('entry_time')"
           >
             <p :class="{ 'active-sort': sortField === 'entry_time' }">
@@ -157,6 +171,7 @@
           <div
             v-if="isFieldVisible('status')"
             class="col status-col"
+            :style="getColStyle('status')"
             @click="sortBy('status')"
           >
             <p :class="{ 'active-sort': sortField === 'status' }">
@@ -168,7 +183,10 @@
               :class="{ 'sorted': sortField === 'status', 'desc': sortField === 'status' && sortDirection === 'desc' }"
             >
           </div>
-          <div class="col actions-col" />
+          <div
+            class="col actions-col"
+            style="order: 9999;"
+          />
         </div>
       </div>
       
@@ -199,10 +217,11 @@
                 <!-- Въезд - кнопка -->
                 <div
                   class="col entry-col"
+                  style="order: 0;"
                   @click.stop
                 >
-                  <button 
-                    class="action-btn entry-btn" 
+                  <button
+                    class="action-btn entry-btn"
                     :class="{ 'active': item.entry_checked }"
                     :disabled="item.entry_checked"
                     @click="handleEntryExit(item, 'entry')"
@@ -213,10 +232,11 @@
                 <!-- Выезд - кнопка -->
                 <div
                   class="col exit-col"
+                  style="order: 1;"
                   @click.stop
                 >
-                  <button 
-                    class="action-btn exit-btn" 
+                  <button
+                    class="action-btn exit-btn"
                     :class="{ 'active': item.exit_checked }"
                     :disabled="!item.entry_checked || item.exit_checked"
                     @click="handleEntryExit(item, 'exit')"
@@ -227,59 +247,69 @@
                 <div
                   v-if="isFieldVisible('car_number')"
                   class="col number-col"
+                  :style="getColStyle('car_number')"
                 >
                   {{ item.car_number }}
                 </div>
                 <div
                   v-if="isFieldVisible('car_brand')"
                   class="col brand-col"
+                  :style="getColStyle('car_brand')"
                 >
                   {{ item.car_brand }}
                 </div>
                 <div
                   v-if="isFieldVisible('organization')"
                   class="col organization-col"
+                  :style="getColStyle('organization')"
                 >
                   {{ item.organization_name }}
                 </div>
                 <div
                   v-if="isFieldVisible('company')"
                   class="col company-col"
+                  :style="getColStyle('company')"
                 >
                   {{ item.company || '-' }}
                 </div>
                 <div
                   v-if="isFieldVisible('application_id')"
                   class="col application-col"
+                  :style="getColStyle('application_id')"
                 >
                   {{ item.applicationNumber || '-' }}
                 </div>
                 <div
                   v-if="isFieldVisible('unload_place')"
                   class="col place-col"
+                  :style="getColStyle('unload_place')"
                 >
                   {{ formatUnloadPlaces(item) }}
                 </div>
                 <div
                   v-if="isFieldVisible('valid_until')"
                   class="col date-col"
+                  :style="getColStyle('valid_until')"
                 >
                   {{ formatDate(item.entry_date_to) }}
                 </div>
                 <div
                   v-if="isFieldVisible('time_range')"
                   class="col time-col"
+                  :style="getColStyle('time_range')"
                 >
                   {{ formatTimeRange(item.entry_time_from, item.entry_time_to) }}
                 </div>
                 <div
                   v-if="isFieldVisible('status')"
                   class="col status-col"
+                  :style="getColStyle('status')"
                 >
                   <StatusBadge :status="item.status" />
                 </div>
                 <div
                   class="col actions-col"
+                  style="order: 9999;"
                   @click.stop
                 >
                   <button
@@ -384,7 +414,8 @@ export default {
       showCarsTableHistory: false,
       pollingInterval: null,
       enlarged: false,
-      fieldsVisibility: {}
+      fieldsVisibility: {},
+      fieldOrders: {}
     };
   },
   computed: {
@@ -886,15 +917,33 @@ export default {
       return v === undefined ? true : v;
     },
 
+    /**
+     * CSS-order для конфигурируемой ячейки. Фиксированные колонки (Въезд/Выезд/Действия)
+     * имеют статические order в шаблоне; конфигурируемые получают 10 + display_order,
+     * чтобы оставаться между фиксированными.
+     */
+    getColStyle(fieldName) {
+      const order = this.fieldOrders[fieldName];
+      if (order === undefined) return null;
+      return { order: 10 + order };
+    },
+
     async fetchFieldsVisibility() {
       if (!this.tableId) return;
       try {
         const response = await apiRequest(`/system-tables/${this.tableId}`, {});
         if (!response.ok) return;
         const data = await response.json();
-        const next = {};
-        (data.fields || []).forEach(f => { next[f.field_name] = f.is_visible !== false; });
-        this.fieldsVisibility = next;
+        const nextVis = {};
+        const nextOrd = {};
+        (data.fields || []).forEach(f => {
+          nextVis[f.field_name] = f.is_visible !== false;
+          if (typeof f.display_order === 'number') {
+            nextOrd[f.field_name] = f.display_order;
+          }
+        });
+        this.fieldsVisibility = nextVis;
+        this.fieldOrders = nextOrd;
       } catch (error) {
         console.error('Ошибка загрузки настроек столбцов:', error);
       }

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -32,15 +32,22 @@
     <div class="card-content">
       <div class="items-header">
         <div class="header-row">
-          <div class="col entry-col">
+          <div
+            class="col entry-col"
+            style="order: 0;"
+          >
             Вход
           </div>
-          <div class="col exit-col">
+          <div
+            class="col exit-col"
+            style="order: 1;"
+          >
             Выход
           </div>
           <div
             v-if="isFieldVisible('last_name')"
             class="col last-name-col"
+            :style="getColStyle('last_name')"
             @click="sortBy('last_name')"
           >
             <p :class="{ 'active-sort': sortField === 'last_name' }">
@@ -55,6 +62,7 @@
           <div
             v-if="isFieldVisible('first_name')"
             class="col first-name-col"
+            :style="getColStyle('first_name')"
             @click="sortBy('first_name')"
           >
             <p :class="{ 'active-sort': sortField === 'first_name' }">
@@ -69,6 +77,7 @@
           <div
             v-if="isFieldVisible('middle_name')"
             class="col middle-name-col"
+            :style="getColStyle('middle_name')"
             @click="sortBy('middle_name')"
           >
             <p :class="{ 'active-sort': sortField === 'middle_name' }">
@@ -83,6 +92,7 @@
           <div
             v-if="isFieldVisible('position')"
             class="col position-col"
+            :style="getColStyle('position')"
             @click="sortBy('position')"
           >
             <p :class="{ 'active-sort': sortField === 'position' }">
@@ -97,6 +107,7 @@
           <div
             v-if="isFieldVisible('citizenship_name')"
             class="col citizenship-col"
+            :style="getColStyle('citizenship_name')"
             @click="sortBy('citizenship_name')"
           >
             <p :class="{ 'active-sort': sortField === 'citizenship_name' }">
@@ -111,6 +122,7 @@
           <div
             v-if="isFieldVisible('organization')"
             class="col organization-col"
+            :style="getColStyle('organization')"
             @click="sortBy('organization')"
           >
             <p :class="{ 'active-sort': sortField === 'organization' }">
@@ -125,6 +137,7 @@
           <div
             v-if="isFieldVisible('company')"
             class="col company-col"
+            :style="getColStyle('company')"
             @click="sortBy('company')"
           >
             <p :class="{ 'active-sort': sortField === 'company' }">
@@ -139,6 +152,7 @@
           <div
             v-if="isFieldVisible('valid_until')"
             class="col date-col"
+            :style="getColStyle('valid_until')"
             @click="sortBy('entry_date_to')"
           >
             <p :class="{ 'active-sort': sortField === 'entry_date_to' }">
@@ -153,6 +167,7 @@
           <div
             v-if="isFieldVisible('pass_time')"
             class="col time-col"
+            :style="getColStyle('pass_time')"
             @click="sortBy('pass_time')"
           >
             <p :class="{ 'active-sort': sortField === 'pass_time' }">
@@ -167,6 +182,7 @@
           <div
             v-if="isFieldVisible('application_id')"
             class="col application-col"
+            :style="getColStyle('application_id')"
             @click="sortBy('application_id')"
           >
             <p :class="{ 'active-sort': sortField === 'application_id' }">
@@ -180,6 +196,7 @@
           </div>
           <div
             class="col status-col"
+            style="order: 9998;"
             @click="sortBy('status')"
           >
             <p :class="{ 'active-sort': sortField === 'status' }">
@@ -191,7 +208,10 @@
               :class="{ 'sorted': sortField === 'status', 'desc': sortField === 'status' && sortDirection === 'desc' }"
             >
           </div>
-          <div class="col actions-col" />
+          <div
+            class="col actions-col"
+            style="order: 9999;"
+          />
         </div>
       </div>
       
@@ -222,10 +242,11 @@
               <div class="item-data">
                 <div
                   class="col entry-col"
+                  style="order: 0;"
                   @click.stop
                 >
-                  <button 
-                    class="action-btn entry-btn" 
+                  <button
+                    class="action-btn entry-btn"
                     :class="{ 'active': item.entry_checked }"
                     :disabled="item.entry_checked"
                     @click="handleEntryExit(item, 'entry')"
@@ -235,10 +256,11 @@
                 </div>
                 <div
                   class="col exit-col"
+                  style="order: 1;"
                   @click.stop
                 >
-                  <button 
-                    class="action-btn exit-btn" 
+                  <button
+                    class="action-btn exit-btn"
                     :class="{ 'active': item.exit_checked }"
                     :disabled="!item.entry_checked || item.exit_checked"
                     @click="handleEntryExit(item, 'exit')"
@@ -249,68 +271,82 @@
                 <div
                   v-if="isFieldVisible('last_name')"
                   class="col last-name-col"
+                  :style="getColStyle('last_name')"
                 >
                   {{ item.last_name }}
                 </div>
                 <div
                   v-if="isFieldVisible('first_name')"
                   class="col first-name-col"
+                  :style="getColStyle('first_name')"
                 >
                   {{ item.first_name }}
                 </div>
                 <div
                   v-if="isFieldVisible('middle_name')"
                   class="col middle-name-col"
+                  :style="getColStyle('middle_name')"
                 >
                   {{ item.middle_name || '-' }}
                 </div>
                 <div
                   v-if="isFieldVisible('position')"
                   class="col position-col"
+                  :style="getColStyle('position')"
                 >
                   {{ item.position || '-' }}
                 </div>
                 <div
                   v-if="isFieldVisible('citizenship_name')"
                   class="col citizenship-col"
+                  :style="getColStyle('citizenship_name')"
                 >
                   {{ item.citizenshipName || '-' }}
                 </div>
                 <div
                   v-if="isFieldVisible('organization')"
                   class="col organization-col"
+                  :style="getColStyle('organization')"
                 >
                   {{ item.organization_name }}
                 </div>
                 <div
                   v-if="isFieldVisible('company')"
                   class="col company-col"
+                  :style="getColStyle('company')"
                 >
                   {{ item.company || '-' }}
                 </div>
                 <div
                   v-if="isFieldVisible('valid_until')"
                   class="col date-col"
+                  :style="getColStyle('valid_until')"
                 >
                   {{ formatDate(item.entry_date_to) }}
                 </div>
                 <div
                   v-if="isFieldVisible('pass_time')"
                   class="col time-col"
+                  :style="getColStyle('pass_time')"
                 >
                   {{ formatPassTime(item.pass_time) }}
                 </div>
                 <div
                   v-if="isFieldVisible('application_id')"
                   class="col application-col"
+                  :style="getColStyle('application_id')"
                 >
                   {{ item.applicationNumber || '-' }}
                 </div>
-                <div class="col status-col">
+                <div
+                  class="col status-col"
+                  style="order: 9998;"
+                >
                   <StatusBadge :status="item.status" />
                 </div>
                 <div
                   class="col actions-col"
+                  style="order: 9999;"
                   @click.stop
                 >
                   <button
@@ -437,7 +473,8 @@ export default {
       showEmployeesHistory: false,
       pollingInterval: null,
       enlarged: false,
-      fieldsVisibility: {}
+      fieldsVisibility: {},
+      fieldOrders: {}
     };
   },
   computed: {
@@ -618,12 +655,17 @@ export default {
         const table = responseData.table;
         this.currentTableId = table.id;
 
-        // Подтягиваем конфиг видимости столбцов из того же ответа.
+        // Подтягиваем конфиг видимости и порядка столбцов из того же ответа.
         const nextVisibility = {};
+        const nextOrders = {};
         (responseData.fields || []).forEach(f => {
           nextVisibility[f.field_name] = f.is_visible !== false;
+          if (typeof f.display_order === 'number') {
+            nextOrders[f.field_name] = f.display_order;
+          }
         });
         this.fieldsVisibility = nextVisibility;
+        this.fieldOrders = nextOrders;
 
         const employeesRes = await apiRequest(`/employees/active-for-table/${table.id}`, { method: "GET" });
         if (!employeesRes.ok) return;
@@ -878,6 +920,16 @@ export default {
       // Пока конфиг не загружен - показываем всё (предотвращает мигание при инициализации).
       const v = this.fieldsVisibility[fieldName];
       return v === undefined ? true : v;
+    },
+
+    /**
+     * CSS-order для конфигурируемой ячейки. Фиксированные (Вход/Выход/Статус/Действия)
+     * имеют статические order; конфигурируемые получают 10 + display_order между ними.
+     */
+    getColStyle(fieldName) {
+      const order = this.fieldOrders[fieldName];
+      if (order === undefined) return null;
+      return { order: 10 + order };
     }
   }
 };

--- a/frontend/src/components/SystemTableColumnsTab.vue
+++ b/frontend/src/components/SystemTableColumnsTab.vue
@@ -21,21 +21,45 @@
       class="columns-tab__list"
     >
       <li
-        v-for="field in localFields"
+        v-for="(field, index) in localFields"
         :key="field.field_name"
         class="columns-tab__item"
         :class="{ 'columns-tab__item--off': !field.is_visible }"
       >
-        <label class="columns-tab__row">
-          <input
-            v-model="field.is_visible"
-            type="checkbox"
-            class="columns-tab__checkbox"
-            :data-field="field.field_name"
-          >
-          <span class="columns-tab__label">{{ humanLabel(field.field_name) }}</span>
-          <span class="columns-tab__field-name">{{ field.field_name }}</span>
-        </label>
+        <div class="columns-tab__row">
+          <div class="columns-tab__order">
+            <button
+              type="button"
+              class="columns-tab__order-btn"
+              :disabled="index === 0"
+              :data-action="`move-up-${field.field_name}`"
+              :title="'Переместить вверх'"
+              @click="moveUp(index)"
+            >
+              &uarr;
+            </button>
+            <button
+              type="button"
+              class="columns-tab__order-btn"
+              :disabled="index === localFields.length - 1"
+              :data-action="`move-down-${field.field_name}`"
+              :title="'Переместить вниз'"
+              @click="moveDown(index)"
+            >
+              &darr;
+            </button>
+          </div>
+          <label class="columns-tab__check-row">
+            <input
+              v-model="field.is_visible"
+              type="checkbox"
+              class="columns-tab__checkbox"
+              :data-field="field.field_name"
+            >
+            <span class="columns-tab__label">{{ humanLabel(field.field_name) }}</span>
+            <span class="columns-tab__field-name">{{ field.field_name }}</span>
+          </label>
+        </div>
       </li>
     </ul>
 
@@ -105,7 +129,8 @@ export default {
   data() {
     return {
       localFields: [],
-      original: {},
+      originalVisibility: {},
+      originalOrder: [],
       saving: false,
       statusMessage: '',
       statusError: false,
@@ -116,7 +141,13 @@ export default {
       return this.localFields;
     },
     isDirty() {
-      return this.localFields.some(f => this.original[f.field_name] !== f.is_visible);
+      const visibilityChanged = this.localFields.some(
+        f => this.originalVisibility[f.field_name] !== f.is_visible,
+      );
+      const orderChanged = this.localFields.some(
+        (f, i) => this.originalOrder[i] !== f.field_name,
+      );
+      return visibilityChanged || orderChanged;
     },
   },
   watch: {
@@ -132,15 +163,34 @@ export default {
       return FIELD_LABELS[name] || name;
     },
     reset() {
-      this.localFields = (this.fields || []).map(f => ({
+      // Сортируем по display_order, чтобы порядок в админке отражал реальный.
+      const sorted = [...(this.fields || [])].sort((a, b) => {
+        const ao = a.display_order ?? 0;
+        const bo = b.display_order ?? 0;
+        return ao - bo;
+      });
+      this.localFields = sorted.map(f => ({
         field_name: f.field_name,
         is_visible: f.is_visible !== false,
       }));
-      this.original = Object.fromEntries(
+      this.originalVisibility = Object.fromEntries(
         this.localFields.map(f => [f.field_name, f.is_visible]),
       );
+      this.originalOrder = this.localFields.map(f => f.field_name);
       this.statusMessage = '';
       this.statusError = false;
+    },
+    moveUp(index) {
+      if (index <= 0) return;
+      const arr = this.localFields.slice();
+      [arr[index - 1], arr[index]] = [arr[index], arr[index - 1]];
+      this.localFields = arr;
+    },
+    moveDown(index) {
+      if (index >= this.localFields.length - 1) return;
+      const arr = this.localFields.slice();
+      [arr[index], arr[index + 1]] = [arr[index + 1], arr[index]];
+      this.localFields = arr;
     },
     async save() {
       if (!this.isDirty || this.saving) return;
@@ -152,9 +202,10 @@ export default {
         const response = await apiRequest(`/system-tables/${this.tableId}/fields`, {
           method: 'PUT',
           body: JSON.stringify({
-            fields: this.localFields.map(f => ({
+            fields: this.localFields.map((f, i) => ({
               field_name: f.field_name,
               is_visible: f.is_visible,
+              display_order: i,
             })),
           }),
         });
@@ -162,10 +213,11 @@ export default {
           const err = await response.json().catch(() => ({}));
           throw new Error(err.message || `HTTP ${response.status}`);
         }
-        this.statusMessage = 'Видимость столбцов сохранена';
-        this.original = Object.fromEntries(
+        this.statusMessage = 'Настройки столбцов сохранены';
+        this.originalVisibility = Object.fromEntries(
           this.localFields.map(f => [f.field_name, f.is_visible]),
         );
+        this.originalOrder = this.localFields.map(f => f.field_name);
         this.$emit('update');
       } catch (e) {
         this.statusError = true;
@@ -241,10 +293,52 @@ export default {
 .columns-tab__row {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 10px 14px;
-  cursor: pointer;
+  gap: 8px;
+  padding: 6px 10px;
   user-select: none;
+}
+
+.columns-tab__order {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.columns-tab__order-btn {
+  width: 24px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #fff;
+  border: 1px solid #e6e6e6;
+  border-radius: 6px;
+  font-size: 11px;
+  line-height: 1;
+  cursor: pointer;
+  color: #4F5BDF;
+  transition: all 0.15s ease;
+}
+
+.columns-tab__order-btn:hover:not(:disabled) {
+  background: #f0f4ff;
+  border-color: #4F5BDF;
+}
+
+.columns-tab__order-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.3;
+  color: #a2a2a2;
+}
+
+.columns-tab__check-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 1;
+  cursor: pointer;
+  padding: 4px 4px 4px 8px;
 }
 
 .columns-tab__checkbox {

--- a/internal/handlers/system_tables_test.go
+++ b/internal/handlers/system_tables_test.go
@@ -315,3 +315,39 @@ func TestSystemTables_UpdateFields_Unauthorized(t *testing.T) {
 	rec := testutil.PUT(t, e, "/system-tables/1/fields", body, nil)
 	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 }
+
+func TestSystemTables_UpdateFields_PersistsDisplayOrder(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	rec := testutil.POST(t, e, "/system-tables",
+		`{"name":"order_test","display_name":"OT","table_type":"cars"}`, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	tableID := int(testutil.ParseMap(t, rec)["id"].(float64))
+
+	// Меняем порядок: car_brand -> 0, car_number -> 5 (всё остальное оставляем без изменений).
+	body := `{"fields":[
+		{"field_name":"car_brand","is_visible":true,"display_order":0},
+		{"field_name":"car_number","is_visible":true,"display_order":5}
+	]}`
+	rec = testutil.PUT(t, e, fmt.Sprintf("/system-tables/%d/fields", tableID), body, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = testutil.GET(t, e, fmt.Sprintf("/system-tables/%d", tableID), h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	fields := testutil.ParseMap(t, rec)["fields"].([]interface{})
+
+	orderByName := map[string]int{}
+	for _, f := range fields {
+		fm := f.(map[string]interface{})
+		if order, ok := fm["display_order"].(float64); ok {
+			orderByName[fm["field_name"].(string)] = int(order)
+		}
+	}
+	assert.Equal(t, 0, orderByName["car_brand"], "car_brand должен иметь display_order 0")
+	assert.Equal(t, 5, orderByName["car_number"], "car_number должен иметь display_order 5")
+}

--- a/internal/models/system_table.go
+++ b/internal/models/system_table.go
@@ -132,10 +132,12 @@ type UpdateTimeSlotRequest struct {
 	IsActive  *bool   `json:"is_active"`
 }
 
-// FieldVisibilityUpdate -- одиночное обновление видимости столбца таблицы (#345).
+// FieldVisibilityUpdate -- одиночное обновление видимости и порядка столбца (#345).
+// DisplayOrder опционален - если не передан, порядок не меняется.
 type FieldVisibilityUpdate struct {
-	FieldName string `json:"field_name" validate:"required"`
-	IsVisible bool   `json:"is_visible"`
+	FieldName    string `json:"field_name" validate:"required"`
+	IsVisible    bool   `json:"is_visible"`
+	DisplayOrder *int   `json:"display_order"`
 }
 
 // UpdateFieldsRequest -- bulk-обновление видимости столбцов системной таблицы.

--- a/internal/services/system_table_service.go
+++ b/internal/services/system_table_service.go
@@ -473,8 +473,8 @@ func (s *systemTableService) Delete(ctx context.Context, id int) error {
 
 
 
-// UpdateFields bulk-обновляет видимость столбцов таблицы по field_name.
-// Поля, отсутствующие в БД, игнорируются.
+// UpdateFields bulk-обновляет видимость и (опционально) порядок столбцов таблицы.
+// Поля, отсутствующие в БД, игнорируются. DisplayOrder применяется только если задан.
 func (s *systemTableService) UpdateFields(ctx context.Context, tableID int, req models.UpdateFieldsRequest) error {
 	var table models.SystemTable
 	if err := s.db.WithContext(ctx).Where("id = ?", tableID).First(&table).Error; err != nil {
@@ -486,13 +486,19 @@ func (s *systemTableService) UpdateFields(ctx context.Context, tableID int, req 
 
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		for _, f := range req.Fields {
+			updates := map[string]interface{}{
+				"is_visible": f.IsVisible,
+			}
+			if f.DisplayOrder != nil {
+				updates["display_order"] = *f.DisplayOrder
+			}
 			result := tx.Model(&models.TableField{}).
 				Where("table_id = ? AND field_name = ?", tableID, f.FieldName).
-				Update("is_visible", f.IsVisible)
+				Updates(updates)
 			if result.Error != nil {
-				slog.Error("не удалось обновить видимость столбца",
+				slog.Error("не удалось обновить столбец",
 					"table_id", tableID, "field", f.FieldName, "error", result.Error)
-				return echo.NewHTTPError(http.StatusInternalServerError, "Error updating field visibility")
+				return echo.NewHTTPError(http.StatusInternalServerError, "Error updating field")
 			}
 		}
 		return nil


### PR DESCRIPTION
Phase 1B #345 - управление порядком столбцов через админ-вкладку "Колонки".

## Backend
- ` + '`FieldVisibilityUpdate`' + ` получил опциональный ` + '`display_order`' + ` (если задан - обновляется, иначе игнорируется).
- ` + '`SystemTableService.UpdateFields`' + ` теперь использует ` + '`Updates(map)`' + ` и записывает оба поля одной транзакцией.
- Новый тест ` + '`UpdateFields_PersistsDisplayOrder`' + ` (3 теста на UpdateFields = 4).

## Admin UI
- В каждой строке списка полей появились стрелки вверх/вниз слева.
- Сортировка локального списка по display_order при загрузке.
- При сохранении ` + '`display_order`' + ` пересчитывается как индекс в массиве.
- isDirty учитывает и видимость, и порядок.

## CarsTable / PeopleTable
- Каждая ячейка получила ` + '`:style="getColStyle(field_name)"`' + ` (CSS-свойство ` + '`order`' + `).
- Фиксированные колонки имеют статические ` + '`order`' + `:
  - entry-col = 0, exit-col = 1
  - actions-col = 9999
  - status-col в PeopleTable = 9998 (всегда перед actions, не настраивается)
- Конфигурируемые получают ` + '`order = 10 + display_order`' + `.
- Никакой реструктуризации DOM - только CSS, нативно поддерживается flexbox.

## Тесты
- Go: handlers зелёные.
- Vitest: 294/294 зелёные.

## Проверка
- [ ] Admin: вкладка "Колонки" показывает поля в текущем порядке.
- [ ] Стрелки переставляют поле вверх/вниз (соседние меняются местами).
- [ ] Сохранить -> в таблице (КПП N4 или ПОСТ N72) столбцы перерисованы в новом порядке.
- [ ] Состояние сохраняется при F5.