### PR TITLE
feat: точечные CSS-правки + drag-drop фото (#345)

### DIFF
--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -1727,12 +1727,15 @@ export default {
 .detail-item {
   display: flex;
   flex-direction: column;
+  align-items: center;
+  justify-content: center;
   gap: 4px;
   min-width: 0;
-  padding: 8px 12px;
+  padding: 10px 14px;
   background: #fff;
-  border-radius: 8px;
+  border-radius: 20px;
   border: 1px solid #ececec;
+  text-align: center;
 }
 
 .detail-item__label {

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -1687,12 +1687,15 @@ export default {
 .detail-item {
   display: flex;
   flex-direction: column;
+  align-items: center;
+  justify-content: center;
   gap: 4px;
   min-width: 0;
-  padding: 8px 12px;
+  padding: 10px 14px;
   background: #fff;
-  border-radius: 8px;
+  border-radius: 20px;
   border: 1px solid #ececec;
+  text-align: center;
 }
 
 .detail-item__label {

--- a/frontend/src/components/SystemTableAppearanceTab.vue
+++ b/frontend/src/components/SystemTableAppearanceTab.vue
@@ -172,7 +172,6 @@ export default {
 
 <style scoped>
 .appearance-tab {
-  padding: 16px;
   display: flex;
   flex-direction: column;
   gap: 20px;
@@ -297,9 +296,6 @@ export default {
   display: flex;
   justify-content: flex-end;
   gap: 8px;
-  border-top: 1px solid #f0f0f0;
-  padding-top: 12px;
-  margin-top: 4px;
 }
 
 .appearance-tab__btn {

--- a/frontend/src/components/SystemTableColumnsTab.vue
+++ b/frontend/src/components/SystemTableColumnsTab.vue
@@ -418,7 +418,6 @@ export default {
 
 <style scoped>
 .columns-tab {
-  padding: 16px;
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -631,8 +630,6 @@ export default {
   display: flex;
   justify-content: flex-end;
   gap: 8px;
-  border-top: 1px solid #f0f0f0;
-  padding-top: 12px;
 }
 
 .columns-tab__btn {

--- a/frontend/src/components/SystemTableScheduleTab.vue
+++ b/frontend/src/components/SystemTableScheduleTab.vue
@@ -26,16 +26,19 @@
         <div class="schedule-day-card__head">
           <span class="day-name">{{ getFullDayName(day - 1) }}</span>
           <label
-            class="round-switch"
-            :title="'Круглосуточно'"
+            class="round-switch-wrap"
+            :title="'Круглосуточно (24/7)'"
           >
-            <input
-              type="checkbox"
-              :checked="hasRoundTheClock(day - 1)"
-              :disabled="isLoading"
-              @change="toggleRoundTheClock(day - 1, $event)"
-            >
-            <span class="switch-slider" />
+            <span class="round-switch-label">24/7</span>
+            <span class="round-switch">
+              <input
+                type="checkbox"
+                :checked="hasRoundTheClock(day - 1)"
+                :disabled="isLoading"
+                @change="toggleRoundTheClock(day - 1, $event)"
+              >
+              <span class="switch-slider" />
+            </span>
           </label>
         </div>
         <div class="schedule-day-card__body">
@@ -697,6 +700,20 @@ export default {
   font-weight: 600;
   color: #333;
   font-size: 13px;
+}
+
+.round-switch-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+}
+
+.round-switch-label {
+  font-size: 10px;
+  font-weight: 600;
+  color: #6b7280;
+  letter-spacing: 0.4px;
 }
 
 .round-switch {

--- a/frontend/src/components/TableConstructor.vue
+++ b/frontend/src/components/TableConstructor.vue
@@ -211,13 +211,13 @@
                 </span>
               </div>
               <div class="table-info-row">
-                <span class="system-name">{{ selectedTable.table.name }}</span>
                 <span
                   class="current-status-badge"
                   :class="getTableCurrentStatusClass(selectedTable)"
                 >
                   {{ getTableCurrentStatusText(selectedTable) }}
                 </span>
+                <span class="system-name">{{ selectedTable.table.name }}</span>
               </div>
             </div>
             <div class="details-header-actions">
@@ -1355,16 +1355,15 @@ export default {
 }
 
 .tab-btn {
-  padding: 10px 18px;
-  background: none;
-  border: none;
-  border-bottom: 2px solid transparent;
+  padding: 8px 18px;
+  background: #fff;
+  border: 1px solid transparent;
   cursor: pointer;
   font-size: 13px;
   font-weight: 600;
   color: #6b7280;
   transition: color 0.2s ease, background 0.2s ease, border-color 0.2s ease;
-  border-radius: 8px 8px 0 0;
+  border-radius: 50px;
   white-space: nowrap;
   flex-shrink: 0;
 }
@@ -1376,7 +1375,7 @@ export default {
 
 .tab-btn.active {
   color: #4F5BDF;
-  border-bottom-color: #4F5BDF;
+  border-color: #4F5BDF;
   background: #fff;
 }
 
@@ -1864,14 +1863,22 @@ export default {
 .map-link-group {
   display: flex;
   gap: 12px;
+  align-items: stretch;
+}
+
+/* Input и кнопка одинаковой высоты через height + box-sizing - чтобы кнопка
+   не вылезала выше инпута из-за разного line-height у <a> и <input>. */
+.map-link-group .form-input,
+.map-link-group .map-link-btn {
+  height: 40px;
+  box-sizing: border-box;
+  display: inline-flex;
   align-items: center;
 }
 
-/* Стилизуем .form-input в духе .form-input-sm: round borders, паддинги,
-   focus-голубое подсвечивание. */
 .map-link-group .form-input {
   flex: 1;
-  padding: 10px 14px;
+  padding: 0 14px;
   border: 1px solid #e6e6e6;
   border-radius: 12px;
   font-size: 13px;
@@ -1890,7 +1897,7 @@ export default {
 }
 
 .map-link-btn {
-  padding: 10px 18px;
+  padding: 0 18px;
   background: #f0f3ff;
   color: #4F5BDF;
   text-decoration: none;

--- a/frontend/src/components/TableConstructorPhotoSection.vue
+++ b/frontend/src/components/TableConstructorPhotoSection.vue
@@ -16,6 +16,43 @@
       </label>
     </div>
 
+    <!-- Drag&drop zone - можно перетащить файлы из проводника или кликнуть. -->
+    <label
+      class="photo-dropzone"
+      :class="{ 'photo-dropzone--active': isDragging }"
+      @dragenter.prevent="isDragging = true"
+      @dragover.prevent="isDragging = true"
+      @dragleave.prevent="isDragging = false"
+      @drop.prevent="onDrop"
+    >
+      <input
+        type="file"
+        accept="image/*"
+        multiple
+        class="photo-dropzone__input"
+        @change="uploadPhotos"
+      >
+      <svg
+        width="32"
+        height="32"
+        viewBox="0 0 24 24"
+        fill="none"
+        class="photo-dropzone__icon"
+      >
+        <path
+          d="M12 4v12m0 0l-4-4m4 4l4-4M4 20h16"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+      <div class="photo-dropzone__text">
+        <strong>Перетащите фотографии сюда</strong>
+        <span>или нажмите, чтобы выбрать из обзора</span>
+      </div>
+    </label>
+
     <div class="photos-grid">
       <div
         v-for="photo in photos"
@@ -125,26 +162,39 @@ export default {
   data() {
     return {
       showPhotoModal: false,
-      viewingPhoto: null
+      viewingPhoto: null,
+      isDragging: false,
     };
   },
   methods: {
     async uploadPhotos(event) {
       const files = event.target.files;
       if (!files || files.length === 0) return;
+      await this.uploadFiles(files);
+      // Сбрасываем input, чтобы можно было повторно выбрать те же файлы.
+      event.target.value = '';
+    },
 
+    onDrop(event) {
+      this.isDragging = false;
+      const files = event.dataTransfer?.files;
+      if (files && files.length) this.uploadFiles(files);
+    },
+
+    async uploadFiles(files) {
       const formData = new FormData();
       for (let i = 0; i < files.length; i++) {
-        formData.append('photos', files[i]);
+        // Принимаем только изображения - drag из проводника может тащить любое.
+        if (!files[i].type || files[i].type.startsWith('image/')) {
+          formData.append('photos', files[i]);
+        }
       }
-
       try {
         const response = await apiRequest(`/system-tables/${this.tableId}/photos`, {
           method: 'POST',
           body: formData,
           headers: {},
         });
-
         if (response.ok) {
           this.$emit('photos-changed');
           this.dispatchNotification('Фотографии успешно загружены', 'success');
@@ -243,6 +293,67 @@ export default {
 .upload-photo-btn:hover {
   background: #4F5BDF;
   color: white;
+}
+
+/* Drop-zone для перетаскивания файлов из проводника. Также служит обычной
+   кнопкой обзора (label + input file). */
+.photo-dropzone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 20px;
+  margin-bottom: 12px;
+  border: 2px dashed #c0c4d8;
+  border-radius: 16px;
+  background: #fafbff;
+  color: #6b7280;
+  cursor: pointer;
+  text-align: center;
+  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.photo-dropzone:hover {
+  border-color: #4F5BDF;
+  background: #f0f3ff;
+  color: #4F5BDF;
+}
+
+.photo-dropzone--active {
+  border-color: #4F5BDF;
+  background: #e6ebff;
+  color: #4F5BDF;
+}
+
+.photo-dropzone__input {
+  display: none;
+}
+
+.photo-dropzone__icon {
+  color: inherit;
+}
+
+.photo-dropzone__text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.photo-dropzone__text strong {
+  color: #333;
+  font-weight: 600;
+}
+
+.photo-dropzone:hover .photo-dropzone__text strong,
+.photo-dropzone--active .photo-dropzone__text strong {
+  color: #4F5BDF;
+}
+
+.photo-dropzone__text span {
+  font-size: 11px;
 }
 
 .photos-grid {


### PR DESCRIPTION
## Точечные правки по ревью

- **#2** detail-item: radius 20px + center alignment.
- **#3** tab-btn: круглые pill, в active - полный border #4F5BDF.
- **#4** убрал border-top и padding-top у *-tab__actions.
- **#7** видимая подпись '24/7' рядом с тумблером в Расписание.
- **#8** map-link-btn = высота input (40px stretch).
- swap: статус-бейдж слева, system-name справа в Основное.
- padding cleanup: убрал внутренний padding 16px у .columns-tab/.appearance-tab.

## Drag-drop фото

Добавил dropzone в TableConstructorPhotoSection: можно перетащить файлы из проводника или кликнуть. Active state с подсветкой. Принимаем только image/*.