### PR TITLE
feat: размер шрифта, плотность и портретный режим таблиц (#345)

### DIFF
--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -1,7 +1,11 @@
 <template>
   <div
     class="selected-table-card"
-    :class="{ 'enlarged': enlarged }"
+    :class="[
+      { 'enlarged': enlarged, 'is-portrait': isCompact },
+      `density-${rowDensity}`,
+    ]"
+    :style="{ '--table-font-size': tableFontSize + 'px' }"
     data-testid="cars-table"
   >
     <div class="card-header">
@@ -209,10 +213,11 @@
             name="fade-list"
             tag="div"
           >
-            <div 
-              v-for="(item, index) in displayItems" 
-              :key="item.id" 
+            <div
+              v-for="(item, index) in displayItems"
+              :key="item.id"
               class="item-row"
+              :class="{ 'item-row--expanded': expandedRows[item.id] }"
               :style="{ animationDelay: `${index * 0.05}s` }"
               @click="preview ? null : openVehicleDetails(item)"
             >
@@ -311,6 +316,36 @@
                   <StatusBadge :status="item.status" />
                 </div>
                 <div
+                  v-if="isCompact && hiddenInPortraitFields().length"
+                  class="col expand-col"
+                  style="order: 9998;"
+                  @click.stop
+                >
+                  <button
+                    type="button"
+                    class="expand-btn"
+                    :class="{ 'expand-btn--open': expandedRows[item.id] }"
+                    :aria-expanded="!!expandedRows[item.id]"
+                    :aria-label="expandedRows[item.id] ? 'Скрыть' : 'Подробнее'"
+                    @click="toggleRowExpand(item.id)"
+                  >
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 14 14"
+                      fill="none"
+                    >
+                      <path
+                        d="M3.5 5L7 8.5L10.5 5"
+                        stroke="currentColor"
+                        stroke-width="1.5"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                  </button>
+                </div>
+                <div
                   class="col actions-col"
                   style="order: 9999;"
                   @click.stop
@@ -326,6 +361,26 @@
                       class="delete-icon"
                     >
                   </button>
+                </div>
+              </div>
+              <div
+                v-if="isCompact && expandedRows[item.id]"
+                class="item-row__details"
+                @click.stop
+              >
+                <div
+                  v-for="name in hiddenInPortraitFields()"
+                  :key="name"
+                  class="detail-item"
+                >
+                  <span class="detail-item__label">{{ portraitFieldLabel(name) }}:</span>
+                  <span class="detail-item__value">
+                    <StatusBadge
+                      v-if="name === 'status'"
+                      :status="item.status"
+                    />
+                    <template v-else>{{ portraitFieldValue(item, name) }}</template>
+                  </span>
                 </div>
               </div>
             </div>
@@ -370,6 +425,7 @@
 <script>
 import { apiRequest } from '@/api/client'
 import { useDeletionsStore } from '@/stores/deletions';
+import { useOrientation } from '@/composables/useOrientation';
 import RefreshButton from './RefreshButton.vue';
 import VehicleDetailsModal from './CreateApplication/VehicleDetailsModal.vue';
 import CarsTableHistoryModal from './CarsTableHistoryModal.vue';
@@ -388,6 +444,10 @@ export default {
     LoaderSpinner,
     StatusBadge,
     EnlargedToggle
+  },
+  setup() {
+    const { isPortrait, isCompact } = useOrientation();
+    return { isPortrait, isCompact };
   },
   props: {
     tableName: { type: String, default: '' },
@@ -424,7 +484,12 @@ export default {
       enlarged: false,
       fieldsVisibility: {},
       fieldOrders: {},
-      fieldWidths: {}
+      fieldWidths: {},
+      fieldPriorities: {},
+      tableFontSize: 14,
+      rowDensity: 'normal',
+      expandedRows: {},
+      compactPriorityThreshold: 2,
     };
   },
   computed: {
@@ -553,14 +618,17 @@ export default {
         const nextVis = {};
         const nextOrd = {};
         const nextW = {};
+        const nextP = {};
         newVal.forEach((f, i) => {
           nextVis[f.field_name] = f.is_visible !== false;
           nextOrd[f.field_name] = typeof f.display_order === 'number' ? f.display_order : i;
           if (typeof f.width === 'number' && f.width > 0) nextW[f.field_name] = f.width;
+          if (typeof f.priority === 'number' && f.priority > 0) nextP[f.field_name] = f.priority;
         });
         this.fieldsVisibility = nextVis;
         this.fieldOrders = nextOrd;
         this.fieldWidths = nextW;
+        this.fieldPriorities = nextP;
       }
     }
   },
