### PR TITLE
feat(blacklist): бэкенд чёрного списка машин с каскадом и историей (#443)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -175,6 +175,8 @@ func main() {
 	bugReportService := services.NewBugReportService(db, telegramService)
 	maintenanceService := services.NewMaintenanceService(db)
 	markService := services.NewMarkService(db)
+	vehicleBlacklistHistoryService := services.NewVehicleBlacklistHistoryService(db)
+	vehicleBlacklistService := services.NewVehicleBlacklistService(db, vehicleBlacklistHistoryService)
 	attachmentTemplateService := services.NewAttachmentTemplateService(db, cfg.UploadPath)
 	attachmentBlankService := services.NewAttachmentBlankService(db)
 	trashService := services.NewTrashService(db)
@@ -213,6 +215,7 @@ func main() {
 	bugReportHandler := handlers.NewBugReportHandler(bugReportService)
 	maintenanceHandler := handlers.NewMaintenanceHandler(maintenanceService)
 	markHandler := handlers.NewMarkHandler(markService)
+	vehicleBlacklistHandler := handlers.NewVehicleBlacklistHandler(vehicleBlacklistService)
 	attachmentTemplateHandler := handlers.NewAttachmentTemplateHandler(attachmentTemplateService)
 	attachmentBlankHandler := handlers.NewAttachmentBlankHandler(attachmentBlankService)
 	trashHandler := handlers.NewTrashHandler(trashService, trashDBRef)
@@ -266,6 +269,7 @@ func main() {
 		BugReport:           bugReportHandler,
 		Maintenance:         maintenanceHandler,
 		Marks:               markHandler,
+		VehicleBlacklist:    vehicleBlacklistHandler,
 		AttachmentTemplates: attachmentTemplateHandler,
 		AttachmentBlanks:    attachmentBlankHandler,
 		Trash:               trashHandler,

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-playground/validator/v10 v10.30.2
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0
+	github.com/jackc/pgx/v5 v5.9.0
 	github.com/labstack/echo/v4 v4.15.1
 	github.com/stretchr/testify v1.11.1
 	github.com/swaggo/echo-swagger v1.5.2
@@ -29,7 +30,6 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.9.0 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -25,6 +25,8 @@ func AllModels() []interface{} {
 		&models.LicensePlateFormat{},
 		&models.Mark{},
 		&models.MarkHistory{},
+		&models.VehicleBlacklist{},
+		&models.VehicleBlacklistHistory{},
 		&models.UnloadPlace{},
 		&models.SystemTable{},
 		&models.SystemTableHistory{},
@@ -300,6 +302,19 @@ func Seed(db *gorm.DB) error {
 	}
 	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uidx_companies_name_active ON companies (name) WHERE is_active = true").Error; err != nil {
 		return fmt.Errorf("failed to create partial unique index on companies.name: %w", err)
+	}
+
+	// Чёрный список машин: уникальность (car_number, mark_id) только среди активных
+	// записей (#443), чтобы снятая запись не мешала повторно добавить ту же машину.
+	// Индекс по LOWER(TRIM(car_number)) - чтобы инвариант совпадал с регистронезависимым
+	// матчем в Check/каскаде (иначе "A123"/"a123" - два активных дубля). DROP+CREATE,
+	// чтобы переопределить старую (raw-column) версию индекса. Идемпотентно. Ошибку
+	// возвращаем громко - от индекса зависит инвариант дублей.
+	if err := db.Exec("DROP INDEX IF EXISTS uidx_vehicle_blacklists_active").Error; err != nil {
+		return fmt.Errorf("failed to drop uidx_vehicle_blacklists_active: %w", err)
+	}
+	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uidx_vehicle_blacklists_active ON vehicle_blacklists (LOWER(TRIM(car_number)), mark_id) WHERE is_active = true").Error; err != nil {
+		return fmt.Errorf("failed to create partial unique index on vehicle_blacklists: %w", err)
 	}
 
 	// Seed default tab permissions

--- a/internal/handlers/vehicle_blacklist.go
+++ b/internal/handlers/vehicle_blacklist.go
@@ -1,0 +1,142 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+
+	"github.com/labstack/echo/v4"
+)
+
+// VehicleBlacklistHandler - HTTP-обработчики чёрного списка автомобилей (#443).
+type VehicleBlacklistHandler struct {
+	service services.VehicleBlacklistService
+}
+
+// NewVehicleBlacklistHandler создаёт обработчик.
+func NewVehicleBlacklistHandler(service services.VehicleBlacklistService) *VehicleBlacklistHandler {
+	return &VehicleBlacklistHandler{service: service}
+}
+
+// GetAll godoc
+// @Summary      Список чёрного списка машин
+// @Tags         vehicle-blacklist
+// @Produce      json
+// @Security     BearerAuth
+// @Param        include_archived query bool false "Включать снятые записи"
+// @Success      200 {array} models.VehicleBlacklist
+// @Router       /vehicle-blacklist [get]
+func (h *VehicleBlacklistHandler) GetAll(c echo.Context) error {
+	includeArchived := c.QueryParam("include_archived") == "true"
+	items, err := h.service.GetAll(c.Request().Context(), includeArchived)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, items)
+}
+
+// Create godoc
+// @Summary      Добавить машину в чёрный список
+// @Tags         vehicle-blacklist
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        request body models.CreateVehicleBlacklistRequest true "Данные записи"
+// @Success      201 {object} models.VehicleBlacklist
+// @Router       /vehicle-blacklist [post]
+func (h *VehicleBlacklistHandler) Create(c echo.Context) error {
+	var req models.CreateVehicleBlacklistRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	userID, _ := c.Get("user_id").(int)
+	entry, err := h.service.Create(c.Request().Context(), req, userID)
+	if err != nil {
+		return err
+	}
+	return RespondCreated(c, entry)
+}
+
+// Delete godoc
+// @Summary      Снять машину с чёрного списка (архивация)
+// @Tags         vehicle-blacklist
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID записи"
+// @Success      200 {string} string "Машина снята с чёрного списка"
+// @Router       /vehicle-blacklist/{id} [delete]
+func (h *VehicleBlacklistHandler) Delete(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	userID, _ := c.Get("user_id").(int)
+	if err := h.service.Archive(c.Request().Context(), id, userID); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Машина снята с чёрного списка")
+}
+
+// Restore godoc
+// @Summary      Вернуть машину в чёрный список
+// @Tags         vehicle-blacklist
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID записи"
+// @Success      200 {string} string "Машина возвращена в чёрный список"
+// @Router       /vehicle-blacklist/{id}/restore [post]
+func (h *VehicleBlacklistHandler) Restore(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	userID, _ := c.Get("user_id").(int)
+	if err := h.service.Restore(c.Request().Context(), id, userID); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Машина возвращена в чёрный список")
+}
+
+// Check godoc
+// @Summary      Проверить, в чёрном ли списке машина
+// @Tags         vehicle-blacklist
+// @Produce      json
+// @Security     BearerAuth
+// @Param        car_number query string true "Номер машины"
+// @Param        mark_id query int true "ID марки"
+// @Success      200 {object} models.VehicleBlacklistCheckResult
+// @Router       /vehicle-blacklist/check [get]
+func (h *VehicleBlacklistHandler) Check(c echo.Context) error {
+	carNumber := c.QueryParam("car_number")
+	markID, err := strconv.Atoi(c.QueryParam("mark_id"))
+	if carNumber == "" || err != nil || markID <= 0 {
+		return echo.NewHTTPError(http.StatusBadRequest, "car_number и mark_id обязательны")
+	}
+	res, err := h.service.Check(c.Request().Context(), carNumber, markID)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, res)
+}
+
+// GetHistory godoc
+// @Summary      История записи чёрного списка машин
+// @Tags         vehicle-blacklist
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID записи"
+// @Success      200 {array} models.VehicleBlacklistHistoryItem
+// @Router       /vehicle-blacklist/{id}/history [get]
+func (h *VehicleBlacklistHandler) GetHistory(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	history, err := h.service.GetHistory(c.Request().Context(), id)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, history)
+}

