### PR TITLE
fix(345): аккордеон-полоса, превью плотности, список изменений в confirm

### DIFF
--- a/frontend/src/components/ApplicationApprovers.vue
+++ b/frontend/src/components/ApplicationApprovers.vue
@@ -770,6 +770,7 @@ export default {
 }
 
 .table-footer {
+  margin-top: auto;
   padding: 6px 20px;
   border-top: 1px solid #e6e6e6;
   text-align: end;

--- a/frontend/src/components/AttachmentsManagement.vue
+++ b/frontend/src/components/AttachmentsManagement.vue
@@ -1397,6 +1397,7 @@ export default {
 }
 
 .table-footer {
+  margin-top: auto;
   padding: 6px 20px;
   border-top: 1px solid #e6e6e6;
   text-align: end;

--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -1711,17 +1711,6 @@ export default {
   min-width: 110px;
 }
 
-/* В enlarged status-col схлопывается; освободившиеся 7 grow распределяются
-   автоматически по ВСЕМ оставшимся столбцам пропорционально их базовым
-   весам - getColStyle в enlarged не задаёт inline flex-grow, и CSS-веса
-   снова в силе. organization получит больше всех (она самая широкая),
-   но остальные тоже подрастут пропорционально. */
-.selected-table-card.enlarged .status-col {
-  flex-grow: 0;
-  opacity: 0;
-  pointer-events: none;
-}
-
 .selected-table-card.enlarged .item-data {
   min-height: 36px;
 }

--- a/frontend/src/components/CitizenshipManagement.vue
+++ b/frontend/src/components/CitizenshipManagement.vue
@@ -758,6 +758,7 @@ export default {
 }
 
 .table-footer {
+  margin-top: auto;
   padding: 6px 20px;
   border-top: 1px solid #e6e6e6;
   text-align: end;

--- a/frontend/src/components/CompaniesManagement.vue
+++ b/frontend/src/components/CompaniesManagement.vue
@@ -685,6 +685,7 @@ export default {
 }
 
 .table-footer {
+  margin-top: auto;
   padding: 6px 20px;
   border-top: 1px solid #e6e6e6;
   text-align: end;

--- a/frontend/src/components/DirtyConfirmModal.vue
+++ b/frontend/src/components/DirtyConfirmModal.vue
@@ -1,22 +1,62 @@
 <template>
-  <ConfirmationModal
-    :show="confirmState.show"
-    title="Несохранённые изменения"
-    :message="confirmState.message"
-    confirm-text="Уйти без сохранения"
-    cancel-text="Остаться"
-    @confirm="onConfirm"
-    @cancel="onCancel"
-  />
+  <Teleport to="body">
+    <transition name="dirty-fade">
+      <div
+        v-if="confirmState.show"
+        class="dirty-overlay"
+        @click.self="onCancel"
+      >
+        <div class="dirty-modal">
+          <div class="dirty-modal__header">
+            Несохранённые изменения
+          </div>
+          <div class="dirty-modal__content">
+            <p class="dirty-modal__message">
+              {{ confirmState.message }}
+            </p>
+            <div
+              v-if="confirmState.changes && confirmState.changes.length"
+              class="dirty-modal__changes"
+            >
+              <div class="dirty-modal__changes-title">
+                Изменения, которые будут потеряны:
+              </div>
+              <ul class="dirty-modal__changes-list">
+                <li
+                  v-for="(item, i) in confirmState.changes"
+                  :key="i"
+                  class="dirty-modal__changes-item"
+                >
+                  {{ item }}
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div class="dirty-modal__actions">
+            <button
+              class="dirty-modal__btn dirty-modal__btn--cancel"
+              @click="onCancel"
+            >
+              Остаться
+            </button>
+            <button
+              class="dirty-modal__btn dirty-modal__btn--confirm"
+              @click="onConfirm"
+            >
+              Уйти без сохранения
+            </button>
+          </div>
+        </div>
+      </div>
+    </transition>
+  </Teleport>
 </template>
 
 <script>
-import ConfirmationModal from './ConfirmationModal.vue';
 import { confirmState, resolveDirtyConfirm } from '@/utils/dirtyTracker';
 
 export default {
   name: 'DirtyConfirmModal',
-  components: { ConfirmationModal },
   data() {
     return { confirmState };
   },
@@ -30,3 +70,132 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+.dirty-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 11000;
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
+}
+
+.dirty-modal {
+  background: #fff;
+  border-radius: 16px;
+  padding: 22px 24px 18px;
+  width: 560px;
+  max-width: calc(100vw - 32px);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.18);
+}
+
+.dirty-modal__header {
+  font-size: 16px;
+  font-weight: 600;
+  color: #1f2937;
+  margin-bottom: 10px;
+}
+
+.dirty-modal__content {
+  margin-bottom: 20px;
+}
+
+.dirty-modal__message {
+  margin: 0 0 12px;
+  font-size: 14px;
+  color: #4b5563;
+  line-height: 1.45;
+}
+
+.dirty-modal__changes {
+  background: #f8f9ff;
+  border: 1px solid #eef0ff;
+  border-radius: 12px;
+  padding: 10px 14px;
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.dirty-modal__changes-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: #4F5BDF;
+  margin-bottom: 6px;
+}
+
+.dirty-modal__changes-list {
+  margin: 0;
+  padding: 0 0 0 18px;
+  list-style: disc;
+}
+
+.dirty-modal__changes-item {
+  font-size: 13px;
+  color: #4b5563;
+  line-height: 1.45;
+  padding: 1px 0;
+}
+
+.dirty-modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.dirty-modal__btn {
+  padding: 9px 18px;
+  border: 1px solid #e6e6e6;
+  border-radius: 10px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.dirty-modal__btn--cancel {
+  background: #fff;
+  color: #4b5563;
+}
+
+.dirty-modal__btn--cancel:hover {
+  background: #f5f5f5;
+  border-color: #d4d4d4;
+}
+
+.dirty-modal__btn--confirm {
+  background: #4F5BDF;
+  color: #fff;
+  border-color: #4F5BDF;
+}
+
+.dirty-modal__btn--confirm:hover {
+  background: #3a45c4;
+  border-color: #3a45c4;
+}
+
+.dirty-fade-enter-active,
+.dirty-fade-leave-active {
+  transition: opacity 0.25s ease;
+}
+
+.dirty-fade-enter-active .dirty-modal,
+.dirty-fade-leave-active .dirty-modal {
+  transition: opacity 0.25s ease, transform 0.25s ease;
+}
+
+.dirty-fade-enter-from,
+.dirty-fade-leave-to {
+  opacity: 0;
+}
+
+.dirty-fade-enter-from .dirty-modal,
+.dirty-fade-leave-to .dirty-modal {
+  opacity: 0;
+  transform: scale(0.95) translateY(-12px);
+}
+</style>

--- a/frontend/src/components/NumberFormat.vue
+++ b/frontend/src/components/NumberFormat.vue
@@ -1201,6 +1201,7 @@ export default {
 }
 
 .table-footer {
+  margin-top: auto;
   padding: 6px 20px;
   border-top: 1px solid #e6e6e6;
   text-align: end;

--- a/frontend/src/components/OrganizationCompanyManagement.vue
+++ b/frontend/src/components/OrganizationCompanyManagement.vue
@@ -712,6 +712,7 @@ export default {
 }
 
 .table-footer {
+  margin-top: auto;
   padding: 12px 16px;
   background: #f8fafc;
   border-top: 1px solid #e2e8f0;

--- a/frontend/src/components/OrganizationsManagement.vue
+++ b/frontend/src/components/OrganizationsManagement.vue
@@ -725,6 +725,7 @@ export default {
 }
 
 .table-footer {
+  margin-top: auto;
   padding: 6px 20px;
   border-top: 1px solid #e6e6e6;
   text-align: end;

--- a/frontend/src/components/SystemTableAppearanceTab.vue
+++ b/frontend/src/components/SystemTableAppearanceTab.vue
@@ -76,6 +76,31 @@
           {{ opt.label }}
         </button>
       </div>
+      <div
+        class="appearance-tab__density-preview"
+        :class="`appearance-tab__density-preview--${rowDensity}`"
+        :style="{ fontSize: fontSize + 'px' }"
+        aria-hidden="true"
+      >
+        <div class="appearance-tab__density-preview-row appearance-tab__density-preview-row--head">
+          <span>Номер</span>
+          <span>Марка</span>
+          <span>Организация</span>
+          <span>Время</span>
+        </div>
+        <div class="appearance-tab__density-preview-row">
+          <span>А123БВ</span>
+          <span>Toyota</span>
+          <span>ООО Ромашка</span>
+          <span>14:30</span>
+        </div>
+        <div class="appearance-tab__density-preview-row">
+          <span>М456ОР</span>
+          <span>Volvo</span>
+          <span>ЗАО Лютик</span>
+          <span>15:00</span>
+        </div>
+      </div>
     </div>
 
   </div>
@@ -138,12 +163,27 @@ export default {
     },
   },
   mounted() {
-    this._stopDirtyGuard = registerDirtyTracker(() => this.isDirty);
+    this._stopDirtyGuard = registerDirtyTracker({
+      isDirty: () => this.isDirty,
+      getChanges: () => this.buildChangesList(),
+    });
   },
   beforeUnmount() {
     this._stopDirtyGuard?.();
   },
   methods: {
+    buildChangesList() {
+      const prefix = this.variant === 'fact' ? 'Оформление "По факту": ' : 'Оформление: ';
+      const out = [];
+      if (this.fontSize !== this.originalFontSize) {
+        out.push(`${prefix}размер шрифта ${this.originalFontSize}px -> ${this.fontSize}px`);
+      }
+      if (this.rowDensity !== this.originalDensity) {
+        const label = v => this.densityOptions.find(o => o.value === v)?.label || v;
+        out.push(`${prefix}плотность строк ${label(this.originalDensity)} -> ${label(this.rowDensity)}`);
+      }
+      return out;
+    },
     reset() {
       const fs = Number(this.table?.[this.fontSizeKey]);
       this.fontSize = fs >= 10 && fs <= 24 ? fs : DEFAULT_FONT_SIZE;
@@ -377,5 +417,52 @@ export default {
 
 .appearance-tab__status--error {
   color: #c62828;
+}
+
+.appearance-tab__density-preview {
+  margin-top: 14px;
+  border: 1px solid #e6e6e6;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #fff;
+}
+
+.appearance-tab__density-preview-row {
+  display: grid;
+  grid-template-columns: 90px 110px 1fr 80px;
+  gap: 12px;
+  align-items: center;
+  padding: 6px 14px;
+  color: #4b5563;
+  border-bottom: 1px solid #f3f4f6;
+  transition: padding 0.25s ease, min-height 0.25s ease;
+}
+
+.appearance-tab__density-preview-row:last-child {
+  border-bottom: none;
+}
+
+.appearance-tab__density-preview-row--head {
+  background: #f8f9ff;
+  color: #4F5BDF;
+  font-weight: 600;
+}
+
+.appearance-tab__density-preview--compact .appearance-tab__density-preview-row {
+  padding-top: 3px;
+  padding-bottom: 3px;
+  min-height: 28px;
+}
+
+.appearance-tab__density-preview--normal .appearance-tab__density-preview-row {
+  padding-top: 6px;
+  padding-bottom: 6px;
+  min-height: 36px;
+}
+
+.appearance-tab__density-preview--spacious .appearance-tab__density-preview-row {
+  padding-top: 12px;
+  padding-bottom: 12px;
+  min-height: 50px;
 }
 </style>

--- a/frontend/src/components/SystemTableColumnsTab.vue
+++ b/frontend/src/components/SystemTableColumnsTab.vue
@@ -46,27 +46,38 @@
       </div>
       <div class="columns-tab__hint-block">
         <template v-if="!enlargedMode">
-          <p class="columns-tab__hint">
-            Переставляйте столбцы перетаскиванием за иконку слева. Скрытые столбцы не отображаются в таблице.
-          </p>
-          <p class="columns-tab__hint">
-            <b>Ширина</b> - относительный вес столбца. Браузер делит доступную ширину
-            видимых столбцов пропорционально этим весам. <b>Приоритет</b> (1-5) -
-            видимость на вертикальном (книжном) экране охранника: 1 - всегда виден,
-            2 - виден на узком экране, 3-5 - скрывается и доступен по кнопке "Подробнее"
-            под строкой.
-          </p>
+          <div class="columns-tab__hint-grid">
+            <div class="columns-tab__hint-card">
+              <span class="columns-tab__hint-badge">Порядок</span>
+              <span class="columns-tab__hint-text">перетащите за иконку слева</span>
+            </div>
+            <div class="columns-tab__hint-card">
+              <span class="columns-tab__hint-badge">Ширина</span>
+              <span class="columns-tab__hint-text">относительный вес, делит ширину пропорционально</span>
+            </div>
+            <div class="columns-tab__hint-card">
+              <span class="columns-tab__hint-badge">Приоритет 1-5</span>
+              <span class="columns-tab__hint-text">1 - всегда виден на портретном экране, 3-5 - под кнопкой "Подробнее"</span>
+            </div>
+          </div>
         </template>
         <template v-else>
-          <p class="columns-tab__hint">
-            Настройки применяются ТОЛЬКО когда у пользователя включён
-            <b>Увеличенный режим</b> в шапке таблицы. <b>Ширина</b> - 0 значит
-            брать обычную. <b>Жирность</b> - 0 значит дефолт (500).
-          </p>
-          <p class="columns-tab__hint">
-            Если строка столбца <b>серая, но с галочкой</b> - значит в
-            <b>Обычном</b> режиме столбец выключен, а в <b>Увеличенном</b> -
-            включён (или наоборот).
+          <div class="columns-tab__hint-grid">
+            <div class="columns-tab__hint-card">
+              <span class="columns-tab__hint-badge">Применение</span>
+              <span class="columns-tab__hint-text">только когда пользователь включил Увеличенный режим</span>
+            </div>
+            <div class="columns-tab__hint-card">
+              <span class="columns-tab__hint-badge">Ширина 0</span>
+              <span class="columns-tab__hint-text">взять обычную</span>
+            </div>
+            <div class="columns-tab__hint-card">
+              <span class="columns-tab__hint-badge">Жирность 0</span>
+              <span class="columns-tab__hint-text">дефолт 500</span>
+            </div>
+          </div>
+          <p class="columns-tab__hint-foot">
+            Серая строка с галочкой - столбец выключен в обычном режиме, но включён в увеличенном (или наоборот).
           </p>
         </template>
       </div>
@@ -390,7 +401,10 @@ export default {
     },
   },
   mounted() {
-    this._stopDirtyGuard = registerDirtyTracker(() => this.isDirty);
+    this._stopDirtyGuard = registerDirtyTracker({
+      isDirty: () => this.isDirty,
+      getChanges: () => this.buildChangesList(),
+    });
   },
   beforeUnmount() {
     // На случай если пользователь ушёл с вкладки во время drag.
@@ -400,6 +414,50 @@ export default {
   methods: {
     humanLabel(name) {
       return FIELD_LABELS[name] || name;
+    },
+    buildChangesList() {
+      const prefix = this.variant === 'fact' ? 'Колонки "По факту": ' : 'Колонки: ';
+      const out = [];
+      const visDiff = this.localFields.filter(
+        f => this.originalVisibility[f.field_name] !== f.is_visible,
+      );
+      if (visDiff.length) {
+        const names = visDiff.slice(0, 3).map(f => `"${this.humanLabel(f.field_name)}"`).join(', ');
+        const more = visDiff.length > 3 ? ` и ещё ${visDiff.length - 3}` : '';
+        out.push(`${prefix}изменена видимость ${names}${more}`);
+      }
+      const orderChanged = this.localFields.some(
+        (f, i) => this.originalOrder[i] !== f.field_name,
+      );
+      if (orderChanged) out.push(`${prefix}изменён порядок столбцов`);
+      const widthDiff = this.localFields.filter(
+        f => this.originalWidth[f.field_name] !== f.width,
+      );
+      if (widthDiff.length) out.push(`${prefix}изменена ширина (${widthDiff.length})`);
+      const priorityDiff = this.localFields.filter(
+        f => this.originalPriority[f.field_name] !== f.priority,
+      );
+      if (priorityDiff.length) out.push(`${prefix}изменён приоритет (${priorityDiff.length})`);
+      const enlPrefix = this.variant === 'fact'
+        ? 'Увеличенный (По факту): '
+        : 'Увеличенный режим: ';
+      const enlVisDiff = this.localFields.filter(
+        f => this.originalEnlargedVisibility[f.field_name] !== f.enlarged_is_visible,
+      );
+      if (enlVisDiff.length) {
+        const names = enlVisDiff.slice(0, 3).map(f => `"${this.humanLabel(f.field_name)}"`).join(', ');
+        const more = enlVisDiff.length > 3 ? ` и ещё ${enlVisDiff.length - 3}` : '';
+        out.push(`${enlPrefix}изменена видимость ${names}${more}`);
+      }
+      const enlWDiff = this.localFields.filter(
+        f => this.originalEnlargedWidth[f.field_name] !== f.enlarged_width,
+      );
+      if (enlWDiff.length) out.push(`${enlPrefix}изменена ширина (${enlWDiff.length})`);
+      const enlWeightDiff = this.localFields.filter(
+        f => this.originalEnlargedWeight[f.field_name] !== f.enlarged_font_weight,
+      );
+      if (enlWeightDiff.length) out.push(`${enlPrefix}изменена жирность (${enlWeightDiff.length})`);
+      return out;
     },
     reset() {
       const sorted = [...(this.fields || [])].sort((a, b) => {
@@ -618,6 +676,47 @@ export default {
   font-size: 13px;
   color: #6b7280;
   line-height: 1.5;
+}
+
+.columns-tab__hint-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 8px;
+}
+
+.columns-tab__hint-card {
+  background: #f8f9ff;
+  border: 1px solid #eef0ff;
+  border-radius: 10px;
+  padding: 8px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.columns-tab__hint-badge {
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-start;
+  background: #4F5BDF;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 10px;
+}
+
+.columns-tab__hint-text {
+  font-size: 12px;
+  color: #4b5563;
+  line-height: 1.35;
+}
+
+.columns-tab__hint-foot {
+  margin: 4px 0 0;
+  font-size: 12px;
+  color: #6b7280;
+  line-height: 1.4;
 }
 
 .columns-tab__empty {

--- a/frontend/src/components/TableConstructor.vue
+++ b/frontend/src/components/TableConstructor.vue
@@ -560,7 +560,7 @@
 
     <!-- Модальное окно создания таблицы -->
     <TableConstructorCreateModal
-      v-if="showAddModal"
+      :show="showAddModal"
       @created="onTableCreated"
       @close="showAddModal = false"
     />

--- a/frontend/src/components/TableConstructorCreateModal.vue
+++ b/frontend/src/components/TableConstructorCreateModal.vue
@@ -1,13 +1,15 @@
 <template>
   <Teleport to="body">
-    <div
-      class="modal-overlay"
-      @click.self="handleClose"
-    >
+    <transition name="modal-fade">
       <div
-        ref="modalContent"
-        class="modal-content horizontal-modal"
+        v-if="show"
+        class="modal-overlay"
+        @click.self="handleClose"
       >
+        <div
+          ref="modalContent"
+          class="modal-content horizontal-modal"
+        >
         <div class="modal-header">
           <h3>Создать новую таблицу</h3>
           <button
@@ -164,7 +166,8 @@
           </button>
         </div>
       </div>
-    </div>
+      </div>
+    </transition>
   </Teleport>
 </template>
 
@@ -177,7 +180,18 @@ export default {
   components: {
     TextConstructor
   },
+  props: {
+    show: { type: Boolean, default: false }
+  },
   emits: ['created', 'close'],
+  watch: {
+    show(v) {
+      if (!v) {
+        this.resetForm()
+        this.typeDropdownOpen = false
+      }
+    }
+  },
   data() {
     return {
       newTable: {

--- a/frontend/src/components/UserTypes.vue
+++ b/frontend/src/components/UserTypes.vue
@@ -769,6 +769,7 @@ export default {
 }
 
 .table-footer {
+  margin-top: auto;
   padding: 6px 20px;
   border-top: 1px solid #e6e6e6;
   text-align: end;

--- a/frontend/src/components/ui/CollapsibleSection.vue
+++ b/frontend/src/components/ui/CollapsibleSection.vue
@@ -6,13 +6,12 @@
   >
     <button
       type="button"
-      class="collapsible-section__toggle"
+      class="collapsible-section__bar"
       :aria-expanded="!collapsed"
       :aria-controls="contentId"
-      :title="collapsed ? `Развернуть: ${title}` : `Свернуть: ${title}`"
-      :aria-label="collapsed ? `Развернуть: ${title}` : `Свернуть: ${title}`"
       @click="collapsed = !collapsed"
     >
+      <span class="collapsible-section__title">{{ title }}</span>
       <svg
         class="collapsible-section__chevron"
         :class="{ rotated: !collapsed }"
@@ -87,39 +86,47 @@ export default {
   position: relative;
 }
 
-/* Кнопка-chevron в правом верхнем углу секции - не дублирует существующий
-   заголовок внутри слота, остаётся над ним. */
-.collapsible-section__toggle {
-  position: absolute;
-  top: 12px;
-  right: 14px;
-  z-index: 5;
-  display: inline-flex;
+.collapsible-section__bar {
+  width: 100%;
+  display: flex;
   align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  padding: 0;
-  border: 1px solid #e6e6e6;
+  justify-content: space-between;
+  padding: 14px 20px;
   background: #fff;
+  border: 1px solid #e6e6e6;
+  border-radius: 16px;
   cursor: pointer;
-  border-radius: 8px;
-  color: #6e7280;
-  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+  color: #1f2937;
+  font-family: inherit;
+  font-size: 16px;
+  font-weight: 600;
+  text-align: left;
+  transition: background 0.15s ease, border-color 0.15s ease;
 }
 
-.collapsible-section__toggle:hover {
-  background: #eef0ff;
-  border-color: #4F5BDF;
-  color: #4F5BDF;
+.collapsible-section__bar:hover {
+  background: #f8f9ff;
+  border-color: #c5cbf4;
 }
 
-.collapsible-section__toggle:focus-visible {
+.collapsible-section__bar:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px rgba(79, 91, 223, 0.25);
 }
 
+.collapsible-section:not(.is-collapsed) .collapsible-section__bar {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.collapsible-section__title {
+  flex: 1;
+}
+
 .collapsible-section__chevron {
+  flex-shrink: 0;
+  color: #6e7280;
   transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
@@ -137,6 +144,12 @@ export default {
 }
 
 .collapsible-section.is-collapsed .collapsible-section__content {
+  display: none;
+}
+
+/* Внутри CollapsibleSection заголовок секции живёт в полосе-шапке -
+   убираем дубликаты-заголовки в Management-компонентах. */
+.collapsible-section :deep(.management-title) {
   display: none;
 }
 </style>

--- a/frontend/src/utils/dirtyTracker.js
+++ b/frontend/src/utils/dirtyTracker.js
@@ -1,14 +1,25 @@
 /**
  * Глобальный реестр форм с несохранёнными изменениями + красивый confirm-модал.
  *
- * Компонент с формой регистрирует геттер isDirty -> при попытке покинуть
- * страницу (роутер, перезагрузка, переключение вкладок внутри view) показывается
- * красивый Vue-модал (DirtyConfirmModal в App.vue). Для window.beforeunload
- * браузер показывает свой нативный диалог - кастомный показать нельзя.
+ * Компонент с формой регистрирует геттер isDirty (и опционально getChanges) -
+ * при попытке покинуть страницу (роутер, перезагрузка, переключение вкладок
+ * внутри view) показывается красивый Vue-модал (DirtyConfirmModal в App.vue)
+ * со списком изменений. Для window.beforeunload браузер показывает свой
+ * нативный диалог - кастомный показать нельзя.
  *
  * Использование в Options API:
  *   import { registerDirtyTracker } from '@/utils/dirtyTracker';
- *   mounted() { this._stopGuard = registerDirtyTracker(() => this.isDirty); },
+ *   // короткая форма (как раньше):
+ *   mounted() {
+ *     this._stopGuard = registerDirtyTracker(() => this.isDirty);
+ *   }
+ *   // расширенная с описанием изменений:
+ *   mounted() {
+ *     this._stopGuard = registerDirtyTracker({
+ *       isDirty: () => this.isDirty,
+ *       getChanges: () => ['Изменена ширина "Марка"', 'Скрыта "Организация"'],
+ *     });
+ *   }
  *   beforeUnmount() { this._stopGuard?.(); }
  *
  * Перед навигацией:
@@ -29,15 +40,27 @@ const DEFAULT_MESSAGE = 'У вас есть несохранённые изме�
 export const confirmState = reactive({
   show: false,
   message: DEFAULT_MESSAGE,
+  changes: [],
   resolve: null,
 });
 
 /**
- * Регистрирует геттер isDirty. Возвращает функцию-отписку.
+ * Регистрирует трекер. Аргумент:
+ *  - функция: () => boolean (backward-compat, без списка изменений)
+ *  - объект:  { isDirty: () => boolean, getChanges?: () => string[] }
+ * Возвращает функцию-отписку.
  */
-export function registerDirtyTracker(getterFn) {
+export function registerDirtyTracker(arg) {
+  const entry = typeof arg === 'function'
+    ? { isDirty: arg, getChanges: null }
+    : { isDirty: arg?.isDirty, getChanges: arg?.getChanges ?? null };
+
+  if (typeof entry.isDirty !== 'function') {
+    throw new Error('registerDirtyTracker: isDirty must be a function');
+  }
+
   const id = nextId++;
-  trackers.set(id, getterFn);
+  trackers.set(id, entry);
   return () => trackers.delete(id);
 }
 
@@ -45,14 +68,36 @@ export function registerDirtyTracker(getterFn) {
  * Есть ли хотя бы одна форма с несохранёнными изменениями?
  */
 export function hasAnyDirty() {
-  for (const get of trackers.values()) {
+  for (const entry of trackers.values()) {
     try {
-      if (get()) return true;
+      if (entry.isDirty()) return true;
     } catch {
       /* геттер мог обратиться к удалённому компоненту - игнорируем */
     }
   }
   return false;
+}
+
+/**
+ * Собирает список изменений со всех dirty-трекеров. Возвращает массив строк.
+ */
+function collectAllChanges() {
+  const all = [];
+  for (const entry of trackers.values()) {
+    try {
+      if (!entry.isDirty()) continue;
+      if (!entry.getChanges) continue;
+      const items = entry.getChanges();
+      if (Array.isArray(items)) {
+        for (const it of items) {
+          if (typeof it === 'string' && it.trim()) all.push(it.trim());
+        }
+      }
+    } catch {
+      /* пропускаем сломанные трекеры */
+    }
+  }
+  return all;
 }
 
 /**
@@ -71,6 +116,7 @@ export function confirmIfAnyDirty(message) {
   }
   return new Promise((resolve) => {
     confirmState.message = message || DEFAULT_MESSAGE;
+    confirmState.changes = collectAllChanges();
     confirmState.resolve = resolve;
     confirmState.show = true;
   });


### PR DESCRIPTION
## Summary

Седьмая порция правок после теста PR #393. Семь точечных доработок плюс перепиленный CollapsibleSection.

- Сворачивание-разворачивание секций (Личный кабинет): кликабельная полоса с заголовком и chevron, дубликаты-заголовки в Management-компонентах скрыты через :deep.
- Оформление: живое превью плотности строк прямо под селектором (2 фейк-строки с заголовком, плавная смена padding/min-height при переключении).
- Колонки: инструкция переформатирована из сплошных абзацев в карточки с бейджами (Порядок / Ширина / Приоритет в обычном; Применение / Ширина 0 / Жирность 0 в Увеличенном).
- DirtyConfirmModal: блок со списком конкретных изменений, ширина 560px чтобы кнопки "Уйти без сохранения" и "Остаться" помещались в одну строку.
- Модалка Создать таблицу: завернута в `<transition name="modal-fade">` для плавного закрытия (стили уже были).
- Убран хардкод `.selected-table-card.enlarged .status-col { opacity: 0 }` в CarsTable - столбец Статус теперь слушает настройку `enlarged_is_visible`.
- `.table-footer { margin-top: auto }` в восьми Management-компонентах, чтобы футер прилипал к низу контейнера при малом числе строк.

## Test plan

- [ ] Личный кабинет -> разделы свернуть/развернуть, видна полоса с заголовком, контент анимируется
- [ ] Таблицы -> Оформление -> переключение Компактно/Обычно/Просторно: превью плавно меняет высоту строк
- [ ] Таблицы -> Колонки в обычном и Увеличенном режиме: видна сетка из 3 карточек с бейджами
- [ ] Изменить настройки в Колонках без сохранения -> кликнуть на Оформление -> модалка с списком изменений, ширина под кнопки в одну строку
- [ ] Открыть/закрыть "+ Создать таблицу": плавная анимация в обе стороны
- [ ] КПП №4 -> включить Увеличенный режим: если стоит галочка enlarged_is_visible на Статус -> виден; снять -> схлопывается через col--collapsed
- [ ] Управление организациями/компаниями/etc. с малым числом строк: футер прибит к низу контейнера, белого пространства нет

vitest: 298/298 зелёный.