### PR TITLE
fix: refresh-иконка не крутится + лоадер в таблице при обновлении (#345)

### DIFF
--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -206,12 +206,12 @@
       
       <div class="items-container">
         <div
-          v-if="isLoading"
+          v-if="isLoading || refreshing"
           class="loading-message"
         >
-          <LoaderSpinner label="Загрузка машин…" />
+          <LoaderSpinner :label="refreshing ? 'Обновление…' : 'Загрузка машин…'" />
         </div>
-        
+
         <div
           v-else-if="displayItems.length > 0"
           class="items-body"

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -230,13 +230,13 @@
       
       <div class="items-container">
         <div
-          v-if="isLoading"
+          v-if="isLoading || refreshing"
           class="loading-message"
         >
           <div class="loader" />
-          <p>Загрузка сотрудников...</p>
+          <p>{{ refreshing ? 'Обновление...' : 'Загрузка сотрудников...' }}</p>
         </div>
-        
+
         <div
           v-else-if="displayItems.length > 0"
           class="items-body"

--- a/frontend/src/components/RefreshButton.vue
+++ b/frontend/src/components/RefreshButton.vue
@@ -9,7 +9,6 @@
     <img
       src="@/assets/icons/refresh.png"
       class="refresh-btn__icon"
-      :class="{ 'refresh-btn__icon--spinning': loading }"
       alt=""
     >
     <p class="refresh-btn__text">
@@ -68,15 +67,6 @@ export default {
     .refresh-btn__icon {
         width: 15px;
         height: 15px;
-    }
-
-    .refresh-btn__icon--spinning {
-        animation: refresh-btn-spin 0.9s linear infinite;
-    }
-
-    @keyframes refresh-btn-spin {
-        from { transform: rotate(0deg); }
-        to { transform: rotate(-360deg); }
     }
 
     .refresh-btn__text {


### PR DESCRIPTION
## №3

При клике 'Обновить' refresh-иконка крутилась бесконечно, а в самой таблице ничего не происходило визуально. Сбивало.

Фикс: убрал spin-анимацию из RefreshButton. В CarsTable/PeopleTable при refreshing=true показываем LoaderSpinner (или .loader для people) вместо данных. silentRefresh (polling) не ставит refreshing - лоадер не мигает каждые N секунд при автообновлении.

## Тесты

vitest 298/298 зелёные.