### PR TITLE
fix(345): анимация enlarged, модальный confirm, чистка модалки создания

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -36,6 +36,7 @@
     </div>
     <ToastContainer />
     <ConfirmDialog />
+    <DirtyConfirmModal />
     <DeleteNotifications />
   </div>
 </template>
@@ -49,6 +50,7 @@ import TheHeader from './components/TheHeader/TheHeader.vue';
 import ScrollTopButton from './components/ScrollTopButton.vue';
 import ToastContainer from './components/ToastContainer.vue';
 import ConfirmDialog from './components/ConfirmDialog.vue';
+import DirtyConfirmModal from './components/DirtyConfirmModal.vue';
 import DeleteNotifications from './components/DeleteNotifications.vue';
 
 export default {
@@ -59,6 +61,7 @@ export default {
     ScrollTopButton,
     ToastContainer,
     ConfirmDialog,
+    DirtyConfirmModal,
     DeleteNotifications,
   },
   computed: {
@@ -178,6 +181,14 @@ body.nav-drawer-open {
 
 .form-input-sm {
   border-radius: 15px !important;
+}
+
+/* Включает анимацию transition между length и intrinsic-значениями (auto / max-content)
+   для width/height/max-width/min-width. Без этого схлопывание столбца таблицы
+   через max-width: 0 -> auto обратно не анимируется и даёт визуальный скачок
+   при выключении "Увеличенного режима". Chromium 129+, Firefox 132+, Safari 18+. */
+:root {
+  interpolate-size: allow-keywords;
 }
 
 .blue {

--- a/frontend/src/components/DirtyConfirmModal.vue
+++ b/frontend/src/components/DirtyConfirmModal.vue
@@ -1,0 +1,32 @@
+<template>
+  <ConfirmationModal
+    :show="confirmState.show"
+    title="Несохранённые изменения"
+    :message="confirmState.message"
+    confirm-text="Уйти без сохранения"
+    cancel-text="Остаться"
+    @confirm="onConfirm"
+    @cancel="onCancel"
+  />
+</template>
+
+<script>
+import ConfirmationModal from './ConfirmationModal.vue';
+import { confirmState, resolveDirtyConfirm } from '@/utils/dirtyTracker';
+
+export default {
+  name: 'DirtyConfirmModal',
+  components: { ConfirmationModal },
+  data() {
+    return { confirmState };
+  },
+  methods: {
+    onConfirm() {
+      resolveDirtyConfirm(true);
+    },
+    onCancel() {
+      resolveDirtyConfirm(false);
+    },
+  },
+};
+</script>

--- a/frontend/src/components/TableConstructor.vue
+++ b/frontend/src/components/TableConstructor.vue
@@ -423,20 +423,6 @@
                   rows="4"
                 />
               </div>
-
-              <div class="fields-section">
-                <label class="section-label">Поля таблицы:</label>
-                <div class="fields-list">
-                  <div 
-                    v-for="field in selectedTable.fields" 
-                    :key="field.id"
-                    class="field-item"
-                  >
-                    <span class="field-name">{{ getFieldDisplayName(field.field_name) }}</span>
-                    <span class="field-type">{{ getFieldTypeLabel(field.field_type) }}</span>
-                  </div>
-                </div>
-              </div>
             </div>
           </div>
         </div>
@@ -731,9 +717,9 @@ export default {
      * правки - сначала спросить подтверждение. confirmIfAnyDirty опрашивает
      * всех зарегистрированных через registerDirtyTracker.
      */
-    switchTab(tab) {
+    async switchTab(tab) {
       if (this.activeTab === tab) return;
-      if (!confirmIfAnyDirty()) return;
+      if (!(await confirmIfAnyDirty())) return;
       this.activeTab = tab;
     },
 
@@ -915,10 +901,10 @@ export default {
   }
 },
     
-    selectTable(table) {
+    async selectTable(table) {
       // Защита от потери: если текущая вкладка settings dirty - спросить.
       if (this.selectedTable && this.selectedTable.table.id !== table.table.id) {
-        if (!confirmIfAnyDirty()) return;
+        if (!(await confirmIfAnyDirty())) return;
       }
       this.selectedTable = JSON.parse(JSON.stringify(table));
       this.originalHint = table.table.fact_table_hint || '';
@@ -995,33 +981,6 @@ export default {
           { name: 'pass_time', displayName: 'Время прохода', type: 'Текст' }
         ];
       }
-    },
-    
-    getFieldDisplayName(fieldName) {
-      const fields = {
-        'car_number': 'Номер машины',
-        'car_brand': 'Марка',
-        'organization': 'Организация',
-        'unload_place': 'Место разгрузки',
-        'valid_until': 'Действует до',
-        'time_range': 'Время',
-        'status': 'Статус',
-        'last_name': 'Фамилия',
-        'first_name': 'Имя',
-        'middle_name': 'Отчество',
-        'pass_time': 'Время прохода'
-      };
-      return fields[fieldName] || fieldName;
-    },
-    
-    getFieldTypeLabel(fieldType) {
-      const types = {
-        'text': 'Текст',
-        'date': 'Дата',
-        'time': 'Время',
-        'number': 'Число'
-      };
-      return types[fieldType] || fieldType;
     },
     
     getDefaultHint(tableType) {
@@ -1607,7 +1566,7 @@ export default {
 
 /* Подсказка под полем настройки - объясняет где видно/зачем нужно. */
 .field-hint {
-  margin: 4px 0 8px;
+  margin: 4px 0 0;
   font-size: 12px;
   color: #a2a2a2;
   line-height: 1.5;
@@ -1776,7 +1735,7 @@ export default {
 .checkbox-group {
   padding: 12px;
   background: #f8f9ff;
-  border-radius: 10px;
+  border-radius: 20px;
   border: 1px solid #e6e6e6;
 }
 
@@ -1796,6 +1755,7 @@ export default {
 
 .checkbox-text {
   font-size: 13px;
+  font-weight: 500;
   color: #333;
 }
 
@@ -1852,45 +1812,6 @@ export default {
 
 .cancel-btn:hover {
   background: #4b5563;
-}
-
-.fields-section {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.fields-list {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  max-height: 150px;
-  overflow-y: auto;
-  padding-right: 4px;
-}
-
-.field-item {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 6px 10px;
-  background: #f8f9fa;
-  border: 1px solid #e6e6e6;
-  border-radius: 8px;
-}
-
-.field-name {
-  font-size: 12px;
-  font-weight: 500;
-  color: #333;
-}
-
-.field-type {
-  font-size: 11px;
-  color: #666;
-  background: #e9ecef;
-  padding: 2px 8px;
-  border-radius: 12px;
 }
 
 .location-section {
@@ -2189,25 +2110,21 @@ export default {
 }
 
 /* Скроллбары */
-.table-body::-webkit-scrollbar,
-.fields-list::-webkit-scrollbar {
+.table-body::-webkit-scrollbar {
   width: 6px;
 }
 
-.table-body::-webkit-scrollbar-track,
-.fields-list::-webkit-scrollbar-track {
+.table-body::-webkit-scrollbar-track {
   background: #f1f1f1;
   border-radius: 3px;
 }
 
-.table-body::-webkit-scrollbar-thumb,
-.fields-list::-webkit-scrollbar-thumb {
+.table-body::-webkit-scrollbar-thumb {
   background: #c1c1c1;
   border-radius: 3px;
 }
 
-.table-body::-webkit-scrollbar-thumb:hover,
-.fields-list::-webkit-scrollbar-thumb:hover {
+.table-body::-webkit-scrollbar-thumb:hover {
   background: #a8a8a8;
 }
 

--- a/frontend/src/components/TableConstructorCreateModal.vue
+++ b/frontend/src/components/TableConstructorCreateModal.vue
@@ -105,18 +105,20 @@
 
             <div class="cells-scroll-container">
               <div class="settings-grid">
-                <div class="setting-item">
-                  <label class="setting-label">
+                <div class="checkbox-group">
+                  <label class="checkbox-label">
                     <input
                       v-model="newTable.show_fact_table"
                       type="checkbox"
-                      class="setting-checkbox"
+                      class="checkbox-input"
                     >
-                    <span class="setting-text">Отображать таблицу "по факту"</span>
+                    <span class="checkbox-text">Отображать таблицу "по факту"</span>
                   </label>
-                  <span class="setting-hint">
-                    Будет показана дополнительная таблица с данными "по факту"
-                  </span>
+                  <p class="field-hint">
+                    На странице с основной таблицей отображается таблица
+                    "по факту". В ней отображаются люди/машины, данные которых
+                    заранее не известны.
+                  </p>
                 </div>
 
                 <div
@@ -138,22 +140,6 @@
                     placeholder="Введите инструкцию для таблицы..."
                     rows="4"
                   />
-                </div>
-
-                <div class="setting-item">
-                  <h5 class="fields-preview-title">
-                    Поля таблицы:
-                  </h5>
-                  <div class="fields-preview">
-                    <div
-                      v-for="field in getTableFields(newTable.table_type)"
-                      :key="field.name"
-                      class="preview-field"
-                    >
-                      <span class="preview-field-name">{{ field.displayName }}</span>
-                      <span class="preview-field-type">{{ field.type }}</span>
-                    </div>
-                  </div>
                 </div>
               </div>
             </div>
@@ -242,29 +228,6 @@ export default {
 
     getTableTypeLabel(type) {
       return type === 'cars' ? 'Машины' : 'Люди'
-    },
-
-    getTableFields(tableType) {
-      if (tableType === 'cars') {
-        return [
-          { name: 'car_number', displayName: 'Номер машины', type: 'Текст' },
-          { name: 'car_brand', displayName: 'Марка', type: 'Текст' },
-          { name: 'organization', displayName: 'Организация', type: 'Текст' },
-          { name: 'unload_place', displayName: 'Место разгрузки', type: 'Текст' },
-          { name: 'valid_until', displayName: 'Действует до', type: 'Дата' },
-          { name: 'time_range', displayName: 'Время', type: 'Текст' },
-          { name: 'status', displayName: 'Статус', type: 'Текст' }
-        ]
-      } else {
-        return [
-          { name: 'organization', displayName: 'Организация', type: 'Текст' },
-          { name: 'last_name', displayName: 'Фамилия', type: 'Текст' },
-          { name: 'first_name', displayName: 'Имя', type: 'Текст' },
-          { name: 'middle_name', displayName: 'Отчество', type: 'Текст' },
-          { name: 'valid_until', displayName: 'Действует до', type: 'Дата' },
-          { name: 'pass_time', displayName: 'Время прохода', type: 'Текст' }
-        ]
-      }
     },
 
     getDefaultHint(tableType) {
@@ -377,12 +340,13 @@ export default {
 
 .modal-content {
   background: #fff;
-  border-radius: 12px;
+  border-radius: 35px;
   padding: 0;
   width: 420px;
   max-width: 90vw;
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
   animation: modalAppear 0.3s ease-out;
+  overflow: hidden;
 }
 
 .modal-content.horizontal-modal {
@@ -435,15 +399,18 @@ export default {
 .modal-body-horizontal {
   display: flex;
   height: 400px;
-  overflow: hidden;
 }
 
 .modal-main-info {
-  width: 35%;
+  width: 25%;
   padding: 20px;
   border-right: 1px solid #e6e6e6;
   background: #fafafa;
-  overflow-y: auto;
+  /* visible нужен чтобы выпадающий список "Тип таблицы" не клиппился
+     scroll-контекстом панели и был кликабелен. */
+  overflow: visible;
+  position: relative;
+  z-index: 2;
 }
 
 .main-fields {
@@ -520,8 +487,8 @@ export default {
 }
 
 .select-arrow {
-  width: 10px;
-  height: 10px;
+  width: 7px;
+  height: 7px;
   transition: transform 0.2s ease;
   transform: rotate(90deg);
 }
@@ -579,7 +546,7 @@ export default {
 }
 
 .modal-cells-section {
-  width: 65%;
+  width: 75%;
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -616,66 +583,41 @@ export default {
   gap: 8px;
 }
 
-.setting-label {
+/* Чекбокс "Отображать таблицу по факту" - тот же визуальный стиль, что в
+   TableConstructor "Основное", чтобы пользователь видел консистентный UI
+   и до создания таблицы, и при редактировании после. */
+.checkbox-group {
+  padding: 12px;
+  background: #f8f9ff;
+  border-radius: 20px;
+  border: 1px solid #e6e6e6;
+}
+
+.checkbox-label {
   display: flex;
   align-items: center;
   gap: 8px;
   cursor: pointer;
 }
 
-.setting-checkbox {
+.checkbox-input {
   width: 16px;
   height: 16px;
   cursor: pointer;
   accent-color: #4F5BDF;
 }
 
-.setting-text {
+.checkbox-text {
   font-size: 13px;
   font-weight: 500;
   color: #333;
 }
 
-.setting-hint {
-  font-size: 11px;
-  color: #666;
-  line-height: 1.4;
-}
-
-.fields-preview-title {
-  margin: 0 0 8px 0;
-  font-size: 13px;
-  font-weight: 600;
-  color: #333;
-}
-
-.fields-preview {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.preview-field {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 4px 8px;
-  background: #f8f9fa;
-  border: 1px solid #e6e6e6;
-  border-radius: 6px;
+.field-hint {
+  margin: 4px 0 0;
   font-size: 12px;
-}
-
-.preview-field-name {
-  color: #333;
-}
-
-.preview-field-type {
-  color: #666;
-  font-size: 10px;
-  background: #e9ecef;
-  padding: 2px 6px;
-  border-radius: 4px;
+  color: #a2a2a2;
+  line-height: 1.5;
 }
 
 .modal-footer {

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -172,7 +172,7 @@ router.beforeEach(async (to, from, next) => {
   // с pending-правками - спросить подтверждение перед navigation. Применяется
   // ко всем переходам, ВКЛЮЧАЯ программные next() ниже - кроме первого
   // монтирования (from.name === undefined).
-  if (from.name !== undefined && !confirmIfAnyDirty()) {
+  if (from.name !== undefined && !(await confirmIfAnyDirty())) {
     next(false);
     return;
   }

--- a/frontend/src/utils/dirtyTracker.js
+++ b/frontend/src/utils/dirtyTracker.js
@@ -1,18 +1,36 @@
 /**
- * Глобальный реестр форм с несохранёнными изменениями.
+ * Глобальный реестр форм с несохранёнными изменениями + красивый confirm-модал.
  *
  * Компонент с формой регистрирует геттер isDirty -> при попытке покинуть
  * страницу (роутер, перезагрузка, переключение вкладок внутри view) показывается
- * confirm. Если ни одной dirty-формы нет - переходы свободные.
+ * красивый Vue-модал (DirtyConfirmModal в App.vue). Для window.beforeunload
+ * браузер показывает свой нативный диалог - кастомный показать нельзя.
  *
  * Использование в Options API:
  *   import { registerDirtyTracker } from '@/utils/dirtyTracker';
  *   mounted() { this._stopGuard = registerDirtyTracker(() => this.isDirty); },
  *   beforeUnmount() { this._stopGuard?.(); }
+ *
+ * Перед навигацией:
+ *   if (!(await confirmIfAnyDirty())) return;
  */
+
+import { reactive } from 'vue';
 
 const trackers = new Map();
 let nextId = 1;
+
+const DEFAULT_MESSAGE = 'У вас есть несохранённые изменения. Покинуть страницу без сохранения?';
+
+/**
+ * Реактивный singleton-стейт для модалки подтверждения. DirtyConfirmModal
+ * монтируется один раз в App.vue, подписан на этот стейт.
+ */
+export const confirmState = reactive({
+  show: false,
+  message: DEFAULT_MESSAGE,
+  resolve: null,
+});
 
 /**
  * Регистрирует геттер isDirty. Возвращает функцию-отписку.
@@ -38,14 +56,35 @@ export function hasAnyDirty() {
 }
 
 /**
- * Если есть dirty-формы - спросить подтверждение. Возвращает true если можно
- * продолжать (нет dirty либо пользователь подтвердил).
+ * Async. Если есть dirty-формы - показывает модал подтверждения, возвращает
+ * Promise<boolean>. true = нет dirty либо пользователь подтвердил выход;
+ * false = пользователь отменил.
+ *
+ * Если есть открытый ранее модал - он перебивается новым (предыдущий
+ * Promise разрешается false, чтобы старый код не висел).
  */
-export function confirmIfAnyDirty(
-  message = 'У вас есть несохранённые изменения. Покинуть страницу без сохранения?',
-) {
-  if (!hasAnyDirty()) return true;
-  return window.confirm(message);
+export function confirmIfAnyDirty(message) {
+  if (!hasAnyDirty()) return Promise.resolve(true);
+  if (confirmState.resolve) {
+    confirmState.resolve(false);
+    confirmState.resolve = null;
+  }
+  return new Promise((resolve) => {
+    confirmState.message = message || DEFAULT_MESSAGE;
+    confirmState.resolve = resolve;
+    confirmState.show = true;
+  });
+}
+
+/**
+ * Вызывается из DirtyConfirmModal кнопками "Подтвердить" / "Отмена".
+ */
+export function resolveDirtyConfirm(value) {
+  if (confirmState.resolve) {
+    confirmState.resolve(value);
+    confirmState.resolve = null;
+  }
+  confirmState.show = false;
 }
 
 let installed = false;


### PR DESCRIPTION
## Что фиксит

После третьего ревью на staging (PR #391) пришли замечания:

**N5 - анимация enlarged криво при выключении.** Включение плавное, выключение телепортирует столбцы. Причина: max-width: auto -> 0 не анимируется браузером дефолтно. Включил interpolate-size: allow-keywords - max-width/min-width теперь интерполируются между intrinsic-значениями и пикселями.

**№2 - confirm-модал вместо window.confirm.** Защита от потери изменений показывала системный браузерный alert вместо кастомного модала. Сделал DirtyConfirmModal на базе ConfirmationModal, подключил в App.vue. dirtyTracker теперь хранит reactive singleton confirmState, confirmIfAnyDirty стал async Promise<boolean>. Поправил все вызовы: router.beforeEach, TableConstructor.switchTab/selectTable.

**Общая 1 - кнопка "Отображать таблицу 'по факту'".** border-radius 20px (был 10), checkbox-text font-weight 500, field-hint без нижнего padding. Перенёс этот же стиль в модалку "Создать таблицу", чтобы UI был одинаковый.

**Общая 2 - убрал fields-section.** Блок "Поля таблицы" дублировал то, что и так видно при редактировании. Снёс из TableConstructor "Основное" и из модалки "Создать таблицу" (включая getFieldDisplayName/getFieldTypeLabel/getTableFields/.preview-field стили).

**Общая 3 - модалка "Создать таблицу".**
- border-radius 35px (был 12), плюс overflow: hidden на modal-content чтобы внутренние границы не торчали за скруглением
- modal-main-info width 25% (была 35%), modal-cells-section 75% (была 65%)
- Главное: overflow на modal-main-info был auto и клиппил dropdown "Тип таблицы" - его не было видно, нельзя было выбрать "Машины". Поставил overflow: visible
- select-arrow 7x7px (был 10x10)

## Test plan

- [ ] Открыть КПП - включить/выключить "Увеличенный режим" - анимация плавная В ОБЕ СТОРОНЫ
- [ ] Settings - изменить любое поле колонки, не сохранять - переключить вкладку - появляется красивая модалка с оверлеем (не браузерный alert)
- [ ] Нажать "Остаться" - dirty-изменения целы; нажать "Уйти без сохранения" - переходишь, форма сбрасывается
- [ ] Settings - чекбокс "Отображать таблицу по факту" в обводке radius 20px, текст полужирный
- [ ] Settings "Основное" - нет блока "Поля таблицы"
- [ ] "+ Создать таблицу" - модалка радиус 35px; dropdown "Тип таблицы" открывается, "Машины" выбирается
- [ ] В этой же модалке нет блока "Поля таблицы"; чекбокс "по факту" выглядит как в Основном