--- a/internal/handlers/vehicle_blacklist_test.go
+++ b/internal/handlers/vehicle_blacklist_test.go
@@ -1,0 +1,243 @@
+package handlers_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+	"systemburo/internal/testutil"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func newVehicleBlacklistService(db *gorm.DB) services.VehicleBlacklistService {
+	return services.NewVehicleBlacklistService(db, services.NewVehicleBlacklistHistoryService(db))
+}
+
+// seedMark пересоздаёт марку с заданным именем (marks не чистятся CleanDB - убираем
+// возможный остаток от прошлого прогона) и регистрирует cleanup.
+func seedMark(t *testing.T, db *gorm.DB, name string) models.Mark {
+	t.Helper()
+	db.Where("name = ?", name).Delete(&models.Mark{})
+	mark := models.Mark{Name: name, IsActive: true}
+	require.NoError(t, db.Create(&mark).Error)
+	t.Cleanup(func() {
+		db.Where("mark_id = ?", mark.ID).Delete(&models.MarkHistory{})
+		db.Delete(&models.Mark{}, mark.ID)
+	})
+	return mark
+}
+
+func assertHTTPStatus(t *testing.T, err error, code int) {
+	t.Helper()
+	require.Error(t, err)
+	var he *echo.HTTPError
+	require.True(t, errors.As(err, &he), "expected *echo.HTTPError, got %T: %v", err, err)
+	assert.Equal(t, code, he.Code)
+}
+
+// TestVehicleBlacklist_Lifecycle покрывает create/check/duplicate/archive/restore без cars.
+func TestVehicleBlacklist_Lifecycle(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	userID, _, userCleanup := setupMWUser(t, db, true, false)
+	defer userCleanup()
+	mark := seedMark(t, db, "BL_Lifecycle")
+	svc := newVehicleBlacklistService(db)
+	ctx := context.Background()
+
+	entry, err := svc.Create(ctx, models.CreateVehicleBlacklistRequest{
+		CarNumber: "A123BC799", MarkID: mark.ID, Reason: "тест",
+	}, userID)
+	require.NoError(t, err)
+	require.NotZero(t, entry.ID)
+	assert.Equal(t, "BL_Lifecycle", entry.MarkName, "должен снапшотить имя марки")
+
+	checks := []struct {
+		name      string
+		number    string
+		markID    int
+		wantBlock bool
+	}{
+		{"matching number+mark", "A123BC799", mark.ID, true},
+		{"case/space insensitive", "  a123bc799 ", mark.ID, true},
+		{"other mark", "A123BC799", mark.ID + 999999, false},
+		{"other number", "X000XX000", mark.ID, false},
+	}
+	for _, tc := range checks {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := svc.Check(ctx, tc.number, tc.markID)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantBlock, res.IsBlacklisted)
+			if tc.wantBlock {
+				assert.Equal(t, "тест", res.Reason)
+			}
+		})
+	}
+
+	// Повторное добавление активной записи (даже в другом регистре) блокируется
+	// partial unique index-ом по LOWER(TRIM(car_number)).
+	_, err = svc.Create(ctx, models.CreateVehicleBlacklistRequest{
+		CarNumber: "a123bc799", MarkID: mark.ID, Reason: "дубль",
+	}, userID)
+	assertHTTPStatus(t, err, 409)
+
+	// Несуществующая марка -> 400.
+	_, err = svc.Create(ctx, models.CreateVehicleBlacklistRequest{
+		CarNumber: "Z999ZZ", MarkID: 99999999, Reason: "x",
+	}, userID)
+	assertHTTPStatus(t, err, 400)
+
+	// Снятие (архивация) - больше не блокирует.
+	require.NoError(t, svc.Archive(ctx, entry.ID, userID))
+	res, err := svc.Check(ctx, "A123BC799", mark.ID)
+	require.NoError(t, err)
+	assert.False(t, res.IsBlacklisted)
+
+	active, err := svc.GetAll(ctx, false)
+	require.NoError(t, err)
+	assert.Empty(t, active)
+	all, err := svc.GetAll(ctx, true)
+	require.NoError(t, err)
+	assert.Len(t, all, 1)
+
+	// После архивации ту же машину можно добавить заново (partial unique).
+	entry2, err := svc.Create(ctx, models.CreateVehicleBlacklistRequest{
+		CarNumber: "A123BC799", MarkID: mark.ID, Reason: "снова",
+	}, userID)
+	require.NoError(t, err)
+	assert.NotEqual(t, entry.ID, entry2.ID)
+
+	// Restore архивной записи при наличии активного дубля -> 409.
+	assertHTTPStatus(t, svc.Restore(ctx, entry.ID, userID), 409)
+
+	// История содержит created + archived для первой записи.
+	hist, err := svc.GetHistory(ctx, entry.ID)
+	require.NoError(t, err)
+	actions := make([]string, 0, len(hist))
+	for _, h := range hist {
+		actions = append(actions, h.ActionType)
+	}
+	assert.Contains(t, actions, models.BlacklistActionCreated)
+	assert.Contains(t, actions, models.BlacklistActionArchived)
+}
+
+// TestVehicleBlacklist_CascadeDeactivatesActiveCar: добавление в ЧС гасит активную машину.
+func TestVehicleBlacklist_CascadeDeactivatesActiveCar(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "blcasc1", "pass123", 1, td.OrgID, td.CompanyID)
+	userID := getUserID(t, db, "blcasc1")
+	appID, _, carID := seedCarViaCompleteApp(t, e, db, token, "Test Organization")
+	activateCarViaApp(t, e, db, appID, td)
+
+	var before models.Car
+	require.NoError(t, db.First(&before, carID).Error)
+	require.NotNil(t, before.Status)
+	require.Equal(t, 1, *before.Status, "машина должна быть активна до ЧС")
+
+	// car_brand="Kamaz" зашит в seedCarViaCompleteApp; марку называем так же, чтобы
+	// каскад сматчил по имени (mark_id у тестовой машины пуст).
+	mark := seedMark(t, db, "Kamaz")
+	svc := newVehicleBlacklistService(db)
+	entry, err := svc.Create(context.Background(), models.CreateVehicleBlacklistRequest{
+		CarNumber: "B002BB799", MarkID: mark.ID, Reason: "угон",
+	}, userID)
+	require.NoError(t, err)
+
+	var after models.Car
+	require.NoError(t, db.First(&after, carID).Error)
+	require.NotNil(t, after.Status)
+	assert.Equal(t, 0, *after.Status, "машина должна деактивироваться")
+	assert.NotNil(t, after.DateRemoved, "date_removed должен проставиться")
+
+	var carHistCount int64
+	db.Model(&models.CarHistory{}).Where("car_id = ? AND action_type = ?", carID, "blacklisted").Count(&carHistCount)
+	assert.Equal(t, int64(1), carHistCount, "должна быть запись cars_history blacklisted")
+
+	var blHistCount int64
+	db.Model(&models.VehicleBlacklistHistory{}).Where("entity_id = ? AND action_type = ?", entry.ID, models.BlacklistActionCreated).Count(&blHistCount)
+	assert.Equal(t, int64(1), blHistCount)
+}
+
+// TestVehicleBlacklist_UnblacklistRestoresActiveApplicationCar: снятие из ЧС возвращает
+// status=1 машине с активной заявкой.
+func TestVehicleBlacklist_UnblacklistRestoresActiveApplicationCar(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "blcasc2", "pass123", 1, td.OrgID, td.CompanyID)
+	userID := getUserID(t, db, "blcasc2")
+	appID, _, carID := seedCarViaCompleteApp(t, e, db, token, "Test Organization")
+	activateCarViaApp(t, e, db, appID, td)
+
+	mark := seedMark(t, db, "Kamaz")
+	svc := newVehicleBlacklistService(db)
+	ctx := context.Background()
+
+	entry, err := svc.Create(ctx, models.CreateVehicleBlacklistRequest{
+		CarNumber: "B002BB799", MarkID: mark.ID, Reason: "проверка",
+	}, userID)
+	require.NoError(t, err)
+
+	var blacklisted models.Car
+	require.NoError(t, db.First(&blacklisted, carID).Error)
+	require.Equal(t, 0, *blacklisted.Status)
+
+	require.NoError(t, svc.Archive(ctx, entry.ID, userID))
+
+	var restored models.Car
+	require.NoError(t, db.First(&restored, carID).Error)
+	require.NotNil(t, restored.Status)
+	assert.Equal(t, 1, *restored.Status, "машина с активной заявкой должна вернуться в status=1")
+	assert.Nil(t, restored.DateRemoved, "date_removed должен очиститься")
+
+	var carHistCount int64
+	db.Model(&models.CarHistory{}).Where("car_id = ? AND action_type = ?", carID, "unblacklisted").Count(&carHistCount)
+	assert.Equal(t, int64(1), carHistCount, "должна быть запись cars_history unblacklisted")
+}
+
+// TestVehicleBlacklist_UnblacklistSkipsExpiredPass: снятие из ЧС не возрождает машину,
+// у которой за время блокировки истёк пропуск (дата неактуальна).
+func TestVehicleBlacklist_UnblacklistSkipsExpiredPass(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "blexp1", "pass123", 1, td.OrgID, td.CompanyID)
+	userID := getUserID(t, db, "blexp1")
+	appID, _, carID := seedCarViaCompleteApp(t, e, db, token, "Test Organization")
+	activateCarViaApp(t, e, db, appID, td)
+
+	mark := seedMark(t, db, "Kamaz")
+	svc := newVehicleBlacklistService(db)
+	ctx := context.Background()
+
+	entry, err := svc.Create(ctx, models.CreateVehicleBlacklistRequest{
+		CarNumber: "B002BB799", MarkID: mark.ID, Reason: "проверка",
+	}, userID)
+	require.NoError(t, err)
+
+	// Пропуск истёк, пока машина была в ЧС.
+	require.NoError(t, db.Model(&models.Car{}).Where("id = ?", carID).Update("entry_date_to", "2000-01-01").Error)
+
+	require.NoError(t, svc.Archive(ctx, entry.ID, userID))
+
+	var after models.Car
+	require.NoError(t, db.First(&after, carID).Error)
+	require.NotNil(t, after.Status)
+	assert.Equal(t, 0, *after.Status, "машина с истёкшим пропуском не должна возрождаться")
+}