@@ -952,7 +1020,64 @@ export default {
     isFieldVisible(fieldName) {
       // Пока конфиг не загружен - показываем всё (предотвращает мигание при инициализации).
       const v = this.fieldsVisibility[fieldName];
-      return v === undefined ? true : v;
+      const visible = v === undefined ? true : v;
+      if (!visible) return false;
+      // В портретном компактном режиме показываем только столбцы с priority<=threshold.
+      if (this.isCompact) {
+        const p = this.fieldPriorities[fieldName];
+        if (typeof p === 'number' && p > this.compactPriorityThreshold) return false;
+      }
+      return true;
+    },
+
+    /**
+     * Возвращает список field_name, которые видимы по is_visible, но скрыты
+     * в текущем портретном режиме из-за priority. Используется для блока
+     * "Подробнее" под строкой - показать пользователю недостающие поля.
+     */
+    hiddenInPortraitFields() {
+      if (!this.isCompact) return [];
+      return Object.keys(this.fieldsVisibility)
+        .filter(name => this.fieldsVisibility[name] !== false)
+        .filter(name => {
+          const p = this.fieldPriorities[name];
+          return typeof p === 'number' && p > this.compactPriorityThreshold;
+        });
+    },
+
+    toggleRowExpand(rowId) {
+      const next = { ...this.expandedRows };
+      next[rowId] = !next[rowId];
+      this.expandedRows = next;
+    },
+
+    portraitFieldLabel(name) {
+      const LABELS = {
+        car_number: 'Номер Т/С',
+        car_brand: 'Марка',
+        organization: 'Организация',
+        company: 'Компания',
+        application_id: 'Номер заявки',
+        unload_place: 'Место разгрузки',
+        valid_until: 'Действует до',
+        time_range: 'Время',
+        status: 'Статус',
+      };
+      return LABELS[name] || name;
+    },
+
+    portraitFieldValue(item, name) {
+      switch (name) {
+        case 'car_number': return item.car_number || '-';
+        case 'car_brand': return item.car_brand || '-';
+        case 'organization': return item.organization_name || '-';
+        case 'company': return item.company || '-';
+        case 'application_id': return item.applicationNumber || '-';
+        case 'unload_place': return this.formatUnloadPlaces(item);
+        case 'valid_until': return this.formatDate(item.entry_date_to);
+        case 'time_range': return this.formatTimeRange(item.entry_time_from, item.entry_time_to);
+        default: return '-';
+      }
     },
 
     /**
@@ -978,6 +1103,7 @@ export default {
         const nextVis = {};
         const nextOrd = {};
         const nextW = {};
+        const nextP = {};
         (data.fields || []).forEach(f => {
           nextVis[f.field_name] = f.is_visible !== false;
           if (typeof f.display_order === 'number') {
@@ -986,10 +1112,20 @@ export default {
           if (typeof f.width === 'number' && f.width > 0) {
             nextW[f.field_name] = f.width;
           }
+          if (typeof f.priority === 'number' && f.priority > 0) {
+            nextP[f.field_name] = f.priority;
+          }
         });
         this.fieldsVisibility = nextVis;
         this.fieldOrders = nextOrd;
         this.fieldWidths = nextW;
+        this.fieldPriorities = nextP;
+        // Применяем стиль уровня таблицы (#345 фазы 1D+1E).
+        const tbl = data.table || {};
+        const fs = Number(tbl.font_size);
+        if (fs >= 10 && fs <= 24) this.tableFontSize = fs;
+        const dens = tbl.row_density;
+        if (['compact', 'normal', 'spacious'].includes(dens)) this.rowDensity = dens;
       } catch (error) {
         console.error('Ошибка загрузки настроек столбцов:', error);
       }
@@ -1448,5 +1584,102 @@ export default {
     height: 28px;
     font-size: 11px;
   }
+}
+
+/* #345 Phase 1D: размер шрифта строк через CSS-переменную с дефолтом 14px.
+   Применяется ТОЛЬКО к телу таблицы - заголовки сохраняют исходный размер. */
+.selected-table-card .items-body .col {
+  font-size: var(--table-font-size, 14px);
+}
+
+/* #345 Phase 1E: плотность строк управляет вертикальным padding в ячейках. */
+.selected-table-card.density-compact .item-data,
+.selected-table-card.density-compact .header-row {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.selected-table-card.density-spacious .item-data,
+.selected-table-card.density-spacious .header-row {
+  padding-top: 16px;
+  padding-bottom: 16px;
+}
+
+/* #345 Phase 1F: портретный режим (узкий экран с orientation: portrait). */
+.expand-col {
+  flex: 2.5 0 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.expand-btn {
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid #e6e6e6;
+  border-radius: 6px;
+  color: #6b7280;
+  cursor: pointer;
+  transition: transform 0.2s ease, color 0.15s ease, background 0.15s ease;
+}
+
+.expand-btn:hover {
+  background: #f5f5f5;
+  color: #4F5BDF;
+}
+
+.expand-btn--open {
+  transform: rotate(180deg);
+  color: #4F5BDF;
+  background: #eef0ff;
+}
+
+.item-row__details {
+  padding: 8px 16px 12px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px 16px;
+  background: #fafafa;
+  border-top: 1px dashed #e6e6e6;
+}
+
+.detail-item {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  min-width: 0;
+  font-size: var(--table-font-size, 14px);
+}
+
+.detail-item__label {
+  color: #6b7280;
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.detail-item__value {
+  color: #000;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+/* В портретном режиме контролы сверху таблицы превращаем в вертикальный стек. */
+.selected-table-card.is-portrait .card-header {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 12px;
+  height: auto;
+  padding: 14px 16px;
+}
+
+.selected-table-card.is-portrait .card-header__settings {
+  width: 100%;
+  justify-content: space-between;
 }
 </style>

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -1,7 +1,11 @@
 <template>
   <div
     class="selected-table-card"
-    :class="{ 'enlarged': enlarged }"
+    :class="[
+      { 'enlarged': enlarged, 'is-portrait': isCompact },
+      `density-${rowDensity}`,
+    ]"
+    :style="{ '--table-font-size': tableFontSize + 'px' }"
     data-testid="people-table"
   >
     <div class="card-header">
@@ -235,10 +239,11 @@
             name="fade-list"
             tag="div"
           >
-            <div 
-              v-for="(item, index) in displayItems" 
-              :key="item.id" 
+            <div
+              v-for="(item, index) in displayItems"
+              :key="item.id"
               class="item-row"
+              :class="{ 'item-row--expanded': expandedRows[item.id] }"
               :style="{ animationDelay: `${index * 0.05}s` }"
               @click="preview ? null : openEmployeeDetails(item)"
             >
@@ -348,6 +353,36 @@
                   <StatusBadge :status="item.status" />
                 </div>
                 <div
+                  v-if="isCompact && hiddenInPortraitFields().length"
+                  class="col expand-col"
+                  style="order: 9997;"
+                  @click.stop
+                >
+                  <button
+                    type="button"
+                    class="expand-btn"
+                    :class="{ 'expand-btn--open': expandedRows[item.id] }"
+                    :aria-expanded="!!expandedRows[item.id]"
+                    :aria-label="expandedRows[item.id] ? 'Скрыть' : 'Подробнее'"
+                    @click="toggleRowExpand(item.id)"
+                  >
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 14 14"
+                      fill="none"
+                    >
+                      <path
+                        d="M3.5 5L7 8.5L10.5 5"
+                        stroke="currentColor"
+                        stroke-width="1.5"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                  </button>
+                </div>
+                <div
                   class="col actions-col"
                   style="order: 9999;"
                   @click.stop
@@ -365,10 +400,24 @@
                   </button>
                 </div>
               </div>
+              <div
+                v-if="isCompact && expandedRows[item.id]"
+                class="item-row__details"
+                @click.stop
+              >
+                <div
+                  v-for="name in hiddenInPortraitFields()"
+                  :key="name"
+                  class="detail-item"
+                >
+                  <span class="detail-item__label">{{ portraitFieldLabel(name) }}:</span>
+                  <span class="detail-item__value">{{ portraitFieldValue(item, name) }}</span>
+                </div>
+              </div>
             </div>
           </transition-group>
         </div>
-        
+
         <div
           v-else
           class="no-data-message"
@@ -404,6 +453,7 @@
 <script>
 import { apiRequest } from '@/api/client';
 import { useDeletionsStore } from '@/stores/deletions';
+import { useOrientation } from '@/composables/useOrientation';
 import RefreshButton from './RefreshButton.vue';
 import EmployeeDetailsModal from './CreateApplication/EmployeeDetailsModal.vue';
 import EmployeesTableHistoryModal from './CreateApplication/EmployeesTableHistoryModal.vue';
@@ -420,6 +470,10 @@ export default {
     EmployeesTableHistoryModal,
     StatusBadge,
     EnlargedToggle
+  },
+  setup() {
+    const { isPortrait, isCompact } = useOrientation();
+    return { isPortrait, isCompact };
   },
   props: {
     tableName: {
@@ -482,7 +536,12 @@ export default {
       enlarged: false,
       fieldsVisibility: {},
       fieldOrders: {},
-      fieldWidths: {}
+      fieldWidths: {},
+      fieldPriorities: {},
+      tableFontSize: 14,
+      rowDensity: 'normal',
+      expandedRows: {},
+      compactPriorityThreshold: 2,
     };
   },
   computed: {
@@ -606,14 +665,17 @@ export default {
         const nextVis = {};
         const nextOrd = {};
         const nextW = {};
+        const nextP = {};
         newVal.forEach((f, i) => {
           nextVis[f.field_name] = f.is_visible !== false;
           nextOrd[f.field_name] = typeof f.display_order === 'number' ? f.display_order : i;
           if (typeof f.width === 'number' && f.width > 0) nextW[f.field_name] = f.width;
+          if (typeof f.priority === 'number' && f.priority > 0) nextP[f.field_name] = f.priority;
         });
         this.fieldsVisibility = nextVis;
         this.fieldOrders = nextOrd;
         this.fieldWidths = nextW;
+        this.fieldPriorities = nextP;
       }
     }
   },
@@ -691,10 +753,12 @@ export default {
         const table = responseData.table;
         this.currentTableId = table.id;
 
-        // Подтягиваем конфиг видимости, порядка и ширины столбцов из того же ответа.
+        // Подтягиваем конфиг видимости, порядка, ширины и приоритета столбцов
+        // из того же ответа. Стиль таблицы (font_size/row_density) - из table.
         const nextVisibility = {};
         const nextOrders = {};
         const nextWidths = {};
+        const nextPriorities = {};
         (responseData.fields || []).forEach(f => {
           nextVisibility[f.field_name] = f.is_visible !== false;
           if (typeof f.display_order === 'number') {
@@ -703,10 +767,18 @@ export default {
           if (typeof f.width === 'number' && f.width > 0) {
             nextWidths[f.field_name] = f.width;
           }
+          if (typeof f.priority === 'number' && f.priority > 0) {
+            nextPriorities[f.field_name] = f.priority;
+          }
         });
         this.fieldsVisibility = nextVisibility;
         this.fieldOrders = nextOrders;
         this.fieldWidths = nextWidths;
+        this.fieldPriorities = nextPriorities;
+        const fs = Number(table.font_size);
+        if (fs >= 10 && fs <= 24) this.tableFontSize = fs;
+        const dens = table.row_density;
+        if (['compact', 'normal', 'spacious'].includes(dens)) this.rowDensity = dens;
 
         const employeesRes = await apiRequest(`/employees/active-for-table/${table.id}`, { method: "GET" });
         if (!employeesRes.ok) return;
@@ -960,7 +1032,13 @@ export default {
     isFieldVisible(fieldName) {
       // Пока конфиг не загружен - показываем всё (предотвращает мигание при инициализации).
       const v = this.fieldsVisibility[fieldName];
-      return v === undefined ? true : v;
+      const visible = v === undefined ? true : v;
+      if (!visible) return false;
+      if (this.isCompact) {
+        const p = this.fieldPriorities[fieldName];
+        if (typeof p === 'number' && p > this.compactPriorityThreshold) return false;
+      }
+      return true;
     },
 
     /**
@@ -975,7 +1053,55 @@ export default {
       if (order !== undefined) style.order = 10 + order;
       if (width !== undefined && width > 0) style.flexGrow = width;
       return Object.keys(style).length ? style : null;
-    }
+    },
+
+    hiddenInPortraitFields() {
+      if (!this.isCompact) return [];
+      return Object.keys(this.fieldsVisibility)
+        .filter(name => this.fieldsVisibility[name] !== false)
+        .filter(name => {
+          const p = this.fieldPriorities[name];
+          return typeof p === 'number' && p > this.compactPriorityThreshold;
+        });
+    },
+
+    toggleRowExpand(rowId) {
+      const next = { ...this.expandedRows };
+      next[rowId] = !next[rowId];
+      this.expandedRows = next;
+    },
+
+    portraitFieldLabel(name) {
+      const LABELS = {
+        last_name: 'Фамилия',
+        first_name: 'Имя',
+        middle_name: 'Отчество',
+        position: 'Должность',
+        citizenship_name: 'Гражданство',
+        organization: 'Организация',
+        company: 'Компания',
+        valid_until: 'Действует до',
+        pass_time: 'Время прохода',
+        application_id: 'Номер заявки',
+      };
+      return LABELS[name] || name;
+    },
+
+    portraitFieldValue(item, name) {
+      switch (name) {
+        case 'last_name': return item.last_name || '-';
+        case 'first_name': return item.first_name || '-';
+        case 'middle_name': return item.middle_name || '-';
+        case 'position': return item.position || '-';
+        case 'citizenship_name': return item.citizenship_name || '-';
+        case 'organization': return item.organization_name || '-';
+        case 'company': return item.company || '-';
+        case 'valid_until': return this.formatDate(item.entry_date_to);
+        case 'pass_time': return item.pass_time || '-';
+        case 'application_id': return item.applicationNumber || '-';
+        default: return '-';
+      }
+    },
   }
 };
 </script>
@@ -1432,5 +1558,100 @@ export default {
     height: 28px;
     font-size: 11px;
   }
+}
+
+/* #345 Phase 1D: размер шрифта строк через CSS-переменную. */
+.selected-table-card .items-body .col {
+  font-size: var(--table-font-size, 14px);
+}
+
+/* #345 Phase 1E: плотность строк - вертикальный padding ячейки. */
+.selected-table-card.density-compact .item-data,
+.selected-table-card.density-compact .header-row {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.selected-table-card.density-spacious .item-data,
+.selected-table-card.density-spacious .header-row {
+  padding-top: 16px;
+  padding-bottom: 16px;
+}
+
+/* #345 Phase 1F: портретный режим. */
+.expand-col {
+  flex: 2.5 0 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.expand-btn {
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid #e6e6e6;
+  border-radius: 6px;
+  color: #6b7280;
+  cursor: pointer;
+  transition: transform 0.2s ease, color 0.15s ease, background 0.15s ease;
+}
+
+.expand-btn:hover {
+  background: #f5f5f5;
+  color: #4F5BDF;
+}
+
+.expand-btn--open {
+  transform: rotate(180deg);
+  color: #4F5BDF;
+  background: #eef0ff;
+}
+
+.item-row__details {
+  padding: 8px 16px 12px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px 16px;
+  background: #fafafa;
+  border-top: 1px dashed #e6e6e6;
+}
+
+.detail-item {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  min-width: 0;
+  font-size: var(--table-font-size, 14px);
+}
+
+.detail-item__label {
+  color: #6b7280;
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.detail-item__value {
+  color: #000;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.selected-table-card.is-portrait .card-header {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 12px;
+  height: auto;
+  padding: 14px 16px;
+}
+
+.selected-table-card.is-portrait .card-header__settings {
+  width: 100%;
+  justify-content: space-between;
 }
 </style>

--- a/frontend/src/components/SystemTableAppearanceTab.vue
+++ b/frontend/src/components/SystemTableAppearanceTab.vue
@@ -1,0 +1,310 @@
+<template>
+  <div class="appearance-tab">
+    <div class="appearance-tab__section">
+      <h4 class="appearance-tab__title">
+        Размер шрифта строк
+      </h4>
+      <p class="appearance-tab__hint">
+        Действует на содержимое строк CarsTable и PeopleTable. Шрифт фиксирован - Montserrat.
+      </p>
+      <div class="appearance-tab__row">
+        <input
+          v-model.number="fontSize"
+          type="range"
+          min="10"
+          max="24"
+          step="1"
+          class="appearance-tab__slider"
+          data-testid="appearance-fontsize-slider"
+        >
+        <span
+          class="appearance-tab__value"
+          data-testid="appearance-fontsize-value"
+        >{{ fontSize }}px</span>
+      </div>
+    </div>
+
+    <div class="appearance-tab__section">
+      <h4 class="appearance-tab__title">
+        Плотность строк
+      </h4>
+      <p class="appearance-tab__hint">
+        Управляет вертикальными отступами в ячейках.
+      </p>
+      <div
+        class="appearance-tab__segment"
+        role="radiogroup"
+        aria-label="Плотность строк"
+      >
+        <button
+          v-for="opt in densityOptions"
+          :key="opt.value"
+          type="button"
+          class="appearance-tab__segment-btn"
+          :class="{ 'appearance-tab__segment-btn--active': rowDensity === opt.value }"
+          :data-density="opt.value"
+          :aria-pressed="rowDensity === opt.value"
+          @click="rowDensity = opt.value"
+        >
+          {{ opt.label }}
+        </button>
+      </div>
+    </div>
+
+    <div class="appearance-tab__actions">
+      <button
+        class="appearance-tab__btn appearance-tab__btn--secondary"
+        :disabled="!isDirty || saving"
+        @click="reset"
+      >
+        Отменить
+      </button>
+      <button
+        class="appearance-tab__btn appearance-tab__btn--primary"
+        :disabled="!isDirty || saving"
+        data-testid="appearance-save"
+        @click="save"
+      >
+        {{ saving ? 'Сохраняем...' : 'Сохранить' }}
+      </button>
+    </div>
+
+    <p
+      v-if="statusMessage"
+      class="appearance-tab__status"
+      :class="{ 'appearance-tab__status--error': statusError }"
+    >
+      {{ statusMessage }}
+    </p>
+  </div>
+</template>
+
+<script>
+import { apiRequest } from '@/api/client';
+
+const DEFAULT_FONT_SIZE = 14;
+const DEFAULT_DENSITY = 'normal';
+
+export default {
+  name: 'SystemTableAppearanceTab',
+  props: {
+    tableId: { type: Number, required: true },
+    table: { type: Object, required: true },
+  },
+  emits: ['update'],
+  data() {
+    return {
+      fontSize: DEFAULT_FONT_SIZE,
+      rowDensity: DEFAULT_DENSITY,
+      originalFontSize: DEFAULT_FONT_SIZE,
+      originalDensity: DEFAULT_DENSITY,
+      saving: false,
+      statusMessage: '',
+      statusError: false,
+      densityOptions: [
+        { value: 'compact', label: 'Компактно' },
+        { value: 'normal', label: 'Обычно' },
+        { value: 'spacious', label: 'Просторно' },
+      ],
+    };
+  },
+  computed: {
+    isDirty() {
+      return this.fontSize !== this.originalFontSize
+        || this.rowDensity !== this.originalDensity;
+    },
+  },
+  watch: {
+    table: {
+      handler() {
+        this.reset();
+      },
+      immediate: true,
+      deep: true,
+    },
+  },
+  methods: {
+    reset() {
+      const fs = Number(this.table?.font_size);
+      this.fontSize = fs >= 10 && fs <= 24 ? fs : DEFAULT_FONT_SIZE;
+      const dens = this.table?.row_density;
+      this.rowDensity = ['compact', 'normal', 'spacious'].includes(dens) ? dens : DEFAULT_DENSITY;
+      this.originalFontSize = this.fontSize;
+      this.originalDensity = this.rowDensity;
+      this.statusMessage = '';
+      this.statusError = false;
+    },
+    async save() {
+      if (!this.isDirty || this.saving) return;
+      this.saving = true;
+      this.statusMessage = '';
+      this.statusError = false;
+      try {
+        const fs = Math.max(10, Math.min(24, Number(this.fontSize) || DEFAULT_FONT_SIZE));
+        const response = await apiRequest(`/system-tables/${this.tableId}`, {
+          method: 'PUT',
+          body: JSON.stringify({
+            font_size: fs,
+            row_density: this.rowDensity,
+          }),
+        });
+        if (!response.ok) {
+          const err = await response.json().catch(() => ({}));
+          throw new Error(err.message || `HTTP ${response.status}`);
+        }
+        this.originalFontSize = fs;
+        this.originalDensity = this.rowDensity;
+        this.statusMessage = 'Оформление сохранено';
+        this.$emit('update');
+      } catch (e) {
+        this.statusError = true;
+        this.statusMessage = `Ошибка сохранения: ${e.message}`;
+      } finally {
+        this.saving = false;
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.appearance-tab {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.appearance-tab__section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.appearance-tab__title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: #000;
+}
+
+.appearance-tab__hint {
+  margin: 0;
+  font-size: 12px;
+  color: #6b7280;
+  line-height: 1.4;
+}
+
+.appearance-tab__row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 0;
+}
+
+.appearance-tab__slider {
+  flex: 1;
+  accent-color: #4F5BDF;
+}
+
+.appearance-tab__value {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 13px;
+  font-weight: 500;
+  color: #4F5BDF;
+  min-width: 48px;
+  text-align: right;
+}
+
+.appearance-tab__segment {
+  display: inline-flex;
+  border: 1px solid #e6e6e6;
+  border-radius: 10px;
+  overflow: hidden;
+  background: #fafafa;
+  width: fit-content;
+}
+
+.appearance-tab__segment-btn {
+  padding: 8px 16px;
+  background: transparent;
+  border: none;
+  border-right: 1px solid #e6e6e6;
+  font-size: 13px;
+  color: #6b7280;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.appearance-tab__segment-btn:last-child {
+  border-right: none;
+}
+
+.appearance-tab__segment-btn:hover:not(.appearance-tab__segment-btn--active) {
+  background: #f0f0f0;
+  color: #333;
+}
+
+.appearance-tab__segment-btn--active {
+  background: #4F5BDF;
+  color: #fff;
+  font-weight: 500;
+}
+
+.appearance-tab__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  border-top: 1px solid #f0f0f0;
+  padding-top: 12px;
+  margin-top: 4px;
+}
+
+.appearance-tab__btn {
+  padding: 8px 18px;
+  border-radius: 14px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border: 1px solid transparent;
+}
+
+.appearance-tab__btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.appearance-tab__btn--secondary {
+  background: #fff;
+  border-color: #e6e6e6;
+  color: #333;
+}
+
+.appearance-tab__btn--secondary:hover:not(:disabled) {
+  background: #f5f5f5;
+  border-color: #c0c0c0;
+}
+
+.appearance-tab__btn--primary {
+  background: #4F5BDF;
+  color: #fff;
+  border-color: #4F5BDF;
+}
+
+.appearance-tab__btn--primary:hover:not(:disabled) {
+  background: #3b48c4;
+  border-color: #3b48c4;
+}
+
+.appearance-tab__status {
+  margin: 0;
+  font-size: 13px;
+  color: #079D1D;
+  text-align: right;
+}
+
+.appearance-tab__status--error {
+  color: #c62828;
+}
+</style>

--- a/frontend/src/components/SystemTableColumnsTab.vue
+++ b/frontend/src/components/SystemTableColumnsTab.vue
@@ -98,6 +98,7 @@
             class="columns-tab__width"
             :title="'Ширина столбца (вес flex-grow). Браузер делит доступную ширину пропорционально весам видимых столбцов.'"
           >
+            <span class="columns-tab__width-label">Ширина:</span>
             <input
               v-model.number="field.width"
               type="number"
@@ -106,7 +107,25 @@
               class="columns-tab__width-input"
               :data-width-field="field.field_name"
             >
-            <span class="columns-tab__width-unit">w</span>
+          </div>
+          <div
+            class="columns-tab__priority"
+            :title="'Приоритет в портретном режиме (1-5). 1 = всегда виден, 2 = виден на узком экране, 3-5 = скрывается в портрете и доступен по кнопке Подробнее.'"
+          >
+            <span class="columns-tab__priority-label">Приоритет:</span>
+            <select
+              v-model.number="field.priority"
+              class="columns-tab__priority-select"
+              :data-priority-field="field.field_name"
+            >
+              <option
+                v-for="n in 5"
+                :key="n"
+                :value="n"
+              >
+                {{ n }}
+              </option>
+            </select>
           </div>
         </div>
       </li>
@@ -219,6 +238,7 @@ export default {
       originalVisibility: {},
       originalOrder: [],
       originalWidth: {},
+      originalPriority: {},
       saving: false,
       statusMessage: '',
       statusError: false,
@@ -234,6 +254,7 @@ export default {
         is_visible: f.is_visible,
         display_order: i,
         width: f.width,
+        priority: f.priority,
       }));
     },
     sampleItems() {
@@ -249,7 +270,10 @@ export default {
       const widthChanged = this.localFields.some(
         f => this.originalWidth[f.field_name] !== f.width,
       );
-      return visibilityChanged || orderChanged || widthChanged;
+      const priorityChanged = this.localFields.some(
+        f => this.originalPriority[f.field_name] !== f.priority,
+      );
+      return visibilityChanged || orderChanged || widthChanged || priorityChanged;
     },
   },
   watch: {
@@ -278,6 +302,7 @@ export default {
         field_name: f.field_name,
         is_visible: f.is_visible !== false,
         width: typeof f.width === 'number' && f.width > 0 ? f.width : 10,
+        priority: typeof f.priority === 'number' && f.priority > 0 ? f.priority : 3,
       }));
       this.originalVisibility = Object.fromEntries(
         this.localFields.map(f => [f.field_name, f.is_visible]),
@@ -285,6 +310,9 @@ export default {
       this.originalOrder = this.localFields.map(f => f.field_name);
       this.originalWidth = Object.fromEntries(
         this.localFields.map(f => [f.field_name, f.width]),
+      );
+      this.originalPriority = Object.fromEntries(
+        this.localFields.map(f => [f.field_name, f.priority]),
       );
       this.statusMessage = '';
       this.statusError = false;
@@ -353,6 +381,7 @@ export default {
               is_visible: f.is_visible,
               display_order: i,
               width: Math.max(1, Math.min(100, Number(f.width) || 10)),
+              priority: Math.max(1, Math.min(5, Number(f.priority) || 3)),
             })),
           }),
         });
@@ -367,6 +396,9 @@ export default {
         this.originalOrder = this.localFields.map(f => f.field_name);
         this.originalWidth = Object.fromEntries(
           this.localFields.map(f => [f.field_name, f.width]),
+        );
+        this.originalPriority = Object.fromEntries(
+          this.localFields.map(f => [f.field_name, f.priority]),
         );
         this.$emit('update');
       } catch (e) {
@@ -523,12 +555,18 @@ export default {
   padding-right: 6px;
 }
 
+.columns-tab__width-label {
+  font-size: 11px;
+  color: #6b7280;
+  white-space: nowrap;
+}
+
 .columns-tab__width-input {
-  width: 42px;
-  padding: 3px 6px;
+  width: 32px;
+  padding: 2px 4px;
   border: 1px solid #e6e6e6;
   border-radius: 6px;
-  font-size: 12px;
+  font-size: 11px;
   text-align: right;
   color: #333;
   background: #fff;
@@ -546,9 +584,34 @@ export default {
   border-color: #4F5BDF;
 }
 
-.columns-tab__width-unit {
+.columns-tab__priority {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+  padding-right: 4px;
+}
+
+.columns-tab__priority-label {
   font-size: 11px;
-  color: #a2a2a2;
+  color: #6b7280;
+  white-space: nowrap;
+}
+
+.columns-tab__priority-select {
+  width: 38px;
+  padding: 2px 4px;
+  border: 1px solid #e6e6e6;
+  border-radius: 6px;
+  font-size: 11px;
+  color: #333;
+  background: #fff;
+  cursor: pointer;
+}
+
+.columns-tab__priority-select:focus {
+  outline: none;
+  border-color: #4F5BDF;
 }
 
 .columns-tab__actions {

--- a/frontend/src/components/TableConstructor.vue
+++ b/frontend/src/components/TableConstructor.vue
@@ -161,6 +161,13 @@
           >
             Колонки
           </button>
+          <button
+            class="tab-btn"
+            :class="{ 'active': activeTab === 'appearance' }"
+            @click="activeTab = 'appearance'"
+          >
+            Оформление
+          </button>
         </div>
 
         <!-- Вкладка Основное -->
@@ -471,6 +478,18 @@
             @update="refreshSelectedTable"
           />
         </div>
+
+        <!-- Вкладка Оформление (#345 фазы 1D+1E) -->
+        <div
+          v-if="activeTab === 'appearance'"
+          class="tab-content"
+        >
+          <SystemTableAppearanceTab
+            :table-id="selectedTable.table.id"
+            :table="selectedTable.table"
+            @update="refreshSelectedTable"
+          />
+        </div>
       </div>
 
       <div
@@ -516,6 +535,7 @@ import SearchComponent from './SearchComponent.vue';
 import TextConstructor from './TextConstructor.vue';
 import SystemTableScheduleTab from './SystemTableScheduleTab.vue';
 import SystemTableColumnsTab from './SystemTableColumnsTab.vue';
+import SystemTableAppearanceTab from './SystemTableAppearanceTab.vue';
 import TableConstructorCreateModal from './TableConstructorCreateModal.vue';
 import TableConstructorPhotoSection from './TableConstructorPhotoSection.vue';
 
@@ -527,6 +547,7 @@ export default {
     TextConstructor,
     SystemTableScheduleTab,
     SystemTableColumnsTab,
+    SystemTableAppearanceTab,
     TableConstructorCreateModal,
     TableConstructorPhotoSection
   },

--- a/frontend/src/composables/__tests__/useOrientation.spec.js
+++ b/frontend/src/composables/__tests__/useOrientation.spec.js
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { defineComponent, h } from 'vue';
+import { useOrientation } from '../useOrientation';
+
+describe('useOrientation', () => {
+  let originalMatchMedia;
+  let originalInnerWidth;
+  let mqlListeners;
+
+  beforeEach(() => {
+    originalMatchMedia = window.matchMedia;
+    originalInnerWidth = window.innerWidth;
+    mqlListeners = [];
+  });
+
+  afterEach(() => {
+    if (originalMatchMedia) {
+      window.matchMedia = originalMatchMedia;
+    } else {
+      delete window.matchMedia;
+    }
+    Object.defineProperty(window, 'innerWidth', {
+      value: originalInnerWidth,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  function mockMatchMedia(portrait) {
+    window.matchMedia = vi.fn().mockImplementation(query => ({
+      matches: query.includes('portrait') ? portrait : false,
+      media: query,
+      addEventListener: (ev, cb) => mqlListeners.push(cb),
+      removeEventListener: (ev, cb) => {
+        const i = mqlListeners.indexOf(cb);
+        if (i >= 0) mqlListeners.splice(i, 1);
+      },
+      addListener: () => {},
+      removeListener: () => {},
+    }));
+  }
+
+  function mountHarness() {
+    const harness = defineComponent({
+      setup() {
+        const { isPortrait, isCompact } = useOrientation();
+        return { isPortrait, isCompact };
+      },
+      render() {
+        return h('div', `${this.isPortrait}-${this.isCompact}`);
+      },
+    });
+    return mount(harness);
+  }
+
+  it('isPortrait=true и isCompact=true на узком вертикальном экране', () => {
+    mockMatchMedia(true);
+    Object.defineProperty(window, 'innerWidth', { value: 800, writable: true, configurable: true });
+    const w = mountHarness();
+    expect(w.vm.isPortrait).toBe(true);
+    expect(w.vm.isCompact).toBe(true);
+  });
+
+  it('isCompact=false если экран портретный но широкий (>=1100)', () => {
+    mockMatchMedia(true);
+    Object.defineProperty(window, 'innerWidth', { value: 1200, writable: true, configurable: true });
+    const w = mountHarness();
+    expect(w.vm.isPortrait).toBe(true);
+    expect(w.vm.isCompact).toBe(false);
+  });
+
+  it('isPortrait=false в горизонтальной ориентации', () => {
+    mockMatchMedia(false);
+    Object.defineProperty(window, 'innerWidth', { value: 1920, writable: true, configurable: true });
+    const w = mountHarness();
+    expect(w.vm.isPortrait).toBe(false);
+    expect(w.vm.isCompact).toBe(false);
+  });
+
+  it('не падает в окружении без matchMedia', () => {
+    delete window.matchMedia;
+    expect(() => mountHarness()).not.toThrow();
+  });
+});

--- a/frontend/src/composables/useOrientation.js
+++ b/frontend/src/composables/useOrientation.js
@@ -1,0 +1,55 @@
+import { ref, onMounted, onBeforeUnmount } from 'vue';
+
+/**
+ * Реактивно отслеживает ориентацию viewport.
+ * isPortrait: высота больше ширины (вертикальный монитор).
+ * isCompact: портрет + узкая ширина (< 1100px) - переключает таблицу
+ * в режим приоритезации столбцов и stacked-фильтров.
+ *
+ * @returns {{ isPortrait: import('vue').Ref<boolean>, isCompact: import('vue').Ref<boolean> }}
+ */
+export function useOrientation(compactWidth = 1100) {
+  const isPortrait = ref(false);
+  const isCompact = ref(false);
+
+  let mqlPortrait = null;
+
+  const hasMatchMedia = () =>
+    typeof window !== 'undefined' && typeof window.matchMedia === 'function';
+
+  const evaluate = () => {
+    if (!hasMatchMedia()) return;
+    isPortrait.value = window.matchMedia('(orientation: portrait)').matches;
+    isCompact.value = isPortrait.value && window.innerWidth < compactWidth;
+  };
+
+  const onChange = () => evaluate();
+  const onResize = () => evaluate();
+
+  onMounted(() => {
+    if (!hasMatchMedia()) return;
+    mqlPortrait = window.matchMedia('(orientation: portrait)');
+    if (mqlPortrait.addEventListener) {
+      mqlPortrait.addEventListener('change', onChange);
+    } else if (mqlPortrait.addListener) {
+      mqlPortrait.addListener(onChange);
+    }
+    window.addEventListener('resize', onResize, { passive: true });
+    evaluate();
+  });
+
+  onBeforeUnmount(() => {
+    if (mqlPortrait) {
+      if (mqlPortrait.removeEventListener) {
+        mqlPortrait.removeEventListener('change', onChange);
+      } else if (mqlPortrait.removeListener) {
+        mqlPortrait.removeListener(onChange);
+      }
+    }
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('resize', onResize);
+    }
+  });
+
+  return { isPortrait, isCompact };
+}

--- a/internal/handlers/system_tables_test.go
+++ b/internal/handlers/system_tables_test.go
@@ -389,3 +389,125 @@ func TestSystemTables_UpdateFields_PersistsWidth(t *testing.T) {
 	// car_brand не трогали - должен сохранить дефолт (9).
 	assert.Equal(t, 9, widthByName["car_brand"], "car_brand остаётся 9 (дефолт)")
 }
+
+// TestSystemTables_UpdateFields_PersistsPriority - #345 Phase 1F:
+// PUT /fields сохраняет priority в БД, не задетые поля сохраняют дефолт каталога.
+func TestSystemTables_UpdateFields_PersistsPriority(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	rec := testutil.POST(t, e, "/system-tables",
+		`{"name":"prio_test","display_name":"PT","table_type":"cars"}`, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	tableID := int(testutil.ParseMap(t, rec)["id"].(float64))
+
+	body := `{"fields":[
+		{"field_name":"car_brand","is_visible":true,"priority":2},
+		{"field_name":"organization","is_visible":true,"priority":5}
+	]}`
+	rec = testutil.PUT(t, e, fmt.Sprintf("/system-tables/%d/fields", tableID), body, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = testutil.GET(t, e, fmt.Sprintf("/system-tables/%d", tableID), h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	fields := testutil.ParseMap(t, rec)["fields"].([]interface{})
+
+	prioByName := map[string]int{}
+	for _, f := range fields {
+		fm := f.(map[string]interface{})
+		if p, ok := fm["priority"].(float64); ok {
+			prioByName[fm["field_name"].(string)] = int(p)
+		}
+	}
+	assert.Equal(t, 2, prioByName["car_brand"], "car_brand priority=2")
+	assert.Equal(t, 5, prioByName["organization"], "organization priority=5")
+	// car_number не трогали - дефолт каталога = 1.
+	assert.Equal(t, 1, prioByName["car_number"], "car_number priority=1 (дефолт)")
+}
+
+// TestSystemTables_UpdateFields_PriorityOutOfRange - валидация priority 1-5.
+func TestSystemTables_UpdateFields_PriorityOutOfRange(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	rec := testutil.POST(t, e, "/system-tables",
+		`{"name":"prio_bad","display_name":"PB","table_type":"cars"}`, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	tableID := int(testutil.ParseMap(t, rec)["id"].(float64))
+
+	body := `{"fields":[{"field_name":"car_number","is_visible":true,"priority":9}]}`
+	rec = testutil.PUT(t, e, fmt.Sprintf("/system-tables/%d/fields", tableID), body, h)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// TestSystemTables_Update_PersistsAppearance - #345 Phase 1D+1E:
+// PUT /system-tables/:id сохраняет font_size и row_density.
+func TestSystemTables_Update_PersistsAppearance(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	rec := testutil.POST(t, e, "/system-tables",
+		`{"name":"style_test","display_name":"ST","table_type":"cars"}`, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	tableID := int(testutil.ParseMap(t, rec)["id"].(float64))
+
+	rec = testutil.PUT(t, e, fmt.Sprintf("/system-tables/%d", tableID),
+		`{"font_size":18,"row_density":"spacious"}`, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = testutil.GET(t, e, fmt.Sprintf("/system-tables/%d", tableID), h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	table := testutil.ParseMap(t, rec)["table"].(map[string]interface{})
+	assert.EqualValues(t, 18, table["font_size"], "font_size=18")
+	assert.Equal(t, "spacious", table["row_density"], "row_density=spacious")
+}
+
+// TestSystemTables_Update_FontSizeOutOfRange - валидация 10-24.
+func TestSystemTables_Update_FontSizeOutOfRange(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	rec := testutil.POST(t, e, "/system-tables",
+		`{"name":"fs_bad","display_name":"FB","table_type":"cars"}`, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	tableID := int(testutil.ParseMap(t, rec)["id"].(float64))
+
+	rec = testutil.PUT(t, e, fmt.Sprintf("/system-tables/%d", tableID),
+		`{"font_size":30}`, h)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// TestSystemTables_Update_BadRowDensity - валидация enum row_density.
+func TestSystemTables_Update_BadRowDensity(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	rec := testutil.POST(t, e, "/system-tables",
+		`{"name":"den_bad","display_name":"DB","table_type":"cars"}`, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	tableID := int(testutil.ParseMap(t, rec)["id"].(float64))
+
+	rec = testutil.PUT(t, e, fmt.Sprintf("/system-tables/%d", tableID),
+		`{"row_density":"huge"}`, h)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}

--- a/internal/models/system_table.go
+++ b/internal/models/system_table.go
@@ -18,6 +18,11 @@ type SystemTable struct {
 	StatusComment       *string   `gorm:"type:text" json:"status_comment"`
 	LocationDescription *string   `gorm:"type:text" json:"location_description"`
 
+	// Оформление таблицы (#345). FontSize - размер шрифта строк (px, 10-24).
+	// RowDensity - плотность строк: compact|normal|spacious.
+	FontSize    int    `gorm:"default:14" json:"font_size"`
+	RowDensity  string `gorm:"size:20;default:'normal'" json:"row_density"`
+
 	Fields    []TableField            `gorm:"foreignKey:TableID" json:"fields,omitempty"`
 	TimeSlots []SystemTableTimeSlot   `gorm:"foreignKey:TableID" json:"time_slots,omitempty"`
 	Photos    []SystemTablePhoto      `gorm:"foreignKey:TableID" json:"photos,omitempty"`
@@ -77,7 +82,10 @@ type TableField struct {
 	IsVisible    bool        `gorm:"default:true" json:"is_visible"`
 	// Width - относительный вес ширины столбца. Используется как flex-grow:
 	// браузер делит доступную ширину пропорционально весам видимых столбцов.
-	Width     int       `gorm:"default:10" json:"width"`
+	Width int `gorm:"default:10" json:"width"`
+	// Priority - приоритет столбца для портретного режима (1-5).
+	// 1 = всегда виден, 2 = виден на компактных экранах, 3-5 = скрывается в портрете.
+	Priority  int       `gorm:"default:3" json:"priority"`
 	CreatedAt time.Time `json:"created_at"`
 }
 
@@ -115,6 +123,10 @@ type UpdateSystemTableRequest struct {
 	Status              *string `json:"status"`
 	StatusComment       *string `json:"status_comment"`
 	LocationDescription *string `json:"location_description"`
+	// Оформление таблицы (#345). Валидируется в сервисе: FontSize 10-24,
+	// RowDensity in {compact, normal, spacious}.
+	FontSize   *int    `json:"font_size"`
+	RowDensity *string `json:"row_density"`
 }
 
 // CreateTimeSlotRequest -- запрос на создание временного слота.
@@ -135,13 +147,14 @@ type UpdateTimeSlotRequest struct {
 	IsActive  *bool   `json:"is_active"`
 }
 
-// FieldVisibilityUpdate -- одиночное обновление видимости, порядка и ширины столбца (#345).
-// DisplayOrder и Width опциональны - если не переданы, не меняются.
+// FieldVisibilityUpdate -- одиночное обновление видимости, порядка, ширины и
+// приоритета столбца (#345). DisplayOrder, Width, Priority опциональны.
 type FieldVisibilityUpdate struct {
 	FieldName    string `json:"field_name" validate:"required"`
 	IsVisible    bool   `json:"is_visible"`
 	DisplayOrder *int   `json:"display_order"`
 	Width        *int   `json:"width"`
+	Priority     *int   `json:"priority"`
 }
 
 // UpdateFieldsRequest -- bulk-обновление видимости столбцов системной таблицы.

--- a/internal/services/system_table_service.go
+++ b/internal/services/system_table_service.go
@@ -231,44 +231,48 @@ func (s *systemTableService) GetByName(ctx context.Context, name string) (*model
 // defaultField -- описание поля по умолчанию для нового типа таблицы.
 // IsVisible: включён ли столбец сразу при создании таблицы.
 // Width: относительный вес ширины (flex-grow) - браузер делит ширину пропорционально.
+// Priority: приоритет столбца в портретном режиме (1-5). 1 = всегда виден,
+// 2 = на компактных экранах, 3-5 = скрывается в портрете.
 type defaultField struct {
 	Name      string
 	FieldType string
 	IsVisible bool
 	Width     int
+	Priority  int
 }
 
 // getDefaultFields возвращает набор полей по умолчанию для типа таблицы.
 // Базовые - видимы сразу. Расширенные - скрыты, включаются админом в "Колонки".
 // Width - относительный вес flex-grow, подобранный под типичный контент столбца.
+// Priority - приоритет для портретного режима (см. defaultField).
 func getDefaultFields(tableType string) []defaultField {
 	switch tableType {
 	case "cars":
 		return []defaultField{
-			{"car_number", "text", true, 10},
-			{"car_brand", "text", true, 9},
-			{"organization", "text", true, 18},
-			{"unload_place", "text", true, 15},
-			{"valid_until", "date", true, 12},
-			{"time_range", "text", true, 10},
-			{"status", "text", true, 7},
+			{"car_number", "text", true, 10, 1},
+			{"car_brand", "text", true, 9, 3},
+			{"organization", "text", true, 18, 3},
+			{"unload_place", "text", true, 15, 3},
+			{"valid_until", "date", true, 12, 2},
+			{"time_range", "text", true, 10, 3},
+			{"status", "text", true, 7, 2},
 			// Расширенные (по умолчанию скрытые)
-			{"company", "text", false, 12},
-			{"application_id", "text", false, 12},
+			{"company", "text", false, 12, 4},
+			{"application_id", "text", false, 12, 4},
 		}
 	case "people":
 		return []defaultField{
-			{"organization", "text", true, 16},
-			{"last_name", "text", true, 14},
-			{"first_name", "text", true, 9},
-			{"middle_name", "text", true, 11},
-			{"valid_until", "date", true, 11},
-			{"pass_time", "text", true, 13},
+			{"organization", "text", true, 16, 3},
+			{"last_name", "text", true, 14, 1},
+			{"first_name", "text", true, 9, 2},
+			{"middle_name", "text", true, 11, 3},
+			{"valid_until", "date", true, 11, 2},
+			{"pass_time", "text", true, 13, 3},
 			// Расширенные (по умолчанию скрытые)
-			{"position", "text", false, 11},
-			{"citizenship_name", "text", false, 10},
-			{"company", "text", false, 11},
-			{"application_id", "text", false, 12},
+			{"position", "text", false, 11, 4},
+			{"citizenship_name", "text", false, 10, 4},
+			{"company", "text", false, 11, 4},
+			{"application_id", "text", false, 12, 4},
 		}
 	default:
 		return nil
@@ -322,6 +326,10 @@ func (s *systemTableService) Create(ctx context.Context, req models.CreateSystem
 		for i, f := range fields {
 			order := i
 			fieldType := f.FieldType
+			priority := f.Priority
+			if priority == 0 {
+				priority = 3
+			}
 			tf := models.TableField{
 				TableID:      table.ID,
 				FieldName:    f.Name,
@@ -329,6 +337,7 @@ func (s *systemTableService) Create(ctx context.Context, req models.CreateSystem
 				DisplayOrder: &order,
 				IsVisible:    f.IsVisible,
 				Width:        f.Width,
+				Priority:     priority,
 			}
 			if err := tx.Create(&tf).Error; err != nil {
 				slog.Error("не удалось создать поле таблицы", "table_id", table.ID, "field", f.Name, "error", err)
@@ -398,6 +407,20 @@ func (s *systemTableService) Update(ctx context.Context, id int, req models.Upda
 	}
 	if req.LocationDescription != nil {
 		updates["location_description"] = *req.LocationDescription
+	}
+	if req.FontSize != nil {
+		if *req.FontSize < 10 || *req.FontSize > 24 {
+			return echo.NewHTTPError(http.StatusBadRequest, "font_size должен быть от 10 до 24")
+		}
+		updates["font_size"] = *req.FontSize
+	}
+	if req.RowDensity != nil {
+		switch *req.RowDensity {
+		case "compact", "normal", "spacious":
+			updates["row_density"] = *req.RowDensity
+		default:
+			return echo.NewHTTPError(http.StatusBadRequest, "row_density должен быть compact|normal|spacious")
+		}
 	}
 
 	if len(updates) == 1 {
@@ -496,6 +519,12 @@ func (s *systemTableService) UpdateFields(ctx context.Context, tableID int, req 
 			if f.Width != nil {
 				updates["width"] = *f.Width
 			}
+			if f.Priority != nil {
+				if *f.Priority < 1 || *f.Priority > 5 {
+					return echo.NewHTTPError(http.StatusBadRequest, "priority должен быть от 1 до 5")
+				}
+				updates["priority"] = *f.Priority
+			}
 			result := tx.Model(&models.TableField{}).
 				Where("table_id = ? AND field_name = ?", tableID, f.FieldName).
 				Updates(updates)
@@ -545,24 +574,35 @@ func (s *systemTableService) SeedMissingFields(ctx context.Context) error {
 			}
 		}
 
-		// Backfill: для существующих полей с width=0 (старые записи без width) -
-		// проставляем дефолтную ширину из getDefaultFields.
+		// Backfill: для существующих полей с width=0 / priority=0 (старые записи) -
+		// проставляем дефолты из getDefaultFields.
 		defaultsByName := make(map[string]defaultField, len(defaults))
 		for _, d := range defaults {
 			defaultsByName[d.Name] = d
 		}
 		for _, f := range existing {
-			if f.Width != 0 {
+			d, ok := defaultsByName[f.FieldName]
+			if !ok {
 				continue
 			}
-			d, ok := defaultsByName[f.FieldName]
-			if !ok || d.Width == 0 {
+			backfill := map[string]interface{}{}
+			if f.Width == 0 && d.Width != 0 {
+				backfill["width"] = d.Width
+			}
+			if f.Priority == 0 {
+				p := d.Priority
+				if p == 0 {
+					p = 3
+				}
+				backfill["priority"] = p
+			}
+			if len(backfill) == 0 {
 				continue
 			}
 			if err := s.db.WithContext(ctx).Model(&models.TableField{}).
 				Where("id = ?", f.ID).
-				Update("width", d.Width).Error; err != nil {
-				slog.Error("не удалось backfill width",
+				Updates(backfill).Error; err != nil {
+				slog.Error("не удалось backfill столбца",
 					"table_id", t.ID, "field", f.FieldName, "error", err)
 			}
 		}
@@ -574,6 +614,10 @@ func (s *systemTableService) SeedMissingFields(ctx context.Context) error {
 			maxOrder++
 			order := maxOrder
 			fieldType := d.FieldType
+			priority := d.Priority
+			if priority == 0 {
+				priority = 3
+			}
 			tf := models.TableField{
 				TableID:      t.ID,
 				FieldName:    d.Name,
@@ -581,6 +625,7 @@ func (s *systemTableService) SeedMissingFields(ctx context.Context) error {
 				DisplayOrder: &order,
 				IsVisible:    d.IsVisible,
 				Width:        d.Width,
+				Priority:     priority,
 			}
 			if err := s.db.WithContext(ctx).Create(&tf).Error; err != nil {
 				slog.Error("не удалось добавить отсутствующее поле",


### PR DESCRIPTION
## Что в PR

Три фазы #345 одним релизом + полировка ширины:

### Polish 1C
- В админ-вкладке "Колонки" вместо буквы "w" - читаемый "Ширина:", сам input стал меньше.

### Phase 1D - размер шрифта
- Бэк: SystemTable.FontSize (10-24, дефолт 14), валидация в PUT /system-tables/:id.
- Фронт: вкладка "Оформление" - слайдер размера. Применяется через CSS-переменную --table-font-size в строках CarsTable/PeopleTable. Шапка не масштабируется (как в "Увеличенном режиме").

### Phase 1E - плотность строк
- Бэк: SystemTable.RowDensity ('compact'|'normal'|'spacious', дефолт 'normal').
- Фронт: сегмент-контрол в той же вкладке "Оформление". Меняет vertical padding строк через class density-*.

### Phase 1F - портретный режим
- Бэк: TableField.Priority (1-5, дефолт 3). Bulk-PUT /fields принимает priority. Валидация.
- Бэк: каталоги cars/people получили дефолтные приоритеты (car_number/last_name = 1, valid_until/status = 2, остальное 3-4).
- Бэк: SeedMissingFields backfill priority для существующих таблиц.
- Фронт: composable useOrientation - реактивный isPortrait/isCompact. isCompact = portrait + ширина < 1100.
- Фронт: в CarsTable/PeopleTable - в isCompact скрываем столбцы с priority>2. Под строкой появляется кнопка "Подробнее" (chevron) - раскрывает inline-блок со скрытыми полями в формате label: value.
- Фронт: card-header в портрете уходит в вертикальный стек.
- Фронт: в админ-вкладке "Колонки" - селектор приоритета 1-5 рядом с шириной.

## Тесты

- Go: TestSystemTables_UpdateFields_PersistsPriority, TestSystemTables_UpdateFields_PriorityOutOfRange, TestSystemTables_Update_PersistsAppearance, TestSystemTables_Update_FontSizeOutOfRange, TestSystemTables_Update_BadRowDensity. Все зелёные.
- Vitest: useOrientation.spec.js. 298 тестов всего, все зелёные.

## Test plan

- [ ] Личный кабинет -> Управление системой -> Таблицы -> выбрать таблицу -> вкладка "Колонки": поле "Ширина:" вместо "w", селектор "Приоритет" 1-5 справа.
- [ ] Вкладка "Оформление": слайдер 12-22, сегмент Компактно/Обычно/Просторно. Сохранить - обновить страницу - значения сохранились.
- [ ] Изменить font_size на 20 - в CarsTable/PeopleTable строки крупнее, заголовки прежние.
- [ ] Изменить плотность на "Просторно" - строки выше.
- [ ] DevTools -> Toggle device toolbar -> 1080x1920 (portrait) - в таблице скрываются столбцы priority>2, появляется chevron под каждой строкой. Клик - раскрытие, повторный клик - сворачивание.