### PR TITLE
feat(345): архив системных таблиц - бэк

### DIFF
--- a/internal/handlers/system_tables.go
+++ b/internal/handlers/system_tables.go
@@ -21,17 +21,19 @@ func NewSystemTableHandler(service services.SystemTableService) *SystemTableHand
 }
 
 // GetAll godoc
-// @Summary      Получение всех системных таблиц
-// @Description  Возвращает все активные системные таблицы с полями, слотами, фото и текущим статусом (open/closed)
+// @Summary      Получение системных таблиц
+// @Description  По умолчанию возвращает только активные. include_archived=true возвращает только архивные (мягко удалённые).
 // @Tags         system-tables
 // @Produce      json
 // @Security     BearerAuth
+// @Param        include_archived query bool false "Вернуть архивные таблицы вместо активных"
 // @Success      200 {array} models.SystemTableWithDetails
 // @Failure      401 {object} models.HTTPError
 // @Failure      500 {object} models.HTTPError
 // @Router       /system-tables [get]
 func (h *SystemTableHandler) GetAll(c echo.Context) error {
-	tables, err := h.service.GetAll(c.Request().Context())
+	includeArchived := c.QueryParam("include_archived") == "true"
+	tables, err := h.service.GetAll(c.Request().Context(), includeArchived)
 	if err != nil {
 		return err
 	}
@@ -141,7 +143,7 @@ func (h *SystemTableHandler) Update(c echo.Context) error {
 
 // Delete godoc
 // @Summary      Удаление системной таблицы
-// @Description  Мягкое удаление (is_active=false). Проверяет привязки к организациям и компаниям
+// @Description  Мягкое удаление (is_active=false) - таблица уходит в архив. Проверяет привязки к организациям и компаниям
 // @Tags         system-tables
 // @Produce      json
 // @Security     BearerAuth
@@ -160,6 +162,29 @@ func (h *SystemTableHandler) Delete(c echo.Context) error {
 		return err
 	}
 	return RespondMessage(c, "Системная таблица успешно удалена")
+}
+
+// Restore godoc
+// @Summary      Восстановление системной таблицы из архива
+// @Description  Возвращает таблицу из архива (is_active=false -> true)
+// @Tags         system-tables
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID таблицы"
+// @Success      200 {string} string "Системная таблица восстановлена"
+// @Failure      400 {object} models.HTTPError
+// @Failure      401 {object} models.HTTPError
+// @Failure      404 {object} models.HTTPError
+// @Router       /system-tables/{id}/restore [post]
+func (h *SystemTableHandler) Restore(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	if err := h.service.Restore(c.Request().Context(), id); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Системная таблица восстановлена")
 }
 
 // UpdateFields godoc

--- a/internal/handlers/system_tables_test.go
+++ b/internal/handlers/system_tables_test.go
@@ -89,6 +89,63 @@ func TestSystemTables_CRUD(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
+func TestSystemTables_ArchiveAndRestore(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	// Create table
+	body := `{"name":"arch_table","display_name":"Arch Table","table_type":"cars"}`
+	rec := testutil.POST(t, e, "/system-tables", body, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	tableID := int(testutil.ParseMap(t, rec)["id"].(float64))
+
+	// Archive via DELETE (soft delete)
+	rec = testutil.DELETE(t, e, fmt.Sprintf("/system-tables/%d", tableID), h)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Default GetAll - архивная таблица не должна быть в списке
+	rec = testutil.GET(t, e, "/system-tables", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	for _, m := range testutil.ParseSlice(t, rec) {
+		tbl := m["table"].(map[string]interface{})
+		assert.NotEqual(t, float64(tableID), tbl["id"], "archived table must NOT be in active list")
+	}
+
+	// GetAll?include_archived=true - архивная таблица ДОЛЖНА быть
+	rec = testutil.GET(t, e, "/system-tables?include_archived=true", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	found := false
+	for _, m := range testutil.ParseSlice(t, rec) {
+		tbl := m["table"].(map[string]interface{})
+		if int(tbl["id"].(float64)) == tableID {
+			found = true
+			assert.Equal(t, false, tbl["is_active"], "include_archived must return is_active=false rows")
+			break
+		}
+	}
+	assert.True(t, found, "archived table must appear in include_archived=true list")
+
+	// Restore - возвращаем из архива
+	rec = testutil.POST(t, e, fmt.Sprintf("/system-tables/%d/restore", tableID), "", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Повторный restore - 400 (уже не в архиве)
+	rec = testutil.POST(t, e, fmt.Sprintf("/system-tables/%d/restore", tableID), "", h)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	// После restore таблица снова в активном списке
+	rec = testutil.GET(t, e, fmt.Sprintf("/system-tables/%d", tableID), h)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Restore несуществующей - 404
+	rec = testutil.POST(t, e, "/system-tables/999999/restore", "", h)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
 func TestSystemTables_DuplicateName(t *testing.T) {
 	e, db, cleanup := testutil.SetupTestApp(t)
 	defer cleanup()

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -300,6 +300,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	stg.GET("/:id", st.GetByID)
 	stg.PUT("/:id", st.Update)
 	stg.DELETE("/:id", st.Delete)
+	stg.POST("/:id/restore", st.Restore)
 	stg.GET("/name/:name", st.GetByName)
 	stg.GET("/:id/time-slots", st.GetTimeSlots)
 	stg.POST("/:id/time-slots", st.AddTimeSlot)

--- a/internal/services/system_table_service.go
+++ b/internal/services/system_table_service.go
@@ -24,12 +24,13 @@ var allowedImageTypes = []string{
 
 // SystemTableService -- интерфейс бизнес-логики системных таблиц.
 type SystemTableService interface {
-	GetAll(ctx context.Context) ([]models.SystemTableWithDetails, error)
+	GetAll(ctx context.Context, includeArchived bool) ([]models.SystemTableWithDetails, error)
 	GetByID(ctx context.Context, id int) (*models.SystemTableWithDetails, error)
 	GetByName(ctx context.Context, name string) (*models.SystemTableWithDetails, error)
 	Create(ctx context.Context, req models.CreateSystemTableRequest) (int, error)
 	Update(ctx context.Context, id int, req models.UpdateSystemTableRequest) error
 	Delete(ctx context.Context, id int) error
+	Restore(ctx context.Context, id int) error
 
 	// Временные слоты
 	GetTimeSlots(ctx context.Context, tableID int) ([]models.SystemTableTimeSlot, error)
@@ -156,8 +157,9 @@ func (s *systemTableService) loadTableWithPreload(_ context.Context, query *gorm
 	}, nil
 }
 
-// GetAll возвращает все активные системные таблицы с полями, слотами и фотографиями.
-func (s *systemTableService) GetAll(ctx context.Context) ([]models.SystemTableWithDetails, error) {
+// GetAll возвращает системные таблицы с полями, слотами и фотографиями.
+// includeArchived=true возвращает только архивные (is_active=false), false - только активные.
+func (s *systemTableService) GetAll(ctx context.Context, includeArchived bool) ([]models.SystemTableWithDetails, error) {
 	tables := make([]models.SystemTable, 0)
 	if err := s.db.WithContext(ctx).
 		Preload("Fields", func(db *gorm.DB) *gorm.DB {
@@ -172,7 +174,7 @@ func (s *systemTableService) GetAll(ctx context.Context) ([]models.SystemTableWi
 		Preload("Photos", func(db *gorm.DB) *gorm.DB {
 			return db.Order("is_main DESC, uploaded_at DESC")
 		}).
-		Where("is_active = ?", true).
+		Where("is_active = ?", !includeArchived).
 		Order("display_name").
 		Find(&tables).Error; err != nil {
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching system tables")
@@ -595,14 +597,39 @@ func (s *systemTableService) Delete(ctx context.Context, id int) error {
 		Where("id = ?", id).
 		Update("is_active", false)
 	if result.Error != nil {
-		slog.Error("не ��далось удалить системную таблицу", "id", id, "error", result.Error)
+		slog.Error("не удалось удалить системную таблицу", "id", id, "error", result.Error)
 		return echo.NewHTTPError(http.StatusInternalServerError, "Error deleting system table")
 	}
 	if result.RowsAffected == 0 {
 		return echo.NewHTTPError(http.StatusNotFound, "Системная таблица не найдена")
 	}
 
-	slog.Info("сист��мная таблица удалена (мягко)", "id", id)
+	slog.Info("системная таблица удалена (мягко)", "id", id)
+	return nil
+}
+
+// Restore восстанавливает мягко удалённую системную таблицу (is_active=false -> true).
+func (s *systemTableService) Restore(ctx context.Context, id int) error {
+	var table models.SystemTable
+	if err := s.db.WithContext(ctx).Where("id = ?", id).First(&table).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return echo.NewHTTPError(http.StatusNotFound, "Системная таблица не найдена")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Error fetching system table")
+	}
+	if table.IsActive {
+		return echo.NewHTTPError(http.StatusBadRequest, "Таблица не в архиве")
+	}
+
+	result := s.db.WithContext(ctx).Model(&models.SystemTable{}).
+		Where("id = ?", id).
+		Update("is_active", true)
+	if result.Error != nil {
+		slog.Error("не удалось восстановить системную таблицу", "id", id, "error", result.Error)
+		return echo.NewHTTPError(http.StatusInternalServerError, "Error restoring system table")
+	}
+
+	slog.Info("системная таблица восстановлена из архива", "id", id)
 	return nil
 }
 


### PR DESCRIPTION
## Что в PR

Бэк часть архива таблиц (PR1 из 4).

### API
- `GET /system-tables?include_archived=true` - вернёт только архивные (`is_active=false`). Без флага - только активные.
- `POST /system-tables/{id}/restore` - восстановить из архива. 404 если таблицы нет, 400 если она не в архиве.
- DELETE остаётся как был (мягкое удаление = архивирование, через `is_active=false`).

### Сервис
- Интерфейс `SystemTableService.GetAll` теперь принимает `includeArchived bool`.
- Новый метод `Restore(ctx, id) error`.
- Реализация: `Where("is_active = ?", !includeArchived)` - один параметр инвертирует фильтр.

### Тест
`TestSystemTables_ArchiveAndRestore` покрывает:
- Архивирование через DELETE -> в обычном списке таблицы нет, в `?include_archived=true` - есть с `is_active=false`.
- Restore -> 200, таблица снова в активном списке.
- Повторный restore -> 400 (не в архиве).
- Restore несуществующей -> 404.

## Test plan
- [x] `go vet ./...` - 0 warnings
- [x] `go test ./...` - все пакеты зелёные (handlers 45s, services 0.05s)
- [x] Новый тест `TestSystemTables_ArchiveAndRestore` зелёный
- [ ] Staging: PR2 (фронт) подхватит endpoint, протестируем визуально вместе с panel-toggle

## Зависимости
- Этот PR разблокирует **PR2** (фронт panel-toggle архива).
- Параллельно с этим можно мержить **PR3** (бэк истории) - не пересекаются.