### PR TITLE
fix: точечные правки после ревью settings и enlarged-режима (#345)

### DIFF
--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -56,8 +56,9 @@
             Выезд
           </div>
           <div
-            v-if="isFieldVisible('car_number')"
+            v-if="isFieldInDom('car_number')"
             class="col number-col"
+            :class="fieldColClass('car_number')"
             :style="getColStyle('car_number')"
             @click="sortBy('car_number')"
           >
@@ -71,8 +72,9 @@
             >
           </div>
           <div
-            v-if="isFieldVisible('car_brand')"
+            v-if="isFieldInDom('car_brand')"
             class="col brand-col"
+            :class="fieldColClass('car_brand')"
             :style="getColStyle('car_brand')"
             @click="sortBy('car_brand')"
           >
@@ -86,8 +88,9 @@
             >
           </div>
           <div
-            v-if="isFieldVisible('organization')"
+            v-if="isFieldInDom('organization')"
             class="col organization-col"
+            :class="fieldColClass('organization')"
             :style="getColStyle('organization')"
             @click="sortBy('organization')"
           >
@@ -101,8 +104,9 @@
             >
           </div>
           <div
-            v-if="isFieldVisible('company')"
+            v-if="isFieldInDom('company')"
             class="col company-col"
+            :class="fieldColClass('company')"
             :style="getColStyle('company')"
             @click="sortBy('company')"
           >
@@ -116,8 +120,9 @@
             >
           </div>
           <div
-            v-if="isFieldVisible('application_id')"
+            v-if="isFieldInDom('application_id')"
             class="col application-col"
+            :class="fieldColClass('application_id')"
             :style="getColStyle('application_id')"
             @click="sortBy('application_id')"
           >
@@ -131,8 +136,9 @@
             >
           </div>
           <div
-            v-if="isFieldVisible('unload_place')"
+            v-if="isFieldInDom('unload_place')"
             class="col place-col"
+            :class="fieldColClass('unload_place')"
             :style="getColStyle('unload_place')"
             @click="sortBy('unload_place')"
           >
@@ -146,8 +152,9 @@
             >
           </div>
           <div
-            v-if="isFieldVisible('valid_until')"
+            v-if="isFieldInDom('valid_until')"
             class="col date-col"
+            :class="fieldColClass('valid_until')"
             :style="getColStyle('valid_until')"
             @click="sortBy('entry_date_to')"
           >
@@ -161,8 +168,9 @@
             >
           </div>
           <div
-            v-if="isFieldVisible('time_range')"
+            v-if="isFieldInDom('time_range')"
             class="col time-col"
+            :class="fieldColClass('time_range')"
             :style="getColStyle('time_range')"
             @click="sortBy('entry_time')"
           >
@@ -176,8 +184,9 @@
             >
           </div>
           <div
-            v-if="isFieldVisible('status')"
+            v-if="isFieldInDom('status')"
             class="col status-col"
+            :class="fieldColClass('status')"
             :style="getColStyle('status')"
             @click="sortBy('status')"
           >
@@ -271,64 +280,73 @@
                   </button>
                 </div>
                 <div
-                  v-if="isFieldVisible('car_number')"
+                  v-if="isFieldInDom('car_number')"
                   class="col number-col"
+                  :class="fieldColClass('car_number')"
                   :style="getColStyle('car_number')"
                 >
                   {{ item.car_number }}
                 </div>
                 <div
-                  v-if="isFieldVisible('car_brand')"
+                  v-if="isFieldInDom('car_brand')"
                   class="col brand-col"
+                  :class="fieldColClass('car_brand')"
                   :style="getColStyle('car_brand')"
                 >
                   {{ item.car_brand }}
                 </div>
                 <div
-                  v-if="isFieldVisible('organization')"
+                  v-if="isFieldInDom('organization')"
                   class="col organization-col"
+                  :class="fieldColClass('organization')"
                   :style="getColStyle('organization')"
                 >
                   {{ item.organization_name }}
                 </div>
                 <div
-                  v-if="isFieldVisible('company')"
+                  v-if="isFieldInDom('company')"
                   class="col company-col"
+                  :class="fieldColClass('company')"
                   :style="getColStyle('company')"
                 >
                   {{ item.company || '-' }}
                 </div>
                 <div
-                  v-if="isFieldVisible('application_id')"
+                  v-if="isFieldInDom('application_id')"
                   class="col application-col"
+                  :class="fieldColClass('application_id')"
                   :style="getColStyle('application_id')"
                 >
                   {{ item.applicationNumber || '-' }}
                 </div>
                 <div
-                  v-if="isFieldVisible('unload_place')"
+                  v-if="isFieldInDom('unload_place')"
                   class="col place-col"
+                  :class="fieldColClass('unload_place')"
                   :style="getColStyle('unload_place')"
                 >
                   {{ formatUnloadPlaces(item) }}
                 </div>
                 <div
-                  v-if="isFieldVisible('valid_until')"
+                  v-if="isFieldInDom('valid_until')"
                   class="col date-col"
+                  :class="fieldColClass('valid_until')"
                   :style="getColStyle('valid_until')"
                 >
                   {{ formatDate(item.entry_date_to) }}
                 </div>
                 <div
-                  v-if="isFieldVisible('time_range')"
+                  v-if="isFieldInDom('time_range')"
                   class="col time-col"
+                  :class="fieldColClass('time_range')"
                   :style="getColStyle('time_range')"
                 >
                   {{ formatTimeRange(item.entry_time_from, item.entry_time_to) }}
                 </div>
                 <div
-                  v-if="isFieldVisible('status')"
+                  v-if="isFieldInDom('status')"
                   class="col status-col"
+                  :class="fieldColClass('status')"
                   :style="getColStyle('status')"
                 >
                   <StatusBadge :status="item.status" />
@@ -1049,21 +1067,47 @@ export default {
     },
 
     isFieldVisible(fieldName) {
-      // В enlarged-режиме - отдельный флаг видимости столбца.
+      // Видимость определяется ОТДЕЛЬНО для каждого режима, иначе enlarged
+      // молча "подтягивал" бы обычные настройки is_visible.
       if (this.enlarged) {
         const ev = this.fieldsEnlargedVisibility[fieldName];
         if (ev === false) return false;
+      } else {
+        const v = this.fieldsVisibility[fieldName];
+        const visible = v === undefined ? true : v;
+        if (!visible) return false;
       }
-      // Пока конфиг не загружен - показываем всё (предотвращает мигание при инициализации).
-      const v = this.fieldsVisibility[fieldName];
-      const visible = v === undefined ? true : v;
-      if (!visible) return false;
       // В портретном компактном режиме показываем только столбцы с priority<=threshold.
       if (this.isCompact) {
         const p = this.fieldPriorities[fieldName];
         if (typeof p === 'number' && p > this.compactPriorityThreshold) return false;
       }
       return true;
+    },
+
+    /**
+     * В enlarged-режиме столбцы НЕ удаляем из DOM, а схлопываем через класс
+     * col--collapsed - даёт плавный transition (flex-grow, max-width, opacity).
+     * В обычном режиме - старая логика v-if, столбец удаляется из DOM.
+     */
+    isFieldInDom(fieldName) {
+      if (this.enlarged) {
+        // В enlarged compact-priority всё равно скрывает (DOM-узел не нужен).
+        if (this.isCompact) {
+          const p = this.fieldPriorities[fieldName];
+          if (typeof p === 'number' && p > this.compactPriorityThreshold) return false;
+        }
+        return true;
+      }
+      return this.isFieldVisible(fieldName);
+    },
+
+    fieldColClass(fieldName) {
+      if (this.enlarged) {
+        const ev = this.fieldsEnlargedVisibility[fieldName];
+        if (ev === false) return 'col--collapsed';
+      }
+      return '';
     },
 
     /**
@@ -1605,7 +1649,29 @@ export default {
    конфликта специфичности (раньше .items-body .col перекрывал отдельные
    правила .status-col / .organization-col и данные не анимировались). */
 .selected-table-card .col {
-  transition: font-size 0.4s ease-in-out, flex-grow 0.4s ease-in-out, opacity 0.3s ease-in-out;
+  transition:
+    font-size 0.4s ease-in-out,
+    flex-grow 0.4s ease-in-out,
+    flex-basis 0.4s ease-in-out,
+    max-width 0.4s ease-in-out,
+    min-width 0.4s ease-in-out,
+    padding 0.4s ease-in-out,
+    opacity 0.3s ease-in-out;
+}
+
+/* Скрытый в "Увеличенный режим" столбец - не удаляем из DOM, а схлопываем.
+   Транзишен на .col даёт плавную анимацию ширины/прозрачности. */
+.selected-table-card .col.col--collapsed {
+  flex-grow: 0 !important;
+  flex-basis: 0 !important;
+  min-width: 0 !important;
+  max-width: 0 !important;
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+  opacity: 0;
+  pointer-events: none;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 /* Пока конфиг не загружен - запрещаем transitions на всех потомках, чтобы
@@ -1626,10 +1692,6 @@ export default {
 
 .selected-table-card.enlarged .items-body .col {
   font-size: 18px;
-}
-
-.selected-table-card.enlarged .items-body .number-col {
-  font-weight: 700;
 }
 
 /* Номер Т/С и Марка - ключевые столбцы, не должны схлопываться по ellipsis

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -52,8 +52,9 @@
             Выход
           </div>
           <div
-            v-if="isFieldVisible('last_name')"
+            v-if="isFieldInDom('last_name')"
             class="col last-name-col"
+            :class="fieldColClass('last_name')"
             :style="getColStyle('last_name')"
             @click="sortBy('last_name')"
           >
@@ -67,8 +68,9 @@
             >
           </div>
           <div
-            v-if="isFieldVisible('first_name')"
+            v-if="isFieldInDom('first_name')"
             class="col first-name-col"
+            :class="fieldColClass('first_name')"
             :style="getColStyle('first_name')"
             @click="sortBy('first_name')"
           >
@@ -82,8 +84,9 @@
             >
           </div>
           <div
-            v-if="isFieldVisible('middle_name')"
+            v-if="isFieldInDom('middle_name')"
             class="col middle-name-col"
+            :class="fieldColClass('middle_name')"
             :style="getColStyle('middle_name')"
             @click="sortBy('middle_name')"
           >
@@ -97,8 +100,9 @@
             >
           </div>
           <div
-            v-if="isFieldVisible('position')"
+            v-if="isFieldInDom('position')"
             class="col position-col"
+            :class="fieldColClass('position')"
             :style="getColStyle('position')"
             @click="sortBy('position')"
           >
@@ -112,8 +116,9 @@
             >
           </div>
           <div
-            v-if="isFieldVisible('citizenship_name')"
+            v-if="isFieldInDom('citizenship_name')"
             class="col citizenship-col"
+            :class="fieldColClass('citizenship_name')"
             :style="getColStyle('citizenship_name')"
             @click="sortBy('citizenship_name')"
           >
@@ -127,8 +132,9 @@
             >
           </div>
           <div
-            v-if="isFieldVisible('organization')"
+            v-if="isFieldInDom('organization')"
             class="col organization-col"
+            :class="fieldColClass('organization')"
             :style="getColStyle('organization')"
             @click="sortBy('organization')"
           >
@@ -142,8 +148,9 @@
             >
           </div>
           <div
-            v-if="isFieldVisible('company')"
+            v-if="isFieldInDom('company')"
             class="col company-col"
+            :class="fieldColClass('company')"
             :style="getColStyle('company')"
             @click="sortBy('company')"
           >
@@ -157,8 +164,9 @@
             >
           </div>
           <div
-            v-if="isFieldVisible('valid_until')"
+            v-if="isFieldInDom('valid_until')"
             class="col date-col"
+            :class="fieldColClass('valid_until')"
             :style="getColStyle('valid_until')"
             @click="sortBy('entry_date_to')"
           >
@@ -172,8 +180,9 @@
             >
           </div>
           <div
-            v-if="isFieldVisible('pass_time')"
+            v-if="isFieldInDom('pass_time')"
             class="col time-col"
+            :class="fieldColClass('pass_time')"
             :style="getColStyle('pass_time')"
             @click="sortBy('pass_time')"
           >
@@ -187,8 +196,9 @@
             >
           </div>
           <div
-            v-if="isFieldVisible('application_id')"
+            v-if="isFieldInDom('application_id')"
             class="col application-col"
+            :class="fieldColClass('application_id')"
             :style="getColStyle('application_id')"
             @click="sortBy('application_id')"
           >
@@ -291,71 +301,81 @@
                   </button>
                 </div>
                 <div
-                  v-if="isFieldVisible('last_name')"
+                  v-if="isFieldInDom('last_name')"
                   class="col last-name-col"
+                  :class="fieldColClass('last_name')"
                   :style="getColStyle('last_name')"
                 >
                   {{ item.last_name }}
                 </div>
                 <div
-                  v-if="isFieldVisible('first_name')"
+                  v-if="isFieldInDom('first_name')"
                   class="col first-name-col"
+                  :class="fieldColClass('first_name')"
                   :style="getColStyle('first_name')"
                 >
                   {{ item.first_name }}
                 </div>
                 <div
-                  v-if="isFieldVisible('middle_name')"
+                  v-if="isFieldInDom('middle_name')"
                   class="col middle-name-col"
+                  :class="fieldColClass('middle_name')"
                   :style="getColStyle('middle_name')"
                 >
                   {{ item.middle_name || '-' }}
                 </div>
                 <div
-                  v-if="isFieldVisible('position')"
+                  v-if="isFieldInDom('position')"
                   class="col position-col"
+                  :class="fieldColClass('position')"
                   :style="getColStyle('position')"
                 >
                   {{ item.position || '-' }}
                 </div>
                 <div
-                  v-if="isFieldVisible('citizenship_name')"
+                  v-if="isFieldInDom('citizenship_name')"
                   class="col citizenship-col"
+                  :class="fieldColClass('citizenship_name')"
                   :style="getColStyle('citizenship_name')"
                 >
                   {{ item.citizenshipName || '-' }}
                 </div>
                 <div
-                  v-if="isFieldVisible('organization')"
+                  v-if="isFieldInDom('organization')"
                   class="col organization-col"
+                  :class="fieldColClass('organization')"
                   :style="getColStyle('organization')"
                 >
                   {{ item.organization_name }}
                 </div>
                 <div
-                  v-if="isFieldVisible('company')"
+                  v-if="isFieldInDom('company')"
                   class="col company-col"
+                  :class="fieldColClass('company')"
                   :style="getColStyle('company')"
                 >
                   {{ item.company || '-' }}
                 </div>
                 <div
-                  v-if="isFieldVisible('valid_until')"
+                  v-if="isFieldInDom('valid_until')"
                   class="col date-col"
+                  :class="fieldColClass('valid_until')"
                   :style="getColStyle('valid_until')"
                 >
                   {{ formatDate(item.entry_date_to) }}
                 </div>
                 <div
-                  v-if="isFieldVisible('pass_time')"
+                  v-if="isFieldInDom('pass_time')"
                   class="col time-col"
+                  :class="fieldColClass('pass_time')"
                   :style="getColStyle('pass_time')"
                 >
                   {{ formatPassTime(item.pass_time) }}
                 </div>
                 <div
-                  v-if="isFieldVisible('application_id')"
+                  v-if="isFieldInDom('application_id')"
                   class="col application-col"
+                  :class="fieldColClass('application_id')"
                   :style="getColStyle('application_id')"
                 >
                   {{ item.applicationNumber || '-' }}
@@ -1065,19 +1085,44 @@ export default {
     },
 
     isFieldVisible(fieldName) {
+      // Видимость определяется ОТДЕЛЬНО для каждого режима, иначе enlarged
+      // молча "подтягивал" бы обычные настройки is_visible.
       if (this.enlarged) {
         const ev = this.fieldsEnlargedVisibility[fieldName];
         if (ev === false) return false;
+      } else {
+        const v = this.fieldsVisibility[fieldName];
+        const visible = v === undefined ? true : v;
+        if (!visible) return false;
       }
-      // Пока конфиг не загружен - показываем всё (предотвращает мигание при инициализации).
-      const v = this.fieldsVisibility[fieldName];
-      const visible = v === undefined ? true : v;
-      if (!visible) return false;
       if (this.isCompact) {
         const p = this.fieldPriorities[fieldName];
         if (typeof p === 'number' && p > this.compactPriorityThreshold) return false;
       }
       return true;
+    },
+
+    /**
+     * В enlarged-режиме столбцы НЕ удаляем из DOM, а схлопываем через класс
+     * col--collapsed - даёт плавный transition (flex-grow, max-width, opacity).
+     */
+    isFieldInDom(fieldName) {
+      if (this.enlarged) {
+        if (this.isCompact) {
+          const p = this.fieldPriorities[fieldName];
+          if (typeof p === 'number' && p > this.compactPriorityThreshold) return false;
+        }
+        return true;
+      }
+      return this.isFieldVisible(fieldName);
+    },
+
+    fieldColClass(fieldName) {
+      if (this.enlarged) {
+        const ev = this.fieldsEnlargedVisibility[fieldName];
+        if (ev === false) return 'col--collapsed';
+      }
+      return '';
     },
 
     /**
@@ -1563,7 +1608,29 @@ export default {
    конфликта специфичности (раньше .items-body .col перекрывал отдельные
    правила .status-col / .organization-col и данные не анимировались). */
 .selected-table-card .col {
-  transition: font-size 0.4s ease-in-out, flex-grow 0.4s ease-in-out, opacity 0.3s ease-in-out;
+  transition:
+    font-size 0.4s ease-in-out,
+    flex-grow 0.4s ease-in-out,
+    flex-basis 0.4s ease-in-out,
+    max-width 0.4s ease-in-out,
+    min-width 0.4s ease-in-out,
+    padding 0.4s ease-in-out,
+    opacity 0.3s ease-in-out;
+}
+
+/* Скрытый в "Увеличенный режим" столбец - не удаляем из DOM, а схлопываем.
+   Транзишен на .col даёт плавную анимацию ширины/прозрачности. */
+.selected-table-card .col.col--collapsed {
+  flex-grow: 0 !important;
+  flex-basis: 0 !important;
+  min-width: 0 !important;
+  max-width: 0 !important;
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+  opacity: 0;
+  pointer-events: none;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 /* Пока конфиг не загружен - запрещаем transitions на всех потомках, чтобы
@@ -1584,10 +1651,6 @@ export default {
 
 .selected-table-card.enlarged .items-body .col {
   font-size: 18px;
-}
-
-.selected-table-card.enlarged .items-body .last-name-col {
-  font-weight: 700;
 }
 
 /* В enlarged status-col схлопывается; освободившиеся 8 grow распределяются

--- a/frontend/src/components/SystemTableColumnsTab.vue
+++ b/frontend/src/components/SystemTableColumnsTab.vue
@@ -826,7 +826,6 @@ export default {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  margin-top: 8px;
 }
 
 .columns-tab__preview-title {

--- a/frontend/src/components/SystemTableScheduleTab.vue
+++ b/frontend/src/components/SystemTableScheduleTab.vue
@@ -893,7 +893,7 @@ input:checked + .switch-slider:before {
   width: 100%;
   padding: 10px 12px;
   border: 1px solid #e0e0e0;
-  border-radius: 10px;
+  border-radius: 15px;
   font-size: 14px;
   transition: border-color 0.2s;
   background: white;
@@ -913,7 +913,7 @@ input:checked + .switch-slider:before {
   justify-content: space-between;
   padding: 10px 12px;
   border: 1px solid #e0e0e0;
-  border-radius: 10px;
+  border-radius: 15px;
   background: white;
   transition: border-color 0.2s;
 }

--- a/frontend/src/components/TableConstructor.vue
+++ b/frontend/src/components/TableConstructor.vue
@@ -1634,7 +1634,7 @@ export default {
   justify-content: space-between;
   padding: 8px 12px;
   border: 1px solid #e6e6e6;
-  border-radius: 10px;
+  border-radius: 15px;
   background: white;
   cursor: pointer;
   font-size: 13px;

--- a/frontend/src/components/TableConstructorCreateModal.vue
+++ b/frontend/src/components/TableConstructorCreateModal.vue
@@ -502,7 +502,7 @@ export default {
   justify-content: space-between;
   padding: 8px 12px;
   border: 1px solid #e6e6e6;
-  border-radius: 10px;
+  border-radius: 15px;
   background: white;
   cursor: pointer;
   font-size: 13px;

--- a/frontend/src/components/UnloadPlaces/ScheduleTab.vue
+++ b/frontend/src/components/UnloadPlaces/ScheduleTab.vue
@@ -599,7 +599,7 @@ export default {
   height: 100%;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 15px;
   font-size: 13px;
   line-height: 1.5;
 }
@@ -920,7 +920,7 @@ input:checked + .switch-slider:before {
   width: 100%;
   padding: 10px 12px;
   border: 1px solid #e0e0e0;
-  border-radius: 10px;
+  border-radius: 15px;
   font-size: 14px;
   transition: border-color 0.2s;
   background: white;
@@ -941,7 +941,7 @@ input:checked + .switch-slider:before {
   justify-content: space-between;
   padding: 10px 12px;
   border: 1px solid #e0e0e0;
-  border-radius: 10px;
+  border-radius: 15px;
   background: white;
   transition: border-color 0.2s;
 }

--- a/frontend/src/components/UnloadPlaces/UnloadPlacesContainer.vue
+++ b/frontend/src/components/UnloadPlaces/UnloadPlacesContainer.vue
@@ -106,27 +106,29 @@
         class="details-section"
       >
         <div class="details-tabs">
-          <button 
-            class="tab-btn" 
-            :class="{ 'active': activeTab === 'main' }"
-            @click="activeTab = 'main'"
-          >
-            Основное
-          </button>
-          <button 
-            class="tab-btn" 
-            :class="{ 'active': activeTab === 'schedule' }"
-            @click="activeTab = 'schedule'"
-          >
-            Расписание
-          </button>
-          <button 
-            class="tab-btn" 
-            :class="{ 'active': activeTab === 'route' }"
-            @click="activeTab = 'route'"
-          >
-            Местоположение и маршрут
-          </button>
+          <div class="details-tabs__row">
+            <button
+              class="tab-btn"
+              :class="{ 'active': activeTab === 'main' }"
+              @click="activeTab = 'main'"
+            >
+              Основное
+            </button>
+            <button
+              class="tab-btn"
+              :class="{ 'active': activeTab === 'schedule' }"
+              @click="activeTab = 'schedule'"
+            >
+              Расписание
+            </button>
+            <button
+              class="tab-btn"
+              :class="{ 'active': activeTab === 'route' }"
+              @click="activeTab = 'route'"
+            >
+              Местоположение и маршрут
+            </button>
+          </div>
         </div>
 
         <!-- Вкладка Основное -->
@@ -269,10 +271,6 @@
               <h4 class="section-title">
                 Изображение(-я)
               </h4>
-              <p class="field-hint">
-                Снимки места разгрузки - схема проезда, КПП, парковка. Видит
-                водитель в карточке места при подаче заявки.
-              </p>
               <label class="upload-photo-btn">
                 + Загрузить
                 <input
@@ -284,6 +282,10 @@
                 >
               </label>
             </div>
+            <p class="field-hint">
+              Снимки места разгрузки - схема проезда, КПП, парковка. Видит
+              водитель в карточке места при подаче заявки.
+            </p>
 
             <!-- Drag&drop zone (как в TableConstructorPhotoSection). -->
             <label
@@ -1219,30 +1221,43 @@ async uploadPhotoFiles(files) {
 
 .details-tabs {
   display: flex;
+  flex-direction: column;
+  gap: 6px;
   border-bottom: 1px solid #e6e6e6;
   background: #f8f9fa;
-  padding: 0 20px;
+  padding: 10px 16px 0;
+}
+
+.details-tabs__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: center;
 }
 
 .tab-btn {
-  padding: 12px 24px;
-  background: none;
-  border: none;
-  border-bottom: 2px solid transparent;
+  padding: 8px 18px;
+  background: #fff;
+  border: 1px solid transparent;
   cursor: pointer;
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 600;
-  color: #666;
-  transition: all 0.2s ease;
+  color: #6b7280;
+  transition: color 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+  border-radius: 50px;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .tab-btn:hover {
   color: #4F5BDF;
+  background: #eef0ff;
 }
 
 .tab-btn.active {
   color: #4F5BDF;
-  border-bottom-color: #4F5BDF;
+  border-color: #4F5BDF;
+  background: #fff;
 }
 
 .tab-content {
@@ -1451,7 +1466,10 @@ async uploadPhotoFiles(files) {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 12px;
+}
+
+.photos-header .section-title {
+  margin: 0;
 }
 
 .upload-photo-btn {
@@ -1634,7 +1652,8 @@ async uploadPhotoFiles(files) {
   color: #a2a2a2;
   background: #f8f9fa;
   border: 1px dashed #e6e6e6;
-  border-radius: 8px;
+  border-radius: 25px;
+  font-size: 15px;
 }
 
 .no-selection-message {


### PR DESCRIPTION
## Summary

Шесть замечаний после ручного теста PR #385-388:

- **N1 radius**: select "Тип таблицы" имел 10px (рапортовал 15) - привёл в порядок, унифицировал radius input/select.
- **N2 gap**: UnloadPlaces/ScheduleTab имел gap 12, поправил на 15. Убрал margin-top: 8 у columns-tab__preview.
- **N3 подсказка**: field-hint над "Изображение(-я)" в Местах разгрузки была внутри flex-row с заголовком и кнопкой - вынес отдельной строкой.
- **N4 плашка нет фото**: в UnloadPlaces привёл к виду TableConstructorPhotoSection (radius 25, font 15).
- **N5 вкладки UnloadPlaces**: переделаны под TableConstructor (round pill, radius 50, активная с border-color, без border-bottom).
- **N6 enlarged-режим**:
  - **6.1** Убрал hardcoded `font-weight: 700` у `.number-col` (CarsTable) и `.last-name-col` (PeopleTable) под `.enlarged`. Теперь жирность полностью управляется `enlarged_font_weight`.
  - **6.2** Видимость теперь определяется ОТДЕЛЬНО для каждого режима. Раньше enlarged "подтягивал" обычную `is_visible` поверх `enlarged_is_visible`.
  - **6.3** Скрытие столбца в enlarged анимируется через класс `col--collapsed` (transition по flex-grow/max-width/opacity/padding). Раньше `v-if` мгновенно удалял из DOM, transition не успевал.

## Test plan
- [ ] DevTools 1080x1920: Управление таблиц - select "Тип таблицы" имеет radius 15px.
- [ ] Места разгрузки: подсказка над "Изображение(-я)" на отдельной строке, не съезжает.
- [ ] Места разгрузки: плашка "Фотографии не загружены" с radius 25, font 15.
- [ ] Места разгрузки: вкладки round pill (как в Управлении таблиц), не подчёркивание.
- [ ] Таблица КПП: в "Колонки" поставить `enlarged_font_weight=0` для Номера ТС - в Увеличенном режиме номер НЕ жирный.
- [ ] Таблица: скрыть "Марка" в обычном режиме (is_visible=false), оставить enlarged_is_visible=true → в Увеличенном Марка видна.
- [ ] Включение тоггла Увеличенный режим: столбцы исчезают плавно, не телепортируются.