### PR TITLE
feat(users): архив пользователей (soft-delete) + блок входа архивных (#410)

### DIFF
--- a/internal/handlers/users.go
+++ b/internal/handlers/users.go
@@ -55,7 +55,8 @@ func (h *UsersHandler) Create(c echo.Context) error {
 // @Router       /users/all [get]
 func (h *UsersHandler) GetAll(c echo.Context) error {
 	typeID := c.Get("type_id").(int)
-	result, err := h.service.GetAll(c.Request().Context(), typeID)
+	includeArchived := c.QueryParam("include_archived") == "true"
+	result, err := h.service.GetAll(c.Request().Context(), typeID, includeArchived)
 	if err != nil {
 		return err
 	}
@@ -194,7 +195,7 @@ func (h *UsersHandler) UpdateCompany(c echo.Context) error {
 }
 
 // Delete godoc
-// @Summary      Удаление пользователя
+// @Summary      Архивация пользователя (soft-delete)
 // @Tags         users
 // @Accept       json
 // @Produce      json
@@ -211,5 +212,26 @@ func (h *UsersHandler) Delete(c echo.Context) error {
 	if err := h.service.Delete(c.Request().Context(), typeID, username); err != nil {
 		return err
 	}
-	return RespondMessage(c, "User deleted successfully")
+	return RespondMessage(c, "User archived successfully")
+}
+
+// Restore godoc
+// @Summary      Восстановление пользователя из архива
+// @Tags         users
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        username path   string true "Имя пользователя"
+// @Success      200 {object} map[string]string "message"
+// @Failure      401 {object} models.HTTPError
+// @Failure      403 {object} models.HTTPError
+// @Failure      500 {object} models.HTTPError
+// @Router       /users/{username}/restore [post]
+func (h *UsersHandler) Restore(c echo.Context) error {
+	typeID := c.Get("type_id").(int)
+	username := c.Param("username")
+	if err := h.service.Restore(c.Request().Context(), typeID, username); err != nil {
+		return err
+	}
+	return RespondMessage(c, "User restored successfully")
 }

--- a/internal/handlers/users_test.go
+++ b/internal/handlers/users_test.go
@@ -336,14 +336,14 @@ func TestUsers_Delete(t *testing.T) {
 	}
 	require.True(t, found, "targetuser should exist before deletion")
 
-	// Delete
+	// Delete (soft-delete: архивация)
 	rec = testutil.DELETE(t, e, "/users/targetuser", h)
 	require.Equal(t, http.StatusOK, rec.Code)
 
 	deleteResp := testutil.ParseMessage(t, rec)
-	assert.Equal(t, "User deleted successfully", deleteResp)
+	assert.Equal(t, "User archived successfully", deleteResp)
 
-	// Verify gone
+	// Verify gone из активного списка
 	rec = testutil.GET(t, e, "/users/all", h)
 	require.Equal(t, http.StatusOK, rec.Code)
 	users = testutil.ParseSlice(t, rec)
@@ -351,6 +351,92 @@ func TestUsers_Delete(t *testing.T) {
 	for _, u := range users {
 		assert.NotEqual(t, "targetuser", u["username"])
 	}
+}
+
+func TestUsers_SoftDeleteAndRestore(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	adminToken := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(adminToken)
+
+	testutil.RegisterUser(t, e, "softtarget", "password123", 1, td.OrgID, td.CompanyID)
+
+	// Архивация
+	rec := testutil.DELETE(t, e, "/users/softtarget", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Не виден в активном списке
+	rec = testutil.GET(t, e, "/users/all", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	for _, u := range testutil.ParseSlice(t, rec) {
+		assert.NotEqual(t, "softtarget", u["username"])
+	}
+
+	// Виден с include_archived=true и is_active=false (строка не удалена физически)
+	rec = testutil.GET(t, e, "/users/all?include_archived=true", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	foundArchived := false
+	for _, u := range testutil.ParseSlice(t, rec) {
+		if u["username"] == "softtarget" {
+			foundArchived = true
+			assert.Equal(t, false, u["is_active"])
+		}
+	}
+	assert.True(t, foundArchived, "архивный пользователь должен возвращаться с include_archived=true")
+
+	// Восстановление
+	rec = testutil.POST(t, e, "/users/softtarget/restore", "", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "User restored successfully", testutil.ParseMessage(t, rec))
+
+	// Снова в активном списке, is_active=true
+	rec = testutil.GET(t, e, "/users/all", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	foundActive := false
+	for _, u := range testutil.ParseSlice(t, rec) {
+		if u["username"] == "softtarget" {
+			foundActive = true
+			assert.Equal(t, true, u["is_active"])
+		}
+	}
+	assert.True(t, foundActive, "восстановленный пользователь должен быть в активном списке")
+}
+
+func TestUsers_ArchivedCannotLogin(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	adminToken := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(adminToken)
+
+	testutil.RegisterUser(t, e, "logintarget", "password123", 1, td.OrgID, td.CompanyID)
+
+	// До архивации login работает
+	rec := testutil.POST(t, e, "/login", `{"username":"logintarget","password":"password123"}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Архивируем
+	rec = testutil.DELETE(t, e, "/users/logintarget", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Архивный не может войти даже с верным паролем - 403 "отключена" (пароль проверен)
+	rec = testutil.POST(t, e, "/login", `{"username":"logintarget","password":"password123"}`, nil)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+
+	// Неверный пароль архивного - всё ещё 401 (не раскрываем статус)
+	rec = testutil.POST(t, e, "/login", `{"username":"logintarget","password":"wrongpass"}`, nil)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	// После восстановления login снова работает
+	rec = testutil.POST(t, e, "/users/logintarget/restore", "", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	rec = testutil.POST(t, e, "/login", `{"username":"logintarget","password":"password123"}`, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
 func TestUsers_Delete_Unauthorized(t *testing.T) {

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -15,6 +15,7 @@ type User struct {
 	RoleID            *int         `json:"role_id"`
 	Role              *Role        `gorm:"foreignKey:RoleID" json:"role,omitempty"`
 	IsSuperAdmin      bool         `gorm:"default:false;index" json:"is_super_admin"`
+	IsActive          bool         `gorm:"default:true;index" json:"is_active"`
 	IsBanned          bool         `gorm:"default:false;index" json:"is_banned"`
 	BannedAt          *time.Time   `json:"banned_at,omitempty"`
 	BannedBy          *int         `json:"banned_by,omitempty"`
@@ -51,6 +52,7 @@ type UserType struct {
 type UserInfoResponse struct {
 	ID             int     `json:"id"`
 	Username       string  `json:"username"`
+	IsActive       bool    `json:"is_active"`
 	Organization   *string `json:"organization"`
 	OrganizationID *int    `json:"organization_id"`
 	Company        *string `json:"company"`

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -261,6 +261,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	protected.PUT("/users/:username/organization", users.UpdateOrganization)
 	protected.PUT("/users/:username/company", users.UpdateCompany)
 	protected.DELETE("/users/:username", users.Delete)
+	protected.POST("/users/:username/restore", users.Restore)
 
 	// Машины (в заявках)
 	carsGroup := protected.Group("/cars")

--- a/internal/services/auth_service.go
+++ b/internal/services/auth_service.go
@@ -211,6 +211,13 @@ func (s *authService) Login(ctx context.Context, req models.LoginRequest, meta *
 		return nil, echo.NewHTTPError(http.StatusUnauthorized, "Invalid credentials")
 	}
 
+	// Архивная учётка (is_active=false): пароль верный, аутентификация прошла,
+	// но доступа нет - токен не выдаём. Пользователь видит, что учётка отключена.
+	if !user.IsActive {
+		s.recordAuthEvent(ctx, &user.ID, user.Username, models.AuthEventLoginFailed, false, meta, "account disabled")
+		return nil, echo.NewHTTPError(http.StatusForbidden, "Учётная запись отключена. Обратитесь к администратору.")
+	}
+
 	// Успешный вход - сбрасываем счётчик неудачных попыток и lock.
 	// Также апдейтим last_login_at для аудита активности.
 	now := time.Now().UTC()
@@ -278,6 +285,11 @@ func (s *authService) RefreshToken(ctx context.Context, req models.RefreshTokenR
 	var user models.User
 	if err := s.db.WithContext(ctx).Where("username = ?", username).First(&user).Error; err != nil {
 		return nil, echo.NewHTTPError(http.StatusUnauthorized, "User not found")
+	}
+
+	// Архивная учётка не может обновлять токены - существующая сессия гаснет.
+	if !user.IsActive {
+		return nil, echo.NewHTTPError(http.StatusForbidden, "Учётная запись отключена")
 	}
 
 	// Ищем запись без фильтра is_revoked - чтобы отличить "не существует" от

--- a/internal/services/user_service.go
+++ b/internal/services/user_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -18,8 +19,9 @@ import (
 type UserService interface {
 	// Create создаёт нового пользователя (admin-only).
 	Create(ctx context.Context, callerTypeID int, req models.RegisterRequest) error
-	// GetAll в��звращает список всех ��ользователей с организацией, компанией и типом.
-	GetAll(ctx context.Context, callerTypeID int) ([]models.UserInfoResponse, error)
+	// GetAll возвращает список пользователей с организацией, компанией и типом.
+	// includeArchived=false отдаёт только активных (is_active=true).
+	GetAll(ctx context.Context, callerTypeID int, includeArchived bool) ([]models.UserInfoResponse, error)
 	// UpdateType обновляет тип пользователя.
 	UpdateType(ctx context.Context, callerTypeID int, username string, req models.UpdateUserTypeRequest) error
 	// UpdatePassword обновляет пароль пользователя.
@@ -30,8 +32,10 @@ type UserService interface {
 	UpdateOrganization(ctx context.Context, callerTypeID int, username string, req models.UpdateUserOrganizationRequest) error
 	// UpdateCompany обновляе�� компан��ю пользователя.
 	UpdateCompany(ctx context.Context, callerTypeID int, username string, req models.UpdateUserCompanyRequest) error
-	// Delete удаляет пользователя по username.
+	// Delete архивирует пользователя по username (soft-delete: is_active=false).
 	Delete(ctx context.Context, callerTypeID int, username string) error
+	// Restore восстанавливает архивного пользователя (is_active=true).
+	Restore(ctx context.Context, callerTypeID int, username string) error
 }
 
 type userService struct {
@@ -102,16 +106,17 @@ func (s *userService) Create(ctx context.Context, callerTypeID int, req models.R
 	return nil
 }
 
-// GetAll возвращает всех пользователей с JOIN на организацию, компанию и тип.
-func (s *userService) GetAll(ctx context.Context, callerTypeID int) ([]models.UserInfoResponse, error) {
+// GetAll возвращает пользователей с JOIN на организацию, компанию и тип.
+// По умолчанию только активные; includeArchived=true добавляет архивных.
+func (s *userService) GetAll(ctx context.Context, callerTypeID int, includeArchived bool) ([]models.UserInfoResponse, error) {
 	if err := s.checkAdmin(ctx, callerTypeID); err != nil {
 		return nil, err
 	}
 
 	result := make([]models.UserInfoResponse, 0)
-	err := s.db.WithContext(ctx).
+	q := s.db.WithContext(ctx).
 		Table("users u").
-		Select(`u.id, u.username,
+		Select(`u.id, u.username, u.is_active,
 			o.name as organization, u.organization_id,
 			c.name as company, u.company_id,
 			u.type_id, ut.name as user_type,
@@ -119,10 +124,11 @@ func (s *userService) GetAll(ctx context.Context, callerTypeID int) ([]models.Us
 			u.position, u.email, u.phone`).
 		Joins("LEFT JOIN organizations o ON u.organization_id = o.id").
 		Joins("LEFT JOIN companies c ON u.company_id = c.id").
-		Joins("LEFT JOIN user_types ut ON u.type_id = ut.id").
-		Order("u.username").
-		Scan(&result).Error
-	if err != nil {
+		Joins("LEFT JOIN user_types ut ON u.type_id = ut.id")
+	if !includeArchived {
+		q = q.Where("u.is_active = ?", true)
+	}
+	if err := q.Order("u.username").Scan(&result).Error; err != nil {
 		slog.Error("не удалось получить список пользователей", "error", err)
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching users")
 	}
@@ -307,19 +313,48 @@ func (s *userService) UpdateCompany(ctx context.Context, callerTypeID int, usern
 	return nil
 }
 
-// Delete удаляет пользователя по username.
+// Delete архивирует пользователя (soft-delete: is_active=false). Строка остаётся,
+// поэтому ссылки заявок (sender_user_id и др.) не осиротевают; login/refresh
+// блокируются по is_active, активные refresh-токены отзываются.
 func (s *userService) Delete(ctx context.Context, callerTypeID int, username string) error {
 	if err := s.checkAdmin(ctx, callerTypeID); err != nil {
 		return err
 	}
+	return s.setActive(ctx, username, false)
+}
 
-	if err := s.db.WithContext(ctx).
-		Table("users").
-		Where("username = ?", username).
-		Delete(&models.User{}).Error; err != nil {
-		slog.Error("не удалось удалить пользователя", "username", username, "error", err)
-		return echo.NewHTTPError(http.StatusInternalServerError, "Error deleting user")
+// Restore восстанавливает архивного пользователя (is_active=true).
+func (s *userService) Restore(ctx context.Context, callerTypeID int, username string) error {
+	if err := s.checkAdmin(ctx, callerTypeID); err != nil {
+		return err
 	}
+	return s.setActive(ctx, username, true)
+}
 
-	return nil
+func (s *userService) setActive(ctx context.Context, username string, active bool) error {
+	var user models.User
+	if err := s.db.WithContext(ctx).Where("username = ?", username).First(&user).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "User not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Error fetching user")
+	}
+	if user.IsActive == active {
+		return nil // no-op
+	}
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&models.User{}).Where("id = ?", user.ID).Update("is_active", active).Error; err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "Error updating user")
+		}
+		if !active {
+			// Отзываем активные refresh-токены: существующая сессия гаснет в пределах
+			// TTL access-токена (login/refresh уже блокируются по is_active).
+			if err := tx.Model(&models.RefreshToken{}).
+				Where("user_id = ? AND is_revoked = ?", user.ID, false).
+				Updates(map[string]any{"is_revoked": true, "revoked_at": time.Now().UTC()}).Error; err != nil {
+				return echo.NewHTTPError(http.StatusInternalServerError, "Error revoking tokens")
+			}
+		}
+		return nil
+	})
 }


### PR DESCRIPTION
Часть эпика #406 (sub-issue #410, backend-срез B). **Содержит правку auth-логики — требует ревью перед мержем.**

## Что сделано
- `User.IsActive` (default true, index). AutoMigrate добавляет колонку (миграция не редактировалась, GORM default true для новых юзеров).
- `Delete` теперь soft (is_active=false) — строка остаётся, ссылки заявок (sender_user_id и др.) не осиротевают. Новый `POST /users/{username}/restore`.
- `GetAll` по умолчанию только активные; `?include_archived=true` — с архивными (+ поле `is_active` в ответе для будущего фронта).
- **Auth (на ревью):** `login` проверяет пароль, но при `is_active=false` отдаёт 403 «Учётная запись отключена» без токена; `refresh` блокируется; при архивации отзываются активные refresh-токены. `jwt.go` не трогался — короткий access-токен гаснет в пределах TTL (уже залогиненная сессия теряет доступ за минуты).

FK-чек «нельзя архивировать при активных заявках-отправителе» НЕ делал: soft-delete сохраняет целостность (строка остаётся), а семантический блок по статусам заявок требует согласования — вынесено отдельно.

## Test plan
- `go build ./...` — ok; полный `go test ./...` — зелёный.
- Новые тесты: `TestUsers_SoftDeleteAndRestore` (видимость + is_active), `TestUsers_ArchivedCannotLogin` (403 при верном пароле, 401 при неверном, login после restore), поправлен `TestUsers_Delete` (архивация).

## Поведение по ТЗ владельца
Архивный пользователь вводит верный пароль -> видит «учётная запись отключена», токен не выдаётся -> не может ничего. Уже выданный access-токен гаснет за TTL (мгновенный kill потребовал бы jwt.go middleware, off-limits — по запросу могу эскалировать).