### PR TITLE
feat(organizations): архив организаций - soft-delete + restore + partial unique (#412)

### DIFF
--- a/cmd/seed/main.go
+++ b/cmd/seed/main.go
@@ -36,9 +36,11 @@ func main() {
 		log.Fatalf("DB connection failed: %v", err)
 	}
 
-	// Убедимся что организация и компания существуют
+	// Убедимся что организация и компания существуют.
+	// У organizations теперь partial unique по name (WHERE is_active=true) - в
+	// ON CONFLICT нужно указать тот же предикат, иначе арбитр-индекс не найдётся.
 	var orgID, compID int
-	db.Raw("INSERT INTO organizations (name) VALUES ('Бюро пропусков') ON CONFLICT (name) DO UPDATE SET name = EXCLUDED.name RETURNING id").Scan(&orgID)
+	db.Raw("INSERT INTO organizations (name) VALUES ('Бюро пропусков') ON CONFLICT (name) WHERE is_active = true DO UPDATE SET name = EXCLUDED.name RETURNING id").Scan(&orgID)
 	db.Raw("INSERT INTO companies (name) VALUES ('Бюро пропусков') ON CONFLICT (name) DO UPDATE SET name = EXCLUDED.name RETURNING id").Scan(&compID)
 
 	// type_id=6 = buropropuskov

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -280,6 +280,18 @@ func Seed(db *gorm.DB) error {
 		slog.Info("backfilled user_types.is_system", "count", result.RowsAffected)
 	}
 
+	// Organizations: глобальный uniqueIndex по name заменяем на partial unique
+	// (только среди активных), чтобы архивная организация не блокировала создание
+	// новой активной с тем же именем (#412). Идемпотентно. Ошибку возвращаем (не
+	// логируем молча): от этого индекса зависит уникальность имён - провал должен
+	// быть громким.
+	if err := db.Exec("DROP INDEX IF EXISTS idx_organizations_name").Error; err != nil {
+		return fmt.Errorf("failed to drop idx_organizations_name: %w", err)
+	}
+	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uidx_organizations_name_active ON organizations (name) WHERE is_active = true").Error; err != nil {
+		return fmt.Errorf("failed to create partial unique index on organizations.name: %w", err)
+	}
+
 	// Seed default tab permissions
 	if db.Migrator().HasTable("permissions") {
 		var permCount int64

--- a/internal/handlers/organizations.go
+++ b/internal/handlers/organizations.go
@@ -136,7 +136,33 @@ func (h *OrganizationHandler) Delete(c echo.Context) error {
 	if err := h.service.Delete(c.Request().Context(), id); err != nil {
 		return err
 	}
-	return RespondMessage(c, "Organization deleted")
+	return RespondMessage(c, "Organization archived")
+}
+
+// Restore godoc
+// @Summary      Восстановить организацию из архива
+// @Tags         organizations
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID организации"
+// @Success      200 {string} string "Organization restored"
+// @Failure      400 {object} models.HTTPError
+// @Failure      401 {object} models.HTTPError
+// @Failure      403 {object} models.HTTPError
+// @Router       /organizations/{id}/restore [post]
+func (h *OrganizationHandler) Restore(c echo.Context) error {
+	username := c.Get("username").(string)
+	if err := services.CheckAdminPermissions(h.db, c.Request().Context(), username); err != nil {
+		return err
+	}
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid organization ID")
+	}
+	if err := h.service.Restore(c.Request().Context(), id); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Organization restored")
 }
 
 // GetWithUsers godoc
