### PR TITLE
fix(marks): partial-unique по имени, архивное имя переиспользуемо (#406)

### DIFF
--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -304,6 +304,15 @@ func Seed(db *gorm.DB) error {
 		return fmt.Errorf("failed to create partial unique index on companies.name: %w", err)
 	}
 
+	// Marks: тот же баг, что и #412 - глобальный uniqueIndex по name не давал
+	// пересоздать активную марку при наличии архивной с тем же именем (#FF-marks).
+	if err := db.Exec("DROP INDEX IF EXISTS idx_marks_name").Error; err != nil {
+		return fmt.Errorf("failed to drop idx_marks_name: %w", err)
+	}
+	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uidx_marks_name_active ON marks (name) WHERE is_active = true").Error; err != nil {
+		return fmt.Errorf("failed to create partial unique index on marks.name: %w", err)
+	}
+
 	// Чёрный список машин: уникальность (car_number, mark_id) только среди активных
 	// записей (#443), чтобы снятая запись не мешала повторно добавить ту же машину.
 	// Индекс по LOWER(TRIM(car_number)) - чтобы инвариант совпадал с регистронезависимым

--- a/internal/handlers/marks_integration_test.go
+++ b/internal/handlers/marks_integration_test.go
@@ -5,12 +5,15 @@ package handlers_test
 
 import (
 	"context"
+	"net/http"
 	"testing"
 	"time"
 
 	"systemburo/internal/models"
 	"systemburo/internal/services"
 	"systemburo/internal/testutil"
+
+	"github.com/labstack/echo/v4"
 )
 
 func uniqMarkName(prefix string) string {
@@ -94,6 +97,43 @@ func TestMarkService_CRUD(t *testing.T) {
 
 	db.Where("mark_id = ?", mark.ID).Delete(&models.MarkHistory{})
 	db.Delete(&models.Mark{}, mark.ID)
+}
+
+func TestMarkService_PartialUnique_ArchivedNameReusable(t *testing.T) {
+	// #FF-marks: partial-unique только среди активных - архивную марку можно
+	// пересоздать активной с тем же именем; восстановление при конфликте даёт 409.
+	_, db, _ := testutil.SetupTestApp(t)
+	svc := services.NewMarkService(db)
+	userID, _, cleanup := setupMWUser(t, db, true, false)
+	defer cleanup()
+	ctx := context.Background()
+
+	name := uniqMarkName("partial")
+	first, err := svc.Create(ctx, models.CreateMarkRequest{Name: name}, userID)
+	if err != nil {
+		t.Fatalf("create first: %v", err)
+	}
+	if err := svc.Archive(ctx, first.ID, userID); err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+
+	// Создание активной с тем же именем при архивной - должно пройти (был баг 409).
+	second, err := svc.Create(ctx, models.CreateMarkRequest{Name: name}, userID)
+	if err != nil {
+		t.Fatalf("expected reuse of archived name to succeed, got: %v", err)
+	}
+	if second.ID == first.ID {
+		t.Error("expected a new mark, got same id")
+	}
+
+	// Восстановление архивной при существующей активной - 409, а не 500.
+	err = svc.Restore(ctx, first.ID, userID)
+	if he, ok := err.(*echo.HTTPError); !ok || he.Code != http.StatusConflict {
+		t.Errorf("expected 409 conflict on restore with active duplicate, got %v", err)
+	}
+
+	db.Where("mark_id IN (?, ?)", first.ID, second.ID).Delete(&models.MarkHistory{})
+	db.Delete(&models.Mark{}, []int{first.ID, second.ID})
 }
 
 func TestMarkService_UpdateSameNameIsNoop(t *testing.T) {

--- a/internal/models/mark.go
+++ b/internal/models/mark.go
@@ -8,7 +8,7 @@ import "time"
 // поэтому переименование/архивация не ломает историю.
 type Mark struct {
 	ID              int       `json:"id"`
-	Name            string    `gorm:"size:100;uniqueIndex" json:"name"`
+	Name            string    `gorm:"size:100" json:"name"`
 	IsActive        bool      `gorm:"default:true;index" json:"is_active"`
 	CreatedAt       time.Time `json:"created_at"`
 	UpdatedAt       time.Time `json:"updated_at"`

--- a/internal/services/mark_service.go
+++ b/internal/services/mark_service.go
@@ -128,6 +128,18 @@ func (s *markService) setActive(ctx context.Context, id int, active bool, userID
 	if existing.IsActive == active {
 		return nil // no-op
 	}
+	if active {
+		// Partial-unique теперь только среди активных: при восстановлении проверяем,
+		// что нет активной марки с тем же именем - иначе Update упал бы 500 вместо 409.
+		var cnt int64
+		if err := s.db.WithContext(ctx).Model(&models.Mark{}).
+			Where("name = ? AND is_active = ? AND id <> ?", existing.Name, true, id).Count(&cnt).Error; err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка проверки имени марки")
+		}
+		if cnt > 0 {
+			return echo.NewHTTPError(http.StatusConflict, "Активная марка с таким именем уже существует")
+		}
+	}
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Model(&existing).Update("is_active", active).Error; err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка обновления марки")


### PR DESCRIPTION
Находка аудита (#FF-marks) - тот же баг, что #412. `Mark.Name` держал глобальный uniqueIndex при archive-via-is_active: архивную марку «BMW» нельзя пересоздать активной (409).

## Что сделал
- `mark.go`: убрал `uniqueIndex` с Name.
- `migrate.go`: `DROP INDEX IF EXISTS idx_marks_name` + `CREATE UNIQUE INDEX uidx_marks_name_active ... WHERE is_active = true` (зеркало org/company #412, идемпотентно, ошибка громкая).
- `mark_service.go`: пре-чек в setActive - восстановление архивной марки при существующей активной с тем же именем даёт 409, а не 500.
- Тест `TestMarkService_PartialUnique_ArchivedNameReusable`.

## Проверка
- go test (marks) зелёный, gofmt/build чисто.

**Содержит constraint-миграцию** (DROP/CREATE INDEX) - паттерн идентичен авторизованному #412. Дифф migrate.go в комментарии PR для ревью.

Часть эпика #406, fix-forward из аудита.