### PR TITLE
fix(notifications): логаут-юзера сбивало с /maintenance и /500 на корень

### DIFF
--- a/frontend/src/components/DeleteNotifications.vue
+++ b/frontend/src/components/DeleteNotifications.vue
@@ -40,10 +40,19 @@
 <script setup>
 import { onMounted } from 'vue';
 import { useDeletionsStore } from '@/stores/deletions';
+import { useAuthStore } from '@/stores/auth';
 
 const store = useDeletionsStore();
+const auth = useAuthStore();
 
-onMounted(() => store.loadDurations());
+// Длительности тянем только под аутентификацией. Этот компонент смонтирован в App.vue
+// всегда, в т.ч. на публичных /maintenance, /500 и логине, где /settings/notifications
+// отдаёт 401; client.js на 401 пробует refresh и при провале делает router.push('/'),
+// сбивая юзера с публичной страницы (флак e2e /maintenance, /500). Залогиненному
+// durations подтянутся при заходе на списки (Cars/People/Trash).
+onMounted(() => {
+  if (auth.isAuthenticated) store.loadDurations();
+});
 
 // Цвет прогресс-бара: 100% (только удалили) - зелёный, 0% (вот-вот исчезнет) - красный.
 // Для type=error всегда красный - нет семантики "истекает".


### PR DESCRIPTION
## Симптом
Плавающие падения e2e на shard 4: `страница /maintenance показывает информацию` и `страница /500 ...` падали по `expect(page).toHaveURL(/\/maintenance/)` с фактическим URL `http://localhost:8081/`. Тесты не связаны с диффом - флак.

## Точная причина (воспроизведено локально)
`DeleteNotifications.vue` смонтирован в `App.vue` безусловно (без `v-if`), т.е. на любой странице, включая публичные `/maintenance`, `/500` и логин. На mount он зовёт `store.loadDurations()` -> `apiRequest('/settings/notifications')`. Под логаутом эндпоинт отдаёт **401**, а `client.js` на 401 (не-auth путь) пытается refresh; refresh тоже 401 -> в catch `router.push('/')`. Корень `/` из редиректа исключён, поэтому сбивает только `/maintenance` и `/500` (path != `/`). Флак - гонка между первым поллом `toHaveURL` и асинхронной цепочкой 401->refresh->redirect.

Локальная репродукция (логаут, goto /maintenance):
```
NAV: /maintenance -> /maintenance -> /maintenance -> /maintenance -> /
API: GET /settings/maintenance 200; POST /refresh-token 401;
     GET /settings/notifications 401; POST /refresh-token 401   -> push('/')
FINAL URL: /
```

## Фикс
Грузим длительности уведомлений только под аутентификацией - logout-юзеру они не нужны, а 401 от них и инициировал спурьёзный редирект. `loadDurations` не латчится на пропуске, так что залогиненному значения подтянутся при заходе на списки (Cars/People/Trash) - поведение durations не меняется, убирается только сайд-эффект.

Это чинит и реальный UX-баг: логаут-юзера на легитимных публичных `/maintenance` и `/500` больше не выбрасывает на корень.

## Проверка (после фикса, та же репродукция)
```
/maintenance: FINAL URL /maintenance, нет 401 на /settings/notifications, нет второго refresh
/500:         FINAL URL /500,         то же
```
eslint 0, vite build ok, deletions store unit-тесты 6/6 (стор не трогал - гард в компоненте).

Предыдущая попытка (PR #457, прогрев vite в globalSetup) была по неверной гипотезе про холодную компиляцию - закрыта, тот URL оставался бы на `/maintenance`, а реально это редирект. Эта правка - точная причина.