### PR TITLE
fix(345): полировка r8 - hint-block и единый стиль уведомлений

### DIFF
--- a/frontend/src/components/DeleteNotifications.vue
+++ b/frontend/src/components/DeleteNotifications.vue
@@ -5,6 +5,7 @@
         v-for="item in store.items"
         :key="item.id"
         class="del-card"
+        :class="{ 'del-card--error': item.type === 'error' }"
       >
         <div class="del-row">
           <span class="del-text">
@@ -21,7 +22,7 @@
         <div class="del-track">
           <div
             class="del-fill"
-            :style="{ width: item.progress + '%', background: colorFor(item.progress) }"
+            :style="{ width: item.progress + '%', background: barColorFor(item) }"
           />
         </div>
       </div>
@@ -38,8 +39,10 @@ const store = useDeletionsStore();
 onMounted(() => store.loadDurations());
 
 // Цвет прогресс-бара: 100% (только удалили) - зелёный, 0% (вот-вот исчезнет) - красный.
-function colorFor(progress) {
-  const t = Math.min(1, Math.max(0, (100 - progress) / 100));
+// Для type=error всегда красный - нет семантики "истекает".
+function barColorFor(item) {
+  if (item.type === 'error') return 'rgb(255, 102, 104)';
+  const t = Math.min(1, Math.max(0, (100 - item.progress) / 100));
   const green = [52, 199, 89];
   const red = [255, 102, 104];
   const c = green.map((g, i) => Math.round(g + (red[i] - g) * t));
@@ -63,6 +66,7 @@ function colorFor(progress) {
 .del-card {
   background: #fff;
   border: 1px solid #e6e6e6;
+  border-left-width: 4px;
   border-radius: 15px;
   padding: 14px 16px;
   box-shadow: 0 3px 10px rgba(0, 0, 0, 0.1);
@@ -70,6 +74,10 @@ function colorFor(progress) {
   width: max-content;
   min-width: 300px;
   max-width: calc(100vw - 40px);
+}
+
+.del-card--error {
+  border-left-color: rgb(255, 102, 104);
 }
 
 .del-row {

--- a/frontend/src/components/SystemTableAppearanceTab.vue
+++ b/frontend/src/components/SystemTableAppearanceTab.vue
@@ -111,7 +111,7 @@
 
 <script>
 import { apiRequest } from '@/api/client';
-import { useToast } from '@/composables/useToast';
+import { useDeletionsStore } from '@/stores/deletions';
 import { registerDirtyTracker } from '@/utils/dirtyTracker';
 import { generateSampleRows } from '@/utils/tableSamples';
 
@@ -166,9 +166,6 @@ const PREVIEW_MAX_FIELDS = 4;
 
 export default {
   name: 'SystemTableAppearanceTab',
-  setup() {
-    return { toast: useToast() };
-  },
   props: {
     tableId: { type: Number, required: true },
     table: { type: Object, required: true },
@@ -296,10 +293,10 @@ export default {
         }
         this.originalFontSize = fs;
         this.originalDensity = this.rowDensity;
-        this.toast.success('Оформление сохранено');
+        useDeletionsStore().notify({ prefix: 'Оформление ', bold: 'сохранено' });
         this.$emit('update');
       } catch (e) {
-        this.toast.error(`Ошибка сохранения: ${e.message}`);
+        useDeletionsStore().notify({ prefix: 'Ошибка сохранения: ', bold: e.message, type: 'error' });
       } finally {
         this.saving = false;
       }

--- a/frontend/src/components/SystemTableColumnsTab.vue
+++ b/frontend/src/components/SystemTableColumnsTab.vue
@@ -298,7 +298,7 @@
 <script>
 import { apiRequest } from '@/api/client';
 import { generateSampleRows } from '@/utils/tableSamples';
-import { useToast } from '@/composables/useToast';
+import { useDeletionsStore } from '@/stores/deletions';
 import { registerDirtyTracker } from '@/utils/dirtyTracker';
 import CarsTable from './CarsTable.vue';
 import PeopleTable from './PeopleTable.vue';
@@ -324,9 +324,6 @@ const FIELD_LABELS = {
 export default {
   name: 'SystemTableColumnsTab',
   components: { CarsTable, PeopleTable },
-  setup() {
-    return { toast: useToast() };
-  },
   props: {
     tableId: { type: Number, required: true },
     tableType: { type: String, required: true },
@@ -572,7 +569,7 @@ export default {
           const err = await response.json().catch(() => ({}));
           throw new Error(err.message || `HTTP ${response.status}`);
         }
-        this.toast.success('Настройки столбцов сохранены');
+        useDeletionsStore().notify({ prefix: 'Настройки столбцов ', bold: 'сохранены' });
         this.originalVisibility = Object.fromEntries(
           this.localFields.map(f => [f.field_name, f.is_visible]),
         );
@@ -594,7 +591,7 @@ export default {
         );
         this.$emit('update');
       } catch (e) {
-        this.toast.error(`Ошибка сохранения: ${e.message}`);
+        useDeletionsStore().notify({ prefix: 'Ошибка сохранения: ', bold: e.message, type: 'error' });
       } finally {
         this.saving = false;
       }
@@ -634,7 +631,7 @@ export default {
 /* Блок подсказок фиксированной высоты - предотвращает скачки высоты вкладки
    при смене режима, где у подсказок разная длина текста. */
 .columns-tab__hint-block {
-  min-height: 140px;
+  min-height: 100px;
   display: flex;
   flex-direction: column;
   gap: 6px;

--- a/frontend/src/components/TableConstructor.vue
+++ b/frontend/src/components/TableConstructor.vue
@@ -568,21 +568,13 @@
       @created="onTableCreated"
       @close="showAddModal = false"
     />
-
-    <!-- Уведомления -->
-    <div
-      v-if="notification.show"
-      class="notification"
-      :class="notification.type"
-    >
-      <span class="notification-message">{{ notification.message }}</span>
-    </div>
   </div>
 </template>
 
 <script>
 import { apiRequest } from '@/api/client'
 import { confirmIfAnyDirty } from '@/utils/dirtyTracker';
+import { useDeletionsStore } from '@/stores/deletions';
 import RefreshButton from './RefreshButton.vue';
 import SearchComponent from './SearchComponent.vue';
 import TextConstructor from './TextConstructor.vue';
@@ -617,11 +609,6 @@ export default {
       originalHint: '',
       originalInstruction: '',
       tableTypeDropdownOpen: false,
-      notification: {
-        show: false,
-        message: '',
-        type: 'info'
-      }
     };
   },
   computed: {
@@ -679,19 +666,13 @@ export default {
   },
   mounted() {
     this.refreshData();
-    
-    // Слушаем события уведомлений от дочерних компонентов
-    window.addEventListener('show-notification', this.handleNotification);
-    
+
     // Закрываем dropdown при клике вне них
     document.addEventListener('click', (e) => {
       if (!this.$el.contains(e.target)) {
         this.tableTypeDropdownOpen = false;
       }
     });
-  },
-  beforeUnmount() {
-    window.removeEventListener('show-notification', this.handleNotification);
   },
   watch: {
     // Если активна вкладка фактовой таблицы, а пользователь снял галочку
@@ -712,10 +693,6 @@ export default {
     },
   },
   methods: {
-    handleNotification(event) {
-      this.showNotification(event.detail.message, event.detail.type);
-    },
-
     /**
      * Переключение вкладки с защитой: если на текущей вкладке есть pending
      * правки - сначала спросить подтверждение. confirmIfAnyDirty опрашивает
@@ -746,7 +723,7 @@ export default {
         }
       } catch (error) {
         console.error("Error fetching system tables:", error);
-        this.showNotification("Ошибка при загрузке таблиц", "error");
+        useDeletionsStore().notify({ prefix: 'Ошибка при ', bold: 'загрузке таблиц', type: 'error' });
       }
     },
     
@@ -789,7 +766,7 @@ export default {
       if (newTable) {
         this.selectTable(newTable);
       }
-      this.showNotification("Таблица успешно создана", "success");
+      useDeletionsStore().notify({ prefix: 'Таблица ', bold: result.display_name || 'создана', suffix: result.display_name ? ' создана' : '' });
     },
 
     async updateTable(field) {
@@ -836,21 +813,21 @@ export default {
         if (response.ok) {
           if (field === 'fact_table_hint') {
             this.originalHint = this.selectedTable.table.fact_table_hint || '';
-            this.showNotification("Подсказка успешно сохранена", "success");
+            useDeletionsStore().notify({ prefix: 'Подсказка ', bold: 'сохранена' });
           } else if (field === 'instruction') {
             this.originalInstruction = this.selectedTable.table.instruction || '';
-            this.showNotification("Инструкция успешно сохранена", "success");
+            useDeletionsStore().notify({ prefix: 'Инструкция ', bold: 'сохранена' });
           } else {
-            this.showNotification("Изменения сохранены", "success");
+            useDeletionsStore().notify({ prefix: 'Изменения ', bold: 'сохранены' });
           }
           await this.refreshSelectedTable();
         } else {
           const errorText = await response.text();
-          this.showNotification(errorText || "Ошибка при обновлении", "error");
+          useDeletionsStore().notify({ prefix: 'Ошибка при обновлении: ', bold: errorText || 'неизвестная', type: 'error' });
         }
       } catch (error) {
         console.error("Error updating table:", error);
-        this.showNotification("Ошибка сети", "error");
+        useDeletionsStore().notify({ prefix: 'Ошибка ', bold: 'сети', type: 'error' });
       }
     },
     
@@ -881,27 +858,26 @@ export default {
     console.log("Response headers:", response.headers);
     
     if (response.ok) {
+      const deletedName = table.table.display_name;
       this.selectedTable = null;
       this.activeTab = 'main';
       await this.refreshData();
-      this.showNotification("Таблица успешно удалена", "success");
+      useDeletionsStore().notify({ prefix: 'Таблица ', bold: deletedName, suffix: ' удалена' });
     } else {
-      // Получаем текст ошибки
       const errorText = await response.text();
       console.error("Error response text:", errorText);
-      
-      // Пробуем распарсить как JSON, если это возможно
+      let message = errorText;
       try {
         const errorJson = JSON.parse(errorText);
-        this.showNotification(errorJson.message || errorText, "error");
+        message = errorJson.message || errorText;
       } catch {
-        // Если не JSON, показываем как текст
-        this.showNotification(errorText, "error");
+        // оставляем сырой текст
       }
+      useDeletionsStore().notify({ prefix: 'Ошибка удаления: ', bold: message, type: 'error' });
     }
   } catch (error) {
     console.error("Error deleting system table:", error);
-    this.showNotification("Ошибка сети", "error");
+    useDeletionsStore().notify({ prefix: 'Ошибка ', bold: 'сети', type: 'error' });
   }
 },
     
@@ -1026,22 +1002,6 @@ export default {
         this.updateTable('table_type');
       }
     },
-    
-    showNotification(message, type = 'info') {
-      this.notification = {
-        show: true,
-        message,
-        type
-      };
-      
-      setTimeout(() => {
-        this.hideNotification();
-      }, 3000);
-    },
-    
-    hideNotification() {
-      this.notification.show = false;
-    }
   },
 }
 </script>
@@ -2065,52 +2025,6 @@ export default {
 .modal-fade-leave-to .modal-content {
   opacity: 0;
   transform: scale(0.8) translateY(-20px);
-}
-
-/* Стили для уведомлений */
-.notification {
-  position: fixed;
-  top: 0;
-  left: 50%;
-  transform: translateX(-50%) translateY(-100%);
-  padding: 12px 24px;
-  border-radius: 0 0 8px 8px;
-  color: white;
-  font-weight: 500;
-  z-index: 10000;
-  text-align: center;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  animation: slideDown 0.3s ease-out forwards;
-  min-width: 300px;
-}
-
-.notification.success {
-  background: #10b981;
-}
-
-.notification.error {
-  background: #ef4444;
-}
-
-.notification.warning {
-  background: #f59e0b;
-}
-
-.notification.info {
-  background: #3b82f6;
-}
-
-.notification-message {
-  font-size: 0.9em;
-}
-
-@keyframes slideDown {
-  from {
-    transform: translateX(-50%) translateY(-100%);
-  }
-  to {
-    transform: translateX(-50%) translateY(0);
-  }
 }
 
 /* Скроллбары */

--- a/frontend/src/components/TableConstructorCreateModal.vue
+++ b/frontend/src/components/TableConstructorCreateModal.vue
@@ -173,6 +173,7 @@
 
 <script>
 import { apiRequest } from '@/api/client'
+import { useDeletionsStore } from '@/stores/deletions'
 import TextConstructor from './TextConstructor.vue'
 
 export default {
@@ -262,17 +263,13 @@ export default {
 
     async createTable() {
       if (!this.newTable.name.trim() || !this.newTable.display_name.trim()) {
-        window.dispatchEvent(new CustomEvent('show-notification', {
-          detail: { message: 'Заполните все обязательные поля', type: 'warning' }
-        }))
+        useDeletionsStore().notify({ prefix: 'Заполните ', bold: 'обязательные поля', type: 'error' });
         return
       }
 
       const nameRegex = /^[a-z0-9_]+$/
       if (!nameRegex.test(this.newTable.name)) {
-        window.dispatchEvent(new CustomEvent('show-notification', {
-          detail: { message: 'Системное имя может содержать только латинские буквы, цифры и подчеркивания', type: 'warning' }
-        }))
+        useDeletionsStore().notify({ prefix: 'Системное имя: только ', bold: 'латиница, цифры, _', type: 'error' });
         return
       }
 
@@ -295,14 +292,10 @@ export default {
           } catch {
             // не JSON — используем текст как есть
           }
-          window.dispatchEvent(new CustomEvent('show-notification', {
-            detail: { message, type: 'error' }
-          }))
+          useDeletionsStore().notify({ prefix: 'Ошибка создания: ', bold: message, type: 'error' });
         }
       } catch (error) {
-        window.dispatchEvent(new CustomEvent('show-notification', {
-          detail: { message: 'Ошибка сети: ' + error.message, type: 'error' }
-        }))
+        useDeletionsStore().notify({ prefix: 'Ошибка сети: ', bold: error.message, type: 'error' });
       }
     },
 

--- a/frontend/src/components/TableConstructorPhotoSection.vue
+++ b/frontend/src/components/TableConstructorPhotoSection.vue
@@ -151,6 +151,7 @@
 
 <script>
 import { apiRequest } from '@/api/client'
+import { useDeletionsStore } from '@/stores/deletions'
 
 export default {
   name: 'TableConstructorPhotoSection',
@@ -254,7 +255,10 @@ export default {
     },
 
     dispatchNotification(message, type) {
-      window.dispatchEvent(new CustomEvent('show-notification', { detail: { message, type } }));
+      const opts = type === 'error'
+        ? { prefix: '', bold: message, type: 'error' }
+        : { prefix: '', bold: message };
+      useDeletionsStore().notify(opts);
     }
   }
 }

--- a/frontend/src/stores/deletions.js
+++ b/frontend/src/stores/deletions.js
@@ -55,10 +55,10 @@ export const useDeletionsStore = defineStore('deletions', () => {
     durationsLoaded = true;
   }
 
-  function enqueue({ prefix = '', bold = '', suffix = '', onConfirm, onUndo, showUndo = true, duration }) {
+  function enqueue({ prefix = '', bold = '', suffix = '', onConfirm, onUndo, showUndo = true, duration, type = 'success' }) {
     const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
     const ms = duration || deleteDuration.value;
-    items.value.push({ id, prefix, bold, suffix, progress: 100, showUndo });
+    items.value.push({ id, prefix, bold, suffix, progress: 100, showUndo, type });
     callbacks.set(id, { onConfirm, onUndo });
     const step = 100 / (Math.max(ms, TICK_MS) / TICK_MS);
     const timer = setInterval(() => tick(id, step), TICK_MS);
@@ -67,8 +67,10 @@ export const useDeletionsStore = defineStore('deletions', () => {
   }
 
   // Информационное уведомление в том же стиле (без отмены), напр. о восстановлении.
-  function notify({ prefix = '', bold = '', suffix = '', duration }) {
-    return enqueue({ prefix, bold, suffix, showUndo: false, duration: duration || restoreDuration.value });
+  // type: 'success' (по умолчанию, зелёный -> красный прогресс) или 'error'
+  // (красный левый бордер, без зелёной фазы прогресса).
+  function notify({ prefix = '', bold = '', suffix = '', duration, type = 'success' }) {
+    return enqueue({ prefix, bold, suffix, showUndo: false, duration: duration || restoreDuration.value, type });
   }
 
   function tick(id, step) {


### PR DESCRIPTION
## Что в PR

Две правки после ревью r7.

### 1. min-height hint-block 140 -> 100
В r7 расширил тексты подсказок и поднял min-height с 96 до 140px. По факту хватает ~100 — лишний воздух убираю.

### 2. Унифицировал уведомления в "Таблицы системы"
Было: `useToast().success(...)` в `SystemTableColumnsTab`/`SystemTableAppearanceTab` (зелёная плашка с галочкой) и собственный `showNotification` (inline-banner сверху по центру) в `TableConstructor`. Через `window.dispatchEvent('show-notification')` пробрасывались сообщения из `TableConstructorCreateModal` и `TableConstructorPhotoSection`.

Стало: все save/create/update/delete используют `useDeletionsStore().notify(...)` — тот же визуал, что и при удалении машин/людей на /table/... (белая карточка справа сверху, прогресс-бар). Для ошибок расширил стор — `type: 'error'` даёт красный левый бордер и сразу красный прогресс-бар без зелёной фазы.

**Убрано**:
- `useToast` в обоих табах конструктора;
- `notification` data + методы + template + CSS в `TableConstructor.vue`;
- `window.dispatchEvent('show-notification')` в Modal/PhotoSection и слушатель в TableConstructor.

**Добавлено**:
- `type` в `deletions.js` (`success` дефолт, `error` для красного варианта);
- `del-card--error` класс и `barColorFor(item)` функция в `DeleteNotifications.vue`.

## Test plan
- [x] vitest: 298/298 (`npm run test:run`)
- [x] eslint: 0 ошибок
- [ ] Staging: сохранить Колонки/Оформление, создать/удалить/переименовать таблицу, загрузить фото — каждый раз белая карточка справа сверху с прогресс-баром. Зелёной плашки с галочкой нет.
- [ ] Триггернуть ошибку (например пустое имя при создании) — карточка с красным левым бордером и красным прогресс-баром.