### PR TITLE
feat(companies): архив компаний - soft-delete + restore + partial unique (#412)

### DIFF
--- a/cmd/seed/main.go
+++ b/cmd/seed/main.go
@@ -41,7 +41,7 @@ func main() {
 	// ON CONFLICT нужно указать тот же предикат, иначе арбитр-индекс не найдётся.
 	var orgID, compID int
 	db.Raw("INSERT INTO organizations (name) VALUES ('Бюро пропусков') ON CONFLICT (name) WHERE is_active = true DO UPDATE SET name = EXCLUDED.name RETURNING id").Scan(&orgID)
-	db.Raw("INSERT INTO companies (name) VALUES ('Бюро пропусков') ON CONFLICT (name) DO UPDATE SET name = EXCLUDED.name RETURNING id").Scan(&compID)
+	db.Raw("INSERT INTO companies (name) VALUES ('Бюро пропусков') ON CONFLICT (name) WHERE is_active = true DO UPDATE SET name = EXCLUDED.name RETURNING id").Scan(&compID)
 
 	// type_id=6 = buropropuskov
 	var typeID int

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -292,6 +292,14 @@ func Seed(db *gorm.DB) error {
 		return fmt.Errorf("failed to create partial unique index on organizations.name: %w", err)
 	}
 
+	// Companies: то же, что и для organizations (#412).
+	if err := db.Exec("DROP INDEX IF EXISTS idx_companies_name").Error; err != nil {
+		return fmt.Errorf("failed to drop idx_companies_name: %w", err)
+	}
+	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uidx_companies_name_active ON companies (name) WHERE is_active = true").Error; err != nil {
+		return fmt.Errorf("failed to create partial unique index on companies.name: %w", err)
+	}
+
 	// Seed default tab permissions
 	if db.Migrator().HasTable("permissions") {
 		var permCount int64

--- a/internal/handlers/companies.go
+++ b/internal/handlers/companies.go
@@ -50,7 +50,8 @@ func (h *CompanyHandler) GetAll(c echo.Context) error {
 // @Failure      500 {object} models.HTTPError
 // @Router       /companies/with-users [get]
 func (h *CompanyHandler) GetWithUsers(c echo.Context) error {
-	companies, err := h.service.GetWithUsers(c.Request().Context())
+	includeArchived := c.QueryParam("include_archived") == "true"
+	companies, err := h.service.GetWithUsers(c.Request().Context(), includeArchived)
 	if err != nil {
 		return err
 	}
@@ -69,7 +70,8 @@ func (h *CompanyHandler) GetWithUsers(c echo.Context) error {
 // @Failure      500 {object} models.HTTPError
 // @Router       /companies/with-users-extended [get]
 func (h *CompanyHandler) GetWithUsersExtended(c echo.Context) error {
-	companies, err := h.service.GetWithUsersExtended(c.Request().Context())
+	includeArchived := c.QueryParam("include_archived") == "true"
+	companies, err := h.service.GetWithUsersExtended(c.Request().Context(), includeArchived)
 	if err != nil {
 		return err
 	}
@@ -163,7 +165,30 @@ func (h *CompanyHandler) Delete(c echo.Context) error {
 	if err := h.service.Delete(c.Request().Context(), username, id); err != nil {
 		return err
 	}
-	return RespondMessage(c, "Company deleted")
+	return RespondMessage(c, "Company archived")
+}
+
+// Restore godoc
+// @Summary      Восстановить компанию из архива
+// @Tags         companies
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID компании"
+// @Success      200 {string} string "Company restored"
+// @Failure      400 {object} models.HTTPError
+// @Failure      401 {object} models.HTTPError
+// @Failure      403 {object} models.HTTPError
+// @Router       /companies/{id}/restore [post]
+func (h *CompanyHandler) Restore(c echo.Context) error {
+	username := c.Get("username").(string)
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid company ID")
+	}
+	if err := h.service.Restore(c.Request().Context(), username, id); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Company restored")
 }
 
 // GetUsers godoc

--- a/internal/handlers/companies_test.go
+++ b/internal/handlers/companies_test.go
@@ -112,7 +112,87 @@ func TestCompanies_Delete(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 	msg := testutil.ParseMessage(t, rec)
-	assert.Equal(t, "Company deleted", msg)
+	assert.Equal(t, "Company archived", msg)
+
+	// Архивная компания скрыта из списка по умолчанию, видна с include_archived.
+	def := testutil.ParseSlice(t, testutil.GET(t, e, "/companies/with-users", testutil.AuthHeader(token)))
+	for _, c := range def {
+		assert.NotEqual(t, float64(compID), c["id"], "архивная компания не должна быть в списке по умолчанию")
+	}
+	arch := testutil.ParseSlice(t, testutil.GET(t, e, "/companies/with-users?include_archived=true", testutil.AuthHeader(token)))
+	var found bool
+	for _, c := range arch {
+		if int(c["id"].(float64)) == compID {
+			found = true
+			assert.Equal(t, false, c["is_active"])
+		}
+	}
+	assert.True(t, found, "архивная компания должна быть видна с include_archived")
+}
+
+func TestCompanies_Restore(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	created := testutil.ParseMap(t, testutil.POST(t, e, "/companies", `{"name":"To Restore"}`, testutil.AuthHeader(token)))
+	compID := int(created["id"].(float64))
+	require.Equal(t, http.StatusOK, testutil.DELETE(t, e, fmt.Sprintf("/companies/%d", compID), testutil.AuthHeader(token)).Code)
+
+	rec := testutil.POST(t, e, fmt.Sprintf("/companies/%d/restore", compID), "", testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "Company restored", testutil.ParseMessage(t, rec))
+
+	def := testutil.ParseSlice(t, testutil.GET(t, e, "/companies/with-users", testutil.AuthHeader(token)))
+	var found bool
+	for _, c := range def {
+		if int(c["id"].(float64)) == compID {
+			found = true
+			assert.Equal(t, true, c["is_active"])
+		}
+	}
+	assert.True(t, found, "восстановленная компания должна быть в списке по умолчанию")
+}
+
+func TestCompanies_Restore_Forbidden(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAndLogin(t, e, "regularuser", "pass123", 1, td.OrgID, td.CompanyID)
+
+	rec := testutil.POST(t, e, fmt.Sprintf("/companies/%d/restore", td.CompanyID), "", testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestCompanies_Restore_NameConflict_Fails(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	first := testutil.ParseMap(t, testutil.POST(t, e, "/companies", `{"name":"Конфликт Ко"}`, testutil.AuthHeader(token)))
+	firstID := int(first["id"].(float64))
+	require.Equal(t, http.StatusOK, testutil.DELETE(t, e, fmt.Sprintf("/companies/%d", firstID), testutil.AuthHeader(token)).Code)
+	require.Equal(t, http.StatusOK, testutil.POST(t, e, "/companies", `{"name":"Конфликт Ко"}`, testutil.AuthHeader(token)).Code)
+
+	rec := testutil.POST(t, e, fmt.Sprintf("/companies/%d/restore", firstID), "", testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestCompanies_Create_DuplicateActiveName_Fails(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	require.Equal(t, http.StatusOK, testutil.POST(t, e, "/companies", `{"name":"Dup Co"}`, testutil.AuthHeader(token)).Code)
+	rec := testutil.POST(t, e, "/companies", `{"name":"Dup Co"}`, testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
 func TestCompanies_Delete_WithUsers_Fails(t *testing.T) {

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -41,7 +41,10 @@ type Organization struct {
 
 type Company struct {
 	ID   int    `json:"id"`
-	Name string `gorm:"uniqueIndex;size:100" json:"name"`
+	Name string `gorm:"size:100" json:"name"`
+	// IsActive - архивный флаг (soft-delete). Уникальность name - partial unique
+	// index (WHERE is_active=true) в migrate.go, см. Organization.
+	IsActive bool `gorm:"default:true;index" json:"is_active"`
 }
 
 type UserType struct {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -230,6 +230,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	cg.POST("", comp.Create)
 	cg.PUT("/:id", comp.Update)
 	cg.DELETE("/:id", comp.Delete)
+	cg.POST("/:id/restore", comp.Restore)
 	cg.GET("/with-users", comp.GetWithUsers)
 	cg.GET("/with-users-extended", comp.GetWithUsersExtended)
 	cg.GET("/:id/users", comp.GetUsers)

--- a/internal/services/company_service.go
+++ b/internal/services/company_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 
@@ -16,11 +17,11 @@ type CompanyService interface {
 	// GetAll возвращает список всех компаний, отсортированных по имени.
 	GetAll(ctx context.Context) ([]models.Company, error)
 
-	// GetWithUsers возвращает компании с количеством привязанных пользователей.
-	GetWithUsers(ctx context.Context) ([]CompanyWithUsersResponse, error)
+	// GetWithUsers возвращает компании с количеством пользователей. includeArchived добавляет архивные.
+	GetWithUsers(ctx context.Context, includeArchived bool) ([]CompanyWithUsersResponse, error)
 
 	// GetWithUsersExtended возвращает компании с количеством пользователей и местами разгрузки.
-	GetWithUsersExtended(ctx context.Context) ([]CompanyWithUsersExtendedResponse, error)
+	GetWithUsersExtended(ctx context.Context, includeArchived bool) ([]CompanyWithUsersExtendedResponse, error)
 
 	// Create создаёт новую компанию. Требуются права buropropuskov.
 	Create(ctx context.Context, username string, req CreateCompanyRequest) (*models.Company, error)
@@ -28,8 +29,11 @@ type CompanyService interface {
 	// Update обновляет название компании. Требуются права buropropuskov.
 	Update(ctx context.Context, username string, companyID int, req CreateCompanyRequest) (*models.Company, error)
 
-	// Delete удаляет компанию. Нельзя удалить если есть пользователи. Требуются права buropropuskov.
+	// Delete архивирует компанию (soft-delete). Нельзя при активных пользователях. Требуются права buropropuskov.
 	Delete(ctx context.Context, username string, companyID int) error
+
+	// Restore восстанавливает компанию из архива. Требуются права buropropuskov.
+	Restore(ctx context.Context, username string, companyID int) error
 
 	// GetUsers возвращает ответственных пользователей компании.
 	GetUsers(ctx context.Context, companyID int) ([]CompanyUserResponse, error)
@@ -85,6 +89,7 @@ type UpdateCompanyTablesRequest struct {
 type CompanyWithUsersResponse struct {
 	ID        int    `json:"id"`
 	Name      string `json:"name"`
+	IsActive  bool   `json:"is_active"`
 	UserCount int64  `json:"user_count"`
 }
 
@@ -107,6 +112,7 @@ type CompanyTableResponse struct {
 type CompanyWithUsersExtendedResponse struct {
 	ID           int                          `json:"id"`
 	Name         string                       `json:"name"`
+	IsActive     bool                         `json:"is_active"`
 	UserCount    *int64                       `json:"user_count"`
 	UnloadPlaces []CompanyUnloadPlaceResponse `json:"unload_places"`
 }
@@ -137,7 +143,7 @@ func NewCompanyService(db *gorm.DB) CompanyService {
 // GetAll возвращает список всех компаний.
 func (s *companyService) GetAll(ctx context.Context) ([]models.Company, error) {
 	companies := make([]models.Company, 0)
-	if err := s.db.WithContext(ctx).Order("name").Find(&companies).Error; err != nil {
+	if err := s.db.WithContext(ctx).Where("is_active = ?", true).Order("name").Find(&companies).Error; err != nil {
 		slog.Error("не удалось получить компании", "error", err)
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching companies")
 	}
@@ -145,16 +151,18 @@ func (s *companyService) GetAll(ctx context.Context) ([]models.Company, error) {
 }
 
 // GetWithUsers возвращает компании с количеством привязанных пользователей.
-func (s *companyService) GetWithUsers(ctx context.Context) ([]CompanyWithUsersResponse, error) {
+func (s *companyService) GetWithUsers(ctx context.Context, includeArchived bool) ([]CompanyWithUsersResponse, error) {
 	result := make([]CompanyWithUsersResponse, 0)
-	err := s.db.WithContext(ctx).
+	q := s.db.WithContext(ctx).
 		Table("companies c").
-		Select("c.id, c.name, COUNT(u.id) as user_count").
+		Select("c.id, c.name, c.is_active, COUNT(u.id) FILTER (WHERE u.is_active = true) as user_count").
 		Joins("LEFT JOIN users u ON u.company_id = c.id").
-		Group("c.id").
-		Order("c.name").
-		Scan(&result).Error
-	if err != nil {
+		Group("c.id, c.name, c.is_active").
+		Order("c.name")
+	if !includeArchived {
+		q = q.Where("c.is_active = ?", true)
+	}
+	if err := q.Scan(&result).Error; err != nil {
 		slog.Error("не удалось получить компании с пользователями", "error", err)
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching companies")
 	}
@@ -162,22 +170,25 @@ func (s *companyService) GetWithUsers(ctx context.Context) ([]CompanyWithUsersRe
 }
 
 // GetWithUsersExtended возвращает компании с пользователями и местами разгрузки.
-func (s *companyService) GetWithUsersExtended(ctx context.Context) ([]CompanyWithUsersExtendedResponse, error) {
+func (s *companyService) GetWithUsersExtended(ctx context.Context, includeArchived bool) ([]CompanyWithUsersExtendedResponse, error) {
 	// Получаем базовые данные компаний с количеством пользователей
 	type companyRow struct {
 		ID        int
 		Name      string
+		IsActive  bool
 		UserCount *int64
 	}
 	companies := make([]companyRow, 0)
-	err := s.db.WithContext(ctx).
+	q := s.db.WithContext(ctx).
 		Table("companies c").
-		Select("c.id, c.name, COUNT(u.id) as user_count").
+		Select("c.id, c.name, c.is_active, COUNT(u.id) FILTER (WHERE u.is_active = true) as user_count").
 		Joins("LEFT JOIN users u ON u.company_id = c.id").
-		Group("c.id, c.name").
-		Order("c.name").
-		Scan(&companies).Error
-	if err != nil {
+		Group("c.id, c.name, c.is_active").
+		Order("c.name")
+	if !includeArchived {
+		q = q.Where("c.is_active = ?", true)
+	}
+	if err := q.Scan(&companies).Error; err != nil {
 		slog.Error("не удалось получить расширенную информацию о компаниях", "error", err)
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching companies")
 	}
@@ -201,6 +212,7 @@ func (s *companyService) GetWithUsersExtended(ctx context.Context) ([]CompanyWit
 		result = append(result, CompanyWithUsersExtendedResponse{
 			ID:           c.ID,
 			Name:         c.Name,
+			IsActive:     c.IsActive,
 			UserCount:    c.UserCount,
 			UnloadPlaces: places,
 		})
@@ -215,7 +227,16 @@ func (s *companyService) Create(ctx context.Context, username string, req Create
 		return nil, err
 	}
 
-	company := models.Company{Name: req.Name}
+	var active int64
+	if err := s.db.WithContext(ctx).Model(&models.Company{}).
+		Where("name = ? AND is_active = ?", req.Name, true).Count(&active).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error checking company")
+	}
+	if active > 0 {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "Компания с таким названием уже существует")
+	}
+
+	company := models.Company{Name: req.Name, IsActive: true}
 	if err := s.db.WithContext(ctx).Create(&company).Error; err != nil {
 		slog.Error("не удалось создать компанию", "error", err)
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error creating company")
@@ -232,7 +253,22 @@ func (s *companyService) Update(ctx context.Context, username string, companyID 
 
 	var company models.Company
 	if err := s.db.WithContext(ctx).First(&company, companyID).Error; err != nil {
-		return nil, echo.NewHTTPError(http.StatusNotFound, "Company not found")
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, echo.NewHTTPError(http.StatusNotFound, "Company not found")
+		}
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching company")
+	}
+	if !company.IsActive {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "Нельзя переименовать архивную компанию")
+	}
+
+	var dup int64
+	if err := s.db.WithContext(ctx).Model(&models.Company{}).
+		Where("name = ? AND is_active = ? AND id <> ?", req.Name, true, companyID).Count(&dup).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error checking company")
+	}
+	if dup > 0 {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "Компания с таким названием уже существует")
 	}
 
 	company.Name = req.Name
@@ -244,26 +280,76 @@ func (s *companyService) Update(ctx context.Context, username string, companyID 
 	return &company, nil
 }
 
-// Delete удаляет компанию с проверкой отсутствия привязанных пользователей.
+// Delete архивирует компанию (soft-delete: is_active=false). Строка остаётся,
+// FK заявок/сотрудников/машин не осиротевают. Блокируется при активных
+// пользователях компании (как у организаций, #412).
 func (s *companyService) Delete(ctx context.Context, username string, companyID int) error {
 	if err := s.checkAdmin(ctx, username); err != nil {
 		return err
 	}
 
-	// Проверяем наличие пользователей у компании
-	var count int64
-	if err := s.db.WithContext(ctx).Model(&models.User{}).Where("company_id = ?", companyID).Count(&count).Error; err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "Error checking users")
+	var company models.Company
+	if err := s.db.WithContext(ctx).First(&company, companyID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "Company not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Error fetching company")
 	}
-	if count > 0 {
-		return echo.NewHTTPError(http.StatusBadRequest, "Cannot delete company with users")
+	if !company.IsActive {
+		return nil // уже в архиве
 	}
 
-	if err := s.db.WithContext(ctx).Delete(&models.Company{}, companyID).Error; err != nil {
-		slog.Error("не удалось удалить компанию", "id", companyID, "error", err)
-		return echo.NewHTTPError(http.StatusInternalServerError, "Error deleting company")
+	var activeUsers int64
+	if err := s.db.WithContext(ctx).Model(&models.User{}).
+		Where("company_id = ? AND is_active = ?", companyID, true).Count(&activeUsers).Error; err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Error checking users")
 	}
-	slog.Info("компания удалена", "id", companyID)
+	if activeUsers > 0 {
+		return echo.NewHTTPError(http.StatusBadRequest, "Нельзя архивировать компанию с активными пользователями")
+	}
+
+	if err := s.db.WithContext(ctx).Model(&models.Company{}).
+		Where("id = ?", companyID).Update("is_active", false).Error; err != nil {
+		slog.Error("не удалось архивировать компанию", "id", companyID, "error", err)
+		return echo.NewHTTPError(http.StatusInternalServerError, "Error archiving company")
+	}
+	slog.Info("компания архивирована", "id", companyID)
+	return nil
+}
+
+// Restore восстанавливает компанию из архива (is_active=true). Конфликт активного
+// имени -> 400.
+func (s *companyService) Restore(ctx context.Context, username string, companyID int) error {
+	if err := s.checkAdmin(ctx, username); err != nil {
+		return err
+	}
+
+	var company models.Company
+	if err := s.db.WithContext(ctx).First(&company, companyID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "Company not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Error fetching company")
+	}
+	if company.IsActive {
+		return nil // уже активна
+	}
+
+	var active int64
+	if err := s.db.WithContext(ctx).Model(&models.Company{}).
+		Where("name = ? AND is_active = ? AND id <> ?", company.Name, true, companyID).Count(&active).Error; err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Error checking company")
+	}
+	if active > 0 {
+		return echo.NewHTTPError(http.StatusBadRequest, "Активная компания с таким названием уже существует - переименуйте перед восстановлением")
+	}
+
+	if err := s.db.WithContext(ctx).Model(&models.Company{}).
+		Where("id = ?", companyID).Update("is_active", true).Error; err != nil {
+		slog.Error("не удалось восстановить компанию", "id", companyID, "error", err)
+		return echo.NewHTTPError(http.StatusInternalServerError, "Error restoring company")
+	}
+	slog.Info("компания восстановлена", "id", companyID)
 	return nil
 }
 


### PR DESCRIPTION
## Что

Срез #412 эпика #406, **backend часть 2** — архив для КОМПАНИЙ. Полное зеркало среза 1 (организации, #434).

- `Company.IsActive`; Delete -> архив, блок только при активных пользователях; POST `/companies/{id}/restore`.
- GetAll только активные; with-users/extended +`include_archived` +`is_active`; user_count FILTER активных; Create/Update пре-чек дубля активного имени; Update блокирует архивную.
- Partial unique `uidx_companies_name_active` вместо глобального `idx_companies_name`.
- cmd/seed: companies `ON CONFLICT (name) WHERE is_active=true` (тот же 42P10-фикс, что для org в #434 — теперь обе строки seed с предикатом).

## Проверка

- `make test` зелёный, go build/vet/gofmt чисто.
- code-reviewer GO, добавлен недостающий тест паритета `Restore_NameConflict_Fails`.
- Тесты: archive-семантика, restore, restore-конфликт, restore-forbidden, дубль активного имени.
- Миграция + seed -> E2E (проверит seed-фикс для companies) + ship-check staging.

## Остаётся по #412

срез 3 (история Org+Company), 4-6 (frontend).