### PR TITLE
feat: настраиваемая ширина столбцов (Phase 1C #345)

### DIFF
--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -423,7 +423,8 @@ export default {
       pollingInterval: null,
       enlarged: false,
       fieldsVisibility: {},
-      fieldOrders: {}
+      fieldOrders: {},
+      fieldWidths: {}
     };
   },
   computed: {
@@ -551,12 +552,15 @@ export default {
         if (!this.preview || !Array.isArray(newVal)) return;
         const nextVis = {};
         const nextOrd = {};
+        const nextW = {};
         newVal.forEach((f, i) => {
           nextVis[f.field_name] = f.is_visible !== false;
           nextOrd[f.field_name] = typeof f.display_order === 'number' ? f.display_order : i;
+          if (typeof f.width === 'number' && f.width > 0) nextW[f.field_name] = f.width;
         });
         this.fieldsVisibility = nextVis;
         this.fieldOrders = nextOrd;
+        this.fieldWidths = nextW;
       }
     }
   },
@@ -952,14 +956,17 @@ export default {
     },
 
     /**
-     * CSS-order для конфигурируемой ячейки. Фиксированные колонки (Въезд/Выезд/Действия)
-     * имеют статические order в шаблоне; конфигурируемые получают 10 + display_order,
-     * чтобы оставаться между фиксированными.
+     * Стиль конфигурируемой ячейки:
+     * - order: 10 + display_order (между фиксированными entry/exit/actions).
+     * - flex-grow: width из конфига (если задан) - переопределяет дефолт из CSS.
      */
     getColStyle(fieldName) {
       const order = this.fieldOrders[fieldName];
-      if (order === undefined) return null;
-      return { order: 10 + order };
+      const width = this.fieldWidths[fieldName];
+      const style = {};
+      if (order !== undefined) style.order = 10 + order;
+      if (width !== undefined && width > 0) style.flexGrow = width;
+      return Object.keys(style).length ? style : null;
     },
 
     async fetchFieldsVisibility() {
@@ -970,14 +977,19 @@ export default {
         const data = await response.json();
         const nextVis = {};
         const nextOrd = {};
+        const nextW = {};
         (data.fields || []).forEach(f => {
           nextVis[f.field_name] = f.is_visible !== false;
           if (typeof f.display_order === 'number') {
             nextOrd[f.field_name] = f.display_order;
           }
+          if (typeof f.width === 'number' && f.width > 0) {
+            nextW[f.field_name] = f.width;
+          }
         });
         this.fieldsVisibility = nextVis;
         this.fieldOrders = nextOrd;
+        this.fieldWidths = nextW;
       } catch (error) {
         console.error('Ошибка загрузки настроек столбцов:', error);
       }

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -481,7 +481,8 @@ export default {
       pollingInterval: null,
       enlarged: false,
       fieldsVisibility: {},
-      fieldOrders: {}
+      fieldOrders: {},
+      fieldWidths: {}
     };
   },
   computed: {
@@ -604,12 +605,15 @@ export default {
         if (!this.preview || !Array.isArray(newVal)) return;
         const nextVis = {};
         const nextOrd = {};
+        const nextW = {};
         newVal.forEach((f, i) => {
           nextVis[f.field_name] = f.is_visible !== false;
           nextOrd[f.field_name] = typeof f.display_order === 'number' ? f.display_order : i;
+          if (typeof f.width === 'number' && f.width > 0) nextW[f.field_name] = f.width;
         });
         this.fieldsVisibility = nextVis;
         this.fieldOrders = nextOrd;
+        this.fieldWidths = nextW;
       }
     }
   },
