### PR TITLE
feat: единый вид settings-вкладок (#345)

### DIFF
--- a/frontend/src/components/SystemTableAppearanceTab.vue
+++ b/frontend/src/components/SystemTableAppearanceTab.vue
@@ -1,5 +1,27 @@
 <template>
   <div class="appearance-tab">
+    <div class="appearance-tab__header-top">
+      <h4 class="appearance-tab__header-title">
+        Оформление таблицы
+      </h4>
+      <div class="appearance-tab__actions">
+        <button
+          class="appearance-tab__btn appearance-tab__btn--secondary"
+          :disabled="!isDirty || saving"
+          @click="reset"
+        >
+          Отменить
+        </button>
+        <button
+          class="appearance-tab__btn appearance-tab__btn--primary"
+          :disabled="!isDirty || saving"
+          data-testid="appearance-save"
+          @click="save"
+        >
+          {{ saving ? 'Сохраняем...' : 'Сохранить' }}
+        </button>
+      </div>
+    </div>
     <div class="appearance-tab__section">
       <h4 class="appearance-tab__title">
         Размер шрифта строк
@@ -51,23 +73,6 @@
       </div>
     </div>
 
-    <div class="appearance-tab__actions">
-      <button
-        class="appearance-tab__btn appearance-tab__btn--secondary"
-        :disabled="!isDirty || saving"
-        @click="reset"
-      >
-        Отменить
-      </button>
-      <button
-        class="appearance-tab__btn appearance-tab__btn--primary"
-        :disabled="!isDirty || saving"
-        data-testid="appearance-save"
-        @click="save"
-      >
-        {{ saving ? 'Сохраняем...' : 'Сохранить' }}
-      </button>
-    </div>
   </div>
 </template>
 
@@ -171,6 +176,22 @@ export default {
   display: flex;
   flex-direction: column;
   gap: 20px;
+  line-height: 1.5;
+}
+
+.appearance-tab__header-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.appearance-tab__header-title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: #000;
 }
 
 .appearance-tab__section {
@@ -190,7 +211,7 @@ export default {
   margin: 0;
   font-size: 12px;
   color: #6b7280;
-  line-height: 1.4;
+  line-height: 1.5;
 }
 
 .appearance-tab__row {

--- a/frontend/src/components/SystemTableColumnsTab.vue
+++ b/frontend/src/components/SystemTableColumnsTab.vue
@@ -1,9 +1,27 @@
 <template>
   <div class="columns-tab">
     <div class="columns-tab__header">
-      <h4 class="columns-tab__title">
-        Видимые столбцы
-      </h4>
+      <div class="columns-tab__header-top">
+        <h4 class="columns-tab__title">
+          Видимые столбцы
+        </h4>
+        <div class="columns-tab__actions">
+          <button
+            class="columns-tab__btn columns-tab__btn--secondary"
+            :disabled="!isDirty || saving"
+            @click="reset"
+          >
+            Отменить
+          </button>
+          <button
+            class="columns-tab__btn columns-tab__btn--primary"
+            :disabled="!isDirty || saving"
+            @click="save"
+          >
+            {{ saving ? 'Сохраняем...' : 'Сохранить' }}
+          </button>
+        </div>
+      </div>
       <p class="columns-tab__hint">
         Переставляйте столбцы перетаскиванием за иконку слева. Скрытые столбцы не отображаются в таблице.
       </p>
@@ -137,23 +155,6 @@
         </div>
       </li>
     </TransitionGroup>
-
-    <div class="columns-tab__actions">
-      <button
-        class="columns-tab__btn columns-tab__btn--secondary"
-        :disabled="!isDirty || saving"
-        @click="reset"
-      >
-        Отменить
-      </button>
-      <button
-        class="columns-tab__btn columns-tab__btn--primary"
-        :disabled="!isDirty || saving"
-        @click="save"
-      >
-        {{ saving ? 'Сохраняем...' : 'Сохранить' }}
-      </button>
-    </div>
 
     <div
       v-if="localFields.length && variant === 'main'"
@@ -421,12 +422,21 @@ export default {
   display: flex;
   flex-direction: column;
   gap: 16px;
+  line-height: 1.5;
 }
 
 .columns-tab__header {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 6px;
+}
+
+.columns-tab__header-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
 }
 
 .columns-tab__title {
@@ -440,7 +450,7 @@ export default {
   margin: 0;
   font-size: 13px;
   color: #6b7280;
-  line-height: 1.4;
+  line-height: 1.5;
 }
 
 .columns-tab__empty {

--- a/frontend/src/components/TableConstructor.vue
+++ b/frontend/src/components/TableConstructor.vue
@@ -133,57 +133,63 @@
         class="details-section"
       >
         <div class="details-tabs">
-          <button 
-            class="tab-btn" 
-            :class="{ 'active': activeTab === 'main' }"
-            @click="activeTab = 'main'"
-          >
-            Основное
-          </button>
-          <button 
-            class="tab-btn" 
-            :class="{ 'active': activeTab === 'schedule' }"
-            @click="activeTab = 'schedule'"
-          >
-            Расписание
-          </button>
-          <button
-            class="tab-btn"
-            :class="{ 'active': activeTab === 'location' }"
-            @click="activeTab = 'location'"
-          >
-            Местоположение
-          </button>
-          <button
-            class="tab-btn"
-            :class="{ 'active': activeTab === 'columns' }"
-            @click="activeTab = 'columns'"
-          >
-            Колонки
-          </button>
-          <button
-            class="tab-btn"
-            :class="{ 'active': activeTab === 'appearance' }"
-            @click="activeTab = 'appearance'"
-          >
-            Оформление
-          </button>
-          <button
+          <div class="details-tabs__row">
+            <button
+              class="tab-btn"
+              :class="{ 'active': activeTab === 'main' }"
+              @click="activeTab = 'main'"
+            >
+              Основное
+            </button>
+            <button
+              class="tab-btn"
+              :class="{ 'active': activeTab === 'schedule' }"
+              @click="activeTab = 'schedule'"
+            >
+              Расписание
+            </button>
+            <button
+              class="tab-btn"
+              :class="{ 'active': activeTab === 'location' }"
+              @click="activeTab = 'location'"
+            >
+              Местоположение
+            </button>
+            <button
+              class="tab-btn"
+              :class="{ 'active': activeTab === 'columns' }"
+              @click="activeTab = 'columns'"
+            >
+              Колонки
+            </button>
+            <button
+              class="tab-btn"
+              :class="{ 'active': activeTab === 'appearance' }"
+              @click="activeTab = 'appearance'"
+            >
+              Оформление
+            </button>
+          </div>
+          <div
             v-if="selectedTable.table.show_fact_table"
-            class="tab-btn"
-            :class="{ 'active': activeTab === 'fact-columns' }"
-            @click="activeTab = 'fact-columns'"
+            class="details-tabs__row details-tabs__row--fact"
           >
-            Колонки (факт)
-          </button>
-          <button
-            v-if="selectedTable.table.show_fact_table"
-            class="tab-btn"
-            :class="{ 'active': activeTab === 'fact-appearance' }"
-            @click="activeTab = 'fact-appearance'"
-          >
-            Оформление (факт)
-          </button>
+            <span class="details-tabs__group-label">По факту:</span>
+            <button
+              class="tab-btn"
+              :class="{ 'active': activeTab === 'fact-columns' }"
+              @click="activeTab = 'fact-columns'"
+            >
+              Колонки
+            </button>
+            <button
+              class="tab-btn"
+              :class="{ 'active': activeTab === 'fact-appearance' }"
+              @click="activeTab = 'fact-appearance'"
+            >
+              Оформление
+            </button>
+          </div>
         </div>
 
         <!-- Вкладка Основное -->
@@ -1320,13 +1326,32 @@ export default {
 
 .details-tabs {
   display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
+  flex-direction: column;
+  gap: 6px;
   border-bottom: 1px solid #e6e6e6;
   background: #f8f9fa;
-  padding: 8px 16px 0;
-  overflow-x: auto;
-  scrollbar-width: thin;
+  padding: 10px 16px 0;
+}
+
+.details-tabs__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: center;
+}
+
+.details-tabs__row--fact {
+  padding: 6px 0;
+  border-top: 1px dashed #e0e0e0;
+  margin-top: 2px;
+}
+
+.details-tabs__group-label {
+  font-size: 11px;
+  color: #a2a2a2;
+  font-weight: 500;
+  letter-spacing: 0.3px;
+  padding-right: 4px;
 }
 
 .tab-btn {
@@ -1367,6 +1392,7 @@ export default {
   overflow-y: auto;
   padding: 20px;
   background: #fff;
+  line-height: 1.5;
 }
 
 .details-header {
@@ -1376,10 +1402,14 @@ export default {
   margin-bottom: 20px;
 }
 
+/* table-info-title + table-info-row в одну строку:
+   слева - название + тип-бейдж, справа - system-name + status-бейдж. */
 .details-title-wrapper {
   display: flex;
-  flex-direction: column;
-  gap: 4px;
+  flex-direction: row;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
 }
 
 .table-info-title {


### PR DESCRIPTION
## Общие правки + №1

### №1 - fact-вкладки на отдельной строке
Вкладки 'Колонки (факт)' / 'Оформление (факт)' переехали в нижний ряд под основными с дашед-разделителем и подписью 'По факту:'. Видно что это вторая группа.

### Сохранить/Отменить - вверху справа
Кнопки переехали из подвала вкладки в header-top рядом с заголовком (flex space-between). Не нужно скроллить длинную форму чтобы сохранить.

### Основное: info-row справа от title
table-info-title (название + тип-бейдж) и table-info-row (system-name + current-status) теперь в одной строке через flex-row у details-title-wrapper.

### Унифицировано
- line-height 1.5 на корне columns-tab, appearance-tab, tab-content
- Hint-параграфы тоже 1.5
- AppearanceTab получил общий заголовок 'Оформление таблицы' над секциями

## Тесты

vitest 298/298 зелёные.