### PR TITLE
fix(345): починил выпадающее меню 'Тип таблицы' в модалке создания

### DIFF
--- a/frontend/src/components/TableConstructorCreateModal.vue
+++ b/frontend/src/components/TableConstructorCreateModal.vue
@@ -4,7 +4,10 @@
       class="modal-overlay"
       @click.self="handleClose"
     >
-      <div class="modal-content horizontal-modal">
+      <div
+        ref="modalContent"
+        class="modal-content horizontal-modal"
+      >
         <div class="modal-header">
           <h3>Создать новую таблицу</h3>
           <button
@@ -202,7 +205,12 @@ export default {
   },
   methods: {
     handleOutsideClick(e) {
-      if (!this.$el.contains(e.target)) {
+      // Через Teleport this.$el остаётся anchor-узлом в исходном месте, а не
+      // содержимым модалки в body - .contains() для него всегда false и любой
+      // клик закрывал dropdown. Проверяем по ref на .modal-content внутри
+      // тела модалки.
+      const root = this.$refs.modalContent
+      if (root && !root.contains(e.target)) {
         this.typeDropdownOpen = false
       }
     },


### PR DESCRIPTION
Verify-app поймал на staging после #392: dropdown 'Тип таблицы' в модалке создания не раскрывается, 'Машины' выбрать нельзя.

Причина: handleOutsideClick проверяет `this.$el.contains(e.target)`, а модалка через `<Teleport to="body">` - `$el` остаётся anchor-узлом, не телепортированным контентом. `.contains()` всегда false, любой клик закрывает dropdown мгновенно.

Фикс: ref="modalContent" на `.modal-content` + проверка через `this.$refs.modalContent.contains`.

## Test plan
- [ ] Открыть '+ Создать таблицу' → клик 'Тип таблицы' → dropdown открывается
- [ ] Клик 'Машины' → выбирается, dropdown закрывается, стрелочка повёрнута обратно
- [ ] Клик вне модалки → dropdown закрывается (старое поведение цело)