### PR TITLE
feat: единство дизайна settings + точечные правки (#345)

### DIFF
--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -1763,7 +1763,6 @@ export default {
 .detail-item {
   display: flex;
   flex-direction: column;
-  align-items: center;
   justify-content: center;
   gap: 4px;
   min-width: 0;
@@ -1771,7 +1770,6 @@ export default {
   background: #fff;
   border-radius: 20px;
   border: 1px solid #ececec;
-  text-align: center;
 }
 
 .detail-item__label {

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -1711,7 +1711,6 @@ export default {
 .detail-item {
   display: flex;
   flex-direction: column;
-  align-items: center;
   justify-content: center;
   gap: 4px;
   min-width: 0;
@@ -1719,7 +1718,6 @@ export default {
   background: #fff;
   border-radius: 20px;
   border: 1px solid #ececec;
-  text-align: center;
 }
 
 .detail-item__label {

--- a/frontend/src/components/SystemTableAppearanceTab.vue
+++ b/frontend/src/components/SystemTableAppearanceTab.vue
@@ -174,7 +174,7 @@ export default {
 .appearance-tab {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 15px;
   line-height: 1.5;
 }
 
@@ -201,7 +201,7 @@ export default {
 
 .appearance-tab__title {
   margin: 0;
-  font-size: 14px;
+  font-size: 16px;
   font-weight: 600;
   color: #000;
 }

--- a/frontend/src/components/SystemTableColumnsTab.vue
+++ b/frontend/src/components/SystemTableColumnsTab.vue
@@ -420,14 +420,14 @@ export default {
 .columns-tab {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 15px;
   line-height: 1.5;
 }
 
 .columns-tab__header {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 15px;
 }
 
 .columns-tab__header-top {

--- a/frontend/src/components/SystemTableScheduleTab.vue
+++ b/frontend/src/components/SystemTableScheduleTab.vue
@@ -572,7 +572,7 @@ export default {
   height: 100%;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 15px;
   font-size: 13px;
   line-height: 1.5;
 }

--- a/frontend/src/components/TableConstructor.vue
+++ b/frontend/src/components/TableConstructor.vue
@@ -295,8 +295,8 @@
               <div class="form-group">
                 <label class="detail-label">Статус:</label>
                 <p class="field-hint">
-                  Виден пользователю в шапке таблицы и на главной. "Не активно" /
-                  "На обслуживании" - таблицу нельзя выбрать в новой заявке.
+                  "Не активно" / "На обслуживании" - таблицу нельзя выбрать в
+                  новой заявке. Пользователь видит причину.
                 </p>
                 <div class="status-toggle">
                   <button 
@@ -352,9 +352,9 @@
                     <span class="checkbox-text">Отображать таблицу "по факту"</span>
                   </label>
                   <p class="field-hint">
-                    Фактовая таблица (синяя плашка сверху основной) показывает
-                    кто реально прошёл/проехал, в отличие от основной "по заявке".
-                    Можно отдельно настроить её колонки и оформление.
+                    На странице с основной таблицей отображается таблица
+                    "по факту". В ней отображаются люди/машины, данные которых
+                    заранее не известны.
                   </p>
                 </div>
 
@@ -1467,9 +1467,10 @@ export default {
 .system-name {
   font-size: 12px;
   color: #666;
-  background: #f5f5f5;
-  padding: 2px 8px;
-  border-radius: 4px;
+  background: transparent;
+  padding: 4px 12px;
+  border: 1px solid #e6e6e6;
+  border-radius: 50px;
 }
 
 .current-status-badge {
@@ -1593,7 +1594,7 @@ export default {
 .form-input-sm {
   padding: 8px 12px;
   border: 1px solid #e6e6e6;
-  border-radius: 10px;
+  border-radius: 15px;
   font-size: 13px;
   width: 100%;
   transition: border-color 0.2s;
@@ -1608,7 +1609,7 @@ export default {
 .form-textarea {
   padding: 8px 12px;
   border: 1px solid #e6e6e6;
-  border-radius: 10px;
+  border-radius: 15px;
   font-size: 13px;
   width: 100%;
   transition: border-color 0.2s;
@@ -1668,7 +1669,7 @@ export default {
   right: 0;
   background: white;
   border: 1px solid #e6e6e6;
-  border-radius: 8px;
+  border-radius: 15px;
   box-shadow: 0 4px 12px rgba(0,0,0,0.1);
   z-index: 10;
   margin-top: 4px;
@@ -1876,9 +1877,9 @@ export default {
 
 .section-title {
   margin: 0 0 12px 0;
-  font-size: 14px;
+  font-size: 16px;
   font-weight: 600;
-  color: #333;
+  color: #000;
 }
 
 .map-link-group {
@@ -1901,7 +1902,7 @@ export default {
   flex: 1;
   padding: 0 14px;
   border: 1px solid #e6e6e6;
-  border-radius: 12px;
+  border-radius: 15px;
   font-size: 13px;
   background: #fff;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;

--- a/frontend/src/components/TableConstructorPhotoSection.vue
+++ b/frontend/src/components/TableConstructorPhotoSection.vue
@@ -306,7 +306,7 @@ export default {
   padding: 20px;
   margin-bottom: 12px;
   border: 2px dashed #c0c4d8;
-  border-radius: 16px;
+  border-radius: 50px;
   background: #fafbff;
   color: #6b7280;
   cursor: pointer;
@@ -469,7 +469,8 @@ export default {
   color: #a2a2a2;
   background: #f8f9fa;
   border: 1px dashed #e6e6e6;
-  border-radius: 8px;
+  border-radius: 25px;
+  font-size: 15px;
 }
 
 /* Модальное окно */


### PR DESCRIPTION
## Точечные

- #1 detail-item: убрал align/text center, оставил justify.
- #2 system-name: border 1px solid #e6e6e6 + radius 50px (без bg).
- #3 photo-dropzone radius 50, no-photos radius 25 + font 15px.
- Тексты подсказок к Статусу и Таблице по факту - обновил по образцу.

## Единство

- Шрифт заголовков везде 16px (section-title, appearance-tab__title).
- Inputs/textarea/dropdown - border-radius 15px.
- Gap 15px на корне всех settings-вкладок (columns, appearance, schedule).