### PR TITLE
fix(marks): шапка управления марками под эталон (#409)

### DIFF
--- a/frontend/src/components/MarksManagement.vue
+++ b/frontend/src/components/MarksManagement.vue
@@ -560,21 +560,27 @@ export default {
 
 <style scoped>
 .marks-container {
-  padding: 20px;
+  background: #fff;
+  border-radius: 16px;
+  border: 1px solid #e6e6e6;
+  overflow: hidden;
 }
 
 .management-header {
   display: flex;
-  align-items: center;
   justify-content: space-between;
-  margin-bottom: 16px;
+  align-items: center;
+  padding: 0 20px;
+  border-bottom: 1px solid #e6e6e6;
+  height: 50px;
   gap: 12px;
-  flex-wrap: wrap;
 }
 
 .management-title {
   margin: 0;
-  font-size: 18px;
+  font-size: 1.2em;
+  font-weight: 600;
+  color: #000;
 }
 
 .header-controls {
@@ -592,8 +598,6 @@ export default {
   display: flex;
   height: 500px;
   width: 100%;
-  border: 1px solid #e6e6e6;
-  border-radius: 15px;
   overflow: hidden;
 }
 
@@ -1049,6 +1053,17 @@ export default {
 }
 
 @media (max-width: 768px) {
+  .management-header {
+    flex-direction: column;
+    align-items: flex-start;
+    height: auto;
+    padding: 16px;
+  }
+  .header-controls {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+  }
   .content-container {
     flex-direction: column;
     height: auto;


### PR DESCRIPTION
Замечание владельца: у `MarksManagement` шапка не как в эталоне - был внутренний padding 20px на контейнере, а шапка без фиксированной высоты 50px и без `border-bottom`. В эталоне (`TableConstructor.vue:1136-1153`) и в остальных карточках управления контейнер без padding, шапка ровно 50px с разделителем.

## Что сделал
- `.marks-container`: убрал `padding: 20px`, добавил `border-radius`/`border`/`overflow: hidden` как у `OrganizationsManagement` (фон/радиус приходят от общего `.dashboard-card`).
- `.management-header`: `height: 50px` + `padding: 0 20px` + `border-bottom: 1px solid #e6e6e6`, убрал `margin-bottom` и `flex-wrap` (шапка больше не «плавающая»).
- `.management-title`: привёл к эталону (`1.2em`, weight 600, color #000).
- `.content-container`: убрал собственные `border`/`border-radius` (рамку теперь даёт контейнер).
- Добавил мобильную раскладку шапки в `@media (max-width: 768px)` (колонкой), т.к. убрал `flex-wrap`.

Проверено локально: контейнер padding 0, шапка 50px, border-bottom присутствует, 0 ошибок в консоли.

Часть эпика #406 (доведение #409 Marks до эталона).