### PR TITLE
fix: видимый placeholder + cursor move + 5 строк превью (#345)

### DIFF
--- a/frontend/src/components/SystemTableColumnsTab.vue
+++ b/frontend/src/components/SystemTableColumnsTab.vue
@@ -21,6 +21,7 @@
       tag="ul"
       name="cols-list"
       class="columns-tab__list"
+      @dragover.prevent="onListDragOver"
     >
       <li
         v-for="(field, index) in localFields"
@@ -223,7 +224,7 @@ export default {
       }));
     },
     sampleItems() {
-      return generateSampleRows(this.tableType, 10);
+      return generateSampleRows(this.tableType, 5);
     },
     isDirty() {
       const visibilityChanged = this.localFields.some(
@@ -269,6 +270,13 @@ export default {
       event.dataTransfer.effectAllowed = 'move';
       // Минимальный data payload для Chromium.
       event.dataTransfer.setData('text/plain', String(index));
+    },
+    /**
+     * Catch-all dragover на контейнере списка: убирает not-allowed/copy курсор
+     * когда мышь оказывается в gap'е между элементами (где нет <li>).
+     */
+    onListDragOver(event) {
+      event.dataTransfer.dropEffect = 'move';
     },
     /**
      * Midpoint-алгоритм перестановки: swap происходит только когда курсор
@@ -398,10 +406,13 @@ export default {
 }
 
 .columns-tab__item--dragging {
-  /* Полностью скрываем перетаскиваемый элемент, чтобы не было дрожания между
-     анимированным DOM-узлом и ghost-картинкой курсора. На экране остаётся
-     только browser-ghost; соседи плавно разъезжаются через TransitionGroup. */
-  opacity: 0;
+  /* Полупрозрачный placeholder в "родной" позиции, чтобы было видно откуда
+     тянем. transition: none убирает анимацию перетаскиваемого узла -
+     дрожания между DOM и ghost-картинкой курсора нет. */
+  opacity: 0.4;
+  background: #f0f4ff;
+  border-color: #4F5BDF;
+  border-style: dashed;
   transition: none !important;
 }
 


### PR DESCRIPTION
Доработки вкладки "Колонки" по фидбеку.

## 1. Перетаскиваемый элемент виден как placeholder
- Было: ` + '`opacity: 0`' + ` - элемент пропадал полностью.
- Стало: ` + '`opacity: 0.4`' + ` + ` + '`background: #f0f4ff`' + ` + dashed-border #4F5BDF. Видно откуда тянем.

## 2. Курсор всегда move (нет not-allowed / copy)
**Корень:** dragover ловился только на ` + '`<li>`' + `. Когда мышь проходила через gap'ы между элементами или попадала в padding контейнера, ни один dragover-handler не срабатывал -> браузер показывал стандартный курсор по effectAllowed.

**Фикс:** добавил ` + '`@dragover.prevent="onListDragOver"`' + ` на ` + '`<TransitionGroup tag="ul">`' + `. Catch-all устанавливает ` + '`dropEffect = 'move'`' + ` везде, где курсор находится внутри списка.

## 3. 5 строк-примеров в превью (было 10)
- ` + '`generateSampleRows(this.tableType, 5)`' + `.

## Тесты
- Vitest: 294/294 зелёные.
- ESLint: чисто.