### PR TITLE
feat(users): роль и группы прав в UserControl - перенос из AdminUsers (#410)

### DIFF
--- a/frontend/src/components/UserControl.vue
+++ b/frontend/src/components/UserControl.vue
@@ -210,6 +210,12 @@
                   Права доступа
                 </button>
                 <button
+                  class="lk-button lk-button--secondary"
+                  @click="openRolesGroups"
+                >
+                  Роль и группы
+                </button>
+                <button
                   class="delete-icon-btn"
                   @click="confirmDeleteUser(selectedUser)"
                 >
@@ -688,6 +694,13 @@
       :current-user-name="currentUserName"
       @close="historyForUser = null"
     />
+
+    <UserPermissionsModal
+      :show="showRolesGroupsModal"
+      :user="selectedUser"
+      @close="showRolesGroupsModal = false"
+      @updated="onRolesGroupsUpdated"
+    />
   </div>
 </template>
 
@@ -706,6 +719,7 @@ import PasswordInput from './ui/PasswordInput.vue';
 import ConfirmationModal from './ConfirmationModal.vue';
 import BaseDropdown from './ui/BaseDropdown.vue';
 import UserHistoryModal from './UserHistoryModal.vue';
+import UserPermissionsModal from './admin/UserPermissionsModal.vue';
 import { useDeletionsStore } from '@/stores/deletions';
 import { getUserPermissions, updateUserPermissions, getPermissionTree } from '@/api/permissions';
 
@@ -717,7 +731,8 @@ export default {
     PasswordInput,
     ConfirmationModal,
     BaseDropdown,
-    UserHistoryModal
+    UserHistoryModal,
+    UserPermissionsModal
   },
   props: {
     allUsers: {
@@ -736,6 +751,7 @@ export default {
       refreshing: false,
       selectedUser: null,
       historyForUser: null,
+      showRolesGroupsModal: false,
       currentUserName: '',
       deleteConfirmUser: null,
       showArchive: false,
@@ -937,6 +953,15 @@ export default {
 
     openHistory(user) {
       this.historyForUser = user;
+    },
+
+    openRolesGroups() {
+      this.showRolesGroupsModal = true;
+    },
+
+    onRolesGroupsUpdated() {
+      // Роль/группы/блокировка изменились - перечитываем список (модалка сама шлёт close).
+      this.$emit('fetch-users');
     },
 
     async fetchCurrentUser() {

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -53,12 +53,15 @@ type UserInfoResponse struct {
 	ID             int     `json:"id"`
 	Username       string  `json:"username"`
 	IsActive       bool    `json:"is_active"`
+	IsBanned       bool    `json:"is_banned"`
+	IsSuperAdmin   bool    `json:"is_super_admin"`
 	Organization   *string `json:"organization"`
 	OrganizationID *int    `json:"organization_id"`
 	Company        *string `json:"company"`
 	CompanyID      *int    `json:"company_id"`
 	TypeID         int     `json:"type_id"`
 	UserType       string  `json:"user_type"`
+	RoleID         *int    `json:"role_id"`
 	LastName       *string `json:"last_name"`
 	FirstName      *string `json:"first_name"`
 	MiddleName     *string `json:"middle_name"`

--- a/internal/services/user_service.go
+++ b/internal/services/user_service.go
@@ -136,10 +136,10 @@ func (s *userService) GetAll(ctx context.Context, callerTypeID int, includeArchi
 	result := make([]models.UserInfoResponse, 0)
 	q := s.db.WithContext(ctx).
 		Table("users u").
-		Select(`u.id, u.username, u.is_active,
+		Select(`u.id, u.username, u.is_active, u.is_banned, u.is_super_admin,
 			o.name as organization, u.organization_id,
 			c.name as company, u.company_id,
-			u.type_id, ut.name as user_type,
+			u.type_id, ut.name as user_type, u.role_id,
 			u.last_name, u.first_name, u.middle_name,
 			u.position, u.email, u.phone`).
 		Joins("LEFT JOIN organizations o ON u.organization_id = o.id").


### PR DESCRIPTION
## Что

Срез **#410 C** эпика #406. UserControl становится единым местом управления правами пользователя.

- Рядом с «Права доступа» (индивидуальные права-оверрайды через PermissionTree) добавлена кнопка **«Роль и группы»**, открывающая существующий `UserPermissionsModal` (роль, permission-группы, блокировка/разблокировка, слияние групп).
- `UserPermissionsModal` **переиспользован как есть** - его permission-логику и сам модал не трогал.
- На `@updated` список перечитывается (`fetch-users`).

## Решение владельца по C

- **AdminUsers.vue НЕ удаляется** - оставлен как архивный бэкап на будущее. Роут `/admin/users`, пункт меню и файл не тронуты.
- Перенести в UserControl именно permission-функционал (то, чего у него не было: роль + группы; индивидуальные права уже были).

## Backend (read-only, additive)

`UserPermissionsModal` читает `user.role_id` (преселект текущей роли), `user.is_banned`/`user.is_super_admin` (секция блокировки + защита super-admin). `GetAll` (`/users/all`, admin-only) этих полей не отдавал - модалка работала бы с пустой ролью и неверным бан-статусом. Добавил их в `UserInfoResponse` + SELECT. Поля уже отдаются в `/users/me` (CurrentUserResponse), бизнес-логику permission/auth не трогал.

## Проверка

- eslint чистый, `make test` (go) зелёный, `npm run test:run` 298/298, go build/vet чистые.
- `code-reviewer`: GO, блокеров нет. Закрыл yellow Y-1/Y-2 (убрал избыточное переприсваивание selectedUser и двойное закрытие модалки).
- Визуальная верификация - ship-check на staging после деплоя.

## Известный долг (не в этом срезе)

`UserPermissionsModal` использует `confirm()` для бана/разбана - легаси #407, компонент переиспользован без правок. Swagger не регенерирую (долг #345).