### PR TITLE
feat(user-types): история изменений типов пользователей (#411)

### DIFF
--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -16,6 +16,7 @@ func AllModels() []interface{} {
 		// Core (no FK dependencies)
 		&models.SystemSetting{},
 		&models.UserType{},
+		&models.UserTypeHistory{},
 		&models.Organization{},
 		&models.Company{},
 		&models.Citizenship{},

--- a/internal/handlers/user_types.go
+++ b/internal/handlers/user_types.go
@@ -55,11 +55,12 @@ func (h *UserTypesHandler) GetAll(c echo.Context) error {
 // @Router       /user-types-management [post]
 func (h *UserTypesHandler) Create(c echo.Context) error {
 	typeID := c.Get("type_id").(int)
+	userID, _ := c.Get("user_id").(int)
 	var req services.CreateUserTypeRequest
 	if err := BindAndValidate(c, &req); err != nil {
 		return err
 	}
-	id, err := h.service.Create(c.Request().Context(), typeID, req)
+	id, err := h.service.Create(c.Request().Context(), typeID, userID, req)
 	if err != nil {
 		return err
 	}
@@ -85,6 +86,7 @@ func (h *UserTypesHandler) Create(c echo.Context) error {
 // @Router       /user-types-management/{id} [put]
 func (h *UserTypesHandler) Update(c echo.Context) error {
 	typeID := c.Get("type_id").(int)
+	userID, _ := c.Get("user_id").(int)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid user type ID")
@@ -93,7 +95,7 @@ func (h *UserTypesHandler) Update(c echo.Context) error {
 	if err := BindAndValidate(c, &req); err != nil {
 		return err
 	}
-	if err := h.service.Update(c.Request().Context(), typeID, id, req); err != nil {
+	if err := h.service.Update(c.Request().Context(), typeID, userID, id, req); err != nil {
 		return err
 	}
 	return RespondMessage(c, "Тип пользователя успешно обновлен")
@@ -114,12 +116,36 @@ func (h *UserTypesHandler) Update(c echo.Context) error {
 // @Router       /user-types-management/{id} [delete]
 func (h *UserTypesHandler) Delete(c echo.Context) error {
 	typeID := c.Get("type_id").(int)
+	userID, _ := c.Get("user_id").(int)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid user type ID")
 	}
-	if err := h.service.Delete(c.Request().Context(), typeID, id); err != nil {
+	if err := h.service.Delete(c.Request().Context(), typeID, userID, id); err != nil {
 		return err
 	}
 	return RespondMessage(c, "Тип пользователя успешно удален")
+}
+
+// GetHistory godoc
+// @Summary      История изменений типа пользователя
+// @Tags         user-types-management
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID типа пользователя"
+// @Success      200 {array} models.UserTypeHistoryItem
+// @Failure      401 {object} models.HTTPError
+// @Failure      403 {object} models.HTTPError
+// @Router       /user-types-management/{id}/history [get]
+func (h *UserTypesHandler) GetHistory(c echo.Context) error {
+	typeID := c.Get("type_id").(int)
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid user type ID")
+	}
+	items, err := h.service.GetHistory(c.Request().Context(), typeID, id)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, items)
 }

--- a/internal/handlers/user_types_test.go
+++ b/internal/handlers/user_types_test.go
@@ -322,6 +322,58 @@ func TestUserTypes_GetAll_IncludesIsSystem(t *testing.T) {
 	assert.True(t, checkedCustom, "custom_type не найден")
 }
 
+func TestUserTypes_History(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	// create -> renamed -> deleted, каждое действие пишется в историю.
+	rec := testutil.POST(t, e, "/user-types-management", `{"name":"Ист тип","code":"hist_type"}`, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	id := int(testutil.ParseMap(t, rec)["id"].(float64))
+
+	rec = testutil.PUT(t, e, fmt.Sprintf("/user-types-management/%d", id),
+		`{"name":"Ист тип 2","code":"hist_type"}`, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// История после create+rename: 2 записи, новые сверху.
+	rec = testutil.GET(t, e, fmt.Sprintf("/user-types-management/%d/history", id), h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	hist := testutil.ParseSlice(t, rec)
+	require.Len(t, hist, 2)
+	assert.Equal(t, "renamed", hist[0]["action_type"])
+	assert.Equal(t, "created", hist[1]["action_type"])
+	// actor проставлен (имя или username админа, не пусто).
+	assert.NotEmpty(t, hist[0]["actor_name"])
+
+	// Удаление логируется; история переживает удаление типа.
+	rec = testutil.DELETE(t, e, fmt.Sprintf("/user-types-management/%d", id), h)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = testutil.GET(t, e, fmt.Sprintf("/user-types-management/%d/history", id), h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	hist = testutil.ParseSlice(t, rec)
+	require.Len(t, hist, 3)
+	assert.Equal(t, "deleted", hist[0]["action_type"])
+}
+
+func TestUserTypes_History_Forbidden_NonAdmin(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "regularuser", "password123", 1, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	rec := testutil.GET(t, e, "/user-types-management/1/history", h)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
 func TestUserTypes_GetAll_IncludesUsersCount(t *testing.T) {
 	e, db, cleanup := testutil.SetupTestApp(t)
 	defer cleanup()

--- a/internal/models/user_type_history.go
+++ b/internal/models/user_type_history.go
@@ -1,0 +1,38 @@
+package models
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// UserTypeHistory логирует действия над типом пользователя: создание,
+// переименование и удаление. Нужна для аудита: code типов используются в
+// авторизации, и важно отследить кто и когда менял справочник типов.
+//
+// UserTypeID - над каким типом действие, ActorUserID - кто его совершил.
+// FK на тип намеренно без constraint: аудит должен пережить удаление типа.
+type UserTypeHistory struct {
+	ID          int             `json:"id"`
+	UserTypeID  int             `gorm:"index;not null" json:"user_type_id"`
+	ActorUserID *int            `gorm:"index" json:"actor_user_id,omitempty"`
+	ActionType  string          `gorm:"size:32;index" json:"action_type"`
+	Details     json.RawMessage `gorm:"type:jsonb" json:"details,omitempty"`
+	CreatedAt   time.Time       `json:"created_at"`
+}
+
+// UserTypeActionType - константы для UserTypeHistory.ActionType.
+const (
+	UserTypeActionCreated = "created"
+	UserTypeActionRenamed = "renamed"
+	UserTypeActionDeleted = "deleted"
+)
+
+// UserTypeHistoryItem - запись истории с именем актора для API (LEFT JOIN users).
+type UserTypeHistoryItem struct {
+	ID          int             `json:"id"`
+	ActionType  string          `json:"action_type"`
+	Details     json.RawMessage `json:"details,omitempty" swaggerignore:"true"`
+	ActorUserID *int            `json:"actor_user_id,omitempty"`
+	ActorName   string          `json:"actor_name"`
+	CreatedAt   time.Time       `json:"created_at"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -19,7 +19,7 @@ type Dependencies struct {
 	UserTypes           *handlers.UserTypesHandler
 	Attachments         *handlers.AttachmentHandler
 	LPF                 *handlers.LicensePlateFormatHandler
-	Citizenship        *handlers.CitizenshipHandler
+	Citizenship         *handlers.CitizenshipHandler
 	Organization        *handlers.OrganizationHandler
 	Company             *handlers.CompanyHandler
 	Users               *handlers.UsersHandler
@@ -163,6 +163,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	utm.POST("", userTypes.Create)
 	utm.PUT("/:id", userTypes.Update)
 	utm.DELETE("/:id", userTypes.Delete)
+	utm.GET("/:id/history", userTypes.GetHistory)
 
 	// Гражданства
 	csg := protected.Group("/citizenships")

--- a/internal/services/user_type_history_service.go
+++ b/internal/services/user_type_history_service.go
@@ -1,0 +1,89 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"systemburo/internal/models"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+// UserTypeHistoryService - аудит действий над типами пользователей (#411).
+type UserTypeHistoryService interface {
+	// Log пишет запись аудита. details - произвольный JSON, опционально.
+	// Ошибка логирования не возвращается: аудит не должен ломать основное действие.
+	Log(ctx context.Context, userTypeID int, actorUserID *int, actionType string, details interface{})
+	// GetHistory возвращает историю по типу пользователя (новые сверху).
+	GetHistory(ctx context.Context, userTypeID int) ([]models.UserTypeHistoryItem, error)
+}
+
+type userTypeHistoryService struct {
+	db *gorm.DB
+}
+
+// NewUserTypeHistoryService создаёт реализацию UserTypeHistoryService.
+func NewUserTypeHistoryService(db *gorm.DB) UserTypeHistoryService {
+	return &userTypeHistoryService{db: db}
+}
+
+func (s *userTypeHistoryService) Log(ctx context.Context, userTypeID int, actorUserID *int, actionType string, details interface{}) {
+	var raw json.RawMessage
+	if details != nil {
+		b, err := json.Marshal(details)
+		if err != nil {
+			slog.Error("user_type_history: marshal details", "type", userTypeID, "error", err)
+		} else {
+			raw = b
+		}
+	}
+	entry := models.UserTypeHistory{
+		UserTypeID:  userTypeID,
+		ActorUserID: actorUserID,
+		ActionType:  actionType,
+		Details:     raw,
+	}
+	if err := s.db.WithContext(ctx).Create(&entry).Error; err != nil {
+		slog.Error("user_type_history: insert", "type", userTypeID, "action", actionType, "error", err)
+	}
+}
+
+func (s *userTypeHistoryService) GetHistory(ctx context.Context, userTypeID int) ([]models.UserTypeHistoryItem, error) {
+	type row struct {
+		ID          int             `gorm:"column:id"`
+		ActionType  string          `gorm:"column:action_type"`
+		Details     json.RawMessage `gorm:"column:details"`
+		ActorUserID *int            `gorm:"column:actor_user_id"`
+		ActorName   string          `gorm:"column:actor_name"`
+		CreatedAt   time.Time       `gorm:"column:created_at"`
+	}
+	var rows []row
+	if err := s.db.WithContext(ctx).
+		Table("user_type_histories AS h").
+		Select(`h.id, h.action_type, h.details, h.actor_user_id,
+			COALESCE(NULLIF(TRIM(BOTH ' ' FROM CONCAT_WS(' ', u.last_name, u.first_name)), ''), u.username, '') AS actor_name,
+			h.created_at`).
+		Joins("LEFT JOIN users u ON u.id = h.actor_user_id").
+		Where("h.user_type_id = ?", userTypeID).
+		Order("h.created_at DESC").
+		Scan(&rows).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching user type history")
+	}
+
+	items := make([]models.UserTypeHistoryItem, 0, len(rows))
+	for _, r := range rows {
+		items = append(items, models.UserTypeHistoryItem{
+			ID:          r.ID,
+			ActionType:  r.ActionType,
+			Details:     r.Details,
+			ActorUserID: r.ActorUserID,
+			ActorName:   r.ActorName,
+			CreatedAt:   r.CreatedAt,
+		})
+	}
+	return items, nil
+}

--- a/internal/services/user_type_service.go
+++ b/internal/services/user_type_service.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 	"net/http"
 
+	"systemburo/internal/models"
+
 	"github.com/labstack/echo/v4"
 	"gorm.io/gorm"
 )
@@ -35,21 +37,24 @@ type UpdateUserTypeRequest struct {
 type UserTypeService interface {
 	// GetAllWithCount возвращает все типы пользователей с количеством пользователей каждого типа.
 	GetAllWithCount(ctx context.Context, typeID int) ([]UserTypeWithCount, error)
-	// Create создаёт новый тип пользователя и возвращает его ID.
-	Create(ctx context.Context, typeID int, req CreateUserTypeRequest) (int, error)
-	// Update обновляет имя типа пользователя по ID.
-	Update(ctx context.Context, typeID int, id int, req UpdateUserTypeRequest) error
-	// Delete удаляет тип пользователя по ID, если с ним не связаны пользователи.
-	Delete(ctx context.Context, typeID int, id int) error
+	// Create создаёт новый тип пользователя и возвращает его ID. callerUserID - актор для аудита.
+	Create(ctx context.Context, typeID, callerUserID int, req CreateUserTypeRequest) (int, error)
+	// Update обновляет имя типа пользователя по ID. callerUserID - актор для аудита.
+	Update(ctx context.Context, typeID, callerUserID, id int, req UpdateUserTypeRequest) error
+	// Delete удаляет тип пользователя по ID, если с ним не связаны пользователи. callerUserID - актор для аудита.
+	Delete(ctx context.Context, typeID, callerUserID, id int) error
+	// GetHistory возвращает историю изменений типа пользователя.
+	GetHistory(ctx context.Context, typeID, id int) ([]models.UserTypeHistoryItem, error)
 }
 
 type userTypeService struct {
-	db *gorm.DB
+	db      *gorm.DB
+	history UserTypeHistoryService
 }
 
 // NewUserTypeService создаёт новый экземпляр сервиса управления типами пользователей.
 func NewUserTypeService(db *gorm.DB) UserTypeService {
-	return &userTypeService{db: db}
+	return &userTypeService{db: db, history: NewUserTypeHistoryService(db)}
 }
 
 // checkAdmin проверяет, что пользователь с данным type_id является администратором
@@ -112,7 +117,7 @@ func (s *userTypeService) GetAllWithCount(ctx context.Context, typeID int) ([]Us
 }
 
 // Create создаёт новый тип пользователя. Возвращает ошибку, если тип с таким кодом уже существует.
-func (s *userTypeService) Create(ctx context.Context, typeID int, req CreateUserTypeRequest) (int, error) {
+func (s *userTypeService) Create(ctx context.Context, typeID, callerUserID int, req CreateUserTypeRequest) (int, error) {
 	if err := s.checkAdmin(ctx, typeID); err != nil {
 		return 0, err
 	}
@@ -139,11 +144,15 @@ func (s *userTypeService) Create(ctx context.Context, typeID int, req CreateUser
 	}
 
 	slog.Info("тип пользователя создан", "id", id)
+	s.history.Log(ctx, id, &callerUserID, models.UserTypeActionCreated, map[string]any{
+		"name": req.Name,
+		"code": req.Code,
+	})
 	return id, nil
 }
 
 // Update обновляет имя типа пользователя. Возвращает ошибку, если тип не найден.
-func (s *userTypeService) Update(ctx context.Context, typeID int, id int, req UpdateUserTypeRequest) error {
+func (s *userTypeService) Update(ctx context.Context, typeID, callerUserID, id int, req UpdateUserTypeRequest) error {
 	if err := s.checkAdmin(ctx, typeID); err != nil {
 		return err
 	}
@@ -166,24 +175,36 @@ func (s *userTypeService) Update(ctx context.Context, typeID int, id int, req Up
 	}
 
 	slog.Info("тип пользователя обновлён", "id", id)
+	s.history.Log(ctx, id, &callerUserID, models.UserTypeActionRenamed, map[string]any{"name": req.Name})
 	return nil
 }
 
 // Delete удаляет тип пользователя. Возвращает ошибку, если с типом связаны пользователи.
-func (s *userTypeService) Delete(ctx context.Context, typeID int, id int) error {
+func (s *userTypeService) Delete(ctx context.Context, typeID, callerUserID, id int) error {
 	if err := s.checkAdmin(ctx, typeID); err != nil {
 		return err
 	}
 
-	// Системные типы (их code используется в авторизации) удалять запрещено.
-	isSystem, found, err := s.typeFlags(ctx, id)
-	if err != nil {
-		return err
+	// Снимок name/code до удаления - для деталей аудита (после удаления строки нет).
+	var snapshot struct {
+		Name     string
+		Code     string
+		IsSystem bool
 	}
-	if !found {
+	err := s.db.WithContext(ctx).
+		Table("user_types").
+		Select("name, code, is_system").
+		Where("id = ?", id).
+		Take(&snapshot).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return echo.NewHTTPError(http.StatusNotFound, "User type not found")
 	}
-	if isSystem {
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Error checking user type")
+	}
+
+	// Системные типы (их code используется в авторизации) удалять запрещено.
+	if snapshot.IsSystem {
 		return echo.NewHTTPError(http.StatusBadRequest, "Системный тип пользователя нельзя удалить")
 	}
 
@@ -202,5 +223,17 @@ func (s *userTypeService) Delete(ctx context.Context, typeID int, id int) error 
 	}
 
 	slog.Info("тип пользователя удалён", "id", id)
+	s.history.Log(ctx, id, &callerUserID, models.UserTypeActionDeleted, map[string]any{
+		"name": snapshot.Name,
+		"code": snapshot.Code,
+	})
 	return nil
+}
+
+// GetHistory возвращает историю изменений типа пользователя (admin-only).
+func (s *userTypeService) GetHistory(ctx context.Context, typeID, id int) ([]models.UserTypeHistoryItem, error) {
+	if err := s.checkAdmin(ctx, typeID); err != nil {
+		return nil, err
+	}
+	return s.history.GetHistory(ctx, id)
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -59,6 +59,7 @@ var tables = []string{
 	"license_plate_format_cells", "license_plate_formats",
 	"citizenships",
 	"companies_users", "organization_users",
+	"user_histories", "user_type_histories",
 	"refresh_tokens", "users",
 	"roles",
 	"companies", "organizations", "user_types",


### PR DESCRIPTION
## Что

Срез #411 эпика #406, **backend часть 2** — аудит изменений типов пользователей. По образцу UserHistory (#410).

- `UserTypeHistory` (модель) + `UserTypeHistoryService` (Log/GetHistory с actor_name через LEFT JOIN users).
- Логирование: `created` ({name,code}) / `renamed` ({name}) / `deleted` ({name,code}, снапшот до удаления) — строго после успешной операции, актор = caller user_id.
- Endpoint `GET /user-types-management/{id}/history` (admin-only).
- История без FK-constraint — переживает удаление типа.

## Тестовая инфра

В `CleanDB` добавлены `user_histories` и `user_type_histories`: без очистки аудит копился между тестами (id типов переиспользуются при сбросе sequence) и ломал проверку истории. Заодно харденит #410 history-тест.

## Проверка

- `make test` зелёный (включая #410 TestUsers_History), go build/vet/gofmt чисто.
- code-reviewer GO. YELLOW-2 (порядок в CleanDB) поправлен.
- Тесты: create->rename->delete timeline + actor + переживание удаления, forbidden для не-админа.

## Off-limits

auth/permission не тронуты. migrate.go additive (новая таблица в AllModels, без drop/constraint).

## Остаётся по #411

frontend: UserTypes.vue под эталон + UserTypeHistory модалка.