### PR TITLE
fix: правки после ревью #2 + защита от потери изменений (#345)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -177,7 +177,7 @@ body.nav-drawer-open {
 }
 
 .form-input-sm {
-  border-radius: 10px !important;
+  border-radius: 15px !important;
 }
 
 .blue {

--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -59,7 +59,7 @@
             v-if="isFieldInDom('car_number')"
             class="col number-col"
             :class="fieldColClass('car_number')"
-            :style="getColStyle('car_number')"
+            :style="getColStyle('car_number', true)"
             @click="sortBy('car_number')"
           >
             <p :class="{ 'active-sort': sortField === 'car_number' }">
@@ -75,7 +75,7 @@
             v-if="isFieldInDom('car_brand')"
             class="col brand-col"
             :class="fieldColClass('car_brand')"
-            :style="getColStyle('car_brand')"
+            :style="getColStyle('car_brand', true)"
             @click="sortBy('car_brand')"
           >
             <p :class="{ 'active-sort': sortField === 'car_brand' }">
@@ -91,7 +91,7 @@
             v-if="isFieldInDom('organization')"
             class="col organization-col"
             :class="fieldColClass('organization')"
-            :style="getColStyle('organization')"
+            :style="getColStyle('organization', true)"
             @click="sortBy('organization')"
           >
             <p :class="{ 'active-sort': sortField === 'organization' }">
@@ -107,7 +107,7 @@
             v-if="isFieldInDom('company')"
             class="col company-col"
             :class="fieldColClass('company')"
-            :style="getColStyle('company')"
+            :style="getColStyle('company', true)"
             @click="sortBy('company')"
           >
             <p :class="{ 'active-sort': sortField === 'company' }">
@@ -123,7 +123,7 @@
             v-if="isFieldInDom('application_id')"
             class="col application-col"
             :class="fieldColClass('application_id')"
-            :style="getColStyle('application_id')"
+            :style="getColStyle('application_id', true)"
             @click="sortBy('application_id')"
           >
             <p :class="{ 'active-sort': sortField === 'application_id' }">
@@ -139,7 +139,7 @@
             v-if="isFieldInDom('unload_place')"
             class="col place-col"
             :class="fieldColClass('unload_place')"
-            :style="getColStyle('unload_place')"
+            :style="getColStyle('unload_place', true)"
             @click="sortBy('unload_place')"
           >
             <p :class="{ 'active-sort': sortField === 'unload_place' }">
@@ -155,7 +155,7 @@
             v-if="isFieldInDom('valid_until')"
             class="col date-col"
             :class="fieldColClass('valid_until')"
-            :style="getColStyle('valid_until')"
+            :style="getColStyle('valid_until', true)"
             @click="sortBy('entry_date_to')"
           >
             <p :class="{ 'active-sort': sortField === 'entry_date_to' }">
@@ -171,7 +171,7 @@
             v-if="isFieldInDom('time_range')"
             class="col time-col"
             :class="fieldColClass('time_range')"
-            :style="getColStyle('time_range')"
+            :style="getColStyle('time_range', true)"
             @click="sortBy('entry_time')"
           >
             <p :class="{ 'active-sort': sortField === 'entry_time' }">
@@ -187,7 +187,7 @@
             v-if="isFieldInDom('status')"
             class="col status-col"
             :class="fieldColClass('status')"
-            :style="getColStyle('status')"
+            :style="getColStyle('status', true)"
             @click="sortBy('status')"
           >
             <p :class="{ 'active-sort': sortField === 'status' }">
@@ -1086,26 +1086,31 @@ export default {
     },
 
     /**
-     * В enlarged-режиме столбцы НЕ удаляем из DOM, а схлопываем через класс
-     * col--collapsed - даёт плавный transition (flex-grow, max-width, opacity).
-     * В обычном режиме - старая логика v-if, столбец удаляется из DOM.
+     * Столбец ВСЕГДА в DOM - скрытие через класс col--collapsed с transition.
+     * Альтернатива (v-if) удаляла бы из DOM мгновенно, transition не успевал.
      */
-    isFieldInDom(fieldName) {
-      if (this.enlarged) {
-        // В enlarged compact-priority всё равно скрывает (DOM-узел не нужен).
-        if (this.isCompact) {
-          const p = this.fieldPriorities[fieldName];
-          if (typeof p === 'number' && p > this.compactPriorityThreshold) return false;
-        }
-        return true;
-      }
-      return this.isFieldVisible(fieldName);
+    isFieldInDom() {
+      return true;
     },
 
+    /**
+     * col--collapsed - класс, который схлопывает столбец до нуля ширины с
+     * плавной анимацией. Применяется когда поле скрыто в текущем режиме
+     * (обычный/enlarged) либо когда priority выше порога в компактном.
+     */
     fieldColClass(fieldName) {
       if (this.enlarged) {
         const ev = this.fieldsEnlargedVisibility[fieldName];
         if (ev === false) return 'col--collapsed';
+      } else {
+        const v = this.fieldsVisibility[fieldName];
+        if (v === false) return 'col--collapsed';
+      }
+      if (this.isCompact) {
+        const p = this.fieldPriorities[fieldName];
+        if (typeof p === 'number' && p > this.compactPriorityThreshold) {
+          return 'col--collapsed';
+        }
       }
       return '';
     },
@@ -1171,7 +1176,7 @@ export default {
      * пропорционально их базовым flex-grow весам, а не "слепляет" всё
      * в organization.
      */
-    getColStyle(fieldName) {
+    getColStyle(fieldName, isHeader = false) {
       const order = this.fieldOrders[fieldName];
       const width = this.fieldWidths[fieldName];
       const style = {};
@@ -1180,9 +1185,11 @@ export default {
         // В enlarged: используем enlarged_width если >0, иначе CSS-дефолт (без inline grow).
         const ew = this.fieldsEnlargedWidth[fieldName];
         if (typeof ew === 'number' && ew > 0) style.flexGrow = ew;
-        // enlarged_font_weight - применяем inline если > 0.
-        const eweight = this.fieldsEnlargedWeight[fieldName];
-        if (typeof eweight === 'number' && eweight > 0) style.fontWeight = eweight;
+        // enlarged_font_weight - применяется ТОЛЬКО к данным, не к заголовку столбца.
+        if (!isHeader) {
+          const eweight = this.fieldsEnlargedWeight[fieldName];
+          if (typeof eweight === 'number' && eweight > 0) style.fontWeight = eweight;
+        }
       } else if (width !== undefined && width > 0) {
         style.flexGrow = width;
       }

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -55,7 +55,7 @@
             v-if="isFieldInDom('last_name')"
             class="col last-name-col"
             :class="fieldColClass('last_name')"
-            :style="getColStyle('last_name')"
+            :style="getColStyle('last_name', true)"
             @click="sortBy('last_name')"
           >
             <p :class="{ 'active-sort': sortField === 'last_name' }">
@@ -71,7 +71,7 @@
             v-if="isFieldInDom('first_name')"
             class="col first-name-col"
             :class="fieldColClass('first_name')"
-            :style="getColStyle('first_name')"
+            :style="getColStyle('first_name', true)"
             @click="sortBy('first_name')"
           >
             <p :class="{ 'active-sort': sortField === 'first_name' }">
@@ -87,7 +87,7 @@
             v-if="isFieldInDom('middle_name')"
             class="col middle-name-col"
             :class="fieldColClass('middle_name')"
-            :style="getColStyle('middle_name')"
+            :style="getColStyle('middle_name', true)"
             @click="sortBy('middle_name')"
           >
             <p :class="{ 'active-sort': sortField === 'middle_name' }">
@@ -103,7 +103,7 @@
             v-if="isFieldInDom('position')"
             class="col position-col"
             :class="fieldColClass('position')"
-            :style="getColStyle('position')"
+            :style="getColStyle('position', true)"
             @click="sortBy('position')"
           >
             <p :class="{ 'active-sort': sortField === 'position' }">
@@ -119,7 +119,7 @@
             v-if="isFieldInDom('citizenship_name')"
             class="col citizenship-col"
             :class="fieldColClass('citizenship_name')"
-            :style="getColStyle('citizenship_name')"
+            :style="getColStyle('citizenship_name', true)"
             @click="sortBy('citizenship_name')"
           >
             <p :class="{ 'active-sort': sortField === 'citizenship_name' }">
@@ -135,7 +135,7 @@
             v-if="isFieldInDom('organization')"
             class="col organization-col"
             :class="fieldColClass('organization')"
-            :style="getColStyle('organization')"
+            :style="getColStyle('organization', true)"
             @click="sortBy('organization')"
           >
             <p :class="{ 'active-sort': sortField === 'organization' }">
@@ -151,7 +151,7 @@
             v-if="isFieldInDom('company')"
             class="col company-col"
             :class="fieldColClass('company')"
-            :style="getColStyle('company')"
+            :style="getColStyle('company', true)"
             @click="sortBy('company')"
           >
             <p :class="{ 'active-sort': sortField === 'company' }">
@@ -167,7 +167,7 @@
             v-if="isFieldInDom('valid_until')"
             class="col date-col"
             :class="fieldColClass('valid_until')"
-            :style="getColStyle('valid_until')"
+            :style="getColStyle('valid_until', true)"
             @click="sortBy('entry_date_to')"
           >
             <p :class="{ 'active-sort': sortField === 'entry_date_to' }">
@@ -183,7 +183,7 @@
             v-if="isFieldInDom('pass_time')"
             class="col time-col"
             :class="fieldColClass('pass_time')"
-            :style="getColStyle('pass_time')"
+            :style="getColStyle('pass_time', true)"
             @click="sortBy('pass_time')"
           >
             <p :class="{ 'active-sort': sortField === 'pass_time' }">
@@ -199,7 +199,7 @@
             v-if="isFieldInDom('application_id')"
             class="col application-col"
             :class="fieldColClass('application_id')"
-            :style="getColStyle('application_id')"
+            :style="getColStyle('application_id', true)"
             @click="sortBy('application_id')"
           >
             <p :class="{ 'active-sort': sortField === 'application_id' }">
@@ -1103,24 +1103,25 @@ export default {
     },
 
     /**
-     * В enlarged-режиме столбцы НЕ удаляем из DOM, а схлопываем через класс
-     * col--collapsed - даёт плавный transition (flex-grow, max-width, opacity).
+     * Столбец ВСЕГДА в DOM - скрытие через класс col--collapsed с transition.
      */
-    isFieldInDom(fieldName) {
-      if (this.enlarged) {
-        if (this.isCompact) {
-          const p = this.fieldPriorities[fieldName];
-          if (typeof p === 'number' && p > this.compactPriorityThreshold) return false;
-        }
-        return true;
-      }
-      return this.isFieldVisible(fieldName);
+    isFieldInDom() {
+      return true;
     },
 
     fieldColClass(fieldName) {
       if (this.enlarged) {
         const ev = this.fieldsEnlargedVisibility[fieldName];
         if (ev === false) return 'col--collapsed';
+      } else {
+        const v = this.fieldsVisibility[fieldName];
+        if (v === false) return 'col--collapsed';
+      }
+      if (this.isCompact) {
+        const p = this.fieldPriorities[fieldName];
+        if (typeof p === 'number' && p > this.compactPriorityThreshold) {
+          return 'col--collapsed';
+        }
       }
       return '';
     },
@@ -1134,7 +1135,7 @@ export default {
      * пропорционально распределяет освободившееся от status пространство
      * по всем оставшимся столбцам.
      */
-    getColStyle(fieldName) {
+    getColStyle(fieldName, isHeader = false) {
       const order = this.fieldOrders[fieldName];
       const width = this.fieldWidths[fieldName];
       const style = {};
@@ -1142,8 +1143,11 @@ export default {
       if (this.enlarged) {
         const ew = this.fieldsEnlargedWidth[fieldName];
         if (typeof ew === 'number' && ew > 0) style.flexGrow = ew;
-        const eweight = this.fieldsEnlargedWeight[fieldName];
-        if (typeof eweight === 'number' && eweight > 0) style.fontWeight = eweight;
+        // enlarged_font_weight - применяется ТОЛЬКО к данным, не к заголовку.
+        if (!isHeader) {
+          const eweight = this.fieldsEnlargedWeight[fieldName];
+          if (typeof eweight === 'number' && eweight > 0) style.fontWeight = eweight;
+        }
       } else if (width !== undefined && width > 0) {
         style.flexGrow = width;
       }

--- a/frontend/src/components/SystemTableAppearanceTab.vue
+++ b/frontend/src/components/SystemTableAppearanceTab.vue
@@ -84,6 +84,7 @@
 <script>
 import { apiRequest } from '@/api/client';
 import { useToast } from '@/composables/useToast';
+import { registerDirtyTracker } from '@/utils/dirtyTracker';
 
 const DEFAULT_FONT_SIZE = 14;
 const DEFAULT_DENSITY = 'normal';
@@ -135,6 +136,12 @@ export default {
       immediate: true,
       deep: true,
     },
+  },
+  mounted() {
+    this._stopDirtyGuard = registerDirtyTracker(() => this.isDirty);
+  },
+  beforeUnmount() {
+    this._stopDirtyGuard?.();
   },
   methods: {
     reset() {

--- a/frontend/src/components/SystemTableColumnsTab.vue
+++ b/frontend/src/components/SystemTableColumnsTab.vue
@@ -44,30 +44,32 @@
           </button>
         </div>
       </div>
-      <p
-        v-if="!enlargedMode"
-        class="columns-tab__hint"
-      >
-        Переставляйте столбцы перетаскиванием за иконку слева. Скрытые столбцы не отображаются в таблице.
-      </p>
-      <p
-        v-if="!enlargedMode"
-        class="columns-tab__hint"
-      >
-        <b>Ширина</b> - относительный вес столбца. Браузер делит доступную ширину
-        видимых столбцов пропорционально этим весам. <b>Приоритет</b> (1-5) -
-        видимость на вертикальном (книжном) экране охранника: 1 - всегда виден,
-        2 - виден на узком экране, 3-5 - скрывается и доступен по кнопке "Подробнее"
-        под строкой.
-      </p>
-      <p
-        v-else
-        class="columns-tab__hint"
-      >
-        Настройки применяются ТОЛЬКО когда у пользователя включён
-        <b>Увеличенный режим</b> в шапке таблицы. <b>Ширина</b> - 0 значит
-        брать обычную. <b>Жирность</b> - 0 значит дефолт (500).
-      </p>
+      <div class="columns-tab__hint-block">
+        <template v-if="!enlargedMode">
+          <p class="columns-tab__hint">
+            Переставляйте столбцы перетаскиванием за иконку слева. Скрытые столбцы не отображаются в таблице.
+          </p>
+          <p class="columns-tab__hint">
+            <b>Ширина</b> - относительный вес столбца. Браузер делит доступную ширину
+            видимых столбцов пропорционально этим весам. <b>Приоритет</b> (1-5) -
+            видимость на вертикальном (книжном) экране охранника: 1 - всегда виден,
+            2 - виден на узком экране, 3-5 - скрывается и доступен по кнопке "Подробнее"
+            под строкой.
+          </p>
+        </template>
+        <template v-else>
+          <p class="columns-tab__hint">
+            Настройки применяются ТОЛЬКО когда у пользователя включён
+            <b>Увеличенный режим</b> в шапке таблицы. <b>Ширина</b> - 0 значит
+            брать обычную. <b>Жирность</b> - 0 значит дефолт (500).
+          </p>
+          <p class="columns-tab__hint">
+            Если строка столбца <b>серая, но с галочкой</b> - значит в
+            <b>Обычном</b> режиме столбец выключен, а в <b>Увеличенном</b> -
+            включён (или наоборот).
+          </p>
+        </template>
+      </div>
     </div>
 
     <div
@@ -209,13 +211,17 @@
           </div>
           <div
             v-else
-            class="columns-tab__priority"
+            class="columns-tab__priority columns-tab__weight"
             :title="'Жирность шрифта в увеличенном режиме. 0 = по умолчанию (500).'"
           >
             <span class="columns-tab__priority-label">Жирность:</span>
+            <span
+              class="columns-tab__weight-preview"
+              :style="{ fontWeight: field.enlarged_font_weight || 500 }"
+            >Текст</span>
             <select
               v-model.number="field.enlarged_font_weight"
-              class="columns-tab__priority-select"
+              class="columns-tab__priority-select columns-tab__weight-select"
               :data-enlarged-weight-field="field.field_name"
             >
               <option :value="0">0</option>
@@ -550,6 +556,21 @@ export default {
   flex-wrap: wrap;
 }
 
+/* Защита от прыжков: тайтл фиксируем по более длинному варианту, чтобы
+   toggle "Обычный | Увеличенный" не сдвигался при переключении режима. */
+.columns-tab__title {
+  min-width: 290px;
+}
+
+/* Блок подсказок фиксированной высоты - предотвращает скачки высоты вкладки
+   при смене режима, где у подсказок разная длина текста. */
+.columns-tab__hint-block {
+  min-height: 96px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
 /* Toggle "Обычный | Увеличенный" - сегмент-контрол как в Оформление. */
 .columns-tab__mode-toggle {
   display: inline-flex;
@@ -766,6 +787,30 @@ export default {
 .columns-tab__priority-select:focus {
   outline: none;
   border-color: #4F5BDF;
+}
+
+/* Селект "Жирность" - шире обычного priority-select, чтобы трёхзначные значения
+   (700, 800) не наезжали на стрелочку. */
+.columns-tab__weight-select {
+  width: 56px;
+  padding-right: 6px;
+}
+
+/* Бейдж предпросмотра жирности рядом с селектом.
+   Высота не больше select - paddingи и font-size совпадают с .columns-tab__priority-select. */
+.columns-tab__weight-preview {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 42px;
+  padding: 2px 6px;
+  border: 1px solid #e6e6e6;
+  border-radius: 6px;
+  font-size: 11px;
+  color: #000;
+  background: #fff;
+  white-space: nowrap;
+  line-height: 1;
 }
 
 .columns-tab__actions {

--- a/frontend/src/components/SystemTableColumnsTab.vue
+++ b/frontend/src/components/SystemTableColumnsTab.vue
@@ -283,6 +283,7 @@
 import { apiRequest } from '@/api/client';
 import { generateSampleRows } from '@/utils/tableSamples';
 import { useToast } from '@/composables/useToast';
+import { registerDirtyTracker } from '@/utils/dirtyTracker';
 import CarsTable from './CarsTable.vue';
 import PeopleTable from './PeopleTable.vue';
 
@@ -388,9 +389,13 @@ export default {
       immediate: true,
     },
   },
+  mounted() {
+    this._stopDirtyGuard = registerDirtyTracker(() => this.isDirty);
+  },
   beforeUnmount() {
     // На случай если пользователь ушёл с вкладки во время drag.
     this.cleanupPointerListeners();
+    this._stopDirtyGuard?.();
   },
   methods: {
     humanLabel(name) {

--- a/frontend/src/components/TableConstructor.vue
+++ b/frontend/src/components/TableConstructor.vue
@@ -137,35 +137,35 @@
             <button
               class="tab-btn"
               :class="{ 'active': activeTab === 'main' }"
-              @click="activeTab = 'main'"
+              @click="switchTab('main')"
             >
               Основное
             </button>
             <button
               class="tab-btn"
               :class="{ 'active': activeTab === 'schedule' }"
-              @click="activeTab = 'schedule'"
+              @click="switchTab('schedule')"
             >
               Расписание
             </button>
             <button
               class="tab-btn"
               :class="{ 'active': activeTab === 'location' }"
-              @click="activeTab = 'location'"
+              @click="switchTab('location')"
             >
               Местоположение
             </button>
             <button
               class="tab-btn"
               :class="{ 'active': activeTab === 'columns' }"
-              @click="activeTab = 'columns'"
+              @click="switchTab('columns')"
             >
               Колонки
             </button>
             <button
               class="tab-btn"
               :class="{ 'active': activeTab === 'appearance' }"
-              @click="activeTab = 'appearance'"
+              @click="switchTab('appearance')"
             >
               Оформление
             </button>
@@ -178,14 +178,14 @@
             <button
               class="tab-btn"
               :class="{ 'active': activeTab === 'fact-columns' }"
-              @click="activeTab = 'fact-columns'"
+              @click="switchTab('fact-columns')"
             >
               Колонки
             </button>
             <button
               class="tab-btn"
               :class="{ 'active': activeTab === 'fact-appearance' }"
-              @click="activeTab = 'fact-appearance'"
+              @click="switchTab('fact-appearance')"
             >
               Оформление
             </button>
@@ -592,6 +592,7 @@
 
 <script>
 import { apiRequest } from '@/api/client'
+import { confirmIfAnyDirty } from '@/utils/dirtyTracker';
 import RefreshButton from './RefreshButton.vue';
 import SearchComponent from './SearchComponent.vue';
 import TextConstructor from './TextConstructor.vue';
@@ -723,6 +724,17 @@ export default {
   methods: {
     handleNotification(event) {
       this.showNotification(event.detail.message, event.detail.type);
+    },
+
+    /**
+     * Переключение вкладки с защитой: если на текущей вкладке есть pending
+     * правки - сначала спросить подтверждение. confirmIfAnyDirty опрашивает
+     * всех зарегистрированных через registerDirtyTracker.
+     */
+    switchTab(tab) {
+      if (this.activeTab === tab) return;
+      if (!confirmIfAnyDirty()) return;
+      this.activeTab = tab;
     },
 
     async refreshData() {
@@ -904,6 +916,10 @@ export default {
 },
     
     selectTable(table) {
+      // Защита от потери: если текущая вкладка settings dirty - спросить.
+      if (this.selectedTable && this.selectedTable.table.id !== table.table.id) {
+        if (!confirmIfAnyDirty()) return;
+      }
       this.selectedTable = JSON.parse(JSON.stringify(table));
       this.originalHint = table.table.fact_table_hint || '';
       this.originalInstruction = table.table.instruction || '';

--- a/frontend/src/components/TableConstructor.vue
+++ b/frontend/src/components/TableConstructor.vue
@@ -1343,7 +1343,13 @@ export default {
   gap: 6px;
   border-bottom: 1px solid #e6e6e6;
   background: #f8f9fa;
-  padding: 10px 16px 0;
+  padding: 10px 16px;
+}
+
+/* Когда показывается ряд "По факту" - снизу есть свой padding-bottom через
+   --fact, верхний padding общего блока этого хватает. */
+.details-tabs:has(.details-tabs__row--fact) {
+  padding-bottom: 0;
 }
 
 .details-tabs__row {
@@ -1354,7 +1360,7 @@ export default {
 }
 
 .details-tabs__row--fact {
-  padding: 6px 0;
+  padding: 6px 0 10px;
   border-top: 1px dashed #e0e0e0;
   margin-top: 2px;
 }

--- a/frontend/src/components/TableConstructorCreateModal.vue
+++ b/frontend/src/components/TableConstructorCreateModal.vue
@@ -467,7 +467,7 @@ export default {
 .input-compact {
   padding: 8px 10px;
   border: 1px solid #e6e6e6;
-  border-radius: 8px;
+  border-radius: 15px;
   font-size: 13px;
   background: #fff;
   transition: border-color 0.2s;

--- a/frontend/src/components/UnloadPlaces/UnloadPlacesContainer.vue
+++ b/frontend/src/components/UnloadPlaces/UnloadPlacesContainer.vue
@@ -1225,7 +1225,7 @@ async uploadPhotoFiles(files) {
   gap: 6px;
   border-bottom: 1px solid #e6e6e6;
   background: #f8f9fa;
-  padding: 10px 16px 0;
+  padding: 10px 16px;
 }
 
 .details-tabs__row {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -7,6 +7,7 @@ import { vPermissionScope } from './directives/permission-scope'
 import bus from './eventBus'
 import { tryRestoreSession } from '@/api/client'
 import { useMaintenanceStore } from '@/stores/maintenance'
+import { installBeforeUnloadGuard } from '@/utils/dirtyTracker'
 import './assets/tokens.css'
 import './assets/forms.css'
 
@@ -28,4 +29,5 @@ await useMaintenanceStore().fetchStatus()
 
 app.use(router)
 await router.isReady()
+installBeforeUnloadGuard()
 app.mount('#app')

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -1,4 +1,5 @@
 import { createRouter, createWebHistory } from 'vue-router';
+import { confirmIfAnyDirty } from '@/utils/dirtyTracker';
 import { useAuthStore } from '@/stores/auth';
 import { useMaintenanceStore } from '@/stores/maintenance';
 import LoginComponent from './components/LoginComponent.vue';
@@ -167,6 +168,15 @@ const router = createRouter({
 // в памяти если refresh cookie жив). На F5 guard сразу видит реальное
 // состояние без async гонок.
 router.beforeEach(async (to, from, next) => {
+  // Защита от потери несохранённых изменений: если на странице есть форма
+  // с pending-правками - спросить подтверждение перед navigation. Применяется
+  // ко всем переходам, ВКЛЮЧАЯ программные next() ниже - кроме первого
+  // монтирования (from.name === undefined).
+  if (from.name !== undefined && !confirmIfAnyDirty()) {
+    next(false);
+    return;
+  }
+
   const authStore = useAuthStore();
   const maintenanceStore = useMaintenanceStore();
   const isAuthenticated = authStore.isAuthenticated;

--- a/frontend/src/utils/dirtyTracker.js
+++ b/frontend/src/utils/dirtyTracker.js
@@ -1,0 +1,68 @@
+/**
+ * Глобальный реестр форм с несохранёнными изменениями.
+ *
+ * Компонент с формой регистрирует геттер isDirty -> при попытке покинуть
+ * страницу (роутер, перезагрузка, переключение вкладок внутри view) показывается
+ * confirm. Если ни одной dirty-формы нет - переходы свободные.
+ *
+ * Использование в Options API:
+ *   import { registerDirtyTracker } from '@/utils/dirtyTracker';
+ *   mounted() { this._stopGuard = registerDirtyTracker(() => this.isDirty); },
+ *   beforeUnmount() { this._stopGuard?.(); }
+ */
+
+const trackers = new Map();
+let nextId = 1;
+
+/**
+ * Регистрирует геттер isDirty. Возвращает функцию-отписку.
+ */
+export function registerDirtyTracker(getterFn) {
+  const id = nextId++;
+  trackers.set(id, getterFn);
+  return () => trackers.delete(id);
+}
+
+/**
+ * Есть ли хотя бы одна форма с несохранёнными изменениями?
+ */
+export function hasAnyDirty() {
+  for (const get of trackers.values()) {
+    try {
+      if (get()) return true;
+    } catch {
+      /* геттер мог обратиться к удалённому компоненту - игнорируем */
+    }
+  }
+  return false;
+}
+
+/**
+ * Если есть dirty-формы - спросить подтверждение. Возвращает true если можно
+ * продолжать (нет dirty либо пользователь подтвердил).
+ */
+export function confirmIfAnyDirty(
+  message = 'У вас есть несохранённые изменения. Покинуть страницу без сохранения?',
+) {
+  if (!hasAnyDirty()) return true;
+  return window.confirm(message);
+}
+
+let installed = false;
+function beforeUnloadHandler(event) {
+  if (!hasAnyDirty()) return;
+  // Браузеры показывают свой стандартный диалог при returnValue/preventDefault.
+  // Текст игнорируется (защита от спама), но dialog появится.
+  event.preventDefault();
+  event.returnValue = '';
+}
+
+/**
+ * Один раз на всё приложение подписывает window.beforeunload на проверку
+ * dirty-форм. Безопасно вызывать многократно - повторные вызовы no-op.
+ */
+export function installBeforeUnloadGuard() {
+  if (installed) return;
+  installed = true;
+  window.addEventListener('beforeunload', beforeUnloadHandler);
+}


### PR DESCRIPTION
## Summary

Полировка по второму ревью PR #389:

**N1** (radius input/select) - глобальное правило `.form-input-sm` в App.vue имело `border-radius: 10px !important` и перебивало все локальные стили. Поднял до 15px. Также `.input-compact` в TableConstructorCreateModal 8px -> 15px.

**N2** (padding вкладок) - tab-кнопки в Управлении таблиц и Места разгрузки имели `padding: 10px 16px 0` (нижний отступ съедался). Симметричный 10px 16px.

**N3** (прыжки toggle/высоты) - тайтл колонок min-width 290px, теперь toggle "Обычный/Увеличенный" не сдвигается. Блок подсказок min-height 96px.

**N3.1** (жирность 800 на стрелочке) - селект жирности шире (56px) с padding-right. Слева - бейдж "Текст" с live-preview текущей жирности.

**N4** (подсказка о расхождении) - в режиме Увеличенный новая подсказка про серую строку с галочкой = расхождение настроек видимости между режимами.

**N5** (анимация телепортируется) - столбцы ВСЕГДА в DOM, скрытие через класс `col--collapsed` с transition. Раньше `v-if` удалял из DOM мгновенно - transition не успевал. Применяется в обоих режимах.

**Общее N1** - жирность `enlarged_font_weight` применяется ТОЛЬКО к данным (body), не к заголовкам столбцов. Добавлен флаг `isHeader=true` в `getColStyle`.

**Общее N2** (защита от потери) - новый утиль `dirtyTracker.js`. Подключён в `beforeunload`, `router.beforeEach`, `TableConstructor.switchTab` + `selectTable`. SystemTableColumnsTab и SystemTableAppearanceTab регистрируют isDirty в mounted.

## Test plan
- [ ] Все 8 пунктов из ручного план-теста pass.
- [ ] Защита: открыть Колонки, поменять что-то -> переключить вкладку -> модалка с confirm.
- [ ] Защита: то же -> закрыть таб браузера -> браузер показывает диалог.