@@ -151,7 +177,8 @@ func (h *OrganizationHandler) Delete(c echo.Context) error {
 // @Failure      500 {object} models.HTTPError
 // @Router       /organizations/with-users [get]
 func (h *OrganizationHandler) GetWithUsers(c echo.Context) error {
-	orgs, err := h.service.GetWithUsers(c.Request().Context())
+	includeArchived := c.QueryParam("include_archived") == "true"
+	orgs, err := h.service.GetWithUsers(c.Request().Context(), includeArchived)
 	if err != nil {
 		return err
 	}
@@ -170,7 +197,8 @@ func (h *OrganizationHandler) GetWithUsers(c echo.Context) error {
 // @Failure      500 {object} models.HTTPError
 // @Router       /organizations/with-users-extended [get]
 func (h *OrganizationHandler) GetWithUsersExtended(c echo.Context) error {
-	orgs, err := h.service.GetWithUsersExtended(c.Request().Context())
+	includeArchived := c.QueryParam("include_archived") == "true"
+	orgs, err := h.service.GetWithUsersExtended(c.Request().Context(), includeArchived)
 	if err != nil {
 		return err
 	}

--- a/internal/handlers/organizations_test.go
+++ b/internal/handlers/organizations_test.go
@@ -100,7 +100,91 @@ func TestOrganizations_Delete(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 	msg := testutil.ParseMessage(t, rec)
-	assert.Equal(t, "Organization deleted", msg)
+	assert.Equal(t, "Organization archived", msg)
+
+	// Архивная организация исчезает из списка по умолчанию, но видна с include_archived.
+	def := testutil.ParseSlice(t, testutil.GET(t, e, "/organizations/with-users", testutil.AuthHeader(token)))
+	for _, o := range def {
+		assert.NotEqual(t, float64(orgID), o["id"], "архивная организация не должна быть в списке по умолчанию")
+	}
+	arch := testutil.ParseSlice(t, testutil.GET(t, e, "/organizations/with-users?include_archived=true", testutil.AuthHeader(token)))
+	var foundArchived bool
+	for _, o := range arch {
+		if int(o["id"].(float64)) == orgID {
+			foundArchived = true
+			assert.Equal(t, false, o["is_active"])
+		}
+	}
+	assert.True(t, foundArchived, "архивная организация должна быть видна с include_archived")
+}
+
+func TestOrganizations_Restore(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	created := testutil.ParseMap(t, testutil.POST(t, e, "/organizations", `{"name":"To Restore"}`, testutil.AuthHeader(token)))
+	orgID := int(created["id"].(float64))
+
+	require.Equal(t, http.StatusOK, testutil.DELETE(t, e, fmt.Sprintf("/organizations/%d", orgID), testutil.AuthHeader(token)).Code)
+
+	rec := testutil.POST(t, e, fmt.Sprintf("/organizations/%d/restore", orgID), "", testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "Organization restored", testutil.ParseMessage(t, rec))
+
+	// После восстановления снова в списке по умолчанию.
+	def := testutil.ParseSlice(t, testutil.GET(t, e, "/organizations/with-users", testutil.AuthHeader(token)))
+	var found bool
+	for _, o := range def {
+		if int(o["id"].(float64)) == orgID {
+			found = true
+			assert.Equal(t, true, o["is_active"])
+		}
+	}
+	assert.True(t, found, "восстановленная организация должна быть в списке по умолчанию")
+}
+
+func TestOrganizations_Restore_Forbidden(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAndLogin(t, e, "regularuser", "pass123", 1, td.OrgID, td.CompanyID)
+
+	rec := testutil.POST(t, e, fmt.Sprintf("/organizations/%d/restore", td.OrgID), "", testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestOrganizations_Restore_NameConflict_Fails(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	// Создаём «Конфликт», архивируем, создаём новую активную «Конфликт».
+	first := testutil.ParseMap(t, testutil.POST(t, e, "/organizations", `{"name":"Конфликт"}`, testutil.AuthHeader(token)))
+	firstID := int(first["id"].(float64))
+	require.Equal(t, http.StatusOK, testutil.DELETE(t, e, fmt.Sprintf("/organizations/%d", firstID), testutil.AuthHeader(token)).Code)
+	require.Equal(t, http.StatusOK, testutil.POST(t, e, "/organizations", `{"name":"Конфликт"}`, testutil.AuthHeader(token)).Code)
+
+	// Восстановление первой невозможно - активное имя занято.
+	rec := testutil.POST(t, e, fmt.Sprintf("/organizations/%d/restore", firstID), "", testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestOrganizations_Create_DuplicateActiveName_Fails(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	require.Equal(t, http.StatusOK, testutil.POST(t, e, "/organizations", `{"name":"Dup Org"}`, testutil.AuthHeader(token)).Code)
+	rec := testutil.POST(t, e, "/organizations", `{"name":"Dup Org"}`, testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
 func TestOrganizations_Delete_WithUsers_Fails(t *testing.T) {

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -32,7 +32,11 @@ type User struct {
 
 type Organization struct {
 	ID   int    `json:"id"`
-	Name string `gorm:"uniqueIndex;size:100" json:"name"`
+	Name string `gorm:"size:100" json:"name"`
+	// IsActive - архивный флаг (soft-delete). Уникальность name обеспечивается
+	// partial unique index (WHERE is_active=true) в migrate.go, а не gorm-тегом,
+	// чтобы архивная запись не блокировала создание новой активной с тем же именем.
+	IsActive bool `gorm:"default:true;index" json:"is_active"`
 }
 
 type Company struct {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -213,6 +213,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	orgg.POST("", org.Create)
 	orgg.PUT("/:id", org.Update)
 	orgg.DELETE("/:id", org.Delete)
+	orgg.POST("/:id/restore", org.Restore)
 	orgg.GET("/with-users", org.GetWithUsers)
 	orgg.GET("/with-users-extended", org.GetWithUsersExtended)
 	orgg.GET("/:id/users", org.GetOrganizationUsers)

--- a/internal/services/organization_service.go
+++ b/internal/services/organization_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 
@@ -13,7 +14,7 @@ import (
 
 // OrganizationService определяет интерфейс бизнес-логики организаций.
 type OrganizationService interface {
-	// GetAll возвращает список всех организаций (id, name).
+	// GetAll возвращает список активных организаций (id, name) - для выпадающих списков.
 	GetAll(ctx context.Context) ([]OrganizationInfoResponse, error)
 
 	// Create создаёт новую организацию. Требует права buropropuskov.
@@ -22,14 +23,17 @@ type OrganizationService interface {
 	// Update обновляет название организации по ID. Требует права buropropuskov.
 	Update(ctx context.Context, id int, req CreateOrganizationRequest) (*OrganizationInfoResponse, error)
 
-	// Delete удаляет организацию. Нельзя удалить если есть пользователи.
+	// Delete архивирует организацию (soft-delete). Нельзя при активных пользователях.
 	Delete(ctx context.Context, id int) error
 
-	// GetWithUsers возвращает организации с количеством пользователей.
-	GetWithUsers(ctx context.Context) ([]OrganizationWithUsersResponse, error)
+	// Restore восстанавливает организацию из архива.
+	Restore(ctx context.Context, id int) error
+
+	// GetWithUsers возвращает организации с количеством пользователей. includeArchived добавляет архивные.
+	GetWithUsers(ctx context.Context, includeArchived bool) ([]OrganizationWithUsersResponse, error)
 
 	// GetWithUsersExtended возвращает организации с количеством пользователей и местами разгрузки.
-	GetWithUsersExtended(ctx context.Context) ([]map[string]any, error)
+	GetWithUsersExtended(ctx context.Context, includeArchived bool) ([]map[string]any, error)
 
 	// GetMyOrganization возвращает организацию текущего пользователя по username.
 	GetMyOrganization(ctx context.Context, username string) (*MyOrganizationResponse, error)
@@ -94,6 +98,7 @@ type OrganizationInfoResponse struct {
 type OrganizationWithUsersResponse struct {
 	ID        int    `json:"id"`
 	Name      string `json:"name"`
+	IsActive  bool   `json:"is_active"`
 	UserCount int64  `json:"user_count"`
 }
 
@@ -168,6 +173,7 @@ func (s *organizationService) GetAll(ctx context.Context) ([]OrganizationInfoRes
 	err := s.db.WithContext(ctx).
 		Table("organizations").
 		Select("id, name").
+		Where("is_active = ?", true).
 		Order("name").
 		Scan(&orgs).Error
 	if err != nil {
@@ -179,7 +185,16 @@ func (s *organizationService) GetAll(ctx context.Context) ([]OrganizationInfoRes
 
 // Create создаёт новую организацию.
 func (s *organizationService) Create(ctx context.Context, req CreateOrganizationRequest) (*OrganizationInfoResponse, error) {
-	org := models.Organization{Name: req.Name}
+	var active int64
+	if err := s.db.WithContext(ctx).Model(&models.Organization{}).
+		Where("name = ? AND is_active = ?", req.Name, true).Count(&active).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error checking organization")
+	}
+	if active > 0 {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "Организация с таким названием уже существует")
+	}
+
+	org := models.Organization{Name: req.Name, IsActive: true}
 	if err := s.db.WithContext(ctx).Create(&org).Error; err != nil {
 		slog.Error("Не удалось создать организацию", "error", err)
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error creating organization")
@@ -191,54 +206,116 @@ func (s *organizationService) Create(ctx context.Context, req CreateOrganization
 // Update обновляет название организации по ID.
 func (s *organizationService) Update(ctx context.Context, id int, req CreateOrganizationRequest) (*OrganizationInfoResponse, error) {
 	var org models.Organization
-	result := s.db.WithContext(ctx).
-		Model(&org).
-		Where("id = ?", id).
-		Update("name", req.Name)
-	if result.Error != nil {
-		slog.Error("Не удалось обновить организацию", "id", id, "error", result.Error)
-		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error updating organization")
+	if err := s.db.WithContext(ctx).First(&org, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, echo.NewHTTPError(http.StatusNotFound, "Organization not found")
+		}
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching organization")
 	}
-	if result.RowsAffected == 0 {
-		return nil, echo.NewHTTPError(http.StatusNotFound, "Organization not found")
+	if !org.IsActive {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "Нельзя переименовать архивную организацию")
+	}
+
+	// Конфликт с другой активной организацией по имени (partial unique).
+	var dup int64
+	if err := s.db.WithContext(ctx).Model(&models.Organization{}).
+		Where("name = ? AND is_active = ? AND id <> ?", req.Name, true, id).Count(&dup).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error checking organization")
+	}
+	if dup > 0 {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "Организация с таким названием уже существует")
+	}
+
+	if err := s.db.WithContext(ctx).Model(&models.Organization{}).
+		Where("id = ?", id).Update("name", req.Name).Error; err != nil {
+		slog.Error("Не удалось обновить организацию", "id", id, "error", err)
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error updating organization")
 	}
 	slog.Info("организация обновлена", "id", id, "name", req.Name)
 	return &OrganizationInfoResponse{ID: id, Name: req.Name}, nil
 }
 
-// Delete удаляет организацию с проверкой отсутствия привязанных пользователей.
+// Delete архивирует организацию (soft-delete: is_active=false). Строка остаётся,
+// поэтому FK заявок/сотрудников/машин не осиротевают. Блокируется при наличии
+// АКТИВНЫХ пользователей в этой организации (их некуда переназначить из активного
+// списка). Исторические заявки/сотрудники/машины архив не блокируют.
 func (s *organizationService) Delete(ctx context.Context, id int) error {
-	// Проверяем наличие пользователей
-	var count int64
-	if err := s.db.WithContext(ctx).
-		Model(&models.User{}).
-		Where("organization_id = ?", id).
-		Count(&count).Error; err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "Error checking users")
+	var org models.Organization
+	if err := s.db.WithContext(ctx).First(&org, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "Organization not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Error fetching organization")
 	}
-	if count > 0 {
-		return echo.NewHTTPError(http.StatusBadRequest, "Cannot delete organization with users")
+	if !org.IsActive {
+		return nil // уже в архиве
 	}
 
-	if err := s.db.WithContext(ctx).Delete(&models.Organization{}, id).Error; err != nil {
-		slog.Error("Не удалось удалить организацию", "id", id, "error", err)
-		return echo.NewHTTPError(http.StatusInternalServerError, "Error deleting organization")
+	var activeUsers int64
+	if err := s.db.WithContext(ctx).
+		Model(&models.User{}).
+		Where("organization_id = ? AND is_active = ?", id, true).
+		Count(&activeUsers).Error; err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Error checking users")
 	}
-	slog.Info("организация удалена", "id", id)
+	if activeUsers > 0 {
+		return echo.NewHTTPError(http.StatusBadRequest, "Нельзя архивировать организацию с активными пользователями")
+	}
+
+	if err := s.db.WithContext(ctx).Model(&models.Organization{}).
+		Where("id = ?", id).Update("is_active", false).Error; err != nil {
+		slog.Error("Не удалось архивировать организацию", "id", id, "error", err)
+		return echo.NewHTTPError(http.StatusInternalServerError, "Error archiving organization")
+	}
+	slog.Info("организация архивирована", "id", id)
+	return nil
+}
+
+// Restore восстанавливает организацию из архива (is_active=true). Если активная
+// организация с таким именем уже есть - конфликт (partial unique), вернём 400.
+func (s *organizationService) Restore(ctx context.Context, id int) error {
+	var org models.Organization
+	if err := s.db.WithContext(ctx).First(&org, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "Organization not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Error fetching organization")
+	}
+	if org.IsActive {
+		return nil // уже активна
+	}
+
+	var active int64
+	if err := s.db.WithContext(ctx).Model(&models.Organization{}).
+		Where("name = ? AND is_active = ? AND id <> ?", org.Name, true, id).Count(&active).Error; err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Error checking organization")
+	}
+	if active > 0 {
+		return echo.NewHTTPError(http.StatusBadRequest, "Активная организация с таким названием уже существует - переименуйте перед восстановлением")
+	}
+
+	if err := s.db.WithContext(ctx).Model(&models.Organization{}).
+		Where("id = ?", id).Update("is_active", true).Error; err != nil {
+		slog.Error("Не удалось восстановить организацию", "id", id, "error", err)
+		return echo.NewHTTPError(http.StatusInternalServerError, "Error restoring organization")
+	}
+	slog.Info("организация восстановлена", "id", id)
 	return nil
 }
 
 // GetWithUsers возвращает организации с количеством привязанных пользователей.
-func (s *organizationService) GetWithUsers(ctx context.Context) ([]OrganizationWithUsersResponse, error) {
+func (s *organizationService) GetWithUsers(ctx context.Context, includeArchived bool) ([]OrganizationWithUsersResponse, error) {
 	orgs := make([]OrganizationWithUsersResponse, 0)
-	err := s.db.WithContext(ctx).
+	q := s.db.WithContext(ctx).
 		Table("organizations o").
-		Select("o.id, o.name, COUNT(u.id) as user_count").
+		Select("o.id, o.name, o.is_active, COUNT(u.id) FILTER (WHERE u.is_active = true) as user_count").
 		Joins("LEFT JOIN users u ON u.organization_id = o.id").
-		Group("o.id").
-		Order("o.name").
-		Scan(&orgs).Error
-	if err != nil {
+		Group("o.id, o.name, o.is_active").
+		Order("o.name")
+	if !includeArchived {
+		q = q.Where("o.is_active = ?", true)
+	}
+	if err := q.Scan(&orgs).Error; err != nil {
 		slog.Error("Не удалось получить организации с пользователями", "error", err)
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching organizations")
 	}
@@ -246,17 +323,19 @@ func (s *organizationService) GetWithUsers(ctx context.Context) ([]OrganizationW
 }
 
 // GetWithUsersExtended возвращает организации с пользователями и местами разгрузки.
-func (s *organizationService) GetWithUsersExtended(ctx context.Context) ([]map[string]any, error) {
+func (s *organizationService) GetWithUsersExtended(ctx context.Context, includeArchived bool) ([]map[string]any, error) {
 	// Получаем базовые данные организаций
 	orgs := make([]OrganizationWithUsersResponse, 0)
-	err := s.db.WithContext(ctx).
+	q := s.db.WithContext(ctx).
 		Table("organizations o").
-		Select("o.id, o.name, COUNT(u.id) as user_count").
+		Select("o.id, o.name, o.is_active, COUNT(u.id) FILTER (WHERE u.is_active = true) as user_count").
 		Joins("LEFT JOIN users u ON u.organization_id = o.id").
-		Group("o.id, o.name").
-		Order("o.name").
-		Scan(&orgs).Error
-	if err != nil {
+		Group("o.id, o.name, o.is_active").
+		Order("o.name")
+	if !includeArchived {
+		q = q.Where("o.is_active = ?", true)
+	}
+	if err := q.Scan(&orgs).Error; err != nil {
 		slog.Error("Не удалось получить расширенную информацию об организациях", "error", err)
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching organizations")
 	}
@@ -276,6 +355,7 @@ func (s *organizationService) GetWithUsersExtended(ctx context.Context) ([]map[s
 		result = append(result, map[string]any{
 			"id":            org.ID,
 			"name":          org.Name,
+			"is_active":     org.IsActive,
 			"user_count":    org.UserCount,
 			"unload_places": places,
 		})


### PR DESCRIPTION
## Что

Срез #412 эпика #406, **backend часть 1** — архив для ОРГАНИЗАЦИЙ (Company - отдельный срез 2).

- `Organization.IsActive` (default true). Delete -> архив (is_active=false), не физическое удаление: заявки/сотрудники/машины не осиротевают.
- Архив блокируется **только при активных пользователях** в орг (решение владельца; applications/employees/cars не блокируют - soft-delete сохраняет их FK, чистого is_active у них нет).
- POST `/organizations/{id}/restore` (admin-only); при конфликте активного имени -> 400.
- GetAll отдаёт только активные (выпадающие списки); with-users/with-users-extended поддерживают `?include_archived=true` и отдают `is_active`. `user_count` считает только активных юзеров.
- Create/Update — пре-проверка дубля активного имени (400); Update блокирует переименование архивной.

## Миграция (санкционировано владельцем)

Глобальный uniqueIndex `idx_organizations_name` заменён на partial unique `WHERE is_active=true` (raw SQL в migrate.go Seed, идемпотентно, ошибка возвращается громко). Архивная «ACME» не блокирует новую активную «ACME».

## Проверка

- `make test` зелёный, go build/vet/gofmt чисто.
- code-reviewer GO. Закрыл все 4 yellow: Y1 (миграция возвращает ошибку), Y2 (Update блокирует архивную + дубль-чек), Y3 (тест restore-конфликта), Y4 (user_count FILTER активных).
- Тесты: archive-семантика (исчезает из default, виден с include_archived), restore, restore-конфликт имени, дубль активного имени, forbidden.
- Миграция (constraint) -> ship-check на staging после деплоя.

## Остаётся по #412

срез 2 (Company архив, то же), срез 3 (история Org+Company), 4-6 (frontend).