### PR TITLE
feat(blacklist): добавление, снятие и возврат записей ЧС из UI (#443)

### DIFF
--- a/frontend/src/api/blacklist.js
+++ b/frontend/src/api/blacklist.js
@@ -16,3 +16,40 @@ export async function listPersonBlacklist({ includeArchived = false } = {}) {
   const res = await apiRequest(`/person-blacklist${qs}`);
   return res.json();
 }
+
+/**
+ * Мутация с пробросом ошибки: apiRequest не кидает на 4xx (возвращает {message}),
+ * поэтому проверяем res.ok сами - иначе 409/400 проглотились бы как успех.
+ */
+async function mutate(path, { method = 'POST', body } = {}) {
+  const res = await apiRequest(path, { method, ...(body && { body: JSON.stringify(body) }) });
+  const data = await res.json();
+  if (!res.ok) {
+    throw new Error((data && data.message) || `Ошибка запроса (${res.status})`);
+  }
+  return data;
+}
+
+export function createVehicleBlacklist({ car_number, mark_id, reason }) {
+  return mutate('/vehicle-blacklist', { body: { car_number, mark_id, reason } });
+}
+
+export function archiveVehicleBlacklist(id) {
+  return mutate(`/vehicle-blacklist/${id}`, { method: 'DELETE' });
+}
+
+export function restoreVehicleBlacklist(id) {
+  return mutate(`/vehicle-blacklist/${id}/restore`);
+}
+
+export function createPersonBlacklist({ last_name, first_name, middle_name, reason }) {
+  return mutate('/person-blacklist', { body: { last_name, first_name, middle_name, reason } });
+}
+
+export function archivePersonBlacklist(id) {
+  return mutate(`/person-blacklist/${id}`, { method: 'DELETE' });
+}
+
+export function restorePersonBlacklist(id) {
+  return mutate(`/person-blacklist/${id}/restore`);
+}

--- a/frontend/src/components/admin/blacklist/BlacklistCreateModal.vue
+++ b/frontend/src/components/admin/blacklist/BlacklistCreateModal.vue
@@ -1,0 +1,311 @@
+<template>
+  <BaseModal
+    :show="show"
+    :title="title"
+    width="520px"
+    @close="close"
+  >
+    <div class="bl-create">
+      <template v-if="type === 'vehicle'">
+        <FormField
+          label="Формат номера"
+          :required="true"
+        >
+          <BaseDropdown
+            :model-value="selectedFormatId"
+            :options="formatOptions"
+            label-key="name"
+            value-key="id"
+            placeholder="Выберите формат"
+            @update:model-value="onFormatChange"
+          />
+        </FormField>
+        <FormField
+          label="Номер"
+          :required="true"
+        >
+          <div
+            v-if="selectedFormat"
+            class="bl-plate"
+          >
+            <input
+              v-for="(cell, i) in selectedFormat.cells"
+              :key="i"
+              :value="numberParts[i]"
+              class="lk-input bl-plate-cell"
+              :style="{ width: cellWidth(cell) }"
+              :maxlength="cell.max_length"
+              :placeholder="placeholder(cell)"
+              @input="onPartInput(i, $event, cell)"
+              @blur="onPartBlur(i, cell)"
+            >
+          </div>
+          <span
+            v-else
+            class="bl-hint"
+          >Сначала выберите формат</span>
+        </FormField>
+        <FormField
+          label="Марка"
+          :required="true"
+        >
+          <BaseDropdown
+            v-model="markId"
+            :options="marks"
+            label-key="name"
+            value-key="id"
+            :searchable="true"
+            placeholder="Выберите марку"
+          />
+        </FormField>
+      </template>
+
+      <template v-else>
+        <FormField
+          label="Фамилия"
+          :required="true"
+        >
+          <input
+            v-model="lastName"
+            class="lk-input"
+            placeholder="Иванов"
+          >
+        </FormField>
+        <FormField
+          label="Имя"
+          :required="true"
+        >
+          <input
+            v-model="firstName"
+            class="lk-input"
+            placeholder="Иван"
+          >
+        </FormField>
+        <FormField label="Отчество">
+          <input
+            v-model="middleName"
+            class="lk-input"
+            placeholder="Иванович (необязательно)"
+          >
+        </FormField>
+      </template>
+
+      <FormField
+        label="Причина"
+        :required="true"
+      >
+        <textarea
+          v-model="reason"
+          class="lk-textarea"
+          rows="3"
+          placeholder="Опишите причину добавления в чёрный список"
+        />
+      </FormField>
+
+      <div
+        v-if="formError"
+        class="bl-form-error"
+      >
+        {{ formError }}
+      </div>
+    </div>
+
+    <template #actions>
+      <button
+        class="lk-button lk-button--ghost"
+        :disabled="saving"
+        @click="close"
+      >
+        Отмена
+      </button>
+      <button
+        class="lk-button lk-button--primary"
+        :disabled="!canSubmit || saving"
+        @click="submit"
+      >
+        {{ saving ? 'Сохранение...' : 'Добавить' }}
+      </button>
+    </template>
+  </BaseModal>
+</template>
+
+<script>
+import BaseModal from '@/components/ui/BaseModal.vue';
+import BaseDropdown from '@/components/ui/BaseDropdown.vue';
+import FormField from '@/components/ui/FormField.vue';
+import { apiRequest } from '@/api/client';
+import { listMarks } from '@/api/marks';
+import { validatePartValue, formatPartValue, initializeNumberParts } from '@/composables/useNumberFormat';
+
+/**
+ * Модалка добавления записи в чёрный список (#443). Тип определяет форму: 'vehicle' -
+ * формат номера + поячеечный ввод (как в VehicleForm) + марка; 'person' - ФИО.
+ * Создание делегируется через prop createFn (API-метод сущности); ошибка сервера
+ * (409 дубль / 400) показывается инлайн.
+ */
+export default {
+  name: 'BlacklistCreateModal',
+  components: { BaseModal, BaseDropdown, FormField },
+  props: {
+    show: { type: Boolean, default: false },
+    type: { type: String, required: true, validator: (v) => ['vehicle', 'person'].includes(v) },
+    createFn: { type: Function, required: true },
+  },
+  emits: ['close', 'created'],
+  data() {
+    return {
+      formats: [],
+      selectedFormatId: null,
+      marks: [],
+      markId: null,
+      numberParts: [],
+      lastName: '',
+      firstName: '',
+      middleName: '',
+      reason: '',
+      saving: false,
+      formError: '',
+    };
+  },
+  computed: {
+    title() {
+      return this.type === 'vehicle' ? 'Добавить машину в чёрный список' : 'Добавить человека в чёрный список';
+    },
+    formatOptions() {
+      return this.formats.map((f) => ({ id: f.format.id, name: f.format.name }));
+    },
+    selectedFormat() {
+      return this.formats.find((f) => f.format.id === this.selectedFormatId) || null;
+    },
+    canSubmit() {
+      if (!this.reason.trim()) return false;
+      if (this.type === 'vehicle') {
+        return !!this.selectedFormat && this.numberParts.length > 0 &&
+          this.numberParts.every((p) => p && p.trim()) && !!this.markId;
+      }
+      return !!this.lastName.trim() && !!this.firstName.trim();
+    },
+  },
+  watch: {
+    show(open) {
+      if (open) {
+        this.resetForm();
+        if (this.type === 'vehicle') this.loadVehicleData();
+      }
+    },
+  },
+  methods: {
+    resetForm() {
+      this.selectedFormatId = null;
+      this.formats = [];
+      this.markId = null;
+      this.numberParts = [];
+      this.lastName = '';
+      this.firstName = '';
+      this.middleName = '';
+      this.reason = '';
+      this.formError = '';
+      this.saving = false;
+    },
+    async loadVehicleData() {
+      try {
+        const res = await apiRequest('/license-plate-formats');
+        const data = await res.json();
+        this.formats = Array.isArray(data) ? data : [];
+        const def = this.formats.find((f) => f.format.is_default) || this.formats[0];
+        if (def) this.onFormatChange(def.format.id);
+      } catch {
+        this.formError = 'Не удалось загрузить форматы номеров';
+      }
+      try {
+        const marks = await listMarks();
+        const arr = Array.isArray(marks) ? marks : [];
+        this.marks = arr.filter((m) => m.is_active !== false).map((m) => ({ id: m.id, name: m.name }));
+      } catch {
+        this.formError = 'Не удалось загрузить марки';
+      }
+    },
+    onFormatChange(id) {
+      this.selectedFormatId = id;
+      this.numberParts = initializeNumberParts(this.selectedFormat);
+    },
+    onPartInput(i, event, cell) {
+      this.numberParts[i] = validatePartValue(event.target.value, cell);
+    },
+    onPartBlur(i, cell) {
+      this.numberParts[i] = formatPartValue(this.numberParts[i], cell);
+    },
+    placeholder(cell) {
+      if (cell.cell_type === 'numbers') return '0'.repeat(cell.max_length || 1);
+      if (cell.cell_type === 'letters') return 'А';
+      return 'А0';
+    },
+    cellWidth(cell) {
+      return `${Math.max(2, cell.max_length || 2) * 16 + 20}px`;
+    },
+    close() {
+      if (this.saving) return;
+      this.$emit('close');
+    },
+    async submit() {
+      if (!this.canSubmit || this.saving) return;
+      this.saving = true;
+      this.formError = '';
+      try {
+        let payload;
+        let displayName;
+        if (this.type === 'vehicle') {
+          const carNumber = this.numberParts.join(' ').trim();
+          const markName = (this.marks.find((m) => m.id === this.markId) || {}).name || '';
+          payload = { car_number: carNumber, mark_id: this.markId, reason: this.reason.trim() };
+          displayName = [carNumber, markName].filter(Boolean).join(' ');
+        } else {
+          payload = {
+            last_name: this.lastName.trim(),
+            first_name: this.firstName.trim(),
+            middle_name: this.middleName.trim(),
+            reason: this.reason.trim(),
+          };
+          displayName = [payload.last_name, payload.first_name, payload.middle_name].filter(Boolean).join(' ');
+        }
+        await this.createFn(payload);
+        this.$emit('created', displayName);
+      } catch (e) {
+        this.formError = e?.message || 'Не удалось добавить запись';
+      } finally {
+        this.saving = false;
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.bl-create {
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.bl-plate {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.bl-plate-cell {
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.bl-hint {
+  color: var(--color-text-muted, #999);
+  font-size: 13px;
+}
+
+.bl-form-error {
+  color: var(--color-danger, #dc3545);
+  font-size: 13px;
+}
+</style>

--- a/frontend/src/components/admin/blacklist/BlacklistTabBase.vue
+++ b/frontend/src/components/admin/blacklist/BlacklistTabBase.vue
@@ -14,6 +14,12 @@
           v-model="searchQuery"
           :title="searchPlaceholder"
         />
+        <button
+          class="lk-button lk-button--primary"
+          @click="$emit('create')"
+        >
+          Создать запись
+        </button>
         <RefreshButton
           :loading="isLoading"
           @refresh="fetchData"
@@ -74,10 +80,26 @@
           <h3 class="bl-details-title">
             {{ getPrimaryText(selected) }}
           </h3>
-          <span
-            v-if="!selected.is_active"
-            class="bl-archive-pill"
-          >В архиве</span>
+          <div class="bl-details-actions">
+            <span
+              v-if="!selected.is_active"
+              class="bl-archive-pill"
+            >В архиве</span>
+            <button
+              v-if="selected.is_active"
+              class="lk-button lk-button--danger"
+              @click="$emit('archive', selected)"
+            >
+              Снять с ЧС
+            </button>
+            <button
+              v-else
+              class="lk-button lk-button--secondary"
+              @click="$emit('restore', selected)"
+            >
+              Вернуть в ЧС
+            </button>
+          </div>
         </div>
         <div class="bl-details-body">
           <div
@@ -111,7 +133,8 @@ import { useDeletionsStore } from '@/stores/deletions';
  * Базовая вкладка чёрного списка (#443): шапка (архив-режим, поиск, обновление),
  * список слева + панель деталей справа. Сущность-специфика (тексты строк, поля
  * деталей, API-метод) приходит через props - так машины и люди переиспользуют один
- * layout. Запись и действия (создание/архив/история) - в следующих срезах.
+ * layout. Действия create/archive/restore эмитятся наружу (обработка - в обёртке);
+ * история - отдельный срез.
  */
 export default {
   name: 'BlacklistTabBase',
@@ -123,7 +146,7 @@ export default {
     getPrimaryText: { type: Function, required: true },
     getDetailRows: { type: Function, required: true },
   },
-  emits: ['count'],
+  emits: ['count', 'create', 'archive', 'restore'],
   data() {
     return {
       items: [],
@@ -162,8 +185,8 @@ export default {
         const data = await this.apiList({ includeArchived: true });
         this.items = Array.isArray(data) ? data : [];
         this.$emit('count', this.items.filter((i) => i.is_active).length);
-        if (this.selected && !this.items.some((i) => i.id === this.selected.id)) {
-          this.selected = null;
+        if (this.selected) {
+          this.selected = this.items.find((i) => i.id === this.selected.id) || null;
         }
       } catch {
         useDeletionsStore().notify({ prefix: 'Не удалось загрузить ', bold: this.emptyNoun, type: 'error' });
@@ -320,6 +343,12 @@ export default {
   font-size: 0.75em;
   font-weight: 500;
   white-space: nowrap;
+}
+
+.bl-details-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
 .bl-details-body {

--- a/frontend/src/components/admin/blacklist/PersonBlacklistTab.vue
+++ b/frontend/src/components/admin/blacklist/PersonBlacklistTab.vue
@@ -1,29 +1,71 @@
 <template>
-  <BlacklistTabBase
-    search-placeholder="Поиск по ФИО..."
-    empty-noun="людей"
-    :api-list="listPersonBlacklist"
-    :get-primary-text="primaryText"
-    :get-detail-rows="detailRows"
-    @count="$emit('count', $event)"
-  />
+  <div>
+    <BlacklistTabBase
+      ref="base"
+      search-placeholder="Поиск по ФИО..."
+      empty-noun="людей"
+      :api-list="listPersonBlacklist"
+      :get-primary-text="primaryText"
+      :get-detail-rows="detailRows"
+      @count="$emit('count', $event)"
+      @create="showCreate = true"
+      @archive="askArchive"
+      @restore="doRestore"
+    />
+    <BlacklistCreateModal
+      :show="showCreate"
+      type="person"
+      :create-fn="createPersonBlacklist"
+      @close="showCreate = false"
+      @created="onCreated"
+    />
+    <ConfirmationModal
+      :show="!!archiveItem"
+      title="Снятие с чёрного списка"
+      :message="archiveMessage"
+      confirm-text="Снять"
+      cancel-text="Отмена"
+      :confirm-button-style="{ background: '#dc3545', borderColor: '#dc3545' }"
+      @confirm="doArchive"
+      @cancel="archiveItem = null"
+    />
+  </div>
 </template>
 
 <script>
 import BlacklistTabBase from './BlacklistTabBase.vue';
-import { listPersonBlacklist } from '@/api/blacklist';
+import BlacklistCreateModal from './BlacklistCreateModal.vue';
+import ConfirmationModal from '@/components/ConfirmationModal.vue';
+import {
+  listPersonBlacklist,
+  createPersonBlacklist,
+  archivePersonBlacklist,
+  restorePersonBlacklist,
+} from '@/api/blacklist';
 import { formatDateTime } from '@/utils/datetime';
+import { useDeletionsStore } from '@/stores/deletions';
 
 /**
- * Вкладка "Люди" чёрного списка (#443). Тонкая обёртка над BlacklistTabBase:
- * задаёт API-метод и отображение строки/деталей человека (ФИО).
+ * Вкладка "Люди" чёрного списка (#443). Конфигурирует BlacklistTabBase под людей
+ * и владеет действиями: создание (модалка), снятие (подтверждение), возврат.
  */
 export default {
   name: 'PersonBlacklistTab',
-  components: { BlacklistTabBase },
+  components: { BlacklistTabBase, BlacklistCreateModal, ConfirmationModal },
   emits: ['count'],
+  data() {
+    return { showCreate: false, archiveItem: null };
+  },
+  computed: {
+    archiveMessage() {
+      return this.archiveItem
+        ? `Снять «${this.primaryText(this.archiveItem)}» с чёрного списка? Совпадающие сотрудники с активной заявкой снова станут активными.`
+        : '';
+    },
+  },
   methods: {
     listPersonBlacklist,
+    createPersonBlacklist,
     primaryText(item) {
       return [item.last_name, item.first_name, item.middle_name].filter(Boolean).join(' ');
     },
@@ -35,6 +77,35 @@ export default {
         { label: 'Причина', value: item.reason },
         { label: 'Добавлен', value: formatDateTime(item.created_at) },
       ];
+    },
+    async onCreated(name) {
+      this.showCreate = false;
+      useDeletionsStore().notify({ prefix: 'Человек ', bold: name, suffix: ' добавлен в чёрный список' });
+      await this.$refs.base.fetchData();
+    },
+    askArchive(item) {
+      this.archiveItem = item;
+    },
+    async doArchive() {
+      const item = this.archiveItem;
+      this.archiveItem = null;
+      if (!item) return;
+      try {
+        await archivePersonBlacklist(item.id);
+        useDeletionsStore().notify({ prefix: 'Человек ', bold: this.primaryText(item), suffix: ' снят с чёрного списка' });
+        await this.$refs.base.fetchData();
+      } catch (e) {
+        useDeletionsStore().notify({ prefix: 'Не удалось снять: ', bold: e?.message || 'ошибка', type: 'error' });
+      }
+    },
+    async doRestore(item) {
+      try {
+        await restorePersonBlacklist(item.id);
+        useDeletionsStore().notify({ prefix: 'Человек ', bold: this.primaryText(item), suffix: ' возвращён в чёрный список' });
+        await this.$refs.base.fetchData();
+      } catch (e) {
+        useDeletionsStore().notify({ prefix: 'Не удалось вернуть: ', bold: e?.message || 'ошибка', type: 'error' });
+      }
     },
   },
 };

--- a/frontend/src/components/admin/blacklist/VehicleBlacklistTab.vue
+++ b/frontend/src/components/admin/blacklist/VehicleBlacklistTab.vue
@@ -1,29 +1,71 @@
 <template>
-  <BlacklistTabBase
-    search-placeholder="Поиск по номеру или марке..."
-    empty-noun="машины"
-    :api-list="listVehicleBlacklist"
-    :get-primary-text="primaryText"
-    :get-detail-rows="detailRows"
-    @count="$emit('count', $event)"
-  />
+  <div>
+    <BlacklistTabBase
+      ref="base"
+      search-placeholder="Поиск по номеру или марке..."
+      empty-noun="машины"
+      :api-list="listVehicleBlacklist"
+      :get-primary-text="primaryText"
+      :get-detail-rows="detailRows"
+      @count="$emit('count', $event)"
+      @create="showCreate = true"
+      @archive="askArchive"
+      @restore="doRestore"
+    />
+    <BlacklistCreateModal
+      :show="showCreate"
+      type="vehicle"
+      :create-fn="createVehicleBlacklist"
+      @close="showCreate = false"
+      @created="onCreated"
+    />
+    <ConfirmationModal
+      :show="!!archiveItem"
+      title="Снятие с чёрного списка"
+      :message="archiveMessage"
+      confirm-text="Снять"
+      cancel-text="Отмена"
+      :confirm-button-style="{ background: '#dc3545', borderColor: '#dc3545' }"
+      @confirm="doArchive"
+      @cancel="archiveItem = null"
+    />
+  </div>
 </template>
 
 <script>
 import BlacklistTabBase from './BlacklistTabBase.vue';
-import { listVehicleBlacklist } from '@/api/blacklist';
+import BlacklistCreateModal from './BlacklistCreateModal.vue';
+import ConfirmationModal from '@/components/ConfirmationModal.vue';
+import {
+  listVehicleBlacklist,
+  createVehicleBlacklist,
+  archiveVehicleBlacklist,
+  restoreVehicleBlacklist,
+} from '@/api/blacklist';
 import { formatDateTime } from '@/utils/datetime';
+import { useDeletionsStore } from '@/stores/deletions';
 
 /**
- * Вкладка "Машины" чёрного списка (#443). Тонкая обёртка над BlacklistTabBase:
- * задаёт API-метод и отображение строки/деталей машины (номер + марка).
+ * Вкладка "Машины" чёрного списка (#443). Конфигурирует BlacklistTabBase под машины
+ * и владеет действиями: создание (модалка), снятие (подтверждение), возврат.
  */
 export default {
   name: 'VehicleBlacklistTab',
-  components: { BlacklistTabBase },
+  components: { BlacklistTabBase, BlacklistCreateModal, ConfirmationModal },
   emits: ['count'],
+  data() {
+    return { showCreate: false, archiveItem: null };
+  },
+  computed: {
+    archiveMessage() {
+      return this.archiveItem
+        ? `Снять «${this.primaryText(this.archiveItem)}» с чёрного списка? Совпадающие машины с активной заявкой снова станут активными.`
+        : '';
+    },
+  },
   methods: {
     listVehicleBlacklist,
+    createVehicleBlacklist,
     primaryText(item) {
       return [item.car_number, item.mark_name].filter(Boolean).join(' ');
     },
@@ -34,6 +76,35 @@ export default {
         { label: 'Причина', value: item.reason },
         { label: 'Добавлена', value: formatDateTime(item.created_at) },
       ];
+    },
+    async onCreated(name) {
+      this.showCreate = false;
+      useDeletionsStore().notify({ prefix: 'Машина ', bold: name, suffix: ' добавлена в чёрный список' });
+      await this.$refs.base.fetchData();
+    },
+    askArchive(item) {
+      this.archiveItem = item;
+    },
+    async doArchive() {
+      const item = this.archiveItem;
+      this.archiveItem = null;
+      if (!item) return;
+      try {
+        await archiveVehicleBlacklist(item.id);
+        useDeletionsStore().notify({ prefix: 'Машина ', bold: this.primaryText(item), suffix: ' снята с чёрного списка' });
+        await this.$refs.base.fetchData();
+      } catch (e) {
+        useDeletionsStore().notify({ prefix: 'Не удалось снять: ', bold: e?.message || 'ошибка', type: 'error' });
+      }
+    },
+    async doRestore(item) {
+      try {
+        await restoreVehicleBlacklist(item.id);
+        useDeletionsStore().notify({ prefix: 'Машина ', bold: this.primaryText(item), suffix: ' возвращена в чёрный список' });
+        await this.$refs.base.fetchData();
+      } catch (e) {
+        useDeletionsStore().notify({ prefix: 'Не удалось вернуть: ', bold: e?.message || 'ошибка', type: 'error' });
+      }
     },
   },
 };

--- a/frontend/src/components/admin/blacklist/__tests__/BlacklistCreateModal.spec.js
+++ b/frontend/src/components/admin/blacklist/__tests__/BlacklistCreateModal.spec.js
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import BlacklistCreateModal from '../BlacklistCreateModal.vue';
+
+// BaseModal использует Teleport - стабим, чтобы не тянуть портал в тест.
+const stubs = {
+  BaseModal: { template: '<div><slot /><slot name="actions" /></div>' },
+  BaseDropdown: true,
+};
+
+function mountModal(props = {}) {
+  return mount(BlacklistCreateModal, {
+    props: { show: true, type: 'person', createFn: vi.fn().mockResolvedValue({}), ...props },
+    global: { stubs },
+  });
+}
+
+describe('BlacklistCreateModal (person)', () => {
+  it('canSubmit требует фамилию, имя и причину', async () => {
+    const wrapper = mountModal();
+    expect(wrapper.vm.canSubmit).toBe(false);
+    wrapper.vm.lastName = 'Иванов';
+    wrapper.vm.firstName = 'Иван';
+    wrapper.vm.reason = 'причина';
+    await flushPromises();
+    expect(wrapper.vm.canSubmit).toBe(true);
+  });
+
+  it('submit вызывает createFn с payload и эмитит created с ФИО', async () => {
+    const createFn = vi.fn().mockResolvedValue({});
+    const wrapper = mountModal({ createFn });
+    wrapper.vm.lastName = 'Иванов';
+    wrapper.vm.firstName = 'Иван';
+    wrapper.vm.middleName = 'Иванович';
+    wrapper.vm.reason = 'причина';
+    await wrapper.vm.submit();
+    expect(createFn).toHaveBeenCalledWith({
+      last_name: 'Иванов', first_name: 'Иван', middle_name: 'Иванович', reason: 'причина',
+    });
+    expect(wrapper.emitted('created')[0]).toEqual(['Иванов Иван Иванович']);
+  });
+
+  it('ошибка createFn (409) показывается в formError, created не эмитится', async () => {
+    const createFn = vi.fn().mockRejectedValue(new Error('Этот человек уже в чёрном списке'));
+    const wrapper = mountModal({ createFn });
+    wrapper.vm.lastName = 'Иванов';
+    wrapper.vm.firstName = 'Иван';
+    wrapper.vm.reason = 'x';
+    await wrapper.vm.submit();
+    await flushPromises();
+    expect(wrapper.vm.formError).toBe('Этот человек уже в чёрном списке');
+    expect(wrapper.emitted('created')).toBeFalsy();
+  });
+
+  it('title зависит от типа', () => {
+    expect(mountModal({ type: 'person' }).vm.title).toContain('человека');
+    expect(mountModal({ type: 'vehicle' }).vm.title).toContain('машину');
+  });
+});
+
+describe('BlacklistCreateModal (vehicle)', () => {
+  const fmt = [{ format: { id: 1, name: 'РФ' }, cells: [{ cell_type: 'letters', max_length: 1 }, { cell_type: 'numbers', max_length: 3 }] }];
+
+  it('canSubmit false без формата, ячеек и марки', () => {
+    const w = mountModal({ type: 'vehicle' });
+    expect(w.vm.canSubmit).toBe(false);
+  });
+
+  it('canSubmit true когда формат, ячейки, марка и причина заполнены', async () => {
+    const w = mountModal({ type: 'vehicle' });
+    w.vm.formats = fmt;
+    w.vm.selectedFormatId = 1;
+    w.vm.numberParts = ['А', '123'];
+    w.vm.markId = 5;
+    w.vm.reason = 'причина';
+    await flushPromises();
+    expect(w.vm.canSubmit).toBe(true);
+  });
+
+  it('submit собирает car_number из ячеек и эмитит created с номером и маркой', async () => {
+    const createFn = vi.fn().mockResolvedValue({});
+    const w = mountModal({ type: 'vehicle', createFn });
+    w.vm.formats = fmt;
+    w.vm.selectedFormatId = 1;
+    w.vm.marks = [{ id: 5, name: 'BMW' }];
+    w.vm.numberParts = ['А', '123'];
+    w.vm.markId = 5;
+    w.vm.reason = 'причина';
+    await w.vm.submit();
+    expect(createFn).toHaveBeenCalledWith({ car_number: 'А 123', mark_id: 5, reason: 'причина' });
+    expect(w.emitted('created')[0]).toEqual(['А 123 BMW']);
+  });
+});

--- a/frontend/src/components/admin/blacklist/__tests__/BlacklistTabBase.spec.js
+++ b/frontend/src/components/admin/blacklist/__tests__/BlacklistTabBase.spec.js
@@ -68,6 +68,34 @@ describe('BlacklistTabBase', () => {
     expect(wrapper.find('.bl-details-title').text()).toBe('Запись 1');
   });
 
+  it('кнопка "Создать запись" эмитит create', async () => {
+    const wrapper = mountBase();
+    await flushPromises();
+    const btn = wrapper.findAll('button').find((b) => b.text() === 'Создать запись');
+    await btn.trigger('click');
+    expect(wrapper.emitted('create')).toBeTruthy();
+  });
+
+  it('кнопка "Снять с ЧС" эмитит archive с активной записью', async () => {
+    const wrapper = mountBase();
+    await flushPromises();
+    await wrapper.findAll('.bl-row')[0].trigger('click');
+    const btn = wrapper.findAll('button').find((b) => b.text() === 'Снять с ЧС');
+    await btn.trigger('click');
+    expect(wrapper.emitted('archive')[0][0].id).toBe(1);
+  });
+
+  it('кнопка "Вернуть в ЧС" эмитит restore для архивной записи', async () => {
+    const wrapper = mountBase();
+    await flushPromises();
+    wrapper.vm.onArchiveModeChange('archive');
+    await flushPromises();
+    await wrapper.findAll('.bl-row')[0].trigger('click');
+    const btn = wrapper.findAll('button').find((b) => b.text() === 'Вернуть в ЧС');
+    await btn.trigger('click');
+    expect(wrapper.emitted('restore')[0][0].id).toBe(3);
+  });
+
   it('пустой список показывает empty-state', async () => {
     const wrapper = mountBase({ apiList: vi.fn().mockResolvedValue([]) });
     await flushPromises();


### PR DESCRIPTION
Срез B2 эпика #443. Действия чёрного списка из UI: создание, снятие, возврат. Read-only страница была B1 (#451). История - срез B3.

## Что добавлено
- BlacklistCreateModal.vue - модалка добавления (prop type): машина = формат номера (BaseDropdown) + поячеечный ввод через composable useNumberFormat (как в VehicleForm) + марка (BaseDropdown searchable) + причина; человек = ФИО (отчество опц.) + причина. Ошибка сервера (409 дубль / 400) - инлайн.
- BlacklistTabBase: кнопка "Создать запись" в шапке (эмит create); в панели деталей "Снять с ЧС" (active) / "Вернуть в ЧС" (archive) - эмиты archive/restore; после мутации fetchData ресинкает выбранную запись.
- VehicleBlacklistTab / PersonBlacklistTab: владеют модалкой + ConfirmationModal (подтверждение снятия) + обработчиками create/archive/restore с уведомлениями (грамматика по роду).
- api/blacklist.js: createVehicleBlacklist/archive/restore + person-аналоги через helper mutate (проверяет res.ok и кидает - apiRequest на 4xx не бросает, иначе 409 проглотился бы как успех).

## Дизайн-система / reuse
BaseModal (Teleport/анимация/Escape/overlay), BaseDropdown, FormField, ConfirmationModal, useDeletionsStore.notify (конкретные формулировки, без alert/confirm), .lk-input/.lk-textarea (15px), .lk-button (pill). Composable useNumberFormat и listMarks переиспользованы - плейт-логика не дублируется. Кнопка "Создать" не скрыта в архив-режиме.

## Проверено
- vitest: 16 blacklist-тестов (9 base incl. эмиты create/archive/restore; 7 modal: person canSubmit/submit/ошибка/title, vehicle canSubmit/submit-сборка-номера). Полный прогон зелёный.
- eslint 0 ошибок в моих файлах, vite build OK.
- Ревью code-reviewer: GO, блокеров нет; Y1 (resetForm чистит формат), Y2 (onCreated await), Y4 (vehicle-тесты) - исправлены. Y3 (warning ConfirmationModal) - ложное (пустая строка удовлетворяет required, паттерн как в MarksManagement).
- Визуально (vite dev + Playwright, моки без мутации БД): модалка машины (формат+ячейки+марка+причина), модалка человека (заполненная), деталь со "Снять с ЧС", архив с "Вернуть в ЧС" - показаны заказчику до мержа.

## Дальше
B3 - модалки истории (VehicleBlacklistHistoryModal / PersonBlacklistHistoryModal по образцу SystemTableHistoryModal + ExcelJS), кнопка "История" в панели деталей.