### PR TITLE
feat(blacklist): бэкенд чёрного списка людей с каскадом и историей (#443)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -178,6 +178,8 @@ func main() {
 	markService := services.NewMarkService(db)
 	vehicleBlacklistHistoryService := services.NewVehicleBlacklistHistoryService(db)
 	vehicleBlacklistService := services.NewVehicleBlacklistService(db, vehicleBlacklistHistoryService)
+	personBlacklistHistoryService := services.NewPersonBlacklistHistoryService(db)
+	personBlacklistService := services.NewPersonBlacklistService(db, personBlacklistHistoryService)
 	attachmentTemplateService := services.NewAttachmentTemplateService(db, cfg.UploadPath)
 	attachmentBlankService := services.NewAttachmentBlankService(db)
 	trashService := services.NewTrashService(db)
@@ -217,6 +219,7 @@ func main() {
 	maintenanceHandler := handlers.NewMaintenanceHandler(maintenanceService)
 	markHandler := handlers.NewMarkHandler(markService)
 	vehicleBlacklistHandler := handlers.NewVehicleBlacklistHandler(vehicleBlacklistService)
+	personBlacklistHandler := handlers.NewPersonBlacklistHandler(personBlacklistService)
 	attachmentTemplateHandler := handlers.NewAttachmentTemplateHandler(attachmentTemplateService)
 	attachmentBlankHandler := handlers.NewAttachmentBlankHandler(attachmentBlankService)
 	trashHandler := handlers.NewTrashHandler(trashService, trashDBRef)
@@ -271,6 +274,7 @@ func main() {
 		Maintenance:         maintenanceHandler,
 		Marks:               markHandler,
 		VehicleBlacklist:    vehicleBlacklistHandler,
+		PersonBlacklist:     personBlacklistHandler,
 		AttachmentTemplates: attachmentTemplateHandler,
 		AttachmentBlanks:    attachmentBlankHandler,
 		Trash:               trashHandler,

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -27,6 +27,8 @@ func AllModels() []interface{} {
 		&models.MarkHistory{},
 		&models.VehicleBlacklist{},
 		&models.VehicleBlacklistHistory{},
+		&models.PersonBlacklist{},
+		&models.PersonBlacklistHistory{},
 		&models.UnloadPlace{},
 		&models.SystemTable{},
 		&models.SystemTableHistory{},
@@ -315,6 +317,16 @@ func Seed(db *gorm.DB) error {
 	}
 	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uidx_vehicle_blacklists_active ON vehicle_blacklists (LOWER(TRIM(car_number)), mark_id) WHERE is_active = true").Error; err != nil {
 		return fmt.Errorf("failed to create partial unique index on vehicle_blacklists: %w", err)
+	}
+
+	// Чёрный список людей: уникальность ФИО только среди активных (#443). COALESCE по
+	// отчеству - иначе NULL/пустое отчество плодит дубли (в обычном unique index NULL-ы
+	// считаются различными). Нормализация LOWER(TRIM) совпадает с Check/каскадом.
+	if err := db.Exec("DROP INDEX IF EXISTS uidx_person_blacklists_active").Error; err != nil {
+		return fmt.Errorf("failed to drop uidx_person_blacklists_active: %w", err)
+	}
+	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uidx_person_blacklists_active ON person_blacklists (LOWER(TRIM(last_name)), LOWER(TRIM(first_name)), LOWER(TRIM(COALESCE(middle_name, '')))) WHERE is_active = true").Error; err != nil {
+		return fmt.Errorf("failed to create partial unique index on person_blacklists: %w", err)
 	}
 
 	// Seed default tab permissions

--- a/internal/handlers/person_blacklist.go
+++ b/internal/handlers/person_blacklist.go
@@ -1,0 +1,143 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+
+	"github.com/labstack/echo/v4"
+)
+
+// PersonBlacklistHandler - HTTP-обработчики чёрного списка людей (#443).
+type PersonBlacklistHandler struct {
+	service services.PersonBlacklistService
+}
+
+// NewPersonBlacklistHandler создаёт обработчик.
+func NewPersonBlacklistHandler(service services.PersonBlacklistService) *PersonBlacklistHandler {
+	return &PersonBlacklistHandler{service: service}
+}
+
+// GetAll godoc
+// @Summary      Список чёрного списка людей
+// @Tags         person-blacklist
+// @Produce      json
+// @Security     BearerAuth
+// @Param        include_archived query bool false "Включать снятые записи"
+// @Success      200 {array} models.PersonBlacklist
+// @Router       /person-blacklist [get]
+func (h *PersonBlacklistHandler) GetAll(c echo.Context) error {
+	includeArchived := c.QueryParam("include_archived") == "true"
+	items, err := h.service.GetAll(c.Request().Context(), includeArchived)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, items)
+}
+
+// Create godoc
+// @Summary      Добавить человека в чёрный список
+// @Tags         person-blacklist
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        request body models.CreatePersonBlacklistRequest true "Данные записи"
+// @Success      201 {object} models.PersonBlacklist
+// @Router       /person-blacklist [post]
+func (h *PersonBlacklistHandler) Create(c echo.Context) error {
+	var req models.CreatePersonBlacklistRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	userID, _ := c.Get("user_id").(int)
+	entry, err := h.service.Create(c.Request().Context(), req, userID)
+	if err != nil {
+		return err
+	}
+	return RespondCreated(c, entry)
+}
+
+// Delete godoc
+// @Summary      Снять человека с чёрного списка (архивация)
+// @Tags         person-blacklist
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID записи"
+// @Success      200 {string} string "Человек снят с чёрного списка"
+// @Router       /person-blacklist/{id} [delete]
+func (h *PersonBlacklistHandler) Delete(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	userID, _ := c.Get("user_id").(int)
+	if err := h.service.Archive(c.Request().Context(), id, userID); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Человек снят с чёрного списка")
+}
+
+// Restore godoc
+// @Summary      Вернуть человека в чёрный список
+// @Tags         person-blacklist
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID записи"
+// @Success      200 {string} string "Человек возвращён в чёрный список"
+// @Router       /person-blacklist/{id}/restore [post]
+func (h *PersonBlacklistHandler) Restore(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	userID, _ := c.Get("user_id").(int)
+	if err := h.service.Restore(c.Request().Context(), id, userID); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Человек возвращён в чёрный список")
+}
+
+// Check godoc
+// @Summary      Проверить, в чёрном ли списке человек
+// @Tags         person-blacklist
+// @Produce      json
+// @Security     BearerAuth
+// @Param        last_name query string true "Фамилия"
+// @Param        first_name query string true "Имя"
+// @Param        middle_name query string false "Отчество"
+// @Success      200 {object} models.PersonBlacklistCheckResult
+// @Router       /person-blacklist/check [get]
+func (h *PersonBlacklistHandler) Check(c echo.Context) error {
+	lastName := c.QueryParam("last_name")
+	firstName := c.QueryParam("first_name")
+	if lastName == "" || firstName == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "last_name и first_name обязательны")
+	}
+	res, err := h.service.Check(c.Request().Context(), lastName, firstName, c.QueryParam("middle_name"))
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, res)
+}
+
+// GetHistory godoc
+// @Summary      История записи чёрного списка людей
+// @Tags         person-blacklist
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID записи"
+// @Success      200 {array} models.PersonBlacklistHistoryItem
+// @Router       /person-blacklist/{id}/history [get]
+func (h *PersonBlacklistHandler) GetHistory(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	history, err := h.service.GetHistory(c.Request().Context(), id)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, history)
+}

