### PR TITLE
feat(users): история изменений пользователя - backend (#410)

### DIFF
--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -28,6 +28,7 @@ func AllModels() []interface{} {
 
 		// Users (depends on UserType, Organization, Company)
 		&models.User{},
+		&models.UserHistory{},
 		&models.RefreshToken{},
 		&models.AuthEvent{},
 		&models.OrganizationUser{},

--- a/internal/handlers/user_password_notification_test.go
+++ b/internal/handlers/user_password_notification_test.go
@@ -38,6 +38,7 @@ func TestUserService_UpdatePassword_CreatesNotification(t *testing.T) {
 	err := userSvc.UpdatePassword(
 		context.Background(),
 		6, // callerTypeID admin
+		0, // callerUserID (для аудита)
 		target.Username,
 		models.UpdatePasswordRequest{Password: "newpassword12345"},
 	)
@@ -82,6 +83,7 @@ func TestUserService_UpdatePassword_NonAdmin_NoNotification(t *testing.T) {
 	err := userSvc.UpdatePassword(
 		context.Background(),
 		1, // обычный юзер -> Forbidden
+		0, // callerUserID (для аудита)
 		target.Username,
 		models.UpdatePasswordRequest{Password: "newpass12345"},
 	)

--- a/internal/handlers/users.go
+++ b/internal/handlers/users.go
@@ -32,11 +32,12 @@ func NewUsersHandler(service services.UserService) *UsersHandler {
 // @Router       /users [post]
 func (h *UsersHandler) Create(c echo.Context) error {
 	typeID := c.Get("type_id").(int)
+	userID, _ := c.Get("user_id").(int)
 	var req models.RegisterRequest
 	if err := BindAndValidate(c, &req); err != nil {
 		return err
 	}
-	if err := h.service.Create(c.Request().Context(), typeID, req); err != nil {
+	if err := h.service.Create(c.Request().Context(), typeID, userID, req); err != nil {
 		return err
 	}
 	return RespondMessage(c, "User created successfully")
@@ -79,12 +80,13 @@ func (h *UsersHandler) GetAll(c echo.Context) error {
 // @Router       /users/{username}/type [put]
 func (h *UsersHandler) UpdateType(c echo.Context) error {
 	typeID := c.Get("type_id").(int)
+	userID, _ := c.Get("user_id").(int)
 	username := c.Param("username")
 	var req models.UpdateUserTypeRequest
 	if err := BindAndValidate(c, &req); err != nil {
 		return err
 	}
-	if err := h.service.UpdateType(c.Request().Context(), typeID, username, req); err != nil {
+	if err := h.service.UpdateType(c.Request().Context(), typeID, userID, username, req); err != nil {
 		return err
 	}
 	return RespondMessage(c, "User type updated successfully")
@@ -105,12 +107,13 @@ func (h *UsersHandler) UpdateType(c echo.Context) error {
 // @Router       /users/{username}/password [put]
 func (h *UsersHandler) UpdatePassword(c echo.Context) error {
 	typeID := c.Get("type_id").(int)
+	userID, _ := c.Get("user_id").(int)
 	username := c.Param("username")
 	var req models.UpdatePasswordRequest
 	if err := BindAndValidate(c, &req); err != nil {
 		return err
 	}
-	if err := h.service.UpdatePassword(c.Request().Context(), typeID, username, req); err != nil {
+	if err := h.service.UpdatePassword(c.Request().Context(), typeID, userID, username, req); err != nil {
 		return err
 	}
 	return RespondMessage(c, "Password updated successfully")
@@ -131,12 +134,13 @@ func (h *UsersHandler) UpdatePassword(c echo.Context) error {
 // @Router       /users/{username}/info [put]
 func (h *UsersHandler) UpdateInfo(c echo.Context) error {
 	typeID := c.Get("type_id").(int)
+	userID, _ := c.Get("user_id").(int)
 	username := c.Param("username")
 	var req models.UpdateUserInfoRequest
 	if err := BindAndValidate(c, &req); err != nil {
 		return err
 	}
-	if err := h.service.UpdateInfo(c.Request().Context(), typeID, username, req); err != nil {
+	if err := h.service.UpdateInfo(c.Request().Context(), typeID, userID, username, req); err != nil {
 		return err
 	}
 	return RespondMessage(c, "User info updated successfully")
@@ -157,12 +161,13 @@ func (h *UsersHandler) UpdateInfo(c echo.Context) error {
 // @Router       /users/{username}/organization [put]
 func (h *UsersHandler) UpdateOrganization(c echo.Context) error {
 	typeID := c.Get("type_id").(int)
+	userID, _ := c.Get("user_id").(int)
 	username := c.Param("username")
 	var req models.UpdateUserOrganizationRequest
 	if err := BindAndValidate(c, &req); err != nil {
 		return err
 	}
-	if err := h.service.UpdateOrganization(c.Request().Context(), typeID, username, req); err != nil {
+	if err := h.service.UpdateOrganization(c.Request().Context(), typeID, userID, username, req); err != nil {
 		return err
 	}
 	return RespondMessage(c, "Organization updated successfully")
@@ -183,12 +188,13 @@ func (h *UsersHandler) UpdateOrganization(c echo.Context) error {
 // @Router       /users/{username}/company [put]
 func (h *UsersHandler) UpdateCompany(c echo.Context) error {
 	typeID := c.Get("type_id").(int)
+	userID, _ := c.Get("user_id").(int)
 	username := c.Param("username")
 	var req models.UpdateUserCompanyRequest
 	if err := BindAndValidate(c, &req); err != nil {
 		return err
 	}
-	if err := h.service.UpdateCompany(c.Request().Context(), typeID, username, req); err != nil {
+	if err := h.service.UpdateCompany(c.Request().Context(), typeID, userID, username, req); err != nil {
 		return err
 	}
 	return RespondMessage(c, "Company updated successfully")
@@ -208,8 +214,9 @@ func (h *UsersHandler) UpdateCompany(c echo.Context) error {
 // @Router       /users/{username} [delete]
 func (h *UsersHandler) Delete(c echo.Context) error {
 	typeID := c.Get("type_id").(int)
+	userID, _ := c.Get("user_id").(int)
 	username := c.Param("username")
-	if err := h.service.Delete(c.Request().Context(), typeID, username); err != nil {
+	if err := h.service.Delete(c.Request().Context(), typeID, userID, username); err != nil {
 		return err
 	}
 	return RespondMessage(c, "User archived successfully")
@@ -229,9 +236,31 @@ func (h *UsersHandler) Delete(c echo.Context) error {
 // @Router       /users/{username}/restore [post]
 func (h *UsersHandler) Restore(c echo.Context) error {
 	typeID := c.Get("type_id").(int)
+	userID, _ := c.Get("user_id").(int)
 	username := c.Param("username")
-	if err := h.service.Restore(c.Request().Context(), typeID, username); err != nil {
+	if err := h.service.Restore(c.Request().Context(), typeID, userID, username); err != nil {
 		return err
 	}
 	return RespondMessage(c, "User restored successfully")
+}
+
+// GetHistory godoc
+// @Summary      История изменений пользователя
+// @Tags         users
+// @Produce      json
+// @Security     BearerAuth
+// @Param        username path int true "Имя пользователя"
+// @Success      200 {array} models.UserHistoryItem
+// @Failure      401 {object} models.HTTPError
+// @Failure      403 {object} models.HTTPError
+// @Failure      404 {object} models.HTTPError
+// @Router       /users/{username}/history [get]
+func (h *UsersHandler) GetHistory(c echo.Context) error {
+	typeID := c.Get("type_id").(int)
+	username := c.Param("username")
+	items, err := h.service.GetHistory(c.Request().Context(), typeID, username)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, items)
 }

--- a/internal/handlers/users_test.go
+++ b/internal/handlers/users_test.go
@@ -439,6 +439,47 @@ func TestUsers_ArchivedCannotLogin(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+func TestUsers_History(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	adminToken := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(adminToken)
+
+	testutil.RegisterUser(t, e, "histtarget", "password123", 1, td.OrgID, td.CompanyID)
+
+	// renter type_id для смены типа
+	rec := testutil.GET(t, e, "/user-types-management", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var renterID int
+	for _, ut := range testutil.ParseSlice(t, rec) {
+		if ut["code"] == "renter" {
+			renterID = int(ut["id"].(float64))
+			break
+		}
+	}
+	require.Greater(t, renterID, 0)
+
+	// Действия, которые должны попасть в историю: смена типа + архивация.
+	testutil.PUT(t, e, "/users/histtarget/type", fmt.Sprintf(`{"type_id":%d}`, renterID), h)
+	testutil.DELETE(t, e, "/users/histtarget", h)
+
+	rec = testutil.GET(t, e, "/users/histtarget/history", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	hist := testutil.ParseSlice(t, rec)
+	require.GreaterOrEqual(t, len(hist), 2, "история должна содержать type_changed + archived")
+
+	actions := map[string]bool{}
+	for _, item := range hist {
+		actions[item["action_type"].(string)] = true
+		assert.NotEmpty(t, item["actor_name"], "actor_name должен быть заполнен именем админа")
+	}
+	assert.True(t, actions["type_changed"], "ожидалась запись type_changed")
+	assert.True(t, actions["archived"], "ожидалась запись archived")
+}
+
 func TestUsers_Delete_Unauthorized(t *testing.T) {
 	e, db, cleanup := testutil.SetupTestApp(t)
 	defer cleanup()

--- a/internal/models/user_history.go
+++ b/internal/models/user_history.go
@@ -1,0 +1,43 @@
+package models
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// UserHistory логирует действия над учётной записью пользователя: создание,
+// изменение данных/типа/организации/компании, сброс пароля, архивацию и
+// восстановление. Нужна для аудита ("кто и что сделал с учёткой").
+//
+// TargetUserID - чья учётка изменена, ActorUserID - кто совершил действие.
+// FK на пользователей намеренно без constraint: аудит должен пережить удаление.
+type UserHistory struct {
+	ID           int             `json:"id"`
+	TargetUserID int             `gorm:"index;not null" json:"target_user_id"`
+	ActorUserID  *int            `gorm:"index" json:"actor_user_id,omitempty"`
+	ActionType   string          `gorm:"size:32;index" json:"action_type"`
+	Details      json.RawMessage `gorm:"type:jsonb" json:"details,omitempty"`
+	CreatedAt    time.Time       `json:"created_at"`
+}
+
+// UserActionType - константы для UserHistory.ActionType.
+const (
+	UserActionCreated        = "created"
+	UserActionUpdated        = "updated"
+	UserActionTypeChanged    = "type_changed"
+	UserActionOrgChanged     = "org_changed"
+	UserActionCompanyChanged = "company_changed"
+	UserActionPasswordReset  = "password_reset"
+	UserActionArchived       = "archived"
+	UserActionRestored       = "restored"
+)
+
+// UserHistoryItem - запись истории с именем актора для API (LEFT JOIN users).
+type UserHistoryItem struct {
+	ID          int             `json:"id"`
+	ActionType  string          `json:"action_type"`
+	Details     json.RawMessage `json:"details,omitempty" swaggerignore:"true"`
+	ActorUserID *int            `json:"actor_user_id,omitempty"`
+	ActorName   string          `json:"actor_name"`
+	CreatedAt   time.Time       `json:"created_at"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -262,6 +262,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	protected.PUT("/users/:username/company", users.UpdateCompany)
 	protected.DELETE("/users/:username", users.Delete)
 	protected.POST("/users/:username/restore", users.Restore)
+	protected.GET("/users/:username/history", users.GetHistory)
 
 	// Машины (в заявках)
 	carsGroup := protected.Group("/cars")

--- a/internal/services/user_history_service.go
+++ b/internal/services/user_history_service.go
@@ -1,0 +1,89 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"systemburo/internal/models"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+// UserHistoryService - аудит действий над учётными записями (#410).
+type UserHistoryService interface {
+	// Log пишет запись аудита. details - произвольный JSON, опционально.
+	// Ошибка логирования не возвращается: аудит не должен ломать основное действие.
+	Log(ctx context.Context, targetUserID int, actorUserID *int, actionType string, details interface{})
+	// GetHistory возвращает историю по целевому пользователю (новые сверху).
+	GetHistory(ctx context.Context, targetUserID int) ([]models.UserHistoryItem, error)
+}
+
+type userHistoryService struct {
+	db *gorm.DB
+}
+
+// NewUserHistoryService создаёт реализацию UserHistoryService.
+func NewUserHistoryService(db *gorm.DB) UserHistoryService {
+	return &userHistoryService{db: db}
+}
+
+func (s *userHistoryService) Log(ctx context.Context, targetUserID int, actorUserID *int, actionType string, details interface{}) {
+	var raw json.RawMessage
+	if details != nil {
+		b, err := json.Marshal(details)
+		if err != nil {
+			slog.Error("user_history: marshal details", "target", targetUserID, "error", err)
+		} else {
+			raw = b
+		}
+	}
+	entry := models.UserHistory{
+		TargetUserID: targetUserID,
+		ActorUserID:  actorUserID,
+		ActionType:   actionType,
+		Details:      raw,
+	}
+	if err := s.db.WithContext(ctx).Create(&entry).Error; err != nil {
+		slog.Error("user_history: insert", "target", targetUserID, "action", actionType, "error", err)
+	}
+}
+
+func (s *userHistoryService) GetHistory(ctx context.Context, targetUserID int) ([]models.UserHistoryItem, error) {
+	type row struct {
+		ID          int             `gorm:"column:id"`
+		ActionType  string          `gorm:"column:action_type"`
+		Details     json.RawMessage `gorm:"column:details"`
+		ActorUserID *int            `gorm:"column:actor_user_id"`
+		ActorName   string          `gorm:"column:actor_name"`
+		CreatedAt   time.Time       `gorm:"column:created_at"`
+	}
+	var rows []row
+	if err := s.db.WithContext(ctx).
+		Table("user_histories AS h").
+		Select(`h.id, h.action_type, h.details, h.actor_user_id,
+			COALESCE(NULLIF(TRIM(BOTH ' ' FROM CONCAT_WS(' ', u.last_name, u.first_name)), ''), u.username, '') AS actor_name,
+			h.created_at`).
+		Joins("LEFT JOIN users u ON u.id = h.actor_user_id").
+		Where("h.target_user_id = ?", targetUserID).
+		Order("h.created_at DESC").
+		Scan(&rows).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching user history")
+	}
+
+	items := make([]models.UserHistoryItem, 0, len(rows))
+	for _, r := range rows {
+		items = append(items, models.UserHistoryItem{
+			ID:          r.ID,
+			ActionType:  r.ActionType,
+			Details:     r.Details,
+			ActorUserID: r.ActorUserID,
+			ActorName:   r.ActorName,
+			CreatedAt:   r.CreatedAt,
+		})
+	}
+	return items, nil
+}

--- a/internal/services/user_service.go
+++ b/internal/services/user_service.go
@@ -17,38 +17,54 @@ import (
 
 // UserService — интерфейс бизнес-логики управления пользователями (admin-only).
 type UserService interface {
-	// Create создаёт нового пользователя (admin-only).
-	Create(ctx context.Context, callerTypeID int, req models.RegisterRequest) error
+	// Create создаёт нового пользователя (admin-only). callerUserID - id админа для аудита.
+	Create(ctx context.Context, callerTypeID, callerUserID int, req models.RegisterRequest) error
 	// GetAll возвращает список пользователей с организацией, компанией и типом.
 	// includeArchived=false отдаёт только активных (is_active=true).
 	GetAll(ctx context.Context, callerTypeID int, includeArchived bool) ([]models.UserInfoResponse, error)
 	// UpdateType обновляет тип пользователя.
-	UpdateType(ctx context.Context, callerTypeID int, username string, req models.UpdateUserTypeRequest) error
+	UpdateType(ctx context.Context, callerTypeID, callerUserID int, username string, req models.UpdateUserTypeRequest) error
 	// UpdatePassword обновляет пароль пользователя.
-	UpdatePassword(ctx context.Context, callerTypeID int, username string, req models.UpdatePasswordRequest) error
+	UpdatePassword(ctx context.Context, callerTypeID, callerUserID int, username string, req models.UpdatePasswordRequest) error
 	// UpdateInfo обновляет ФИО, должность, email и телефон пользователя.
-	UpdateInfo(ctx context.Context, callerTypeID int, username string, req models.UpdateUserInfoRequest) error
-	// UpdateOrganization обновляе�� организацию пользовате��я.
-	UpdateOrganization(ctx context.Context, callerTypeID int, username string, req models.UpdateUserOrganizationRequest) error
-	// UpdateCompany обновляе�� компан��ю пользователя.
-	UpdateCompany(ctx context.Context, callerTypeID int, username string, req models.UpdateUserCompanyRequest) error
+	UpdateInfo(ctx context.Context, callerTypeID, callerUserID int, username string, req models.UpdateUserInfoRequest) error
+	// UpdateOrganization обновляет организацию пользователя.
+	UpdateOrganization(ctx context.Context, callerTypeID, callerUserID int, username string, req models.UpdateUserOrganizationRequest) error
+	// UpdateCompany обновляет компанию пользователя.
+	UpdateCompany(ctx context.Context, callerTypeID, callerUserID int, username string, req models.UpdateUserCompanyRequest) error
 	// Delete архивирует пользователя по username (soft-delete: is_active=false).
-	Delete(ctx context.Context, callerTypeID int, username string) error
+	Delete(ctx context.Context, callerTypeID, callerUserID int, username string) error
 	// Restore восстанавливает архивного пользователя (is_active=true).
-	Restore(ctx context.Context, callerTypeID int, username string) error
+	Restore(ctx context.Context, callerTypeID, callerUserID int, username string) error
+	// GetHistory возвращает историю действий над пользователем (по username).
+	GetHistory(ctx context.Context, callerTypeID int, username string) ([]models.UserHistoryItem, error)
 }
 
 type userService struct {
 	db                  *gorm.DB
 	notificationService NotificationService
+	history             UserHistoryService
 }
 
 // NewUserService создаёт новый экземпляр сервиса управления пользователями.
 // notificationService может быть nil — в этом случае уведомления просто
 // не будут создаваться (legacy совместимость в местах, где notification
 // не подключён). Триггерные методы проверяют nil перед использованием.
+// История аудита создаётся внутри из db (сигнатура конструктора не меняется).
 func NewUserService(db *gorm.DB, notificationService NotificationService) UserService {
-	return &userService{db: db, notificationService: notificationService}
+	return &userService{
+		db:                  db,
+		notificationService: notificationService,
+		history:             NewUserHistoryService(db),
+	}
+}
+
+// targetUserID резолвит id пользователя по username для записи в историю.
+// Возвращает 0, если не найден (тогда лог пропускается).
+func (s *userService) targetUserID(ctx context.Context, username string) int {
+	var id int
+	s.db.WithContext(ctx).Table("users").Select("id").Where("username = ?", username).Scan(&id)
+	return id
 }
 
 // checkAdmin проверяет, что вызывающий пользователь является администратором
@@ -74,7 +90,7 @@ func (s *userService) checkAdmin(ctx context.Context, typeID int) error {
 //
 // Пользователь может быть привязан к организации, компании или к обеим сразу.
 // Хотя бы одно из двух поле должно быть > 0. Значение 0 означает "не привязан".
-func (s *userService) Create(ctx context.Context, callerTypeID int, req models.RegisterRequest) error {
+func (s *userService) Create(ctx context.Context, callerTypeID, callerUserID int, req models.RegisterRequest) error {
 	if err := s.checkAdmin(ctx, callerTypeID); err != nil {
 		return err
 	}
@@ -103,6 +119,10 @@ func (s *userService) Create(ctx context.Context, callerTypeID int, req models.R
 		slog.Error("не удалось создать пользователя", "error", err)
 		return echo.NewHTTPError(http.StatusInternalServerError, "Error creating user")
 	}
+	s.history.Log(ctx, user.ID, &callerUserID, models.UserActionCreated, map[string]any{
+		"username": user.Username,
+		"type_id":  user.TypeID,
+	})
 	return nil
 }
 
@@ -137,7 +157,7 @@ func (s *userService) GetAll(ctx context.Context, callerTypeID int, includeArchi
 }
 
 // UpdateType обновляет type_id пользователя с проверкой существования типа.
-func (s *userService) UpdateType(ctx context.Context, callerTypeID int, username string, req models.UpdateUserTypeRequest) error {
+func (s *userService) UpdateType(ctx context.Context, callerTypeID, callerUserID int, username string, req models.UpdateUserTypeRequest) error {
 	if err := s.checkAdmin(ctx, callerTypeID); err != nil {
 		return err
 	}
@@ -162,13 +182,16 @@ func (s *userService) UpdateType(ctx context.Context, callerTypeID int, username
 		return echo.NewHTTPError(http.StatusInternalServerError, "Error updating user type")
 	}
 
+	if id := s.targetUserID(ctx, username); id != 0 {
+		s.history.Log(ctx, id, &callerUserID, models.UserActionTypeChanged, map[string]any{"type_id": req.TypeID})
+	}
 	return nil
 }
 
 // UpdatePassword хеширует и обновляет пароль пользователя.
 // После смены пароля все refresh_tokens юзера отзываются - иначе старые
 // сессии (возможно скомпрометированные) продолжили бы жить до истечения TTL.
-func (s *userService) UpdatePassword(ctx context.Context, callerTypeID int, username string, req models.UpdatePasswordRequest) error {
+func (s *userService) UpdatePassword(ctx context.Context, callerTypeID, callerUserID int, username string, req models.UpdatePasswordRequest) error {
 	if err := s.checkAdmin(ctx, callerTypeID); err != nil {
 		return err
 	}
@@ -192,6 +215,9 @@ func (s *userService) UpdatePassword(ctx context.Context, callerTypeID int, user
 			Model(&models.RefreshToken{}).
 			Where("user_id = ? AND is_revoked = false", user.ID).
 			Update("is_revoked", true)
+
+		// Аудит: факт сброса пароля без значения.
+		s.history.Log(ctx, user.ID, &callerUserID, models.UserActionPasswordReset, nil)
 
 		// Уведомление о смене пароля. Сейчас UpdatePassword вызывается только
 		// admin'ом (manager/buropropuskov) — даже если username совпадает с
@@ -259,7 +285,7 @@ func (s *userService) notifyPasswordChanged(ctx context.Context, target *models.
 }
 
 // UpdateInfo обновляет персональные данные пользователя.
-func (s *userService) UpdateInfo(ctx context.Context, callerTypeID int, username string, req models.UpdateUserInfoRequest) error {
+func (s *userService) UpdateInfo(ctx context.Context, callerTypeID, callerUserID int, username string, req models.UpdateUserInfoRequest) error {
 	if err := s.checkAdmin(ctx, callerTypeID); err != nil {
 		return err
 	}
@@ -278,11 +304,34 @@ func (s *userService) UpdateInfo(ctx context.Context, callerTypeID int, username
 		return echo.NewHTTPError(http.StatusInternalServerError, "Error updating user info")
 	}
 
+	if id := s.targetUserID(ctx, username); id != 0 {
+		// В детали пишем только переданные (non-nil) поля - иначе история покажет "поле: -".
+		details := map[string]any{}
+		if req.LastName != nil {
+			details["last_name"] = *req.LastName
+		}
+		if req.FirstName != nil {
+			details["first_name"] = *req.FirstName
+		}
+		if req.MiddleName != nil {
+			details["middle_name"] = *req.MiddleName
+		}
+		if req.Position != nil {
+			details["position"] = *req.Position
+		}
+		if req.Email != nil {
+			details["email"] = *req.Email
+		}
+		if req.Phone != nil {
+			details["phone"] = *req.Phone
+		}
+		s.history.Log(ctx, id, &callerUserID, models.UserActionUpdated, details)
+	}
 	return nil
 }
 
 // UpdateOrganization обновляет organization_id пользователя.
-func (s *userService) UpdateOrganization(ctx context.Context, callerTypeID int, username string, req models.UpdateUserOrganizationRequest) error {
+func (s *userService) UpdateOrganization(ctx context.Context, callerTypeID, callerUserID int, username string, req models.UpdateUserOrganizationRequest) error {
 	if err := s.checkAdmin(ctx, callerTypeID); err != nil {
 		return err
 	}
@@ -294,11 +343,14 @@ func (s *userService) UpdateOrganization(ctx context.Context, callerTypeID int, 
 		return echo.NewHTTPError(http.StatusInternalServerError, "Error updating organization")
 	}
 
+	if id := s.targetUserID(ctx, username); id != 0 {
+		s.history.Log(ctx, id, &callerUserID, models.UserActionOrgChanged, map[string]any{"organization_id": req.OrganizationID})
+	}
 	return nil
 }
 
 // UpdateCompany обновляет company_id пользователя.
-func (s *userService) UpdateCompany(ctx context.Context, callerTypeID int, username string, req models.UpdateUserCompanyRequest) error {
+func (s *userService) UpdateCompany(ctx context.Context, callerTypeID, callerUserID int, username string, req models.UpdateUserCompanyRequest) error {
 	if err := s.checkAdmin(ctx, callerTypeID); err != nil {
 		return err
 	}
@@ -310,28 +362,31 @@ func (s *userService) UpdateCompany(ctx context.Context, callerTypeID int, usern
 		return echo.NewHTTPError(http.StatusInternalServerError, "Error updating company")
 	}
 
+	if id := s.targetUserID(ctx, username); id != 0 {
+		s.history.Log(ctx, id, &callerUserID, models.UserActionCompanyChanged, map[string]any{"company_id": req.CompanyID})
+	}
 	return nil
 }
 
 // Delete архивирует пользователя (soft-delete: is_active=false). Строка остаётся,
 // поэтому ссылки заявок (sender_user_id и др.) не осиротевают; login/refresh
 // блокируются по is_active, активные refresh-токены отзываются.
-func (s *userService) Delete(ctx context.Context, callerTypeID int, username string) error {
+func (s *userService) Delete(ctx context.Context, callerTypeID, callerUserID int, username string) error {
 	if err := s.checkAdmin(ctx, callerTypeID); err != nil {
 		return err
 	}
-	return s.setActive(ctx, username, false)
+	return s.setActive(ctx, username, false, callerUserID)
 }
 
 // Restore восстанавливает архивного пользователя (is_active=true).
-func (s *userService) Restore(ctx context.Context, callerTypeID int, username string) error {
+func (s *userService) Restore(ctx context.Context, callerTypeID, callerUserID int, username string) error {
 	if err := s.checkAdmin(ctx, callerTypeID); err != nil {
 		return err
 	}
-	return s.setActive(ctx, username, true)
+	return s.setActive(ctx, username, true, callerUserID)
 }
 
-func (s *userService) setActive(ctx context.Context, username string, active bool) error {
+func (s *userService) setActive(ctx context.Context, username string, active bool, callerUserID int) error {
 	var user models.User
 	if err := s.db.WithContext(ctx).Where("username = ?", username).First(&user).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -342,7 +397,7 @@ func (s *userService) setActive(ctx context.Context, username string, active boo
 	if user.IsActive == active {
 		return nil // no-op
 	}
-	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	if err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Model(&models.User{}).Where("id = ?", user.ID).Update("is_active", active).Error; err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "Error updating user")
 		}
@@ -356,5 +411,25 @@ func (s *userService) setActive(ctx context.Context, username string, active boo
 			}
 		}
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
+	action := models.UserActionRestored
+	if !active {
+		action = models.UserActionArchived
+	}
+	s.history.Log(ctx, user.ID, &callerUserID, action, nil)
+	return nil
+}
+
+// GetHistory возвращает историю действий над пользователем по username (admin-only).
+func (s *userService) GetHistory(ctx context.Context, callerTypeID int, username string) ([]models.UserHistoryItem, error) {
+	if err := s.checkAdmin(ctx, callerTypeID); err != nil {
+		return nil, err
+	}
+	id := s.targetUserID(ctx, username)
+	if id == 0 {
+		return nil, echo.NewHTTPError(http.StatusNotFound, "User not found")
+	}
+	return s.history.GetHistory(ctx, id)
 }


### PR DESCRIPTION
Часть #406 (#410, backend-срез D). «История везде» для пользователей.

## Что сделано
- Модель `UserHistory` (target_user_id, actor_user_id, action_type, details jsonb) + `UserHistoryItem` (с actor_name).
- Сервис `user_history_service.go`: `Log` (аудит, ошибка не ломает основное действие) + `GetHistory` (LEFT JOIN users, COALESCE ФИО/username актора).
- Логирование во всех мутациях user-сервиса: created, type_changed, org_changed, company_changed, updated (только переданные поля), password_reset, archived, restored — с id того, КТО совершил (callerUserID проброшен из хендлеров).
- Endpoint `GET /users/{username}/history`.
- `UserHistory` в AutoMigrate (новая таблица, additive, не destructive).

## Test plan
- `go build ./...` — ok; полный `go test ./...` — зелёный.
- Новый `TestUsers_History`: смена типа -> type_changed, архив -> archived в истории, actor_name заполнен. Поправлены прямые вызовы UpdatePassword в тесте (новая сигнатура с callerUserID).

Фронт-модалка истории пользователя (по образцу SystemTableHistoryModal) — следующим срезом.