### PR TITLE
fix(users): дифф истории старое->новое + анимация и стиль модалки (#410)

### DIFF
--- a/frontend/src/components/UserControl.vue
+++ b/frontend/src/components/UserControl.vue
@@ -1703,6 +1703,12 @@ export default {
   color: #a2a2a2;
 }
 
+/* Значения дропдаунов (Организация/Компания/Тип) в деталях - как обычный текст,
+   вровень с соседними инпутами (а не полужирным весом BaseDropdown по умолчанию). */
+.detail-group :deep(.base-dropdown__text) {
+  font-weight: 400;
+}
+
 /* Уменьшенные инпуты */
 .form-input-sm {
   padding: 6px 10px;

--- a/frontend/src/components/UserHistoryModal.vue
+++ b/frontend/src/components/UserHistoryModal.vue
@@ -2,6 +2,7 @@
   <Teleport to="body">
     <div
       class="modal-overlay"
+      :class="{ 'modal-leaving': leaving }"
       data-testid="user-history-modal"
       @mousedown="onOverlayMousedown"
       @mouseup="onOverlayMouseup"
@@ -232,9 +233,11 @@ export default {
     currentUserName: { type: String, default: '' },
   },
   emits: ['close'],
-  setup(_, { emit }) {
-    const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(() => emit('close'));
-    return { onOverlayMousedown, onOverlayMouseup };
+  setup() {
+    // close() (с leave-анимацией) присваивается в created - чтобы overlay-клик уходил через неё.
+    const overlay = { close: () => {} };
+    const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(() => overlay.close());
+    return { onOverlayMousedown, onOverlayMouseup, overlay };
   },
   data() {
     return {
@@ -247,6 +250,7 @@ export default {
       dateTo: '',
       userDropdownOpen: false,
       isExporting: false,
+      leaving: false,
     };
   },
   computed: {
@@ -341,6 +345,9 @@ export default {
       }));
     },
   },
+  created() {
+    this.overlay.close = () => this.close();
+  },
   mounted() {
     this.loadHistory();
     document.addEventListener('click', this.handleClickOutside);
@@ -355,10 +362,14 @@ export default {
       if (e.key === 'Escape') this.close();
     },
     close() {
-      this.$emit('close');
+      // leave-анимация: ставим флаг, эмитим close после её завершения.
+      if (this.leaving) return;
+      this.leaving = true;
+      setTimeout(() => this.$emit('close'), 250);
     },
     handleClickOutside(event) {
-      const select = this.$el && this.$el.querySelector ? this.$el.querySelector('.custom-select') : null;
+      // Контент в Teleport -> ищем дропдаун в body (this.$el под Teleport = якорь-коммент).
+      const select = document.querySelector('.user-history-modal .custom-select');
       if (select && !select.contains(event.target)) {
         this.userDropdownOpen = false;
       }
@@ -371,6 +382,8 @@ export default {
         if (response.ok) {
           const data = await response.json();
           this.history = Array.isArray(data) ? data : [];
+        } else {
+          useDeletionsStore().notify({ prefix: 'Не удалось загрузить ', bold: 'историю пользователя', type: 'error' });
         }
       } catch (error) {
         console.error('Error loading user history:', error);
@@ -424,17 +437,24 @@ export default {
         case 'updated': {
           const parts = [];
           for (const [key, raw] of Object.entries(d)) {
-            if (raw === null || raw === undefined || raw === '') continue;
             const label = FIELD_LABELS[key] || key;
-            parts.push(`${label}: ${this.formatFieldValue(raw)}`);
+            if (this.isDiff(raw)) {
+              parts.push(`${label}: ${this.fieldOrDash(raw.old)} → ${this.fieldOrDash(raw.new)}`);
+            } else if (raw !== null && raw !== undefined && raw !== '') {
+              // старый формат записей (снапшот значения без old/new)
+              parts.push(`${label}: ${this.formatFieldValue(raw)}`);
+            }
           }
           return parts.join(' / ');
         }
         case 'type_changed':
+          if (this.isDiff(d)) return `${this.typeName(d.old)} → ${this.typeName(d.new)}`;
           return `Новый тип: ${this.typeName(d.type_id)}`;
         case 'org_changed':
+          if (this.isDiff(d)) return `${this.orgName(d.old)} → ${this.orgName(d.new)}`;
           return `Новая организация: ${this.orgName(d.organization_id)}`;
         case 'company_changed':
+          if (this.isDiff(d)) return `${this.companyName(d.old)} → ${this.companyName(d.new)}`;
           return `Новая компания: ${this.companyName(d.company_id)}`;
         case 'password_reset':
         case 'archived':
@@ -442,6 +462,15 @@ export default {
         default:
           return '';
       }
+    },
+
+    isDiff(v) {
+      return v !== null && typeof v === 'object' && ('old' in v || 'new' in v);
+    },
+
+    fieldOrDash(value) {
+      if (value === null || value === undefined || value === '') return '—';
+      return this.formatFieldValue(value);
     },
 
     formatFieldValue(value) {
@@ -618,6 +647,25 @@ export default {
 @keyframes slideUp {
   from { transform: translateY(20px); opacity: 0; }
   to { transform: translateY(0); opacity: 1; }
+}
+
+/* Анимация закрытия: класс modal-leaving вешается на overlay перед эмитом close. */
+.modal-overlay.modal-leaving {
+  animation: fadeOut 0.25s ease-in forwards;
+}
+
+.modal-overlay.modal-leaving .user-history-modal {
+  animation: slideDown 0.25s ease-in forwards;
+}
+
+@keyframes fadeOut {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
+@keyframes slideDown {
+  from { transform: translateY(0); opacity: 1; }
+  to { transform: translateY(20px); opacity: 0; }
 }
 
 .modal-header {

--- a/internal/services/user_service.go
+++ b/internal/services/user_service.go
@@ -175,6 +175,9 @@ func (s *userService) UpdateType(ctx context.Context, callerTypeID, callerUserID
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid user type")
 	}
 
+	var oldType int
+	s.db.WithContext(ctx).Table("users").Where("username = ?", username).Select("type_id").Row().Scan(&oldType)
+
 	if err := s.db.WithContext(ctx).
 		Table("users").
 		Where("username = ?", username).
@@ -182,8 +185,10 @@ func (s *userService) UpdateType(ctx context.Context, callerTypeID, callerUserID
 		return echo.NewHTTPError(http.StatusInternalServerError, "Error updating user type")
 	}
 
-	if id := s.targetUserID(ctx, username); id != 0 {
-		s.history.Log(ctx, id, &callerUserID, models.UserActionTypeChanged, map[string]any{"type_id": req.TypeID})
+	if req.TypeID != oldType {
+		if id := s.targetUserID(ctx, username); id != 0 {
+			s.history.Log(ctx, id, &callerUserID, models.UserActionTypeChanged, map[string]any{"old": oldType, "new": req.TypeID})
+		}
 	}
 	return nil
 }
@@ -290,6 +295,22 @@ func (s *userService) UpdateInfo(ctx context.Context, callerTypeID, callerUserID
 		return err
 	}
 
+	// Снимок старых значений до апдейта - чтобы в историю писать дифф "старое -> новое"
+	// и только по реально изменившимся полям (фронт шлёт все поля каждый раз).
+	var prev struct {
+		LastName   string
+		FirstName  string
+		MiddleName string
+		Position   string
+		Email      string
+		Phone      string
+	}
+	s.db.WithContext(ctx).
+		Table("users").
+		Where("username = ?", username).
+		Select("last_name", "first_name", "middle_name", "position", "email", "phone").
+		Scan(&prev)
+
 	if err := s.db.WithContext(ctx).
 		Table("users").
 		Where("username = ?", username).
@@ -305,27 +326,22 @@ func (s *userService) UpdateInfo(ctx context.Context, callerTypeID, callerUserID
 	}
 
 	if id := s.targetUserID(ctx, username); id != 0 {
-		// В детали пишем только переданные (non-nil) поля - иначе история покажет "поле: -".
+		// Только изменившиеся поля, как {old, new}. Если ничего не поменялось - не логируем.
 		details := map[string]any{}
-		if req.LastName != nil {
-			details["last_name"] = *req.LastName
+		diff := func(key string, np *string, old string) {
+			if np != nil && *np != old {
+				details[key] = map[string]any{"old": old, "new": *np}
+			}
 		}
-		if req.FirstName != nil {
-			details["first_name"] = *req.FirstName
+		diff("last_name", req.LastName, prev.LastName)
+		diff("first_name", req.FirstName, prev.FirstName)
+		diff("middle_name", req.MiddleName, prev.MiddleName)
+		diff("position", req.Position, prev.Position)
+		diff("email", req.Email, prev.Email)
+		diff("phone", req.Phone, prev.Phone)
+		if len(details) > 0 {
+			s.history.Log(ctx, id, &callerUserID, models.UserActionUpdated, details)
 		}
-		if req.MiddleName != nil {
-			details["middle_name"] = *req.MiddleName
-		}
-		if req.Position != nil {
-			details["position"] = *req.Position
-		}
-		if req.Email != nil {
-			details["email"] = *req.Email
-		}
-		if req.Phone != nil {
-			details["phone"] = *req.Phone
-		}
-		s.history.Log(ctx, id, &callerUserID, models.UserActionUpdated, details)
 	}
 	return nil
 }
@@ -336,6 +352,13 @@ func (s *userService) UpdateOrganization(ctx context.Context, callerTypeID, call
 		return err
 	}
 
+	var prev struct{ OrganizationID *int }
+	s.db.WithContext(ctx).Table("users").Where("username = ?", username).Select("organization_id").Scan(&prev)
+	oldVal := 0
+	if prev.OrganizationID != nil {
+		oldVal = *prev.OrganizationID
+	}
+
 	if err := s.db.WithContext(ctx).
 		Table("users").
 		Where("username = ?", username).
@@ -343,8 +366,10 @@ func (s *userService) UpdateOrganization(ctx context.Context, callerTypeID, call
 		return echo.NewHTTPError(http.StatusInternalServerError, "Error updating organization")
 	}
 
-	if id := s.targetUserID(ctx, username); id != 0 {
-		s.history.Log(ctx, id, &callerUserID, models.UserActionOrgChanged, map[string]any{"organization_id": req.OrganizationID})
+	if req.OrganizationID != oldVal {
+		if id := s.targetUserID(ctx, username); id != 0 {
+			s.history.Log(ctx, id, &callerUserID, models.UserActionOrgChanged, map[string]any{"old": prev.OrganizationID, "new": req.OrganizationID})
+		}
 	}
 	return nil
 }
@@ -355,6 +380,13 @@ func (s *userService) UpdateCompany(ctx context.Context, callerTypeID, callerUse
 		return err
 	}
 
+	var prev struct{ CompanyID *int }
+	s.db.WithContext(ctx).Table("users").Where("username = ?", username).Select("company_id").Scan(&prev)
+	oldVal := 0
+	if prev.CompanyID != nil {
+		oldVal = *prev.CompanyID
+	}
+
 	if err := s.db.WithContext(ctx).
 		Table("users").
 		Where("username = ?", username).
@@ -362,8 +394,10 @@ func (s *userService) UpdateCompany(ctx context.Context, callerTypeID, callerUse
 		return echo.NewHTTPError(http.StatusInternalServerError, "Error updating company")
 	}
 
-	if id := s.targetUserID(ctx, username); id != 0 {
-		s.history.Log(ctx, id, &callerUserID, models.UserActionCompanyChanged, map[string]any{"company_id": req.CompanyID})
+	if req.CompanyID != oldVal {
+		if id := s.targetUserID(ctx, username); id != 0 {
+			s.history.Log(ctx, id, &callerUserID, models.UserActionCompanyChanged, map[string]any{"old": prev.CompanyID, "new": req.CompanyID})
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Замечания владельца по ревью раздела «Учётные записи пользователей».

## Что чинит
1. **История пишет дифф, а не снапшот.** При смене фамилии история показывала `Email: … / Телефон: … / Должность: … / Фамилия: … / Имя: … / Отчество: …` (фронт шлёт все поля каждый раз). Теперь `UpdateInfo` снимает старые значения до апдейта и логирует только реально изменившиеся поля как `{old, new}`. Смена типа/организации/компании тоже пишется как `старое → новое` и только при фактическом изменении (если значение не поменялось — записи нет).
2. **Модалка истории читает дифф:** `Фамилия: Соколов → Медведев`, `Организация: АО Демо-Логистика → ООО Демо-Партнёр`. Старые записи (без `old/new`) по-прежнему читаются (backward-compat).
3. **Анимация закрытия** модалки истории (leave-fade + slide-down) — раньше она просто пропадала.
4. **Закрытие по клику вне** под `Teleport` теперь ищет дропдаун через `document` (раньше `this.$el` = якорь-коммент, дропдаун не закрывался), + `notify` при ошибке загрузки истории.
5. **Значения Организация/Компания/Тип в деталях пользователя** больше не полужирные (`.base-dropdown__text` 500 → 400 в деталях) — вровень с соседними инпутами.

## Проверка
- Backend: `go test ./internal/services/... ./internal/handlers/...` зелёный, gofmt чисто.
- Frontend: `npm run test:run` — 301 зелёный, eslint чисто.
- Локально на staging-сборке backend: сменил фамилию + организацию у пользователя, история показала корректный дифф `старое → новое`, модалка закрывается с анимацией, дропдауны деталей не жирные, 0 ошибок в консоли.

## Отдельным PR (по согласованию)
- Объединение кнопок «Права доступа» + «Роль и группы» в одну с табами — следующий срез (#410), требует аккуратного рефактора общего `UserPermissionsModal`.

Часть эпика #406.