### PR TITLE
refactor(marks): управление марками по эталону «Таблицы системы» (#409)

### DIFF
--- a/frontend/src/components/MarkHistoryModal.vue
+++ b/frontend/src/components/MarkHistoryModal.vue
@@ -1,74 +1,513 @@
 <template>
   <Teleport to="body">
-  <div class="modal-overlay" data-testid="mark-history-modal" @click.self="$emit('close')">
-    <div class="modal-content">
-      <h3 class="modal-title">История марки «{{ mark.name }}»</h3>
-      <div v-if="isLoading" class="loader">Загрузка...</div>
-      <div v-else-if="!history.length" class="empty">Записей нет</div>
-      <ul v-else class="history-list">
-        <li
-          v-for="h in history"
-          :key="h.id"
-          class="history-item"
-        >
-          <div class="history-action">{{ actionLabel(h.action_type) }}</div>
-          <div v-if="h.old_value || h.new_value" class="history-values">
-            <span v-if="h.old_value" class="old">{{ h.old_value }}</span>
-            <span v-if="h.old_value && h.new_value" class="arrow">→</span>
-            <span v-if="h.new_value" class="new">{{ h.new_value }}</span>
+    <div
+      class="modal-overlay"
+      data-testid="mark-history-modal"
+      @mousedown="onOverlayMousedown"
+      @mouseup="onOverlayMouseup"
+    >
+      <div
+        class="mark-history-modal"
+        @mousedown.stop
+      >
+        <div class="modal-header">
+          <h3>История марки «{{ mark.name }}»</h3>
+          <div class="header-actions">
+            <button
+              class="export-btn"
+              :disabled="filteredHistory.length === 0 || isExporting"
+              @click="exportToExcel"
+            >
+              <img
+                v-if="!isExporting"
+                src="@/assets/icons/export.png"
+                class="export-icon"
+              >
+              <span v-if="!isExporting">Экспорт</span>
+              <div
+                v-else
+                class="export-loader"
+              />
+            </button>
+            <button
+              class="close-btn"
+              aria-label="Закрыть"
+              @click="close"
+            >
+              ×
+            </button>
           </div>
-          <div class="history-meta">
-            {{ formatDate(h.created_at) }}
+        </div>
+
+        <div class="history-filters">
+          <div class="filter-row">
+            <div class="search-filter">
+              <span class="filter-label">Поиск:</span>
+              <input
+                v-model="searchQuery"
+                type="text"
+                class="search-input"
+                placeholder="Поиск по пользователю, действию..."
+              >
+            </div>
+
+            <div class="user-filter">
+              <span class="filter-label">Пользователь:</span>
+              <!-- Кастомный select, не BaseDropdown: повторяет фильтр-строку эталона
+                   SystemTableHistoryModal (32px-контролы поиск/период/сортировка в ряд). -->
+              <div
+                class="custom-select"
+                @click="toggleUserDropdown"
+              >
+                <div class="select-trigger">
+                  <span class="selected-value">{{ selectedUserName }}</span>
+                  <img
+                    src="@/assets/icons/arrow.png"
+                    class="select-arrow"
+                    :class="{ 'arrow-open': userDropdownOpen }"
+                  >
+                </div>
+                <transition name="fade">
+                  <div
+                    v-if="userDropdownOpen"
+                    class="select-dropdown"
+                  >
+                    <div
+                      class="select-option"
+                      :class="{ 'selected': selectedUserId === null }"
+                      @click.stop="selectUser(null)"
+                    >
+                      Все пользователи
+                    </div>
+                    <div
+                      v-for="user in uniqueUsers"
+                      :key="user.id"
+                      class="select-option"
+                      :class="{ 'selected': selectedUserId === user.id }"
+                      @click.stop="selectUser(user.id)"
+                    >
+                      {{ user.name }}
+                    </div>
+                  </div>
+                </transition>
+              </div>
+            </div>
+
+            <div class="date-filter">
+              <span class="filter-label">Период:</span>
+              <input
+                v-model="dateFrom"
+                type="date"
+                class="date-input"
+              >
+              <span class="date-separator">-</span>
+              <input
+                v-model="dateTo"
+                type="date"
+                class="date-input"
+              >
+            </div>
+
+            <div class="sort-filter">
+              <span class="filter-label">Сортировка:</span>
+              <button
+                class="sort-btn"
+                @click="toggleSortOrder"
+              >
+                <img
+                  src="@/assets/icons/sort.png"
+                  class="sort-icon"
+                  :class="{ 'sort-asc': sortOrder === 'asc' }"
+                >
+                <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
+              </button>
+            </div>
           </div>
-        </li>
-      </ul>
-      <div class="modal-actions">
-        <button class="lk-btn" @click="$emit('close')">Закрыть</button>
+        </div>
+
+        <div class="modal-content">
+          <div
+            v-if="loading"
+            class="history-loading"
+          >
+            <LoaderSpinner label="Загрузка истории..." />
+          </div>
+
+          <div
+            v-else-if="filteredHistory.length === 0"
+            class="history-empty"
+          >
+            История пуста
+          </div>
+
+          <div
+            v-else
+            class="history-timeline"
+          >
+            <div
+              v-for="(item, index) in filteredHistory"
+              :key="item.id"
+              class="history-item"
+            >
+              <div
+                class="timeline-dot"
+                :class="getActionClass(item.action_type)"
+              />
+              <div
+                v-if="index < filteredHistory.length - 1"
+                class="timeline-line"
+              />
+
+              <div class="history-content">
+                <div class="history-header">
+                  <span class="user-name">{{ item.user_name || 'Система' }}</span>
+                  <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                </div>
+
+                <div class="action-text">
+                  {{ getActionText(item) }}
+                </div>
+
+                <div
+                  v-if="getActionComment(item)"
+                  class="action-comment"
+                >
+                  {{ getActionComment(item) }}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
-  </div>
   </Teleport>
 </template>
 
 <script>
 import { getMarkHistory } from '@/api/marks';
+import { useDeletionsStore } from '@/stores/deletions';
+import { useOverlayClose } from '@/composables/useOverlayClose';
+import LoaderSpinner from './ui/LoaderSpinner.vue';
+import ExcelJS from 'exceljs';
 
-const ACTION_LABELS = {
-  created: 'Создана',
-  renamed: 'Переименована',
-  archived: 'Архивирована',
-  restored: 'Восстановлена',
+const ACTION_TEXTS = {
+  created: 'Марка создана',
+  renamed: 'Марка переименована',
+  archived: 'Марка архивирована',
+  restored: 'Марка восстановлена из архива',
+};
+
+const ACTION_DOT_CLASS = {
+  created: 'dot-create',
+  renamed: 'dot-update',
+  archived: 'dot-deactivate',
+  restored: 'dot-activate',
 };
 
 export default {
   name: 'MarkHistoryModal',
+  components: { LoaderSpinner },
   props: {
     mark: { type: Object, required: true },
+    currentUserName: { type: String, default: '' },
   },
   emits: ['close'],
+  setup(_, { emit }) {
+    const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(() => emit('close'));
+    return { onOverlayMousedown, onOverlayMouseup };
+  },
   data() {
-    return { history: [], isLoading: false };
+    return {
+      loading: false,
+      history: [],
+      sortOrder: 'desc',
+      searchQuery: '',
+      selectedUserId: null,
+      dateFrom: '',
+      dateTo: '',
+      userDropdownOpen: false,
+      isExporting: false,
+    };
+  },
+  computed: {
+    uniqueUsers() {
+      const users = new Map();
+      this.history.forEach((item) => {
+        if (item.user_id && !users.has(item.user_id)) {
+          users.set(item.user_id, {
+            id: item.user_id,
+            name: item.user_name || 'Система',
+          });
+        }
+      });
+      return Array.from(users.values()).sort((a, b) => a.name.localeCompare(b.name));
+    },
+
+    selectedUserName() {
+      if (this.selectedUserId === null) return 'Все пользователи';
+      const user = this.uniqueUsers.find((u) => u.id === this.selectedUserId);
+      return user ? user.name : 'Все пользователи';
+    },
+
+    filteredHistory() {
+      let filtered = [...this.history];
+
+      if (this.searchQuery && this.searchQuery.trim() !== '') {
+        const query = this.searchQuery.toLowerCase().trim();
+        filtered = filtered.filter((item) => {
+          const userName = (item.user_name || '').toLowerCase();
+          const actionText = this.getActionText(item).toLowerCase();
+          const comment = this.getActionComment(item).toLowerCase();
+          return userName.includes(query)
+            || actionText.includes(query)
+            || comment.includes(query);
+        });
+      }
+
+      if (this.selectedUserId) {
+        filtered = filtered.filter((item) => item.user_id === this.selectedUserId);
+      }
+
+      if (this.dateFrom) {
+        const fromDate = new Date(this.dateFrom);
+        fromDate.setHours(0, 0, 0, 0);
+        filtered = filtered.filter((item) => new Date(item.created_at) >= fromDate);
+      }
+
+      if (this.dateTo) {
+        const toDate = new Date(this.dateTo);
+        toDate.setHours(23, 59, 59, 999);
+        filtered = filtered.filter((item) => new Date(item.created_at) <= toDate);
+      }
+
+      return filtered.sort((a, b) => {
+        const timeA = new Date(a.created_at).getTime();
+        const timeB = new Date(b.created_at).getTime();
+        return this.sortOrder === 'desc' ? timeB - timeA : timeA - timeB;
+      });
+    },
+
+    formattedCurrentDateTime() {
+      const now = new Date();
+      return now.toLocaleString('ru-RU', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+      }).replace(',', '');
+    },
+
+    currentUserDisplayName() {
+      if (!this.currentUserName) return 'Пользователь';
+      const parts = this.currentUserName.split(' ').filter((p) => p && p !== 'null' && p !== 'undefined');
+      return parts.length > 0 ? parts.join(' ') : 'Пользователь';
+    },
+
+    safeMarkName() {
+      const name = this.mark.name || `id_${this.mark.id}`;
+      return name.replace(/[\\/:"*?<>|]/g, '_').replace(/\s+/g, '_');
+    },
+
+    exportData() {
+      return this.filteredHistory.map((item) => ({
+        'Дата и время': this.formatDateTime(item.created_at),
+        'Пользователь': item.user_name || 'Система',
+        'Действие': this.getActionText(item),
+        'Детали': this.getActionComment(item),
+        'Тип действия': item.action_type,
+        'ID записи': item.id,
+      }));
+    },
   },
   mounted() {
-    this.load();
+    this.loadHistory();
+    document.addEventListener('click', this.handleClickOutside);
+    document.addEventListener('keydown', this.onKeydown);
+  },
+  beforeUnmount() {
+    document.removeEventListener('click', this.handleClickOutside);
+    document.removeEventListener('keydown', this.onKeydown);
   },
   methods: {
-    async load() {
-      this.isLoading = true;
+    onKeydown(e) {
+      if (e.key === 'Escape') this.close();
+    },
+    close() {
+      this.$emit('close');
+    },
+    handleClickOutside(event) {
+      const select = this.$el && this.$el.querySelector ? this.$el.querySelector('.custom-select') : null;
+      if (select && !select.contains(event.target)) {
+        this.userDropdownOpen = false;
+      }
+    },
+
+    async loadHistory() {
+      this.loading = true;
       try {
         const data = await getMarkHistory(this.mark.id);
         this.history = Array.isArray(data) ? data : [];
+      } catch (error) {
+        console.error('Error loading mark history:', error);
+        useDeletionsStore().notify({ prefix: 'Не удалось загрузить ', bold: 'историю марки', type: 'error' });
       } finally {
-        this.isLoading = false;
+        this.loading = false;
       }
     },
-    actionLabel(t) {
-      return ACTION_LABELS[t] || t;
+
+    getActionClass(actionType) {
+      return ACTION_DOT_CLASS[actionType] || 'dot-default';
     },
-    formatDate(s) {
+
+    getActionText(item) {
+      return ACTION_TEXTS[item.action_type] || item.action_type;
+    },
+
+    /**
+     * Читаемые детали для timeline. Для переименования - старое -> новое имя,
+     * для создания - исходное имя. Архив/восстановление деталей не имеют.
+     */
+    getActionComment(item) {
+      if (item.action_type === 'created') {
+        return item.new_value ? `Название: ${item.new_value}` : '';
+      }
+      if (item.action_type === 'renamed') {
+        const oldV = item.old_value || '';
+        const newV = item.new_value || '';
+        if (oldV && newV) return `${oldV} → ${newV}`;
+        return newV || oldV;
+      }
+      return item.comment || '';
+    },
+
+    formatDateTime(s) {
       if (!s) return '';
       const d = new Date(s);
-      return d.toLocaleString('ru-RU');
+      return d.toLocaleString('ru-RU', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+      }).replace(',', '');
+    },
+
+    toggleSortOrder() {
+      this.sortOrder = this.sortOrder === 'desc' ? 'asc' : 'desc';
+    },
+
+    toggleUserDropdown() {
+      this.userDropdownOpen = !this.userDropdownOpen;
+    },
+
+    selectUser(userId) {
+      this.selectedUserId = userId;
+      this.userDropdownOpen = false;
+    },
+
+    async exportToExcel() {
+      if (this.filteredHistory.length === 0) return;
+      this.isExporting = true;
+      try {
+        const workbook = new ExcelJS.Workbook();
+        const worksheet = workbook.addWorksheet(`Istoriya_${this.safeMarkName}`);
+
+        const headers = ['Дата и время', 'Пользователь', 'Действие', 'Детали', 'Тип действия', 'ID записи'];
+        const headerRow = worksheet.addRow(headers);
+        headerRow.height = 25;
+        headerRow.eachCell((cell) => {
+          cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FF4F5BDF' } };
+          cell.font = { name: 'Verdana', size: 11, bold: true, color: { argb: 'FFFFFFFF' } };
+          cell.alignment = { vertical: 'middle', horizontal: 'center' };
+          cell.border = {
+            top: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+            bottom: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+            left: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+            right: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+          };
+        });
+
+        this.exportData.forEach((item, index) => {
+          const row = worksheet.addRow([
+            item['Дата и время'],
+            item['Пользователь'],
+            item['Действие'],
+            item['Детали'],
+            item['Тип действия'],
+            item['ID записи'],
+          ]);
+          row.height = 20;
+          const fillColor = index % 2 === 0 ? 'FFF0F5FF' : 'FFE0E9FF';
+          row.eachCell((cell) => {
+            cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: fillColor } };
+            cell.font = { name: 'Verdana', size: 9, color: { argb: 'FF333333' } };
+            cell.alignment = { vertical: 'middle', wrapText: true };
+            cell.border = {
+              top: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+              bottom: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+              left: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+              right: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+            };
+          });
+        });
+
+        const lastDataRow = this.exportData.length;
+        const cols = headers.length;
+        for (let row = 1; row <= lastDataRow + 1; row++) {
+          const rightCell = worksheet.getCell(row, cols);
+          rightCell.border = { ...rightCell.border, right: { style: 'medium', color: { argb: 'FF000000' } } };
+          const leftCell = worksheet.getCell(row, 1);
+          leftCell.border = { ...leftCell.border, left: { style: 'medium', color: { argb: 'FF000000' } } };
+        }
+        for (let col = 1; col <= cols; col++) {
+          const topCell = worksheet.getCell(1, col);
+          topCell.border = { ...topCell.border, top: { style: 'medium', color: { argb: 'FF000000' } } };
+          const bottomCell = worksheet.getCell(lastDataRow + 1, col);
+          bottomCell.border = { ...bottomCell.border, bottom: { style: 'medium', color: { argb: 'FF000000' } } };
+        }
+
+        worksheet.addRow([]);
+        const infoRow1 = worksheet.addRow(['Отчёт сформировал:', this.currentUserDisplayName]);
+        const infoRow2 = worksheet.addRow(['Дата формирования:', this.formattedCurrentDateTime]);
+        [infoRow1, infoRow2].forEach((row) => {
+          row.eachCell((cell) => {
+            cell.font = { name: 'Verdana', size: 10, color: { argb: 'FF333333' } };
+            cell.alignment = { vertical: 'middle' };
+            cell.border = {
+              top: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+              bottom: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+              left: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+              right: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+            };
+          });
+        });
+
+        worksheet.columns = [
+          { width: 22 },
+          { width: 30 },
+          { width: 30 },
+          { width: 60 },
+          { width: 22 },
+          { width: 12 },
+        ];
+
+        const buffer = await workbook.xlsx.writeBuffer();
+        const blob = new Blob([buffer], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.download = `Istoriya_marki_${this.safeMarkName}_${this.formattedCurrentDateTime.replace(/[.:,]/g, '-')}.xlsx`;
+        a.href = url;
+        a.click();
+        window.URL.revokeObjectURL(url);
+      } catch (error) {
+        console.error('Error exporting mark history to Excel:', error);
+        useDeletionsStore().notify({ prefix: 'Не удалось ', bold: 'выгрузить историю', type: 'error' });
+      } finally {
+        this.isExporting = false;
+      }
     },
   },
 };
@@ -77,92 +516,415 @@ export default {
 <style scoped>
 .modal-overlay {
   position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.4);
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 12000;
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
+  animation: fadeIn 0.2s ease-out;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.mark-history-modal {
+  background: white;
+  border-radius: 30px;
+  width: 900px;
+  max-width: 95%;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+  animation: slideUp 0.2s ease-out;
+}
+
+@keyframes slideUp {
+  from { transform: translateY(20px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 15px 25px;
+  border-bottom: 1px solid #e6e6e6;
+}
+
+.modal-header h3 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: #333;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.export-btn {
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 100;
+  gap: 8px;
+  padding: 6px 16px;
+  background: white;
+  border: 1px solid #e6e6e6;
+  border-radius: 20px;
+  font-size: 13px;
+  color: #000;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  height: 32px;
+}
+
+.export-btn:hover:not(:disabled) {
+  background: #f5f5f5;
+  border-color: #4F5BDF;
+}
+
+.export-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.export-icon {
+  width: 14px;
+  height: 14px;
+}
+
+.export-loader {
+  width: 16px;
+  height: 16px;
+  border: 2px solid #e6e6e6;
+  border-top: 2px solid #4F5BDF;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  font-size: 24px;
+  color: #a2a2a2;
+  cursor: pointer;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  transition: all 0.2s ease;
+}
+
+.close-btn:hover {
+  background: #f5f5f5;
+  color: #333;
+}
+
+.history-filters {
+  padding: 15px 25px;
+  border-bottom: 1px solid #e6e6e6;
+  background-color: #fafafa;
+}
+
+.filter-row {
+  display: flex;
+  gap: 15px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.search-filter,
+.user-filter,
+.date-filter,
+.sort-filter {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.filter-label {
+  font-size: 12px;
+  color: #a2a2a2;
+  white-space: nowrap;
+}
+
+.search-input {
+  padding: 6px 12px;
+  border: 1px solid #e6e6e6;
+  border-radius: 15px;
+  font-size: 12px;
+  width: 200px;
+  height: 32px;
+  transition: all 0.2s ease;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: #4F5BDF;
+  box-shadow: 0 0 0 3px rgba(79, 91, 223, 0.1);
+}
+
+.custom-select {
+  position: relative;
+  width: 200px;
+  cursor: pointer;
+}
+
+.select-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 12px;
+  background: white;
+  border: 1px solid #e6e6e6;
+  border-radius: 15px;
+  transition: all 0.2s ease;
+  height: 32px;
+}
+
+.select-trigger:hover {
+  border-color: #4F5BDF;
+  background: #f5f5f5;
+}
+
+.selected-value {
+  font-size: 12px;
+  color: #000;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+}
+
+.select-arrow {
+  width: 8px;
+  height: 8px;
+  transition: transform 0.2s ease;
+}
+
+.select-arrow.arrow-open {
+  transform: rotate(90deg);
+}
+
+.fade-enter-active, .fade-leave-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.fade-enter-from, .fade-leave-to {
+  opacity: 0;
+  transform: translateY(-10px);
+}
+
+.select-dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  max-height: 300px;
+  overflow-y: auto;
+  background: white;
+  border: 1px solid #e6e6e6;
+  border-radius: 15px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  z-index: 1000;
+}
+
+.select-option {
+  padding: 10px 14px;
+  font-size: 12px;
+  color: #000;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.select-option:hover {
+  background-color: #f0f3ff;
+}
+
+.select-option.selected {
+  background-color: #f0f3ff;
+  font-weight: 500;
+}
+
+.date-input {
+  padding: 6px 8px;
+  border: 1px solid #e6e6e6;
+  border-radius: 15px;
+  font-size: 12px;
+  width: 120px;
+  height: 32px;
+}
+
+.date-separator {
+  color: #a2a2a2;
+  font-size: 12px;
+}
+
+.sort-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  background: white;
+  border: 1px solid #e6e6e6;
+  border-radius: 20px;
+  font-size: 12px;
+  color: #000;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  height: 32px;
+  width: 170px;
+}
+
+.sort-btn:hover {
+  background: #f5f5f5;
+  border-color: #4F5BDF;
+}
+
+.sort-icon {
+  width: 14px;
+  height: 14px;
+  transition: transform 0.2s ease;
+}
+
+.sort-icon.sort-asc {
+  transform: rotate(180deg);
 }
 
 .modal-content {
-  background: #fff;
-  border-radius: 12px;
-  padding: 24px;
-  width: 480px;
-  max-width: 92vw;
-  max-height: 80vh;
+  padding: 20px 25px;
   overflow-y: auto;
+  max-height: calc(80vh - 180px);
+  position: relative;
 }
 
-.modal-title {
-  margin: 0 0 16px;
-  font-size: 18px;
+.history-loading,
+.history-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px;
+  color: #a2a2a2;
 }
 
-.loader,
-.empty {
-  text-align: center;
-  color: #888;
-  padding: 20px 0;
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
 }
 
-.history-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
+.history-timeline {
+  position: relative;
+  padding-left: 20px;
+  min-height: 100px;
 }
 
 .history-item {
-  padding: 10px 0;
-  border-bottom: 1px solid var(--color-border);
+  display: flex;
+  gap: 12px;
+  margin-bottom: 20px;
+  position: relative;
 }
 
 .history-item:last-child {
-  border-bottom: 0;
+  margin-bottom: 0;
 }
 
-.history-action {
-  font-weight: 600;
-  margin-bottom: 4px;
+.timeline-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  margin-top: 4px;
+  z-index: 1;
+  position: relative;
 }
 
-.history-values {
-  font-size: 13px;
-  margin-bottom: 4px;
+.timeline-line {
+  position: absolute;
+  left: 4px;
+  top: 18px;
+  width: 2px;
+  height: calc(100% + 2px);
+  background: #e6e6e6;
 }
 
-.history-values .old {
-  color: #888;
-  text-decoration: line-through;
+.dot-create { background: #4F5BDF; }
+.dot-update { background: #f59e0b; }
+.dot-activate { background: #10b981; }
+.dot-deactivate { background: #6b7280; }
+.dot-default { background: #9ca3af; }
+
+.history-content {
+  flex: 1;
+  min-width: 0;
 }
 
-.history-values .arrow {
-  margin: 0 6px;
-  color: #888;
-}
-
-.history-values .new {
-  color: var(--color-primary);
-}
-
-.history-meta {
-  font-size: 12px;
-  color: #888;
-}
-
-.modal-actions {
+.history-header {
   display: flex;
-  justify-content: flex-end;
-  margin-top: 16px;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 4px;
 }
 
-.lk-btn {
-  padding: 8px 16px;
-  border-radius: 8px;
-  border: 0;
-  background: var(--color-primary);
-  color: #fff;
-  cursor: pointer;
+.user-name {
+  font-weight: 500;
+  color: #333;
+  font-size: 13px;
+}
+
+.action-time {
+  color: #a2a2a2;
+  font-size: 11px;
+}
+
+.action-text {
+  color: #666;
+  font-size: 12px;
+  margin-bottom: 2px;
+}
+
+.action-comment {
+  font-size: 11px;
+  color: #666;
+  font-style: italic;
+  margin-top: 4px;
+  padding-left: 6px;
+  border-left: 2px solid #e6e6e6;
+  word-break: break-word;
+}
+
+@media (max-width: 768px) {
+  .filter-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .search-filter,
+  .user-filter,
+  .date-filter,
+  .sort-filter {
+    width: 100%;
+  }
+  .custom-select,
+  .search-input,
+  .date-input,
+  .sort-btn {
+    width: 100%;
+  }
+  .date-input {
+    width: calc(50% - 20px);
+  }
 }
 </style>

--- a/frontend/src/components/MarksManagement.vue
+++ b/frontend/src/components/MarksManagement.vue
@@ -5,6 +5,14 @@
         Управление марками автомобилей
       </h3>
       <div class="header-controls">
+        <BaseDropdown
+          class="archive-dropdown"
+          :model-value="showArchive ? 'archive' : 'active'"
+          :options="archiveOptions"
+          label-key="label"
+          value-key="value"
+          @update:model-value="onArchiveModeChange"
+        />
         <SearchComponent
           v-model="searchQuery"
           :title="'Поиск марок...'"
@@ -23,30 +31,45 @@
       </div>
     </div>
 
-    <div class="filter-tabs">
-      <button
-        class="filter-tab"
-        :class="{ active: filter === 'active' }"
-        @click="filter = 'active'"
-      >
-        Активные
-      </button>
-      <button
-        class="filter-tab"
-        :class="{ active: filter === 'archived' }"
-        @click="filter = 'archived'"
-      >
-        Архив
-      </button>
+    <div
+      v-if="isLoading && !marks.length"
+      class="marks-loading"
+    >
+      <LoaderSpinner label="Загрузка марок..." />
     </div>
 
-    <div class="table-wrap">
+    <div
+      v-else
+      class="table-wrap"
+    >
       <table class="marks-table">
         <thead>
           <tr>
-            <th class="th-id">ID</th>
-            <th>Наименование</th>
-            <th class="th-actions">Действия</th>
+            <th
+              class="th-id sortable"
+              @click="sortBy('id')"
+            >
+              <span :class="{ 'active-sort': sortField === 'id' }">ID</span>
+              <img
+                src="@/assets/icons/sort.png"
+                class="sort-icon"
+                :class="{ sorted: sortField === 'id', desc: sortField === 'id' && sortDirection === 'desc' }"
+              >
+            </th>
+            <th
+              class="sortable"
+              @click="sortBy('name')"
+            >
+              <span :class="{ 'active-sort': sortField === 'name' }">Наименование</span>
+              <img
+                src="@/assets/icons/sort.png"
+                class="sort-icon"
+                :class="{ sorted: sortField === 'name', desc: sortField === 'name' && sortDirection === 'desc' }"
+              >
+            </th>
+            <th class="th-actions">
+              Действия
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -54,11 +77,19 @@
             v-for="m in filteredMarks"
             :key="m.id"
             data-testid="marks-row"
+            :class="{ inactive: !m.is_active }"
           >
             <td>{{ m.id }}</td>
-            <td>{{ m.name }}</td>
+            <td>
+              <span class="mark-name">{{ m.name }}</span>
+              <span
+                v-if="!m.is_active"
+                class="inactive-badge"
+              >(архив)</span>
+            </td>
             <td class="actions">
               <button
+                v-if="m.is_active"
                 class="link-btn"
                 data-testid="marks-edit"
                 @click="openEditModal(m)"
@@ -76,7 +107,7 @@
                 v-if="m.is_active"
                 class="link-btn danger"
                 data-testid="marks-archive"
-                @click="onArchive(m)"
+                @click="onArchiveClick(m)"
               >
                 В архив
               </button>
@@ -91,7 +122,12 @@
             </td>
           </tr>
           <tr v-if="!filteredMarks.length && !isLoading">
-            <td colspan="3" class="empty">Марок не найдено</td>
+            <td
+              colspan="3"
+              class="empty"
+            >
+              {{ emptyText }}
+            </td>
           </tr>
         </tbody>
       </table>
@@ -99,67 +135,89 @@
 
     <!-- Add / Edit modal -->
     <Teleport to="body">
-      <div
-        v-if="modalMode"
-        class="modal-overlay"
-        data-testid="marks-modal"
-        @click.self="closeModal"
-      >
-        <div class="modal-content small-modal">
-          <div class="modal-header">
-            <h3>{{ modalMode === 'add' ? 'Новая марка' : 'Переименование марки' }}</h3>
-            <button
-              class="modal-close"
-              data-testid="marks-modal-close"
-              @click="closeModal"
-            >
-              ×
-            </button>
-          </div>
-
-          <div class="modal-body">
-            <div class="form-group">
-              <label class="form-label">Название марки</label>
-              <input
-                v-model.trim="form.name"
-                type="text"
-                placeholder="Например, Toyota"
-                maxlength="100"
-                class="form-input"
-                data-testid="marks-input-name"
-                @keyup.enter="onSubmit"
+      <transition name="modal-fade">
+        <div
+          v-if="modalMode"
+          class="modal-overlay"
+          data-testid="marks-modal"
+          @mousedown="onOverlayMousedown"
+          @mouseup="onOverlayMouseup"
+        >
+          <div
+            class="marks-modal"
+            @mousedown.stop
+          >
+            <div class="modal-header">
+              <h3>{{ modalMode === 'add' ? 'Новая марка' : 'Переименование марки' }}</h3>
+              <button
+                class="modal-close"
+                aria-label="Закрыть"
+                data-testid="marks-modal-close"
+                @click="requestCloseModal"
               >
+                ×
+              </button>
             </div>
-            <div v-if="error" class="form-error">
-              {{ error }}
-            </div>
-          </div>
 
-          <div class="modal-footer">
-            <button
-              class="modal-cancel"
-              data-testid="marks-modal-cancel"
-              @click="closeModal"
-            >
-              Отмена
-            </button>
-            <button
-              class="modal-confirm"
-              :disabled="!form.name || isSubmitting"
-              data-testid="marks-modal-save"
-              @click="onSubmit"
-            >
-              {{ modalMode === 'add' ? 'Добавить' : 'Сохранить' }}
-            </button>
+            <div class="modal-body">
+              <div class="form-group">
+                <label class="form-label">Название марки</label>
+                <input
+                  v-model.trim="form.name"
+                  type="text"
+                  placeholder="Например, Toyota"
+                  maxlength="100"
+                  class="lk-input"
+                  data-testid="marks-input-name"
+                  @keyup.enter="onSubmit"
+                >
+              </div>
+              <div
+                v-if="error"
+                class="form-error"
+              >
+                {{ error }}
+              </div>
+            </div>
+
+            <div class="modal-footer">
+              <button
+                class="lk-button lk-button--ghost"
+                data-testid="marks-modal-cancel"
+                @click="requestCloseModal"
+              >
+                Отмена
+              </button>
+              <button
+                class="lk-button lk-button--primary"
+                :disabled="!form.name || isSubmitting"
+                data-testid="marks-modal-save"
+                @click="onSubmit"
+              >
+                {{ modalMode === 'add' ? 'Добавить' : 'Сохранить' }}
+              </button>
+            </div>
           </div>
         </div>
-      </div>
+      </transition>
     </Teleport>
 
     <MarkHistoryModal
       v-if="historyForMark"
       :mark="historyForMark"
+      :current-user-name="currentUserName"
       @close="historyForMark = null"
+    />
+
+    <ConfirmationModal
+      :show="!!archiveConfirmMark"
+      title="Архивация марки"
+      :message="archiveConfirmMark ? `Архивировать марку «${archiveConfirmMark.name}»? Её можно будет восстановить из архива.` : ''"
+      confirm-text="В архив"
+      cancel-text="Отмена"
+      :confirm-button-style="{ background: '#c62828', borderColor: '#c62828' }"
+      @confirm="performArchive"
+      @cancel="archiveConfirmMark = null"
     />
   </div>
 </template>
@@ -168,7 +226,13 @@
 import SearchComponent from './SearchComponent.vue';
 import RefreshButton from './RefreshButton.vue';
 import MarkHistoryModal from './MarkHistoryModal.vue';
-import { useUiStore } from '@/stores/ui';
+import ConfirmationModal from './ConfirmationModal.vue';
+import BaseDropdown from './ui/BaseDropdown.vue';
+import LoaderSpinner from './ui/LoaderSpinner.vue';
+import { useDeletionsStore } from '@/stores/deletions';
+import { registerDirtyTracker, confirmIfAnyDirty } from '@/utils/dirtyTracker';
+import { useOverlayClose } from '@/composables/useOverlayClose';
+import { apiRequest } from '@/api/client';
 import {
   listMarks,
   createMark,
@@ -179,77 +243,171 @@ import {
 
 export default {
   name: 'MarksManagement',
-  components: { SearchComponent, RefreshButton, MarkHistoryModal },
+  components: { SearchComponent, RefreshButton, MarkHistoryModal, ConfirmationModal, BaseDropdown, LoaderSpinner },
+  setup() {
+    // Колбэк закрытия присваивается в created - нужен доступ к this с проверкой dirty.
+    const overlay = { close: () => {} };
+    const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(() => overlay.close());
+    return { onOverlayMousedown, onOverlayMouseup, overlay };
+  },
   data() {
     return {
       marks: [],
       searchQuery: '',
-      filter: 'active',
+      showArchive: false,
+      sortField: null,
+      sortDirection: 'asc',
       isLoading: false,
       modalMode: null, // 'add' | 'edit' | null
       editingId: null,
+      originalName: '',
       form: { name: '' },
       error: '',
       isSubmitting: false,
       historyForMark: null,
+      currentUserName: '',
+      archiveConfirmMark: null,
+      archiveOptions: [
+        { label: 'Активные', value: 'active' },
+        { label: 'Архив', value: 'archive' },
+      ],
     };
   },
   computed: {
     filteredMarks() {
       const q = this.searchQuery.trim().toLowerCase();
-      const filtered = this.marks.filter(m =>
-        this.filter === 'archived' ? !m.is_active : m.is_active,
-      );
-      if (!q) return filtered;
-      return filtered.filter(m => m.name.toLowerCase().includes(q));
+      let list = this.marks.filter(m => (this.showArchive ? !m.is_active : m.is_active));
+      if (q) {
+        list = list.filter(m => m.name.toLowerCase().includes(q) || String(m.id).includes(q));
+      }
+      return this.sortList(list);
     },
+    emptyText() {
+      if (this.searchQuery.trim()) return 'Ничего не найдено по запросу';
+      return this.showArchive ? 'В архиве пусто' : 'Марок пока нет';
+    },
+    isFormDirty() {
+      if (!this.modalMode) return false;
+      return this.form.name.trim() !== (this.originalName || '');
+    },
+  },
+  created() {
+    this.overlay.close = () => { this.requestCloseModal(); };
   },
   mounted() {
     this.refresh();
+    this.fetchCurrentUser();
+    this._stopGuard = registerDirtyTracker({
+      isDirty: () => this.isFormDirty,
+      getChanges: () => (this.modalMode === 'add'
+        ? [`Новая марка: "${this.form.name.trim()}"`]
+        : [{ label: 'Название марки', from: this.originalName, to: this.form.name.trim() }]),
+      save: async () => { await this.onSubmit(); },
+    });
+    document.addEventListener('keydown', this.onKeydown);
+  },
+  beforeUnmount() {
+    this._stopGuard?.();
+    document.removeEventListener('keydown', this.onKeydown);
   },
   methods: {
+    onKeydown(e) {
+      if (e.key === 'Escape' && this.modalMode) this.requestCloseModal();
+    },
+    sortList(list) {
+      const arr = [...list];
+      if (!this.sortField) {
+        return arr.sort((a, b) => a.name.localeCompare(b.name));
+      }
+      return arr.sort((a, b) => {
+        if (this.sortField === 'id') {
+          return this.sortDirection === 'asc' ? a.id - b.id : b.id - a.id;
+        }
+        const r = a.name.localeCompare(b.name);
+        return this.sortDirection === 'asc' ? r : -r;
+      });
+    },
+    sortBy(field) {
+      if (this.sortField === field) {
+        this.sortDirection = this.sortDirection === 'asc' ? 'desc' : 'asc';
+      } else {
+        this.sortField = field;
+        this.sortDirection = 'asc';
+      }
+    },
     async refresh() {
       this.isLoading = true;
       try {
         const data = await listMarks({ includeArchived: true });
         this.marks = Array.isArray(data) ? data : [];
       } catch {
-        useUiStore().error('Не удалось загрузить марки');
+        useDeletionsStore().notify({ prefix: 'Не удалось загрузить ', bold: 'марки', type: 'error' });
       } finally {
         this.isLoading = false;
       }
     },
+    async fetchCurrentUser() {
+      // Имя нужно для футера Excel-экспорта истории ("Отчёт сформировал").
+      try {
+        const res = await apiRequest('/users/me');
+        if (!res.ok) return;
+        const u = await res.json();
+        const parts = [u.last_name, u.first_name, u.middle_name].filter(Boolean);
+        this.currentUserName = parts.join(' ') || u.username || '';
+      } catch {
+        // Имя - необязательная деталь экспорта, молчим (footer покажет дефолт).
+      }
+    },
+    onArchiveModeChange(value) {
+      this.showArchive = value === 'archive';
+    },
     openAddModal() {
       this.modalMode = 'add';
       this.editingId = null;
+      this.originalName = '';
       this.form.name = '';
       this.error = '';
     },
     openEditModal(mark) {
       this.modalMode = 'edit';
       this.editingId = mark.id;
+      this.originalName = mark.name;
       this.form.name = mark.name;
       this.error = '';
     },
-    closeModal() {
+    async requestCloseModal() {
+      if (this.isFormDirty) {
+        const ok = await confirmIfAnyDirty();
+        if (!ok) return;
+      }
+      this.forceCloseModal();
+    },
+    forceCloseModal() {
       this.modalMode = null;
       this.editingId = null;
+      this.originalName = '';
       this.form.name = '';
       this.error = '';
     },
     async onSubmit() {
-      if (!this.form.name.trim()) return;
+      const name = this.form.name.trim();
+      if (!name || this.isSubmitting) return;
+      // Редактирование без изменений - просто закрыть, не дёргать API.
+      if (this.modalMode === 'edit' && name === this.originalName) {
+        this.forceCloseModal();
+        return;
+      }
       this.isSubmitting = true;
       this.error = '';
       try {
         if (this.modalMode === 'add') {
-          await createMark({ name: this.form.name });
-          useUiStore().success('Марка создана');
+          await createMark({ name });
+          useDeletionsStore().notify({ prefix: 'Марка ', bold: name, suffix: ' создана' });
         } else {
-          await renameMark(this.editingId, { name: this.form.name });
-          useUiStore().success('Марка переименована');
+          await renameMark(this.editingId, { name });
+          useDeletionsStore().notify({ prefix: 'Марка переименована в ', bold: name });
         }
-        this.closeModal();
+        this.forceCloseModal();
         await this.refresh();
       } catch (e) {
         this.error = e?.message || 'Не удалось сохранить';
@@ -257,22 +415,28 @@ export default {
         this.isSubmitting = false;
       }
     },
-    async onArchive(mark) {
+    onArchiveClick(mark) {
+      this.archiveConfirmMark = mark;
+    },
+    async performArchive() {
+      const mark = this.archiveConfirmMark;
+      this.archiveConfirmMark = null;
+      if (!mark) return;
       try {
         await archiveMark(mark.id);
-        useUiStore().success('Марка архивирована');
+        useDeletionsStore().notify({ prefix: 'Марка ', bold: mark.name, suffix: ' архивирована' });
         await this.refresh();
-      } catch {
-        useUiStore().error('Не удалось архивировать');
+      } catch (e) {
+        useDeletionsStore().notify({ prefix: 'Не удалось архивировать: ', bold: e?.message || 'ошибка', type: 'error' });
       }
     },
     async onRestore(mark) {
       try {
         await restoreMark(mark.id);
-        useUiStore().success('Марка восстановлена');
+        useDeletionsStore().notify({ prefix: 'Марка ', bold: mark.name, suffix: ' восстановлена из архива' });
         await this.refresh();
-      } catch {
-        useUiStore().error('Не удалось восстановить');
+      } catch (e) {
+        useDeletionsStore().notify({ prefix: 'Не удалось восстановить: ', bold: e?.message || 'ошибка', type: 'error' });
       }
     },
     openHistory(mark) {
@@ -292,6 +456,8 @@ export default {
   align-items: center;
   justify-content: space-between;
   margin-bottom: 16px;
+  gap: 12px;
+  flex-wrap: wrap;
 }
 
 .management-title {
@@ -305,30 +471,13 @@ export default {
   align-items: center;
 }
 
-.filter-tabs {
-  display: flex;
-  gap: 8px;
-  margin-bottom: 12px;
-}
-
-.filter-tab {
-  padding: 6px 14px;
-  border-radius: 16px;
-  border: 1px solid var(--color-border);
-  background: var(--color-bg-secondary);
-  cursor: pointer;
-  font-size: 13px;
-}
-
-.filter-tab.active {
-  background: var(--color-primary);
-  color: #fff;
-  border-color: var(--color-primary);
+.archive-dropdown {
+  width: 150px;
 }
 
 .table-wrap {
   border: 1px solid var(--color-border);
-  border-radius: 8px;
+  border-radius: 15px;
   overflow: hidden;
 }
 
@@ -339,7 +488,7 @@ export default {
 
 .marks-table th,
 .marks-table td {
-  padding: 10px 12px;
+  padding: 10px 14px;
   text-align: left;
   border-bottom: 1px solid var(--color-border);
   font-size: 14px;
@@ -351,12 +500,53 @@ export default {
   color: #666;
 }
 
+.marks-table th.sortable {
+  cursor: pointer;
+  user-select: none;
+}
+
+.marks-table th.sortable span {
+  vertical-align: middle;
+}
+
+.marks-table th .active-sort {
+  color: var(--color-primary);
+}
+
+.sort-icon {
+  width: 12px;
+  height: 12px;
+  margin-left: 6px;
+  opacity: 0.35;
+  vertical-align: middle;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.sort-icon.sorted {
+  opacity: 1;
+}
+
+.sort-icon.desc {
+  transform: rotate(180deg);
+}
+
 .th-id {
-  width: 60px;
+  width: 70px;
 }
 
 .th-actions {
   width: 320px;
+}
+
+.marks-table tr.inactive td {
+  color: #9aa0a6;
+  background: #fafafa;
+}
+
+.inactive-badge {
+  margin-left: 6px;
+  font-size: 11px;
+  color: #9aa0a6;
 }
 
 .actions {
@@ -383,6 +573,13 @@ export default {
   padding: 30px 0;
 }
 
+.marks-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 50px 0;
+}
+
 .add-header-button {
   padding: 8px 16px;
   background: #4F5BDF;
@@ -402,6 +599,7 @@ export default {
   background: #3a45b2;
 }
 
+/* Модалка добавления/переименования */
 .modal-overlay {
   position: fixed;
   top: 0;
@@ -418,14 +616,11 @@ export default {
   -webkit-backdrop-filter: blur(0.1px);
 }
 
-.small-modal {
-  max-width: 400px;
-}
-
-.modal-content {
+.marks-modal {
   width: 100%;
+  max-width: 440px;
   background: #fff;
-  border-radius: 16px;
+  border-radius: 30px;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
   overflow: hidden;
 }
@@ -434,9 +629,8 @@ export default {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 16px 20px;
+  padding: 18px 24px;
   border-bottom: 1px solid #e6e6e6;
-  background: #fff;
 }
 
 .modal-header h3 {
@@ -447,26 +641,28 @@ export default {
 }
 
 .modal-close {
-  background: none;
-  border: none;
-  font-size: 18px;
-  cursor: pointer;
-  color: #999;
-  padding: 0;
-  width: 24px;
-  height: 24px;
+  width: 30px;
+  height: 30px;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: color 0.2s;
+  font-size: 24px;
+  line-height: 1;
+  color: #999;
+  background: none;
+  border: none;
+  cursor: pointer;
+  border-radius: 50%;
+  transition: all 0.2s;
 }
 
 .modal-close:hover {
   color: #333;
+  background: #f5f5f5;
 }
 
 .modal-body {
-  padding: 20px;
+  padding: 22px 24px;
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -484,22 +680,6 @@ export default {
   font-weight: 500;
 }
 
-.form-input {
-  padding: 8px 12px;
-  border: 1px solid #e6e6e6;
-  border-radius: 8px;
-  font-size: 0.9em;
-  transition: border-color 0.2s;
-  background: #fff;
-  width: 100%;
-  height: 35px;
-}
-
-.form-input:focus {
-  border-color: #4F5BDF;
-  outline: none;
-}
-
 .form-error {
   color: #d73a3a;
   font-size: 0.85em;
@@ -509,45 +689,29 @@ export default {
   display: flex;
   justify-content: flex-end;
   gap: 10px;
-  padding: 16px 20px;
+  padding: 16px 24px;
   border-top: 1px solid #e6e6e6;
-  background: #fff;
 }
 
-.modal-cancel {
-  padding: 8px 16px;
-  background: #f8f9fa;
-  color: #666;
-  border: 1px solid #e6e6e6;
-  border-radius: 6px;
-  cursor: pointer;
-  font-size: 0.85em;
-  font-weight: 500;
-  transition: all 0.2s ease;
+/* Анимация открытия/закрытия */
+.modal-fade-enter-active,
+.modal-fade-leave-active {
+  transition: all 0.25s ease;
 }
 
-.modal-cancel:hover {
-  background: #e9ecef;
+.modal-fade-enter-active .marks-modal,
+.modal-fade-leave-active .marks-modal {
+  transition: all 0.25s ease;
 }
 
-.modal-confirm {
-  padding: 8px 16px;
-  background: #4F5BDF;
-  color: white;
-  border: none;
-  border-radius: 6px;
-  cursor: pointer;
-  font-size: 0.85em;
-  font-weight: 600;
-  transition: background-color 0.2s ease;
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+  background: rgba(0, 0, 0, 0);
 }
 
-.modal-confirm:hover {
-  background: #3a45b2;
-}
-
-.modal-confirm:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
+.modal-fade-enter-from .marks-modal,
+.modal-fade-leave-to .marks-modal {
+  opacity: 0;
+  transform: translateY(20px);
 }
 </style>

--- a/internal/handlers/marks.go
+++ b/internal/handlers/marks.go
@@ -131,7 +131,7 @@ func (h *MarkHandler) Restore(c echo.Context) error {
 // @Produce      json
 // @Security     BearerAuth
 // @Param        id path int true "ID марки"
-// @Success      200 {array} models.MarkHistory
+// @Success      200 {array} models.MarkHistoryItem
 // @Router       /marks/{id}/history [get]
 func (h *MarkHandler) GetHistory(c echo.Context) error {
 	id, err := strconv.Atoi(c.Param("id"))

--- a/internal/models/mark.go
+++ b/internal/models/mark.go
@@ -38,6 +38,21 @@ const (
 	MarkActionRestored = "restored"
 )
 
+// MarkHistoryItem - элемент истории марки с именем пользователя для UI.
+// UserName собирается через COALESCE(ФИО, username) при выборке (LEFT JOIN users),
+// чтобы timeline показывал кто сделал действие, а не только user_id.
+type MarkHistoryItem struct {
+	ID         int       `json:"id"`
+	MarkID     int       `json:"mark_id"`
+	ActionType string    `json:"action_type"`
+	OldValue   *string   `json:"old_value,omitempty"`
+	NewValue   *string   `json:"new_value,omitempty"`
+	UserID     *int      `json:"user_id,omitempty"`
+	UserName   string    `json:"user_name"`
+	Comment    *string   `json:"comment,omitempty"`
+	CreatedAt  time.Time `json:"created_at"`
+}
+
 // CreateMarkRequest - запрос на создание марки.
 type CreateMarkRequest struct {
 	Name string `json:"name" validate:"required,min=1,max=100"`

--- a/internal/services/mark_service.go
+++ b/internal/services/mark_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"time"
 
 	"systemburo/internal/models"
 
@@ -19,7 +20,7 @@ type MarkService interface {
 	Update(ctx context.Context, id int, req models.UpdateMarkRequest, userID int) error
 	Archive(ctx context.Context, id int, userID int) error
 	Restore(ctx context.Context, id int, userID int) error
-	GetHistory(ctx context.Context, id int) ([]models.MarkHistory, error)
+	GetHistory(ctx context.Context, id int) ([]models.MarkHistoryItem, error)
 }
 
 type markService struct {
@@ -139,13 +140,44 @@ func (s *markService) setActive(ctx context.Context, id int, active bool, userID
 	})
 }
 
-func (s *markService) GetHistory(ctx context.Context, id int) ([]models.MarkHistory, error) {
-	history := make([]models.MarkHistory, 0)
+func (s *markService) GetHistory(ctx context.Context, id int) ([]models.MarkHistoryItem, error) {
+	type row struct {
+		ID         int       `gorm:"column:id"`
+		MarkID     int       `gorm:"column:mark_id"`
+		ActionType string    `gorm:"column:action_type"`
+		OldValue   *string   `gorm:"column:old_value"`
+		NewValue   *string   `gorm:"column:new_value"`
+		UserID     *int      `gorm:"column:user_id"`
+		UserName   string    `gorm:"column:user_name"`
+		Comment    *string   `gorm:"column:comment"`
+		CreatedAt  time.Time `gorm:"column:created_at"`
+	}
+	var rows []row
 	if err := s.db.WithContext(ctx).
-		Where("mark_id = ?", id).
-		Order("created_at DESC").
-		Find(&history).Error; err != nil {
+		Table("mark_histories AS h").
+		Select(`h.id, h.mark_id, h.action_type, h.old_value, h.new_value, h.user_id, h.comment,
+			COALESCE(NULLIF(TRIM(BOTH ' ' FROM CONCAT_WS(' ', u.last_name, u.first_name)), ''), u.username, '') AS user_name,
+			h.created_at`).
+		Joins("LEFT JOIN users u ON u.id = h.user_id").
+		Where("h.mark_id = ?", id).
+		Order("h.created_at DESC").
+		Scan(&rows).Error; err != nil {
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения истории")
 	}
-	return history, nil
+
+	items := make([]models.MarkHistoryItem, 0, len(rows))
+	for _, r := range rows {
+		items = append(items, models.MarkHistoryItem{
+			ID:         r.ID,
+			MarkID:     r.MarkID,
+			ActionType: r.ActionType,
+			OldValue:   r.OldValue,
+			NewValue:   r.NewValue,
+			UserID:     r.UserID,
+			UserName:   r.UserName,
+			Comment:    r.Comment,
+			CreatedAt:  r.CreatedAt,
+		})
+	}
+	return items, nil
 }


### PR DESCRIPTION
Closes #409 (часть эпика #406).

## Что было
Справочник марок (`MarksManagement.vue` + `MarkHistoryModal.vue`) не соответствовал эталону «Таблицы системы»: переключатель архива пилл-табами, legacy-тосты `useUiStore`, архивация одним кликом без подтверждения, модалка без анимации/Escape/защиты формы, примитивная история без фильтров и экспорта.

## Что сделано
- Архив: пилл-табы → `BaseDropdown` (Активные/Архив), серые архивные строки + бейдж `(архив)`, для архивных скрыт «Переименовать», сортировка по ID/наименованию, `LoaderSpinner` при загрузке.
- Уведомления: всё на `useDeletionsStore.notify()` с конкретными именами («Марка X создана/архивирована/восстановлена»), `ConfirmationModal` на архивацию вместо тихого клика.
- Модалка добавления/переименования: анимация открытия/закрытия, `useOverlayClose`, Escape, `registerDirtyTracker`, `lk-input`/`lk-button`, radius 30px.
- История (`MarkHistoryModal`): переписана по образцу `SystemTableHistoryModal` — фильтры (поиск/пользователь/период/сортировка), timeline с цветными точками, экспорт в Excel (ExcelJS), `useOverlayClose`+Escape, radius 30px, z-index 12000.
- Backend: `GetHistory` теперь отдаёт `user_name` (LEFT JOIN users + COALESCE ФИО/username), DTO `MarkHistoryItem` — чтобы timeline и фильтр по пользователю показывали имена, а не id. Схему/миграции не трогал.

Закрывает кусок #407 (уведомления) и #408 (radius/Teleport/архив-переключатель) для этого компонента.

## Test plan
- `go build ./...` — ok; полный `go test ./...` — зелёный (вкл. `TestMarkService_CRUD`).
- `npm run test:run` — 298/298.
- ESLint по изменённым файлам — чисто.
- Самогреп: 0 `alert/confirm/useToast/useUiStore`, 0 radius-нарушений на форм-элементах, Teleport на месте.
- Код-ревью (агент): вердикт GO, блокеров нет.
- Визуальная проверка на staging — после деплоя (ship-check).

## Не доводит до эталона полностью (осталось)
- Анимация закрытия `MarkHistoryModal` — общий gap семейства `*HistoryModal` (эталон `SystemTableHistoryModal` тоже без неё); чинить семейство одним PR в рамках #408.
- `MarkHistory.Mark` имеет `OnDelete:CASCADE` — при soft-delete не срабатывает; смена FK-constraint требует миграции, вынесено отдельно.
- Swagger не регенерирован (общий долг #345, по решению владельца не трогаем в этом эпике).