### PR TITLE
chore: поднял Go до 1.25.11 (CVE GO-2026-5037 / 5039)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module systemburo
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/caarlos0/env/v11 v11.4.0


### PR DESCRIPTION
## Summary

Govulncheck на свежем прогоне нашёл две CVE в стандартной библиотеке Go 1.25.10:
- **GO-2026-5037** - inefficient candidate hostname parsing в crypto/x509
- **GO-2026-5039** - arbitrary inputs included in errors without escaping в net/textproto

Обе фиксаются апгрейдом до 1.25.11. Без этого Go Vulnerability Check блокирует merge любого PR в dev.

## Test plan
- [ ] CI зелёный (Go Vulnerability Check pass)