### PR TITLE
fix(345): полировка r9 - Teleport модалок, dropdown архива, конкретика в notify

### DIFF
--- a/frontend/src/components/DeleteNotifications.vue
+++ b/frontend/src/components/DeleteNotifications.vue
@@ -7,6 +7,13 @@
         class="del-card"
         :class="{ 'del-card--error': item.type === 'error' }"
       >
+        <div
+          v-if="item.title"
+          class="del-title"
+          :class="{ 'del-title--error': item.type === 'error' }"
+        >
+          {{ item.title }}
+        </div>
         <div class="del-row">
           <span class="del-text">
             {{ item.prefix }}<strong>{{ item.bold }}</strong>{{ item.suffix }}
@@ -66,7 +73,6 @@ function barColorFor(item) {
 .del-card {
   background: #fff;
   border: 1px solid #e6e6e6;
-  border-left-width: 4px;
   border-radius: 15px;
   padding: 14px 16px;
   box-shadow: 0 3px 10px rgba(0, 0, 0, 0.1);
@@ -76,8 +82,15 @@ function barColorFor(item) {
   max-width: calc(100vw - 40px);
 }
 
-.del-card--error {
-  border-left-color: rgb(255, 102, 104);
+.del-title {
+  font-size: 13px;
+  font-weight: 700;
+  color: #1f2937;
+  margin-bottom: 4px;
+}
+
+.del-title--error {
+  color: #c62828;
 }
 
 .del-row {

--- a/frontend/src/components/MarkHistoryModal.vue
+++ b/frontend/src/components/MarkHistoryModal.vue
@@ -1,4 +1,5 @@
 <template>
+  <Teleport to="body">
   <div class="modal-overlay" data-testid="mark-history-modal" @click.self="$emit('close')">
     <div class="modal-content">
       <h3 class="modal-title">История марки «{{ mark.name }}»</h3>
@@ -26,6 +27,7 @@
       </div>
     </div>
   </div>
+  </Teleport>
 </template>
 
 <script>

--- a/frontend/src/components/SystemTableHistoryModal.vue
+++ b/frontend/src/components/SystemTableHistoryModal.vue
@@ -1,8 +1,9 @@
 <template>
-  <div
-    class="modal-overlay"
-    data-testid="system-table-history-modal"
-  >
+  <Teleport to="body">
+    <div
+      class="modal-overlay"
+      data-testid="system-table-history-modal"
+    >
     <div class="modal-content">
       <div class="modal-header">
         <h3 class="modal-title">
@@ -77,7 +78,8 @@
         </button>
       </div>
     </div>
-  </div>
+    </div>
+  </Teleport>
 </template>
 
 <script>

--- a/frontend/src/components/TableConstructor.vue
+++ b/frontend/src/components/TableConstructor.vue
@@ -5,19 +5,19 @@
         Таблицы системы
       </h3>
       <div class="header-controls">
-        <button
-          class="archive-header-button"
-          :class="{ active: showArchive }"
-          @click="toggleArchiveView"
-        >
-          {{ showArchive ? 'Активные' : 'Архив' }}
-        </button>
+        <BaseDropdown
+          class="archive-dropdown"
+          :model-value="showArchive ? 'archive' : 'active'"
+          :options="archiveOptions"
+          label-key="label"
+          value-key="value"
+          @update:model-value="onArchiveModeChange"
+        />
         <SearchComponent
           v-model="searchQuery"
           :title="'Поиск таблиц...'"
         />
         <button
-          v-if="!showArchive"
           class="add-header-button"
           @click="showAddModal = true"
         >
@@ -614,6 +614,18 @@
       :table="historyTable"
       @close="historyTable = null"
     />
+
+    <!-- Подтверждение удаления таблицы -->
+    <ConfirmationModal
+      :show="!!deleteConfirmTable"
+      title="Удаление таблицы"
+      :message="deleteConfirmTable ? `Удалить таблицу &quot;${deleteConfirmTable.table.display_name}&quot;? Её можно будет восстановить из архива.` : ''"
+      confirm-text="Удалить"
+      cancel-text="Отмена"
+      :confirm-button-style="{ background: '#c62828', borderColor: '#c62828' }"
+      @confirm="performDeleteTable"
+      @cancel="deleteConfirmTable = null"
+    />
   </div>
 </template>
 
@@ -630,6 +642,8 @@ import SystemTableAppearanceTab from './SystemTableAppearanceTab.vue';
 import TableConstructorCreateModal from './TableConstructorCreateModal.vue';
 import TableConstructorPhotoSection from './TableConstructorPhotoSection.vue';
 import SystemTableHistoryModal from './SystemTableHistoryModal.vue';
+import ConfirmationModal from './ConfirmationModal.vue';
+import BaseDropdown from './ui/BaseDropdown.vue';
 
 export default {
   name: 'TableConstructor',
@@ -643,6 +657,8 @@ export default {
     TableConstructorCreateModal,
     TableConstructorPhotoSection,
     SystemTableHistoryModal,
+    ConfirmationModal,
+    BaseDropdown,
   },
   data() {
     return {
@@ -659,6 +675,11 @@ export default {
       tableTypeDropdownOpen: false,
       showArchive: false,
       historyTable: null,
+      deleteConfirmTable: null,
+      archiveOptions: [
+        { label: 'Активные', value: 'active' },
+        { label: 'Архив', value: 'archive' },
+      ],
     };
   },
   computed: {
@@ -780,9 +801,11 @@ export default {
       }
     },
 
-    async toggleArchiveView() {
+    async onArchiveModeChange(value) {
+      const wantArchive = value === 'archive';
+      if (wantArchive === this.showArchive) return;
       if (!(await confirmIfAnyDirty())) return;
-      this.showArchive = !this.showArchive;
+      this.showArchive = wantArchive;
       this.selectedTable = null;
       this.activeTab = 'main';
       await this.refreshData();
@@ -847,12 +870,20 @@ export default {
     
     async onTableCreated(result) {
       this.showAddModal = false;
+      // Новая таблица всегда активна - если юзер был в архиве, переключаем на Активные,
+      // чтобы он увидел созданную (иначе она "пропала бы" из списка).
+      if (this.showArchive) {
+        this.showArchive = false;
+      }
       await this.refreshData();
       const newTable = this.tables.find(t => t.table.id === result.id);
       if (newTable) {
         this.selectTable(newTable);
       }
-      useDeletionsStore().notify({ prefix: 'Таблица ', bold: result.display_name || 'создана', suffix: result.display_name ? ' создана' : '' });
+      useDeletionsStore().notify({
+        bold: result.display_name || 'Таблица',
+        suffix: result.display_name ? ' создана' : '',
+      });
     },
 
     async updateTable(field) {
@@ -899,21 +930,30 @@ export default {
         if (response.ok) {
           if (field === 'fact_table_hint') {
             this.originalHint = this.selectedTable.table.fact_table_hint || '';
-            useDeletionsStore().notify({ prefix: 'Подсказка ', bold: 'сохранена' });
           } else if (field === 'instruction') {
             this.originalInstruction = this.selectedTable.table.instruction || '';
-            useDeletionsStore().notify({ prefix: 'Инструкция ', bold: 'сохранена' });
-          } else {
-            useDeletionsStore().notify({ prefix: 'Изменения ', bold: 'сохранены' });
           }
+          const fieldPhrases = {
+            display_name: { bold: 'Наименование таблицы', suffix: ' изменено' },
+            table_type: { bold: 'Тип таблицы', suffix: ' изменён' },
+            show_fact_table: { bold: 'Отображение таблицы по факту', suffix: ' изменено' },
+            fact_table_hint: { bold: 'Подсказка', suffix: ' изменена' },
+            instruction: { bold: 'Инструкция', suffix: ' изменена' },
+            map_link: { bold: 'Ссылка на карту', suffix: ' изменена' },
+            status: { bold: 'Статус', suffix: ' изменён' },
+            status_comment: { bold: 'Комментарий статуса', suffix: ' изменён' },
+            location_description: { bold: 'Описание местоположения', suffix: ' изменено' },
+          };
+          const phrase = fieldPhrases[field] || { bold: 'Изменения', suffix: ' сохранены' };
+          useDeletionsStore().notify(phrase);
           await this.refreshSelectedTable();
         } else {
           const errorText = await response.text();
-          useDeletionsStore().notify({ prefix: 'Ошибка при обновлении: ', bold: errorText || 'неизвестная', type: 'error' });
+          useDeletionsStore().notify({ prefix: 'Не удалось обновить: ', bold: errorText || 'неизвестная ошибка', type: 'error' });
         }
       } catch (error) {
         console.error("Error updating table:", error);
-        useDeletionsStore().notify({ prefix: 'Ошибка ', bold: 'сети', type: 'error' });
+        useDeletionsStore().notify({ prefix: 'Не удалось подключиться: ', bold: 'нет связи с сервером', type: 'error' });
       }
     },
     
@@ -930,42 +970,42 @@ export default {
       this.updateTable('status');
     },
     
-    async confirmDeleteTable(table) {
-  if (!confirm(`Вы уверены, что хотите удалить таблицу "${table.table.display_name}"?`)) return;
-  
-  try {
-    console.log("Deleting table ID:", table.table.id);
-    
-    const response = await apiRequest(`/system-tables/${table.table.id}`, {
-      method: "DELETE",
-    });
-    
-    console.log("Response status:", response.status);
-    console.log("Response headers:", response.headers);
-    
-    if (response.ok) {
-      const deletedName = table.table.display_name;
-      this.selectedTable = null;
-      this.activeTab = 'main';
-      await this.refreshData();
-      useDeletionsStore().notify({ prefix: 'Таблица ', bold: deletedName, suffix: ' удалена' });
-    } else {
-      const errorText = await response.text();
-      console.error("Error response text:", errorText);
-      let message = errorText;
+    confirmDeleteTable(table) {
+      // Открываем ConfirmationModal вместо window.confirm. Реальный delete делает performDeleteTable.
+      this.deleteConfirmTable = table;
+    },
+
+    async performDeleteTable() {
+      const table = this.deleteConfirmTable;
+      this.deleteConfirmTable = null;
+      if (!table) return;
       try {
-        const errorJson = JSON.parse(errorText);
-        message = errorJson.message || errorText;
-      } catch {
-        // оставляем сырой текст
+        const response = await apiRequest(`/system-tables/${table.table.id}`, {
+          method: "DELETE",
+        });
+        if (response.ok) {
+          const deletedName = table.table.display_name;
+          this.selectedTable = null;
+          this.activeTab = 'main';
+          await this.refreshData();
+          useDeletionsStore().notify({ bold: deletedName, suffix: ' удалена' });
+        } else {
+          const errorText = await response.text();
+          console.error('Error response text:', errorText);
+          let message = errorText;
+          try {
+            const errorJson = JSON.parse(errorText);
+            message = errorJson.message || errorText;
+          } catch {
+            // оставляем сырой текст
+          }
+          useDeletionsStore().notify({ prefix: 'Не удалось удалить: ', bold: message, type: 'error' });
+        }
+      } catch (error) {
+        console.error('Error deleting system table:', error);
+        useDeletionsStore().notify({ prefix: 'Не удалось подключиться: ', bold: 'нет связи с сервером', type: 'error' });
       }
-      useDeletionsStore().notify({ prefix: 'Ошибка удаления: ', bold: message, type: 'error' });
-    }
-  } catch (error) {
-    console.error("Error deleting system table:", error);
-    useDeletionsStore().notify({ prefix: 'Ошибка ', bold: 'сети', type: 'error' });
-  }
-},
+    },
     
     async selectTable(table) {
       // Защита от потери: если текущая вкладка settings dirty - спросить.
@@ -1144,27 +1184,8 @@ export default {
   background: #3a45b2;
 }
 
-.archive-header-button {
-  padding: 2px 16px;
-  background: #f8f9fa;
-  color: #666;
-  border: 1px solid #e6e6e6;
-  border-radius: 50px;
-  cursor: pointer;
-  font-size: 0.7em;
-  transition: all 0.2s ease;
-  white-space: nowrap;
-}
-
-.archive-header-button:hover {
-  background: #e9ecef;
-  border-color: #ccc;
-}
-
-.archive-header-button.active {
-  background: #6b7280;
-  color: white;
-  border-color: #6b7280;
+.archive-dropdown {
+  min-width: 130px;
 }
 
 .table-row.inactive {

--- a/frontend/src/stores/deletions.js
+++ b/frontend/src/stores/deletions.js
@@ -55,10 +55,13 @@ export const useDeletionsStore = defineStore('deletions', () => {
     durationsLoaded = true;
   }
 
-  function enqueue({ prefix = '', bold = '', suffix = '', onConfirm, onUndo, showUndo = true, duration, type = 'success' }) {
+  const DEFAULT_TITLES = { success: 'Успешно', error: 'Ошибка' };
+
+  function enqueue({ prefix = '', bold = '', suffix = '', onConfirm, onUndo, showUndo = true, duration, type = 'success', title }) {
     const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
     const ms = duration || deleteDuration.value;
-    items.value.push({ id, prefix, bold, suffix, progress: 100, showUndo, type });
+    const resolvedTitle = title === '' ? '' : title || DEFAULT_TITLES[type] || '';
+    items.value.push({ id, title: resolvedTitle, prefix, bold, suffix, progress: 100, showUndo, type });
     callbacks.set(id, { onConfirm, onUndo });
     const step = 100 / (Math.max(ms, TICK_MS) / TICK_MS);
     const timer = setInterval(() => tick(id, step), TICK_MS);
@@ -67,10 +70,10 @@ export const useDeletionsStore = defineStore('deletions', () => {
   }
 
   // Информационное уведомление в том же стиле (без отмены), напр. о восстановлении.
-  // type: 'success' (по умолчанию, зелёный -> красный прогресс) или 'error'
-  // (красный левый бордер, без зелёной фазы прогресса).
-  function notify({ prefix = '', bold = '', suffix = '', duration, type = 'success' }) {
-    return enqueue({ prefix, bold, suffix, showUndo: false, duration: duration || restoreDuration.value, type });
+  // type: 'success' (по умолчанию, зелёный -> красный прогресс) или 'error'.
+  // title: явный заголовок ("Успешно"/"Ошибка" по дефолту от type, пустая строка = без заголовка).
+  function notify({ prefix = '', bold = '', suffix = '', duration, type = 'success', title }) {
+    return enqueue({ prefix, bold, suffix, showUndo: false, duration: duration || restoreDuration.value, type, title });
   }
 
   function tick(id, step) {


### PR DESCRIPTION
## Что в PR

7 правок после тестирования r8 + архив + история.

### Критические
1. **Teleport во всех модалках** (`SystemTableHistoryModal`, `MarkHistoryModal`): обёрнул в `<Teleport to="body">`. Без этого `position: fixed` ломается, когда родитель имеет stacking context (`.dashboard-card` с `transform`/`opacity`). Юзер не смог открыть историю — модалка обрезалась внутри секции "Таблицы системы". Грепнул проект на тот же паттерн (`grep -L 'Teleport to=\"body\"' *Modal.vue`): остальные 3 (`PasswordRecoveryModal`, `AnnouncementModal`, `FeedbackModal`) уже используют `<teleport>` lowercase или BaseModal-обёртку — не трогал.
2. **Удаление через ConfirmationModal**: `window.confirm` → `<ConfirmationModal>` с красной кнопкой "Удалить" и сообщением "...Её можно будет восстановить из архива".

### Среднее
3. **Кнопка "+ Создать таблицу" в архиве**: больше не скрывается. При успешном создании из архива — `showArchive=false`, переключаемся на Активные и selectaем новую таблицу (иначе она "исчезала" из списка).
4. **Архив как dropdown**: вместо toggle-кнопки `<BaseDropdown>` с опциями "Активные"/"Архив", стрелочка, по дефолту Активные. Переключение защищено `confirmIfAnyDirty`.
5. **Конкретика в notify**: словарь `field -> {bold, suffix}` для всех полей таблицы. Было "Изменения сохранены" — стало "Наименование таблицы изменено" / "Тип таблицы изменён" / "Подсказка изменена" / "Инструкция изменена" / etc.

### Косметика
6. **Убрал левый красный бордер у error-уведомлений**: достаточно красного прогресс-бара. Меньше визуального шума.
7. **Мини-заголовок в notify**: "Успешно" / "Ошибка" жирной строкой над текстом (через `title` в store, опционально кастомный, пустая строка = без заголовка).

## Test plan
- [x] vitest: 298/298
- [x] eslint: 0
- [ ] Staging: открыть таблицу → **"История"** — модалка теперь на весь экран поверх всего, не обрезается ничем.
- [ ] Создать таблицу из архива — после создания юзер на Активных с открытой новой таблицей.
- [ ] Удалить таблицу — открывается ConfirmationModal (не browser-confirm).
- [ ] Сохранить разные поля → notify пишет конкретное название поля.
- [ ] Dropdown "Активные"/"Архив" со стрелочкой.