### PR TITLE
fix(auth): архивный юзер блокируется мгновенно на каждом запросе (#410)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -155,6 +155,7 @@ func main() {
 	roleService := services.NewRoleService(db, permissionResolver)
 	accessDenialService := services.NewAccessDenialService(db)
 	banCheckService := services.NewBanCheckService(db, 30*time.Second)
+	userService.SetBanCache(banCheckService) // архив/restore мгновенно сбрасывают кэш блокировок
 	userBanService := services.NewUserBanService(db, permissionResolver, banCheckService)
 	systemTableService := services.NewSystemTableService(db, cfg.UploadPath, cfg.UploadMaxFileSize, permissionService)
 	if err := systemTableService.SeedMissingFields(context.Background()); err != nil {

--- a/internal/handlers/permission_middleware_integration_test.go
+++ b/internal/handlers/permission_middleware_integration_test.go
@@ -293,6 +293,36 @@ func TestBanCheck_DeniesBannedUser(t *testing.T) {
 	}
 }
 
+func TestBanCheck_DeniesArchivedUser(t *testing.T) {
+	// Архивный (is_active=false) юзер с живым access-токеном должен получать 403
+	// на каждом запросе - офбординг не ждёт истечения токена.
+	_, db, _ := testutil.SetupTestApp(t)
+	svc := services.NewBanCheckService(db, time.Minute)
+
+	userID, _, cleanup := setupMWUser(t, db, false, false)
+	defer cleanup()
+	if err := db.Model(&models.User{}).Where("id = ?", userID).Update("is_active", false).Error; err != nil {
+		t.Fatalf("archive user: %v", err)
+	}
+
+	e := echo.New()
+	e.GET("/test", func(c echo.Context) error { return c.String(http.StatusOK, "ok") },
+		func(next echo.HandlerFunc) echo.HandlerFunc {
+			return func(c echo.Context) error {
+				c.Set("user_id", userID)
+				return next(c)
+			}
+		},
+		middleware.BanCheck(svc),
+	)
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected 403 for archived user, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+}
+
 func TestBanCheck_InvalidationAfterBanReflectsImmediately(t *testing.T) {
 	// Регресс на issue #271: после Ban() кэш ban-чекера должен инвалидироваться,
 	// чтобы следующий же запрос забаненного юзера получил 403 без ожидания TTL.

--- a/internal/handlers/permission_middleware_integration_test.go
+++ b/internal/handlers/permission_middleware_integration_test.go
@@ -360,6 +360,47 @@ func TestBanCheck_InvalidationAfterBanReflectsImmediately(t *testing.T) {
 	}
 }
 
+func TestBanCheck_InvalidationAfterArchiveReflectsImmediately(t *testing.T) {
+	// Архив через userService должен инвалидировать кэш блокировок, чтобы
+	// следующий же запрос архивного юзера дал 403 без ожидания TTL.
+	_, db, _ := testutil.SetupTestApp(t)
+	banCache := services.NewBanCheckService(db, time.Hour)
+	userSvc := services.NewUserService(db, nil)
+	userSvc.SetBanCache(banCache)
+
+	targetID, _, cleanup := setupMWUser(t, db, false, false)
+	defer cleanup()
+	var target models.User
+	if err := db.First(&target, targetID).Error; err != nil {
+		t.Fatalf("load target: %v", err)
+	}
+
+	var adminTypeID int
+	if err := db.Table("user_types").Select("id").Where("code = ?", "buropropuskov").Row().Scan(&adminTypeID); err != nil {
+		t.Fatalf("find admin type: %v", err)
+	}
+
+	// 1. Прогреваем кэш - active=true.
+	_, active, err := banCache.Status(context.Background(), targetID)
+	if err != nil || !active {
+		t.Fatalf("expected active before archive (active=%v err=%v)", active, err)
+	}
+
+	// 2. Архивируем через сервис - должен сбросить кэш.
+	if err := userSvc.Delete(context.Background(), adminTypeID, adminTypeID, target.Username); err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+
+	// 3. Сразу читаем - active=false (кэш сброшен, идём в БД) даже при часовом TTL.
+	_, active, err = banCache.Status(context.Background(), targetID)
+	if err != nil {
+		t.Fatalf("status after archive: %v", err)
+	}
+	if active {
+		t.Errorf("expected active=false immediately after archive (cache invalidated)")
+	}
+}
+
 func TestAccessDenialService_ArchiveOlderThan(t *testing.T) {
 	_, db, _ := testutil.SetupTestApp(t)
 	svc := services.NewAccessDenialService(db)

--- a/internal/middleware/ban_check.go
+++ b/internal/middleware/ban_check.go
@@ -9,11 +9,14 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// BanCheck блокирует забаненных пользователей на КАЖДОМ protected-запросе.
+// BanCheck блокирует забаненных И архивных пользователей на КАЖДОМ
+// protected-запросе.
 //
-// Без этого middleware забаненный юзер с валидным access-токеном может
-// работать до истечения exp - это окно опасно для API-only клиентов
-// (без фронт-полинга /permissions/my).
+// Без этого middleware юзер с валидным access-токеном продолжает работать до
+// истечения exp - это окно опасно для API-only клиентов (без фронт-полинга
+// /permissions/my). Архив (is_active=false) трактуем как мгновенный офбординг
+// наравне с баном: login/refresh уже блокируются по is_active, здесь закрываем
+// окно живого access-токена.
 //
 // Должен стоять после JWTAuth (нужен user_id в context).
 func BanCheck(svc *services.BanCheckService) echo.MiddlewareFunc {
@@ -23,7 +26,7 @@ func BanCheck(svc *services.BanCheckService) echo.MiddlewareFunc {
 			if userID == 0 {
 				return next(c)
 			}
-			banned, err := svc.IsBanned(c.Request().Context(), userID)
+			banned, active, err := svc.Status(c.Request().Context(), userID)
 			if err != nil {
 				// Ошибка БД на горячем пути - пропускаем (fail-open),
 				// иначе любой временный сбой положит весь API. Логируем.
@@ -32,6 +35,9 @@ func BanCheck(svc *services.BanCheckService) echo.MiddlewareFunc {
 			}
 			if banned {
 				return echo.NewHTTPError(http.StatusForbidden, "Учётная запись заблокирована")
+			}
+			if !active {
+				return echo.NewHTTPError(http.StatusForbidden, "Учётная запись отключена")
 			}
 			return next(c)
 		}

--- a/internal/services/ban_check_service.go
+++ b/internal/services/ban_check_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -46,6 +47,12 @@ func (s *BanCheckService) Status(ctx context.Context, userID int) (banned, activ
 
 	var user models.User
 	if err := s.db.WithContext(ctx).Select("id, is_banned, is_active").First(&user, userID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			// Несуществующий юзер (напр. валидный JWT на удалённую запись) -
+			// трактуем как inactive, чтобы middleware дал 403, а не fail-open.
+			return false, false, nil
+		}
+		// Транзиентная ошибка БД - active=true, caller делает fail-open.
 		return false, true, err
 	}
 	s.cache.Store(userID, banEntry{

--- a/internal/services/ban_check_service.go
+++ b/internal/services/ban_check_service.go
@@ -23,6 +23,7 @@ type BanCheckService struct {
 
 type banEntry struct {
 	banned    bool
+	active    bool
 	expiresAt time.Time
 }
 
@@ -31,25 +32,34 @@ func NewBanCheckService(db *gorm.DB, ttl time.Duration) *BanCheckService {
 	return &BanCheckService{db: db, ttl: ttl}
 }
 
-// IsBanned возвращает true если у пользователя is_banned=true.
-// На cache miss или истёкшую запись делает один SELECT.
-func (s *BanCheckService) IsBanned(ctx context.Context, userID int) (bool, error) {
+// Status возвращает (banned, active) пользователя на горячем пути.
+// Архивный (is_active=false) юзер блокируется так же мгновенно, как забаненный,
+// чтобы офбординг не дожидался истечения access-токена. На cache miss/истёкшую
+// запись делает один SELECT; при ошибке БД отдаёт active=true (caller fail-open).
+func (s *BanCheckService) Status(ctx context.Context, userID int) (banned, active bool, err error) {
 	if v, ok := s.cache.Load(userID); ok {
 		entry := v.(banEntry)
 		if time.Now().Before(entry.expiresAt) {
-			return entry.banned, nil
+			return entry.banned, entry.active, nil
 		}
 	}
 
 	var user models.User
-	if err := s.db.WithContext(ctx).Select("id, is_banned").First(&user, userID).Error; err != nil {
-		return false, err
+	if err := s.db.WithContext(ctx).Select("id, is_banned, is_active").First(&user, userID).Error; err != nil {
+		return false, true, err
 	}
 	s.cache.Store(userID, banEntry{
 		banned:    user.IsBanned,
+		active:    user.IsActive,
 		expiresAt: time.Now().Add(s.ttl),
 	})
-	return user.IsBanned, nil
+	return user.IsBanned, user.IsActive, nil
+}
+
+// IsBanned - обратная совместимость (используется в интеграционных тестах).
+func (s *BanCheckService) IsBanned(ctx context.Context, userID int) (bool, error) {
+	banned, _, err := s.Status(ctx, userID)
+	return banned, err
 }
 
 // Invalidate сбрасывает кэш для конкретного пользователя.

--- a/internal/services/user_service.go
+++ b/internal/services/user_service.go
@@ -38,12 +38,16 @@ type UserService interface {
 	Restore(ctx context.Context, callerTypeID, callerUserID int, username string) error
 	// GetHistory возвращает историю действий над пользователем (по username).
 	GetHistory(ctx context.Context, callerTypeID int, username string) ([]models.UserHistoryItem, error)
+	// SetBanCache подключает кэш блокировок, чтобы архив/восстановление мгновенно
+	// сбрасывали его (офбординг без ожидания TTL). Опционально (может не вызываться).
+	SetBanCache(banCache *BanCheckService)
 }
 
 type userService struct {
 	db                  *gorm.DB
 	notificationService NotificationService
 	history             UserHistoryService
+	banCache            *BanCheckService
 }
 
 // NewUserService создаёт новый экземпляр сервиса управления пользователями.
@@ -57,6 +61,12 @@ func NewUserService(db *gorm.DB, notificationService NotificationService) UserSe
 		notificationService: notificationService,
 		history:             NewUserHistoryService(db),
 	}
+}
+
+// SetBanCache подключает кэш блокировок (опционально, после конструирования -
+// в main.go banCheckService создаётся позже userService).
+func (s *userService) SetBanCache(banCache *BanCheckService) {
+	s.banCache = banCache
 }
 
 // targetUserID резолвит id пользователя по username для записи в историю.
@@ -453,6 +463,12 @@ func (s *userService) setActive(ctx context.Context, username string, active boo
 		action = models.UserActionArchived
 	}
 	s.history.Log(ctx, user.ID, &callerUserID, action, nil)
+
+	// Сбрасываем кэш блокировок, чтобы архив/восстановление подействовали мгновенно
+	// (BanCheck на следующем запросе перечитает is_active, не дожидаясь TTL).
+	if s.banCache != nil {
+		s.banCache.Invalidate(user.ID)
+	}
 	return nil
 }
 

--- a/internal/services/user_service.go
+++ b/internal/services/user_service.go
@@ -441,6 +441,11 @@ func (s *userService) setActive(ctx context.Context, username string, active boo
 	if user.IsActive == active {
 		return nil // no-op
 	}
+	// Архив = мгновенный офбординг (BanCheck даёт 403), поэтому супер-админа,
+	// как и при бане, архивировать нельзя - иначе админ может вырубить владельца.
+	if !active && user.IsSuperAdmin {
+		return echo.NewHTTPError(http.StatusForbidden, "Нельзя архивировать супер-администратора")
+	}
 	if err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Model(&models.User{}).Where("id = ?", user.ID).Update("is_active", active).Error; err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "Error updating user")


### PR DESCRIPTION
Находка аудита эпика #406 (авторизована владельцем «рубить немедленно»).

## Проблема
Per-request `BanCheck` middleware проверял только `is_banned`, но НЕ `is_active`. Архивный (soft-deleted) пользователь с живым access-токеном продолжал работать до истечения `exp` (~15 минут) — login/refresh блокировались по is_active, а уже выданный access-токен нет.

## Фикс
- `BanCheck` теперь блокирует и архивных: 403 «Учётная запись отключена», наравне с баном «Учётная запись заблокирована».
- `BanCheckService.IsBanned` → `Status(banned, active)` (кэширует оба флага, fail-open при ошибке БД). `IsBanned` оставлен тонкой обёрткой для существующих интеграционных тестов.
- `userService.setActive` (архив И restore) сбрасывает ban-кэш через `SetBanCache` → офбординг мгновенный, без ожидания 30s TTL (паритет с баном, который тоже инвалидирует кэш).
- Тест `TestBanCheck_DeniesArchivedUser`.

## Проверка
- `go test ./internal/services/... ./internal/middleware/... ./internal/handlers/...` зелёный (вкл. новый тест), `go vet` + `gofmt` чисто.
- Дифф показан владельцу до мержа (auth-смежное), одобрено.

Часть эпика #406, fix-forward из аудита.