### PR TITLE
feat(unload-places): история изменений - модель, сервис, endpoint (#413)

### DIFF
--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -30,6 +30,7 @@ func AllModels() []interface{} {
 		&models.PersonBlacklist{},
 		&models.PersonBlacklistHistory{},
 		&models.UnloadPlace{},
+		&models.UnloadPlaceHistory{},
 		&models.SystemTable{},
 		&models.SystemTableHistory{},
 

--- a/internal/handlers/unload_places.go
+++ b/internal/handlers/unload_places.go
@@ -101,7 +101,8 @@ func (h *UnloadPlaceHandler) Create(c echo.Context) error {
 	if err := BindAndValidate(c, &req); err != nil {
 		return err
 	}
-	id, err := h.service.Create(c.Request().Context(), req)
+	userID, _ := c.Get("user_id").(int)
+	id, err := h.service.Create(c.Request().Context(), userID, req)
 	if err != nil {
 		return err
 	}
@@ -135,7 +136,8 @@ func (h *UnloadPlaceHandler) Update(c echo.Context) error {
 	if err := BindAndValidate(c, &req); err != nil {
 		return err
 	}
-	if err := h.service.Update(c.Request().Context(), id, req); err != nil {
+	userID, _ := c.Get("user_id").(int)
+	if err := h.service.Update(c.Request().Context(), userID, id, req); err != nil {
 		return err
 	}
 	return RespondMessage(c, "Место разгрузки успешно обновлено")
@@ -159,7 +161,8 @@ func (h *UnloadPlaceHandler) Delete(c echo.Context) error {
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
 	}
-	if err := h.service.Delete(c.Request().Context(), id); err != nil {
+	userID, _ := c.Get("user_id").(int)
+	if err := h.service.Delete(c.Request().Context(), userID, id); err != nil {
 		return err
 	}
 	return RespondMessage(c, "Место разгрузки архивировано")
@@ -181,10 +184,36 @@ func (h *UnloadPlaceHandler) Restore(c echo.Context) error {
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
 	}
-	if err := h.service.Restore(c.Request().Context(), id); err != nil {
+	userID, _ := c.Get("user_id").(int)
+	if err := h.service.Restore(c.Request().Context(), userID, id); err != nil {
 		return err
 	}
 	return RespondMessage(c, "Место разгрузки восстановлено")
+}
+
+// GetHistory возвращает историю изменений места разгрузки. Без отдельного
+// admin-гейта - намеренно, как и весь CRUD мест разгрузки (в отличие от
+// org/company, где история под buropropuskov): доступ управляется группой protected.
+// @Summary      История изменений места разгрузки
+// @Description  Возвращает аудит создания/переименования/архивации/восстановления места разгрузки
+// @Tags         unload-places
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID места разгрузки"
+// @Success      200 {array} models.UnloadPlaceHistoryItem
+// @Failure      401 {object} models.HTTPError
+// @Failure      500 {object} models.HTTPError
+// @Router       /unload-places/{id}/history [get]
+func (h *UnloadPlaceHandler) GetHistory(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	items, err := h.service.GetHistory(c.Request().Context(), id)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, items)
 }
 
 // --- Временные слоты ---

--- a/internal/handlers/unload_places_test.go
+++ b/internal/handlers/unload_places_test.go
@@ -101,6 +101,35 @@ func TestUnloadPlaces_CRUD(t *testing.T) {
 	assert.True(t, found, "восстановленное место должно быть в дефолтном списке")
 }
 
+func TestUnloadPlaces_History(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	created := testutil.ParseMap(t, testutil.POST(t, e, "/unload-places", `{"name":"Ист Место"}`, h))
+	id := int(created["id"].(float64))
+	require.Equal(t, http.StatusOK, testutil.PUT(t, e, fmt.Sprintf("/unload-places/%d", id), `{"name":"Ист Место 2"}`, h).Code)
+	// Смена только статуса (без имени) не должна попадать в историю как переименование.
+	require.Equal(t, http.StatusOK, testutil.PUT(t, e, fmt.Sprintf("/unload-places/%d", id), `{"status":"maintenance"}`, h).Code)
+	require.Equal(t, http.StatusOK, testutil.DELETE(t, e, fmt.Sprintf("/unload-places/%d", id), h).Code)
+	require.Equal(t, http.StatusOK, testutil.POST(t, e, fmt.Sprintf("/unload-places/%d/restore", id), "", h).Code)
+
+	hist := testutil.ParseSlice(t, testutil.GET(t, e, fmt.Sprintf("/unload-places/%d/history", id), h))
+	require.Len(t, hist, 4)
+	// Новые сверху: restored, archived, renamed, created.
+	assert.Equal(t, "restored", hist[0]["action_type"])
+	assert.Equal(t, "archived", hist[1]["action_type"])
+	assert.Equal(t, "renamed", hist[2]["action_type"])
+	assert.Equal(t, "created", hist[3]["action_type"])
+	assert.NotEmpty(t, hist[0]["actor_name"])
+	assert.NotEmpty(t, hist[3]["actor_name"])
+	assert.Equal(t, "Ист Место 2", hist[2]["details"].(map[string]interface{})["name"])
+	assert.Equal(t, "Ист Место", hist[3]["details"].(map[string]interface{})["name"])
+}
+
 func TestUnloadPlaces_GetByID_NotFound(t *testing.T) {
 	e, db, cleanup := testutil.SetupTestApp(t)
 	defer cleanup()

--- a/internal/models/unload_place_history.go
+++ b/internal/models/unload_place_history.go
@@ -1,0 +1,38 @@
+package models
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// UnloadPlaceHistory логирует действия над местом разгрузки: создание,
+// переименование, архивацию и восстановление. Нужна для аудита (#413).
+//
+// UnloadPlaceID - над каким местом действие, ActorUserID - кто его совершил.
+// FK намеренно без constraint: аудит должен пережить любые изменения.
+type UnloadPlaceHistory struct {
+	ID            int             `json:"id"`
+	UnloadPlaceID int             `gorm:"index;not null" json:"unload_place_id"`
+	ActorUserID   *int            `gorm:"index" json:"actor_user_id,omitempty"`
+	ActionType    string          `gorm:"size:32;index" json:"action_type"`
+	Details       json.RawMessage `gorm:"type:jsonb" json:"details,omitempty"`
+	CreatedAt     time.Time       `json:"created_at"`
+}
+
+// UnloadPlaceActionType - константы для UnloadPlaceHistory.ActionType.
+const (
+	UnloadPlaceActionCreated  = "created"
+	UnloadPlaceActionRenamed  = "renamed"
+	UnloadPlaceActionArchived = "archived"
+	UnloadPlaceActionRestored = "restored"
+)
+
+// UnloadPlaceHistoryItem - запись истории с именем актора для API (LEFT JOIN users).
+type UnloadPlaceHistoryItem struct {
+	ID          int             `json:"id"`
+	ActionType  string          `json:"action_type"`
+	Details     json.RawMessage `json:"details,omitempty" swaggerignore:"true"`
+	ActorUserID *int            `json:"actor_user_id,omitempty"`
+	ActorName   string          `json:"actor_name"`
+	CreatedAt   time.Time       `json:"created_at"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -275,6 +275,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	upg.PUT("/:id", up.Update)
 	upg.DELETE("/:id", up.Delete)
 	upg.POST("/:id/restore", up.Restore)
+	upg.GET("/:id/history", up.GetHistory)
 	upg.GET("/:id/time-slots", up.GetTimeSlots)
 	upg.POST("/:id/time-slots", up.AddTimeSlot)
 	upg.PUT("/:place_id/time-slots/:slot_id", up.UpdateTimeSlot)

--- a/internal/services/unload_place_history_service.go
+++ b/internal/services/unload_place_history_service.go
@@ -1,0 +1,88 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"systemburo/internal/models"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+// UnloadPlaceHistoryService - аудит действий над местами разгрузки (#413).
+type UnloadPlaceHistoryService interface {
+	// Log пишет запись аудита. Ошибка не возвращается: аудит не ломает основное действие.
+	Log(ctx context.Context, unloadPlaceID int, actorUserID *int, actionType string, details interface{})
+	// GetHistory возвращает историю по месту разгрузки (новые сверху).
+	GetHistory(ctx context.Context, unloadPlaceID int) ([]models.UnloadPlaceHistoryItem, error)
+}
+
+type unloadPlaceHistoryService struct {
+	db *gorm.DB
+}
+
+// NewUnloadPlaceHistoryService создаёт реализацию UnloadPlaceHistoryService.
+func NewUnloadPlaceHistoryService(db *gorm.DB) UnloadPlaceHistoryService {
+	return &unloadPlaceHistoryService{db: db}
+}
+
+func (s *unloadPlaceHistoryService) Log(ctx context.Context, unloadPlaceID int, actorUserID *int, actionType string, details interface{}) {
+	var raw json.RawMessage
+	if details != nil {
+		b, err := json.Marshal(details)
+		if err != nil {
+			slog.Error("unload_place_history: marshal details", "place", unloadPlaceID, "error", err)
+		} else {
+			raw = b
+		}
+	}
+	entry := models.UnloadPlaceHistory{
+		UnloadPlaceID: unloadPlaceID,
+		ActorUserID:   actorUserID,
+		ActionType:    actionType,
+		Details:       raw,
+	}
+	if err := s.db.WithContext(ctx).Create(&entry).Error; err != nil {
+		slog.Error("unload_place_history: insert", "place", unloadPlaceID, "action", actionType, "error", err)
+	}
+}
+
+func (s *unloadPlaceHistoryService) GetHistory(ctx context.Context, unloadPlaceID int) ([]models.UnloadPlaceHistoryItem, error) {
+	type row struct {
+		ID          int             `gorm:"column:id"`
+		ActionType  string          `gorm:"column:action_type"`
+		Details     json.RawMessage `gorm:"column:details"`
+		ActorUserID *int            `gorm:"column:actor_user_id"`
+		ActorName   string          `gorm:"column:actor_name"`
+		CreatedAt   time.Time       `gorm:"column:created_at"`
+	}
+	var rows []row
+	if err := s.db.WithContext(ctx).
+		Table("unload_place_histories AS h").
+		Select(`h.id, h.action_type, h.details, h.actor_user_id,
+			COALESCE(NULLIF(TRIM(BOTH ' ' FROM CONCAT_WS(' ', u.last_name, u.first_name)), ''), u.username, '') AS actor_name,
+			h.created_at`).
+		Joins("LEFT JOIN users u ON u.id = h.actor_user_id").
+		Where("h.unload_place_id = ?", unloadPlaceID).
+		Order("h.created_at DESC").
+		Scan(&rows).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching unload place history")
+	}
+
+	items := make([]models.UnloadPlaceHistoryItem, 0, len(rows))
+	for _, r := range rows {
+		items = append(items, models.UnloadPlaceHistoryItem{
+			ID:          r.ID,
+			ActionType:  r.ActionType,
+			Details:     r.Details,
+			ActorUserID: r.ActorUserID,
+			ActorName:   r.ActorName,
+			CreatedAt:   r.CreatedAt,
+		})
+	}
+	return items, nil
+}

--- a/internal/services/unload_place_service.go
+++ b/internal/services/unload_place_service.go
@@ -66,13 +66,17 @@ type UnloadPlaceWithDetails struct {
 }
 
 // UnloadPlaceService -- интерфейс бизнес-логики мест разгрузки.
+// В мутациях callerUserID - актор для аудита (#413).
 type UnloadPlaceService interface {
 	GetAll(ctx context.Context, includeArchived bool) ([]UnloadPlaceWithDetails, error)
 	GetByID(ctx context.Context, id int) (*UnloadPlaceWithDetails, error)
-	Create(ctx context.Context, req CreateUnloadPlaceRequest) (int, error)
-	Update(ctx context.Context, id int, req UpdateUnloadPlaceRequest) error
-	Delete(ctx context.Context, id int) error
-	Restore(ctx context.Context, id int) error
+	Create(ctx context.Context, callerUserID int, req CreateUnloadPlaceRequest) (int, error)
+	Update(ctx context.Context, callerUserID, id int, req UpdateUnloadPlaceRequest) error
+	Delete(ctx context.Context, callerUserID, id int) error
+	Restore(ctx context.Context, callerUserID, id int) error
+
+	// GetHistory возвращает историю изменений места разгрузки (новые сверху).
+	GetHistory(ctx context.Context, id int) ([]models.UnloadPlaceHistoryItem, error)
 
 	// Временные слоты
 	GetTimeSlots(ctx context.Context, placeID int) ([]models.UnloadPlaceTimeSlot, error)
@@ -87,12 +91,13 @@ type UnloadPlaceService interface {
 }
 
 type unloadPlaceService struct {
-	db *gorm.DB
+	db      *gorm.DB
+	history UnloadPlaceHistoryService
 }
 
 // NewUnloadPlaceService создаёт реализацию UnloadPlaceService.
 func NewUnloadPlaceService(db *gorm.DB) UnloadPlaceService {
-	return &unloadPlaceService{db: db}
+	return &unloadPlaceService{db: db, history: NewUnloadPlaceHistoryService(db)}
 }
 
 // computeUnloadPlaceStatus определяет текущий статус (open/closed) по расписанию.
@@ -201,7 +206,7 @@ func (s *unloadPlaceService) GetByID(ctx context.Context, id int) (*UnloadPlaceW
 }
 
 // Create создаёт новое место разгрузки.
-func (s *unloadPlaceService) Create(ctx context.Context, req CreateUnloadPlaceRequest) (int, error) {
+func (s *unloadPlaceService) Create(ctx context.Context, callerUserID int, req CreateUnloadPlaceRequest) (int, error) {
 	status := "active"
 	if req.Status != nil {
 		status = *req.Status
@@ -222,11 +227,13 @@ func (s *unloadPlaceService) Create(ctx context.Context, req CreateUnloadPlaceRe
 		return 0, echo.NewHTTPError(http.StatusInternalServerError, "Error creating unload place")
 	}
 	slog.Info("место разгрузки создано", "id", place.ID)
+	s.history.Log(ctx, place.ID, &callerUserID, models.UnloadPlaceActionCreated, map[string]any{"name": place.Name})
 	return place.ID, nil
 }
 
-// Update обновляет место разгрузки по ID.
-func (s *unloadPlaceService) Update(ctx context.Context, id int, req UpdateUnloadPlaceRequest) error {
+// Update обновляет место разгрузки по ID. Переименование логируется в историю;
+// смена статуса/описания/ссылки аудитом этого среза не покрывается.
+func (s *unloadPlaceService) Update(ctx context.Context, callerUserID, id int, req UpdateUnloadPlaceRequest) error {
 	var place models.UnloadPlace
 	if err := s.db.WithContext(ctx).First(&place, id).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
@@ -263,6 +270,9 @@ func (s *unloadPlaceService) Update(ctx context.Context, id int, req UpdateUnloa
 		return echo.NewHTTPError(http.StatusNotFound, "Место разгрузки не найдено")
 	}
 	slog.Info("место разгрузки обновлено", "id", id)
+	if req.Name != nil && *req.Name != place.Name {
+		s.history.Log(ctx, id, &callerUserID, models.UnloadPlaceActionRenamed, map[string]any{"name": *req.Name})
+	}
 	return nil
 }
 
@@ -271,7 +281,7 @@ func (s *unloadPlaceService) Update(ctx context.Context, id int, req UpdateUnloa
 // машины планируются на место только через орг/компания-привязку, поэтому после
 // отвязки новые car_unload_places не появятся, а существующие переживут архив
 // (soft-delete не сиротит). Отдельный блок по car_unload_places не нужен.
-func (s *unloadPlaceService) Delete(ctx context.Context, id int) error {
+func (s *unloadPlaceService) Delete(ctx context.Context, callerUserID, id int) error {
 	// Проверяем привязку к организациям
 	var orgCount int64
 	if err := s.db.WithContext(ctx).
@@ -321,11 +331,12 @@ func (s *unloadPlaceService) Delete(ctx context.Context, id int) error {
 		return echo.NewHTTPError(http.StatusNotFound, "Место разгрузки не найдено")
 	}
 	slog.Info("место разгрузки архивировано", "id", id)
+	s.history.Log(ctx, id, &callerUserID, models.UnloadPlaceActionArchived, nil)
 	return nil
 }
 
 // Restore восстанавливает архивное место разгрузки (is_active=true).
-func (s *unloadPlaceService) Restore(ctx context.Context, id int) error {
+func (s *unloadPlaceService) Restore(ctx context.Context, callerUserID, id int) error {
 	result := s.db.WithContext(ctx).
 		Model(&models.UnloadPlace{}).
 		Where("id = ?", id).
@@ -338,5 +349,11 @@ func (s *unloadPlaceService) Restore(ctx context.Context, id int) error {
 		return echo.NewHTTPError(http.StatusNotFound, "Место разгрузки не найдено")
 	}
 	slog.Info("место разгрузки восстановлено", "id", id)
+	s.history.Log(ctx, id, &callerUserID, models.UnloadPlaceActionRestored, nil)
 	return nil
+}
+
+// GetHistory возвращает историю изменений места разгрузки.
+func (s *unloadPlaceService) GetHistory(ctx context.Context, id int) ([]models.UnloadPlaceHistoryItem, error) {
+	return s.history.GetHistory(ctx, id)
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -54,6 +54,7 @@ var tables = []string{
 	"application_reads", "application_viewers", "application_approvers", "application_responsible_users",
 	"application_status_history", "application_history", "applications",
 	"companies_unload_places", "organization_unload_places",
+	"unload_place_histories",
 	"unload_place_time_slots", "unload_place_photos", "unload_places",
 	"table_fields", "table_field_facts", "companies_tables", "organization_tables",
 	"system_table_trash_histories", "system_table_histories",


### PR DESCRIPTION
## Что

Срез 2 эпика #406 по issue #413 (места разгрузки): backend-аудит истории изменений по образцу истории организаций/компаний (#412).

- `UnloadPlaceHistory` (модель + `*HistoryItem` для API) и `UnloadPlaceHistoryService` (`Log`/`GetHistory`) - копия `OrganizationHistoryService` 1-в-1: panic-safe JSON marshal, LEFT JOIN users, `COALESCE` имени актора, новые сверху.
- Логирование `created` / `renamed` / `archived` / `restored` с актором (`user_id` из JWT-контекста) во всех мутациях `UnloadPlaceService`.
- `GET /unload-places/{id}/history` - лента с именем актора.
- Регистрация `UnloadPlaceHistory` в `AllModels` (additive, под blanket OK эпика на migrate.go) + `unload_place_histories` в `CleanDB`.
- `TestUnloadPlaces_History`: created -> renamed -> archived -> restored, проверка порядка, актора и деталей.

## Решения

- **renamed логируется только при реальной смене имени** (`req.Name != nil && *req.Name != place.Name`) - намеренное отличие от org/company, где `renamed` пишется на каждый Update (там name - единственное поле). У места разгрузки Update меняет и статус/описание, поэтому `renamed` на status-only апдейте вводил бы в заблуждение. Тест это фиксирует (status-only PUT -> нет записи).
- **Аудит статуса/описания/расписания вне скоупа среза** - инструкция среза: created/renamed/archived/restored. Расписание меняется через отдельные time-slots эндпоинты (без актора), это возможный follow-up.
- **GET history без отдельного admin-гейта** - намеренно, консистентно со всем CRUD мест разгрузки (в отличие от org/company); задокументировано комментарием в хендлере.

## Проверка

- `go build ./...` чисто, `go test ./... -count=1` весь суит зелёный (в worktree, `-buildvcs=false`).
- `gofmt -l` по изменённым файлам - пусто.
- code-reviewer: вердикт GO, блокеров нет; закрыты YELLOW (комментарий про no-admin-gate, доп. assert actor_name на created). YELLOW-1 (primaryKey-тег) оставлен - bare `ID int` консистентен с эталонами org/company/user history.

Остаётся по #413: срез 3 (фронт под эталон + история-модалка + дедуп ScheduleTab).