### PR TITLE
fix: midpoint-DnD без джиттера + неактивные кнопки в превью (#345)

### DIFF
--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -224,11 +224,10 @@
                   @click.stop
                 >
                   <button
-                    v-if="!preview"
                     class="action-btn entry-btn"
                     :class="{ 'active': item.entry_checked }"
-                    :disabled="item.entry_checked"
-                    @click="handleEntryExit(item, 'entry')"
+                    :disabled="preview || item.entry_checked"
+                    @click="preview ? null : handleEntryExit(item, 'entry')"
                   >
                     Въезд
                   </button>
@@ -240,11 +239,10 @@
                   @click.stop
                 >
                   <button
-                    v-if="!preview"
                     class="action-btn exit-btn"
                     :class="{ 'active': item.exit_checked }"
-                    :disabled="!item.entry_checked || item.exit_checked"
-                    @click="handleEntryExit(item, 'exit')"
+                    :disabled="preview || !item.entry_checked || item.exit_checked"
+                    @click="preview ? null : handleEntryExit(item, 'exit')"
                   >
                     Выезд
                   </button>
@@ -318,10 +316,9 @@
                   @click.stop
                 >
                   <button
-                    v-if="!preview"
                     class="delete-btn"
-                    :disabled="isLoading"
-                    @click="removeItemWithNotification(item)"
+                    :disabled="preview || isLoading"
+                    @click="preview ? null : removeItemWithNotification(item)"
                   >
                     <img
                       src="@/assets/icons/trashcan.png"

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -249,11 +249,10 @@
                   @click.stop
                 >
                   <button
-                    v-if="!preview"
                     class="action-btn entry-btn"
                     :class="{ 'active': item.entry_checked }"
-                    :disabled="item.entry_checked"
-                    @click="handleEntryExit(item, 'entry')"
+                    :disabled="preview || item.entry_checked"
+                    @click="preview ? null : handleEntryExit(item, 'entry')"
                   >
                     Вход
                   </button>
@@ -264,11 +263,10 @@
                   @click.stop
                 >
                   <button
-                    v-if="!preview"
                     class="action-btn exit-btn"
                     :class="{ 'active': item.exit_checked }"
-                    :disabled="!item.entry_checked || item.exit_checked"
-                    @click="handleEntryExit(item, 'exit')"
+                    :disabled="preview || !item.entry_checked || item.exit_checked"
+                    @click="preview ? null : handleEntryExit(item, 'exit')"
                   >
                     Выход
                   </button>
@@ -355,10 +353,9 @@
                   @click.stop
                 >
                   <button
-                    v-if="!preview"
                     class="delete-btn"
-                    :disabled="isLoading"
-                    @click="removeItemWithNotification(item)"
+                    :disabled="preview || isLoading"
+                    @click="preview ? null : removeItemWithNotification(item)"
                   >
                     <img
                       src="@/assets/icons/trashcan.png"

--- a/frontend/src/components/SystemTableColumnsTab.vue
+++ b/frontend/src/components/SystemTableColumnsTab.vue
@@ -33,8 +33,7 @@
         :draggable="true"
         :data-field="field.field_name"
         @dragstart="onDragStart(index, $event)"
-        @dragenter.prevent="onDragEnter(index)"
-        @dragover.prevent="onDragOver($event)"
+        @dragover.prevent="onDragOver(index, $event)"
         @drop.prevent="onDrop"
         @dragend="onDragEnd"
       >
@@ -271,14 +270,22 @@ export default {
       // Минимальный data payload для Chromium.
       event.dataTransfer.setData('text/plain', String(index));
     },
-    onDragOver(event) {
-      // Всегда move - никаких "копировать"/"запрещено" курсоров.
+    /**
+     * Midpoint-алгоритм перестановки: swap происходит только когда курсор
+     * пересекает вертикальную середину целевого элемента. Это убирает
+     * "дрожание" на границах и быстрые повторные перестановки.
+     */
+    onDragOver(targetIndex, event) {
       event.dataTransfer.dropEffect = 'move';
-    },
-    onDragEnter(targetIndex) {
-      // Live-перестановка: как только курсор над другим элементом - меняем порядок сразу.
       const from = this.draggingIndex;
       if (from === null || from === targetIndex) return;
+      const rect = event.currentTarget.getBoundingClientRect();
+      const midpoint = rect.top + rect.height / 2;
+      // Двигаемся вниз: меняем только когда курсор прошёл за середину цели.
+      // Двигаемся вверх: меняем когда курсор ещё перед серединой цели.
+      const movingDown = from < targetIndex;
+      if (movingDown && event.clientY < midpoint) return;
+      if (!movingDown && event.clientY > midpoint) return;
       const arr = this.localFields.slice();
       const [moved] = arr.splice(from, 1);
       arr.splice(targetIndex, 0, moved);
@@ -391,7 +398,11 @@ export default {
 }
 
 .columns-tab__item--dragging {
-  opacity: 0.35;
+  /* Полностью скрываем перетаскиваемый элемент, чтобы не было дрожания между
+     анимированным DOM-узлом и ghost-картинкой курсора. На экране остаётся
+     только browser-ghost; соседи плавно разъезжаются через TransitionGroup. */
+  opacity: 0;
+  transition: none !important;
 }
 
 .columns-tab__row {


### PR DESCRIPTION
Доработки вкладки "Колонки" по фидбеку.

## 1. DnD без дрожания
**Корень джиттера:** swap на ` + '`dragenter`' + ` срабатывал каждый раз когда курсор пересекал границу элемента. После перестановки соседний элемент сразу оказывался под курсором -> повторный ` + '`dragenter`' + ` -> повторный swap. Между этими swap'ами проигрывалась анимация FLIP - получалось дрожание.

**Решение - midpoint-алгоритм:**
- Убрал ` + '`@dragenter`' + `, логика перенесена в ` + '`@dragover`' + `.
- Swap происходит только когда курсор пересекает вертикальную середину целевого элемента в правильном направлении (для движения вниз - после середины; вверх - до середины).
- Это стандартный паттерн для DnD-сортировок (Trello, Notion и т.п.) - даёт устойчивые "слоты" для каждой позиции.

**Доп. фикс:** ` + '`columns-tab__item--dragging`' + ` теперь ` + '`opacity: 0`' + ` + ` + '`transition: none`' + `. Перетаскиваемый DOM-элемент полностью невидим, ghost-картинка курсора единственное визуальное представление. Соседи плавно разъезжаются через TransitionGroup без конфликта с дёргающимся "родным" DOM.

## 2. Кнопки въезд/выезд/удалить видны в превью (неактивны)
- Раньше ` + '`v-if="!preview"`' + ` полностью убирал кнопки.
- Теперь ` + '`:disabled="preview || ..."`' + ` + ` + '`@click="preview ? null : ..."`' + ` - кнопки на месте, кликаются, но в превью disabled.

## Тесты
- Vitest: 294/294 зелёные.
- ESLint: чисто.