--- a/internal/handlers/person_blacklist_test.go
+++ b/internal/handlers/person_blacklist_test.go
@@ -1,0 +1,189 @@
+package handlers_test
+
+import (
+	"context"
+	"testing"
+
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func newPersonBlacklistService(db *gorm.DB) services.PersonBlacklistService {
+	return services.NewPersonBlacklistService(db, services.NewPersonBlacklistHistoryService(db))
+}
+
+// TestPersonBlacklist_Lifecycle: create/check/строгое-ФИО/дубль/archive/restore без employees.
+func TestPersonBlacklist_Lifecycle(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	userID, _, userCleanup := setupMWUser(t, db, true, false)
+	defer userCleanup()
+	svc := newPersonBlacklistService(db)
+	ctx := context.Background()
+
+	withMiddle, err := svc.Create(ctx, models.CreatePersonBlacklistRequest{
+		LastName: "Петров", FirstName: "Пётр", MiddleName: "Петрович", Reason: "тест",
+	}, userID)
+	require.NoError(t, err)
+	require.NotZero(t, withMiddle.ID)
+
+	noMiddle, err := svc.Create(ctx, models.CreatePersonBlacklistRequest{
+		LastName: "Сидоров", FirstName: "Сидор", Reason: "тест2",
+	}, userID)
+	require.NoError(t, err)
+	require.Nil(t, noMiddle.MiddleName, "пустое отчество должно храниться как NULL")
+
+	checks := []struct {
+		name                string
+		last, first, middle string
+		wantBlock           bool
+	}{
+		{"полное совпадение с отчеством", "Петров", "Пётр", "Петрович", true},
+		{"регистр/пробелы", " петров ", "ПЁТР", "петрович", true},
+		{"есть отчество в ЧС - без отчества не матчит", "Петров", "Пётр", "", false},
+		{"есть отчество в ЧС - другое отчество не матчит", "Петров", "Пётр", "Другое", false},
+		{"нет отчества в ЧС - без отчества матчит", "Сидоров", "Сидор", "", true},
+		{"нет отчества в ЧС - с отчеством не матчит", "Сидоров", "Сидор", "Иванович", false},
+	}
+	for _, tc := range checks {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := svc.Check(ctx, tc.last, tc.first, tc.middle)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantBlock, res.IsBlacklisted)
+		})
+	}
+
+	// Дубль (даже в другом регистре/с пробелами) блокируется partial unique index-ом.
+	_, err = svc.Create(ctx, models.CreatePersonBlacklistRequest{
+		LastName: "ПЕТРОВ", FirstName: "пётр", MiddleName: " Петрович ", Reason: "дубль",
+	}, userID)
+	assertHTTPStatus(t, err, 409)
+
+	// После снятия можно добавить заново.
+	require.NoError(t, svc.Archive(ctx, withMiddle.ID, userID))
+	res, err := svc.Check(ctx, "Петров", "Пётр", "Петрович")
+	require.NoError(t, err)
+	assert.False(t, res.IsBlacklisted)
+
+	again, err := svc.Create(ctx, models.CreatePersonBlacklistRequest{
+		LastName: "Петров", FirstName: "Пётр", MiddleName: "Петрович", Reason: "снова",
+	}, userID)
+	require.NoError(t, err)
+	assert.NotEqual(t, withMiddle.ID, again.ID)
+
+	// Restore архивной при активном дубле -> 409.
+	assertHTTPStatus(t, svc.Restore(ctx, withMiddle.ID, userID), 409)
+}
+
+// TestPersonBlacklist_CascadeDeactivatesActiveEmployee: добавление в ЧС гасит активного сотрудника.
+func TestPersonBlacklist_CascadeDeactivatesActiveEmployee(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "pblcasc1", "pass123", 1, td.OrgID, td.CompanyID)
+	userID := getUserID(t, db, "pblcasc1")
+	appID, _, empID := seedEmployeeViaCompleteApp(t, e, db, token, "Test Organization")
+	activateCarViaApp(t, e, db, appID, td)
+
+	var before models.Employee
+	require.NoError(t, db.First(&before, empID).Error)
+	require.NotNil(t, before.Status)
+	require.Equal(t, 1, *before.Status, "сотрудник должен быть активен до ЧС")
+
+	svc := newPersonBlacklistService(db)
+	entry, err := svc.Create(context.Background(), models.CreatePersonBlacklistRequest{
+		LastName: "Ivanov", FirstName: "Ivan", MiddleName: "Ivanovich", Reason: "запрет",
+	}, userID)
+	require.NoError(t, err)
+
+	var after models.Employee
+	require.NoError(t, db.First(&after, empID).Error)
+	require.NotNil(t, after.Status)
+	assert.Equal(t, 0, *after.Status, "сотрудник должен деактивироваться")
+	assert.NotNil(t, after.DateDeleted, "date_deleted должен проставиться")
+
+	var empHistCount int64
+	db.Model(&models.EmployeeHistory{}).Where("employee_id = ? AND action_type = ?", empID, "blacklisted").Count(&empHistCount)
+	assert.Equal(t, int64(1), empHistCount, "должна быть запись employees_history blacklisted")
+
+	var blHistCount int64
+	db.Model(&models.PersonBlacklistHistory{}).Where("entity_id = ? AND action_type = ?", entry.ID, models.BlacklistActionCreated).Count(&blHistCount)
+	assert.Equal(t, int64(1), blHistCount)
+}
+
+// TestPersonBlacklist_UnblacklistRestoresActiveApplicationEmployee: снятие возвращает status=1.
+func TestPersonBlacklist_UnblacklistRestoresActiveApplicationEmployee(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "pblcasc2", "pass123", 1, td.OrgID, td.CompanyID)
+	userID := getUserID(t, db, "pblcasc2")
+	appID, _, empID := seedEmployeeViaCompleteApp(t, e, db, token, "Test Organization")
+	activateCarViaApp(t, e, db, appID, td)
+
+	svc := newPersonBlacklistService(db)
+	ctx := context.Background()
+
+	entry, err := svc.Create(ctx, models.CreatePersonBlacklistRequest{
+		LastName: "Ivanov", FirstName: "Ivan", MiddleName: "Ivanovich", Reason: "проверка",
+	}, userID)
+	require.NoError(t, err)
+
+	var blacklisted models.Employee
+	require.NoError(t, db.First(&blacklisted, empID).Error)
+	require.Equal(t, 0, *blacklisted.Status)
+
+	require.NoError(t, svc.Archive(ctx, entry.ID, userID))
+
+	var restored models.Employee
+	require.NoError(t, db.First(&restored, empID).Error)
+	require.NotNil(t, restored.Status)
+	assert.Equal(t, 1, *restored.Status, "сотрудник с активной заявкой должен вернуться в status=1")
+	assert.Nil(t, restored.DateDeleted, "date_deleted должен очиститься")
+
+	var empHistCount int64
+	db.Model(&models.EmployeeHistory{}).Where("employee_id = ? AND action_type = ?", empID, "unblacklisted").Count(&empHistCount)
+	assert.Equal(t, int64(1), empHistCount)
+}
+
+// TestPersonBlacklist_UnblacklistSkipsExpiredPass: просроченный пропуск не возрождается
+// (дата берётся из attachments.entry_date_to - у employees своего поля нет).
+func TestPersonBlacklist_UnblacklistSkipsExpiredPass(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "pblexp1", "pass123", 1, td.OrgID, td.CompanyID)
+	userID := getUserID(t, db, "pblexp1")
+	appID, attID, empID := seedEmployeeViaCompleteApp(t, e, db, token, "Test Organization")
+	activateCarViaApp(t, e, db, appID, td)
+
+	svc := newPersonBlacklistService(db)
+	ctx := context.Background()
+
+	entry, err := svc.Create(ctx, models.CreatePersonBlacklistRequest{
+		LastName: "Ivanov", FirstName: "Ivan", MiddleName: "Ivanovich", Reason: "проверка",
+	}, userID)
+	require.NoError(t, err)
+
+	require.NoError(t, db.Exec("UPDATE attachments SET entry_date_to = ? WHERE id = ?", "2000-01-01", attID).Error)
+
+	require.NoError(t, svc.Archive(ctx, entry.ID, userID))
+
+	var after models.Employee
+	require.NoError(t, db.First(&after, empID).Error)
+	require.NotNil(t, after.Status)
+	assert.Equal(t, 0, *after.Status, "сотрудник с истёкшим пропуском не должен возрождаться")
+}

