### PR TITLE
fix: пропорциональное распределение места при скрытии Статус в enlarged (#345)

### DIFF
--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -1102,17 +1102,18 @@ export default {
      * - order: 10 + display_order (между фиксированными entry/exit/actions).
      * - flex-grow: width из конфига (если задан) - переопределяет дефолт из CSS.
      *
-     * Исключение: в enlarged-режиме НЕ задаём inline flex-grow для organization
-     * и status, чтобы CSS-правила .enlarged.status-col {grow:0} и
-     * .enlarged.organization-col {grow:25} могли отработать с анимацией.
+     * В enlarged-режиме НЕ задаём inline flex-grow ни для одного столбца -
+     * пусть CSS управляет пропорциями. Это даёт честное распределение
+     * освободившегося status-пространства по ВСЕМ оставшимся столбцам
+     * пропорционально их базовым flex-grow весам, а не "слепляет" всё
+     * в organization.
      */
     getColStyle(fieldName) {
       const order = this.fieldOrders[fieldName];
       const width = this.fieldWidths[fieldName];
       const style = {};
       if (order !== undefined) style.order = 10 + order;
-      const skipWidth = this.enlarged && (fieldName === 'organization' || fieldName === 'status');
-      if (!skipWidth && width !== undefined && width > 0) style.flexGrow = width;
+      if (!this.enlarged && width !== undefined && width > 0) style.flexGrow = width;
       return Object.keys(style).length ? style : null;
     },
 
@@ -1556,16 +1557,15 @@ export default {
   font-weight: 700;
 }
 
-/* В enlarged переливаем вес status-col (7) в organization-col (18 -> 25).
-   Остальные пропорции сохраняются. */
+/* В enlarged status-col схлопывается; освободившиеся 7 grow распределяются
+   автоматически по ВСЕМ оставшимся столбцам пропорционально их базовым
+   весам - getColStyle в enlarged не задаёт inline flex-grow, и CSS-веса
+   снова в силе. organization получит больше всех (она самая широкая),
+   но остальные тоже подрастут пропорционально. */
 .selected-table-card.enlarged .status-col {
   flex-grow: 0;
   opacity: 0;
   pointer-events: none;
-}
-
-.selected-table-card.enlarged .organization-col {
-  flex-grow: 25;
 }
 
 .selected-table-card.enlarged .item-data {

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -1057,17 +1057,16 @@ export default {
      * - order: 10 + display_order (между фиксированными entry/exit/status/actions).
      * - flex-grow: width из конфига (если задан) - переопределяет дефолт из CSS.
      *
-     * Исключение: в enlarged НЕ задаём inline flex-grow для organization и
-     * status, иначе CSS-правила enlarged-режима (status -> grow 0, organization
-     * -> grow 24) не сработают и анимация перетекания пропадает.
+     * В enlarged НЕ задаём inline flex-grow ни одному столбцу - пусть CSS
+     * пропорционально распределяет освободившееся от status пространство
+     * по всем оставшимся столбцам.
      */
     getColStyle(fieldName) {
       const order = this.fieldOrders[fieldName];
       const width = this.fieldWidths[fieldName];
       const style = {};
       if (order !== undefined) style.order = 10 + order;
-      const skipWidth = this.enlarged && (fieldName === 'organization' || fieldName === 'status');
-      if (!skipWidth && width !== undefined && width > 0) style.flexGrow = width;
+      if (!this.enlarged && width !== undefined && width > 0) style.flexGrow = width;
       return Object.keys(style).length ? style : null;
     },
 
@@ -1521,16 +1520,13 @@ export default {
   font-weight: 700;
 }
 
-/* В enlarged переливаем вес status-col (8) в organization-col (16 -> 24).
-   Остальные пропорции сохраняются. */
+/* В enlarged status-col схлопывается; освободившиеся 8 grow распределяются
+   автоматически по ВСЕМ оставшимся столбцам пропорционально базовым весам -
+   inline flex-grow для них не задаётся (getColStyle пропускает). */
 .selected-table-card.enlarged .status-col {
   flex-grow: 0;
   opacity: 0;
   pointer-events: none;
-}
-
-.selected-table-card.enlarged .organization-col {
-  flex-grow: 24;
 }
 
 .selected-table-card.enlarged .item-data {


### PR DESCRIPTION
## Общее замечание №2

При включении 'Увеличенный режим' status-col схлопывался, но освободившиеся 7-8 единиц flex-grow раньше отдавались только organization-col (CSS: `.enlarged .organization-col {flex-grow: 25}`). Organization съедала всё свободное место, а соседние столбцы (Действует до, Время, Марка...) даже не подрастали - между organization и date появлялась пустота.

## Фикс

- Убрал жёсткое правило `flex-grow: 25` (и 24 для people) на organization в enlarged.
- В `getColStyle` исключил inline flex-grow для ВСЕХ столбцов когда enlarged=true (раньше пропускал только organization и status).

Теперь оставшиеся 6-7 столбцов делят освободившиеся 7-8 grow автоматически по базовым CSS-весам - organization получит больше (она и базово 18), но остальные тоже пропорционально подрастут.

Применил к CarsTable и PeopleTable.

## Тесты

vitest 298/298 зелёные.