### PR TITLE
feat(companies): история изменений компаний (#412)

### DIFF
--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -20,6 +20,7 @@ func AllModels() []interface{} {
 		&models.Organization{},
 		&models.OrganizationHistory{},
 		&models.Company{},
+		&models.CompanyHistory{},
 		&models.Citizenship{},
 		&models.LicensePlateFormat{},
 		&models.Mark{},

--- a/internal/handlers/companies.go
+++ b/internal/handlers/companies.go
@@ -99,7 +99,8 @@ func (h *CompanyHandler) Create(c echo.Context) error {
 		return err
 	}
 
-	company, err := h.service.Create(c.Request().Context(), username, req)
+	userID, _ := c.Get("user_id").(int)
+	company, err := h.service.Create(c.Request().Context(), username, userID, req)
 	if err != nil {
 		return err
 	}
@@ -133,7 +134,8 @@ func (h *CompanyHandler) Update(c echo.Context) error {
 		return err
 	}
 
-	company, err := h.service.Update(c.Request().Context(), username, id, req)
+	userID, _ := c.Get("user_id").(int)
+	company, err := h.service.Update(c.Request().Context(), username, userID, id, req)
 	if err != nil {
 		return err
 	}
@@ -162,7 +164,8 @@ func (h *CompanyHandler) Delete(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid company ID")
 	}
 
-	if err := h.service.Delete(c.Request().Context(), username, id); err != nil {
+	userID, _ := c.Get("user_id").(int)
+	if err := h.service.Delete(c.Request().Context(), username, userID, id); err != nil {
 		return err
 	}
 	return RespondMessage(c, "Company archived")
@@ -185,10 +188,34 @@ func (h *CompanyHandler) Restore(c echo.Context) error {
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid company ID")
 	}
-	if err := h.service.Restore(c.Request().Context(), username, id); err != nil {
+	userID, _ := c.Get("user_id").(int)
+	if err := h.service.Restore(c.Request().Context(), username, userID, id); err != nil {
 		return err
 	}
 	return RespondMessage(c, "Company restored")
+}
+
+// GetHistory godoc
+// @Summary      История изменений компании
+// @Tags         companies
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID компании"
+// @Success      200 {array} models.CompanyHistoryItem
+// @Failure      401 {object} models.HTTPError
+// @Failure      403 {object} models.HTTPError
+// @Router       /companies/{id}/history [get]
+func (h *CompanyHandler) GetHistory(c echo.Context) error {
+	username := c.Get("username").(string)
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid company ID")
+	}
+	items, err := h.service.GetHistory(c.Request().Context(), username, id)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, items)
 }
 
 // GetUsers godoc

--- a/internal/handlers/companies_test.go
+++ b/internal/handlers/companies_test.go
@@ -167,6 +167,40 @@ func TestCompanies_Restore_Forbidden(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 }
 
+func TestCompanies_History(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	created := testutil.ParseMap(t, testutil.POST(t, e, "/companies", `{"name":"Ист Ко"}`, h))
+	id := int(created["id"].(float64))
+	require.Equal(t, http.StatusOK, testutil.PUT(t, e, fmt.Sprintf("/companies/%d", id), `{"name":"Ист Ко 2"}`, h).Code)
+	require.Equal(t, http.StatusOK, testutil.DELETE(t, e, fmt.Sprintf("/companies/%d", id), h).Code)
+	require.Equal(t, http.StatusOK, testutil.POST(t, e, fmt.Sprintf("/companies/%d/restore", id), "", h).Code)
+
+	hist := testutil.ParseSlice(t, testutil.GET(t, e, fmt.Sprintf("/companies/%d/history", id), h))
+	require.Len(t, hist, 4)
+	assert.Equal(t, "restored", hist[0]["action_type"])
+	assert.Equal(t, "archived", hist[1]["action_type"])
+	assert.Equal(t, "renamed", hist[2]["action_type"])
+	assert.Equal(t, "created", hist[3]["action_type"])
+	assert.NotEmpty(t, hist[0]["actor_name"])
+}
+
+func TestCompanies_History_Forbidden(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAndLogin(t, e, "regularuser", "pass123", 1, td.OrgID, td.CompanyID)
+
+	rec := testutil.GET(t, e, fmt.Sprintf("/companies/%d/history", td.CompanyID), testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
 func TestCompanies_Restore_NameConflict_Fails(t *testing.T) {
 	e, db, cleanup := testutil.SetupTestApp(t)
 	defer cleanup()

--- a/internal/models/company_history.go
+++ b/internal/models/company_history.go
@@ -1,0 +1,38 @@
+package models
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// CompanyHistory логирует действия над компанией: создание, переименование,
+// архивацию и восстановление. Нужна для аудита (#412).
+//
+// CompanyID - над какой компанией действие, ActorUserID - кто его совершил.
+// FK намеренно без constraint: аудит должен пережить любые изменения.
+type CompanyHistory struct {
+	ID          int             `json:"id"`
+	CompanyID   int             `gorm:"index;not null" json:"company_id"`
+	ActorUserID *int            `gorm:"index" json:"actor_user_id,omitempty"`
+	ActionType  string          `gorm:"size:32;index" json:"action_type"`
+	Details     json.RawMessage `gorm:"type:jsonb" json:"details,omitempty"`
+	CreatedAt   time.Time       `json:"created_at"`
+}
+
+// CompanyActionType - константы для CompanyHistory.ActionType.
+const (
+	CompanyActionCreated  = "created"
+	CompanyActionRenamed  = "renamed"
+	CompanyActionArchived = "archived"
+	CompanyActionRestored = "restored"
+)
+
+// CompanyHistoryItem - запись истории с именем актора для API (LEFT JOIN users).
+type CompanyHistoryItem struct {
+	ID          int             `json:"id"`
+	ActionType  string          `json:"action_type"`
+	Details     json.RawMessage `json:"details,omitempty" swaggerignore:"true"`
+	ActorUserID *int            `json:"actor_user_id,omitempty"`
+	ActorName   string          `json:"actor_name"`
+	CreatedAt   time.Time       `json:"created_at"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -232,6 +232,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	cg.PUT("/:id", comp.Update)
 	cg.DELETE("/:id", comp.Delete)
 	cg.POST("/:id/restore", comp.Restore)
+	cg.GET("/:id/history", comp.GetHistory)
 	cg.GET("/with-users", comp.GetWithUsers)
 	cg.GET("/with-users-extended", comp.GetWithUsersExtended)
 	cg.GET("/:id/users", comp.GetUsers)

--- a/internal/services/company_history_service.go
+++ b/internal/services/company_history_service.go
@@ -1,0 +1,88 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"systemburo/internal/models"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+// CompanyHistoryService - аудит действий над компаниями (#412).
+type CompanyHistoryService interface {
+	// Log пишет запись аудита. Ошибка не возвращается: аудит не ломает основное действие.
+	Log(ctx context.Context, companyID int, actorUserID *int, actionType string, details interface{})
+	// GetHistory возвращает историю по компании (новые сверху).
+	GetHistory(ctx context.Context, companyID int) ([]models.CompanyHistoryItem, error)
+}
+
+type companyHistoryService struct {
+	db *gorm.DB
+}
+
+// NewCompanyHistoryService создаёт реализацию CompanyHistoryService.
+func NewCompanyHistoryService(db *gorm.DB) CompanyHistoryService {
+	return &companyHistoryService{db: db}
+}
+
+func (s *companyHistoryService) Log(ctx context.Context, companyID int, actorUserID *int, actionType string, details interface{}) {
+	var raw json.RawMessage
+	if details != nil {
+		b, err := json.Marshal(details)
+		if err != nil {
+			slog.Error("company_history: marshal details", "company", companyID, "error", err)
+		} else {
+			raw = b
+		}
+	}
+	entry := models.CompanyHistory{
+		CompanyID:   companyID,
+		ActorUserID: actorUserID,
+		ActionType:  actionType,
+		Details:     raw,
+	}
+	if err := s.db.WithContext(ctx).Create(&entry).Error; err != nil {
+		slog.Error("company_history: insert", "company", companyID, "action", actionType, "error", err)
+	}
+}
+
+func (s *companyHistoryService) GetHistory(ctx context.Context, companyID int) ([]models.CompanyHistoryItem, error) {
+	type row struct {
+		ID          int             `gorm:"column:id"`
+		ActionType  string          `gorm:"column:action_type"`
+		Details     json.RawMessage `gorm:"column:details"`
+		ActorUserID *int            `gorm:"column:actor_user_id"`
+		ActorName   string          `gorm:"column:actor_name"`
+		CreatedAt   time.Time       `gorm:"column:created_at"`
+	}
+	var rows []row
+	if err := s.db.WithContext(ctx).
+		Table("company_histories AS h").
+		Select(`h.id, h.action_type, h.details, h.actor_user_id,
+			COALESCE(NULLIF(TRIM(BOTH ' ' FROM CONCAT_WS(' ', u.last_name, u.first_name)), ''), u.username, '') AS actor_name,
+			h.created_at`).
+		Joins("LEFT JOIN users u ON u.id = h.actor_user_id").
+		Where("h.company_id = ?", companyID).
+		Order("h.created_at DESC").
+		Scan(&rows).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching company history")
+	}
+
+	items := make([]models.CompanyHistoryItem, 0, len(rows))
+	for _, r := range rows {
+		items = append(items, models.CompanyHistoryItem{
+			ID:          r.ID,
+			ActionType:  r.ActionType,
+			Details:     r.Details,
+			ActorUserID: r.ActorUserID,
+			ActorName:   r.ActorName,
+			CreatedAt:   r.CreatedAt,
+		})
+	}
+	return items, nil
+}

--- a/internal/services/company_service.go
+++ b/internal/services/company_service.go
@@ -23,17 +23,20 @@ type CompanyService interface {
 	// GetWithUsersExtended возвращает компании с количеством пользователей и местами разгрузки.
 	GetWithUsersExtended(ctx context.Context, includeArchived bool) ([]CompanyWithUsersExtendedResponse, error)
 
-	// Create создаёт новую компанию. Требуются права buropropuskov.
-	Create(ctx context.Context, username string, req CreateCompanyRequest) (*models.Company, error)
+	// Create создаёт новую компанию. callerUserID - актор для аудита. Требуются права buropropuskov.
+	Create(ctx context.Context, username string, callerUserID int, req CreateCompanyRequest) (*models.Company, error)
 
-	// Update обновляет название компании. Требуются права buropropuskov.
-	Update(ctx context.Context, username string, companyID int, req CreateCompanyRequest) (*models.Company, error)
+	// Update обновляет название компании. callerUserID - актор для аудита. Требуются права buropropuskov.
+	Update(ctx context.Context, username string, callerUserID, companyID int, req CreateCompanyRequest) (*models.Company, error)
 
-	// Delete архивирует компанию (soft-delete). Нельзя при активных пользователях. Требуются права buropropuskov.
-	Delete(ctx context.Context, username string, companyID int) error
+	// Delete архивирует компанию (soft-delete). callerUserID - актор. Нельзя при активных пользователях. Требуются права buropropuskov.
+	Delete(ctx context.Context, username string, callerUserID, companyID int) error
 
-	// Restore восстанавливает компанию из архива. Требуются права buropropuskov.
-	Restore(ctx context.Context, username string, companyID int) error
+	// Restore восстанавливает компанию из архива. callerUserID - актор. Требуются права buropropuskov.
+	Restore(ctx context.Context, username string, callerUserID, companyID int) error
+
+	// GetHistory возвращает историю изменений компании. Требуются права buropropuskov.
+	GetHistory(ctx context.Context, username string, companyID int) ([]models.CompanyHistoryItem, error)
 
 	// GetUsers возвращает ответственных пользователей компании.
 	GetUsers(ctx context.Context, companyID int) ([]CompanyUserResponse, error)
@@ -132,12 +135,13 @@ type CompanyUserResponse struct {
 // --- Реализация ---
 
 type companyService struct {
-	db *gorm.DB
+	db      *gorm.DB
+	history CompanyHistoryService
 }
 
 // NewCompanyService создаёт экземпляр сервиса компаний.
 func NewCompanyService(db *gorm.DB) CompanyService {
-	return &companyService{db: db}
+	return &companyService{db: db, history: NewCompanyHistoryService(db)}
 }
 
 // GetAll возвращает список всех компаний.
@@ -222,7 +226,7 @@ func (s *companyService) GetWithUsersExtended(ctx context.Context, includeArchiv
 }
 
 // Create создаёт новую компанию (admin-only).
-func (s *companyService) Create(ctx context.Context, username string, req CreateCompanyRequest) (*models.Company, error) {
+func (s *companyService) Create(ctx context.Context, username string, callerUserID int, req CreateCompanyRequest) (*models.Company, error) {
 	if err := s.checkAdmin(ctx, username); err != nil {
 		return nil, err
 	}
@@ -242,11 +246,12 @@ func (s *companyService) Create(ctx context.Context, username string, req Create
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error creating company")
 	}
 	slog.Info("компания создана", "id", company.ID, "name", company.Name)
+	s.history.Log(ctx, company.ID, &callerUserID, models.CompanyActionCreated, map[string]any{"name": company.Name})
 	return &company, nil
 }
 
 // Update обновляет название компании (admin-only).
-func (s *companyService) Update(ctx context.Context, username string, companyID int, req CreateCompanyRequest) (*models.Company, error) {
+func (s *companyService) Update(ctx context.Context, username string, callerUserID, companyID int, req CreateCompanyRequest) (*models.Company, error) {
 	if err := s.checkAdmin(ctx, username); err != nil {
 		return nil, err
 	}
@@ -277,13 +282,14 @@ func (s *companyService) Update(ctx context.Context, username string, companyID 
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error updating company")
 	}
 	slog.Info("компания обновлена", "id", companyID, "name", company.Name)
+	s.history.Log(ctx, companyID, &callerUserID, models.CompanyActionRenamed, map[string]any{"name": company.Name})
 	return &company, nil
 }
 
 // Delete архивирует компанию (soft-delete: is_active=false). Строка остаётся,
 // FK заявок/сотрудников/машин не осиротевают. Блокируется при активных
 // пользователях компании (как у организаций, #412).
-func (s *companyService) Delete(ctx context.Context, username string, companyID int) error {
+func (s *companyService) Delete(ctx context.Context, username string, callerUserID, companyID int) error {
 	if err := s.checkAdmin(ctx, username); err != nil {
 		return err
 	}
@@ -314,12 +320,13 @@ func (s *companyService) Delete(ctx context.Context, username string, companyID 
 		return echo.NewHTTPError(http.StatusInternalServerError, "Error archiving company")
 	}
 	slog.Info("компания архивирована", "id", companyID)
+	s.history.Log(ctx, companyID, &callerUserID, models.CompanyActionArchived, nil)
 	return nil
 }
 
 // Restore восстанавливает компанию из архива (is_active=true). Конфликт активного
 // имени -> 400.
-func (s *companyService) Restore(ctx context.Context, username string, companyID int) error {
+func (s *companyService) Restore(ctx context.Context, username string, callerUserID, companyID int) error {
 	if err := s.checkAdmin(ctx, username); err != nil {
 		return err
 	}
@@ -350,7 +357,16 @@ func (s *companyService) Restore(ctx context.Context, username string, companyID
 		return echo.NewHTTPError(http.StatusInternalServerError, "Error restoring company")
 	}
 	slog.Info("компания восстановлена", "id", companyID)
+	s.history.Log(ctx, companyID, &callerUserID, models.CompanyActionRestored, nil)
 	return nil
+}
+
+// GetHistory возвращает историю изменений компании (admin-only).
+func (s *companyService) GetHistory(ctx context.Context, username string, companyID int) ([]models.CompanyHistoryItem, error) {
+	if err := s.checkAdmin(ctx, username); err != nil {
+		return nil, err
+	}
+	return s.history.GetHistory(ctx, companyID)
 }
 
 // GetUsers возвращает ответственных пользователей компании.

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -59,7 +59,7 @@ var tables = []string{
 	"license_plate_format_cells", "license_plate_formats",
 	"citizenships",
 	"companies_users", "organization_users",
-	"user_histories", "user_type_histories", "organization_histories",
+	"user_histories", "user_type_histories", "organization_histories", "company_histories",
 	"refresh_tokens", "users",
 	"roles",
 	"companies", "organizations", "user_types",


### PR DESCRIPTION
## Что

Срез #412 эпика #406, **backend 3b** — аудит изменений компаний. Зеркало org-history (#436).

- CompanyHistory модель + сервис (Log/GetHistory с actor_name).
- Логирование created/renamed/archived/restored с актором в Create/Update/Delete/Restore (после успеха).
- GET /companies/{id}/history (admin-проверка в сервисе через username, т.к. CompanyHandler без db).
- company_histories в AllModels + CleanDB.

## Проверка

make test зелёный, code-reviewer GO. Тесты: create->rename->archive->restore -> 4 события + actor + forbidden для не-админа.

## #412 далее

backend (1,2,3a,3b) ГОТОВ. Осталось frontend: 4 (Orgs + удаление мёртвого OrganizationCompanyManagement.vue), 5 (Companies), 6 (история-модалки).