### PR TITLE
fix: responsive layout для узких экранов 960x1305 (#345)

### DIFF
--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -1236,6 +1236,25 @@ export default {
   display: flex;
   align-items: center;
   gap: 10px;
+  white-space: nowrap;
+}
+
+@media (max-width: 1100px) {
+  .card-header {
+    gap: 8px;
+    padding: 6px 12px;
+  }
+  .card-title {
+    font-size: 0.95em;
+  }
+  .items-count {
+    font-size: 0.8em;
+    gap: 6px;
+  }
+  .history-btn {
+    padding: 2px 8px;
+    font-size: 11px;
+  }
 }
 
 .history-btn {

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -1197,6 +1197,25 @@ export default {
   display: flex;
   align-items: center;
   gap: 10px;
+  white-space: nowrap;
+}
+
+@media (max-width: 1100px) {
+  .card-header {
+    gap: 8px;
+    padding: 6px 12px;
+  }
+  .card-title {
+    font-size: 0.95em;
+  }
+  .items-count {
+    font-size: 0.8em;
+    gap: 6px;
+  }
+  .history-btn {
+    padding: 2px 8px;
+    font-size: 11px;
+  }
 }
 
 .history-btn {

--- a/frontend/src/components/TablesComponent.vue
+++ b/frontend/src/components/TablesComponent.vue
@@ -510,6 +510,7 @@ export default {
     gap: 10px;
     padding-bottom: 15px;
     align-items: center;
+    flex-wrap: wrap;
 }
 
 .tables__header-actions {
@@ -517,6 +518,8 @@ export default {
     align-items: center;
     gap: 10px;
     margin-left: auto;
+    flex-wrap: wrap;
+    justify-content: flex-end;
 }
 
 .tables__instruction {
@@ -554,6 +557,9 @@ export default {
     justify-content: space-between;
     padding-bottom: 15px;
     border-bottom: 1px solid #e6e6e6;
+    flex-wrap: wrap;
+    gap: 10px;
+    min-width: 0;
 }
 
 .filters__fields {
@@ -561,6 +567,8 @@ export default {
     align-items: center;
     gap: 10px;
     position: relative;
+    flex-wrap: wrap;
+    min-width: 0;
 }
 
 
@@ -606,6 +614,8 @@ export default {
     display: flex;
     align-items: center;
     gap: 15px;
+    flex-wrap: wrap;
+    justify-content: flex-end;
 }
 
 .options__icon {

--- a/frontend/src/components/TheHeader/TheHeader.vue
+++ b/frontend/src/components/TheHeader/TheHeader.vue
@@ -274,20 +274,24 @@ h3 {
 
 .header {
   width: 100%;
-  height: 60px;
+  min-height: 60px;
   display: flex;
   align-items: center;
   justify-content: space-between;
   border-bottom: 1px solid #e6e6e6;
-  padding: 0 20px;
+  padding: 8px 20px;
   position: relative;
   z-index: 100;
+  flex-wrap: wrap;
+  gap: 12px;
 }
 
 .header__title {
   display:flex;
   flex-direction: column;
   gap: 0px;
+  min-width: 0;
+  flex-shrink: 1;
 }
 
 .header__subtitle {
@@ -301,6 +305,8 @@ h3 {
   align-items: center;
   gap: 15px;
   position: relative;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .feedback-btn {


### PR DESCRIPTION
## №2

На разрешении 960x1305 ломалась шапка TheHeader (Подать заявку, Сообщить о проблеме уходили за экран) и card-header CarsTable/PeopleTable (Номера автомобилей по заявке + items-count прыгали на 2 строки).

Фикс:
- TheHeader: flex-wrap + gap, min-height вместо height, info-блок wrap-right.
- TablesComponent: tables__header/filters/fields/options - все flex-wrap + min-width:0.
- CarsTable/PeopleTable card-header: на <=1100px уменьшен gap, padding, шрифт title (0.95em), items-count (0.8em) и history-btn (11px). Всё в одну строку до 960px.

## Тесты

vitest 298/298.