### PR TITLE
feat(blacklist): модалки истории ЧС машин и людей (#443)

### DIFF
--- a/frontend/src/api/blacklist.js
+++ b/frontend/src/api/blacklist.js
@@ -53,3 +53,13 @@ export function archivePersonBlacklist(id) {
 export function restorePersonBlacklist(id) {
   return mutate(`/person-blacklist/${id}/restore`);
 }
+
+export async function getVehicleBlacklistHistory(id) {
+  const res = await apiRequest(`/vehicle-blacklist/${id}/history`);
+  return res.json();
+}
+
+export async function getPersonBlacklistHistory(id) {
+  const res = await apiRequest(`/person-blacklist/${id}/history`);
+  return res.json();
+}

--- a/frontend/src/components/admin/blacklist/BlacklistHistoryModalBase.vue
+++ b/frontend/src/components/admin/blacklist/BlacklistHistoryModalBase.vue
@@ -1,0 +1,926 @@
+<template>
+  <Teleport to="body">
+    <div
+      class="modal-overlay"
+      data-testid="blacklist-history-modal"
+      @mousedown="onOverlayMousedown"
+      @mouseup="onOverlayMouseup"
+    >
+      <div
+        class="blacklist-history-modal"
+        @mousedown.stop
+      >
+        <div class="modal-header">
+          <h3>{{ title }}</h3>
+          <div class="header-actions">
+            <button
+              class="export-btn"
+              :disabled="filteredHistory.length === 0 || isExporting"
+              @click="exportToExcel"
+            >
+              <img
+                v-if="!isExporting"
+                src="@/assets/icons/export.png"
+                class="export-icon"
+              >
+              <span v-if="!isExporting">Экспорт</span>
+              <div
+                v-else
+                class="export-loader"
+              />
+            </button>
+            <button
+              class="close-btn"
+              aria-label="Закрыть"
+              @click="close"
+            >
+              ×
+            </button>
+          </div>
+        </div>
+
+        <div class="history-filters">
+          <div class="filter-row">
+            <div class="search-filter">
+              <span class="filter-label">Поиск:</span>
+              <input
+                v-model="searchQuery"
+                type="text"
+                class="search-input"
+                placeholder="Поиск по пользователю, действию..."
+              >
+            </div>
+
+            <div class="user-filter">
+              <span class="filter-label">Пользователь:</span>
+              <div
+                ref="userSelect"
+                class="custom-select"
+                @click="toggleUserDropdown"
+              >
+                <div class="select-trigger">
+                  <span class="selected-value">{{ selectedUserName }}</span>
+                  <img
+                    src="@/assets/icons/arrow.png"
+                    class="select-arrow"
+                    :class="{ 'arrow-open': userDropdownOpen }"
+                  >
+                </div>
+                <transition name="fade">
+                  <div
+                    v-if="userDropdownOpen"
+                    class="select-dropdown"
+                  >
+                    <div
+                      class="select-option"
+                      :class="{ selected: selectedUserId === null }"
+                      @click.stop="selectUser(null)"
+                    >
+                      Все пользователи
+                    </div>
+                    <div
+                      v-for="user in uniqueUsers"
+                      :key="user.id"
+                      class="select-option"
+                      :class="{ selected: selectedUserId === user.id }"
+                      @click.stop="selectUser(user.id)"
+                    >
+                      {{ user.name }}
+                    </div>
+                  </div>
+                </transition>
+              </div>
+            </div>
+
+            <div class="date-filter">
+              <span class="filter-label">Период:</span>
+              <input
+                v-model="dateFrom"
+                type="date"
+                class="date-input"
+              >
+              <span class="date-separator">-</span>
+              <input
+                v-model="dateTo"
+                type="date"
+                class="date-input"
+              >
+            </div>
+
+            <div class="sort-filter">
+              <span class="filter-label">Сортировка:</span>
+              <button
+                class="sort-btn"
+                @click="toggleSortOrder"
+              >
+                <img
+                  src="@/assets/icons/sort.png"
+                  class="sort-icon"
+                  :class="{ 'sort-asc': sortOrder === 'asc' }"
+                >
+                <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div class="modal-content">
+          <div
+            v-if="loading"
+            class="history-loading"
+          >
+            <LoaderSpinner label="Загрузка истории..." />
+          </div>
+
+          <div
+            v-else-if="filteredHistory.length === 0"
+            class="history-empty"
+          >
+            История пуста
+          </div>
+
+          <div
+            v-else
+            class="history-timeline"
+          >
+            <div
+              v-for="(item, index) in filteredHistory"
+              :key="item.id"
+              class="history-item"
+            >
+              <div
+                class="timeline-dot"
+                :class="getActionClass(item.action_type)"
+              />
+              <div
+                v-if="index < filteredHistory.length - 1"
+                class="timeline-line"
+              />
+
+              <div class="history-content">
+                <div class="history-header">
+                  <span class="user-name">{{ item.user_name || 'Система' }}</span>
+                  <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                </div>
+
+                <div class="action-text">
+                  {{ getActionText(item) }}
+                </div>
+
+                <div
+                  v-if="getActionComment(item)"
+                  class="action-comment"
+                >
+                  {{ getActionComment(item) }}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script>
+import { useOverlayClose } from '@/composables/useOverlayClose';
+import { useDeletionsStore } from '@/stores/deletions';
+import { formatDateTime } from '@/utils/datetime';
+import LoaderSpinner from '@/components/ui/LoaderSpinner.vue';
+import ExcelJS from 'exceljs';
+
+const ACTION_DOT_CLASS = {
+  created: 'dot-create',
+  archived: 'dot-deactivate',
+  restored: 'dot-activate',
+};
+
+/**
+ * Базовая модалка истории записи чёрного списка (#443). Структура и оформление -
+ * по образцу SystemTableHistoryModal (Teleport, фильтры в строку, timeline,
+ * ExcelJS-экспорт). Сущность-специфика (заголовок, тексты действий, лейблы полей
+ * details, загрузчик) приходит через props - так машины и люди делят один layout.
+ */
+export default {
+  name: 'BlacklistHistoryModalBase',
+  components: { LoaderSpinner },
+  props: {
+    title: { type: String, required: true },
+    /** Имя записи для имени файла экспорта (санируется). */
+    entityLabel: { type: String, default: 'zapis' },
+    /** Загрузчик истории: () => Promise<Array>. */
+    loadFn: { type: Function, required: true },
+    /** action_type -> человекочитаемый текст действия. */
+    actionTexts: { type: Object, required: true },
+    /** ключ поля details -> лейбл; показываются только присутствующие тут ключи. */
+    fieldLabels: { type: Object, default: () => ({}) },
+    currentUserName: { type: String, default: '' },
+  },
+  emits: ['close'],
+  setup(_, { emit }) {
+    const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(() => emit('close'));
+    return { onOverlayMousedown, onOverlayMouseup };
+  },
+  data() {
+    return {
+      loading: false,
+      history: [],
+      sortOrder: 'desc',
+      searchQuery: '',
+      selectedUserId: null,
+      dateFrom: '',
+      dateTo: '',
+      userDropdownOpen: false,
+      isExporting: false,
+    };
+  },
+  computed: {
+    uniqueUsers() {
+      const users = new Map();
+      this.history.forEach((item) => {
+        if (item.user_id && !users.has(item.user_id)) {
+          users.set(item.user_id, { id: item.user_id, name: item.user_name || 'Система' });
+        }
+      });
+      return Array.from(users.values()).sort((a, b) => a.name.localeCompare(b.name));
+    },
+
+    selectedUserName() {
+      if (this.selectedUserId === null) return 'Все пользователи';
+      const user = this.uniqueUsers.find((u) => u.id === this.selectedUserId);
+      return user ? user.name : 'Все пользователи';
+    },
+
+    filteredHistory() {
+      let filtered = [...this.history];
+
+      if (this.searchQuery && this.searchQuery.trim() !== '') {
+        const query = this.searchQuery.toLowerCase().trim();
+        filtered = filtered.filter((item) => {
+          const userName = (item.user_name || '').toLowerCase();
+          const actionText = this.getActionText(item).toLowerCase();
+          const comment = this.getActionComment(item).toLowerCase();
+          return userName.includes(query) || actionText.includes(query) || comment.includes(query);
+        });
+      }
+
+      if (this.selectedUserId) {
+        filtered = filtered.filter((item) => item.user_id === this.selectedUserId);
+      }
+
+      if (this.dateFrom) {
+        const fromDate = new Date(this.dateFrom);
+        fromDate.setHours(0, 0, 0, 0);
+        filtered = filtered.filter((item) => new Date(item.created_at) >= fromDate);
+      }
+
+      if (this.dateTo) {
+        const toDate = new Date(this.dateTo);
+        toDate.setHours(23, 59, 59, 999);
+        filtered = filtered.filter((item) => new Date(item.created_at) <= toDate);
+      }
+
+      return filtered.sort((a, b) => {
+        const timeA = new Date(a.created_at).getTime();
+        const timeB = new Date(b.created_at).getTime();
+        return this.sortOrder === 'desc' ? timeB - timeA : timeA - timeB;
+      });
+    },
+
+    formattedCurrentDateTime() {
+      const now = new Date();
+      return now.toLocaleString('ru-RU', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+      }).replace(',', '');
+    },
+
+    currentUserDisplayName() {
+      if (!this.currentUserName) return 'Пользователь';
+      const parts = this.currentUserName.split(' ').filter((p) => p && p !== 'null' && p !== 'undefined');
+      return parts.length > 0 ? parts.join(' ') : 'Пользователь';
+    },
+
+    safeEntityLabel() {
+      const name = this.entityLabel || 'zapis';
+      return name.replace(/[\\/:"*?<>|]/g, '_').replace(/\s+/g, '_');
+    },
+
+    exportData() {
+      return this.filteredHistory.map((item) => ({
+        'Дата и время': this.formatDateTime(item.created_at),
+        Пользователь: item.user_name || 'Система',
+        Действие: this.getActionText(item),
+        Детали: this.getActionComment(item),
+        'Тип действия': item.action_type,
+        'ID записи': item.id,
+      }));
+    },
+  },
+  mounted() {
+    this.loadHistory();
+    document.addEventListener('click', this.handleClickOutside);
+    document.addEventListener('keydown', this.onKeydown);
+  },
+  beforeUnmount() {
+    document.removeEventListener('click', this.handleClickOutside);
+    document.removeEventListener('keydown', this.onKeydown);
+  },
+  methods: {
+    formatDateTime,
+    onKeydown(e) {
+      if (e.key === 'Escape') this.close();
+    },
+    close() {
+      this.$emit('close');
+    },
+    handleClickOutside(event) {
+      // Через Teleport this.$el - anchor-комментарий без querySelector, поэтому
+      // селект ищем по template-ref (он резолвится в реальный DOM-узел в body).
+      const select = this.$refs.userSelect;
+      if (select && !select.contains(event.target)) {
+        this.userDropdownOpen = false;
+      }
+    },
+
+    async loadHistory() {
+      this.loading = true;
+      try {
+        const data = await this.loadFn();
+        this.history = Array.isArray(data) ? data : [];
+      } catch (error) {
+        console.error('Error loading blacklist history:', error);
+        this.history = [];
+        useDeletionsStore().notify({ prefix: 'Не удалось загрузить ', bold: 'историю', type: 'error' });
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    getActionClass(actionType) {
+      return ACTION_DOT_CLASS[actionType] || 'dot-default';
+    },
+
+    getActionText(item) {
+      return this.actionTexts[item.action_type] || item.action_type;
+    },
+
+    /**
+     * Читаемые детали для timeline. Показываем только ключи из fieldLabels,
+     * пропуская пустые значения и нулевые счётчики (иначе "Деактивировано: 0" - шум).
+     */
+    getActionComment(item) {
+      const d = item.details;
+      if (!d || typeof d !== 'object') return '';
+      const parts = [];
+      for (const [key, raw] of Object.entries(d)) {
+        if (!(key in this.fieldLabels)) continue;
+        if (raw === null || raw === undefined || raw === '') continue;
+        if (typeof raw === 'number' && raw === 0) continue;
+        parts.push(`${this.fieldLabels[key]}: ${this.formatFieldValue(raw)}`);
+      }
+      return parts.join(' / ');
+    },
+
+    formatFieldValue(value) {
+      if (typeof value === 'boolean') return value ? 'да' : 'нет';
+      const s = String(value);
+      return s.length > 80 ? `${s.slice(0, 80)}...` : s;
+    },
+
+    toggleSortOrder() {
+      this.sortOrder = this.sortOrder === 'desc' ? 'asc' : 'desc';
+    },
+
+    toggleUserDropdown() {
+      this.userDropdownOpen = !this.userDropdownOpen;
+    },
+
+    selectUser(userId) {
+      this.selectedUserId = userId;
+      this.userDropdownOpen = false;
+    },
+
+    async exportToExcel() {
+      if (this.filteredHistory.length === 0) return;
+      this.isExporting = true;
+      try {
+        const workbook = new ExcelJS.Workbook();
+        const worksheet = workbook.addWorksheet('История');
+
+        const headers = ['Дата и время', 'Пользователь', 'Действие', 'Детали', 'Тип действия', 'ID записи'];
+        const headerRow = worksheet.addRow(headers);
+        headerRow.height = 25;
+        headerRow.eachCell((cell) => {
+          cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FF4F5BDF' } };
+          cell.font = { name: 'Verdana', size: 11, bold: true, color: { argb: 'FFFFFFFF' } };
+          cell.alignment = { vertical: 'middle', horizontal: 'center' };
+          cell.border = {
+            top: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+            bottom: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+            left: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+            right: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+          };
+        });
+
+        this.exportData.forEach((item, index) => {
+          const row = worksheet.addRow([
+            item['Дата и время'],
+            item.Пользователь,
+            item.Действие,
+            item.Детали,
+            item['Тип действия'],
+            item['ID записи'],
+          ]);
+          row.height = 20;
+          const fillColor = index % 2 === 0 ? 'FFF0F5FF' : 'FFE0E9FF';
+          row.eachCell((cell) => {
+            cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: fillColor } };
+            cell.font = { name: 'Verdana', size: 9, color: { argb: 'FF333333' } };
+            cell.alignment = { vertical: 'middle', wrapText: true };
+            cell.border = {
+              top: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+              bottom: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+              left: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+              right: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+            };
+          });
+        });
+
+        const lastDataRow = this.exportData.length;
+        const cols = headers.length;
+        for (let row = 1; row <= lastDataRow + 1; row++) {
+          const rightCell = worksheet.getCell(row, cols);
+          rightCell.border = { ...rightCell.border, right: { style: 'medium', color: { argb: 'FF000000' } } };
+          const leftCell = worksheet.getCell(row, 1);
+          leftCell.border = { ...leftCell.border, left: { style: 'medium', color: { argb: 'FF000000' } } };
+        }
+        for (let col = 1; col <= cols; col++) {
+          const topCell = worksheet.getCell(1, col);
+          topCell.border = { ...topCell.border, top: { style: 'medium', color: { argb: 'FF000000' } } };
+          const bottomCell = worksheet.getCell(lastDataRow + 1, col);
+          bottomCell.border = { ...bottomCell.border, bottom: { style: 'medium', color: { argb: 'FF000000' } } };
+        }
+
+        worksheet.addRow([]);
+        const infoRow1 = worksheet.addRow(['Отчёт сформировал:', this.currentUserDisplayName]);
+        const infoRow2 = worksheet.addRow(['Дата формирования:', this.formattedCurrentDateTime]);
+        [infoRow1, infoRow2].forEach((row) => {
+          row.eachCell((cell) => {
+            cell.font = { name: 'Verdana', size: 10, color: { argb: 'FF333333' } };
+            cell.alignment = { vertical: 'middle' };
+            cell.border = {
+              top: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+              bottom: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+              left: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+              right: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+            };
+          });
+        });
+
+        worksheet.columns = [
+          { width: 22 },
+          { width: 30 },
+          { width: 30 },
+          { width: 60 },
+          { width: 22 },
+          { width: 12 },
+        ];
+
+        const buffer = await workbook.xlsx.writeBuffer();
+        const blob = new Blob([buffer], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.download = `Istoriya_chs_${this.safeEntityLabel}_${this.formattedCurrentDateTime.replace(/[.:,]/g, '-')}.xlsx`;
+        a.href = url;
+        a.click();
+        window.URL.revokeObjectURL(url);
+      } catch (error) {
+        console.error('Error exporting blacklist history to Excel:', error);
+        useDeletionsStore().notify({ prefix: 'Не удалось ', bold: 'выгрузить историю', type: 'error' });
+      } finally {
+        this.isExporting = false;
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 12000;
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
+  animation: fadeIn 0.2s ease-out;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.blacklist-history-modal {
+  background: white;
+  border-radius: 30px;
+  width: 900px;
+  max-width: 95%;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+  animation: slideUp 0.2s ease-out;
+}
+
+@keyframes slideUp {
+  from { transform: translateY(20px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 15px 25px;
+  border-bottom: 1px solid #e6e6e6;
+}
+
+.modal-header h3 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: #333;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.export-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 6px 16px;
+  background: white;
+  border: 1px solid #e6e6e6;
+  border-radius: 20px;
+  font-size: 13px;
+  color: #000;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  height: 32px;
+}
+
+.export-btn:hover:not(:disabled) {
+  background: #f5f5f5;
+  border-color: #4F5BDF;
+}
+
+.export-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.export-icon {
+  width: 14px;
+  height: 14px;
+}
+
+.export-loader {
+  width: 16px;
+  height: 16px;
+  border: 2px solid #e6e6e6;
+  border-top: 2px solid #4F5BDF;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  font-size: 24px;
+  color: #a2a2a2;
+  cursor: pointer;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  transition: all 0.2s ease;
+}
+
+.close-btn:hover {
+  background: #f5f5f5;
+  color: #333;
+}
+
+.history-filters {
+  padding: 15px 25px;
+  border-bottom: 1px solid #e6e6e6;
+  background-color: #fafafa;
+}
+
+.filter-row {
+  display: flex;
+  gap: 15px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.search-filter,
+.user-filter,
+.date-filter,
+.sort-filter {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.filter-label {
+  font-size: 12px;
+  color: #a2a2a2;
+  white-space: nowrap;
+}
+
+.search-input {
+  padding: 6px 12px;
+  border: 1px solid #e6e6e6;
+  border-radius: 20px;
+  font-size: 12px;
+  width: 200px;
+  height: 32px;
+  transition: all 0.2s ease;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: #4F5BDF;
+  box-shadow: 0 0 0 3px rgba(79, 91, 223, 0.1);
+}
+
+.custom-select {
+  position: relative;
+  width: 200px;
+  cursor: pointer;
+}
+
+.select-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 12px;
+  background: white;
+  border: 1px solid #e6e6e6;
+  border-radius: 20px;
+  transition: all 0.2s ease;
+  height: 32px;
+}
+
+.select-trigger:hover {
+  border-color: #4F5BDF;
+  background: #f5f5f5;
+}
+
+.selected-value {
+  font-size: 12px;
+  color: #000;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+}
+
+.select-arrow {
+  width: 8px;
+  height: 8px;
+  transition: transform 0.2s ease;
+}
+
+.select-arrow.arrow-open {
+  transform: rotate(90deg);
+}
+
+.fade-enter-active, .fade-leave-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.fade-enter-from, .fade-leave-to {
+  opacity: 0;
+  transform: translateY(-10px);
+}
+
+.select-dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  max-height: 300px;
+  overflow-y: auto;
+  background: white;
+  border: 1px solid #e6e6e6;
+  border-radius: 15px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  z-index: 1000;
+}
+
+.select-option {
+  padding: 10px 14px;
+  font-size: 12px;
+  color: #000;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.select-option:hover {
+  background-color: #f0f3ff;
+}
+
+.select-option.selected {
+  background-color: #f0f3ff;
+  font-weight: 500;
+}
+
+.date-input {
+  padding: 6px 8px;
+  border: 1px solid #e6e6e6;
+  border-radius: 15px;
+  font-size: 12px;
+  width: 120px;
+  height: 32px;
+}
+
+.date-separator {
+  color: #a2a2a2;
+  font-size: 12px;
+}
+
+.sort-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  background: white;
+  border: 1px solid #e6e6e6;
+  border-radius: 20px;
+  font-size: 12px;
+  color: #000;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  height: 32px;
+  width: 170px;
+}
+
+.sort-btn:hover {
+  background: #f5f5f5;
+  border-color: #4F5BDF;
+}
+
+.sort-icon {
+  width: 14px;
+  height: 14px;
+  transition: transform 0.2s ease;
+}
+
+.sort-icon.sort-asc {
+  transform: rotate(180deg);
+}
+
+.modal-content {
+  padding: 20px 25px;
+  overflow-y: auto;
+  max-height: calc(80vh - 180px);
+  position: relative;
+}
+
+.history-loading,
+.history-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px;
+  color: #a2a2a2;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.history-timeline {
+  position: relative;
+  padding-left: 20px;
+  min-height: 100px;
+}
+
+.history-item {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 20px;
+  position: relative;
+}
+
+.history-item:last-child {
+  margin-bottom: 0;
+}
+
+.timeline-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  margin-top: 4px;
+  z-index: 1;
+  position: relative;
+}
+
+.timeline-line {
+  position: absolute;
+  left: 4px;
+  top: 18px;
+  width: 2px;
+  height: calc(100% + 2px);
+  background: #e6e6e6;
+}
+
+.dot-create { background: #4F5BDF; }
+.dot-activate { background: #10b981; }
+.dot-deactivate { background: #6b7280; }
+.dot-default { background: #9ca3af; }
+
+.history-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.history-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 4px;
+}
+
+.user-name {
+  font-weight: 500;
+  color: #333;
+  font-size: 13px;
+}
+
+.action-time {
+  color: #a2a2a2;
+  font-size: 11px;
+}
+
+.action-text {
+  color: #666;
+  font-size: 12px;
+  margin-bottom: 2px;
+}
+
+.action-comment {
+  font-size: 11px;
+  color: #666;
+  font-style: italic;
+  margin-top: 4px;
+  padding-left: 6px;
+  border-left: 2px solid #e6e6e6;
+  word-break: break-word;
+}
+
+@media (max-width: 768px) {
+  .filter-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .search-filter,
+  .user-filter,
+  .date-filter,
+  .sort-filter {
+    width: 100%;
+  }
+  .custom-select,
+  .search-input,
+  .date-input,
+  .sort-btn {
+    width: 100%;
+  }
+  .date-input {
+    width: calc(50% - 20px);
+  }
+}
+</style>

--- a/frontend/src/components/admin/blacklist/BlacklistTabBase.vue
+++ b/frontend/src/components/admin/blacklist/BlacklistTabBase.vue
@@ -86,6 +86,12 @@
               class="bl-archive-pill"
             >В архиве</span>
             <button
+              class="lk-button lk-button--ghost"
+              @click="$emit('history', selected)"
+            >
+              История
+            </button>
+            <button
               v-if="selected.is_active"
               class="lk-button lk-button--danger"
               @click="$emit('archive', selected)"
@@ -146,7 +152,7 @@ export default {
     getPrimaryText: { type: Function, required: true },
     getDetailRows: { type: Function, required: true },
   },
-  emits: ['count', 'create', 'archive', 'restore'],
+  emits: ['count', 'create', 'archive', 'restore', 'history'],
   data() {
     return {
       items: [],

--- a/frontend/src/components/admin/blacklist/PersonBlacklistHistoryModal.vue
+++ b/frontend/src/components/admin/blacklist/PersonBlacklistHistoryModal.vue
@@ -1,0 +1,61 @@
+<template>
+  <BlacklistHistoryModalBase
+    :title="title"
+    :entity-label="entityLabel"
+    :load-fn="loadFn"
+    :action-texts="actionTexts"
+    :field-labels="fieldLabels"
+    :current-user-name="currentUserName"
+    @close="$emit('close')"
+  />
+</template>
+
+<script>
+import BlacklistHistoryModalBase from './BlacklistHistoryModalBase.vue';
+import { getPersonBlacklistHistory } from '@/api/blacklist';
+
+const ACTION_TEXTS = {
+  created: 'Добавлен в чёрный список',
+  archived: 'Снят с чёрного списка',
+  restored: 'Возвращён в чёрный список',
+};
+
+const FIELD_LABELS = {
+  reason: 'Причина',
+  employees_deactivated: 'Деактивировано сотрудников',
+  employees_reactivated: 'Возвращено сотрудников',
+};
+
+/**
+ * Модалка истории записи ЧС людей (#443). Тонкая обёртка над
+ * BlacklistHistoryModalBase: задаёт заголовок, словари действий/полей и загрузчик.
+ */
+export default {
+  name: 'PersonBlacklistHistoryModal',
+  components: { BlacklistHistoryModalBase },
+  props: {
+    item: { type: Object, required: true },
+    currentUserName: { type: String, default: '' },
+  },
+  emits: ['close'],
+  computed: {
+    actionTexts() {
+      return ACTION_TEXTS;
+    },
+    fieldLabels() {
+      return FIELD_LABELS;
+    },
+    entityLabel() {
+      return [this.item.last_name, this.item.first_name, this.item.middle_name].filter(Boolean).join(' ');
+    },
+    title() {
+      return `История человека «${this.entityLabel}»`;
+    },
+  },
+  methods: {
+    loadFn() {
+      return getPersonBlacklistHistory(this.item.id);
+    },
+  },
+};
+</script>

--- a/frontend/src/components/admin/blacklist/PersonBlacklistTab.vue
+++ b/frontend/src/components/admin/blacklist/PersonBlacklistTab.vue
@@ -11,6 +11,7 @@
       @create="showCreate = true"
       @archive="askArchive"
       @restore="doRestore"
+      @history="historyItem = $event"
     />
     <BlacklistCreateModal
       :show="showCreate"
@@ -18,6 +19,12 @@
       :create-fn="createPersonBlacklist"
       @close="showCreate = false"
       @created="onCreated"
+    />
+    <PersonBlacklistHistoryModal
+      v-if="historyItem"
+      :item="historyItem"
+      :current-user-name="currentUserName"
+      @close="historyItem = null"
     />
     <ConfirmationModal
       :show="!!archiveItem"
@@ -35,6 +42,7 @@
 <script>
 import BlacklistTabBase from './BlacklistTabBase.vue';
 import BlacklistCreateModal from './BlacklistCreateModal.vue';
+import PersonBlacklistHistoryModal from './PersonBlacklistHistoryModal.vue';
 import ConfirmationModal from '@/components/ConfirmationModal.vue';
 import {
   listPersonBlacklist,
@@ -51,10 +59,13 @@ import { useDeletionsStore } from '@/stores/deletions';
  */
 export default {
   name: 'PersonBlacklistTab',
-  components: { BlacklistTabBase, BlacklistCreateModal, ConfirmationModal },
+  components: { BlacklistTabBase, BlacklistCreateModal, PersonBlacklistHistoryModal, ConfirmationModal },
+  props: {
+    currentUserName: { type: String, default: '' },
+  },
   emits: ['count'],
   data() {
-    return { showCreate: false, archiveItem: null };
+    return { showCreate: false, archiveItem: null, historyItem: null };
   },
   computed: {
     archiveMessage() {

--- a/frontend/src/components/admin/blacklist/VehicleBlacklistHistoryModal.vue
+++ b/frontend/src/components/admin/blacklist/VehicleBlacklistHistoryModal.vue
@@ -1,0 +1,61 @@
+<template>
+  <BlacklistHistoryModalBase
+    :title="title"
+    :entity-label="entityLabel"
+    :load-fn="loadFn"
+    :action-texts="actionTexts"
+    :field-labels="fieldLabels"
+    :current-user-name="currentUserName"
+    @close="$emit('close')"
+  />
+</template>
+
+<script>
+import BlacklistHistoryModalBase from './BlacklistHistoryModalBase.vue';
+import { getVehicleBlacklistHistory } from '@/api/blacklist';
+
+const ACTION_TEXTS = {
+  created: 'Добавлена в чёрный список',
+  archived: 'Снята с чёрного списка',
+  restored: 'Возвращена в чёрный список',
+};
+
+const FIELD_LABELS = {
+  reason: 'Причина',
+  cars_deactivated: 'Деактивировано машин',
+  cars_reactivated: 'Возвращено машин в оборот',
+};
+
+/**
+ * Модалка истории записи ЧС машин (#443). Тонкая обёртка над
+ * BlacklistHistoryModalBase: задаёт заголовок, словари действий/полей и загрузчик.
+ */
+export default {
+  name: 'VehicleBlacklistHistoryModal',
+  components: { BlacklistHistoryModalBase },
+  props: {
+    item: { type: Object, required: true },
+    currentUserName: { type: String, default: '' },
+  },
+  emits: ['close'],
+  computed: {
+    actionTexts() {
+      return ACTION_TEXTS;
+    },
+    fieldLabels() {
+      return FIELD_LABELS;
+    },
+    entityLabel() {
+      return [this.item.car_number, this.item.mark_name].filter(Boolean).join(' ');
+    },
+    title() {
+      return `История машины «${this.entityLabel}»`;
+    },
+  },
+  methods: {
+    loadFn() {
+      return getVehicleBlacklistHistory(this.item.id);
+    },
+  },
+};
+</script>

--- a/frontend/src/components/admin/blacklist/VehicleBlacklistTab.vue
+++ b/frontend/src/components/admin/blacklist/VehicleBlacklistTab.vue
@@ -11,6 +11,7 @@
       @create="showCreate = true"
       @archive="askArchive"
       @restore="doRestore"
+      @history="historyItem = $event"
     />
     <BlacklistCreateModal
       :show="showCreate"
@@ -18,6 +19,12 @@
       :create-fn="createVehicleBlacklist"
       @close="showCreate = false"
       @created="onCreated"
+    />
+    <VehicleBlacklistHistoryModal
+      v-if="historyItem"
+      :item="historyItem"
+      :current-user-name="currentUserName"
+      @close="historyItem = null"
     />
     <ConfirmationModal
       :show="!!archiveItem"
@@ -35,6 +42,7 @@
 <script>
 import BlacklistTabBase from './BlacklistTabBase.vue';
 import BlacklistCreateModal from './BlacklistCreateModal.vue';
+import VehicleBlacklistHistoryModal from './VehicleBlacklistHistoryModal.vue';
 import ConfirmationModal from '@/components/ConfirmationModal.vue';
 import {
   listVehicleBlacklist,
@@ -51,10 +59,13 @@ import { useDeletionsStore } from '@/stores/deletions';
  */
 export default {
   name: 'VehicleBlacklistTab',
-  components: { BlacklistTabBase, BlacklistCreateModal, ConfirmationModal },
+  components: { BlacklistTabBase, BlacklistCreateModal, VehicleBlacklistHistoryModal, ConfirmationModal },
+  props: {
+    currentUserName: { type: String, default: '' },
+  },
   emits: ['count'],
   data() {
-    return { showCreate: false, archiveItem: null };
+    return { showCreate: false, archiveItem: null, historyItem: null };
   },
   computed: {
     archiveMessage() {

--- a/frontend/src/components/admin/blacklist/__tests__/BlacklistHistoryModalBase.spec.js
+++ b/frontend/src/components/admin/blacklist/__tests__/BlacklistHistoryModalBase.spec.js
@@ -1,0 +1,147 @@
+import {
+  describe, it, expect, vi,
+} from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import BlacklistHistoryModalBase from '../BlacklistHistoryModalBase.vue';
+
+const ACTION_TEXTS = {
+  created: 'Добавлена в чёрный список',
+  archived: 'Снята с чёрного списка',
+  restored: 'Возвращена в чёрный список',
+};
+
+const FIELD_LABELS = {
+  reason: 'Причина',
+  cars_deactivated: 'Деактивировано машин',
+  cars_reactivated: 'Возвращено машин в оборот',
+};
+
+const history = [
+  {
+    id: 1,
+    action_type: 'created',
+    user_id: 7,
+    user_name: 'Иванов Иван',
+    created_at: '2026-06-01T10:00:00Z',
+    details: {
+      car_number: 'A1', mark_name: 'BMW', reason: 'угон', cars_deactivated: 2,
+    },
+  },
+  {
+    id: 2,
+    action_type: 'archived',
+    user_id: 8,
+    user_name: 'Петров Пётр',
+    created_at: '2026-06-02T10:00:00Z',
+    details: { car_number: 'A1', mark_name: 'BMW', cars_reactivated: 0 },
+  },
+  {
+    id: 3,
+    action_type: 'restored',
+    user_id: 7,
+    user_name: 'Иванов Иван',
+    created_at: '2026-06-03T10:00:00Z',
+    details: { car_number: 'A1', mark_name: 'BMW', cars_deactivated: 1 },
+  },
+];
+
+function mountModal(overrides = {}) {
+  return mount(BlacklistHistoryModalBase, {
+    props: {
+      title: 'История машины «A1 BMW»',
+      entityLabel: 'A1 BMW',
+      loadFn: vi.fn().mockResolvedValue(history),
+      actionTexts: ACTION_TEXTS,
+      fieldLabels: FIELD_LABELS,
+      ...overrides,
+    },
+    global: {
+      stubs: { teleport: true, LoaderSpinner: true },
+    },
+  });
+}
+
+describe('BlacklistHistoryModalBase', () => {
+  it('загружает историю через loadFn и рендерит тексты действий', async () => {
+    const wrapper = mountModal();
+    await flushPromises();
+    expect(wrapper.findAll('.history-item')).toHaveLength(3);
+    expect(wrapper.text()).toContain('Добавлена в чёрный список');
+    expect(wrapper.text()).toContain('Снята с чёрного списка');
+    expect(wrapper.text()).toContain('Возвращена в чёрный список');
+  });
+
+  it('детали показывают только ключи из fieldLabels, нулевые счётчики скрыты', async () => {
+    const wrapper = mountModal();
+    await flushPromises();
+    expect(wrapper.vm.getActionComment(history[0])).toBe('Причина: угон / Деактивировано машин: 2');
+    // archived: cars_reactivated=0 -> пусто (car_number/mark_name не в fieldLabels)
+    expect(wrapper.vm.getActionComment(history[1])).toBe('');
+    expect(wrapper.vm.getActionComment(history[2])).toBe('Деактивировано машин: 1');
+  });
+
+  it('цвет точки маппится по типу действия', async () => {
+    const wrapper = mountModal();
+    await flushPromises();
+    expect(wrapper.vm.getActionClass('created')).toBe('dot-create');
+    expect(wrapper.vm.getActionClass('archived')).toBe('dot-deactivate');
+    expect(wrapper.vm.getActionClass('restored')).toBe('dot-activate');
+    expect(wrapper.vm.getActionClass('unknown')).toBe('dot-default');
+  });
+
+  it('по умолчанию сортировка desc (новые сверху), toggle переключает на asc', async () => {
+    const wrapper = mountModal();
+    await flushPromises();
+    expect(wrapper.vm.filteredHistory[0].id).toBe(3);
+    wrapper.vm.toggleSortOrder();
+    expect(wrapper.vm.filteredHistory[0].id).toBe(1);
+  });
+
+  it('поиск фильтрует по имени пользователя', async () => {
+    const wrapper = mountModal();
+    await flushPromises();
+    wrapper.vm.searchQuery = 'Петров';
+    await flushPromises();
+    expect(wrapper.vm.filteredHistory).toHaveLength(1);
+    expect(wrapper.vm.filteredHistory[0].id).toBe(2);
+  });
+
+  it('фильтр по пользователю оставляет только его записи', async () => {
+    const wrapper = mountModal();
+    await flushPromises();
+    wrapper.vm.selectUser(7);
+    await flushPromises();
+    expect(wrapper.vm.filteredHistory).toHaveLength(2);
+    expect(wrapper.vm.filteredHistory.every((i) => i.user_id === 7)).toBe(true);
+  });
+
+  it('уникальные пользователи собираются из истории', async () => {
+    const wrapper = mountModal();
+    await flushPromises();
+    expect(wrapper.vm.uniqueUsers.map((u) => u.id).sort()).toEqual([7, 8]);
+  });
+
+  it('клик вне селекта закрывает дропдаун пользователей (через ref, не $el)', async () => {
+    const wrapper = mountModal();
+    await flushPromises();
+    wrapper.vm.userDropdownOpen = true;
+    const inside = wrapper.find('.custom-select').element;
+    wrapper.vm.handleClickOutside({ target: inside });
+    expect(wrapper.vm.userDropdownOpen).toBe(true);
+    wrapper.vm.handleClickOutside({ target: document.body });
+    expect(wrapper.vm.userDropdownOpen).toBe(false);
+  });
+
+  it('крестик эмитит close', async () => {
+    const wrapper = mountModal();
+    await flushPromises();
+    await wrapper.find('.close-btn').trigger('click');
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+
+  it('пустая история показывает заглушку', async () => {
+    const wrapper = mountModal({ loadFn: vi.fn().mockResolvedValue([]) });
+    await flushPromises();
+    expect(wrapper.find('.history-empty').exists()).toBe(true);
+  });
+});

--- a/frontend/src/components/admin/blacklist/__tests__/BlacklistTabBase.spec.js
+++ b/frontend/src/components/admin/blacklist/__tests__/BlacklistTabBase.spec.js
@@ -96,6 +96,15 @@ describe('BlacklistTabBase', () => {
     expect(wrapper.emitted('restore')[0][0].id).toBe(3);
   });
 
+  it('кнопка "История" эмитит history с выбранной записью', async () => {
+    const wrapper = mountBase();
+    await flushPromises();
+    await wrapper.findAll('.bl-row')[0].trigger('click');
+    const btn = wrapper.findAll('button').find((b) => b.text() === 'История');
+    await btn.trigger('click');
+    expect(wrapper.emitted('history')[0][0].id).toBe(1);
+  });
+
   it('пустой список показывает empty-state', async () => {
     const wrapper = mountBase({ apiList: vi.fn().mockResolvedValue([]) });
     await flushPromises();

--- a/frontend/src/views/admin/BlacklistView.vue
+++ b/frontend/src/views/admin/BlacklistView.vue
@@ -14,10 +14,12 @@
     <div class="blacklist-card">
       <VehicleBlacklistTab
         v-show="activeTab === 'vehicles'"
+        :current-user-name="currentUserName"
         @count="vehicleCount = $event"
       />
       <PersonBlacklistTab
         v-show="activeTab === 'persons'"
+        :current-user-name="currentUserName"
         @count="personCount = $event"
       />
     </div>
@@ -28,11 +30,13 @@
 import FilterTabs from '@/components/ui/FilterTabs.vue';
 import VehicleBlacklistTab from '@/components/admin/blacklist/VehicleBlacklistTab.vue';
 import PersonBlacklistTab from '@/components/admin/blacklist/PersonBlacklistTab.vue';
+import { apiRequest } from '@/api/client';
 
 /**
  * Страница "Чёрный список" (#443): две вкладки (Машины / Люди) со счётчиками
  * активных записей. Обе вкладки смонтированы (v-show), чтобы счётчики
- * подтягивались сразу. Создание/история/архив-действия - в следующих срезах.
+ * подтягивались сразу. Имя текущего пользователя грузим один раз тут и
+ * прокидываем в обе вкладки - для подписи в Excel-экспорте истории.
  */
 export default {
   name: 'BlacklistView',
@@ -42,6 +46,7 @@ export default {
       activeTab: 'vehicles',
       vehicleCount: 0,
       personCount: 0,
+      currentUserName: '',
     };
   },
   computed: {
@@ -50,6 +55,21 @@ export default {
         { key: 'vehicles', label: `Машины (${this.vehicleCount})` },
         { key: 'persons', label: `Люди (${this.personCount})` },
       ];
+    },
+  },
+  mounted() {
+    this.fetchCurrentUser();
+  },
+  methods: {
+    async fetchCurrentUser() {
+      try {
+        const res = await apiRequest('/users/me');
+        const data = await res.json();
+        const parts = [data.last_name, data.first_name, data.middle_name].filter(Boolean);
+        this.currentUserName = parts.join(' ') || data.username || '';
+      } catch {
+        this.currentUserName = '';
+      }
     },
   },
 };


### PR DESCRIPTION
Срез B3 эпика #443. Таймлайн-история по записи чёрного списка (машины и люди).

## Что сделано
- `BlacklistHistoryModalBase.vue` - общая модалка по образцу `SystemTableHistoryModal.vue` (Teleport, useOverlayClose, Escape, фильтры в строку поиск/пользователь/период/сортировка, timeline с цветными точками, ExcelJS-экспорт). Сущность-специфика через props.
- `VehicleBlacklistHistoryModal.vue` / `PersonBlacklistHistoryModal.vue` - тонкие обёртки со словарями ACTION_TEXTS/FIELD_LABELS, заголовком и загрузчиком (как обёртки вкладок).
- `api/blacklist.js` - `getVehicleBlacklistHistory`/`getPersonBlacklistHistory` (GET /:id/history, envelope разворачивается через apiRequest+res.json()).
- Кнопка "История" в панели деталей `BlacklistTabBase` (emit history); обёртки вкладок открывают свою модалку. Имя текущего пользователя для подписи в экспорте грузится один раз в `BlacklistView` и прокидывается во вкладки.

Детали timeline строятся из реального jsonb `details`: показываются только осмысленные ключи (причина, счётчики каскада), нулевые счётчики скрыты как шум.

## Ревью (code-reviewer) - исправлено
- catch в loadHistory и exportToExcel теперь шлёт `useDeletionsStore().notify({type:'error'})` (раньше только console.error - нарушение ui-notifications.md).
- click-outside для селекта пользователей переведён с `this.$el.querySelector` на template-ref: через Teleport `$el` это anchor-комментарий, querySelector не работал и дропдаун не закрывался по клику вне (латентный баг, унаследованный всеми 9 history-модалями; здесь починен правильно).
- Статичные словари вынесены из `data()` в `computed` (не оборачивать константы в реактивный proxy).

## Сознательно оставлено по эталону (не баг)
- Нет `<transition>`-обёртки overlay: анимация открытия через CSS `fadeIn`/`slideUp` на mount - ровно как у `SystemTableHistoryModal`/`MarkHistoryModal` и всех 9 history-модалей. Менять только тут = расхождение со всем семейством.
- Радиус контролов фильтр-бара (search/select/sort 20px) скопирован из эталона дословно; date-input 15px - тоже как в эталоне. Миграция всего семейства на 15px - отдельный кросс-каттинг polish, не этот срез.
- Имя записи (номер+марка / ФИО) в строках timeline не дублируется: оно в заголовке модалки, каждая строка про ту же запись.

## Проверено
- vitest: 27 passed (BlacklistHistoryModalBase 10, BlacklistTabBase 11, BlacklistCreateModal остались зелёными).
- eslint: 0, vite build: ok.
- Локальный скриншот обеих модалок (vite dev + Playwright, моки API) - визуальная приёмка у владельца до мержа.