### PR TITLE
fix(orgs,companies): архивные юзеры не в списке ответственных (#406)

### DIFF
--- a/internal/handlers/companies_test.go
+++ b/internal/handlers/companies_test.go
@@ -360,6 +360,28 @@ func TestCompanies_UpdateUsers(t *testing.T) {
 	assert.Equal(t, true, users[0]["required_approval"])
 }
 
+func TestCompanies_GetUsers_ExcludesArchived(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	testutil.RegisterUser(t, e, "archcompuser", "pass123", 1, td.OrgID, td.CompanyID)
+	body := `{"users":[{"username":"archcompuser","is_primary":true}]}`
+	require.Equal(t, http.StatusOK, testutil.PUT(t, e, fmt.Sprintf("/companies/%d/users", td.CompanyID), body, testutil.AuthHeader(token)).Code)
+
+	// До архива ответственный в списке.
+	users := testutil.ParseSlice(t, testutil.GET(t, e, fmt.Sprintf("/companies/%d/users", td.CompanyID), testutil.AuthHeader(token)))
+	require.Len(t, users, 1)
+
+	// Архивируем юзера - должен исчезнуть из ответственных.
+	require.Equal(t, http.StatusOK, testutil.DELETE(t, e, "/users/archcompuser", testutil.AuthHeader(token)).Code)
+
+	users = testutil.ParseSlice(t, testutil.GET(t, e, fmt.Sprintf("/companies/%d/users", td.CompanyID), testutil.AuthHeader(token)))
+	assert.Len(t, users, 0)
+}
+
 func TestCompanies_UpdateUsers_MultiplePrimary_Fails(t *testing.T) {
 	e, db, cleanup := testutil.SetupTestApp(t)
 	defer cleanup()

--- a/internal/services/company_service.go
+++ b/internal/services/company_service.go
@@ -376,7 +376,7 @@ func (s *companyService) GetUsers(ctx context.Context, companyID int) ([]Company
 		Table("users u").
 		Select("u.id, u.username, u.last_name, u.first_name, u.middle_name, u.position, cu.is_primary, cu.required_approval").
 		Joins("INNER JOIN companies_users cu ON u.id = cu.user_id").
-		Where("cu.company_id = ?", companyID).
+		Where("cu.company_id = ? AND u.is_active = ?", companyID, true).
 		Order("cu.is_primary DESC, u.last_name, u.first_name").
 		Scan(&users).Error
 	if err != nil {

--- a/internal/services/organization_service.go
+++ b/internal/services/organization_service.go
@@ -399,7 +399,7 @@ func (s *organizationService) GetOrganizationUsers(ctx context.Context, orgID in
 		Table("users u").
 		Select("u.id, u.username, u.last_name, u.first_name, u.middle_name, u.position, ou.is_primary, ou.required_approval").
 		Joins("INNER JOIN organization_users ou ON u.id = ou.user_id").
-		Where("ou.organization_id = ?", orgID).
+		Where("ou.organization_id = ? AND u.is_active = ?", orgID, true).
 		Order("ou.is_primary DESC, u.last_name, u.first_name").
 		Scan(&users).Error
 	if err != nil {


### PR DESCRIPTION
Находка аудита (#FF-orgusers). `GetOrganizationUsers`/`GetUsers` джойнили junction-таблицы без фильтра `users.is_active` - архивный пользователь оставался ответственным организации/компании. Добавил `u.is_active = true` в оба запроса + тест `TestCompanies_GetUsers_ExcludesArchived` (org-запрос идентичен). go test зелёный, gofmt чисто. Часть эпика #406, fix-forward из аудита.