### PR TITLE
fix(e2e): дождаться загрузки списка групп прав перед проверкой карточки

### DIFF
--- a/frontend/e2e/pages/AdminPermissionGroupsPage.cjs
+++ b/frontend/e2e/pages/AdminPermissionGroupsPage.cjs
@@ -5,6 +5,7 @@ class AdminPermissionGroupsPage {
     this.createButton = page.getByRole('button', { name: '+ Создать группу' });
     this.cards = page.locator('.permission-groups .cards .card');
     this.emptyState = page.locator('.permission-groups .empty');
+    this.loadingIndicator = page.locator('.permission-groups .loading');
 
     // Модалка имеет класс .rename-modal в AdminPermissionGroups.vue,
     // h3 - "Новая группа прав" (create) или "Имя и описание" (edit).
@@ -49,6 +50,10 @@ class AdminPermissionGroupsPage {
   async goto() {
     await this.page.goto('/admin/permission-groups');
     await this.title.waitFor({ state: 'visible' });
+    // Дожидаемся завершения загрузки списка (спиннер исчез). Без этого assert
+    // карточки упирается в 5с-таймаут expect, пока под нагрузкой CI ещё идёт
+    // GET /permission-groups - источник флака shard 4 (#413/#437).
+    await this.loadingIndicator.waitFor({ state: 'hidden' });
   }
 
   card(name) {


### PR DESCRIPTION
## Что

Стабилизация флака E2E shard 4/4, который блокировал мерж FE-срузов эпика #406 (всплыл на #413/3b, документирован в #437 как кандидат на стабилизацию).

`AdminPermissionGroupsPage.goto()` дожидался только заголовка «Группы прав», но НЕ исчезновения спиннера загрузки списка. Тест `permissions-groups-edit-tree` сразу делал `expect(card).toBeVisible()` с дефолтным 5с expect-таймаутом. Под нагрузкой CI `GET /permission-groups` + рендер не укладывались в 5с -> `card not found` -> красный shard 4.

Фикс: в `goto()` добавлено ожидание `.permission-groups .loading` в состоянии `hidden`. `locator.waitFor()` использует action-таймаут (~30с, бо́льший общего test-timeout), а не 5с expect, поэтому список гарантированно загружается до проверки карточки. Правка в общем POM -> стабилизирует все тесты, использующие `goto()` (crud/edit-tree/merge/delete).

## Проверка

- `node --check` POM - OK.
- Локальный прогон `permissions-groups-edit-tree --repeat-each=3 --workers=1` - 3/3 зелёные (раньше падал 3x подряд в CI на этом же тесте).
- В CI этого PR shard 4 должен пройти там, где падал.

Не меняет прод-код, только e2e-POM. Корневой фикс таймингового флака, не маскировка retry'ями.