### PR TITLE
feat(unload-places): оживил архив (soft-delete + restore + include_archived) (#413)

### DIFF
--- a/internal/handlers/unload_places.go
+++ b/internal/handlers/unload_places.go
@@ -45,6 +45,7 @@ func NewUnloadPlaceHandler(service services.UnloadPlaceService, maxFileSize int6
 // @Tags         unload-places
 // @Produce      json
 // @Security     BearerAuth
+// @Param        include_archived query bool false "Включить архивные места"
 // @Success      200 {array} services.UnloadPlaceWithDetails
 // @Failure      401 {object} models.HTTPError
 // @Failure      500 {object} models.HTTPError

--- a/internal/handlers/unload_places.go
+++ b/internal/handlers/unload_places.go
@@ -50,7 +50,8 @@ func NewUnloadPlaceHandler(service services.UnloadPlaceService, maxFileSize int6
 // @Failure      500 {object} models.HTTPError
 // @Router       /unload-places [get]
 func (h *UnloadPlaceHandler) GetAll(c echo.Context) error {
-	places, err := h.service.GetAll(c.Request().Context())
+	includeArchived := c.QueryParam("include_archived") == "true"
+	places, err := h.service.GetAll(c.Request().Context(), includeArchived)
 	if err != nil {
 		return err
 	}
@@ -160,7 +161,29 @@ func (h *UnloadPlaceHandler) Delete(c echo.Context) error {
 	if err := h.service.Delete(c.Request().Context(), id); err != nil {
 		return err
 	}
-	return RespondMessage(c, "Место разгрузки успешно удалено")
+	return RespondMessage(c, "Место разгрузки архивировано")
+}
+
+// Restore восстанавливает архивное место разгрузки.
+// @Summary      Восстановление места разгрузки из архива
+// @Tags         unload-places
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID места разгрузки"
+// @Success      200 {string} string "Место разгрузки восстановлено"
+// @Failure      401 {object} models.HTTPError
+// @Failure      404 {object} models.HTTPError
+// @Failure      500 {object} models.HTTPError
+// @Router       /unload-places/{id}/restore [post]
+func (h *UnloadPlaceHandler) Restore(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	if err := h.service.Restore(c.Request().Context(), id); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Место разгрузки восстановлено")
 }
 
 // --- Временные слоты ---

--- a/internal/handlers/unload_places_test.go
+++ b/internal/handlers/unload_places_test.go
@@ -113,6 +113,18 @@ func TestUnloadPlaces_GetByID_NotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
+func TestUnloadPlaces_Restore_NotFound(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	rec := testutil.POST(t, e, "/unload-places/99999/restore", "", h)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
 func TestUnloadPlaces_TimeSlots_CRUD(t *testing.T) {
 	e, db, cleanup := testutil.SetupTestApp(t)
 	defer cleanup()

--- a/internal/handlers/unload_places_test.go
+++ b/internal/handlers/unload_places_test.go
@@ -66,13 +66,39 @@ func TestUnloadPlaces_CRUD(t *testing.T) {
 	assert.Equal(t, "Updated Place", getResp["name"])
 	assert.Equal(t, "maintenance", getResp["status"])
 
-	// Delete
+	// Delete = архив (soft-delete)
 	rec = testutil.DELETE(t, e, fmt.Sprintf("/unload-places/%d", placeID), h)
 	require.Equal(t, http.StatusOK, rec.Code)
 
-	// Verify deleted (404)
-	rec = testutil.GET(t, e, fmt.Sprintf("/unload-places/%d", placeID), h)
-	assert.Equal(t, http.StatusNotFound, rec.Code)
+	// Архивное место скрыто из дефолтного списка
+	def := testutil.ParseSlice(t, testutil.GET(t, e, "/unload-places", h))
+	for _, p := range def {
+		assert.NotEqual(t, float64(placeID), p["id"], "архивное место не должно быть в дефолтном списке")
+	}
+
+	// ...но видно с include_archived (is_active=false)
+	arch := testutil.ParseSlice(t, testutil.GET(t, e, "/unload-places?include_archived=true", h))
+	var found bool
+	for _, p := range arch {
+		if int(p["id"].(float64)) == placeID {
+			found = true
+			assert.Equal(t, false, p["is_active"])
+		}
+	}
+	assert.True(t, found, "архивное место должно быть видно с include_archived")
+
+	// Restore возвращает в дефолтный список
+	rec = testutil.POST(t, e, fmt.Sprintf("/unload-places/%d/restore", placeID), "", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	def = testutil.ParseSlice(t, testutil.GET(t, e, "/unload-places", h))
+	found = false
+	for _, p := range def {
+		if int(p["id"].(float64)) == placeID {
+			found = true
+			assert.Equal(t, true, p["is_active"])
+		}
+	}
+	assert.True(t, found, "восстановленное место должно быть в дефолтном списке")
 }
 
 func TestUnloadPlaces_GetByID_NotFound(t *testing.T) {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -263,6 +263,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	upg.GET("/:id", up.GetByID)
 	upg.PUT("/:id", up.Update)
 	upg.DELETE("/:id", up.Delete)
+	upg.POST("/:id/restore", up.Restore)
 	upg.GET("/:id/time-slots", up.GetTimeSlots)
 	upg.POST("/:id/time-slots", up.AddTimeSlot)
 	upg.PUT("/:place_id/time-slots/:slot_id", up.UpdateTimeSlot)

--- a/internal/services/unload_place_service.go
+++ b/internal/services/unload_place_service.go
@@ -266,7 +266,11 @@ func (s *unloadPlaceService) Update(ctx context.Context, id int, req UpdateUnloa
 	return nil
 }
 
-// Delete удаляет место разгрузки с проверкой зависимостей организаций и компаний.
+// Delete архивирует место разгрузки (soft-delete). Блокируется, если место
+// привязано к организациям/компаниям - это и есть гейт активных зависимостей:
+// машины планируются на место только через орг/компания-привязку, поэтому после
+// отвязки новые car_unload_places не появятся, а существующие переживут архив
+// (soft-delete не сиротит). Отдельный блок по car_unload_places не нужен.
 func (s *unloadPlaceService) Delete(ctx context.Context, id int) error {
 	// Проверяем привязку к организациям
 	var orgCount int64
@@ -304,7 +308,7 @@ func (s *unloadPlaceService) Delete(ctx context.Context, id int) error {
 		return echo.NewHTTPError(http.StatusBadRequest, msg)
 	}
 
-	// Архив (soft-delete): фото/слоты НЕ удаляем физически - запись можно восстановить.
+	// Фото/слоты не трогаем - restore должен вернуть запись целой.
 	result := s.db.WithContext(ctx).
 		Model(&models.UnloadPlace{}).
 		Where("id = ?", id).

--- a/internal/services/unload_place_service.go
+++ b/internal/services/unload_place_service.go
@@ -33,11 +33,11 @@ type UpdateUnloadPlaceRequest struct {
 
 // CreateTimeSlotRequest -- тело запроса на создание временного слота.
 type CreateTimeSlotRequest struct {
-	DayOfWeek int     `json:"day_of_week" validate:"min=0,max=6"`
-	OpenTime  string  `json:"open_time" validate:"required"`
-	CloseTime string  `json:"close_time" validate:"required"`
-	IsNextDay *bool   `json:"is_next_day"`
-	IsActive  *bool   `json:"is_active"`
+	DayOfWeek int    `json:"day_of_week" validate:"min=0,max=6"`
+	OpenTime  string `json:"open_time" validate:"required"`
+	CloseTime string `json:"close_time" validate:"required"`
+	IsNextDay *bool  `json:"is_next_day"`
+	IsActive  *bool  `json:"is_active"`
 }
 
 // UpdateTimeSlotRequest -- тело запроса на обновление временного слота.
@@ -67,11 +67,12 @@ type UnloadPlaceWithDetails struct {
 
 // UnloadPlaceService -- интерфейс бизнес-логики мест разгрузки.
 type UnloadPlaceService interface {
-	GetAll(ctx context.Context) ([]UnloadPlaceWithDetails, error)
+	GetAll(ctx context.Context, includeArchived bool) ([]UnloadPlaceWithDetails, error)
 	GetByID(ctx context.Context, id int) (*UnloadPlaceWithDetails, error)
 	Create(ctx context.Context, req CreateUnloadPlaceRequest) (int, error)
 	Update(ctx context.Context, id int, req UpdateUnloadPlaceRequest) error
 	Delete(ctx context.Context, id int) error
+	Restore(ctx context.Context, id int) error
 
 	// Временные слоты
 	GetTimeSlots(ctx context.Context, placeID int) ([]models.UnloadPlaceTimeSlot, error)
@@ -168,9 +169,13 @@ func (s *unloadPlaceService) buildDetails(ctx context.Context, place models.Unlo
 }
 
 // GetAll возвращает все места разгрузки с расписанием и фотографиями.
-func (s *unloadPlaceService) GetAll(ctx context.Context) ([]UnloadPlaceWithDetails, error) {
+func (s *unloadPlaceService) GetAll(ctx context.Context, includeArchived bool) ([]UnloadPlaceWithDetails, error) {
 	places := make([]models.UnloadPlace, 0)
-	if err := s.db.WithContext(ctx).Order("name").Find(&places).Error; err != nil {
+	q := s.db.WithContext(ctx).Order("name")
+	if !includeArchived {
+		q = q.Where("is_active = ?", true)
+	}
+	if err := q.Find(&places).Error; err != nil {
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching unload places")
 	}
 
@@ -299,22 +304,35 @@ func (s *unloadPlaceService) Delete(ctx context.Context, id int) error {
 		return echo.NewHTTPError(http.StatusBadRequest, msg)
 	}
 
-	// Получаем URL фотографий для удаления файлов
-	var photoURLs []string
-	s.db.WithContext(ctx).
-		Model(&models.UnloadPlacePhoto{}).
-		Where("unload_place_id = ?", id).
-		Pluck("photo_url", &photoURLs)
-
-	result := s.db.WithContext(ctx).Delete(&models.UnloadPlace{}, id)
+	// Архив (soft-delete): фото/слоты НЕ удаляем физически - запись можно восстановить.
+	result := s.db.WithContext(ctx).
+		Model(&models.UnloadPlace{}).
+		Where("id = ?", id).
+		Update("is_active", false)
 	if result.Error != nil {
-		slog.Error("не удалось удалить место разгрузки", "id", id, "error", result.Error)
-		return echo.NewHTTPError(http.StatusInternalServerError, "Error deleting unload place")
+		slog.Error("не удалось архивировать место разгрузки", "id", id, "error", result.Error)
+		return echo.NewHTTPError(http.StatusInternalServerError, "Error archiving unload place")
 	}
 	if result.RowsAffected == 0 {
 		return echo.NewHTTPError(http.StatusNotFound, "Место разгрузки не найдено")
 	}
-	slog.Info("место разгрузки удалено", "id", id)
+	slog.Info("место разгрузки архивировано", "id", id)
 	return nil
 }
 
+// Restore восстанавливает архивное место разгрузки (is_active=true).
+func (s *unloadPlaceService) Restore(ctx context.Context, id int) error {
+	result := s.db.WithContext(ctx).
+		Model(&models.UnloadPlace{}).
+		Where("id = ?", id).
+		Update("is_active", true)
+	if result.Error != nil {
+		slog.Error("не удалось восстановить место разгрузки", "id", id, "error", result.Error)
+		return echo.NewHTTPError(http.StatusInternalServerError, "Error restoring unload place")
+	}
+	if result.RowsAffected == 0 {
+		return echo.NewHTTPError(http.StatusNotFound, "Место разгрузки не найдено")
+	}
+	slog.Info("место разгрузки восстановлено", "id", id)
+	return nil
+}


### PR DESCRIPTION
#413 срез 1 (backend). У мест разгрузки `IsActive` существовал, но не использовался: `GetAll` не фильтровал, `Delete` удалял запись физически (и фото).

## Что сделал
- `GetAll(ctx, includeArchived)` — по умолчанию только `is_active=true`, с `?include_archived=true` все. Handler читает query-param.
- `Delete` → soft (is_active=false). Фото и тайм-слоты НЕ удаляются физически (восстановимо). Блок при привязке к организациям/компаниям сохранён.
- Новый `POST /unload-places/{id}/restore` + handler.
- `GetByID` отдаёт и архивные (для деталей/восстановления).
- FK `car_unload_places` (планирование машин) при soft-delete целостность сохраняет — отдельный блок не нужен (в отличие от прежнего hard-delete, где он осиротел бы).

`Status` (active/inactive/maintenance — бизнес-статус) и `IsActive` (архивный флаг) не путаются.

## Проверка
- `go test ./internal/services/... ./internal/handlers/...` зелёный (TestUnloadPlaces_CRUD обновлён под архив/restore), gofmt/build чисто. Без миграции (поле уже было).

## Дальше по #413
- Срез 2: история (UnloadPlaceHistory). Срез 3: фронт под эталон (архив-UI, уведомления, модалки). Дедуп ScheduleTab — отдельно.

Часть эпика #406.