### PR TITLE
fix: видимость факт-полей из каталога после Create (#345)

### DIFF
--- a/internal/handlers/system_tables_test.go
+++ b/internal/handlers/system_tables_test.go
@@ -598,3 +598,40 @@ func TestSystemTables_Update_FactFontSizeOutOfRange(t *testing.T) {
 		`{"font_size_fact":50}`, h)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
+
+// TestSystemTables_FactFields_DefaultVisibilityFromCatalog - регрессия:
+// при включении show_fact_table факт-поля сохраняют is_visible из каталога
+// (часть видна, часть скрыта). Без Select("*") в seedFactFields все скрытые
+// поля уезжали в visible=true из-за GORM default tag.
+func TestSystemTables_FactFields_DefaultVisibilityFromCatalog(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	rec := testutil.POST(t, e, "/system-tables",
+		`{"name":"fact_def_vis","display_name":"FV","table_type":"cars","show_fact_table":true}`, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	tableID := int(testutil.ParseMap(t, rec)["id"].(float64))
+
+	rec = testutil.GET(t, e, fmt.Sprintf("/system-tables/%d", tableID), h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	factFields := testutil.ParseMap(t, rec)["fact_fields"].([]interface{})
+
+	visByName := map[string]bool{}
+	for _, f := range factFields {
+		fm := f.(map[string]interface{})
+		visByName[fm["field_name"].(string)] = fm["is_visible"].(bool)
+	}
+	assert.True(t, visByName["organization"], "organization видим (каталог)")
+	assert.True(t, visByName["car_brand"], "car_brand видим (каталог)")
+	assert.True(t, visByName["valid_until"], "valid_until видим (каталог)")
+	assert.True(t, visByName["time_range"], "time_range видим (каталог)")
+	assert.False(t, visByName["car_number"], "car_number скрыт (каталог)")
+	assert.False(t, visByName["unload_place"], "unload_place скрыт (каталог)")
+	assert.False(t, visByName["status"], "status скрыт (каталог)")
+	assert.False(t, visByName["company"], "company скрыт (каталог)")
+	assert.False(t, visByName["application_id"], "application_id скрыт (каталог)")
+}

--- a/internal/services/system_table_service.go
+++ b/internal/services/system_table_service.go
@@ -421,6 +421,15 @@ func (s *systemTableService) Create(ctx context.Context, req models.CreateSystem
 				slog.Error("не удалось создать факт-поле таблицы", "table_id", table.ID, "field", f.Name, "error", err)
 				return echo.NewHTTPError(http.StatusInternalServerError, "Error creating fact fields")
 			}
+			// GORM v2 при Create игнорирует zero-value bool, БД применяет
+			// default:true вместо явного false. Дофикс через Update.
+			if !f.IsVisible {
+				if err := tx.Model(&models.TableFieldFact{}).
+					Where("id = ?", tff.ID).
+					Update("is_visible", false).Error; err != nil {
+					return echo.NewHTTPError(http.StatusInternalServerError, "Error setting fact field visibility")
+				}
+			}
 		}
 		return nil
 	})
@@ -865,11 +874,87 @@ func (s *systemTableService) seedFactFields(ctx context.Context, tables []models
 					"table_id", t.ID, "field", d.Name, "error", err)
 				continue
 			}
+			// GORM v2 при Create игнорирует zero-value bool, БД применяет
+			// default:true вместо явного false. Дофикс через Update.
+			if !d.IsVisible {
+				if err := s.db.WithContext(ctx).Model(&models.TableFieldFact{}).
+					Where("id = ?", tff.ID).
+					Update("is_visible", false).Error; err != nil {
+					slog.Error("не удалось проставить is_visible=false",
+						"table_id", t.ID, "field", d.Name, "error", err)
+				}
+			}
 			added++
 		}
 	}
 	if added > 0 {
 		slog.Info("досидил факт-поля таблиц (#345)", "added", added)
+	}
+	// Одноразовый фикс: если у таблицы ВСЕ факт-поля is_visible=true и каталог
+	// содержит скрытые - значит сидинг отработал с багом GORM. Применяем каталог.
+	if err := s.fixFactVisibilityFromCatalog(ctx, tables); err != nil {
+		return err
+	}
+	return nil
+}
+
+// fixFactVisibilityFromCatalog исправляет is_visible на каталожное значение
+// для таблиц где ВСЕ факт-поля сейчас true (признак бага из первого PR-B
+// релиза). Идемпотентно: если хоть одно поле уже false - не трогаем.
+func (s *systemTableService) fixFactVisibilityFromCatalog(ctx context.Context, tables []models.SystemTable) error {
+	fixed := 0
+	for _, t := range tables {
+		if !t.ShowFactTable {
+			continue
+		}
+		defaults := getDefaultFactFields(t.TableType)
+		if len(defaults) == 0 {
+			continue
+		}
+		var existing []models.TableFieldFact
+		if err := s.db.WithContext(ctx).
+			Where("table_id = ?", t.ID).
+			Find(&existing).Error; err != nil {
+			continue
+		}
+		allVisible := true
+		for _, f := range existing {
+			if !f.IsVisible {
+				allVisible = false
+				break
+			}
+		}
+		anyShouldBeHidden := false
+		for _, d := range defaults {
+			if !d.IsVisible {
+				anyShouldBeHidden = true
+				break
+			}
+		}
+		if !(allVisible && anyShouldBeHidden) {
+			continue
+		}
+		defByName := make(map[string]bool, len(defaults))
+		for _, d := range defaults {
+			defByName[d.Name] = d.IsVisible
+		}
+		for _, f := range existing {
+			want, ok := defByName[f.FieldName]
+			if !ok || want == f.IsVisible {
+				continue
+			}
+			if err := s.db.WithContext(ctx).Model(&models.TableFieldFact{}).
+				Where("id = ?", f.ID).
+				Update("is_visible", want).Error; err != nil {
+				slog.Error("не удалось fix факт-видимость",
+					"table_id", t.ID, "field", f.FieldName, "error", err)
+				continue
+			}
+			fixed++
+		}
+	}
+	if fixed > 0 {
+		slog.Info("исправил факт-видимость до каталога (#345)", "fixed", fixed)
 	}
 	return nil
 }


### PR DESCRIPTION
## Что чинит

Через MCP на staging обнаружил: в "Колонки (факт)" все 9 полей показывались как visible, хотя по каталогу должны быть только 4 (organization, car_brand, valid_until, time_range для cars).

## Причина

GORM v2 при `Create` игнорирует zero-value bool (false). БД применяет `default:true` из gorm tag. В итоге все IsVisible=false из каталога превращались в true в БД.

В обычном service.Create() для TableField этого не происходило, потому что таблицы уже были созданы до релиза PR-B и main fields не пересоздавались. Факт-поля же только что засеялись через seedFactFields с тем же багом.

## Что делает фикс

1. После Create явный Update is_visible=false если в каталоге IsVisible=false. Применил в service.Create() и в seedFactFields.
2. Одноразовый fixFactVisibilityFromCatalog: если у таблицы ВСЕ факт-поля visible и каталог содержит скрытые - значит сидинг отработал с багом, применяем каталог. Идемпотентно: после любой ручной правки админа не сработает.

## Тесты

TestSystemTables_FactFields_DefaultVisibilityFromCatalog - регрессия. Все 4 fact-теста и полный go test ./... зелёные.