### PR TITLE
fix: polish #1+#3+#4 + responsive card-header (#345)

### DIFF
--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -633,7 +633,7 @@ export default {
         this.fieldOrders = nextOrd;
         this.fieldWidths = nextW;
         this.fieldPriorities = nextP;
-        this.configReady = true;
+        this.markConfigReady();
       }
     }
   },
@@ -1139,17 +1139,23 @@ export default {
       } catch (error) {
         console.error('Ошибка загрузки настроек столбцов:', error);
       } finally {
-        // Снимаем флаг config-not-ready после первой загрузки. Делаем через
-        // requestAnimationFrame, чтобы браузер успел применить итоговые
-        // ширины БЕЗ transition (иначе при снятии класса первая анимация
-        // запустится со старого значения на новое).
-        if (typeof requestAnimationFrame === 'function') {
-          requestAnimationFrame(() => { this.configReady = true; });
-        } else {
-          this.configReady = true;
-        }
+        // Снимаем флаг config-not-ready после первой загрузки.
+        // 2 rAF + 100ms - гарантия что layout с итоговыми ширинами применился
+        // и transition не сработает на стартовом расхождении.
+        this.markConfigReady();
       }
-    }
+    },
+    markConfigReady() {
+      if (typeof requestAnimationFrame !== 'function') {
+        this.configReady = true;
+        return;
+      }
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          setTimeout(() => { this.configReady = true; }, 100);
+        });
+      });
+    },
   }
 };
 </script>
@@ -1173,21 +1179,27 @@ export default {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0px 20px;
-  height: 50px;
+  gap: 12px;
+  padding: 8px 20px;
+  min-height: 50px;
   flex-shrink: 0;
+  flex-wrap: wrap;
 }
 
 .card-header__title {
   display: flex;
   gap: 12px;
   align-items: center;
+  min-width: 0;
+  flex-shrink: 1;
 }
 
 .card-header__settings {
   display: flex;
   gap: 12px;
   align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .card-title {
@@ -1195,6 +1207,9 @@ export default {
   color: #000;
   font-weight: 600;
   font-size: 1.1em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .blue {
@@ -1505,11 +1520,11 @@ export default {
   transition: font-size 0.4s ease-in-out, flex-grow 0.4s ease-in-out, opacity 0.3s ease-in-out;
 }
 
-/* Пока конфиг не загружен - запрещаем transitions на col/item-data, чтобы
+/* Пока конфиг не загружен - запрещаем transitions на всех потомках, чтобы
    шапка/столбцы не "ездили" между дефолтными и сохранёнными значениями
    при первом рендере. */
-.selected-table-card.config-not-ready .col,
-.selected-table-card.config-not-ready .item-data {
+.selected-table-card.config-not-ready,
+.selected-table-card.config-not-ready * {
   transition: none !important;
 }
 

--- a/frontend/src/components/FactTable.vue
+++ b/frontend/src/components/FactTable.vue
@@ -451,11 +451,7 @@ export default {
         if (fs >= 10 && fs <= 24) this.tableFontSize = fs;
         const dens = tbl.row_density_fact;
         if (['compact', 'normal', 'spacious'].includes(dens)) this.rowDensity = dens;
-        if (typeof requestAnimationFrame === 'function') {
-          requestAnimationFrame(() => { this.configReady = true; });
-        } else {
-          this.configReady = true;
-        }
+        this.markConfigReady();
       },
     },
   },
@@ -478,6 +474,18 @@ export default {
       if (order !== undefined) style.order = 10 + order;
       if (width !== undefined && width > 0) style.flexGrow = width;
       return Object.keys(style).length ? style : null;
+    },
+
+    markConfigReady() {
+      if (typeof requestAnimationFrame !== 'function') {
+        this.configReady = true;
+        return;
+      }
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          setTimeout(() => { this.configReady = true; }, 100);
+        });
+      });
     },
 
     async _loadData() {
@@ -1177,9 +1185,10 @@ export default {
   padding-bottom: 16px;
 }
 
-/* Пока конфиг не загружен - запрещаем transitions на col, чтобы шапка не
-   "ездила" между дефолтными и сохранёнными ширинами при первом рендере. */
-.fact-table-card.config-not-ready .col {
+/* Пока конфиг не загружен - запрещаем transitions на всех потомках, чтобы
+   шапка/строки не "ездили" между дефолтами и сохранёнными значениями. */
+.fact-table-card.config-not-ready,
+.fact-table-card.config-not-ready * {
   transition: none !important;
 }
 </style>

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -679,7 +679,7 @@ export default {
         this.fieldOrders = nextOrd;
         this.fieldWidths = nextW;
         this.fieldPriorities = nextP;
-        this.configReady = true;
+        this.markConfigReady();
       }
     }
   },
