### PR TITLE
feat: реальная таблица в превью + live DnD + чекбокс 12px (#345)

### DIFF
--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -10,7 +10,10 @@
           <span class="blue">Номера автомобилей</span> по заявке
         </h3>
       </div>
-      <div class="card-header__settings">
+      <div
+        v-if="!preview"
+        class="card-header__settings"
+      >
         <span class="items-count">
           Машин на территории: {{ carsOnTerritory }}
           <button
@@ -211,7 +214,7 @@
               :key="item.id" 
               class="item-row"
               :style="{ animationDelay: `${index * 0.05}s` }"
-              @click="openVehicleDetails(item)"
+              @click="preview ? null : openVehicleDetails(item)"
             >
               <div class="item-data">
                 <!-- Въезд - кнопка -->
@@ -221,6 +224,7 @@
                   @click.stop
                 >
                   <button
+                    v-if="!preview"
                     class="action-btn entry-btn"
                     :class="{ 'active': item.entry_checked }"
                     :disabled="item.entry_checked"
@@ -236,6 +240,7 @@
                   @click.stop
                 >
                   <button
+                    v-if="!preview"
                     class="action-btn exit-btn"
                     :class="{ 'active': item.exit_checked }"
                     :disabled="!item.entry_checked || item.exit_checked"
@@ -313,6 +318,7 @@
                   @click.stop
                 >
                   <button
+                    v-if="!preview"
                     class="delete-btn"
                     :disabled="isLoading"
                     @click="removeItemWithNotification(item)"
@@ -340,6 +346,7 @@
 
     <!-- Модальное окно с деталями автомобиля -->
     <VehicleDetailsModal
+      v-if="!preview"
       :show="showVehicleDetails"
       :vehicle="selectedVehicle"
       :all-unloading-places="allUnloadingPlaces"
@@ -354,7 +361,7 @@
 
     <!-- Модальное окно истории всех машин -->
     <CarsTableHistoryModal
-      v-if="showCarsTableHistory"
+      v-if="!preview && showCarsTableHistory"
       :cars="itemsData"
       :current-user-id="currentUserId"
       :current-user-name="currentUserName"
@@ -395,7 +402,11 @@ export default {
     dateRangeEnd: { type: Date, default: null },
     selectedDate: { type: Date, default: null },
     currentUserId: { type: Number, default: null },
-    currentUserName: { type: String, default: '' }
+    currentUserName: { type: String, default: '' },
+    // Preview-режим для админ-вкладки "Колонки" (#345): seed-данные, без API и без кнопок.
+    preview: { type: Boolean, default: false },
+    previewFields: { type: Array, default: null },
+    previewItems: { type: Array, default: null }
   },
   data() {
     return {
@@ -508,6 +519,7 @@ export default {
     tableName: {
       immediate: true,
       handler(newVal) {
+        if (this.preview) return;
         if (newVal) {
           this.stopPolling();
           this.startPolling();
@@ -517,6 +529,7 @@ export default {
     tableId: {
       immediate: true,
       handler(newVal) {
+        if (this.preview) return;
         this.loadEnlargedFromStorage();
         if (newVal) {
           this.fetchFieldsVisibility();
@@ -524,10 +537,34 @@ export default {
       }
     },
     enlarged(value) {
+      if (this.preview) return;
       this.saveEnlargedToStorage(value);
+    },
+    previewItems: {
+      immediate: true,
+      handler(newVal) {
+        if (this.preview && Array.isArray(newVal)) {
+          this.itemsData = newVal;
+        }
+      }
+    },
+    previewFields: {
+      immediate: true,
+      handler(newVal) {
+        if (!this.preview || !Array.isArray(newVal)) return;
+        const nextVis = {};
+        const nextOrd = {};
+        newVal.forEach((f, i) => {
+          nextVis[f.field_name] = f.is_visible !== false;
+          nextOrd[f.field_name] = typeof f.display_order === 'number' ? f.display_order : i;
+        });
+        this.fieldsVisibility = nextVis;
+        this.fieldOrders = nextOrd;
+      }
     }
   },
   mounted() {
+    if (this.preview) return;
     this.startPolling();
     this.loadEnlargedFromStorage();
     // Подгружаем настроенные длительности уведомлений после авторизации

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -10,7 +10,10 @@
           <span class="blue">Люди</span> по заявке
         </h3>
       </div>
-      <div class="card-header__settings">
+      <div
+        v-if="!preview"
+        class="card-header__settings"
+      >
         <span class="items-count">
           Людей зашло: {{ peopleOnTerritory }}
           <button
@@ -237,7 +240,7 @@
               :key="item.id" 
               class="item-row"
               :style="{ animationDelay: `${index * 0.05}s` }"
-              @click="openEmployeeDetails(item)"
+              @click="preview ? null : openEmployeeDetails(item)"
             >
               <div class="item-data">
                 <div
@@ -246,6 +249,7 @@
                   @click.stop
                 >
                   <button
+                    v-if="!preview"
                     class="action-btn entry-btn"
                     :class="{ 'active': item.entry_checked }"
                     :disabled="item.entry_checked"
@@ -260,6 +264,7 @@
                   @click.stop
                 >
                   <button
+                    v-if="!preview"
                     class="action-btn exit-btn"
                     :class="{ 'active': item.exit_checked }"
                     :disabled="!item.entry_checked || item.exit_checked"
@@ -350,6 +355,7 @@
                   @click.stop
                 >
                   <button
+                    v-if="!preview"
                     class="delete-btn"
                     :disabled="isLoading"
                     @click="removeItemWithNotification(item)"
@@ -377,7 +383,7 @@
 
     <!-- Модальное окно деталей сотрудника -->
     <EmployeeDetailsModal
-      v-if="showDetailsModal"
+      v-if="!preview && showDetailsModal"
       :show="showDetailsModal"
       :employee="selectedEmployee"
       :all-tables="allTables"
@@ -389,7 +395,7 @@
     />
 
     <EmployeesTableHistoryModal
-      v-if="showEmployeesHistory"
+      v-if="!preview && showEmployeesHistory"
       :table-id="currentTableId"
       :current-user-id="currentUserId"
       :current-user-name="currentUserName"
@@ -421,7 +427,7 @@ export default {
   props: {
     tableName: {
       type: String,
-      required: true
+      default: ''
     },
     searchQuery: {
       type: String,
@@ -454,7 +460,11 @@ export default {
     currentUserName: {
       type: String,
       default: ''
-    }
+    },
+    // Preview-режим для админ-вкладки "Колонки" (#345): seed-данные, без API и без кнопок.
+    preview: { type: Boolean, default: false },
+    previewFields: { type: Array, default: null },
+    previewItems: { type: Array, default: null }
   },
   emits: ['open-application'],
   data() {
@@ -572,6 +582,7 @@ export default {
   watch: {
     tableName: {
       handler() {
+        if (this.preview) return;
         this.stopPolling();
         this.startPolling();
         this.loadEnlargedFromStorage();
@@ -579,10 +590,34 @@ export default {
       immediate: true
     },
     enlarged(value) {
+      if (this.preview) return;
       this.saveEnlargedToStorage(value);
+    },
+    previewItems: {
+      immediate: true,
+      handler(newVal) {
+        if (this.preview && Array.isArray(newVal)) {
+          this.itemsData = newVal;
+        }
+      }
+    },
+    previewFields: {
+      immediate: true,
+      handler(newVal) {
+        if (!this.preview || !Array.isArray(newVal)) return;
+        const nextVis = {};
+        const nextOrd = {};
+        newVal.forEach((f, i) => {
+          nextVis[f.field_name] = f.is_visible !== false;
+          nextOrd[f.field_name] = typeof f.display_order === 'number' ? f.display_order : i;
+        });
+        this.fieldsVisibility = nextVis;
+        this.fieldOrders = nextOrd;
+      }
     }
   },
   mounted() {
+    if (this.preview) return;
     this.startPolling();
     this.loadEnlargedFromStorage();
     // Подгружаем настроенные длительности уведомлений после авторизации

--- a/frontend/src/components/SystemTableColumnsTab.vue
+++ b/frontend/src/components/SystemTableColumnsTab.vue
@@ -27,14 +27,13 @@
         :class="{
           'columns-tab__item--off': !field.is_visible,
           'columns-tab__item--dragging': draggingIndex === index,
-          'columns-tab__item--drop-target': dragOverIndex === index && draggingIndex !== index,
         }"
         :draggable="true"
         :data-field="field.field_name"
         @dragstart="onDragStart(index, $event)"
-        @dragover.prevent="onDragOver(index, $event)"
-        @dragleave="onDragLeave(index)"
-        @drop.prevent="onDrop(index)"
+        @dragenter.prevent="onDragEnter(index)"
+        @dragover.prevent="onDragOver($event)"
+        @drop.prevent="onDrop"
         @dragend="onDragEnd"
       >
         <div class="columns-tab__row">
@@ -127,7 +126,7 @@
     </p>
 
     <div
-      v-if="visibleFieldsInOrder.length"
+      v-if="localFields.length"
       class="columns-tab__preview"
     >
       <h4 class="columns-tab__preview-title">
@@ -136,28 +135,26 @@
       <p class="columns-tab__preview-hint">
         Так таблица будет выглядеть с текущими настройками (примерные данные).
       </p>
-      <div class="preview-card">
-        <div class="preview-row preview-row--header">
-          <div
-            v-for="f in visibleFieldsInOrder"
-            :key="f.field_name"
-            class="preview-cell"
-          >
-            {{ humanLabel(f.field_name) }}
-          </div>
-        </div>
+      <div class="columns-tab__preview-frame">
+        <CarsTable
+          v-if="tableType === 'cars'"
+          :preview="true"
+          :preview-fields="previewFieldsWithOrder"
+          :preview-items="sampleItems"
+          :table-id="tableId"
+        />
+        <PeopleTable
+          v-else-if="tableType === 'people'"
+          :preview="true"
+          :preview-fields="previewFieldsWithOrder"
+          :preview-items="sampleItems"
+          :table-name="''"
+        />
         <div
-          v-for="(row, rowIdx) in sampleRows"
-          :key="rowIdx"
-          class="preview-row preview-row--data"
+          v-else
+          class="columns-tab__preview-unknown"
         >
-          <div
-            v-for="f in visibleFieldsInOrder"
-            :key="f.field_name"
-            class="preview-cell"
-          >
-            {{ row[f.field_name] || '-' }}
-          </div>
+          Превью недоступно для этого типа таблицы.
         </div>
       </div>
     </div>
@@ -166,13 +163,11 @@
 
 <script>
 import { apiRequest } from '@/api/client';
+import { generateSampleRows } from '@/utils/tableSamples';
+import CarsTable from './CarsTable.vue';
+import PeopleTable from './PeopleTable.vue';
 
-/**
- * Маппинг внутреннего имени поля -> человеческое название столбца.
- * Используется и в админ-вкладке "Колонки", и в реальных таблицах для совпадения подписей.
- */
 const FIELD_LABELS = {
-  // Базовые поля cars
   car_number: 'Номер Т/С',
   car_brand: 'Марка',
   organization: 'Организация',
@@ -180,60 +175,22 @@ const FIELD_LABELS = {
   valid_until: 'Действует до',
   time_range: 'Время',
   status: 'Статус',
-  // Расширенные поля cars (по умолчанию скрыты)
   application_id: 'Номер заявки',
-  // Базовые поля people
   last_name: 'Фамилия',
   first_name: 'Имя',
   middle_name: 'Отчество',
   pass_time: 'Время прохода',
-  // Расширенные поля people (по умолчанию скрыты)
   position: 'Должность',
   citizenship_name: 'Гражданство',
-  // Общие
   company: 'Компания',
-};
-
-/**
- * Примеры значений для каждого поля. Из них генерируются 10 строк-примеров в предпросмотре.
- * Длина массивов должна быть >= 10.
- */
-const SAMPLE_VALUES = {
-  car_number: ['А 123 БВ 77', 'М 456 ГД 99', 'О 789 ЕЖ 50', 'Х 012 ЗИ 77', 'Т 345 КЛ 99',
-    'Е 678 МН 50', 'У 901 ОП 77', 'К 234 РС 99', 'В 567 ТУ 50', 'С 890 ФХ 77'],
-  car_brand: ['Тойота', 'Лада', 'Газель', 'Камаз', 'Вольво', 'МАН', 'Мерседес', 'Рено', 'Скания', 'ДАФ'],
-  organization: ['ООО Альфа', 'ООО Бета', 'ЗАО Гамма', 'ИП Дельта', 'ООО Эпсилон',
-    'АО Дзета', 'ООО Эта', 'ИП Тета', 'ООО Йота', 'ЗАО Каппа'],
-  company: ['Альфа-Сервис', 'Бета-Логистик', 'Гамма-Транс', 'Дельта-Карго', 'Эпсилон-Экспресс',
-    'Дзета-Авто', 'Эта-Логист', 'Тета-Линия', 'Йота-Доставка', 'Каппа-Транс'],
-  application_id: ['20260530/00148', '20260530/00149', '20260530/00150', '20260530/00151',
-    '20260530/00152', '20260531/00001', '20260531/00002', '20260531/00003', '20260531/00004', '20260531/00005'],
-  unload_place: ['Дебаркадер №1', 'Дебаркадер №2', 'Склад А', 'Склад Б', 'Площадка №3',
-    'Зона разгрузки', 'Пандус', 'Склад В', 'Площадка №7', 'Дебаркадер №5'],
-  valid_until: ['31.05.2026', '01.06.2026', '15.06.2026', '30.06.2026', '07.06.2026',
-    '14.06.2026', '21.06.2026', '28.06.2026', '05.07.2026', '12.07.2026'],
-  time_range: ['08:00 - 23:59', '09:00 - 18:00', '06:00 - 22:00', '10:00 - 16:00', '08:00 - 20:00',
-    '07:00 - 19:00', '00:00 - 23:59', '08:00 - 17:00', '09:00 - 21:00', '06:00 - 14:00'],
-  status: ['В работе', 'В работе', 'В работе', 'В работе', 'В работе',
-    'В работе', 'В работе', 'В работе', 'В работе', 'В работе'],
-  last_name: ['Иванов', 'Петров', 'Сидоров', 'Кузнецов', 'Смирнов',
-    'Попов', 'Лебедев', 'Соколов', 'Морозов', 'Волков'],
-  first_name: ['Иван', 'Пётр', 'Александр', 'Сергей', 'Михаил',
-    'Андрей', 'Дмитрий', 'Николай', 'Алексей', 'Владимир'],
-  middle_name: ['Иванович', 'Петрович', 'Сергеевич', 'Александрович', 'Михайлович',
-    'Андреевич', 'Дмитриевич', 'Николаевич', 'Алексеевич', 'Владимирович'],
-  position: ['Грузчик', 'Водитель', 'Экспедитор', 'Кладовщик', 'Менеджер',
-    'Оператор', 'Инженер', 'Логист', 'Контролёр', 'Бригадир'],
-  citizenship_name: ['Россия', 'Россия', 'Беларусь', 'Казахстан', 'Россия',
-    'Узбекистан', 'Россия', 'Армения', 'Россия', 'Таджикистан'],
-  pass_time: ['10:00 - 15:00', '09:00 - 18:00', '08:00 - 17:00', '07:00 - 14:00', '11:00 - 19:00',
-    '06:00 - 12:00', '13:00 - 21:00', '08:00 - 16:00', '10:00 - 18:00', '14:00 - 22:00'],
 };
 
 export default {
   name: 'SystemTableColumnsTab',
+  components: { CarsTable, PeopleTable },
   props: {
     tableId: { type: Number, required: true },
+    tableType: { type: String, required: true },
     fields: { type: Array, required: true },
   },
   emits: ['update'],
@@ -246,22 +203,19 @@ export default {
       statusMessage: '',
       statusError: false,
       draggingIndex: null,
-      dragOverIndex: null,
     };
   },
   computed: {
-    visibleFieldsInOrder() {
-      return this.localFields.filter(f => f.is_visible);
+    previewFieldsWithOrder() {
+      // Передаём текущий локальный порядок в превью, чтобы оно реагировало до save.
+      return this.localFields.map((f, i) => ({
+        field_name: f.field_name,
+        is_visible: f.is_visible,
+        display_order: i,
+      }));
     },
-    sampleRows() {
-      return Array.from({ length: 10 }, (_, i) => {
-        const row = {};
-        for (const field of this.localFields) {
-          const values = SAMPLE_VALUES[field.field_name];
-          row[field.field_name] = values ? values[i % values.length] : '—';
-        }
-        return row;
-      });
+    sampleItems() {
+      return generateSampleRows(this.tableType, 10);
     },
     isDirty() {
       const visibilityChanged = this.localFields.some(
@@ -286,7 +240,6 @@ export default {
       return FIELD_LABELS[name] || name;
     },
     reset() {
-      // Сортируем по display_order, чтобы порядок в админке отражал реальный.
       const sorted = [...(this.fields || [])].sort((a, b) => {
         const ao = a.display_order ?? 0;
         const bo = b.display_order ?? 0;
@@ -306,34 +259,28 @@ export default {
     onDragStart(index, event) {
       this.draggingIndex = index;
       event.dataTransfer.effectAllowed = 'move';
+      // Минимальный data payload для Chromium.
       event.dataTransfer.setData('text/plain', String(index));
     },
-    onDragOver(index, event) {
+    onDragOver(event) {
+      // Всегда move - никаких "копировать"/"запрещено" курсоров.
       event.dataTransfer.dropEffect = 'move';
-      this.dragOverIndex = index;
     },
-    onDragLeave(index) {
-      if (this.dragOverIndex === index) {
-        this.dragOverIndex = null;
-      }
-    },
-    onDrop(targetIndex) {
+    onDragEnter(targetIndex) {
+      // Live-перестановка: как только курсор над другим элементом - меняем порядок сразу.
       const from = this.draggingIndex;
-      if (from === null || from === targetIndex) {
-        this.draggingIndex = null;
-        this.dragOverIndex = null;
-        return;
-      }
+      if (from === null || from === targetIndex) return;
       const arr = this.localFields.slice();
       const [moved] = arr.splice(from, 1);
       arr.splice(targetIndex, 0, moved);
       this.localFields = arr;
+      this.draggingIndex = targetIndex;
+    },
+    onDrop() {
       this.draggingIndex = null;
-      this.dragOverIndex = null;
     },
     onDragEnd() {
       this.draggingIndex = null;
-      this.dragOverIndex = null;
     },
     async save() {
       if (!this.isDirty || this.saving) return;
@@ -421,7 +368,7 @@ export default {
 .columns-tab__item {
   border: 1px solid #e6e6e6;
   border-radius: 10px;
-  transition: background-color 0.2s ease, transform 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease;
+  transition: opacity 0.15s ease, background-color 0.2s ease;
   background: #fff;
 }
 
@@ -435,13 +382,7 @@ export default {
 }
 
 .columns-tab__item--dragging {
-  opacity: 0.4;
-  border-style: dashed;
-}
-
-.columns-tab__item--drop-target {
-  border-color: #4F5BDF;
-  box-shadow: 0 0 0 2px rgba(79, 91, 223, 0.18);
+  opacity: 0.35;
 }
 
 .columns-tab__row {
@@ -468,6 +409,7 @@ export default {
   color: #4F5BDF;
 }
 
+.columns-tab__item--dragging .columns-tab__handle,
 .columns-tab__handle:active {
   cursor: grabbing;
 }
@@ -478,12 +420,12 @@ export default {
   gap: 10px;
   flex: 1;
   cursor: pointer;
-  padding: 4px 4px 4px 4px;
+  padding: 4px;
 }
 
 .columns-tab__checkbox {
-  width: 14px;
-  height: 14px;
+  width: 12px;
+  height: 12px;
   accent-color: #4F5BDF;
   cursor: pointer;
   flex-shrink: 0;
@@ -562,7 +504,6 @@ export default {
   color: #c62828;
 }
 
-/* Preview pane: миниатюрная таблица, отражает видимость и порядок столбцов. */
 .columns-tab__preview {
   display: flex;
   flex-direction: column;
@@ -583,47 +524,16 @@ export default {
   color: #6b7280;
 }
 
-.preview-card {
+.columns-tab__preview-frame {
+  width: 100%;
+}
+
+.columns-tab__preview-unknown {
+  padding: 16px;
+  text-align: center;
+  color: #a2a2a2;
+  background: #f9fafb;
   border: 1px solid #e6e6e6;
   border-radius: 12px;
-  overflow: hidden;
-  background: #fff;
-  font-size: 9px;
-  line-height: 1.2;
-}
-
-.preview-row {
-  display: flex;
-  width: 100%;
-  align-items: center;
-  gap: 2px;
-  padding: 3px 6px;
-}
-
-.preview-row--header {
-  background: #f9fafb;
-  border-bottom: 1px solid #e6e6e6;
-  color: #6b7280;
-  font-weight: 500;
-  font-size: 8px;
-  text-transform: uppercase;
-  letter-spacing: 0.02em;
-}
-
-.preview-row--data + .preview-row--data {
-  border-top: 1px solid #f3f4f6;
-}
-
-.preview-cell {
-  flex: 1 0 0;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  color: #1f2937;
-}
-
-.preview-row--header .preview-cell {
-  color: #6b7280;
 }
 </style>

--- a/frontend/src/components/TableConstructor.vue
+++ b/frontend/src/components/TableConstructor.vue
@@ -466,6 +466,7 @@
         >
           <SystemTableColumnsTab
             :table-id="selectedTable.table.id"
+            :table-type="selectedTable.table.table_type"
             :fields="selectedTable.fields || []"
             @update="refreshSelectedTable"
           />

--- a/frontend/src/utils/tableSamples.js
+++ b/frontend/src/utils/tableSamples.js
@@ -1,0 +1,96 @@
+/**
+ * Примеры данных для превью системных таблиц (#345).
+ * Используется в SystemTableColumnsTab и CarsTable/PeopleTable в preview-режиме.
+ */
+
+const SAMPLE_VALUES = {
+  car_number: ['А 123 БВ 77', 'М 456 ГД 99', 'О 789 ЕЖ 50', 'Х 012 ЗИ 77', 'Т 345 КЛ 99',
+    'Е 678 МН 50', 'У 901 ОП 77', 'К 234 РС 99', 'В 567 ТУ 50', 'С 890 ФХ 77'],
+  car_brand: ['Тойота', 'Лада', 'Газель', 'Камаз', 'Вольво', 'МАН', 'Мерседес', 'Рено', 'Скания', 'ДАФ'],
+  organization: ['ООО Альфа', 'ООО Бета', 'ЗАО Гамма', 'ИП Дельта', 'ООО Эпсилон',
+    'АО Дзета', 'ООО Эта', 'ИП Тета', 'ООО Йота', 'ЗАО Каппа'],
+  company: ['Альфа-Сервис', 'Бета-Логистик', 'Гамма-Транс', 'Дельта-Карго', 'Эпсилон-Экспресс',
+    'Дзета-Авто', 'Эта-Логист', 'Тета-Линия', 'Йота-Доставка', 'Каппа-Транс'],
+  application_id: ['20260530/00148', '20260530/00149', '20260530/00150', '20260530/00151',
+    '20260530/00152', '20260531/00001', '20260531/00002', '20260531/00003', '20260531/00004', '20260531/00005'],
+  unload_place: ['Дебаркадер №1', 'Дебаркадер №2', 'Склад А', 'Склад Б', 'Площадка №3',
+    'Зона разгрузки', 'Пандус', 'Склад В', 'Площадка №7', 'Дебаркадер №5'],
+  valid_until: ['31.05.2026', '01.06.2026', '15.06.2026', '30.06.2026', '07.06.2026',
+    '14.06.2026', '21.06.2026', '28.06.2026', '05.07.2026', '12.07.2026'],
+  time_range: ['08:00 - 23:59', '09:00 - 18:00', '06:00 - 22:00', '10:00 - 16:00', '08:00 - 20:00',
+    '07:00 - 19:00', '00:00 - 23:59', '08:00 - 17:00', '09:00 - 21:00', '06:00 - 14:00'],
+  last_name: ['Иванов', 'Петров', 'Сидоров', 'Кузнецов', 'Смирнов',
+    'Попов', 'Лебедев', 'Соколов', 'Морозов', 'Волков'],
+  first_name: ['Иван', 'Пётр', 'Александр', 'Сергей', 'Михаил',
+    'Андрей', 'Дмитрий', 'Николай', 'Алексей', 'Владимир'],
+  middle_name: ['Иванович', 'Петрович', 'Сергеевич', 'Александрович', 'Михайлович',
+    'Андреевич', 'Дмитриевич', 'Николаевич', 'Алексеевич', 'Владимирович'],
+  position: ['Грузчик', 'Водитель', 'Экспедитор', 'Кладовщик', 'Менеджер',
+    'Оператор', 'Инженер', 'Логист', 'Контролёр', 'Бригадир'],
+  citizenship_name: ['Россия', 'Россия', 'Беларусь', 'Казахстан', 'Россия',
+    'Узбекистан', 'Россия', 'Армения', 'Россия', 'Таджикистан'],
+  pass_time: ['10:00 - 15:00', '09:00 - 18:00', '08:00 - 17:00', '07:00 - 14:00', '11:00 - 19:00',
+    '06:00 - 12:00', '13:00 - 21:00', '08:00 - 16:00', '10:00 - 18:00', '14:00 - 22:00'],
+};
+
+/**
+ * Генерирует N строк примерных данных для таблицы заданного типа.
+ * @param {'cars'|'people'} tableType
+ * @param {number} count
+ * @returns {Array<object>} массив строк в формате, ожидаемом CarsTable/PeopleTable
+ */
+export function generateSampleRows(tableType, count = 10) {
+  const rows = [];
+  for (let i = 0; i < count; i++) {
+    const pick = (key) => {
+      const values = SAMPLE_VALUES[key];
+      return values ? values[i % values.length] : null;
+    };
+    if (tableType === 'cars') {
+      const [tf, tt] = pick('time_range').split(' - ');
+      rows.push({
+        id: -1 - i,
+        car_number: pick('car_number'),
+        car_brand: pick('car_brand'),
+        organization_id: i + 1,
+        organization_name: pick('organization'),
+        company: pick('company'),
+        company_id: i + 1,
+        unload_place: pick('unload_place'),
+        unload_place_ids: [],
+        entry_date_to: '2026-06-15',
+        entry_time_from: tf,
+        entry_time_to: tt,
+        status: 'В работе',
+        entry_checked: false,
+        exit_checked: false,
+        applicationId: i + 100,
+        applicationNumber: pick('application_id'),
+        territory_status: 0,
+      });
+    } else if (tableType === 'people') {
+      const [tf, tt] = pick('pass_time').split(' - ');
+      rows.push({
+        id: -1 - i,
+        last_name: pick('last_name'),
+        first_name: pick('first_name'),
+        middle_name: pick('middle_name'),
+        organization_id: i + 1,
+        organization_name: pick('organization'),
+        company: pick('company'),
+        company_id: i + 1,
+        position: pick('position'),
+        citizenshipName: pick('citizenship_name'),
+        entry_date_to: '2026-06-15',
+        pass_time: `${tf} - ${tt}`,
+        status: 'Активен',
+        applicationId: i + 100,
+        applicationNumber: pick('application_id'),
+        entry_checked: false,
+        exit_checked: false,
+        territory_status: 0,
+      });
+    }
+  }
+  return rows;
+}


### PR DESCRIPTION
Доработка вкладки "Колонки" по фидбеку.

## 1. Превью - реальная таблица 1:1
- Убрал кастомный мини-table.
- ` + '`CarsTable`' + ` и ` + '`PeopleTable`' + ` получили props ` + '`preview`' + `/` + '`previewFields`' + `/` + '`previewItems`' + `.
- В preview-режиме:
  - watch на ` + '`tableName`' + `/` + '`tableId`' + ` не дёргает API.
  - ` + '`itemsData`' + ` берётся из ` + '`previewItems`' + ` (10 примерных строк).
  - ` + '`fieldsVisibility`' + `/` + '`fieldOrders`' + ` берутся из ` + '`previewFields`' + ` (локальное состояние ` + '`localFields`' + ` до save).
  - Скрыты: Въезд/Выезд/Удалить кнопки, История, Обновить, EnlargedToggle, клик на строку, все модалки.
  - Сама структура DOM/CSS - идентична реальной странице.
- Примеры данных вынесены в ` + '`utils/tableSamples.js`' + ` (русские ФИО, номера, организации, должности и т.п.).
- Тип таблицы (` + '`cars`' + `/` + '`people`' + `) приходит prop'ом ` + '`tableType`' + ` от TableConstructor.

## 2. Live drag-and-drop
- Раньше столбец перемещался только на ` + '`drop`' + ` - не было понятно куда он встанет.
- Теперь на ` + '`dragenter`' + ` соседнего элемента порядок меняется мгновенно - визуально видно, куда встанет колонка.
- ` + '`draggingIndex`' + ` обновляется при каждом movement, чтобы продолжать тянуть от нового положения.

## 3. Курсор всегда move
- ` + '`effectAllowed = 'move'`' + ` в ` + '`dragstart`' + `.
- ` + '`dropEffect = 'move'`' + ` в ` + '`dragover`' + `.
- ` + '`event.preventDefault()`' + ` модификатор на ` + '`@dragenter`' + ` и ` + '`@dragover`' + ` - не выпадает no-drop курсор.
- Никаких копирование/запрещено иконок.

## 4. Чекбокс меньше
- 14px -> 12px.

## Тесты
- Vitest: 294/294 зелёные.
- ESLint: чисто.