--- a/internal/models/blacklist.go
+++ b/internal/models/blacklist.go
@@ -56,11 +56,12 @@ type CreateVehicleBlacklistRequest struct {
 }
 
 // VehicleBlacklistHistoryItem - элемент истории для API (с именем пользователя).
+// Details игнорируется swag-ом (json.RawMessage он не резолвит) - как в SystemTableHistoryItem.
 type VehicleBlacklistHistoryItem struct {
 	ID         int             `json:"id"`
 	EntityID   int             `json:"entity_id"`
 	ActionType string          `json:"action_type"`
-	Details    json.RawMessage `json:"details,omitempty"`
+	Details    json.RawMessage `json:"details,omitempty" swaggerignore:"true"`
 	UserID     *int            `json:"user_id,omitempty"`
 	UserName   string          `json:"user_name"`
 	CreatedAt  time.Time       `json:"created_at"`

--- a/internal/models/blacklist.go
+++ b/internal/models/blacklist.go
@@ -1,0 +1,73 @@
+package models
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// VehicleBlacklist - запись чёрного списка автомобилей (#443).
+//
+// Активная запись (is_active=true) блокирует подачу новых заявок на машину с такими
+// номером и маркой и каскадно деактивирует совпадающие cars. Снятие из списка - это
+// архивация (is_active=false), а не физическое удаление: история и аудит должны
+// пережить запись.
+//
+// Уникальность (car_number, mark_id) обеспечивается partial unique index-ом
+// WHERE is_active = true (создаётся в database.Seed), чтобы архивная запись не мешала
+// повторно добавить ту же машину.
+type VehicleBlacklist struct {
+	ID              int       `json:"id"`
+	CarNumber       string    `gorm:"size:50;index" json:"car_number"`
+	MarkID          int       `gorm:"index" json:"mark_id"`
+	MarkName        string    `gorm:"size:100" json:"mark_name"` // снапшот имени марки на момент добавления
+	Reason          string    `gorm:"type:text" json:"reason"`
+	IsActive        bool      `gorm:"default:true;index" json:"is_active"`
+	CreatedByUserID *int      `json:"created_by_user_id,omitempty"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
+}
+
+// VehicleBlacklistHistory - аудит действий над записью чёрного списка машин.
+//
+// EntityID намеренно без FK constraint на vehicle_blacklists: аудит должен пережить
+// удаление родителя (как SystemTableHistory). UserID ссылается на users для join-а имени.
+type VehicleBlacklistHistory struct {
+	ID         int             `json:"id"`
+	EntityID   int             `gorm:"index" json:"entity_id"`
+	ActionType string          `gorm:"size:30;index" json:"action_type"`
+	Details    json.RawMessage `gorm:"type:jsonb" json:"details,omitempty"`
+	UserID     *int            `gorm:"index" json:"user_id,omitempty"`
+	User       *User           `gorm:"foreignKey:UserID" json:"-"`
+	CreatedAt  time.Time       `json:"created_at"`
+}
+
+// Action-types для истории чёрного списка (машины и люди используют одни и те же).
+const (
+	BlacklistActionCreated  = "created"
+	BlacklistActionArchived = "archived"
+	BlacklistActionRestored = "restored"
+)
+
+// CreateVehicleBlacklistRequest - тело POST /vehicle-blacklist.
+type CreateVehicleBlacklistRequest struct {
+	CarNumber string `json:"car_number" validate:"required,min=1,max=50"`
+	MarkID    int    `json:"mark_id" validate:"required"`
+	Reason    string `json:"reason" validate:"required,min=1"`
+}
+
+// VehicleBlacklistHistoryItem - элемент истории для API (с именем пользователя).
+type VehicleBlacklistHistoryItem struct {
+	ID         int             `json:"id"`
+	EntityID   int             `json:"entity_id"`
+	ActionType string          `json:"action_type"`
+	Details    json.RawMessage `json:"details,omitempty"`
+	UserID     *int            `json:"user_id,omitempty"`
+	UserName   string          `json:"user_name"`
+	CreatedAt  time.Time       `json:"created_at"`
+}
+
+// VehicleBlacklistCheckResult - ответ GET /vehicle-blacklist/check.
+type VehicleBlacklistCheckResult struct {
+	IsBlacklisted bool   `json:"is_blacklisted"`
+	Reason        string `json:"reason,omitempty"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -46,6 +46,7 @@ type Dependencies struct {
 	BugReport           *handlers.BugReportHandler
 	Maintenance         *handlers.MaintenanceHandler
 	Marks               *handlers.MarkHandler
+	VehicleBlacklist    *handlers.VehicleBlacklistHandler
 	AttachmentTemplates *handlers.AttachmentTemplateHandler
 	AttachmentBlanks    *handlers.AttachmentBlankHandler
 	Trash               *handlers.TrashHandler
@@ -96,6 +97,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	bugReport := d.BugReport
 	maintenance := d.Maintenance
 	marks := d.Marks
+	vehicleBlacklist := d.VehicleBlacklist
 	attachmentTemplates := d.AttachmentTemplates
 	attachmentBlanks := d.AttachmentBlanks
 	trash := d.Trash
@@ -188,6 +190,18 @@ func Setup(e *echo.Echo, d Dependencies) {
 	marksGroup.POST("/:id/archive", marks.Archive)
 	marksGroup.POST("/:id/restore", marks.Restore)
 	marksGroup.GET("/:id/history", marks.GetHistory)
+
+	// Чёрный список машин (#443). POST/DELETE/restore защищены page.admin.blacklist.
+	// GET списка/истории и /check открыты любым авторизованным: фронт рендерит
+	// страницу даже без права, а /check нужен всем при подаче заявки.
+	requireBlacklist := mw.RequirePermissionV2(permResolver, denialLog, services.KeyPageBlacklist)
+	vblGroup := protected.Group("/vehicle-blacklist")
+	vblGroup.GET("", vehicleBlacklist.GetAll)
+	vblGroup.GET("/check", vehicleBlacklist.Check)
+	vblGroup.GET("/:id/history", vehicleBlacklist.GetHistory)
+	vblGroup.POST("", vehicleBlacklist.Create, requireBlacklist)
+	vblGroup.DELETE("/:id", vehicleBlacklist.Delete, requireBlacklist)
+	vblGroup.POST("/:id/restore", vehicleBlacklist.Restore, requireBlacklist)
 
 	// Attachment Excel-templates (#183) - вложенные ручки под /attachments/:id/...
 	attRoot := protected.Group("/attachments")

--- a/internal/services/permission_keys.go
+++ b/internal/services/permission_keys.go
@@ -37,6 +37,7 @@ const (
 	KeyPageSystemControl = "page.admin.system_control"
 	KeyPageAdminUsers    = "page.admin.users"
 	KeyPageAdminFeedback = "page.admin.feedback"
+	KeyPageBlacklist     = "page.admin.blacklist"
 )
 
 // Entity-level CRUD keys.
@@ -78,6 +79,7 @@ func AllStaticKeys() []string {
 		KeyPageSystemControl,
 		KeyPageAdminUsers,
 		KeyPageAdminFeedback,
+		KeyPageBlacklist,
 		KeyEntityCarsRead,
 		KeyEntityCarsWrite,
 		KeyEntityCarsDelete,

--- a/internal/services/vehicle_blacklist_history_service.go
+++ b/internal/services/vehicle_blacklist_history_service.go
@@ -1,0 +1,93 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"systemburo/internal/models"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+// VehicleBlacklistHistoryService - аудит действий над чёрным списком машин (#443).
+type VehicleBlacklistHistoryService interface {
+	// Log пишет запись аудита через переданный executor (передавать tx для
+	// атомарности с основной операцией). details - произвольный JSON, опционально.
+	// В отличие от лучших-усилий SystemTableHistory, ошибку возвращаем: запись
+	// аудита - часть транзакции каскада, её провал должен откатить всю операцию.
+	Log(ctx context.Context, exec *gorm.DB, entityID int, userID *int, actionType string, details interface{}) error
+	// GetHistory возвращает историю по записи (новые сверху) с именем пользователя.
+	GetHistory(ctx context.Context, entityID int) ([]models.VehicleBlacklistHistoryItem, error)
+}
+
+type vehicleBlacklistHistoryService struct {
+	db *gorm.DB
+}
+
+// NewVehicleBlacklistHistoryService создаёт реализацию.
+func NewVehicleBlacklistHistoryService(db *gorm.DB) VehicleBlacklistHistoryService {
+	return &vehicleBlacklistHistoryService{db: db}
+}
+
+func (s *vehicleBlacklistHistoryService) Log(ctx context.Context, exec *gorm.DB, entityID int, userID *int, actionType string, details interface{}) error {
+	var raw json.RawMessage
+	if details != nil {
+		b, err := json.Marshal(details)
+		if err != nil {
+			return fmt.Errorf("marshal vehicle blacklist history details: %w", err)
+		}
+		raw = b
+	}
+	entry := models.VehicleBlacklistHistory{
+		EntityID:   entityID,
+		ActionType: actionType,
+		Details:    raw,
+		UserID:     userID,
+	}
+	if err := exec.WithContext(ctx).Create(&entry).Error; err != nil {
+		return fmt.Errorf("insert vehicle blacklist history: %w", err)
+	}
+	return nil
+}
+
+func (s *vehicleBlacklistHistoryService) GetHistory(ctx context.Context, entityID int) ([]models.VehicleBlacklistHistoryItem, error) {
+	type row struct {
+		ID         int             `gorm:"column:id"`
+		EntityID   int             `gorm:"column:entity_id"`
+		ActionType string          `gorm:"column:action_type"`
+		Details    json.RawMessage `gorm:"column:details"`
+		UserID     *int            `gorm:"column:user_id"`
+		UserName   string          `gorm:"column:user_name"`
+		CreatedAt  time.Time       `gorm:"column:created_at"`
+	}
+	var rows []row
+	if err := s.db.WithContext(ctx).
+		Table("vehicle_blacklist_histories AS h").
+		Select(`h.id, h.entity_id, h.action_type, h.details, h.user_id,
+			COALESCE(NULLIF(TRIM(BOTH ' ' FROM CONCAT_WS(' ', u.last_name, u.first_name)), ''), u.username, '') AS user_name,
+			h.created_at`).
+		Joins("LEFT JOIN users u ON u.id = h.user_id").
+		Where("h.entity_id = ?", entityID).
+		Order("h.created_at DESC").
+		Scan(&rows).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения истории чёрного списка")
+	}
+
+	items := make([]models.VehicleBlacklistHistoryItem, 0, len(rows))
+	for _, r := range rows {
+		items = append(items, models.VehicleBlacklistHistoryItem{
+			ID:         r.ID,
+			EntityID:   r.EntityID,
+			ActionType: r.ActionType,
+			Details:    r.Details,
+			UserID:     r.UserID,
+			UserName:   r.UserName,
+			CreatedAt:  r.CreatedAt,
+		})
+	}
+	return items, nil
+}

--- a/internal/services/vehicle_blacklist_service.go
+++ b/internal/services/vehicle_blacklist_service.go
@@ -1,0 +1,279 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"systemburo/internal/models"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+// VehicleBlacklistService - бизнес-логика чёрного списка автомобилей (#443).
+//
+// Create/Restore каскадно деактивируют совпадающие cars (status 1 -> 0) в одной
+// транзакции; Archive (снятие) восстанавливает status=1 только тем cars, у которых
+// есть активная заявка. Все каскады пишут cars_history и историю самой записи.
+type VehicleBlacklistService interface {
+	GetAll(ctx context.Context, includeArchived bool) ([]models.VehicleBlacklist, error)
+	GetByID(ctx context.Context, id int) (*models.VehicleBlacklist, error)
+	Create(ctx context.Context, req models.CreateVehicleBlacklistRequest, userID int) (*models.VehicleBlacklist, error)
+	// Archive - снятие из чёрного списка (soft-delete): is_active=false + восстановление
+	// status=1 у совпадающих cars с активной заявкой.
+	Archive(ctx context.Context, id int, userID int) error
+	// Restore - повторное добавление архивной записи в список: is_active=true +
+	// повторная деактивация совпадающих активных cars.
+	Restore(ctx context.Context, id int, userID int) error
+	// Check - заблокирована ли машина (number+mark) активной записью.
+	Check(ctx context.Context, carNumber string, markID int) (models.VehicleBlacklistCheckResult, error)
+	GetHistory(ctx context.Context, id int) ([]models.VehicleBlacklistHistoryItem, error)
+}
+
+type vehicleBlacklistService struct {
+	db      *gorm.DB
+	history VehicleBlacklistHistoryService
+}
+
+// NewVehicleBlacklistService создаёт реализацию.
+func NewVehicleBlacklistService(db *gorm.DB, history VehicleBlacklistHistoryService) VehicleBlacklistService {
+	return &vehicleBlacklistService{db: db, history: history}
+}
+
+func (s *vehicleBlacklistService) GetAll(ctx context.Context, includeArchived bool) ([]models.VehicleBlacklist, error) {
+	items := make([]models.VehicleBlacklist, 0)
+	q := s.db.WithContext(ctx).Order("created_at DESC")
+	if !includeArchived {
+		q = q.Where("is_active = ?", true)
+	}
+	if err := q.Find(&items).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения чёрного списка")
+	}
+	return items, nil
+}
+
+func (s *vehicleBlacklistService) GetByID(ctx context.Context, id int) (*models.VehicleBlacklist, error) {
+	var e models.VehicleBlacklist
+	if err := s.db.WithContext(ctx).First(&e, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, echo.NewHTTPError(http.StatusNotFound, "Запись чёрного списка не найдена")
+		}
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения записи чёрного списка")
+	}
+	return &e, nil
+}
+
+func (s *vehicleBlacklistService) Create(ctx context.Context, req models.CreateVehicleBlacklistRequest, userID int) (*models.VehicleBlacklist, error) {
+	var mark models.Mark
+	if err := s.db.WithContext(ctx).First(&mark, req.MarkID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, echo.NewHTTPError(http.StatusBadRequest, "Марка не найдена")
+		}
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения марки")
+	}
+
+	entry := models.VehicleBlacklist{
+		CarNumber:       strings.TrimSpace(req.CarNumber),
+		MarkID:          req.MarkID,
+		MarkName:        mark.Name,
+		Reason:          strings.TrimSpace(req.Reason),
+		IsActive:        true,
+		CreatedByUserID: &userID,
+	}
+
+	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(&entry).Error; err != nil {
+			return err
+		}
+		deactivated, err := s.deactivateMatchingCars(ctx, tx, entry, userID)
+		if err != nil {
+			return err
+		}
+		details := map[string]interface{}{
+			"car_number":       entry.CarNumber,
+			"mark_name":        entry.MarkName,
+			"reason":           entry.Reason,
+			"cars_deactivated": deactivated,
+		}
+		return s.history.Log(ctx, tx, entry.ID, &userID, models.BlacklistActionCreated, details)
+	})
+	if err != nil {
+		if isUniqueViolation(err) {
+			return nil, echo.NewHTTPError(http.StatusConflict, "Эта машина уже в чёрном списке")
+		}
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка добавления в чёрный список")
+	}
+	return &entry, nil
+}
+
+func (s *vehicleBlacklistService) Archive(ctx context.Context, id int, userID int) error {
+	e, err := s.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	if !e.IsActive {
+		return nil // уже снята - no-op
+	}
+	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&models.VehicleBlacklist{}).Where("id = ?", e.ID).Update("is_active", false).Error; err != nil {
+			return err
+		}
+		reactivated, err := s.reactivateMatchingCars(ctx, tx, *e, userID)
+		if err != nil {
+			return err
+		}
+		details := map[string]interface{}{
+			"car_number":       e.CarNumber,
+			"mark_name":        e.MarkName,
+			"cars_reactivated": reactivated,
+		}
+		return s.history.Log(ctx, tx, e.ID, &userID, models.BlacklistActionArchived, details)
+	})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка снятия из чёрного списка")
+	}
+	return nil
+}
+
+func (s *vehicleBlacklistService) Restore(ctx context.Context, id int, userID int) error {
+	e, err := s.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	if e.IsActive {
+		return nil // уже активна - no-op
+	}
+	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&models.VehicleBlacklist{}).Where("id = ?", e.ID).Update("is_active", true).Error; err != nil {
+			return err
+		}
+		deactivated, err := s.deactivateMatchingCars(ctx, tx, *e, userID)
+		if err != nil {
+			return err
+		}
+		details := map[string]interface{}{
+			"car_number":       e.CarNumber,
+			"mark_name":        e.MarkName,
+			"cars_deactivated": deactivated,
+		}
+		return s.history.Log(ctx, tx, e.ID, &userID, models.BlacklistActionRestored, details)
+	})
+	if err != nil {
+		if isUniqueViolation(err) {
+			return echo.NewHTTPError(http.StatusConflict, "Эта машина уже в активном чёрном списке")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка возврата в чёрный список")
+	}
+	return nil
+}
+
+func (s *vehicleBlacklistService) Check(ctx context.Context, carNumber string, markID int) (models.VehicleBlacklistCheckResult, error) {
+	var e models.VehicleBlacklist
+	err := s.db.WithContext(ctx).
+		Where("is_active = ?", true).
+		Where("LOWER(TRIM(car_number)) = LOWER(TRIM(?))", carNumber).
+		Where("mark_id = ?", markID).
+		First(&e).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return models.VehicleBlacklistCheckResult{IsBlacklisted: false}, nil
+		}
+		return models.VehicleBlacklistCheckResult{}, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка проверки чёрного списка")
+	}
+	return models.VehicleBlacklistCheckResult{IsBlacklisted: true, Reason: e.Reason}, nil
+}
+
+func (s *vehicleBlacklistService) GetHistory(ctx context.Context, id int) ([]models.VehicleBlacklistHistoryItem, error) {
+	return s.history.GetHistory(ctx, id)
+}
+
+// deactivateMatchingCars деактивирует (status 1 -> 0) активные cars, совпадающие с записью
+// по номеру и марке, и пишет cars_history. Возвращает число затронутых машин.
+// Совпадение по марке: c.mark_id ИЛИ имя (mark_name/устаревший car_brand) - чтобы покрыть
+// и новые (mark_id), и легаси (только car_brand) машины.
+func (s *vehicleBlacklistService) deactivateMatchingCars(ctx context.Context, tx *gorm.DB, e models.VehicleBlacklist, userID int) (int, error) {
+	var ids []int
+	if err := tx.WithContext(ctx).
+		Table("cars c").
+		Where("LOWER(TRIM(c.car_number)) = LOWER(TRIM(?))", e.CarNumber).
+		Where("(c.mark_id = ? OR (c.mark_id IS NULL AND LOWER(TRIM(COALESCE(c.mark_name, c.car_brand))) = LOWER(TRIM(?))))", e.MarkID, e.MarkName).
+		Where("c.status = ?", 1).
+		Where("c.is_purged = ?", false).
+		Pluck("c.id", &ids).Error; err != nil {
+		return 0, err
+	}
+	now := time.Now().UTC()
+	comment := fmt.Sprintf("Автомобиль %s %s добавлен в чёрный список: %s", e.CarNumber, e.MarkName, e.Reason)
+	for _, id := range ids {
+		if err := tx.Model(&models.Car{}).Where("id = ?", id).
+			Updates(map[string]interface{}{"status": 0, "date_removed": now}).Error; err != nil {
+			return 0, err
+		}
+		hist := models.CarHistory{CarID: id, UserID: &userID, ActionType: "blacklisted", Comment: &comment, CreatedAt: now}
+		if err := tx.Create(&hist).Error; err != nil {
+			return 0, err
+		}
+	}
+	return len(ids), nil
+}
+
+// reactivateMatchingCars восстанавливает status=1 у деактивированных (status=0) cars,
+// совпадающих с записью, у которых есть активная заявка (confirmation='Согласовано',
+// application.status в рабочих статусах) И не истёк пропуск (дата актуальна). Машины без
+// активной заявки или с просроченным пропуском остаются деактивированными. Совпадение по
+// марке - как в deactivateMatchingCars (mark_id, для легаси - имя).
+func (s *vehicleBlacklistService) reactivateMatchingCars(ctx context.Context, tx *gorm.DB, e models.VehicleBlacklist, userID int) (int, error) {
+	var ids []int
+	if err := tx.WithContext(ctx).
+		Table("cars c").
+		Joins("JOIN attachments a ON c.attachment_id = a.id").
+		Joins("JOIN applications app ON a.application_id = app.id").
+		Where("LOWER(TRIM(c.car_number)) = LOWER(TRIM(?))", e.CarNumber).
+		Where("(c.mark_id = ? OR (c.mark_id IS NULL AND LOWER(TRIM(COALESCE(c.mark_name, c.car_brand))) = LOWER(TRIM(?))))", e.MarkID, e.MarkName).
+		Where("c.status = ?", 0).
+		Where("c.is_purged = ?", false).
+		Where("app.confirmation = ?", models.ConfirmationApproved).
+		Where("app.status IN ?", []string{models.StatusInWork, models.StatusCompleted}).
+		// "дата актуальна" из ТЗ: не возрождаем просроченный пропуск. NULLIF защищает
+		// от пустой строки в entry_date_to (иначе ''::date упадёт).
+		Where("(NULLIF(TRIM(c.entry_date_to), '') IS NULL OR (NULLIF(TRIM(c.entry_date_to), ''))::date >= CURRENT_DATE)").
+		Pluck("c.id", &ids).Error; err != nil {
+		return 0, err
+	}
+	now := time.Now().UTC()
+	comment := fmt.Sprintf("Автомобиль %s %s снят с чёрного списка", e.CarNumber, e.MarkName)
+	for _, id := range ids {
+		if err := tx.Model(&models.Car{}).Where("id = ?", id).
+			Updates(map[string]interface{}{"status": 1, "date_removed": nil}).Error; err != nil {
+			return 0, err
+		}
+		hist := models.CarHistory{CarID: id, UserID: &userID, ActionType: "unblacklisted", Comment: &comment, CreatedAt: now}
+		if err := tx.Create(&hist).Error; err != nil {
+			return 0, err
+		}
+	}
+	return len(ids), nil
+}
+
+// isUniqueViolation распознаёт нарушение partial unique index (повторное добавление
+// активной записи) по pg-коду 23505. TranslateError в gorm-конфигах не включён, поэтому
+// проверяем сам *pgconn.PgError; gorm.ErrDuplicatedKey и строковый матч - фолбэки на
+// случай другого драйвера/обёртки.
+func isUniqueViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == "23505"
+	}
+	if errors.Is(err, gorm.ErrDuplicatedKey) {
+		return true
+	}
+	return strings.Contains(err.Error(), "23505") || strings.Contains(err.Error(), "duplicate key value")
+}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -46,6 +46,7 @@ var tables = []string{
 	"feedback", "application_items", "items",
 	"employee_target_tables", "employee_files", "application_employees", "employees_history", "employees",
 	"car_unload_places", "cars_history", "cars",
+	"vehicle_blacklist_histories", "vehicle_blacklists",
 	"attachments",
 	"unique_employees_history", "unique_cars_history",
 	"unique_employees", "unique_cars", "unique_attachments",
@@ -130,6 +131,8 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	// Create maintenance service early so authHandler can get it.
 	maintenanceService := services.NewMaintenanceService(db)
 	markService := services.NewMarkService(db)
+	vehicleBlacklistHistoryService := services.NewVehicleBlacklistHistoryService(db)
+	vehicleBlacklistService := services.NewVehicleBlacklistService(db, vehicleBlacklistHistoryService)
 	attachmentTemplateService := services.NewAttachmentTemplateService(db, "./uploads")
 	attachmentBlankService := services.NewAttachmentBlankService(db)
 	trashService := services.NewTrashService(db)
@@ -170,6 +173,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	bugReportHandler := handlers.NewBugReportHandler(bugReportService)
 	maintenanceHandler := handlers.NewMaintenanceHandler(maintenanceService)
 	markHandler := handlers.NewMarkHandler(markService)
+	vehicleBlacklistHandler := handlers.NewVehicleBlacklistHandler(vehicleBlacklistService)
 	attachmentTemplateHandler := handlers.NewAttachmentTemplateHandler(attachmentTemplateService)
 	attachmentBlankHandler := handlers.NewAttachmentBlankHandler(attachmentBlankService)
 	trashHandler := handlers.NewTrashHandler(trashService, trashDBRef)
@@ -213,6 +217,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 		BugReport:           bugReportHandler,
 		Maintenance:         maintenanceHandler,
 		Marks:               markHandler,
+		VehicleBlacklist:    vehicleBlacklistHandler,
 		AttachmentTemplates: attachmentTemplateHandler,
 		AttachmentBlanks:    attachmentBlankHandler,
 		Trash:               trashHandler,


### PR DESCRIPTION
Срез A1 эпика #443 (Чёрный список). Чистый бэкенд для blacklist МАШИН: модель + история, сервис, handler, регистрация, тесты. Люди (PersonBlacklist) - отдельный срез A2.

## Что добавлено
- Модели VehicleBlacklist + VehicleBlacklistHistory (история без FK на entity_id, jsonb details - по образцу SystemTableHistory).
- vehicle_blacklist_service.go: GetAll(includeArchived), Create (каскад в транзакции), Archive (снятие = soft + восстановление cars), Restore (повторное добавление), Check, GetHistory.
- vehicle_blacklist_history_service.go: Log (транзакционный, ошибку возвращает - часть каскада) + GetHistory.
- Handler vehicle_blacklist.go, регистрация в router (RequirePermissionV2 на POST/DELETE/restore; GET списка/истории и /check открыты любым авторизованным).
- Permission key page.admin.blacklist (константа + AllStaticKeys).
- migrate.go: регистрация моделей + partial unique index.
- Table-driven тесты против реального Postgres (make test).

## Каскад
- Создание: гасит совпадающие активные cars (status 1->0, date_removed), пишет cars_history blacklisted + историю записи. Всё в одной транзакции.
- Снятие: возвращает status=1 только cars с активной заявкой (confirmation=Согласовано, app.status в В работе/Завершено) И актуальной датой пропуска. Остальные остаются 0.

## Решения (отклонения от буквы ТЗ - обоснованы)
- unique_cars.status НЕ трогаем: это вычисляемое на чтении значение (коррелированный подзапрос в unique_car_service.GetAll), хранимая колонка мёртвая. status=0 на cars уже деактивирует отображаемый статus машины.
- Активная заявка определяется по канону кодовой базы (Согласовано + В работе/Завершено), а не по буквальному "В обработке" из тикета - машина в обработке ещё не активна.
- Совпадение по марке: mark_id, а для легаси-машин (mark_id пуст) - по имени марки (mark_name/car_brand). Имя-фолбэк ограничен mark_id IS NULL, чтобы не задеть машины другой марки с совпадающим названием.

## Учтённые замечания ревью (до мержа)
- Дата-гард при снятии: не возрождаем просроченный пропуск (был баг - expiry ставит cars.status=0, машина с истёкшей датой возрождалась). Покрыто тестом.
- Уникальность по LOWER(TRIM(car_number)) в индексе - иначе "A123"/"a123" давали два активных дубля. Покрыто тестом.
- Определение конфликта по pgconn 23505 (TranslateError в gorm не включён, errors.Is был мёртвым).
- Check валидирует mark_id > 0.

## Остаётся обсудить
Снятие возвращает в строй любую совпадающую status=0 машину с актуальной активной заявкой (как в ТЗ). Ручную деактивацию (status=2) это не трогает; точную привязку "только то, что деактивировал именно этот blacklist" можно добавить отдельным polish-срезом при необходимости.

## Проверено
- go build ./..., go vet ./... - чисто.
- go test ./... (полный пакет, реальный Postgres) - зелёно, 0 фейлов.
- Новые тесты: lifecycle (create/check/дубль-в-другом-регистре/archive/restore/409), каскад деактивации, восстановление активной машины, пропуск просроченной.
- gofmt - новые файлы чисты.

Следующий срез: A2 - бэкенд чёрного списка людей (PersonBlacklist, строгое совпадение ФИО).