### PR TITLE
fix(e2e): прогрел vite перед прогоном e2e (флак первых навигаций)

### DIFF
--- a/frontend/e2e/global-setup.cjs
+++ b/frontend/e2e/global-setup.cjs
@@ -1,0 +1,37 @@
+const { chromium } = require('@playwright/test');
+
+/**
+ * Прогрев vite dev-сервера перед прогоном E2E.
+ *
+ * В CI фронт поднимается как vite dev-сервер. Health-check курлит только index.html
+ * (отвечает мгновенно) и НЕ триггерит dep-оптимизацию vite - она запускается на первом
+ * запросе модуля и блокирует его до конца пребандла. Когда параллельные воркеры разом
+ * делают первые навигации к холодному vite, они упираются в это одновременно, и самые
+ * ранние навигации шарда проигрывают 5s-таймауту toHaveURL (флак /500, /maintenance:
+ * приложение не успевает смонтироваться, URL остаётся на корне).
+ *
+ * Один заход браузером по публичным маршрутам проходит главный граф модулей и чанки
+ * этих роутов, снимая холодную стоимость до старта тестов. Best-effort: ошибки прогрева
+ * не валят прогон (если сервер реально лежит - тесты упадут сами и покажут это явно).
+ */
+module.exports = async () => {
+  const baseURL = process.env.E2E_BASE_URL || 'http://localhost:8081';
+  const routes = ['/', '/500', '/maintenance'];
+
+  const browser = await chromium.launch();
+  try {
+    const page = await browser.newPage({ baseURL });
+    for (const route of routes) {
+      try {
+        await page.goto(route, { waitUntil: 'domcontentloaded', timeout: 90000 });
+        // Дождаться монтирования SPA (#app получил содержимое) - значит главный граф
+        // и чанк роута уже скомпилированы vite-ом.
+        await page.waitForSelector('#app > *', { timeout: 60000 });
+      } catch (err) {
+        console.warn(`[e2e warmup] ${route}: ${err.message}`);
+      }
+    }
+  } finally {
+    await browser.close();
+  }
+};

--- a/frontend/playwright.config.cjs
+++ b/frontend/playwright.config.cjs
@@ -2,6 +2,9 @@ const { defineConfig } = require('@playwright/test');
 
 module.exports = defineConfig({
   testDir: './e2e/tests',
+  // Прогрев холодного vite dev-сервера до старта тестов (см. e2e/global-setup.cjs) -
+  // иначе первые параллельные навигации шарда проигрывают 5s-таймауту toHaveURL.
+  globalSetup: require.resolve('./e2e/global-setup.cjs'),
   timeout: 30000,
   retries: 1,
   // Пропущенные спеки - полагаются на отсутствующий /register endpoint


### PR DESCRIPTION
## Проблема
E2E периодически флачит на первых тестах шарда (наблюдалось на shard 4/4: `/500`, `/maintenance`, `permissions-groups` - не связаны с диффом конкретного PR). Симптом: `expect(page).toHaveURL(/\/500/)` падает по 5s-таймауту, фактический URL остаётся `http://localhost:8081/` - приложение не успевает смонтироваться.

## Корень
Фронт в e2e поднимается как **vite dev-сервер**. Health-check в `e2e.yml` курлит только index.html (отвечает мгновенно) и НЕ триггерит dep-оптимизацию vite - она запускается на первом запросе модуля и блокирует его до конца пребандла. Когда параллельные воркеры Playwright разом делают первые навигации к холодному vite, они упираются в это одновременно, и самые ранние навигации шарда проигрывают строгому 5s-таймауту `toHaveURL` (дефолт expect в `playwright.config`).

Замерено локально: прогрев холодного vite по трём публичным маршрутам занимает ~6s - именно эту стоимость 4 воркера и гоняли против 5s-ассерта.

## Фикс
Playwright `globalSetup` (`e2e/global-setup.cjs`): один заход браузером по публичным маршрутам (`/`, `/500`, `/maintenance`) с ожиданием монтирования `#app`. Прогревает граф модулей и чанки роутов до старта параллельных тестов. globalSetup выполняется один раз на каждый shard-прогон (у каждого шарда свой vite), best-effort - ошибки прогрева прогон не валят.

Выбрал этот слой (а не шаг в `e2e.yml`), потому что: (1) прогревает именно тот vite, что бьют тесты, через реальный браузер - включая лениво-импортируемые чанки роутов, не только dep-пребандл; (2) помогает и локальным прогонам; (3) не требует workflow-scope на токене.

## Проверка
- `node --check` обоих файлов, eslint 0, `npx playwright test --list` (конфиг грузится, globalSetup резолвится, 146 тестов).
- globalSetup прогнан standalone против живого холодного vite: завершился за 6.1s без warmup-warning'ов (все три роута смонтировались = vite их скомпилировал).
- Финальная проверка - зелёный E2E на этом PR и устойчивость на последующих FE-PR.