--- a/internal/models/blacklist.go
+++ b/internal/models/blacklist.go
@@ -72,3 +72,58 @@ type VehicleBlacklistCheckResult struct {
 	IsBlacklisted bool   `json:"is_blacklisted"`
 	Reason        string `json:"reason,omitempty"`
 }
+
+// PersonBlacklist - запись чёрного списка людей (#443).
+//
+// Совпадение строгое по всем трём полям ФИО; отсутствие отчества (NULL/пусто) считается
+// "без отчества" и матчит только такое же отсутствие (отчество приводится через COALESCE к пустой строке).
+// Активная запись блокирует подачу заявок и каскадно деактивирует совпадающих employees.
+// Уникальность активных - partial unique index по нормализованному ФИО (см. database.Seed).
+type PersonBlacklist struct {
+	ID              int       `json:"id"`
+	LastName        string    `gorm:"size:100;index" json:"last_name"`
+	FirstName       string    `gorm:"size:100;index" json:"first_name"`
+	MiddleName      *string   `gorm:"size:100" json:"middle_name,omitempty"`
+	Reason          string    `gorm:"type:text" json:"reason"`
+	IsActive        bool      `gorm:"default:true;index" json:"is_active"`
+	CreatedByUserID *int      `json:"created_by_user_id,omitempty"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
+}
+
+// PersonBlacklistHistory - аудит действий над записью чёрного списка людей.
+// EntityID без FK (аудит переживает удаление родителя), как VehicleBlacklistHistory.
+type PersonBlacklistHistory struct {
+	ID         int             `json:"id"`
+	EntityID   int             `gorm:"index" json:"entity_id"`
+	ActionType string          `gorm:"size:30;index" json:"action_type"`
+	Details    json.RawMessage `gorm:"type:jsonb" json:"details,omitempty"`
+	UserID     *int            `gorm:"index" json:"user_id,omitempty"`
+	User       *User           `gorm:"foreignKey:UserID" json:"-"`
+	CreatedAt  time.Time       `json:"created_at"`
+}
+
+// CreatePersonBlacklistRequest - тело POST /person-blacklist. Отчество опционально.
+type CreatePersonBlacklistRequest struct {
+	LastName   string `json:"last_name" validate:"required,min=1,max=100"`
+	FirstName  string `json:"first_name" validate:"required,min=1,max=100"`
+	MiddleName string `json:"middle_name" validate:"omitempty,max=100"`
+	Reason     string `json:"reason" validate:"required,min=1"`
+}
+
+// PersonBlacklistHistoryItem - элемент истории для API. Details игнорируется swag-ом.
+type PersonBlacklistHistoryItem struct {
+	ID         int             `json:"id"`
+	EntityID   int             `json:"entity_id"`
+	ActionType string          `json:"action_type"`
+	Details    json.RawMessage `json:"details,omitempty" swaggerignore:"true"`
+	UserID     *int            `json:"user_id,omitempty"`
+	UserName   string          `json:"user_name"`
+	CreatedAt  time.Time       `json:"created_at"`
+}
+
+// PersonBlacklistCheckResult - ответ GET /person-blacklist/check.
+type PersonBlacklistCheckResult struct {
+	IsBlacklisted bool   `json:"is_blacklisted"`
+	Reason        string `json:"reason,omitempty"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -47,6 +47,7 @@ type Dependencies struct {
 	Maintenance         *handlers.MaintenanceHandler
 	Marks               *handlers.MarkHandler
 	VehicleBlacklist    *handlers.VehicleBlacklistHandler
+	PersonBlacklist     *handlers.PersonBlacklistHandler
 	AttachmentTemplates *handlers.AttachmentTemplateHandler
 	AttachmentBlanks    *handlers.AttachmentBlankHandler
 	Trash               *handlers.TrashHandler
@@ -98,6 +99,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	maintenance := d.Maintenance
 	marks := d.Marks
 	vehicleBlacklist := d.VehicleBlacklist
+	personBlacklist := d.PersonBlacklist
 	attachmentTemplates := d.AttachmentTemplates
 	attachmentBlanks := d.AttachmentBlanks
 	trash := d.Trash
@@ -202,6 +204,15 @@ func Setup(e *echo.Echo, d Dependencies) {
 	vblGroup.POST("", vehicleBlacklist.Create, requireBlacklist)
 	vblGroup.DELETE("/:id", vehicleBlacklist.Delete, requireBlacklist)
 	vblGroup.POST("/:id/restore", vehicleBlacklist.Restore, requireBlacklist)
+
+	// Чёрный список людей (#443). Та же permission page.admin.blacklist (одна страница).
+	pblGroup := protected.Group("/person-blacklist")
+	pblGroup.GET("", personBlacklist.GetAll)
+	pblGroup.GET("/check", personBlacklist.Check)
+	pblGroup.GET("/:id/history", personBlacklist.GetHistory)
+	pblGroup.POST("", personBlacklist.Create, requireBlacklist)
+	pblGroup.DELETE("/:id", personBlacklist.Delete, requireBlacklist)
+	pblGroup.POST("/:id/restore", personBlacklist.Restore, requireBlacklist)
 
 	// Attachment Excel-templates (#183) - вложенные ручки под /attachments/:id/...
 	attRoot := protected.Group("/attachments")

--- a/internal/services/person_blacklist_history_service.go
+++ b/internal/services/person_blacklist_history_service.go
@@ -1,0 +1,90 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"systemburo/internal/models"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+// PersonBlacklistHistoryService - аудит действий над чёрным списком людей (#443).
+type PersonBlacklistHistoryService interface {
+	// Log пишет запись аудита через переданный executor (tx для атомарности с каскадом).
+	// Ошибку возвращает: запись - часть транзакции, провал откатывает операцию.
+	Log(ctx context.Context, exec *gorm.DB, entityID int, userID *int, actionType string, details interface{}) error
+	GetHistory(ctx context.Context, entityID int) ([]models.PersonBlacklistHistoryItem, error)
+}
+
+type personBlacklistHistoryService struct {
+	db *gorm.DB
+}
+
+// NewPersonBlacklistHistoryService создаёт реализацию.
+func NewPersonBlacklistHistoryService(db *gorm.DB) PersonBlacklistHistoryService {
+	return &personBlacklistHistoryService{db: db}
+}
+
+func (s *personBlacklistHistoryService) Log(ctx context.Context, exec *gorm.DB, entityID int, userID *int, actionType string, details interface{}) error {
+	var raw json.RawMessage
+	if details != nil {
+		b, err := json.Marshal(details)
+		if err != nil {
+			return fmt.Errorf("marshal person blacklist history details: %w", err)
+		}
+		raw = b
+	}
+	entry := models.PersonBlacklistHistory{
+		EntityID:   entityID,
+		ActionType: actionType,
+		Details:    raw,
+		UserID:     userID,
+	}
+	if err := exec.WithContext(ctx).Create(&entry).Error; err != nil {
+		return fmt.Errorf("insert person blacklist history: %w", err)
+	}
+	return nil
+}
+
+func (s *personBlacklistHistoryService) GetHistory(ctx context.Context, entityID int) ([]models.PersonBlacklistHistoryItem, error) {
+	type row struct {
+		ID         int             `gorm:"column:id"`
+		EntityID   int             `gorm:"column:entity_id"`
+		ActionType string          `gorm:"column:action_type"`
+		Details    json.RawMessage `gorm:"column:details"`
+		UserID     *int            `gorm:"column:user_id"`
+		UserName   string          `gorm:"column:user_name"`
+		CreatedAt  time.Time       `gorm:"column:created_at"`
+	}
+	var rows []row
+	if err := s.db.WithContext(ctx).
+		Table("person_blacklist_histories AS h").
+		Select(`h.id, h.entity_id, h.action_type, h.details, h.user_id,
+			COALESCE(NULLIF(TRIM(BOTH ' ' FROM CONCAT_WS(' ', u.last_name, u.first_name)), ''), u.username, '') AS user_name,
+			h.created_at`).
+		Joins("LEFT JOIN users u ON u.id = h.user_id").
+		Where("h.entity_id = ?", entityID).
+		Order("h.created_at DESC").
+		Scan(&rows).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения истории чёрного списка")
+	}
+
+	items := make([]models.PersonBlacklistHistoryItem, 0, len(rows))
+	for _, r := range rows {
+		items = append(items, models.PersonBlacklistHistoryItem{
+			ID:         r.ID,
+			EntityID:   r.EntityID,
+			ActionType: r.ActionType,
+			Details:    r.Details,
+			UserID:     r.UserID,
+			UserName:   r.UserName,
+			CreatedAt:  r.CreatedAt,
+		})
+	}
+	return items, nil
+}

--- a/internal/services/person_blacklist_service.go
+++ b/internal/services/person_blacklist_service.go
@@ -1,0 +1,259 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"systemburo/internal/models"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+// PersonBlacklistService - бизнес-логика чёрного списка людей (#443).
+//
+// Зеркало VehicleBlacklistService: каскад в транзакции деактивирует/восстанавливает
+// совпадающих employees. Совпадение строгое по ФИО (фамилия+имя+отчество), отсутствие
+// отчества (NULL/пусто) приводится через COALESCE к пустой строке.
+type PersonBlacklistService interface {
+	GetAll(ctx context.Context, includeArchived bool) ([]models.PersonBlacklist, error)
+	GetByID(ctx context.Context, id int) (*models.PersonBlacklist, error)
+	Create(ctx context.Context, req models.CreatePersonBlacklistRequest, userID int) (*models.PersonBlacklist, error)
+	Archive(ctx context.Context, id int, userID int) error
+	Restore(ctx context.Context, id int, userID int) error
+	Check(ctx context.Context, lastName, firstName, middleName string) (models.PersonBlacklistCheckResult, error)
+	GetHistory(ctx context.Context, id int) ([]models.PersonBlacklistHistoryItem, error)
+}
+
+type personBlacklistService struct {
+	db      *gorm.DB
+	history PersonBlacklistHistoryService
+}
+
+// NewPersonBlacklistService создаёт реализацию.
+func NewPersonBlacklistService(db *gorm.DB, history PersonBlacklistHistoryService) PersonBlacklistService {
+	return &personBlacklistService{db: db, history: history}
+}
+
+func (s *personBlacklistService) GetAll(ctx context.Context, includeArchived bool) ([]models.PersonBlacklist, error) {
+	items := make([]models.PersonBlacklist, 0)
+	q := s.db.WithContext(ctx).Order("created_at DESC")
+	if !includeArchived {
+		q = q.Where("is_active = ?", true)
+	}
+	if err := q.Find(&items).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения чёрного списка")
+	}
+	return items, nil
+}
+
+func (s *personBlacklistService) GetByID(ctx context.Context, id int) (*models.PersonBlacklist, error) {
+	var e models.PersonBlacklist
+	if err := s.db.WithContext(ctx).First(&e, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, echo.NewHTTPError(http.StatusNotFound, "Запись чёрного списка не найдена")
+		}
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения записи чёрного списка")
+	}
+	return &e, nil
+}
+
+func (s *personBlacklistService) Create(ctx context.Context, req models.CreatePersonBlacklistRequest, userID int) (*models.PersonBlacklist, error) {
+	entry := models.PersonBlacklist{
+		LastName:        strings.TrimSpace(req.LastName),
+		FirstName:       strings.TrimSpace(req.FirstName),
+		MiddleName:      normalizeMiddleName(req.MiddleName),
+		Reason:          strings.TrimSpace(req.Reason),
+		IsActive:        true,
+		CreatedByUserID: &userID,
+	}
+
+	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(&entry).Error; err != nil {
+			return err
+		}
+		deactivated, err := s.deactivateMatchingEmployees(ctx, tx, entry, userID)
+		if err != nil {
+			return err
+		}
+		details := map[string]interface{}{
+			"full_name":             personFullName(entry),
+			"reason":                entry.Reason,
+			"employees_deactivated": deactivated,
+		}
+		return s.history.Log(ctx, tx, entry.ID, &userID, models.BlacklistActionCreated, details)
+	})
+	if err != nil {
+		if isUniqueViolation(err) {
+			return nil, echo.NewHTTPError(http.StatusConflict, "Этот человек уже в чёрном списке")
+		}
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка добавления в чёрный список")
+	}
+	return &entry, nil
+}
+
+func (s *personBlacklistService) Archive(ctx context.Context, id int, userID int) error {
+	e, err := s.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	if !e.IsActive {
+		return nil
+	}
+	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&models.PersonBlacklist{}).Where("id = ?", e.ID).Update("is_active", false).Error; err != nil {
+			return err
+		}
+		reactivated, err := s.reactivateMatchingEmployees(ctx, tx, *e, userID)
+		if err != nil {
+			return err
+		}
+		details := map[string]interface{}{
+			"full_name":             personFullName(*e),
+			"employees_reactivated": reactivated,
+		}
+		return s.history.Log(ctx, tx, e.ID, &userID, models.BlacklistActionArchived, details)
+	})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка снятия из чёрного списка")
+	}
+	return nil
+}
+
+func (s *personBlacklistService) Restore(ctx context.Context, id int, userID int) error {
+	e, err := s.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	if e.IsActive {
+		return nil
+	}
+	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&models.PersonBlacklist{}).Where("id = ?", e.ID).Update("is_active", true).Error; err != nil {
+			return err
+		}
+		deactivated, err := s.deactivateMatchingEmployees(ctx, tx, *e, userID)
+		if err != nil {
+			return err
+		}
+		details := map[string]interface{}{
+			"full_name":             personFullName(*e),
+			"employees_deactivated": deactivated,
+		}
+		return s.history.Log(ctx, tx, e.ID, &userID, models.BlacklistActionRestored, details)
+	})
+	if err != nil {
+		if isUniqueViolation(err) {
+			return echo.NewHTTPError(http.StatusConflict, "Этот человек уже в активном чёрном списке")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка возврата в чёрный список")
+	}
+	return nil
+}
+
+func (s *personBlacklistService) Check(ctx context.Context, lastName, firstName, middleName string) (models.PersonBlacklistCheckResult, error) {
+	var e models.PersonBlacklist
+	err := s.db.WithContext(ctx).
+		Where("is_active = ?", true).
+		Where("LOWER(TRIM(last_name)) = LOWER(TRIM(?))", lastName).
+		Where("LOWER(TRIM(first_name)) = LOWER(TRIM(?))", firstName).
+		Where("LOWER(TRIM(COALESCE(middle_name, ''))) = LOWER(TRIM(?))", middleName).
+		First(&e).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return models.PersonBlacklistCheckResult{IsBlacklisted: false}, nil
+		}
+		return models.PersonBlacklistCheckResult{}, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка проверки чёрного списка")
+	}
+	return models.PersonBlacklistCheckResult{IsBlacklisted: true, Reason: e.Reason}, nil
+}
+
+func (s *personBlacklistService) GetHistory(ctx context.Context, id int) ([]models.PersonBlacklistHistoryItem, error) {
+	return s.history.GetHistory(ctx, id)
+}
+
+// deactivateMatchingEmployees гасит (status 1 -> 0, date_deleted) активных employees,
+// совпадающих по ФИО, и пишет employees_history. Возвращает число затронутых.
+func (s *personBlacklistService) deactivateMatchingEmployees(ctx context.Context, tx *gorm.DB, e models.PersonBlacklist, userID int) (int, error) {
+	var ids []int
+	if err := tx.WithContext(ctx).
+		Table("employees").
+		Where("LOWER(TRIM(last_name)) = LOWER(TRIM(?))", e.LastName).
+		Where("LOWER(TRIM(first_name)) = LOWER(TRIM(?))", e.FirstName).
+		Where("LOWER(TRIM(COALESCE(middle_name, ''))) = LOWER(TRIM(COALESCE(?, '')))", e.MiddleName).
+		Where("status = ?", 1).
+		Where("is_purged = ?", false).
+		Pluck("id", &ids).Error; err != nil {
+		return 0, err
+	}
+	now := time.Now().UTC()
+	comment := fmt.Sprintf("Сотрудник %s добавлен в чёрный список: %s", personFullName(e), e.Reason)
+	for _, id := range ids {
+		if err := tx.Model(&models.Employee{}).Where("id = ?", id).
+			Updates(map[string]interface{}{"status": 0, "date_deleted": now}).Error; err != nil {
+			return 0, err
+		}
+		hist := models.EmployeeHistory{EmployeeID: id, UserID: &userID, ActionType: "blacklisted", Comment: &comment, CreatedAt: now}
+		if err := tx.Create(&hist).Error; err != nil {
+			return 0, err
+		}
+	}
+	return len(ids), nil
+}
+
+// reactivateMatchingEmployees восстанавливает status=1 у деактивированных employees,
+// совпадающих по ФИО, с активной заявкой (Согласовано + рабочий статус) и актуальной
+// датой пропуска (attachments.entry_date_to - у employees своего поля даты нет).
+func (s *personBlacklistService) reactivateMatchingEmployees(ctx context.Context, tx *gorm.DB, e models.PersonBlacklist, userID int) (int, error) {
+	var ids []int
+	if err := tx.WithContext(ctx).
+		Table("employees emp").
+		Joins("JOIN attachments a ON emp.attachment_id = a.id").
+		Joins("JOIN applications app ON a.application_id = app.id").
+		Where("LOWER(TRIM(emp.last_name)) = LOWER(TRIM(?))", e.LastName).
+		Where("LOWER(TRIM(emp.first_name)) = LOWER(TRIM(?))", e.FirstName).
+		Where("LOWER(TRIM(COALESCE(emp.middle_name, ''))) = LOWER(TRIM(COALESCE(?, '')))", e.MiddleName).
+		Where("emp.status = ?", 0).
+		Where("emp.is_purged = ?", false).
+		Where("app.confirmation = ?", models.ConfirmationApproved).
+		Where("app.status IN ?", []string{models.StatusInWork, models.StatusCompleted}).
+		Where("(NULLIF(TRIM(a.entry_date_to), '') IS NULL OR (NULLIF(TRIM(a.entry_date_to), ''))::date >= CURRENT_DATE)").
+		Pluck("emp.id", &ids).Error; err != nil {
+		return 0, err
+	}
+	now := time.Now().UTC()
+	comment := fmt.Sprintf("Сотрудник %s снят с чёрного списка", personFullName(e))
+	for _, id := range ids {
+		if err := tx.Model(&models.Employee{}).Where("id = ?", id).
+			Updates(map[string]interface{}{"status": 1, "date_deleted": nil}).Error; err != nil {
+			return 0, err
+		}
+		hist := models.EmployeeHistory{EmployeeID: id, UserID: &userID, ActionType: "unblacklisted", Comment: &comment, CreatedAt: now}
+		if err := tx.Create(&hist).Error; err != nil {
+			return 0, err
+		}
+	}
+	return len(ids), nil
+}
+
+// normalizeMiddleName приводит отчество к *string: пустое/пробелы -> nil (нет отчества).
+func normalizeMiddleName(s string) *string {
+	t := strings.TrimSpace(s)
+	if t == "" {
+		return nil
+	}
+	return &t
+}
+
+// personFullName собирает ФИО для логов/деталей.
+func personFullName(e models.PersonBlacklist) string {
+	fio := strings.TrimSpace(e.LastName + " " + e.FirstName)
+	if e.MiddleName != nil && strings.TrimSpace(*e.MiddleName) != "" {
+		fio += " " + strings.TrimSpace(*e.MiddleName)
+	}
+	return fio
+}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -47,6 +47,7 @@ var tables = []string{
 	"employee_target_tables", "employee_files", "application_employees", "employees_history", "employees",
 	"car_unload_places", "cars_history", "cars",
 	"vehicle_blacklist_histories", "vehicle_blacklists",
+	"person_blacklist_histories", "person_blacklists",
 	"attachments",
 	"unique_employees_history", "unique_cars_history",
 	"unique_employees", "unique_cars", "unique_attachments",
@@ -133,6 +134,8 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	markService := services.NewMarkService(db)
 	vehicleBlacklistHistoryService := services.NewVehicleBlacklistHistoryService(db)
 	vehicleBlacklistService := services.NewVehicleBlacklistService(db, vehicleBlacklistHistoryService)
+	personBlacklistHistoryService := services.NewPersonBlacklistHistoryService(db)
+	personBlacklistService := services.NewPersonBlacklistService(db, personBlacklistHistoryService)
 	attachmentTemplateService := services.NewAttachmentTemplateService(db, "./uploads")
 	attachmentBlankService := services.NewAttachmentBlankService(db)
 	trashService := services.NewTrashService(db)
@@ -174,6 +177,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	maintenanceHandler := handlers.NewMaintenanceHandler(maintenanceService)
 	markHandler := handlers.NewMarkHandler(markService)
 	vehicleBlacklistHandler := handlers.NewVehicleBlacklistHandler(vehicleBlacklistService)
+	personBlacklistHandler := handlers.NewPersonBlacklistHandler(personBlacklistService)
 	attachmentTemplateHandler := handlers.NewAttachmentTemplateHandler(attachmentTemplateService)
 	attachmentBlankHandler := handlers.NewAttachmentBlankHandler(attachmentBlankService)
 	trashHandler := handlers.NewTrashHandler(trashService, trashDBRef)
@@ -218,6 +222,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 		Maintenance:         maintenanceHandler,
 		Marks:               markHandler,
 		VehicleBlacklist:    vehicleBlacklistHandler,
+		PersonBlacklist:     personBlacklistHandler,
 		AttachmentTemplates: attachmentTemplateHandler,
 		AttachmentBlanks:    attachmentBlankHandler,
 		Trash:               trashHandler,


### PR DESCRIPTION
Срез A2 эпика #443 (Чёрный список). Бэкенд для blacklist ЛЮДЕЙ - зеркало A1 (#446) для машин. После A2 бэкенд ЧС закрыт; дальше фронт (B1/B2) и интеграция в формы (C).

## Что добавлено
- Модели PersonBlacklist + PersonBlacklistHistory (структурно как Vehicle*).
- person_blacklist_service.go: GetAll(includeArchived), Create (каскад в транзакции), Archive (снятие), Restore, Check, GetHistory.
- person_blacklist_history_service.go (Log транзакционный + GetHistory).
- Handler person_blacklist.go, группа /person-blacklist в router (та же permission page.admin.blacklist, новый ключ не нужен).
- migrate.go: модели + partial unique index по ФИО.
- testutil + main wiring. Table-driven тесты против реального Postgres.

## Person-специфика
- **Строгое совпадение ФИО** по всем 3 полям. Отсутствие отчества (NULL/пусто) матчит только отсутствие - через LOWER(TRIM(COALESCE(middle_name, ''))) одинаково в индексе, Check и каскаде.
- **Уникальность с NULL-отчеством**: в обычном unique index NULL-ы различны (два "Сидоров Сидор" без отчества прошли бы). COALESCE(middle_name,'') в выражении индекса сворачивает NULL/пусто к одному значению - дубли блокируются.
- **Дата пропуска**: у employees нет своего entry_date_to, дата берётся через JOIN attachments.entry_date_to (у машин было c.entry_date_to). Каскад снятия не возрождает просроченный пропуск.
- **date_deleted** (у машин было date_removed).

## Переносит фиксы A1
date guard на снятии, pgconn-23505 для конфликта (isUniqueViolation переиспользована из vehicle-сервиса), регистронезависимый partial unique index, каскад в транзакции с историей.

## Проверено
- go build / go vet чисто, gofmt чисто (мои файлы).
- go test ./... (полный пакет, реальный Postgres) - зелёно, 0 фейлов.
- 5 тестов: lifecycle (create/check/строгое-ФИО 6 кейсов/дубль-в-другом-регистре/archive/restore/409), каскад деактивации, восстановление активного сотрудника, пропуск просроченного.
- Ревью code-reviewer: GO, блокеров нет; все фокус-зоны (NULL-отчество, дата через attachment, date_deleted, отсутствие ре-шифрования паспорта при status-update) подтверждены.

## Остаётся обсудить (как в A1)
Снятие возвращает status=1 любому совпадающему status=0 сотруднику с актуальной активной заявкой (по ТЗ). Точную привязку "только то, что деактивировал этот blacklist" - polish-срезом при желании.

Следующий срез: B1 - админ-страница (табы Машины/Люди, список/детали) + nav + роут.