### PR TITLE
feat(unload-places): модалки контейнера к эталону + инпуты 15px + RefreshButton loading (#413)

### DIFF
--- a/frontend/src/components/UnloadPlaces/UnloadPlacesContainer.vue
+++ b/frontend/src/components/UnloadPlaces/UnloadPlacesContainer.vue
@@ -15,7 +15,10 @@
         >
           Добавить
         </button>
-        <RefreshButton @refresh="refreshData" />
+        <RefreshButton
+          :loading="refreshing"
+          @refresh="refreshData"
+        />
       </div>
     </div>
 
@@ -401,9 +404,14 @@
         <div
           v-if="showAddModal"
           class="modal-overlay"
-          @click.self="closeModal"
+          @mousedown="onAddOverlayMousedown"
+          @mouseup="onAddOverlayMouseup"
         >
-          <div class="modal-content">
+          <div
+            class="modal-content"
+            @mousedown.stop
+            @click.stop
+          >
             <div class="modal-header">
               <h3 class="modal-title">
                 Добавить место разгрузки
@@ -478,9 +486,14 @@
         <div
           v-if="showPhotoModal"
           class="modal-overlay"
-          @click.self="showPhotoModal = false"
+          @mousedown="onPhotoOverlayMousedown"
+          @mouseup="onPhotoOverlayMouseup"
         >
-          <div class="modal-content photo-view-modal">
+          <div
+            class="modal-content photo-view-modal"
+            @mousedown.stop
+            @click.stop
+          >
             <div class="modal-header">
               <h3 class="modal-title">
                 {{ viewingPhoto?.file_name }}
@@ -541,6 +554,7 @@
 <script>
 import { apiRequest } from '@/api/client'
 import { useDeletionsStore } from '@/stores/deletions';
+import { useOverlayClose } from '@/composables/useOverlayClose';
 import RefreshButton from '../RefreshButton.vue';
 import SearchComponent from '../SearchComponent.vue';
 import ConfirmationModal from '../ConfirmationModal.vue';
@@ -552,6 +566,21 @@ export default {
     RefreshButton,
     ConfirmationModal,
     ScheduleTab
+  },
+  setup() {
+    // Колбэк закрытия присваивается в created (нужен доступ к this).
+    const addOverlay = { close: () => {} };
+    const photoOverlay = { close: () => {} };
+    const add = useOverlayClose(() => addOverlay.close());
+    const photo = useOverlayClose(() => photoOverlay.close());
+    return {
+      onAddOverlayMousedown: add.onOverlayMousedown,
+      onAddOverlayMouseup: add.onOverlayMouseup,
+      onPhotoOverlayMousedown: photo.onOverlayMousedown,
+      onPhotoOverlayMouseup: photo.onOverlayMouseup,
+      addOverlay,
+      photoOverlay
+    };
   },
   data() {
     return {
@@ -567,6 +596,7 @@ export default {
       sortDirection: 'asc',
       activeTab: 'main',
       isDraggingPhoto: false,
+      refreshing: false,
       deleteConfirmPlace: null,
       deleteConfirmPhoto: null
     };
@@ -615,19 +645,52 @@ export default {
   },
   watch: {
     showAddModal(newVal) {
+      this.syncBodyScroll();
       if (newVal) {
         this.$nextTick(() => {
           this.$refs.nameInput?.focus();
         });
       }
+    },
+    showPhotoModal() {
+      this.syncBodyScroll();
     }
+  },
+  created() {
+    this.addOverlay.close = () => { this.closeModal(); };
+    this.photoOverlay.close = () => { this.showPhotoModal = false; };
   },
   mounted() {
     this.refreshData();
+    document.addEventListener('keydown', this.onKeydown);
+  },
+  beforeUnmount() {
+    document.removeEventListener('keydown', this.onKeydown);
+    document.body.style.overflow = '';
   },
   methods: {
+    // Скролл body блокируется, пока открыта ЛЮБАЯ из модалок (не залипает при
+    // закрытии одной, если вдруг открыта другая).
+    syncBodyScroll() {
+      document.body.style.overflow = (this.showAddModal || this.showPhotoModal) ? 'hidden' : '';
+    },
+
+    onKeydown(e) {
+      if (e.key !== 'Escape') return;
+      if (this.showPhotoModal) {
+        this.showPhotoModal = false;
+      } else if (this.showAddModal) {
+        this.closeModal();
+      }
+    },
+
     async refreshData() {
-      await this.fetchUnloadPlaces();
+      this.refreshing = true;
+      try {
+        await this.fetchUnloadPlaces();
+      } finally {
+        this.refreshing = false;
+      }
     },
     
     async fetchUnloadPlaces() {
@@ -1365,7 +1428,7 @@ async uploadPhotoFiles(files) {
 .form-input {
   padding: 8px 12px;
   border: 1px solid #e6e6e6;
-  border-radius: 10px;
+  border-radius: 15px;
   font-size: 14px;
   width: 100%;
   transition: border-color 0.2s ease;
@@ -1380,7 +1443,7 @@ async uploadPhotoFiles(files) {
 .form-textarea {
   padding: 8px 12px;
   border: 1px solid #e6e6e6;
-  border-radius: 10px;
+  border-radius: 15px;
   font-size: 14px;
   width: 100%;
   transition: border-color 0.2s ease;
@@ -1714,7 +1777,7 @@ async uploadPhotoFiles(files) {
 
 .modal-content {
   background: #fff;
-  border-radius: 12px;
+  border-radius: 30px;
   padding: 0;
   width: 420px;
   max-width: 90vw;
@@ -1758,7 +1821,7 @@ async uploadPhotoFiles(files) {
   border: none;
   cursor: pointer;
   padding: 6px;
-  border-radius: 6px;
+  border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1808,7 +1871,7 @@ async uploadPhotoFiles(files) {
   width: 100%;
   padding: 10px 12px;
   border: 1px solid #e0e0e0;
-  border-radius: 8px;
+  border-radius: 15px;
   font-size: 0.9em;
   transition: border-color 0.2s ease;
   background: #fff;
@@ -1836,7 +1899,7 @@ async uploadPhotoFiles(files) {
 .modal-btn {
   padding: 8px 20px;
   border: none;
-  border-radius: 8px;
+  border-radius: 999px;
   cursor: pointer;
   font-size: 0.85em;
   font-weight: 500;


### PR DESCRIPTION
## Что

Срез 3b эпика #406 (issue #413). Две собственные модалки `UnloadPlacesContainer.vue` (добавление места, просмотр фото) доведены до эталона.

- **Модалки:** `border-radius` 12 -> 30px; `useOverlayClose` вместо `@click.self` (защита от закрытия при drag-select из контента) - `setup()` с двумя инстансами overlay (late-bind `close` в `created()`), `@mousedown/@mouseup` на оверлеях, `@mousedown.stop`+`@click.stop` на контенте; Escape-listener в `mounted`/`beforeUnmount`; блокировка body-scroll через единый `syncBodyScroll()` (hidden пока открыта любая модалка).
- **Инпуты:** `.form-input`/`.form-textarea` 10 -> 15px, `.modal-input`/`.modal-textarea` 8 -> 15px.
- **Кнопки модалок:** крестик закрытия круглый (50%), footer-кнопки pill (999px).
- **RefreshButton:** `:loading="refreshing"`, `refreshData` оборачивает флаг в try/finally.

## Проверка

- eslint чист, vitest 324/324.
- Браузер (verify-app, vite 8081 -> backend 8090): модалка с углами 30px, инпуты 15px, footer-кнопки таблетки, крестик круглый; закрытие по крестику/Отмене работает; 0 console-ошибок. Скриншот `check-413-3b-add-modal.png` показан владельцу (chafa-inline).
- code-reviewer: исходно NO-GO по RED-1; **исправлено**.

## Ответ на ревью

- **RED-1 (body-scroll залипал)** - ИСПРАВЛЕНО: единый `syncBodyScroll()` ставит `overflow:hidden` только если открыта хоть одна модалка, сброс безопасен при любом порядке закрытия.
- **YELLOW-3 (только `@mousedown.stop`)** - ИСПРАВЛЕНО: добавлен `@click.stop` на оба контента (по доке `useOverlayClose`).
- **RED-2 / YELLOW-1 (`.modal-overlay` анимирует `background`/`backdrop-filter` через keyframe `overlayAppear` + двойная система с Vue-transition)** - НЕ регрессия 3b: это **pre-existing** код, в диффе 3b изменений анимаций нет вообще (подтверждено `git diff`). Рерайт overlay-анимации на opacity-only - отдельный polish, транзиентно-визуальный, в скоуп 3b (радиусы/overlay-close/escape) не тащу. Остаётся долгом.
- **YELLOW-2 (`.delete-icon-btn` 10px, фото-кнопки 8/4px)** - не инпуты, pre-existing, правило мягче; оставлены.

Следующие срезы #413: 3c (архив-UI), 3d (история-модалка #452), 3e (дедуп ScheduleTab), 3f (cleanup select/filter).