### PR TITLE
feat: фактовая таблица с собственными настройками колонок и оформления (#345)

### DIFF
--- a/frontend/src/components/FactTable.vue
+++ b/frontend/src/components/FactTable.vue
@@ -1,6 +1,11 @@
 <template>
   <div
     class="fact-table-card"
+    :class="[
+      { 'config-not-ready': !configReady },
+      `density-${rowDensity}`,
+    ]"
+    :style="{ '--table-font-size': tableFontSize + 'px' }"
     data-testid="fact-table"
   >
     <div class="card-header">
@@ -35,36 +40,39 @@
             Выезд
           </div>
           <div
+            v-if="isFieldVisible('organization')"
             class="col organization-col"
+            :style="getColStyle('organization')"
             @click="sortBy('organization')"
           >
             <p :class="{ 'active-sort': sortField === 'organization' }">
               Организация
             </p>
-            <img 
-              src="@/assets/icons/sort.png" 
-              class="sort-icon" 
-              :class="{ 
+            <img
+              src="@/assets/icons/sort.png"
+              class="sort-icon"
+              :class="{
                 'sorted': sortField === 'organization',
                 'desc': sortField === 'organization' && sortDirection === 'desc'
-              }" 
+              }"
             >
           </div>
           <div
-            v-if="tableType === 'cars'"
+            v-if="tableType === 'cars' && isFieldVisible('car_brand')"
             class="col brand-col"
+            :style="getColStyle('car_brand')"
             @click="sortBy('car_brand')"
           >
             <p :class="{ 'active-sort': sortField === 'car_brand' }">
               Марка
             </p>
-            <img 
-              src="@/assets/icons/sort.png" 
-              class="sort-icon" 
-              :class="{ 
+            <img
+              src="@/assets/icons/sort.png"
+              class="sort-icon"
+              :class="{
                 'sorted': sortField === 'car_brand',
                 'desc': sortField === 'car_brand' && sortDirection === 'desc'
-              }" 
+              }"
             >
           </div>
           <!-- Компания скрыта -->
@@ -87,35 +95,39 @@
           </div>
           -->
           <div
+            v-if="isFieldVisible('valid_until')"
             class="col date-col"
+            :style="getColStyle('valid_until')"
             @click="sortBy('entry_date_to')"
           >
             <p :class="{ 'active-sort': sortField === 'entry_date_to' }">
               Действует до
             </p>
-            <img 
-              src="@/assets/icons/sort.png" 
-              class="sort-icon" 
-              :class="{ 
+            <img
+              src="@/assets/icons/sort.png"
+              class="sort-icon"
+              :class="{
                 'sorted': sortField === 'entry_date_to',
                 'desc': sortField === 'entry_date_to' && sortDirection === 'desc'
-              }" 
+              }"
             >
           </div>
           <div
+            v-if="isFieldVisible(tableType === 'cars' ? 'time_range' : 'pass_time')"
             class="col time-col"
+            :style="getColStyle(tableType === 'cars' ? 'time_range' : 'pass_time')"
             @click="sortBy('entry_time')"
           >
             <p :class="{ 'active-sort': sortField === 'entry_time' }">
               {{ tableType === 'cars' ? 'Время' : 'Время прохода' }}
             </p>
-            <img 
-              src="@/assets/icons/sort.png" 
-              class="sort-icon" 
-              :class="{ 
+            <img
+              src="@/assets/icons/sort.png"
+              class="sort-icon"
+              :class="{
                 'sorted': sortField === 'entry_time',
                 'desc': sortField === 'entry_time' && sortDirection === 'desc'
-              }" 
+              }"
             >
           </div>
           <!--<div class="col status-col" @click="sortBy('status')">
@@ -189,31 +201,33 @@
                     Выезд
                   </button>
                 </div>
-                <div class="col organization-col">
+                <div
+                  v-if="isFieldVisible('organization')"
+                  class="col organization-col"
+                  :style="getColStyle('organization')"
+                >
                   {{ item.organization_name }}
                 </div>
                 <div
-                  v-if="tableType === 'cars'"
+                  v-if="tableType === 'cars' && isFieldVisible('car_brand')"
                   class="col brand-col"
+                  :style="getColStyle('car_brand')"
                 >
                   {{ item.car_brand || '-' }}
                 </div>
-                <!-- Компания скрыта -->
                 <div
-                  v-if="tableType === 'cars'"
-                  class="col company-col"
-                  style="display: none;"
-                />
-                <!-- Место разгрузки – закомментировано по требованию
-                <div v-if="tableType === 'cars'" class="col place-col">
-                  {{ formatUnloadPlaces(item) }}
-                </div>
-                -->
-                <div class="col date-col">
+                  v-if="isFieldVisible('valid_until')"
+                  class="col date-col"
+                  :style="getColStyle('valid_until')"
+                >
                   {{ formatDate(item.entry_date_to) }}
                 </div>