@@ -687,17 +691,22 @@ export default {
         const table = responseData.table;
         this.currentTableId = table.id;
 
-        // Подтягиваем конфиг видимости и порядка столбцов из того же ответа.
+        // Подтягиваем конфиг видимости, порядка и ширины столбцов из того же ответа.
         const nextVisibility = {};
         const nextOrders = {};
+        const nextWidths = {};
         (responseData.fields || []).forEach(f => {
           nextVisibility[f.field_name] = f.is_visible !== false;
           if (typeof f.display_order === 'number') {
             nextOrders[f.field_name] = f.display_order;
           }
+          if (typeof f.width === 'number' && f.width > 0) {
+            nextWidths[f.field_name] = f.width;
+          }
         });
         this.fieldsVisibility = nextVisibility;
         this.fieldOrders = nextOrders;
+        this.fieldWidths = nextWidths;
 
         const employeesRes = await apiRequest(`/employees/active-for-table/${table.id}`, { method: "GET" });
         if (!employeesRes.ok) return;
@@ -955,13 +964,17 @@ export default {
     },
 
     /**
-     * CSS-order для конфигурируемой ячейки. Фиксированные (Вход/Выход/Статус/Действия)
-     * имеют статические order; конфигурируемые получают 10 + display_order между ними.
+     * Стиль конфигурируемой ячейки:
+     * - order: 10 + display_order (между фиксированными entry/exit/status/actions).
+     * - flex-grow: width из конфига (если задан) - переопределяет дефолт из CSS.
      */
     getColStyle(fieldName) {
       const order = this.fieldOrders[fieldName];
-      if (order === undefined) return null;
-      return { order: 10 + order };
+      const width = this.fieldWidths[fieldName];
+      const style = {};
+      if (order !== undefined) style.order = 10 + order;
+      if (width !== undefined && width > 0) style.flexGrow = width;
+      return Object.keys(style).length ? style : null;
     }
   }
 };

--- a/frontend/src/components/SystemTableColumnsTab.vue
+++ b/frontend/src/components/SystemTableColumnsTab.vue
@@ -94,6 +94,20 @@
             <span class="columns-tab__label">{{ humanLabel(field.field_name) }}</span>
             <span class="columns-tab__field-name">{{ field.field_name }}</span>
           </label>
+          <div
+            class="columns-tab__width"
+            :title="'Ширина столбца (вес flex-grow). Браузер делит доступную ширину пропорционально весам видимых столбцов.'"
+          >
+            <input
+              v-model.number="field.width"
+              type="number"
+              min="1"
+              max="100"
+              class="columns-tab__width-input"
+              :data-width-field="field.field_name"
+            >
+            <span class="columns-tab__width-unit">w</span>
+          </div>
         </div>
       </li>
     </TransitionGroup>
@@ -204,6 +218,7 @@ export default {
       localFields: [],
       originalVisibility: {},
       originalOrder: [],
+      originalWidth: {},
       saving: false,
       statusMessage: '',
       statusError: false,
@@ -213,11 +228,12 @@ export default {
   },
   computed: {
     previewFieldsWithOrder() {
-      // Передаём текущий локальный порядок в превью, чтобы оно реагировало до save.
+      // Передаём текущий локальный порядок+ширину в превью, чтобы оно реагировало до save.
       return this.localFields.map((f, i) => ({
         field_name: f.field_name,
         is_visible: f.is_visible,
         display_order: i,
+        width: f.width,
       }));
     },
     sampleItems() {
@@ -230,7 +246,10 @@ export default {
       const orderChanged = this.localFields.some(
         (f, i) => this.originalOrder[i] !== f.field_name,
       );
-      return visibilityChanged || orderChanged;
+      const widthChanged = this.localFields.some(
+        f => this.originalWidth[f.field_name] !== f.width,
+      );
+      return visibilityChanged || orderChanged || widthChanged;
     },
   },
   watch: {
@@ -258,11 +277,15 @@ export default {
       this.localFields = sorted.map(f => ({
         field_name: f.field_name,
         is_visible: f.is_visible !== false,
+        width: typeof f.width === 'number' && f.width > 0 ? f.width : 10,
       }));
       this.originalVisibility = Object.fromEntries(
         this.localFields.map(f => [f.field_name, f.is_visible]),
       );
       this.originalOrder = this.localFields.map(f => f.field_name);
+      this.originalWidth = Object.fromEntries(
+        this.localFields.map(f => [f.field_name, f.width]),
+      );
       this.statusMessage = '';
       this.statusError = false;
     },
@@ -329,6 +352,7 @@ export default {
               field_name: f.field_name,
               is_visible: f.is_visible,
               display_order: i,
+              width: Math.max(1, Math.min(100, Number(f.width) || 10)),
             })),
           }),
         });
