### PR TITLE
feat(user-types): is_system + защита системных типов (#411)

### DIFF
--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -255,16 +255,28 @@ func Seed(db *gorm.DB) error {
 	if count == 0 {
 		slog.Info("seeding user_types")
 		types := []models.UserType{
-			{Name: "Пользователь", Code: "user"},
-			{Name: "Арендатор", Code: "renter"},
-			{Name: "Подрядчик", Code: "contractor"},
-			{Name: "Охранник", Code: "security"},
-			{Name: "Руководитель", Code: "manager"},
-			{Name: "Бюро пропусков", Code: "buropropuskov"},
+			{Name: "Пользователь", Code: "user", IsSystem: true},
+			{Name: "Арендатор", Code: "renter", IsSystem: true},
+			{Name: "Подрядчик", Code: "contractor", IsSystem: true},
+			{Name: "Охранник", Code: "security", IsSystem: true},
+			{Name: "Руководитель", Code: "manager", IsSystem: true},
+			{Name: "Бюро пропусков", Code: "buropropuskov", IsSystem: true},
 		}
 		if err := db.Create(&types).Error; err != nil {
 			return err
 		}
+	}
+
+	// Backfill is_system для уже засеянных БД (staging/prod): эти code используются
+	// в авторизации (internal/auth/permissions.go), их нельзя удалять/переименовывать.
+	// Идемпотентно: повторный прогон не меняет уже помеченные строки.
+	if result := db.Model(&models.UserType{}).
+		Where("code IN ? AND is_system = ?",
+			[]string{"user", "renter", "contractor", "security", "manager", "buropropuskov"}, false).
+		Update("is_system", true); result.Error != nil {
+		slog.Error("failed to backfill user_types.is_system", "error", result.Error)
+	} else if result.RowsAffected > 0 {
+		slog.Info("backfilled user_types.is_system", "count", result.RowsAffected)
 	}
 
 	// Seed default tab permissions

--- a/internal/handlers/user_types_test.go
+++ b/internal/handlers/user_types_test.go
@@ -184,7 +184,9 @@ func TestUserTypes_Delete_WithAssociatedUsers(t *testing.T) {
 	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
 	h := testutil.AuthHeader(token)
 
-	// buropropuskov type (ID 6) has the admin user, so deletion should fail.
+	// buropropuskov - системный тип (is_system), удаление блокируется (400).
+	// FK-защита несистемных типов с пользователями проверяется отдельно
+	// в TestUserTypes_Delete_NonSystemWithUsers.
 	// Find the buropropuskov type ID by listing
 	rec := testutil.GET(t, e, "/user-types-management", h)
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -215,6 +217,109 @@ func TestUserTypes_Delete_Forbidden_NonAdmin(t *testing.T) {
 
 	rec := testutil.DELETE(t, e, "/user-types-management/1", h)
 	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+// findTypeIDByCode возвращает id типа по его code из ответа GetAll.
+func findTypeIDByCode(t *testing.T, list []map[string]interface{}, code string) int {
+	t.Helper()
+	for _, item := range list {
+		if item["code"] == code {
+			return int(item["id"].(float64))
+		}
+	}
+	t.Fatalf("user type with code %q not found", code)
+	return 0
+}
+
+func TestUserTypes_Update_SystemTypeBlocked(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	rec := testutil.GET(t, e, "/user-types-management", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	// Системный тип "user" нельзя переименовать.
+	userID := findTypeIDByCode(t, testutil.ParseSlice(t, rec), "user")
+
+	rec = testutil.PUT(t, e, fmt.Sprintf("/user-types-management/%d", userID),
+		`{"name":"Переименован","code":"user"}`, h)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestUserTypes_Delete_SystemTypeBlocked(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	rec := testutil.GET(t, e, "/user-types-management", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	// "renter" - системный тип без связанных пользователей: блокируется именно
+	// по is_system, а не по FK-проверке.
+	renterID := findTypeIDByCode(t, testutil.ParseSlice(t, rec), "renter")
+
+	rec = testutil.DELETE(t, e, fmt.Sprintf("/user-types-management/%d", renterID), h)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestUserTypes_Delete_NonSystemWithUsers(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	// Несистемный тип с привязанным пользователем должен блокироваться FK-проверкой.
+	rec := testutil.POST(t, e, "/user-types-management", `{"name":"FK тип","code":"fk_type"}`, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	fkTypeID := int(testutil.ParseMap(t, rec)["id"].(float64))
+
+	testutil.RegisterAndLogin(t, e, "fkuser", "password123", fkTypeID, td.OrgID, td.CompanyID)
+
+	rec = testutil.DELETE(t, e, fmt.Sprintf("/user-types-management/%d", fkTypeID), h)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestUserTypes_GetAll_IncludesIsSystem(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	// Кастомный (несистемный) тип.
+	rec := testutil.POST(t, e, "/user-types-management", `{"name":"Кастомный","code":"custom_type"}`, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = testutil.GET(t, e, "/user-types-management", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	list := testutil.ParseSlice(t, rec)
+
+	var checkedSystem, checkedCustom bool
+	for _, item := range list {
+		assert.Contains(t, item, "is_system")
+		switch item["code"] {
+		case "buropropuskov":
+			assert.Equal(t, true, item["is_system"], "системный тип должен быть is_system=true")
+			checkedSystem = true
+		case "custom_type":
+			assert.Equal(t, false, item["is_system"], "кастомный тип должен быть is_system=false")
+			checkedCustom = true
+		}
+	}
+	assert.True(t, checkedSystem, "buropropuskov не найден")
+	assert.True(t, checkedCustom, "custom_type не найден")
 }
 
 func TestUserTypes_GetAll_IncludesUsersCount(t *testing.T) {

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -3,31 +3,31 @@ package models
 import "time"
 
 type User struct {
-	ID                int          `json:"id"`
-	Username          string       `gorm:"uniqueIndex;size:100" json:"username"`
-	Password          string       `gorm:"size:255" json:"-"`
-	OrganizationID    *int         `json:"organization_id"`
-	Organization      Organization `json:"organization,omitempty"`
-	CompanyID         *int         `json:"company_id"`
-	Company           Company      `json:"company,omitempty"`
-	TypeID            int          `gorm:"default:1" json:"type_id"`
-	UserType          UserType     `gorm:"foreignKey:TypeID" json:"user_type,omitempty"`
-	RoleID            *int         `json:"role_id"`
-	Role              *Role        `gorm:"foreignKey:RoleID" json:"role,omitempty"`
-	IsSuperAdmin      bool         `gorm:"default:false;index" json:"is_super_admin"`
-	IsActive          bool         `gorm:"default:true;index" json:"is_active"`
-	IsBanned          bool         `gorm:"default:false;index" json:"is_banned"`
-	BannedAt          *time.Time   `json:"banned_at,omitempty"`
-	BannedBy          *int         `json:"banned_by,omitempty"`
-	LastName          *string      `gorm:"size:100" json:"last_name"`
-	FirstName         *string      `gorm:"size:100" json:"first_name"`
-	MiddleName        *string      `gorm:"size:100" json:"middle_name"`
-	Position          *string      `gorm:"size:100;column:position" json:"position"`
-	Email             *string      `gorm:"size:100" json:"email"`
-	Phone             *string      `gorm:"size:20" json:"phone"`
-	LastLoginAt       *time.Time   `json:"last_login_at,omitempty"`
-	FailedLoginCount  int          `gorm:"default:0" json:"-"`
-	LockedUntil       *time.Time   `json:"-"`
+	ID               int          `json:"id"`
+	Username         string       `gorm:"uniqueIndex;size:100" json:"username"`
+	Password         string       `gorm:"size:255" json:"-"`
+	OrganizationID   *int         `json:"organization_id"`
+	Organization     Organization `json:"organization,omitempty"`
+	CompanyID        *int         `json:"company_id"`
+	Company          Company      `json:"company,omitempty"`
+	TypeID           int          `gorm:"default:1" json:"type_id"`
+	UserType         UserType     `gorm:"foreignKey:TypeID" json:"user_type,omitempty"`
+	RoleID           *int         `json:"role_id"`
+	Role             *Role        `gorm:"foreignKey:RoleID" json:"role,omitempty"`
+	IsSuperAdmin     bool         `gorm:"default:false;index" json:"is_super_admin"`
+	IsActive         bool         `gorm:"default:true;index" json:"is_active"`
+	IsBanned         bool         `gorm:"default:false;index" json:"is_banned"`
+	BannedAt         *time.Time   `json:"banned_at,omitempty"`
+	BannedBy         *int         `json:"banned_by,omitempty"`
+	LastName         *string      `gorm:"size:100" json:"last_name"`
+	FirstName        *string      `gorm:"size:100" json:"first_name"`
+	MiddleName       *string      `gorm:"size:100" json:"middle_name"`
+	Position         *string      `gorm:"size:100;column:position" json:"position"`
+	Email            *string      `gorm:"size:100" json:"email"`
+	Phone            *string      `gorm:"size:20" json:"phone"`
+	LastLoginAt      *time.Time   `json:"last_login_at,omitempty"`
+	FailedLoginCount int          `gorm:"default:0" json:"-"`
+	LockedUntil      *time.Time   `json:"-"`
 }
 
 type Organization struct {
@@ -44,6 +44,9 @@ type UserType struct {
 	ID   int    `json:"id"`
 	Name string `gorm:"size:50" json:"name"`
 	Code string `gorm:"uniqueIndex;size:20" json:"code"`
+	// IsSystem помечает встроенные типы, чьи code используются в авторизации
+	// (internal/auth/permissions.go). Такие типы нельзя переименовать или удалить.
+	IsSystem bool `gorm:"default:false" json:"is_system"`
 }
 
 // --- Users management DTOs ---

--- a/internal/services/user_type_service.go
+++ b/internal/services/user_type_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 
@@ -14,6 +15,7 @@ type UserTypeWithCount struct {
 	ID         int    `json:"id"`
 	Name       string `json:"name"`
 	Code       string `json:"code"`
+	IsSystem   bool   `json:"is_system"`
 	UsersCount int64  `json:"users_count"`
 }
 
@@ -69,6 +71,25 @@ func (s *userTypeService) checkAdmin(ctx context.Context, typeID int) error {
 	return nil
 }
 
+// typeFlags возвращает признак системного типа и факт его существования.
+func (s *userTypeService) typeFlags(ctx context.Context, id int) (isSystem bool, found bool, err error) {
+	var row struct {
+		IsSystem bool
+	}
+	err = s.db.WithContext(ctx).
+		Table("user_types").
+		Select("is_system").
+		Where("id = ?", id).
+		Take(&row).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return false, false, nil
+	}
+	if err != nil {
+		return false, false, echo.NewHTTPError(http.StatusInternalServerError, "Error checking user type")
+	}
+	return row.IsSystem, true, nil
+}
+
 // GetAllWithCount возвращает все типы пользователей с количеством связанных пользователей.
 func (s *userTypeService) GetAllWithCount(ctx context.Context, typeID int) ([]UserTypeWithCount, error) {
 	if err := s.checkAdmin(ctx, typeID); err != nil {
@@ -78,9 +99,9 @@ func (s *userTypeService) GetAllWithCount(ctx context.Context, typeID int) ([]Us
 	result := make([]UserTypeWithCount, 0)
 	err := s.db.WithContext(ctx).
 		Table("user_types ut").
-		Select("ut.id, ut.name, ut.code, COUNT(u.username) as users_count").
+		Select("ut.id, ut.name, ut.code, ut.is_system, COUNT(u.username) as users_count").
 		Joins("LEFT JOIN users u ON ut.id = u.type_id").
-		Group("ut.id, ut.name, ut.code").
+		Group("ut.id, ut.name, ut.code, ut.is_system").
 		Order("ut.name").
 		Scan(&result).Error
 	if err != nil {
@@ -127,13 +148,16 @@ func (s *userTypeService) Update(ctx context.Context, typeID int, id int, req Up
 		return err
 	}
 
-	// Проверяем существование типа
-	var count int64
-	if err := s.db.WithContext(ctx).Table("user_types").Where("id = ?", id).Count(&count).Error; err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "Error checking user type existence")
+	// Проверяем существование типа и его системность одним запросом
+	isSystem, found, err := s.typeFlags(ctx, id)
+	if err != nil {
+		return err
 	}
-	if count == 0 {
+	if !found {
 		return echo.NewHTTPError(http.StatusNotFound, "User type not found")
+	}
+	if isSystem {
+		return echo.NewHTTPError(http.StatusBadRequest, "Системный тип пользователя нельзя переименовать")
 	}
 
 	if err := s.db.WithContext(ctx).Table("user_types").Where("id = ?", id).Update("name", req.Name).Error; err != nil {
@@ -149,6 +173,18 @@ func (s *userTypeService) Update(ctx context.Context, typeID int, id int, req Up
 func (s *userTypeService) Delete(ctx context.Context, typeID int, id int) error {
 	if err := s.checkAdmin(ctx, typeID); err != nil {
 		return err
+	}
+
+	// Системные типы (их code используется в авторизации) удалять запрещено.
+	isSystem, found, err := s.typeFlags(ctx, id)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return echo.NewHTTPError(http.StatusNotFound, "User type not found")
+	}
+	if isSystem {
+		return echo.NewHTTPError(http.StatusBadRequest, "Системный тип пользователя нельзя удалить")
 	}
 
 	// Проверяем, есть ли пользователи с этим типом


### PR DESCRIPTION
## Что

Срез #411 эпика #406, **backend часть 1** (защита). UserTypes — без архива, с флагом is_system.

Встроенные типы (code `user/renter/contractor/security/manager/buropropuskov`) используются в авторизации (`internal/auth/permissions.go`) — их переименование/удаление ломает доступ. Помечаю их `is_system=true` и блокирую мутации:
- `UserType.IsSystem bool` (default false).
- `Seed`: 6 системных типов сидятся с IsSystem:true + идемпотентный backfill `UPDATE ... WHERE code IN (...) AND is_system=false` для уже развёрнутых БД (additive, не destructive).
- `Update` (переименование) и `Delete` системного типа -> 400 с понятным сообщением. Несистемные правятся/удаляются свободно (FK-защита по пользователям сохранена).
- `is_system` отдаётся в списке типов (нужно фронту следующего среза).

## Off-limits

`internal/auth/permissions.go` НЕ тронут — слайс только защищает type codes, не меняет auth-логику. migrate.go-изменение additive (поле через AutoMigrate + DML backfill в Seed), без drop/constraint.

## Проверка

- `make test` зелёный, go build/vet/gofmt чисто.
- code-reviewer GO. Закрыл Y-1 (typeFlags на Take+ErrRecordNotFound вместо хрупкого RowsAffected) и Y-3 (добавил тест FK-ветки для несистемного типа с юзером + уточнил комментарий старого теста).
- Новые тесты: Update системного -> 400, Delete системного без юзеров -> 400, Delete несистемного с юзером -> 400 (FK), GetAll содержит is_system.

## Остаётся по #411

Под-срезы: backend UserTypeHistory (+endpoint+логирование) -> frontend UserTypes.vue под эталон -> frontend UserTypeHistory модалка.

## Долг (не в этом срезе)

UpdateUserTypeRequest.Code не используется в Update (code иммутабелен) — pre-existing, не трогал. Swagger реген -> #345.