### PR TITLE
feat(organizations): история изменений организаций (#412)

### DIFF
--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -18,6 +18,7 @@ func AllModels() []interface{} {
 		&models.UserType{},
 		&models.UserTypeHistory{},
 		&models.Organization{},
+		&models.OrganizationHistory{},
 		&models.Company{},
 		&models.Citizenship{},
 		&models.LicensePlateFormat{},

--- a/internal/handlers/organizations.go
+++ b/internal/handlers/organizations.go
@@ -64,7 +64,8 @@ func (h *OrganizationHandler) Create(c echo.Context) error {
 		return err
 	}
 
-	org, err := h.service.Create(c.Request().Context(), req)
+	userID, _ := c.Get("user_id").(int)
+	org, err := h.service.Create(c.Request().Context(), userID, req)
 	if err != nil {
 		return err
 	}
@@ -101,7 +102,8 @@ func (h *OrganizationHandler) Update(c echo.Context) error {
 		return err
 	}
 
-	org, err := h.service.Update(c.Request().Context(), id, req)
+	userID, _ := c.Get("user_id").(int)
+	org, err := h.service.Update(c.Request().Context(), userID, id, req)
 	if err != nil {
 		return err
 	}
@@ -133,7 +135,8 @@ func (h *OrganizationHandler) Delete(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid organization ID")
 	}
 
-	if err := h.service.Delete(c.Request().Context(), id); err != nil {
+	userID, _ := c.Get("user_id").(int)
+	if err := h.service.Delete(c.Request().Context(), userID, id); err != nil {
 		return err
 	}
 	return RespondMessage(c, "Organization archived")
@@ -159,10 +162,37 @@ func (h *OrganizationHandler) Restore(c echo.Context) error {
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid organization ID")
 	}
-	if err := h.service.Restore(c.Request().Context(), id); err != nil {
+	userID, _ := c.Get("user_id").(int)
+	if err := h.service.Restore(c.Request().Context(), userID, id); err != nil {
 		return err
 	}
 	return RespondMessage(c, "Organization restored")
+}
+
+// GetHistory godoc
+// @Summary      История изменений организации
+// @Tags         organizations
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID организации"
+// @Success      200 {array} models.OrganizationHistoryItem
+// @Failure      401 {object} models.HTTPError
+// @Failure      500 {object} models.HTTPError
+// @Router       /organizations/{id}/history [get]
+func (h *OrganizationHandler) GetHistory(c echo.Context) error {
+	username := c.Get("username").(string)
+	if err := services.CheckAdminPermissions(h.db, c.Request().Context(), username); err != nil {
+		return err
+	}
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid organization ID")
+	}
+	items, err := h.service.GetHistory(c.Request().Context(), id)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, items)
 }
 
 // GetWithUsers godoc

--- a/internal/handlers/organizations_test.go
+++ b/internal/handlers/organizations_test.go
@@ -157,6 +157,30 @@ func TestOrganizations_Restore_Forbidden(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 }
 
+func TestOrganizations_History(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	created := testutil.ParseMap(t, testutil.POST(t, e, "/organizations", `{"name":"Ист Орг"}`, h))
+	id := int(created["id"].(float64))
+	require.Equal(t, http.StatusOK, testutil.PUT(t, e, fmt.Sprintf("/organizations/%d", id), `{"name":"Ист Орг 2"}`, h).Code)
+	require.Equal(t, http.StatusOK, testutil.DELETE(t, e, fmt.Sprintf("/organizations/%d", id), h).Code)
+	require.Equal(t, http.StatusOK, testutil.POST(t, e, fmt.Sprintf("/organizations/%d/restore", id), "", h).Code)
+
+	hist := testutil.ParseSlice(t, testutil.GET(t, e, fmt.Sprintf("/organizations/%d/history", id), h))
+	require.Len(t, hist, 4)
+	// Новые сверху: restored, archived, renamed, created.
+	assert.Equal(t, "restored", hist[0]["action_type"])
+	assert.Equal(t, "archived", hist[1]["action_type"])
+	assert.Equal(t, "renamed", hist[2]["action_type"])
+	assert.Equal(t, "created", hist[3]["action_type"])
+	assert.NotEmpty(t, hist[0]["actor_name"])
+}
+
 func TestOrganizations_Restore_NameConflict_Fails(t *testing.T) {
 	e, db, cleanup := testutil.SetupTestApp(t)
 	defer cleanup()

--- a/internal/models/organization_history.go
+++ b/internal/models/organization_history.go
@@ -1,0 +1,38 @@
+package models
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// OrganizationHistory логирует действия над организацией: создание,
+// переименование, архивацию и восстановление. Нужна для аудита (#412).
+//
+// OrganizationID - над какой организацией действие, ActorUserID - кто его
+// совершил. FK намеренно без constraint: аудит должен пережить любые изменения.
+type OrganizationHistory struct {
+	ID             int             `json:"id"`
+	OrganizationID int             `gorm:"index;not null" json:"organization_id"`
+	ActorUserID    *int            `gorm:"index" json:"actor_user_id,omitempty"`
+	ActionType     string          `gorm:"size:32;index" json:"action_type"`
+	Details        json.RawMessage `gorm:"type:jsonb" json:"details,omitempty"`
+	CreatedAt      time.Time       `json:"created_at"`
+}
+
+// OrganizationActionType - константы для OrganizationHistory.ActionType.
+const (
+	OrganizationActionCreated  = "created"
+	OrganizationActionRenamed  = "renamed"
+	OrganizationActionArchived = "archived"
+	OrganizationActionRestored = "restored"
+)
+
+// OrganizationHistoryItem - запись истории с именем актора для API (LEFT JOIN users).
+type OrganizationHistoryItem struct {
+	ID          int             `json:"id"`
+	ActionType  string          `json:"action_type"`
+	Details     json.RawMessage `json:"details,omitempty" swaggerignore:"true"`
+	ActorUserID *int            `json:"actor_user_id,omitempty"`
+	ActorName   string          `json:"actor_name"`
+	CreatedAt   time.Time       `json:"created_at"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -214,6 +214,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	orgg.PUT("/:id", org.Update)
 	orgg.DELETE("/:id", org.Delete)
 	orgg.POST("/:id/restore", org.Restore)
+	orgg.GET("/:id/history", org.GetHistory)
 	orgg.GET("/with-users", org.GetWithUsers)
 	orgg.GET("/with-users-extended", org.GetWithUsersExtended)
 	orgg.GET("/:id/users", org.GetOrganizationUsers)

--- a/internal/services/organization_history_service.go
+++ b/internal/services/organization_history_service.go
@@ -1,0 +1,88 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"systemburo/internal/models"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+// OrganizationHistoryService - аудит действий над организациями (#412).
+type OrganizationHistoryService interface {
+	// Log пишет запись аудита. Ошибка не возвращается: аудит не ломает основное действие.
+	Log(ctx context.Context, organizationID int, actorUserID *int, actionType string, details interface{})
+	// GetHistory возвращает историю по организации (новые сверху).
+	GetHistory(ctx context.Context, organizationID int) ([]models.OrganizationHistoryItem, error)
+}
+
+type organizationHistoryService struct {
+	db *gorm.DB
+}
+
+// NewOrganizationHistoryService создаёт реализацию OrganizationHistoryService.
+func NewOrganizationHistoryService(db *gorm.DB) OrganizationHistoryService {
+	return &organizationHistoryService{db: db}
+}
+
+func (s *organizationHistoryService) Log(ctx context.Context, organizationID int, actorUserID *int, actionType string, details interface{}) {
+	var raw json.RawMessage
+	if details != nil {
+		b, err := json.Marshal(details)
+		if err != nil {
+			slog.Error("organization_history: marshal details", "org", organizationID, "error", err)
+		} else {
+			raw = b
+		}
+	}
+	entry := models.OrganizationHistory{
+		OrganizationID: organizationID,
+		ActorUserID:    actorUserID,
+		ActionType:     actionType,
+		Details:        raw,
+	}
+	if err := s.db.WithContext(ctx).Create(&entry).Error; err != nil {
+		slog.Error("organization_history: insert", "org", organizationID, "action", actionType, "error", err)
+	}
+}
+
+func (s *organizationHistoryService) GetHistory(ctx context.Context, organizationID int) ([]models.OrganizationHistoryItem, error) {
+	type row struct {
+		ID          int             `gorm:"column:id"`
+		ActionType  string          `gorm:"column:action_type"`
+		Details     json.RawMessage `gorm:"column:details"`
+		ActorUserID *int            `gorm:"column:actor_user_id"`
+		ActorName   string          `gorm:"column:actor_name"`
+		CreatedAt   time.Time       `gorm:"column:created_at"`
+	}
+	var rows []row
+	if err := s.db.WithContext(ctx).
+		Table("organization_histories AS h").
+		Select(`h.id, h.action_type, h.details, h.actor_user_id,
+			COALESCE(NULLIF(TRIM(BOTH ' ' FROM CONCAT_WS(' ', u.last_name, u.first_name)), ''), u.username, '') AS actor_name,
+			h.created_at`).
+		Joins("LEFT JOIN users u ON u.id = h.actor_user_id").
+		Where("h.organization_id = ?", organizationID).
+		Order("h.created_at DESC").
+		Scan(&rows).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching organization history")
+	}
+
+	items := make([]models.OrganizationHistoryItem, 0, len(rows))
+	for _, r := range rows {
+		items = append(items, models.OrganizationHistoryItem{
+			ID:          r.ID,
+			ActionType:  r.ActionType,
+			Details:     r.Details,
+			ActorUserID: r.ActorUserID,
+			ActorName:   r.ActorName,
+			CreatedAt:   r.CreatedAt,
+		})
+	}
+	return items, nil
+}

--- a/internal/services/organization_service.go
+++ b/internal/services/organization_service.go
@@ -17,17 +17,20 @@ type OrganizationService interface {
 	// GetAll возвращает список активных организаций (id, name) - для выпадающих списков.
 	GetAll(ctx context.Context) ([]OrganizationInfoResponse, error)
 
-	// Create создаёт новую организацию. Требует права buropropuskov.
-	Create(ctx context.Context, req CreateOrganizationRequest) (*OrganizationInfoResponse, error)
+	// Create создаёт новую организацию. callerUserID - актор для аудита.
+	Create(ctx context.Context, callerUserID int, req CreateOrganizationRequest) (*OrganizationInfoResponse, error)
 
-	// Update обновляет название организации по ID. Требует права buropropuskov.
-	Update(ctx context.Context, id int, req CreateOrganizationRequest) (*OrganizationInfoResponse, error)
+	// Update обновляет название организации по ID. callerUserID - актор для аудита.
+	Update(ctx context.Context, callerUserID, id int, req CreateOrganizationRequest) (*OrganizationInfoResponse, error)
 
 	// Delete архивирует организацию (soft-delete). Нельзя при активных пользователях.
-	Delete(ctx context.Context, id int) error
+	Delete(ctx context.Context, callerUserID, id int) error
 
 	// Restore восстанавливает организацию из архива.
-	Restore(ctx context.Context, id int) error
+	Restore(ctx context.Context, callerUserID, id int) error
+
+	// GetHistory возвращает историю изменений организации.
+	GetHistory(ctx context.Context, id int) ([]models.OrganizationHistoryItem, error)
 
 	// GetWithUsers возвращает организации с количеством пользователей. includeArchived добавляет архивные.
 	GetWithUsers(ctx context.Context, includeArchived bool) ([]OrganizationWithUsersResponse, error)
@@ -138,12 +141,13 @@ type MyOrganizationResponse struct {
 // --- Реализация ---
 
 type organizationService struct {
-	db *gorm.DB
+	db      *gorm.DB
+	history OrganizationHistoryService
 }
 
 // NewOrganizationService создаёт новый экземпляр сервиса организаций.
 func NewOrganizationService(db *gorm.DB) OrganizationService {
-	return &organizationService{db: db}
+	return &organizationService{db: db, history: NewOrganizationHistoryService(db)}
 }
 
 // CheckAdminPermissions проверяет, что пользователь имеет тип buropropuskov.
@@ -184,7 +188,7 @@ func (s *organizationService) GetAll(ctx context.Context) ([]OrganizationInfoRes
 }
 
 // Create создаёт новую организацию.
-func (s *organizationService) Create(ctx context.Context, req CreateOrganizationRequest) (*OrganizationInfoResponse, error) {
+func (s *organizationService) Create(ctx context.Context, callerUserID int, req CreateOrganizationRequest) (*OrganizationInfoResponse, error) {
 	var active int64
 	if err := s.db.WithContext(ctx).Model(&models.Organization{}).
 		Where("name = ? AND is_active = ?", req.Name, true).Count(&active).Error; err != nil {
@@ -200,11 +204,12 @@ func (s *organizationService) Create(ctx context.Context, req CreateOrganization
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error creating organization")
 	}
 	slog.Info("организация создана", "id", org.ID, "name", org.Name)
+	s.history.Log(ctx, org.ID, &callerUserID, models.OrganizationActionCreated, map[string]any{"name": org.Name})
 	return &OrganizationInfoResponse{ID: org.ID, Name: org.Name}, nil
 }
 
 // Update обновляет название организации по ID.
-func (s *organizationService) Update(ctx context.Context, id int, req CreateOrganizationRequest) (*OrganizationInfoResponse, error) {
+func (s *organizationService) Update(ctx context.Context, callerUserID, id int, req CreateOrganizationRequest) (*OrganizationInfoResponse, error) {
 	var org models.Organization
 	if err := s.db.WithContext(ctx).First(&org, id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -232,6 +237,7 @@ func (s *organizationService) Update(ctx context.Context, id int, req CreateOrga
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error updating organization")
 	}
 	slog.Info("организация обновлена", "id", id, "name", req.Name)
+	s.history.Log(ctx, id, &callerUserID, models.OrganizationActionRenamed, map[string]any{"name": req.Name})
 	return &OrganizationInfoResponse{ID: id, Name: req.Name}, nil
 }
 
@@ -239,7 +245,7 @@ func (s *organizationService) Update(ctx context.Context, id int, req CreateOrga
 // поэтому FK заявок/сотрудников/машин не осиротевают. Блокируется при наличии
 // АКТИВНЫХ пользователей в этой организации (их некуда переназначить из активного
 // списка). Исторические заявки/сотрудники/машины архив не блокируют.
-func (s *organizationService) Delete(ctx context.Context, id int) error {
+func (s *organizationService) Delete(ctx context.Context, callerUserID, id int) error {
 	var org models.Organization
 	if err := s.db.WithContext(ctx).First(&org, id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -268,12 +274,13 @@ func (s *organizationService) Delete(ctx context.Context, id int) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "Error archiving organization")
 	}
 	slog.Info("организация архивирована", "id", id)
+	s.history.Log(ctx, id, &callerUserID, models.OrganizationActionArchived, nil)
 	return nil
 }
 
 // Restore восстанавливает организацию из архива (is_active=true). Если активная
 // организация с таким именем уже есть - конфликт (partial unique), вернём 400.
-func (s *organizationService) Restore(ctx context.Context, id int) error {
+func (s *organizationService) Restore(ctx context.Context, callerUserID, id int) error {
 	var org models.Organization
 	if err := s.db.WithContext(ctx).First(&org, id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -300,7 +307,13 @@ func (s *organizationService) Restore(ctx context.Context, id int) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "Error restoring organization")
 	}
 	slog.Info("организация восстановлена", "id", id)
+	s.history.Log(ctx, id, &callerUserID, models.OrganizationActionRestored, nil)
 	return nil
+}
+
+// GetHistory возвращает историю изменений организации.
+func (s *organizationService) GetHistory(ctx context.Context, id int) ([]models.OrganizationHistoryItem, error) {
+	return s.history.GetHistory(ctx, id)
 }
 
 // GetWithUsers возвращает организации с количеством привязанных пользователей.

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -59,7 +59,7 @@ var tables = []string{
 	"license_plate_format_cells", "license_plate_formats",
 	"citizenships",
 	"companies_users", "organization_users",
-	"user_histories", "user_type_histories",
+	"user_histories", "user_type_histories", "organization_histories",
 	"refresh_tokens", "users",
 	"roles",
 	"companies", "organizations", "user_types",


### PR DESCRIPTION
## Что

Срез #412 эпика #406, **backend часть 3a** — аудит изменений организаций (Company - срез 3b).

- `OrganizationHistory` модель + сервис (Log/GetHistory с actor_name) по образцу UserTypeHistory.
- Логирование created/renamed/archived/restored с актором (caller user_id) в Create/Update/Delete/Restore (строго после успеха).
- `GET /organizations/{id}/history` (admin-only).
- История без FK-constraint; organization_histories в CleanDB тестов.

## Проверка

- `make test` зелёный, go build/vet/gofmt чисто.
- code-reviewer GO. Закрыл yellow — добавил CheckAdminPermissions на GetHistory (содержит actor-имена, как другие history-эндпоинты).
- Тест: create->rename->archive->restore -> 4 события в timeline + actor.

## Остаётся по #412

3b (Company история), 4-6 (frontend).