### PR TITLE
feat: настройки увеличенного режима по столбцам (#345)

### DIFF
--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -504,6 +504,9 @@ export default {
       fieldOrders: {},
       fieldWidths: {},
       fieldPriorities: {},
+      fieldsEnlargedVisibility: {},
+      fieldsEnlargedWidth: {},
+      fieldsEnlargedWeight: {},
       tableFontSize: 14,
       rowDensity: 'normal',
       expandedRows: {},
@@ -1046,6 +1049,11 @@ export default {
     },
 
     isFieldVisible(fieldName) {
+      // В enlarged-режиме - отдельный флаг видимости столбца.
+      if (this.enlarged) {
+        const ev = this.fieldsEnlargedVisibility[fieldName];
+        if (ev === false) return false;
+      }
       // Пока конфиг не загружен - показываем всё (предотвращает мигание при инициализации).
       const v = this.fieldsVisibility[fieldName];
       const visible = v === undefined ? true : v;
@@ -1124,7 +1132,16 @@ export default {
       const width = this.fieldWidths[fieldName];
       const style = {};
       if (order !== undefined) style.order = 10 + order;
-      if (!this.enlarged && width !== undefined && width > 0) style.flexGrow = width;
+      if (this.enlarged) {
+        // В enlarged: используем enlarged_width если >0, иначе CSS-дефолт (без inline grow).
+        const ew = this.fieldsEnlargedWidth[fieldName];
+        if (typeof ew === 'number' && ew > 0) style.flexGrow = ew;
+        // enlarged_font_weight - применяем inline если > 0.
+        const eweight = this.fieldsEnlargedWeight[fieldName];
+        if (typeof eweight === 'number' && eweight > 0) style.fontWeight = eweight;
+      } else if (width !== undefined && width > 0) {
+        style.flexGrow = width;
+      }
       return Object.keys(style).length ? style : null;
     },
 
@@ -1138,6 +1155,9 @@ export default {
         const nextOrd = {};
         const nextW = {};
         const nextP = {};
+        const nextEnlVis = {};
+        const nextEnlW = {};
+        const nextEnlWeight = {};
         (data.fields || []).forEach(f => {
           nextVis[f.field_name] = f.is_visible !== false;
           if (typeof f.display_order === 'number') {
@@ -1149,11 +1169,21 @@ export default {
           if (typeof f.priority === 'number' && f.priority > 0) {
             nextP[f.field_name] = f.priority;
           }
+          nextEnlVis[f.field_name] = f.enlarged_is_visible !== false;
+          if (typeof f.enlarged_width === 'number' && f.enlarged_width > 0) {
+            nextEnlW[f.field_name] = f.enlarged_width;
+          }
+          if (typeof f.enlarged_font_weight === 'number' && f.enlarged_font_weight > 0) {
+            nextEnlWeight[f.field_name] = f.enlarged_font_weight;
+          }
         });
         this.fieldsVisibility = nextVis;
         this.fieldOrders = nextOrd;
         this.fieldWidths = nextW;
         this.fieldPriorities = nextP;
+        this.fieldsEnlargedVisibility = nextEnlVis;
+        this.fieldsEnlargedWidth = nextEnlW;
+        this.fieldsEnlargedWeight = nextEnlWeight;
         // Применяем стиль уровня таблицы (#345 фазы 1D+1E).
         const tbl = data.table || {};
         const fs = Number(tbl.font_size);

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -552,6 +552,9 @@ export default {
       fieldOrders: {},
       fieldWidths: {},
       fieldPriorities: {},
+      fieldsEnlargedVisibility: {},
+      fieldsEnlargedWidth: {},
+      fieldsEnlargedWeight: {},
       tableFontSize: 14,
       rowDensity: 'normal',
       expandedRows: {},
@@ -777,6 +780,9 @@ export default {
         const nextOrders = {};
         const nextWidths = {};
         const nextPriorities = {};
+        const nextEnlVis = {};
+        const nextEnlW = {};
+        const nextEnlWeight = {};
         (responseData.fields || []).forEach(f => {
           nextVisibility[f.field_name] = f.is_visible !== false;
           if (typeof f.display_order === 'number') {
@@ -788,11 +794,21 @@ export default {
           if (typeof f.priority === 'number' && f.priority > 0) {
             nextPriorities[f.field_name] = f.priority;
           }
+          nextEnlVis[f.field_name] = f.enlarged_is_visible !== false;
+          if (typeof f.enlarged_width === 'number' && f.enlarged_width > 0) {
+            nextEnlW[f.field_name] = f.enlarged_width;
+          }
+          if (typeof f.enlarged_font_weight === 'number' && f.enlarged_font_weight > 0) {
+            nextEnlWeight[f.field_name] = f.enlarged_font_weight;
+          }
         });
         this.fieldsVisibility = nextVisibility;
         this.fieldOrders = nextOrders;
         this.fieldWidths = nextWidths;
         this.fieldPriorities = nextPriorities;
+        this.fieldsEnlargedVisibility = nextEnlVis;
+        this.fieldsEnlargedWidth = nextEnlW;
+        this.fieldsEnlargedWeight = nextEnlWeight;
         const fs = Number(table.font_size);
         if (fs >= 10 && fs <= 24) this.tableFontSize = fs;
         const dens = table.row_density;
@@ -1049,6 +1065,10 @@ export default {
     },
 
     isFieldVisible(fieldName) {
+      if (this.enlarged) {
+        const ev = this.fieldsEnlargedVisibility[fieldName];
+        if (ev === false) return false;
+      }
       // Пока конфиг не загружен - показываем всё (предотвращает мигание при инициализации).
       const v = this.fieldsVisibility[fieldName];
       const visible = v === undefined ? true : v;
@@ -1074,7 +1094,14 @@ export default {
       const width = this.fieldWidths[fieldName];
       const style = {};
       if (order !== undefined) style.order = 10 + order;
-      if (!this.enlarged && width !== undefined && width > 0) style.flexGrow = width;
+      if (this.enlarged) {
+        const ew = this.fieldsEnlargedWidth[fieldName];
+        if (typeof ew === 'number' && ew > 0) style.flexGrow = ew;
+        const eweight = this.fieldsEnlargedWeight[fieldName];
+        if (typeof eweight === 'number' && eweight > 0) style.fontWeight = eweight;
+      } else if (width !== undefined && width > 0) {
+        style.flexGrow = width;
+      }
       return Object.keys(style).length ? style : null;
     },
 

--- a/frontend/src/components/SystemTableColumnsTab.vue
+++ b/frontend/src/components/SystemTableColumnsTab.vue
@@ -3,8 +3,30 @@
     <div class="columns-tab__header">
       <div class="columns-tab__header-top">
         <h4 class="columns-tab__title">
-          Видимые столбцы
+          {{ enlargedMode ? 'Столбцы в увеличенном режиме' : 'Видимые столбцы' }}
         </h4>
+        <div
+          class="columns-tab__mode-toggle"
+          role="radiogroup"
+          aria-label="Режим настройки"
+        >
+          <button
+            type="button"
+            class="columns-tab__mode-btn"
+            :class="{ 'columns-tab__mode-btn--active': !enlargedMode }"
+            @click="enlargedMode = false"
+          >
+            Обычный
+          </button>
+          <button
+            type="button"
+            class="columns-tab__mode-btn"
+            :class="{ 'columns-tab__mode-btn--active': enlargedMode }"
+            @click="enlargedMode = true"
+          >
+            Увеличенный
+          </button>
+        </div>
         <div class="columns-tab__actions">
           <button
             class="columns-tab__btn columns-tab__btn--secondary"
@@ -22,15 +44,29 @@
           </button>
         </div>
       </div>
-      <p class="columns-tab__hint">
+      <p
+        v-if="!enlargedMode"
+        class="columns-tab__hint"
+      >
         Переставляйте столбцы перетаскиванием за иконку слева. Скрытые столбцы не отображаются в таблице.
       </p>
-      <p class="columns-tab__hint">
+      <p
+        v-if="!enlargedMode"
+        class="columns-tab__hint"
+      >
         <b>Ширина</b> - относительный вес столбца. Браузер делит доступную ширину
         видимых столбцов пропорционально этим весам. <b>Приоритет</b> (1-5) -
         видимость на вертикальном (книжном) экране охранника: 1 - всегда виден,
         2 - виден на узком экране, 3-5 - скрывается и доступен по кнопке "Подробнее"
         под строкой.
+      </p>
+      <p
+        v-else
+        class="columns-tab__hint"
+      >
+        Настройки применяются ТОЛЬКО когда у пользователя включён
+        <b>Увеличенный режим</b> в шапке таблицы. <b>Ширина</b> - 0 значит
+        брать обычную. <b>Жирность</b> - 0 значит дефолт (500).
       </p>
     </div>
 
@@ -111,20 +147,29 @@
           </span>
           <label class="columns-tab__check-row">
             <input
+              v-if="!enlargedMode"
               v-model="field.is_visible"
               type="checkbox"
               class="columns-tab__checkbox"
               :data-field="field.field_name"
+            >
+            <input
+              v-else
+              v-model="field.enlarged_is_visible"
+              type="checkbox"
+              class="columns-tab__checkbox"
+              :data-field-enlarged="field.field_name"
             >
             <span class="columns-tab__label">{{ humanLabel(field.field_name) }}</span>
             <span class="columns-tab__field-name">{{ field.field_name }}</span>
           </label>
           <div
             class="columns-tab__width"
-            :title="'Ширина столбца (вес flex-grow). Браузер делит доступную ширину пропорционально весам видимых столбцов.'"
+            :title="enlargedMode ? 'Ширина в увеличенном режиме (0 = брать обычную)' : 'Ширина столбца (flex-grow). Браузер делит ширину пропорционально весам видимых столбцов.'"
           >
             <span class="columns-tab__width-label">Ширина:</span>
             <input
+              v-if="!enlargedMode"
               v-model.number="field.width"
               type="number"
               min="1"
@@ -132,8 +177,18 @@
               class="columns-tab__width-input"
               :data-width-field="field.field_name"
             >
+            <input
+              v-else
+              v-model.number="field.enlarged_width"
+              type="number"
+              min="0"
+              max="100"
+              class="columns-tab__width-input"
+              :data-enlarged-width-field="field.field_name"
+            >
           </div>
           <div
+            v-if="!enlargedMode"
             class="columns-tab__priority"
             :title="'Приоритет в портретном режиме (1-5). 1 = всегда виден, 2 = виден на узком экране, 3-5 = скрывается в портрете и доступен по кнопке Подробнее.'"
           >
@@ -150,6 +205,25 @@
               >
                 {{ n }}
               </option>
+            </select>
+          </div>
+          <div
+            v-else
+            class="columns-tab__priority"
+            :title="'Жирность шрифта в увеличенном режиме. 0 = по умолчанию (500).'"
+          >
+            <span class="columns-tab__priority-label">Жирность:</span>
+            <select
+              v-model.number="field.enlarged_font_weight"
+              class="columns-tab__priority-select"
+              :data-enlarged-weight-field="field.field_name"
+            >
+              <option :value="0">0</option>
+              <option :value="400">400</option>
+              <option :value="500">500</option>
+              <option :value="600">600</option>
+              <option :value="700">700</option>
+              <option :value="800">800</option>
             </select>
           </div>
         </div>
@@ -246,9 +320,13 @@ export default {
       originalOrder: [],
       originalWidth: {},
       originalPriority: {},
+      originalEnlargedVisibility: {},
+      originalEnlargedWidth: {},
+      originalEnlargedWeight: {},
       saving: false,
       draggingIndex: null,
       prevBodyCursor: '',
+      enlargedMode: false,
     };
   },
   computed: {
@@ -283,7 +361,17 @@ export default {
       const priorityChanged = this.localFields.some(
         f => this.originalPriority[f.field_name] !== f.priority,
       );
-      return visibilityChanged || orderChanged || widthChanged || priorityChanged;
+      const enlargedVisChanged = this.localFields.some(
+        f => this.originalEnlargedVisibility[f.field_name] !== f.enlarged_is_visible,
+      );
+      const enlargedWChanged = this.localFields.some(
+        f => this.originalEnlargedWidth[f.field_name] !== f.enlarged_width,
+      );
+      const enlargedWeightChanged = this.localFields.some(
+        f => this.originalEnlargedWeight[f.field_name] !== f.enlarged_font_weight,
+      );
+      return visibilityChanged || orderChanged || widthChanged || priorityChanged
+        || enlargedVisChanged || enlargedWChanged || enlargedWeightChanged;
     },
   },
   watch: {
@@ -313,6 +401,9 @@ export default {
         is_visible: f.is_visible !== false,
         width: typeof f.width === 'number' && f.width > 0 ? f.width : 10,
         priority: typeof f.priority === 'number' && f.priority > 0 ? f.priority : 3,
+        enlarged_is_visible: f.enlarged_is_visible !== false,
+        enlarged_width: typeof f.enlarged_width === 'number' ? f.enlarged_width : 0,
+        enlarged_font_weight: typeof f.enlarged_font_weight === 'number' ? f.enlarged_font_weight : 0,
       }));
       this.originalVisibility = Object.fromEntries(
         this.localFields.map(f => [f.field_name, f.is_visible]),
@@ -323,6 +414,15 @@ export default {
       );
       this.originalPriority = Object.fromEntries(
         this.localFields.map(f => [f.field_name, f.priority]),
+      );
+      this.originalEnlargedVisibility = Object.fromEntries(
+        this.localFields.map(f => [f.field_name, f.enlarged_is_visible]),
+      );
+      this.originalEnlargedWidth = Object.fromEntries(
+        this.localFields.map(f => [f.field_name, f.enlarged_width]),
+      );
+      this.originalEnlargedWeight = Object.fromEntries(
+        this.localFields.map(f => [f.field_name, f.enlarged_font_weight]),
       );
     },
     /**
@@ -387,6 +487,9 @@ export default {
               display_order: i,
               width: Math.max(1, Math.min(100, Number(f.width) || 10)),
               priority: Math.max(1, Math.min(5, Number(f.priority) || 3)),
+              enlarged_is_visible: f.enlarged_is_visible !== false,
+              enlarged_width: Math.max(0, Math.min(100, Number(f.enlarged_width) || 0)),
+              enlarged_font_weight: Number(f.enlarged_font_weight) || 0,
             })),
           }),
         });
@@ -404,6 +507,15 @@ export default {
         );
         this.originalPriority = Object.fromEntries(
           this.localFields.map(f => [f.field_name, f.priority]),
+        );
+        this.originalEnlargedVisibility = Object.fromEntries(
+          this.localFields.map(f => [f.field_name, f.enlarged_is_visible]),
+        );
+        this.originalEnlargedWidth = Object.fromEntries(
+          this.localFields.map(f => [f.field_name, f.enlarged_width]),
+        );
+        this.originalEnlargedWeight = Object.fromEntries(
+          this.localFields.map(f => [f.field_name, f.enlarged_font_weight]),
         );
         this.$emit('update');
       } catch (e) {
@@ -436,6 +548,36 @@ export default {
   align-items: center;
   gap: 12px;
   flex-wrap: wrap;
+}
+
+/* Toggle "Обычный | Увеличенный" - сегмент-контрол как в Оформление. */
+.columns-tab__mode-toggle {
+  display: inline-flex;
+  border: 1px solid #e6e6e6;
+  border-radius: 50px;
+  overflow: hidden;
+  background: #fafafa;
+}
+
+.columns-tab__mode-btn {
+  padding: 6px 14px;
+  background: transparent;
+  border: none;
+  font-size: 12px;
+  color: #6b7280;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.columns-tab__mode-btn:hover:not(.columns-tab__mode-btn--active) {
+  background: #f0f0f0;
+  color: #333;
+}
+
+.columns-tab__mode-btn--active {
+  background: #4F5BDF;
+  color: #fff;
+  font-weight: 500;
 }
 
 .columns-tab__title {

--- a/internal/models/system_table.go
+++ b/internal/models/system_table.go
@@ -89,8 +89,15 @@ type TableField struct {
 	Width int `gorm:"default:10" json:"width"`
 	// Priority - приоритет столбца для портретного режима (1-5).
 	// 1 = всегда виден, 2 = виден на компактных экранах, 3-5 = скрывается в портрете.
-	Priority  int       `gorm:"default:3" json:"priority"`
-	CreatedAt time.Time `json:"created_at"`
+	Priority int `gorm:"default:3" json:"priority"`
+	// Настройки для режима "Увеличенный" (#345).
+	// EnlargedIsVisible - видимость в enlarged (по умолчанию true).
+	// EnlargedWidth - вес ширины в enlarged (0 = брать обычный Width).
+	// EnlargedFontWeight - жирность шрифта в enlarged (400/500/600/700; 0 = default 500).
+	EnlargedIsVisible  bool      `gorm:"default:true" json:"enlarged_is_visible"`
+	EnlargedWidth      int       `gorm:"default:0" json:"enlarged_width"`
+	EnlargedFontWeight int       `gorm:"default:0" json:"enlarged_font_weight"`
+	CreatedAt          time.Time `json:"created_at"`
 }
 
 // TableFieldFact - настраиваемые столбцы FactTable. Хранится отдельно от
@@ -171,13 +178,17 @@ type UpdateTimeSlotRequest struct {
 }
 
 // FieldVisibilityUpdate -- одиночное обновление видимости, порядка, ширины и
-// приоритета столбца (#345). DisplayOrder, Width, Priority опциональны.
+// приоритета столбца (#345). DisplayOrder, Width, Priority и enlarged-поля
+// опциональны - не передаются, если их не меняли.
 type FieldVisibilityUpdate struct {
-	FieldName    string `json:"field_name" validate:"required"`
-	IsVisible    bool   `json:"is_visible"`
-	DisplayOrder *int   `json:"display_order"`
-	Width        *int   `json:"width"`
-	Priority     *int   `json:"priority"`
+	FieldName          string `json:"field_name" validate:"required"`
+	IsVisible          bool   `json:"is_visible"`
+	DisplayOrder       *int   `json:"display_order"`
+	Width              *int   `json:"width"`
+	Priority           *int   `json:"priority"`
+	EnlargedIsVisible  *bool  `json:"enlarged_is_visible"`
+	EnlargedWidth      *int   `json:"enlarged_width"`
+	EnlargedFontWeight *int   `json:"enlarged_font_weight"`
 }
 
 // UpdateFieldsRequest -- bulk-обновление видимости столбцов системной таблицы.

--- a/internal/services/system_table_service.go
+++ b/internal/services/system_table_service.go
@@ -636,6 +636,23 @@ func (s *systemTableService) UpdateFields(ctx context.Context, tableID int, req 
 				}
 				updates["priority"] = *f.Priority
 			}
+			if f.EnlargedIsVisible != nil {
+				updates["enlarged_is_visible"] = *f.EnlargedIsVisible
+			}
+			if f.EnlargedWidth != nil {
+				if *f.EnlargedWidth < 0 || *f.EnlargedWidth > 100 {
+					return echo.NewHTTPError(http.StatusBadRequest, "enlarged_width должен быть от 0 до 100")
+				}
+				updates["enlarged_width"] = *f.EnlargedWidth
+			}
+			if f.EnlargedFontWeight != nil {
+				switch *f.EnlargedFontWeight {
+				case 0, 400, 500, 600, 700, 800:
+					updates["enlarged_font_weight"] = *f.EnlargedFontWeight
+				default:
+					return echo.NewHTTPError(http.StatusBadRequest, "enlarged_font_weight должен быть 400, 500, 600, 700, 800 или 0")
+				}
+			}
 			result := tx.Model(&models.TableField{}).
 				Where("table_id = ? AND field_name = ?", tableID, f.FieldName).
 				Updates(updates)
@@ -643,6 +660,15 @@ func (s *systemTableService) UpdateFields(ctx context.Context, tableID int, req 
 				slog.Error("не удалось обновить столбец",
 					"table_id", tableID, "field", f.FieldName, "error", result.Error)
 				return echo.NewHTTPError(http.StatusInternalServerError, "Error updating field")
+			}
+			// GORM пропускает enlarged_is_visible=false (zero-value bool) -
+			// дофиксим явным Update как для fact-полей.
+			if f.EnlargedIsVisible != nil && !*f.EnlargedIsVisible {
+				if err := tx.Model(&models.TableField{}).
+					Where("table_id = ? AND field_name = ?", tableID, f.FieldName).
+					Update("enlarged_is_visible", false).Error; err != nil {
+					return echo.NewHTTPError(http.StatusInternalServerError, "Error setting enlarged visibility")
+				}
 			}
 		}
 		return nil


### PR DESCRIPTION
## Замечание №4

Независимые настройки enlarged-режима по каждому столбцу: видимость, ширина, жирность шрифта.

### Бэк
- TableField += EnlargedIsVisible (default true), EnlargedWidth (0 = обычная), EnlargedFontWeight (0 = CSS-дефолт 500).
- FieldVisibilityUpdate принимает opt-поля enlarged_*.
- Валидация: width 0-100, weight in {0,400,500,600,700,800}.
- GORM bool zero-value дофикс для enlarged_is_visible=false.

### Фронт
- Toggle 'Обычный | Увеличенный' в SystemTableColumnsTab. В Увеличенном чекбокс/ширина/select переключаются на enlarged-варианты, последний меняется с 'Приоритет' на 'Жирность'.
- CarsTable/PeopleTable: в isFieldVisible учитывают enlarged-видимость, getColStyle в enlarged применяет enlarged_width + inline fontWeight.

## Тесты

vitest 298/298, go test зелёные.