### PR TITLE
fix: drag только за иконку handle, курсор только там (#345)

### DIFF
--- a/frontend/src/components/SystemTableColumnsTab.vue
+++ b/frontend/src/components/SystemTableColumnsTab.vue
@@ -32,13 +32,13 @@
         }"
         :data-field="field.field_name"
         :data-index="index"
-        @pointerdown="onItemPointerDown(index, $event)"
       >
         <div class="columns-tab__row">
           <span
             class="columns-tab__handle"
             :title="'Перетащите для смены порядка'"
             aria-hidden="true"
+            @pointerdown="onItemPointerDown(index, $event)"
           >
             <svg
               width="14"
@@ -84,10 +84,7 @@
               />
             </svg>
           </span>
-          <label
-            class="columns-tab__check-row"
-            @pointerdown.stop
-          >
+          <label class="columns-tab__check-row">
             <input
               v-model="field.is_visible"
               type="checkbox"
@@ -271,10 +268,9 @@ export default {
     },
     /**
      * Pointer-events DnD (вместо HTML5 native, который не даёт контроля над курсором).
-     * - pointerdown на любом месте элемента (кроме чекбокса): запускаем drag.
+     * - pointerdown на handle: запускаем drag, ставим body cursor=grabbing.
      * - pointermove document: определяем элемент под курсором, midpoint-swap.
      * - pointerup document: останавливаем drag, восстанавливаем курсор.
-     * Чекбокс/label имеет @pointerdown.stop - клик на нём не запускает drag.
      */
     onItemPointerDown(index, event) {
       event.preventDefault();
@@ -407,13 +403,6 @@ export default {
   border-radius: 10px;
   transition: opacity 0.15s ease, background-color 0.2s ease;
   background: #fff;
-  /* Весь элемент - drag-source. Чекбокс/label имеет @pointerdown.stop,
-     так что клик на нём не перехватывается drag-логикой. */
-  cursor: grab;
-}
-
-.columns-tab__item:active {
-  cursor: grabbing;
 }
 
 .columns-tab__item:hover {
@@ -472,10 +461,6 @@ export default {
   flex: 1;
   cursor: pointer;
   padding: 4px;
-}
-
-.columns-tab__check-row:hover {
-  cursor: pointer;
 }
 
 .columns-tab__checkbox {


### PR DESCRIPTION
- ` + '`@pointerdown`' + ` обратно на ` + '`.columns-tab__handle`' + ` (а не на ` + '`<li>`' + `).
- Убрал ` + '`cursor: grab`' + ` с ` + '`.columns-tab__item`' + ` - только handle имеет grab/grabbing.
- Убрал ` + '`@pointerdown.stop`' + ` с label (больше не нужен).
- Никаких конфликтов курсора с дочерними элементами (checkbox/label) - drag начинается только когда курсор уже над handle.

## Тесты
- Vitest: 294/294 зелёные.
- ESLint: чисто.