### PR TITLE
feat(345): история изменений системных таблиц - фронт

### DIFF
--- a/frontend/src/components/SystemTableHistoryModal.vue
+++ b/frontend/src/components/SystemTableHistoryModal.vue
@@ -1,0 +1,324 @@
+<template>
+  <div
+    class="modal-overlay"
+    data-testid="system-table-history-modal"
+    @click.self="$emit('close')"
+  >
+    <div class="modal-content">
+      <h3 class="modal-title">
+        История таблицы «{{ table.display_name }}»
+      </h3>
+      <div
+        v-if="isLoading"
+        class="loader"
+      >
+        Загрузка...
+      </div>
+      <div
+        v-else-if="!groups.length"
+        class="empty"
+      >
+        История пуста
+      </div>
+      <ul
+        v-else
+        class="history-list"
+      >
+        <li
+          v-for="(g, gi) in groups"
+          :key="gi"
+          class="history-item"
+        >
+          <div class="history-row">
+            <span
+              class="history-badge"
+              :class="`history-badge--${g.action_type}`"
+            >{{ actionLabel(g.action_type) }}</span>
+            <span class="history-user">{{ g.user_name || 'Система' }}</span>
+            <span class="history-time">{{ formatDate(g.created_at) }}</span>
+          </div>
+          <button
+            v-if="g.entries.length > 1 || hasDetails(g.entries[0])"
+            class="history-toggle"
+            @click="toggle(gi)"
+          >
+            {{ expanded[gi] ? 'Свернуть' : `Раскрыть (${g.entries.length})` }}
+          </button>
+          <ul
+            v-if="expanded[gi]"
+            class="history-details"
+          >
+            <li
+              v-for="entry in g.entries"
+              :key="entry.id"
+              class="history-detail-row"
+            >
+              <pre>{{ formatDetails(entry.details) }}</pre>
+            </li>
+          </ul>
+        </li>
+      </ul>
+      <div class="modal-actions">
+        <button
+          class="lk-btn"
+          @click="$emit('close')"
+        >
+          Закрыть
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { apiRequest } from '@/api/client';
+
+const ACTION_LABELS = {
+  created: 'Создана',
+  updated: 'Изменена',
+  archived: 'Архивирована',
+  restored: 'Восстановлена',
+  columns_updated: 'Столбцы',
+  appearance_updated: 'Оформление',
+};
+
+// Окно для слипания соседних записей одного юзера и одного типа.
+const GROUP_WINDOW_MS = 60_000;
+
+export default {
+  name: 'SystemTableHistoryModal',
+  props: {
+    table: { type: Object, required: true },
+  },
+  emits: ['close'],
+  data() {
+    return {
+      history: [],
+      isLoading: false,
+      expanded: {},
+    };
+  },
+  computed: {
+    groups() {
+      // Склеиваем соседние записи одного user_id + action_type в окно 60с.
+      const out = [];
+      for (const h of this.history) {
+        const tail = out[out.length - 1];
+        const sameType = tail && tail.action_type === h.action_type;
+        const sameUser = tail && tail.user_id === h.user_id;
+        const close = tail && Math.abs(
+          new Date(tail.created_at).getTime() - new Date(h.created_at).getTime(),
+        ) <= GROUP_WINDOW_MS;
+        if (sameType && sameUser && close) {
+          tail.entries.push(h);
+        } else {
+          out.push({
+            action_type: h.action_type,
+            user_id: h.user_id,
+            user_name: h.user_name,
+            created_at: h.created_at,
+            entries: [h],
+          });
+        }
+      }
+      return out;
+    },
+  },
+  mounted() {
+    this.load();
+  },
+  methods: {
+    async load() {
+      this.isLoading = true;
+      try {
+        const response = await apiRequest(`/system-tables/${this.table.id}/history`);
+        if (response.ok) {
+          const data = await response.json();
+          this.history = Array.isArray(data) ? data : [];
+        }
+      } catch (e) {
+        console.error('Error loading history:', e);
+      } finally {
+        this.isLoading = false;
+      }
+    },
+    toggle(gi) {
+      this.expanded = { ...this.expanded, [gi]: !this.expanded[gi] };
+    },
+    hasDetails(entry) {
+      return entry && entry.details && Object.keys(entry.details).length > 0;
+    },
+    actionLabel(t) {
+      return ACTION_LABELS[t] || t;
+    },
+    formatDate(s) {
+      if (!s) return '';
+      return new Date(s).toLocaleString('ru-RU');
+    },
+    formatDetails(d) {
+      if (!d) return '';
+      try {
+        return JSON.stringify(d, null, 2);
+      } catch {
+        return String(d);
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 11000;
+}
+
+.modal-content {
+  background: #fff;
+  border-radius: 16px;
+  padding: 24px;
+  width: 600px;
+  max-width: 92vw;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.modal-title {
+  margin: 0 0 16px;
+  font-size: 18px;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.loader,
+.empty {
+  text-align: center;
+  color: #6b7280;
+  padding: 20px 0;
+}
+
+.history-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.history-item {
+  padding: 12px 0;
+  border-bottom: 1px solid #e6e6e6;
+}
+
+.history-item:last-child {
+  border-bottom: 0;
+}
+
+.history-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.history-badge {
+  display: inline-flex;
+  align-items: center;
+  background: #4F5BDF;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 3px 10px;
+  border-radius: 50px;
+}
+
+.history-badge--archived {
+  background: #6b7280;
+}
+
+.history-badge--restored {
+  background: #10b981;
+}
+
+.history-badge--columns_updated,
+.history-badge--appearance_updated,
+.history-badge--updated {
+  background: #f59e0b;
+}
+
+.history-badge--created {
+  background: #10b981;
+}
+
+.history-user {
+  font-size: 13px;
+  color: #1f2937;
+  font-weight: 500;
+}
+
+.history-time {
+  font-size: 12px;
+  color: #6b7280;
+  margin-left: auto;
+}
+
+.history-toggle {
+  margin-top: 6px;
+  background: transparent;
+  border: 0;
+  color: #4F5BDF;
+  font-size: 12px;
+  cursor: pointer;
+  padding: 0;
+}
+
+.history-toggle:hover {
+  text-decoration: underline;
+}
+
+.history-details {
+  list-style: none;
+  padding: 8px 0 0;
+  margin: 0;
+}
+
+.history-detail-row {
+  background: #f9fafb;
+  border: 1px solid #e6e6e6;
+  border-radius: 8px;
+  padding: 8px 10px;
+  margin-top: 6px;
+}
+
+.history-detail-row pre {
+  margin: 0;
+  font-size: 11px;
+  color: #4b5563;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 16px;
+}
+
+.lk-btn {
+  padding: 8px 16px;
+  border-radius: 10px;
+  border: 0;
+  background: #4F5BDF;
+  color: #fff;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.lk-btn:hover {
+  background: #3a45b2;
+}
+</style>

--- a/frontend/src/components/TableConstructor.vue
+++ b/frontend/src/components/TableConstructor.vue
@@ -246,6 +246,12 @@
                 class="archive-badge"
               >В архиве</span>
               <button
+                class="action-btn history-btn"
+                @click="historyTable = selectedTable.table"
+              >
+                История
+              </button>
+              <button
                 v-if="selectedTable.table.is_active"
                 class="action-btn view-btn"
                 @click="openTable"
@@ -601,6 +607,13 @@
       @created="onTableCreated"
       @close="showAddModal = false"
     />
+
+    <!-- Модалка истории таблицы -->
+    <SystemTableHistoryModal
+      v-if="historyTable"
+      :table="historyTable"
+      @close="historyTable = null"
+    />
   </div>
 </template>
 
@@ -616,6 +629,7 @@ import SystemTableColumnsTab from './SystemTableColumnsTab.vue';
 import SystemTableAppearanceTab from './SystemTableAppearanceTab.vue';
 import TableConstructorCreateModal from './TableConstructorCreateModal.vue';
 import TableConstructorPhotoSection from './TableConstructorPhotoSection.vue';
+import SystemTableHistoryModal from './SystemTableHistoryModal.vue';
 
 export default {
   name: 'TableConstructor',
@@ -627,7 +641,8 @@ export default {
     SystemTableColumnsTab,
     SystemTableAppearanceTab,
     TableConstructorCreateModal,
-    TableConstructorPhotoSection
+    TableConstructorPhotoSection,
+    SystemTableHistoryModal,
   },
   data() {
     return {
@@ -643,6 +658,7 @@ export default {
       originalInstruction: '',
       tableTypeDropdownOpen: false,
       showArchive: false,
+      historyTable: null,
     };
   },
   computed: {
@@ -1187,6 +1203,22 @@ export default {
 
 .restore-btn:hover {
   background: #0da271;
+}
+
+.history-btn {
+  padding: 8px 16px;
+  background: #fff;
+  color: #4F5BDF;
+  border: 1px solid #4F5BDF;
+  border-radius: 10px;
+  font-size: 0.85em;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.history-btn:hover {
+  background: #eef0ff;
 }
 
 .content-container {


### PR DESCRIPTION
## Что в PR

PR4 из 4 - финальный срез. Опирается на PR3 (`#400` смержен).

### Поведение
- В правой панели TableConstructor в шапке-actions появилась кнопка **"История"** (белая, синяя обводка), доступна и для активной и для архивной таблицы.
- Клик → открывается `SystemTableHistoryModal` (новый компонент). Заголовок "История таблицы «X»".
- Запрос `GET /system-tables/{id}/history`. На время загрузки показывается "Загрузка...". Если пусто - "История пуста".
- Каждая группа записей:
  - **Pill-бейдж** action_type с семантическим цветом: `created/restored` зелёный, `archived` серый, `updated/columns_updated/appearance_updated` жёлтый.
  - Имя пользователя (через fallback на 'Система' если null).
  - Время в локали `ru-RU`.
- **Группировка**: соседние записи одного `user_id + action_type` в окне **60 секунд** сжимаются в одну группу. Под группой кнопка "Раскрыть (N)" - разворачивает список с `JSON.stringify(details, null, 2)` в `<pre>` для технической детали. Не загромождаем UI one-line-per-keystroke spam.

### Стиль
- Модалка по образцу `MarkHistoryModal` (минималистичная, 600px wide, max-height 80vh, z-index 11000 над DirtyConfirm).
- Закрытие: клик по затемнению, кнопка "Закрыть", `Esc` пока не привязан (можно добавить отдельно).

## Test plan
- [x] vitest: 298/298
- [x] eslint: 0
- [ ] Staging: открыть таблицу → "История" → видны все действия. Сделать несколько правок Колонки/Оформление подряд - они склеиваются в одну группу с раскрытием.

## Зависимости
- Закрывает эпик архив+история (PR1-4: #398, #399, #400, этот).
- После merge - запущу полный план-тест.