-                <div class="col time-col">
-                  {{ tableType === 'cars' 
+                <div
+                  v-if="isFieldVisible(tableType === 'cars' ? 'time_range' : 'pass_time')"
+                  class="col time-col"
+                  :style="getColStyle(tableType === 'cars' ? 'time_range' : 'pass_time')"
+                >
+                  {{ tableType === 'cars'
                     ? formatTimeRange(item.entry_time_from, item.entry_time_to)
                     : formatPassTime(item.pass_time)
                   }}
@@ -283,6 +297,8 @@ export default {
   },
   props: {
     tableType: { type: String, default: 'cars', validator: (v) => ['cars', 'people'].includes(v) },
+    tableId: { type: Number, default: null },
+    tableData: { type: Object, default: null },
     searchQuery: { type: String, default: '' },
     selectedOrganizationId: { type: [Number, String], default: null },
     selectedUnloadingPlaceId: { type: [Number, String], default: null },
@@ -305,7 +321,13 @@ export default {
       licensePlateFormats: [],
       showDetailsModal: false,
       selectedVehicle: null,
-      pollingInterval: null
+      pollingInterval: null,
+      fieldsVisibility: {},
+      fieldOrders: {},
+      fieldWidths: {},
+      tableFontSize: 14,
+      rowDensity: 'normal',
+      configReady: false,
     };
   },
   computed: {
@@ -405,7 +427,37 @@ export default {
         this.startPolling();
       },
       immediate: true
-    }
+    },
+    // Применяем фактовые настройки таблицы (#345 PR-B).
+    tableData: {
+      immediate: true,
+      deep: true,
+      handler(newVal) {
+        if (!newVal) return;
+        const tbl = newVal.table || {};
+        const factFields = newVal.fact_fields || [];
+        const nextVis = {};
+        const nextOrd = {};
+        const nextW = {};
+        factFields.forEach(f => {
+          nextVis[f.field_name] = f.is_visible !== false;
+          if (typeof f.display_order === 'number') nextOrd[f.field_name] = f.display_order;
+          if (typeof f.width === 'number' && f.width > 0) nextW[f.field_name] = f.width;
+        });
+        this.fieldsVisibility = nextVis;
+        this.fieldOrders = nextOrd;
+        this.fieldWidths = nextW;
+        const fs = Number(tbl.font_size_fact);
+        if (fs >= 10 && fs <= 24) this.tableFontSize = fs;
+        const dens = tbl.row_density_fact;
+        if (['compact', 'normal', 'spacious'].includes(dens)) this.rowDensity = dens;
+        if (typeof requestAnimationFrame === 'function') {
+          requestAnimationFrame(() => { this.configReady = true; });
+        } else {
+          this.configReady = true;
+        }
+      },
+    },
   },
   mounted() {
     this.startPolling();
@@ -414,6 +466,20 @@ export default {
     this.stopPolling();
   },
   methods: {
+    isFieldVisible(fieldName) {
+      const v = this.fieldsVisibility[fieldName];
+      return v === undefined ? true : v;
+    },
+
+    getColStyle(fieldName) {
+      const order = this.fieldOrders[fieldName];
+      const width = this.fieldWidths[fieldName];
+      const style = {};
+      if (order !== undefined) style.order = 10 + order;
+      if (width !== undefined && width > 0) style.flexGrow = width;
+      return Object.keys(style).length ? style : null;
+    },
+
     async _loadData() {
       try {
         await this.fetchUnloadingPlaces();
@@ -1091,5 +1157,29 @@ export default {
   align-items: center;
   justify-content: center;
   gap: 12px;
+}
+
+/* #345 PR-B: размер шрифта строк через CSS-переменную (только тело). */
+.fact-table-card .fact-body .col {
+  font-size: var(--table-font-size, 14px);
+}
+
+/* Плотность строк через padding row. */
+.fact-table-card.density-compact .fact-row,
+.fact-table-card.density-compact .header-row {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.fact-table-card.density-spacious .fact-row,
+.fact-table-card.density-spacious .header-row {
+  padding-top: 16px;
+  padding-bottom: 16px;
+}
+
+/* Пока конфиг не загружен - запрещаем transitions на col, чтобы шапка не
+   "ездила" между дефолтными и сохранёнными ширинами при первом рендере. */
+.fact-table-card.config-not-ready .col {
+  transition: none !important;
 }
 </style>

--- a/frontend/src/components/SystemTableAppearanceTab.vue
+++ b/frontend/src/components/SystemTableAppearanceTab.vue
@@ -90,6 +90,9 @@ export default {
   props: {
     tableId: { type: Number, required: true },
     table: { type: Object, required: true },
+    // 'main' - читает/пишет font_size, row_density. 'fact' - font_size_fact,
+    // row_density_fact (отдельные настройки для FactTable).
+    variant: { type: String, default: 'main' },
   },
   emits: ['update'],
   data() {
@@ -109,6 +112,12 @@ export default {
     };
   },
   computed: {
+    fontSizeKey() {
+      return this.variant === 'fact' ? 'font_size_fact' : 'font_size';
+    },
+    densityKey() {
+      return this.variant === 'fact' ? 'row_density_fact' : 'row_density';
+    },
     isDirty() {
       return this.fontSize !== this.originalFontSize
         || this.rowDensity !== this.originalDensity;
@@ -125,9 +134,9 @@ export default {
   },
   methods: {
     reset() {
-      const fs = Number(this.table?.font_size);
+      const fs = Number(this.table?.[this.fontSizeKey]);
       this.fontSize = fs >= 10 && fs <= 24 ? fs : DEFAULT_FONT_SIZE;
-      const dens = this.table?.row_density;
+      const dens = this.table?.[this.densityKey];
       this.rowDensity = ['compact', 'normal', 'spacious'].includes(dens) ? dens : DEFAULT_DENSITY;
       this.originalFontSize = this.fontSize;
       this.originalDensity = this.rowDensity;
@@ -144,8 +153,8 @@ export default {
         const response = await apiRequest(`/system-tables/${this.tableId}`, {
           method: 'PUT',
           body: JSON.stringify({
-            font_size: fs,
-            row_density: this.rowDensity,
+            [this.fontSizeKey]: fs,
+            [this.densityKey]: this.rowDensity,
           }),
         });
         if (!response.ok) {

--- a/frontend/src/components/SystemTableColumnsTab.vue
+++ b/frontend/src/components/SystemTableColumnsTab.vue
@@ -164,7 +164,7 @@
     </p>
 
     <div
-      v-if="localFields.length"
+      v-if="localFields.length && variant === 'main'"
       class="columns-tab__preview"
     >
       <h4 class="columns-tab__preview-title">
@@ -237,6 +237,9 @@ export default {
     tableId: { type: Number, required: true },
     tableType: { type: String, required: true },
     fields: { type: Array, required: true },
+    // 'main' = настройки обычной CarsTable/PeopleTable (endpoint /fields).
+    // 'fact' = настройки FactTable (endpoint /fact-fields).
+    variant: { type: String, default: 'main' },
   },
   emits: ['update'],
   data() {
@@ -254,6 +257,11 @@ export default {
     };
   },
   computed: {
+    apiPath() {
+      return this.variant === 'fact'
+        ? `/system-tables/${this.tableId}/fact-fields`
+        : `/system-tables/${this.tableId}/fields`;
+    },
     previewFieldsWithOrder() {
       // Передаём текущий локальный порядок+ширину в превью, чтобы оно реагировало до save.
       return this.localFields.map((f, i) => ({
@@ -380,7 +388,7 @@ export default {
       this.statusError = false;
 
       try {
-        const response = await apiRequest(`/system-tables/${this.tableId}/fields`, {
+        const response = await apiRequest(this.apiPath, {
           method: 'PUT',
           body: JSON.stringify({
             fields: this.localFields.map((f, i) => ({

--- a/frontend/src/components/TableConstructor.vue
+++ b/frontend/src/components/TableConstructor.vue
@@ -168,6 +168,22 @@
           >
             Оформление
           </button>
+          <button
+            v-if="selectedTable.table.show_fact_table"
+            class="tab-btn"
+            :class="{ 'active': activeTab === 'fact-columns' }"
+            @click="activeTab = 'fact-columns'"
+          >
+            Колонки (факт)
+          </button>
+          <button
+            v-if="selectedTable.table.show_fact_table"
+            class="tab-btn"
+            :class="{ 'active': activeTab === 'fact-appearance' }"
+            @click="activeTab = 'fact-appearance'"
+          >
+            Оформление (факт)
+          </button>
         </div>
 
         <!-- Вкладка Основное -->
@@ -490,6 +506,33 @@
             @update="refreshSelectedTable"
           />
         </div>
+
+        <!-- Колонки FactTable (#345) -->
+        <div
+          v-if="activeTab === 'fact-columns' && selectedTable.table.show_fact_table"
+          class="tab-content"
+        >
+          <SystemTableColumnsTab
+            :table-id="selectedTable.table.id"
+            :table-type="selectedTable.table.table_type"
+            :fields="selectedTable.fact_fields || []"
+            variant="fact"
+            @update="refreshSelectedTable"
+          />
+        </div>
+
+        <!-- Оформление FactTable (#345) -->
+        <div
+          v-if="activeTab === 'fact-appearance' && selectedTable.table.show_fact_table"
+          class="tab-content"
+        >
+          <SystemTableAppearanceTab
+            :table-id="selectedTable.table.id"
+            :table="selectedTable.table"
+            variant="fact"
+            @update="refreshSelectedTable"
+          />
+        </div>
       </div>
 
       <div
@@ -639,6 +682,24 @@ export default {
   },
   beforeUnmount() {
     window.removeEventListener('show-notification', this.handleNotification);
+  },
+  watch: {
+    // Если активна вкладка фактовой таблицы, а пользователь снял галочку
+    // show_fact_table - возвращаем на главную, чтобы не висел пустой контент.
+    'selectedTable.table.show_fact_table'(val) {
+      if (!val && (this.activeTab === 'fact-columns' || this.activeTab === 'fact-appearance')) {
+        this.activeTab = 'main';
+      }
+    },
+    selectedTable(newVal) {
+      // При переключении таблицы сбрасываем тикеры fact-вкладок, если на новой
+      // таблице фактовая часть выключена.
+      if (newVal && !newVal.table?.show_fact_table) {
+        if (this.activeTab === 'fact-columns' || this.activeTab === 'fact-appearance') {
+          this.activeTab = 'main';
+        }
+      }
+    },
   },
   methods: {
     handleNotification(event) {

--- a/frontend/src/components/TablesComponent.vue
+++ b/frontend/src/components/TablesComponent.vue
@@ -140,6 +140,8 @@
         <FactTable
           v-if="currentUserId"
           :table-type="tableType"
+          :table-id="tableData?.table?.id"
+          :table-data="tableData"
           :search-query="searchQuery"
           :selected-organization="selectedOrganizationName"
           :selected-unloading-place="selectedUnloadingPlaceName"

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -41,6 +41,7 @@ func AllModels() []interface{} {
 		&models.OrganizationTable{},
 		&models.CompaniesTable{},
 		&models.TableField{},
+		&models.TableFieldFact{},
 
 		// Unload places relations
 		&models.UnloadPlacePhoto{},

--- a/internal/handlers/system_tables.go
+++ b/internal/handlers/system_tables.go
@@ -191,6 +191,35 @@ func (h *SystemTableHandler) UpdateFields(c echo.Context) error {
 	return RespondMessage(c, "Видимость столбцов обновлена")
 }
 
+// UpdateFactFields godoc
+// @Summary      Bulk-обновление столбцов FactTable (#345)
+// @Description  То же что UpdateFields, но для table_fields_fact.
+// @Tags         system-tables
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID таблицы"
+// @Param        request body models.UpdateFieldsRequest true "Список столбцов с новой видимостью"
+// @Success      200 {string} string "Видимость столбцов FactTable обновлена"
+// @Failure      400 {object} models.HTTPError
+// @Failure      401 {object} models.HTTPError
+// @Failure      404 {object} models.HTTPError
+// @Router       /system-tables/{id}/fact-fields [put]
+func (h *SystemTableHandler) UpdateFactFields(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	var req models.UpdateFieldsRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	if err := h.service.UpdateFactFields(c.Request().Context(), id, req); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Видимость столбцов FactTable обновлена")
+}
+
 // --- Временные слоты ---
 
 // GetTimeSlots godoc

--- a/internal/handlers/system_tables_test.go
+++ b/internal/handlers/system_tables_test.go
@@ -511,3 +511,90 @@ func TestSystemTables_Update_BadRowDensity(t *testing.T) {
 		`{"row_density":"huge"}`, h)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
+
+// TestSystemTables_UpdateFactFields_PersistsVisibility - #345 PR-B:
+// PUT /:id/fact-fields сохраняет видимость в table_field_facts. Существующие
+// fact-поля создаются при включении show_fact_table.
+func TestSystemTables_UpdateFactFields_PersistsVisibility(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	rec := testutil.POST(t, e, "/system-tables",
+		`{"name":"fact_vis","display_name":"FV","table_type":"cars","show_fact_table":true}`, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	tableID := int(testutil.ParseMap(t, rec)["id"].(float64))
+
+	// Скрываем organization, показываем car_number.
+	body := `{"fields":[
+		{"field_name":"organization","is_visible":false},
+		{"field_name":"car_number","is_visible":true}
+	]}`
+	rec = testutil.PUT(t, e, fmt.Sprintf("/system-tables/%d/fact-fields", tableID), body, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = testutil.GET(t, e, fmt.Sprintf("/system-tables/%d", tableID), h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	factFields := testutil.ParseMap(t, rec)["fact_fields"].([]interface{})
+
+	visByName := map[string]bool{}
+	for _, f := range factFields {
+		fm := f.(map[string]interface{})
+		visByName[fm["field_name"].(string)] = fm["is_visible"].(bool)
+	}
+	assert.False(t, visByName["organization"], "organization скрыта")
+	assert.True(t, visByName["car_number"], "car_number видима")
+	// Поле, которое не трогали, сохранило дефолт каталога (car_brand=visible).
+	assert.True(t, visByName["car_brand"], "car_brand видимо (дефолт)")
+}
+
+// TestSystemTables_Update_PersistsAppearanceFact - валидация и сохранение
+// font_size_fact и row_density_fact.
+func TestSystemTables_Update_PersistsAppearanceFact(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	rec := testutil.POST(t, e, "/system-tables",
+		`{"name":"fact_style","display_name":"FS","table_type":"cars","show_fact_table":true}`, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	tableID := int(testutil.ParseMap(t, rec)["id"].(float64))
+
+	rec = testutil.PUT(t, e, fmt.Sprintf("/system-tables/%d", tableID),
+		`{"font_size_fact":20,"row_density_fact":"compact"}`, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = testutil.GET(t, e, fmt.Sprintf("/system-tables/%d", tableID), h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	tbl := testutil.ParseMap(t, rec)["table"].(map[string]interface{})
+	assert.EqualValues(t, 20, tbl["font_size_fact"], "font_size_fact=20")
+	assert.Equal(t, "compact", tbl["row_density_fact"], "row_density_fact=compact")
+	// Обычное оформление не изменилось.
+	assert.EqualValues(t, 14, tbl["font_size"], "font_size остался 14")
+	assert.Equal(t, "normal", tbl["row_density"], "row_density остался normal")
+}
+
+// TestSystemTables_Update_FactFontSizeOutOfRange - валидация 10-24 для fact-варианта.
+func TestSystemTables_Update_FactFontSizeOutOfRange(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	rec := testutil.POST(t, e, "/system-tables",
+		`{"name":"fact_fs_bad","display_name":"FF","table_type":"cars","show_fact_table":true}`, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	tableID := int(testutil.ParseMap(t, rec)["id"].(float64))
+
+	rec = testutil.PUT(t, e, fmt.Sprintf("/system-tables/%d", tableID),
+		`{"font_size_fact":50}`, h)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}

--- a/internal/models/system_table.go
+++ b/internal/models/system_table.go
@@ -22,10 +22,14 @@ type SystemTable struct {
 	// RowDensity - плотность строк: compact|normal|spacious.
 	FontSize    int    `gorm:"default:14" json:"font_size"`
 	RowDensity  string `gorm:"size:20;default:'normal'" json:"row_density"`
+	// То же самое, но для FactTable (отдельные настройки).
+	FontSizeFact   int    `gorm:"default:14" json:"font_size_fact"`
+	RowDensityFact string `gorm:"size:20;default:'normal'" json:"row_density_fact"`
 
-	Fields    []TableField            `gorm:"foreignKey:TableID" json:"fields,omitempty"`
-	TimeSlots []SystemTableTimeSlot   `gorm:"foreignKey:TableID" json:"time_slots,omitempty"`
-	Photos    []SystemTablePhoto      `gorm:"foreignKey:TableID" json:"photos,omitempty"`
+	Fields     []TableField          `gorm:"foreignKey:TableID" json:"fields,omitempty"`
+	FactFields []TableFieldFact      `gorm:"foreignKey:TableID" json:"fact_fields,omitempty"`
+	TimeSlots  []SystemTableTimeSlot `gorm:"foreignKey:TableID" json:"time_slots,omitempty"`
+	Photos     []SystemTablePhoto    `gorm:"foreignKey:TableID" json:"photos,omitempty"`
 }
 
 type SystemTablePhoto struct {
@@ -89,13 +93,30 @@ type TableField struct {
 	CreatedAt time.Time `json:"created_at"`
 }
 
+// TableFieldFact - настраиваемые столбцы FactTable. Хранится отдельно от
+// TableField, чтобы основная и фактовая таблицы конфигурировались независимо.
+// Семантика полей идентична TableField.
+type TableFieldFact struct {
+	ID           int         `json:"id"`
+	TableID      int         `gorm:"index" json:"table_id"`
+	Table        SystemTable `gorm:"foreignKey:TableID;constraint:OnDelete:CASCADE" json:"-"`
+	FieldName    string      `gorm:"size:100" json:"field_name"`
+	FieldType    *string     `gorm:"size:50" json:"field_type"`
+	DisplayOrder *int        `json:"display_order"`
+	IsVisible    bool        `gorm:"default:true" json:"is_visible"`
+	Width        int         `gorm:"default:10" json:"width"`
+	Priority     int         `gorm:"default:3" json:"priority"`
+	CreatedAt    time.Time   `json:"created_at"`
+}
+
 // SystemTableWithDetails -- таблица с полями, слотами, фото и текущим статусом (открыто/закрыто).
 type SystemTableWithDetails struct {
-	Table         SystemTable          `json:"table"`
-	Fields        []TableField         `json:"fields"`
+	Table         SystemTable           `json:"table"`
+	Fields        []TableField          `json:"fields"`
+	FactFields    []TableFieldFact      `json:"fact_fields"`
 	TimeSlots     []SystemTableTimeSlot `json:"time_slots"`
-	Photos        []SystemTablePhoto   `json:"photos"`
-	CurrentStatus string               `json:"current_status"`
+	Photos        []SystemTablePhoto    `json:"photos"`
+	CurrentStatus string                `json:"current_status"`
 }
 
 // CreateSystemTableRequest -- запрос на создание системной таблицы.
@@ -125,8 +146,10 @@ type UpdateSystemTableRequest struct {
 	LocationDescription *string `json:"location_description"`
 	// Оформление таблицы (#345). Валидируется в сервисе: FontSize 10-24,
 	// RowDensity in {compact, normal, spacious}.
-	FontSize   *int    `json:"font_size"`
-	RowDensity *string `json:"row_density"`
+	FontSize       *int    `json:"font_size"`
+	RowDensity     *string `json:"row_density"`
+	FontSizeFact   *int    `json:"font_size_fact"`
+	RowDensityFact *string `json:"row_density_fact"`
 }
 
 // CreateTimeSlotRequest -- запрос на создание временного слота.

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -311,6 +311,8 @@ func Setup(e *echo.Echo, d Dependencies) {
 
 	// Столбцы таблицы (#345)
 	stg.PUT("/:id/fields", st.UpdateFields)
+	// Столбцы фактовой таблицы (#345)
+	stg.PUT("/:id/fact-fields", st.UpdateFactFields)
 
 	// Корзина таблицы (#186) - удалённые элементы с возможностью восстановить
 	// или окончательно удалить. Тип элементов определяется по table_type

--- a/internal/services/system_table_service.go
+++ b/internal/services/system_table_service.go
@@ -44,6 +44,8 @@ type SystemTableService interface {
 
 	// Столбцы таблицы (#345): bulk-обновление видимости.
 	UpdateFields(ctx context.Context, tableID int, req models.UpdateFieldsRequest) error
+	// Столбцы фактовой таблицы (#345).
+	UpdateFactFields(ctx context.Context, tableID int, req models.UpdateFieldsRequest) error
 
 	// SeedMissingFields добавляет default-поля, которых ещё нет у существующих таблиц.
 	// Вызывается один раз при старте сервиса для миграции старых таблиц.
@@ -112,6 +114,9 @@ func (s *systemTableService) loadTableWithPreload(_ context.Context, query *gorm
 		Preload("Fields", func(db *gorm.DB) *gorm.DB {
 			return db.Order("display_order")
 		}).
+		Preload("FactFields", func(db *gorm.DB) *gorm.DB {
+			return db.Order("display_order")
+		}).
 		Preload("TimeSlots", func(db *gorm.DB) *gorm.DB {
 			return db.Order("day_of_week, open_time")
 		}).
@@ -125,6 +130,9 @@ func (s *systemTableService) loadTableWithPreload(_ context.Context, query *gorm
 
 	if table.Fields == nil {
 		table.Fields = []models.TableField{}
+	}
+	if table.FactFields == nil {
+		table.FactFields = []models.TableFieldFact{}
 	}
 	if table.TimeSlots == nil {
 		table.TimeSlots = []models.SystemTableTimeSlot{}
@@ -141,6 +149,7 @@ func (s *systemTableService) loadTableWithPreload(_ context.Context, query *gorm
 	return &models.SystemTableWithDetails{
 		Table:         table,
 		Fields:        table.Fields,
+		FactFields:    table.FactFields,
 		TimeSlots:     table.TimeSlots,
 		Photos:        table.Photos,
 		CurrentStatus: computeCurrentStatus(status, table.TimeSlots),
@@ -152,6 +161,9 @@ func (s *systemTableService) GetAll(ctx context.Context) ([]models.SystemTableWi
 	tables := make([]models.SystemTable, 0)
 	if err := s.db.WithContext(ctx).
 		Preload("Fields", func(db *gorm.DB) *gorm.DB {
+			return db.Order("display_order")
+		}).
+		Preload("FactFields", func(db *gorm.DB) *gorm.DB {
 			return db.Order("display_order")
 		}).
 		Preload("TimeSlots", func(db *gorm.DB) *gorm.DB {
@@ -176,6 +188,10 @@ func (s *systemTableService) GetAll(ctx context.Context) ([]models.SystemTableWi
 		if fields == nil {
 			fields = []models.TableField{}
 		}
+		factFields := t.FactFields
+		if factFields == nil {
+			factFields = []models.TableFieldFact{}
+		}
 		slots := t.TimeSlots
 		if slots == nil {
 			slots = []models.SystemTableTimeSlot{}
@@ -193,6 +209,7 @@ func (s *systemTableService) GetAll(ctx context.Context) ([]models.SystemTableWi
 		result = append(result, models.SystemTableWithDetails{
 			Table:         t,
 			Fields:        fields,
+			FactFields:    factFields,
 			TimeSlots:     slots,
 			Photos:        photos,
 			CurrentStatus: computeCurrentStatus(status, slots),
@@ -279,6 +296,45 @@ func getDefaultFields(tableType string) []defaultField {
 	}
 }
 
+// getDefaultFactFields - дефолты для FactTable. Отражают то, что сейчас
+// рендерится FactTable.vue: для cars - organization+car_brand+valid_until+time_range
+// (company скрыт, status/unload_place закомментированы); для people -
+// organization+valid_until+pass_time. Остальные поля каталога - скрыты,
+// чтобы админ мог их включить, если нужно.
+func getDefaultFactFields(tableType string) []defaultField {
+	switch tableType {
+	case "cars":
+		return []defaultField{
+			{"organization", "text", true, 18, 3},
+			{"car_brand", "text", true, 10, 3},
+			{"valid_until", "date", true, 12, 2},
+			{"time_range", "text", true, 10, 3},
+			// Скрыты (как сейчас в хардкоде)
+			{"car_number", "text", false, 10, 1},
+			{"unload_place", "text", false, 15, 3},
+			{"status", "text", false, 7, 2},
+			{"company", "text", false, 12, 4},
+			{"application_id", "text", false, 12, 4},
+		}
+	case "people":
+		return []defaultField{
+			{"organization", "text", true, 18, 3},
+			{"valid_until", "date", true, 12, 2},
+			{"pass_time", "text", true, 12, 3},
+			// Скрыты
+			{"last_name", "text", false, 14, 1},
+			{"first_name", "text", false, 9, 2},
+			{"middle_name", "text", false, 11, 3},
+			{"position", "text", false, 11, 4},
+			{"citizenship_name", "text", false, 10, 4},
+			{"company", "text", false, 11, 4},
+			{"application_id", "text", false, 12, 4},
+		}
+	default:
+		return nil
+	}
+}
+
 // Create создаёт системную таблицу с полями по умолчанию и автогенерацией разрешений.
 func (s *systemTableService) Create(ctx context.Context, req models.CreateSystemTableRequest) (int, error) {
 	// Проверяем уникальность имени
@@ -342,6 +398,28 @@ func (s *systemTableService) Create(ctx context.Context, req models.CreateSystem
 			if err := tx.Create(&tf).Error; err != nil {
 				slog.Error("не удалось создать поле таблицы", "table_id", table.ID, "field", f.Name, "error", err)
 				return echo.NewHTTPError(http.StatusInternalServerError, "Error creating table fields")
+			}
+		}
+		factFields := getDefaultFactFields(req.TableType)
+		for i, f := range factFields {
+			order := i
+			fieldType := f.FieldType
+			priority := f.Priority
+			if priority == 0 {
+				priority = 3
+			}
+			tff := models.TableFieldFact{
+				TableID:      table.ID,
+				FieldName:    f.Name,
+				FieldType:    &fieldType,
+				DisplayOrder: &order,
+				IsVisible:    f.IsVisible,
+				Width:        f.Width,
+				Priority:     priority,
+			}
+			if err := tx.Create(&tff).Error; err != nil {
+				slog.Error("не удалось создать факт-поле таблицы", "table_id", table.ID, "field", f.Name, "error", err)
+				return echo.NewHTTPError(http.StatusInternalServerError, "Error creating fact fields")
 			}
 		}
 		return nil
@@ -422,6 +500,20 @@ func (s *systemTableService) Update(ctx context.Context, id int, req models.Upda
 			return echo.NewHTTPError(http.StatusBadRequest, "row_density должен быть compact|normal|spacious")
 		}
 	}
+	if req.FontSizeFact != nil {
+		if *req.FontSizeFact < 10 || *req.FontSizeFact > 24 {
+			return echo.NewHTTPError(http.StatusBadRequest, "font_size_fact должен быть от 10 до 24")
+		}
+		updates["font_size_fact"] = *req.FontSizeFact
+	}
+	if req.RowDensityFact != nil {
+		switch *req.RowDensityFact {
+		case "compact", "normal", "spacious":
+			updates["row_density_fact"] = *req.RowDensityFact
+		default:
+			return echo.NewHTTPError(http.StatusBadRequest, "row_density_fact должен быть compact|normal|spacious")
+		}
+	}
 
 	if len(updates) == 1 {
 		// Только updated_at, нечего менять
@@ -437,6 +529,16 @@ func (s *systemTableService) Update(ctx context.Context, id int, req models.Upda
 	}
 	if result.RowsAffected == 0 {
 		return echo.NewHTTPError(http.StatusNotFound, "Системная таблица не найдена")
+	}
+
+	// Если только что включили show_fact_table - сидим факт-поля. Идемпотентно:
+	// уже существующие поля не дублируются.
+	if req.ShowFactTable != nil && *req.ShowFactTable && !table.ShowFactTable {
+		table.ShowFactTable = true
+		if err := s.seedFactFields(ctx, []models.SystemTable{table}); err != nil {
+			slog.Error("не удалось засидить факт-поля при включении флага",
+				"table_id", id, "error", err)
+		}
 	}
 
 	slog.Info("системная таблица обновлена", "id", id)
@@ -532,6 +634,46 @@ func (s *systemTableService) UpdateFields(ctx context.Context, tableID int, req 
 				slog.Error("не удалось обновить столбец",
 					"table_id", tableID, "field", f.FieldName, "error", result.Error)
 				return echo.NewHTTPError(http.StatusInternalServerError, "Error updating field")
+			}
+		}
+		return nil
+	})
+}
+
+// UpdateFactFields - тоже что UpdateFields, но для table_fields_fact.
+func (s *systemTableService) UpdateFactFields(ctx context.Context, tableID int, req models.UpdateFieldsRequest) error {
+	var table models.SystemTable
+	if err := s.db.WithContext(ctx).Where("id = ?", tableID).First(&table).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return echo.NewHTTPError(http.StatusNotFound, "Системная таблица не найдена")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Error fetching system table")
+	}
+
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		for _, f := range req.Fields {
+			updates := map[string]interface{}{
+				"is_visible": f.IsVisible,
+			}
+			if f.DisplayOrder != nil {
+				updates["display_order"] = *f.DisplayOrder
+			}
+			if f.Width != nil {
+				updates["width"] = *f.Width
+			}
+			if f.Priority != nil {
+				if *f.Priority < 1 || *f.Priority > 5 {
+					return echo.NewHTTPError(http.StatusBadRequest, "priority должен быть от 1 до 5")
+				}
+				updates["priority"] = *f.Priority
+			}
+			result := tx.Model(&models.TableFieldFact{}).
+				Where("table_id = ? AND field_name = ?", tableID, f.FieldName).
+				Updates(updates)
+			if result.Error != nil {
+				slog.Error("не удалось обновить факт-столбец",
+					"table_id", tableID, "field", f.FieldName, "error", result.Error)
+				return echo.NewHTTPError(http.StatusInternalServerError, "Error updating fact field")
 			}
 		}
 		return nil
@@ -658,6 +800,76 @@ func (s *systemTableService) SeedMissingFields(ctx context.Context) error {
 
 	if added > 0 {
 		slog.Info("досидил отсутствующие поля таблиц (#345)", "added", added)
+	}
+
+	// Параллельно сидим факт-поля для таблиц, где показывается фактовая таблица.
+	// Для остальных таблиц фактовые поля не создаём - они появятся, когда админ
+	// включит "Отображать таблицу по факту" (см. ensureFactFields).
+	if err := s.seedFactFields(ctx, tables); err != nil {
+		return err
+	}
+	return nil
+}
+
+// seedFactFields идентичен SeedMissingFields, но для table_fields_fact.
+// Создаёт записи только для таблиц с ShowFactTable=true. Без backfill priority
+// (поля при первом запуске уже создаются с правильными priority через Create).
+func (s *systemTableService) seedFactFields(ctx context.Context, tables []models.SystemTable) error {
+	added := 0
+	for _, t := range tables {
+		if !t.ShowFactTable {
+			continue
+		}
+		defaults := getDefaultFactFields(t.TableType)
+		if len(defaults) == 0 {
+			continue
+		}
+		var existing []models.TableFieldFact
+		if err := s.db.WithContext(ctx).
+			Where("table_id = ?", t.ID).
+			Find(&existing).Error; err != nil {
+			slog.Error("не удалось загрузить существующие факт-поля",
+				"table_id", t.ID, "error", err)
+			continue
+		}
+		existingSet := make(map[string]bool, len(existing))
+		maxOrder := -1
+		for _, f := range existing {
+			existingSet[f.FieldName] = true
+			if f.DisplayOrder != nil && *f.DisplayOrder > maxOrder {
+				maxOrder = *f.DisplayOrder
+			}
+		}
+		for _, d := range defaults {
+			if existingSet[d.Name] {
+				continue
+			}
+			maxOrder++
+			order := maxOrder
+			fieldType := d.FieldType
+			priority := d.Priority
+			if priority == 0 {
+				priority = 3
+			}
+			tff := models.TableFieldFact{
+				TableID:      t.ID,
+				FieldName:    d.Name,
+				FieldType:    &fieldType,
+				DisplayOrder: &order,
+				IsVisible:    d.IsVisible,
+				Width:        d.Width,
+				Priority:     priority,
+			}
+			if err := s.db.WithContext(ctx).Create(&tff).Error; err != nil {
+				slog.Error("не удалось добавить факт-поле",
+					"table_id", t.ID, "field", d.Name, "error", err)
+				continue
+			}
+			added++
+		}
+	}
+	if added > 0 {
+		slog.Info("досидил факт-поля таблиц (#345)", "added", added)
 	}
 	return nil
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -53,7 +53,7 @@ var tables = []string{
 	"application_status_history", "application_history", "applications",
 	"companies_unload_places", "organization_unload_places",
 	"unload_place_time_slots", "unload_place_photos", "unload_places",
-	"table_fields", "companies_tables", "organization_tables",
+	"table_fields", "table_field_facts", "companies_tables", "organization_tables",
 	"system_table_trash_histories",
 	"system_table_time_slots", "system_table_photos", "system_tables",
 	"license_plate_format_cells", "license_plate_formats",


### PR DESCRIPTION
## Что в PR

Независимые настройки для FactTable, появляются только когда стоит галка "Отображать таблицу по факту".

### Бэк
- Новая таблица `table_field_facts` (отдельно от `table_fields`).
- `SystemTable.FontSizeFact / RowDensityFact` - оформление FactTable независимо от обычной таблицы.
- Дефолты под текущий хардкод FactTable.vue: для cars видны organization+car_brand+valid_until+time_range (остальные скрыты), для people - organization+valid_until+pass_time.
- `seedFactFields` сидит факт-поля только для таблиц с show_fact_table=true. В Update() при включении флажка - засевает сразу, без перезапуска сервера.
- API: `PUT /system-tables/:id/fact-fields` (видимость/порядок/ширина/приоритет), `PUT /system-tables/:id` принимает `font_size_fact`, `row_density_fact`.

### Фронт
- `SystemTableColumnsTab` принимает prop `variant='main'|'fact'` - меняет endpoint и не показывает превью в варианте fact.
- `SystemTableAppearanceTab` variant выбирает ключи (font_size vs font_size_fact, row_density vs row_density_fact).
- `TableConstructor` показывает 2 новые вкладки "Колонки (факт)" и "Оформление (факт)" только при show_fact_table=true. При снятии флажка возвращает activeTab на main.
- `FactTable` читает fact_fields из tableData, применяет isFieldVisible/getColStyle/--table-font-size/density-* класс. `config-not-ready` чтобы заголовки не дёргались на старте.

### Тесты

3 новых Go-теста: UpdateFactFields_PersistsVisibility, Update_PersistsAppearanceFact, Update_FactFontSizeOutOfRange. Vitest 298/298 зелёные.

## Test plan

- [ ] Создать новую таблицу с галочкой "Отображать таблицу по факту" - появляются вкладки "Колонки (факт)" и "Оформление (факт)".
- [ ] В "Колонки (факт)" - тот же UI что и в обычных Колонках (без превью). Изменения видны только в FactTable, не затрагивают основную таблицу.
- [ ] В "Оформление (факт)" - слайдер размера + сегмент плотности. Изменения видны в FactTable.
- [ ] Существующая таблица с включённым show_fact_table - факт-поля засеваются автоматом при первом старте бэка после миграции.
- [ ] Выключить "Отображать таблицу по факту" - вкладки исчезают, activeTab возвращается на main.
- [ ] Включить обратно - вкладки появляются, настройки сохранились.