@@ -341,6 +365,9 @@ export default {
           this.localFields.map(f => [f.field_name, f.is_visible]),
         );
         this.originalOrder = this.localFields.map(f => f.field_name);
+        this.originalWidth = Object.fromEntries(
+          this.localFields.map(f => [f.field_name, f.width]),
+        );
         this.$emit('update');
       } catch (e) {
         this.statusError = true;
@@ -486,6 +513,42 @@ export default {
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 11px;
   color: #c0c0c0;
+}
+
+.columns-tab__width {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+  padding-right: 6px;
+}
+
+.columns-tab__width-input {
+  width: 42px;
+  padding: 3px 6px;
+  border: 1px solid #e6e6e6;
+  border-radius: 6px;
+  font-size: 12px;
+  text-align: right;
+  color: #333;
+  background: #fff;
+  -moz-appearance: textfield;
+}
+
+.columns-tab__width-input::-webkit-outer-spin-button,
+.columns-tab__width-input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.columns-tab__width-input:focus {
+  outline: none;
+  border-color: #4F5BDF;
+}
+
+.columns-tab__width-unit {
+  font-size: 11px;
+  color: #a2a2a2;
 }
 
 .columns-tab__actions {

--- a/internal/handlers/system_tables_test.go
+++ b/internal/handlers/system_tables_test.go
@@ -351,3 +351,41 @@ func TestSystemTables_UpdateFields_PersistsDisplayOrder(t *testing.T) {
 	assert.Equal(t, 0, orderByName["car_brand"], "car_brand должен иметь display_order 0")
 	assert.Equal(t, 5, orderByName["car_number"], "car_number должен иметь display_order 5")
 }
+
+func TestSystemTables_UpdateFields_PersistsWidth(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	rec := testutil.POST(t, e, "/system-tables",
+		`{"name":"width_test","display_name":"WT","table_type":"cars"}`, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	tableID := int(testutil.ParseMap(t, rec)["id"].(float64))
+
+	// Меняем ширину для car_number и organization.
+	body := `{"fields":[
+		{"field_name":"car_number","is_visible":true,"width":20},
+		{"field_name":"organization","is_visible":true,"width":30}
+	]}`
+	rec = testutil.PUT(t, e, fmt.Sprintf("/system-tables/%d/fields", tableID), body, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = testutil.GET(t, e, fmt.Sprintf("/system-tables/%d", tableID), h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	fields := testutil.ParseMap(t, rec)["fields"].([]interface{})
+
+	widthByName := map[string]int{}
+	for _, f := range fields {
+		fm := f.(map[string]interface{})
+		if w, ok := fm["width"].(float64); ok {
+			widthByName[fm["field_name"].(string)] = int(w)
+		}
+	}
+	assert.Equal(t, 20, widthByName["car_number"], "car_number ширина 20")
+	assert.Equal(t, 30, widthByName["organization"], "organization ширина 30")
+	// car_brand не трогали - должен сохранить дефолт (9).
+	assert.Equal(t, 9, widthByName["car_brand"], "car_brand остаётся 9 (дефолт)")
+}

--- a/internal/models/system_table.go
+++ b/internal/models/system_table.go
@@ -75,7 +75,10 @@ type TableField struct {
 	FieldType    *string     `gorm:"size:50" json:"field_type"`
 	DisplayOrder *int        `json:"display_order"`
 	IsVisible    bool        `gorm:"default:true" json:"is_visible"`
-	CreatedAt    time.Time   `json:"created_at"`
+	// Width - относительный вес ширины столбца. Используется как flex-grow:
+	// браузер делит доступную ширину пропорционально весам видимых столбцов.
+	Width     int       `gorm:"default:10" json:"width"`
+	CreatedAt time.Time `json:"created_at"`
 }
 
 // SystemTableWithDetails -- таблица с полями, слотами, фото и текущим статусом (открыто/закрыто).
@@ -132,12 +135,13 @@ type UpdateTimeSlotRequest struct {
 	IsActive  *bool   `json:"is_active"`
 }
 
-// FieldVisibilityUpdate -- одиночное обновление видимости и порядка столбца (#345).
-// DisplayOrder опционален - если не передан, порядок не меняется.
+// FieldVisibilityUpdate -- одиночное обновление видимости, порядка и ширины столбца (#345).
+// DisplayOrder и Width опциональны - если не переданы, не меняются.
 type FieldVisibilityUpdate struct {
 	FieldName    string `json:"field_name" validate:"required"`
 	IsVisible    bool   `json:"is_visible"`
 	DisplayOrder *int   `json:"display_order"`
+	Width        *int   `json:"width"`
 }
 
 // UpdateFieldsRequest -- bulk-обновление видимости столбцов системной таблицы.

--- a/internal/services/system_table_service.go
+++ b/internal/services/system_table_service.go
@@ -229,46 +229,46 @@ func (s *systemTableService) GetByName(ctx context.Context, name string) (*model
 }
 
 // defaultField -- описание поля по умолчанию для нового типа таблицы.
-// IsVisible определяет, включён ли столбец сразу при создании таблицы.
-// "Базовые" столбцы видимы, "дополнительные" - скрыты и включаются админом по необходимости.
+// IsVisible: включён ли столбец сразу при создании таблицы.
+// Width: относительный вес ширины (flex-grow) - браузер делит ширину пропорционально.
 type defaultField struct {
 	Name      string
 	FieldType string
 	IsVisible bool
+	Width     int
 }
 
 // getDefaultFields возвращает набор полей по умолчанию для типа таблицы.
-// Видимые сразу после создания таблицы - типовые поля гостевого пропуска.
-// Скрытые - расширенные поля (компания, должность, гражданство и т.п.),
-// которые админ может включить в "Колонки".
+// Базовые - видимы сразу. Расширенные - скрыты, включаются админом в "Колонки".
+// Width - относительный вес flex-grow, подобранный под типичный контент столбца.
 func getDefaultFields(tableType string) []defaultField {
 	switch tableType {
 	case "cars":
 		return []defaultField{
-			{"car_number", "text", true},
-			{"car_brand", "text", true},
-			{"organization", "text", true},
-			{"unload_place", "text", true},
-			{"valid_until", "date", true},
-			{"time_range", "text", true},
-			{"status", "text", true},
+			{"car_number", "text", true, 10},
+			{"car_brand", "text", true, 9},
+			{"organization", "text", true, 18},
+			{"unload_place", "text", true, 15},
+			{"valid_until", "date", true, 12},
+			{"time_range", "text", true, 10},
+			{"status", "text", true, 7},
 			// Расширенные (по умолчанию скрытые)
-			{"company", "text", false},
-			{"application_id", "text", false},
+			{"company", "text", false, 12},
+			{"application_id", "text", false, 12},
 		}
 	case "people":
 		return []defaultField{
-			{"organization", "text", true},
-			{"last_name", "text", true},
-			{"first_name", "text", true},
-			{"middle_name", "text", true},
-			{"valid_until", "date", true},
-			{"pass_time", "text", true},
+			{"organization", "text", true, 16},
+			{"last_name", "text", true, 14},
+			{"first_name", "text", true, 9},
+			{"middle_name", "text", true, 11},
+			{"valid_until", "date", true, 11},
+			{"pass_time", "text", true, 13},
 			// Расширенные (по умолчанию скрытые)
-			{"position", "text", false},
-			{"citizenship_name", "text", false},
-			{"company", "text", false},
-			{"application_id", "text", false},
+			{"position", "text", false, 11},
+			{"citizenship_name", "text", false, 10},
+			{"company", "text", false, 11},
+			{"application_id", "text", false, 12},
 		}
 	default:
 		return nil
@@ -328,6 +328,7 @@ func (s *systemTableService) Create(ctx context.Context, req models.CreateSystem
 				FieldType:    &fieldType,
 				DisplayOrder: &order,
 				IsVisible:    f.IsVisible,
+				Width:        f.Width,
 			}
 			if err := tx.Create(&tf).Error; err != nil {
 				slog.Error("не удалось создать поле таблицы", "table_id", table.ID, "field", f.Name, "error", err)
@@ -492,6 +493,9 @@ func (s *systemTableService) UpdateFields(ctx context.Context, tableID int, req 
 			if f.DisplayOrder != nil {
 				updates["display_order"] = *f.DisplayOrder
 			}
+			if f.Width != nil {
+				updates["width"] = *f.Width
+			}
 			result := tx.Model(&models.TableField{}).
 				Where("table_id = ? AND field_name = ?", tableID, f.FieldName).
 				Updates(updates)
@@ -541,6 +545,28 @@ func (s *systemTableService) SeedMissingFields(ctx context.Context) error {
 			}
 		}
 
+		// Backfill: для существующих полей с width=0 (старые записи без width) -
+		// проставляем дефолтную ширину из getDefaultFields.
+		defaultsByName := make(map[string]defaultField, len(defaults))
+		for _, d := range defaults {
+			defaultsByName[d.Name] = d
+		}
+		for _, f := range existing {
+			if f.Width != 0 {
+				continue
+			}
+			d, ok := defaultsByName[f.FieldName]
+			if !ok || d.Width == 0 {
+				continue
+			}
+			if err := s.db.WithContext(ctx).Model(&models.TableField{}).
+				Where("id = ?", f.ID).
+				Update("width", d.Width).Error; err != nil {
+				slog.Error("не удалось backfill width",
+					"table_id", t.ID, "field", f.FieldName, "error", err)
+			}
+		}
+
 		for _, d := range defaults {
 			if existingSet[d.Name] {
 				continue
@@ -554,6 +580,7 @@ func (s *systemTableService) SeedMissingFields(ctx context.Context) error {
 				FieldType:    &fieldType,
 				DisplayOrder: &order,
 				IsVisible:    d.IsVisible,
+				Width:        d.Width,
 			}
 			if err := s.db.WithContext(ctx).Create(&tf).Error; err != nil {
 				slog.Error("не удалось добавить отсутствующее поле",


### PR DESCRIPTION
Phase 1C #345 - админ задаёт ширину каждого столбца в "Колонки".

## Backend
- ` + '`TableField.Width int`' + ` (default 10), миграция GORM AutoMigrate.
- ` + '`FieldVisibilityUpdate`' + ` получил опциональный ` + '`width *int`' + `.
- ` + '`UpdateFields`' + ` пишет width одной транзакцией с is_visible/display_order.
- ` + '`getDefaultFields`' + ` теперь содержит per-field веса (cars: 10/9/18/15/12/10/7/12/12; people: 16/14/9/11/11/13/11/10/11/12).
- ` + '`SeedMissingFields`' + ` дополнительно backfill'ит ширину для существующих полей с ` + '`width=0`' + ` (старые записи без миграции).
- Новый тест ` + '`UpdateFields_PersistsWidth`' + ` (5 тестов на UpdateFields).

## Admin UI (SystemTableColumnsTab)
- Справа в каждом ряду - числовой input (1-100) с подписью "w".
- ` + '`localFields[i].width`' + ` в reactive state, isDirty следит за изменениями.
- Превью таблицы сразу реагирует на изменение width (передаётся через ` + '`preview-fields`' + `).

## Реальные таблицы (CarsTable/PeopleTable)
- ` + '`fieldWidths: {}`' + ` map - имя поля -> вес.
- ` + '`getColStyle(name)`' + ` возвращает ` + '`{ order, flexGrow }`' + ` - flex-grow переопределяет дефолт из CSS.
- ` + '`fetchFieldsVisibility`' + ` подтягивает ` + '`width`' + ` из API в ` + '`fieldWidths`' + `.
- В preview-режиме width берётся из ` + '`previewFields[i].width`' + `.

## Тесты
- Go: 5/5 UpdateFields зелёные.
- Vitest: 294/294 зелёные.