@@ -783,12 +783,7 @@ export default {
         if (fs >= 10 && fs <= 24) this.tableFontSize = fs;
         const dens = table.row_density;
         if (['compact', 'normal', 'spacious'].includes(dens)) this.rowDensity = dens;
-        // Конфиг загружен - снимаем no-transition после применения через rAF.
-        if (typeof requestAnimationFrame === 'function') {
-          requestAnimationFrame(() => { this.configReady = true; });
-        } else {
-          this.configReady = true;
-        }
+        this.markConfigReady();
 
         const employeesRes = await apiRequest(`/employees/active-for-table/${table.id}`, { method: "GET" });
         if (!employeesRes.ok) return;
@@ -1086,6 +1081,20 @@ export default {
       this.expandedRows = next;
     },
 
+    markConfigReady() {
+      // 2 rAF + 100ms - гарантия что layout с итоговыми ширинами применился
+      // и transition не сработает на стартовом расхождении.
+      if (typeof requestAnimationFrame !== 'function') {
+        this.configReady = true;
+        return;
+      }
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          setTimeout(() => { this.configReady = true; }, 100);
+        });
+      });
+    },
+
     portraitFieldLabel(name) {
       const LABELS = {
         last_name: 'Фамилия',
@@ -1139,21 +1148,27 @@ export default {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0px 20px;
-  height: 50px;
+  gap: 12px;
+  padding: 8px 20px;
+  min-height: 50px;
   flex-shrink: 0;
+  flex-wrap: wrap;
 }
 
 .card-header__title {
   display: flex;
   gap: 12px;
   align-items: center;
+  min-width: 0;
+  flex-shrink: 1;
 }
 
 .card-header__settings {
   display: flex;
   gap: 12px;
   align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .card-title {
@@ -1161,6 +1176,9 @@ export default {
   color: #000;
   font-weight: 600;
   font-size: 1.1em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .blue {
@@ -1473,10 +1491,11 @@ export default {
   transition: font-size 0.4s ease-in-out, flex-grow 0.4s ease-in-out, opacity 0.3s ease-in-out;
 }
 
-/* Пока конфиг не загружен - запрещаем transitions, чтобы шапка/столбцы не
-   "ездили" между дефолтными и сохранёнными ширинами при первом рендере. */
-.selected-table-card.config-not-ready .col,
-.selected-table-card.config-not-ready .item-data {
+/* Пока конфиг не загружен - запрещаем transitions на всех потомках, чтобы
+   шапка/столбцы не "ездили" между дефолтными и сохранёнными значениями
+   при первом рендере. */
+.selected-table-card.config-not-ready,
+.selected-table-card.config-not-ready * {
   transition: none !important;
 }
 

--- a/frontend/src/components/SystemTableAppearanceTab.vue
+++ b/frontend/src/components/SystemTableAppearanceTab.vue
@@ -68,25 +68,21 @@
         {{ saving ? 'Сохраняем...' : 'Сохранить' }}
       </button>
     </div>
-
-    <p
-      v-if="statusMessage"
-      class="appearance-tab__status"
-      :class="{ 'appearance-tab__status--error': statusError }"
-    >
-      {{ statusMessage }}
-    </p>
   </div>
 </template>
 
 <script>
 import { apiRequest } from '@/api/client';
+import { useToast } from '@/composables/useToast';
 
 const DEFAULT_FONT_SIZE = 14;
 const DEFAULT_DENSITY = 'normal';
 
 export default {
   name: 'SystemTableAppearanceTab',
+  setup() {
+    return { toast: useToast() };
+  },
   props: {
     tableId: { type: Number, required: true },
     table: { type: Object, required: true },
@@ -102,8 +98,6 @@ export default {
       originalFontSize: DEFAULT_FONT_SIZE,
       originalDensity: DEFAULT_DENSITY,
       saving: false,
-      statusMessage: '',
-      statusError: false,
       densityOptions: [
         { value: 'compact', label: 'Компактно' },
         { value: 'normal', label: 'Обычно' },
@@ -140,14 +134,10 @@ export default {
       this.rowDensity = ['compact', 'normal', 'spacious'].includes(dens) ? dens : DEFAULT_DENSITY;
       this.originalFontSize = this.fontSize;
       this.originalDensity = this.rowDensity;
-      this.statusMessage = '';
-      this.statusError = false;
     },
     async save() {
       if (!this.isDirty || this.saving) return;
       this.saving = true;
-      this.statusMessage = '';
-      this.statusError = false;
       try {
         const fs = Math.max(10, Math.min(24, Number(this.fontSize) || DEFAULT_FONT_SIZE));
         const response = await apiRequest(`/system-tables/${this.tableId}`, {
@@ -163,11 +153,10 @@ export default {
         }
         this.originalFontSize = fs;
         this.originalDensity = this.rowDensity;
-        this.statusMessage = 'Оформление сохранено';
+        this.toast.success('Оформление сохранено');
         this.$emit('update');
       } catch (e) {
-        this.statusError = true;
-        this.statusMessage = `Ошибка сохранения: ${e.message}`;
+        this.toast.error(`Ошибка сохранения: ${e.message}`);
       } finally {
         this.saving = false;
       }

--- a/frontend/src/components/SystemTableColumnsTab.vue
+++ b/frontend/src/components/SystemTableColumnsTab.vue
@@ -155,14 +155,6 @@
       </button>
     </div>
 
-    <p
-      v-if="statusMessage"
-      class="columns-tab__status"
-      :class="{ 'columns-tab__status--error': statusError }"
-    >
-      {{ statusMessage }}
-    </p>
-
     <div
       v-if="localFields.length && variant === 'main'"
       class="columns-tab__preview"
@@ -209,6 +201,7 @@
 <script>
 import { apiRequest } from '@/api/client';
 import { generateSampleRows } from '@/utils/tableSamples';
+import { useToast } from '@/composables/useToast';
 import CarsTable from './CarsTable.vue';
 import PeopleTable from './PeopleTable.vue';
 
@@ -233,6 +226,9 @@ const FIELD_LABELS = {
 export default {
   name: 'SystemTableColumnsTab',
   components: { CarsTable, PeopleTable },
+  setup() {
+    return { toast: useToast() };
+  },
   props: {
     tableId: { type: Number, required: true },
     tableType: { type: String, required: true },
@@ -250,8 +246,6 @@ export default {
       originalWidth: {},
       originalPriority: {},
       saving: false,
-      statusMessage: '',
-      statusError: false,
       draggingIndex: null,
       prevBodyCursor: '',
     };
@@ -329,8 +323,6 @@ export default {
       this.originalPriority = Object.fromEntries(
         this.localFields.map(f => [f.field_name, f.priority]),
       );
-      this.statusMessage = '';
-      this.statusError = false;
     },
     /**
      * Pointer-events DnD (вместо HTML5 native, который не даёт контроля над курсором).
@@ -384,9 +376,6 @@ export default {
     async save() {
       if (!this.isDirty || this.saving) return;
       this.saving = true;
-      this.statusMessage = '';
-      this.statusError = false;
-
       try {
         const response = await apiRequest(this.apiPath, {
           method: 'PUT',
@@ -404,7 +393,7 @@ export default {
           const err = await response.json().catch(() => ({}));
           throw new Error(err.message || `HTTP ${response.status}`);
         }
-        this.statusMessage = 'Настройки столбцов сохранены';
+        this.toast.success('Настройки столбцов сохранены');
         this.originalVisibility = Object.fromEntries(
           this.localFields.map(f => [f.field_name, f.is_visible]),
         );
@@ -417,8 +406,7 @@ export default {
         );
         this.$emit('update');
       } catch (e) {
-        this.statusError = true;
-        this.statusMessage = `Ошибка сохранения: ${e.message}`;
+        this.toast.error(`Ошибка сохранения: ${e.message}`);
       } finally {
         this.saving = false;
       }

--- a/frontend/src/components/TableConstructor.vue
+++ b/frontend/src/components/TableConstructor.vue
@@ -1320,30 +1320,46 @@ export default {
 
 .details-tabs {
   display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
   border-bottom: 1px solid #e6e6e6;
   background: #f8f9fa;
-  padding: 0 20px;
+  padding: 8px 16px 0;
+  overflow-x: auto;
+  scrollbar-width: thin;
 }
 
 .tab-btn {
-  padding: 12px 24px;
+  padding: 10px 18px;
   background: none;
   border: none;
   border-bottom: 2px solid transparent;
   cursor: pointer;
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 600;
-  color: #666;
-  transition: all 0.2s ease;
+  color: #6b7280;
+  transition: color 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+  border-radius: 8px 8px 0 0;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .tab-btn:hover {
   color: #4F5BDF;
+  background: #eef0ff;
 }
 
 .tab-btn.active {
   color: #4F5BDF;
   border-bottom-color: #4F5BDF;
+  background: #fff;
+}
+
+@media (max-width: 1100px) {
+  .tab-btn {
+    padding: 8px 12px;
+    font-size: 12px;
+  }
 }
 
 .tab-content {


### PR DESCRIPTION
## Полировочные правки по ревью

### №1 - Уведомления сохранения через toast
Inline `<p>` со "Оформление сохранено" / "Настройки столбцов сохранены" исчезал быстрее, чем пользователь успевал прочитать (сбрасывался по reset). Заменил на `useToast().success()` в SystemTableColumnsTab и SystemTableAppearanceTab.

### №3 - Заголовки столбцов 'ездили' при F5
Класс `config-not-ready` снимался через 1 rAF, но layout с итоговыми ширинами ещё не успевал примениться - transition срабатывал. Поднял до 2 rAF + 100ms через метод `markConfigReady()`. CSS-подавление расширил на все потомки: `.config-not-ready *`.

### №4 - Вкладки 'Колонки (факт)' / 'Оформление (факт)' уезжали за края
В details-tabs не было wrap/scroll. Добавил `flex-wrap: wrap` + `overflow-x: auto` + красивый hover/active стиль (rounded top, background). На <=1100px шрифт и padding меньше.

### Общее - card-header съезжал на 960x1305
В card-header CarsTable/PeopleTable была фиксированная `height: 50px` без wrap, и заголовок 'Номера автомобилей по заявке' уезжал. Заменил на `min-height` + `flex-wrap`, добавил `min-width: 0` + `text-overflow: ellipsis` для title.

## Тесты

vitest 298/298 зелёные.