### PR TITLE
feat: расписание day-card + стилизованный input ссылки (#345)

### DIFF
--- a/frontend/src/components/SystemTableScheduleTab.vue
+++ b/frontend/src/components/SystemTableScheduleTab.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="schedule-tab">
-    <div class="schedule-header">
-      <h4 class="schedule-title">
-        Рабочее время
+    <div class="schedule-tab__header-top">
+      <h4 class="schedule-tab__header-title">
+        Режим работы
       </h4>
       <button
         class="add-btn"
@@ -12,83 +12,82 @@
         + Добавить окно
       </button>
     </div>
+    <p class="schedule-tab__hint">
+      Дни без активных окон считаются нерабочими. Круглосуточный режим заменяет
+      обычные окна на 24/7.
+    </p>
 
-    <div class="days-list">
+    <div class="schedule-grid">
       <div
         v-for="day in 7"
         :key="day"
-        class="day-group"
+        class="schedule-day-card"
       >
-        <div class="day-header">
+        <div class="schedule-day-card__head">
           <span class="day-name">{{ getFullDayName(day - 1) }}</span>
-          <div class="round-control">
-            <span class="round-label">Круглосуточно</span>
-            <label class="round-switch">
-              <input
-                type="checkbox"
-                :checked="hasRoundTheClock(day - 1)"
-                :disabled="isLoading"
-                @change="toggleRoundTheClock(day - 1, $event)"
-              >
-              <span class="switch-slider" />
-            </label>
-          </div>
+          <label
+            class="round-switch"
+            :title="'Круглосуточно'"
+          >
+            <input
+              type="checkbox"
+              :checked="hasRoundTheClock(day - 1)"
+              :disabled="isLoading"
+              @change="toggleRoundTheClock(day - 1, $event)"
+            >
+            <span class="switch-slider" />
+          </label>
         </div>
-
-        <div class="day-content">
+        <div class="schedule-day-card__body">
           <div
             v-if="hasActiveRoundTheClock(day - 1)"
-            class="round-badge"
+            class="slot-badge slot-badge--round"
           >
-            Круглосуточно (24/7)
+            <span class="round-clock-text">круглосуточно</span>
           </div>
-
           <div
+            v-for="slot in getActiveSlotsForDay(day - 1)"
             v-else
-            class="slots-wrapper"
+            :key="slot.id"
+            class="slot-badge"
           >
-            <div
-              v-for="slot in getActiveSlotsForDay(day - 1)"
-              :key="slot.id"
-              class="slot-item"
-            >
-              <span class="slot-time">
-                {{ formatTime(slot.open_time) }} – {{ formatTime(slot.close_time) }}
-                <span
-                  v-if="slot.is_next_day"
-                  class="next-mark"
-                >(след. день)</span>
-              </span>
-              <div class="slot-actions">
-                <button
-                  class="icon-btn"
-                  title="Редактировать"
-                  @click="editSlot(slot)"
-                >
-                  <img
-                    src="@/assets/icons/edit.png"
-                    class="icon"
-                  >
-                </button>
-                <button
-                  class="icon-btn"
-                  title="Удалить"
-                  @click="deleteSlot(slot)"
-                >
-                  <img
-                    src="@/assets/icons/trashcan.png"
-                    class="icon"
-                  >
-                </button>
-              </div>
+            <span class="slot-time">
+              {{ formatTime(slot.open_time) }} – {{ formatTime(slot.close_time) }}
+            </span>
+            <div class="slot-badges">
+              <span
+                v-if="slot.is_next_day"
+                class="next-day-badge"
+              >+1</span>
             </div>
-
-            <div
-              v-if="getActiveSlotsForDay(day - 1).length === 0"
-              class="empty-text"
-            >
-              Нет временных окон
+            <div class="slot-actions">
+              <button
+                class="icon-btn"
+                title="Редактировать"
+                @click="editSlot(slot)"
+              >
+                <img
+                  src="@/assets/icons/edit.png"
+                  class="icon"
+                >
+              </button>
+              <button
+                class="icon-btn"
+                title="Удалить"
+                @click="deleteSlot(slot)"
+              >
+                <img
+                  src="@/assets/icons/trashcan.png"
+                  class="icon"
+                >
+              </button>
             </div>
+          </div>
+          <div
+            v-if="!hasActiveRoundTheClock(day - 1) && getActiveSlotsForDay(day - 1).length === 0"
+            class="schedule-day-card__empty"
+          >
+            нет окон
           </div>
         </div>
       </div>
@@ -570,24 +569,110 @@ export default {
   height: 100%;
   display: flex;
   flex-direction: column;
+  gap: 12px;
   font-size: 13px;
+  line-height: 1.5;
 }
 
-.schedule-header {
+.schedule-tab__header-top {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding-bottom: 12px;
-  border-bottom: 1px solid #e6e6e6;
-  margin-bottom: 12px;
-  flex-shrink: 0;
+  gap: 12px;
+  flex-wrap: wrap;
 }
 
-.schedule-title {
+.schedule-tab__header-title {
   margin: 0;
-  font-size: 15px;
+  font-size: 16px;
   font-weight: 600;
-  color: #333;
+  color: #000;
+}
+
+.schedule-tab__hint {
+  margin: 0;
+  font-size: 12px;
+  color: #6b7280;
+  line-height: 1.5;
+}
+
+/* Сетка карточек дней - как в TableInfoModal "Режим работы". */
+.schedule-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 12px;
+}
+
+.schedule-day-card {
+  background: #fff;
+  border: 1px solid #e6e6e6;
+  border-radius: 14px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.schedule-day-card__head {
+  background: #f0f3ff;
+  padding: 8px 10px;
+  border-bottom: 1px solid #e6e6e6;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.schedule-day-card__body {
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.schedule-day-card__empty {
+  text-align: center;
+  color: #aaa;
+  font-size: 11px;
+  font-style: italic;
+  padding: 6px 0;
+}
+
+.slot-badge {
+  position: relative;
+  padding: 6px 8px;
+  background: #f8f9fa;
+  border-radius: 12px;
+  border: 1px solid #e6e6e6;
+  font-size: 11px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.slot-badge--round {
+  background: #eef0ff;
+  border-color: #c7caf5;
+}
+
+.round-clock-text {
+  font-weight: 500;
+  color: #4F5BDF;
+  font-size: 11px;
+}
+
+.slot-badges {
+  display: flex;
+  gap: 4px;
+}
+
+.next-day-badge {
+  background: #4F5BDF;
+  color: #fff;
+  padding: 1px 6px;
+  border-radius: 10px;
+  font-size: 9px;
+  font-weight: 500;
 }
 
 .add-btn {
@@ -608,53 +693,17 @@ export default {
   cursor: not-allowed;
 }
 
-.days-list {
-  flex: 1;
-  overflow-y: auto;
-  padding-right: 4px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.day-group {
-  border: 1px solid #e6e6e6;
-  border-radius: 12px;
-  background: white;
-}
-
-.day-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 10px 14px;
-  background: #f8f9fa;
-  border-bottom: 1px solid #e6e6e6;
-  border-radius: 12px 12px 0 0;
-}
-
 .day-name {
   font-weight: 600;
   color: #333;
   font-size: 13px;
 }
 
-.round-control {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.round-label {
-  font-size: 12px;
-  color: #666;
-}
-
 .round-switch {
   position: relative;
   display: inline-block;
-  width: 40px;
-  height: 22px;
+  width: 34px;
+  height: 18px;
   cursor: pointer;
 }
 .round-switch input {
@@ -676,8 +725,8 @@ export default {
 .switch-slider:before {
   position: absolute;
   content: '';
-  height: 18px;
-  width: 18px;
+  height: 14px;
+  width: 14px;
   left: 2px;
   bottom: 2px;
   background-color: white;
@@ -688,54 +737,19 @@ input:checked + .switch-slider {
   background-color: #4F5BDF;
 }
 input:checked + .switch-slider:before {
-  transform: translateX(18px);
-}
-
-.day-content {
-  padding: 12px 14px;
-}
-
-.round-badge {
-  text-align: center;
-  color: #4F5BDF;
-  font-size: 13px;
-  font-weight: 500;
-  padding: 8px 0;
-  background: #f0f3ff;
-  border-radius: 8px;
-}
-
-.slots-wrapper {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.slot-item {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 8px 10px;
-  background: #f8f9fa;
-  border-radius: 8px;
-  border: 1px solid #e6e6e6;
+  transform: translateX(16px);
 }
 
 .slot-time {
-  font-size: 13px;
+  font-size: 12px;
   color: #333;
-}
-
-.next-mark {
-  font-size: 11px;
-  color: #999;
-  margin-left: 4px;
-  font-style: italic;
+  font-weight: 500;
 }
 
 .slot-actions {
   display: flex;
-  gap: 6px;
+  gap: 2px;
+  margin-top: 2px;
 }
 
 .icon-btn {
@@ -753,17 +767,9 @@ input:checked + .switch-slider:before {
   background-color: #e6e6e6;
 }
 .icon {
-  width: 14px;
-  height: 14px;
+  width: 12px;
+  height: 12px;
   opacity: 0.6;
-}
-
-.empty-text {
-  text-align: center;
-  color: #aaa;
-  font-size: 12px;
-  font-style: italic;
-  padding: 8px 0;
 }
 
 .modal-overlay {

--- a/frontend/src/components/TableConstructor.vue
+++ b/frontend/src/components/TableConstructor.vue
@@ -1837,17 +1837,36 @@ export default {
   align-items: center;
 }
 
+/* Стилизуем .form-input в духе .form-input-sm: round borders, паддинги,
+   focus-голубое подсвечивание. */
 .map-link-group .form-input {
   flex: 1;
+  padding: 10px 14px;
+  border: 1px solid #e6e6e6;
+  border-radius: 12px;
+  font-size: 13px;
+  background: #fff;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  outline: none;
+}
+
+.map-link-group .form-input:focus {
+  border-color: #4F5BDF;
+  box-shadow: 0 0 0 3px rgba(79, 91, 223, 0.12);
+}
+
+.map-link-group .form-input::placeholder {
+  color: #c0c0c0;
 }
 
 .map-link-btn {
-  padding: 8px 16px;
+  padding: 10px 18px;
   background: #f0f3ff;
   color: #4F5BDF;
   text-decoration: none;
   border-radius: 30px;
   font-size: 13px;
+  font-weight: 500;
   white-space: nowrap;
   transition: background-color 0.2s ease;
   border: 1px solid #4F5BDF;


### PR DESCRIPTION
## Общие пункты

### Расписание
Переделал старый день-секции стиль (.day-group/.day-header/.slot-item) на schedule-grid с day-card как в TableInfoModal 'Режим работы'. Каждый день - карточка с голубой шапкой (название + переключатель Круглосуточно) и телом со slot-badge. Edit/delete иконки внутри badge. Empty-state ('нет окон') вместо большого пустого блока. Round-switch уменьшен (34x18 вместо 40x22) под компактную карточку.

### Местоположение - input ссылки
Раньше был дефолтный браузерный input. Теперь: 12px radius, паддинги 10x14, focus-bordering #4F5BDF + box-shadow halo. map-link-btn получил weight 500 и больший padding.

## Что НЕ вошло

Drag&drop для фотографий - оставил на следующую итерацию, чтобы не раздувать PR. Текущий file-input сохранил функциональность.

## Тесты

vitest 298/298 зелёные.