### PR TITLE
feat(blacklist): проверка ЧС в формах заявок и серверный гард (#443)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -168,7 +168,6 @@ func main() {
 	notificationService := notificationServiceEarly
 	requestLogsService := services.NewRequestLogsService(db)
 	employeesHistoryService := services.NewEmployeesHistoryService(db)
-	applicationService := services.NewApplicationService(db, permissionService, notificationService)
 	approverService := services.NewApproverService(db)
 	consentService := services.NewConsentService(db)
 	settingsService := services.NewSettingsService(db, cfg)
@@ -180,6 +179,7 @@ func main() {
 	vehicleBlacklistService := services.NewVehicleBlacklistService(db, vehicleBlacklistHistoryService)
 	personBlacklistHistoryService := services.NewPersonBlacklistHistoryService(db)
 	personBlacklistService := services.NewPersonBlacklistService(db, personBlacklistHistoryService)
+	applicationService := services.NewApplicationService(db, permissionService, notificationService, vehicleBlacklistService, personBlacklistService)
 	attachmentTemplateService := services.NewAttachmentTemplateService(db, cfg.UploadPath)
 	attachmentBlankService := services.NewAttachmentBlankService(db)
 	trashService := services.NewTrashService(db)

--- a/frontend/src/api/blacklist.js
+++ b/frontend/src/api/blacklist.js
@@ -63,3 +63,23 @@ export async function getPersonBlacklistHistory(id) {
   const res = await apiRequest(`/person-blacklist/${id}/history`);
   return res.json();
 }
+
+/**
+ * Проверка машины в активном ЧС по номеру и марке (#443).
+ * Возвращает { is_blacklisted, reason } - см. wrapJsonUnwrap.
+ */
+export async function checkVehicleBlacklist({ car_number, mark_id }) {
+  const qs = new URLSearchParams({ car_number, mark_id: String(mark_id) });
+  const res = await apiRequest(`/vehicle-blacklist/check?${qs.toString()}`);
+  return res.json();
+}
+
+/**
+ * Проверка человека в активном ЧС по ФИО (#443).
+ * Совпадение строгое: фамилия + имя + отчество (пустое отчество матчит только пустое).
+ */
+export async function checkPersonBlacklist({ last_name, first_name, middle_name = '' }) {
+  const qs = new URLSearchParams({ last_name, first_name, middle_name: middle_name || '' });
+  const res = await apiRequest(`/person-blacklist/check?${qs.toString()}`);
+  return res.json();
+}

--- a/frontend/src/components/CreateApplication/EmployeeForm.vue
+++ b/frontend/src/components/CreateApplication/EmployeeForm.vue
@@ -147,8 +147,8 @@
             <div class="completion__position-header">
               <label class="input__label">Должность <span class="required">*</span></label>
             </div>
-            <input 
-              v-model="position" 
+            <input
+              v-model="position"
               class="name__input"
               placeholder="Введите должность"
               :disabled="editingEmployee && editingEmployee.isExisting"
@@ -156,7 +156,21 @@
             >
           </div>
         </div>
-                
+
+        <div
+          v-if="blacklistInfo"
+          class="blacklist-warning"
+          data-testid="person-blacklist-warning"
+        >
+          <p class="warning-title">
+            Человек в чёрном списке
+          </p>
+          <p class="warning-details">
+            Причина: {{ blacklistInfo.reason || 'не указана' }}<br>
+            Добавить этого человека в заявку нельзя.
+          </p>
+        </div>
+
         <div class="completion__name-row">
           <div class="completion__passport">
             <div class="completion__passport-header">
@@ -351,6 +365,7 @@
 
 <script>
 import { apiRequest } from '@/api/client'
+import { checkPersonBlacklist } from '@/api/blacklist'
 import { useAuthStore } from '@/stores/auth'
 import { useToast } from '@/composables/useToast'
 import ExistingEmployeesModal from '@/components/CreateApplication/ExistingEmployeesModal.vue'
@@ -401,6 +416,7 @@ export default {
             return [
                 { check: !!vm.lastName.trim(), message: 'фамилию' },
                 { check: !!vm.firstName.trim(), message: 'имя' },
+                { check: !vm.blacklistInfo, message: 'Человек в чёрном списке' },
                 { check: !!vm.position.trim(), message: 'должность' },
                 { check: !!vm.selectedCitizenship, message: 'гражданство' },
                 { check: !!vm.passportSeriesNumber.trim(), message: 'паспортные данные' },
@@ -470,7 +486,10 @@ export default {
                 text: '',
                 x: 0,
                 y: 0
-            }
+            },
+            // Проверка ЧС (#443): null или { is_blacklisted, reason }
+            blacklistInfo: null,
+            blacklistTimeout: null
         }
     },
     computed: {
@@ -505,6 +524,11 @@ export default {
             });
         }
     },
+    watch: {
+        lastName() { this.checkBlacklist(); },
+        firstName() { this.checkBlacklist(); },
+        middleName() { this.checkBlacklist(); }
+    },
     async mounted() {
         await Promise.all([
             this.loadCitizenships(),
@@ -520,6 +544,11 @@ export default {
                 this.isPermissionDropdownOpen = false;
             }
         });
+    },
+    beforeUnmount() {
+        if (this.blacklistTimeout) {
+            clearTimeout(this.blacklistTimeout);
+        }
     },
     methods: {
         async loadCitizenships() {
@@ -734,6 +763,33 @@ export default {
                 .split(' ')
                 .map(word => word.charAt(0).toUpperCase() + word.slice(1))
                 .join(' ');
+        },
+
+        // Проверка человека в чёрном списке (#443): строгое совпадение ФИО,
+        // как и серверный гард. Отчество опционально.
+        checkBlacklist() {
+            if (this.blacklistTimeout) {
+                clearTimeout(this.blacklistTimeout);
+            }
+
+            const last = this.lastName.trim();
+            const first = this.firstName.trim();
+            if (!last || !first) {
+                this.blacklistInfo = null;
+                return;
+            }
+            const middle = this.middleName.trim();
+
+            this.blacklistTimeout = setTimeout(async () => {
+                try {
+                    const res = await checkPersonBlacklist({ last_name: last, first_name: first, middle_name: middle });
+                    this.blacklistInfo = res && res.is_blacklisted ? res : null;
+                } catch (error) {
+                    // Тихо: фоновая проверка не блокирует ввод; серверный гард - бэкстоп.
+                    console.error('Ошибка при проверке ЧС человека:', error);
+                    this.blacklistInfo = null;
+                }
+            }, 500);
         },
 
         togglePassageTable(table) {
@@ -1697,5 +1753,28 @@ export default {
 .dropdown-leave-to {
     opacity: 0;
     transform: translateY(-10px);
+}
+
+.blacklist-warning {
+    width: 100%;
+    margin-top: 12px;
+    padding: 12px;
+    background: #fff5f5;
+    border: 1px solid #f5c2c7;
+    border-radius: 10px;
+}
+
+.blacklist-warning .warning-title {
+    font-weight: 600;
+    color: #b02a37;
+    margin: 0 0 5px 0;
+    font-size: 14px;
+}
+
+.blacklist-warning .warning-details {
+    color: #b02a37;
+    margin: 0;
+    font-size: 12px;
+    line-height: 1.5;
 }
 </style>

--- a/frontend/src/components/CreateApplication/VehicleForm.vue
+++ b/frontend/src/components/CreateApplication/VehicleForm.vue
@@ -251,6 +251,21 @@
           </p>
         </div>
       </div>
+      <div
+        v-if="blacklistInfo"
+        class="blacklist-warning"
+        data-testid="vehicle-blacklist-warning"
+      >
+        <div class="warning-text">
+          <p class="warning-title">
+            Машина в чёрном списке
+          </p>
+          <p class="warning-details">
+            Причина: {{ blacklistInfo.reason || 'не указана' }}<br>
+            Добавить эту машину в заявку нельзя.
+          </p>
+        </div>
+      </div>
     </div>
 
     <!-- Места разгрузки -->
@@ -322,6 +337,7 @@
 
 <script>
 import { apiRequest } from '@/api/client'
+import { checkVehicleBlacklist } from '@/api/blacklist'
 import { useAuthStore } from '@/stores/auth'
 import { useToast } from '@/composables/useToast'
 import { useFormValidation } from '@/composables/useFormValidation'
@@ -376,6 +392,7 @@ export default {
 
             return [
                 { check: !vm.activeCarInfo || vm.isNumberByFact, message: 'На этот автомобиль уже есть активная заявка' },
+                { check: !vm.blacklistInfo, message: 'Машина в чёрном списке' },
                 { check: (vm.isNumberByFact && vm.isMarkByFact) || !hasInactiveSelected, message: 'Невозможно выбрать неактивные места разгрузки' },
                 { check: vm.isNumberByFact || !!vm.selectedFormat, message: 'формат номера' },
                 {
@@ -428,7 +445,10 @@ export default {
             },
             // Новые поля для проверки активных заявок
             activeCarInfo: null,
-            checkingTimeout: null
+            checkingTimeout: null,
+            // Проверка ЧС (#443): null или { is_blacklisted, reason }
+            blacklistInfo: null,
+            blacklistTimeout: null
         }
     },
     computed: {
@@ -454,6 +474,7 @@ export default {
             deep: true,
             handler() {
                 this.checkVehicleActive();
+                this.checkBlacklist();
             }
         }
     },
@@ -477,6 +498,9 @@ export default {
     beforeUnmount() {
         if (this.checkingTimeout) {
             clearTimeout(this.checkingTimeout);
+        }
+        if (this.blacklistTimeout) {
+            clearTimeout(this.blacklistTimeout);
         }
     },
     methods: {
@@ -518,6 +542,34 @@ export default {
                 } catch (error) {
                     console.error('Ошибка при проверке активности авто:', error);
                     this.activeCarInfo = null;
+                }
+            }, 500);
+        },
+
+        // Проверка машины в чёрном списке (#443): номер + mark_id, как и серверный гард.
+        // "По факту" не проверяем - нет конкретного номера/марки для совпадения.
+        checkBlacklist() {
+            if (this.blacklistTimeout) {
+                clearTimeout(this.blacklistTimeout);
+            }
+
+            if (this.isNumberByFact || this.isMarkByFact || !this.selectedMarkId ||
+                !this.selectedFormat || !this.numberParts.every(part => part)) {
+                this.blacklistInfo = null;
+                return;
+            }
+
+            const plateNumber = this.numberParts.join(' ');
+            const markId = this.selectedMarkId;
+
+            this.blacklistTimeout = setTimeout(async () => {
+                try {
+                    const res = await checkVehicleBlacklist({ car_number: plateNumber, mark_id: markId });
+                    this.blacklistInfo = res && res.is_blacklisted ? res : null;
+                } catch (error) {
+                    // Тихо: фоновая проверка не блокирует ввод; серверный гард - бэкстоп.
+                    console.error('Ошибка при проверке ЧС машины:', error);
+                    this.blacklistInfo = null;
                 }
             }, 500);
         },
@@ -777,6 +829,7 @@ export default {
             this.isNumberByFact = false;
             this.isMarkByFact = false;
             this.activeCarInfo = null;
+            this.blacklistInfo = null;
         },
 
         clearVehicleForm() {
@@ -790,6 +843,7 @@ export default {
             this.selectedExistingCars = [];
             this.editingVehicle = null;
             this.activeCarInfo = null;
+            this.blacklistInfo = null;
         },
 
         openExistingCarsModal() {
@@ -886,6 +940,10 @@ export default {
 
                 this.selectedUnloadingPlaces = vehicle.unloadPlaces || [];
             }
+
+            // Перепроверяем ЧС для редактируемой машины (для "по факту" watcher
+            // numberParts не сработает - сбросит/обновит баннер явно).
+            this.checkBlacklist();
         },
 
         cancelEdit() {
@@ -935,6 +993,7 @@ export default {
             this.markSearch = '';
 
             this.checkVehicleActive();
+            this.checkBlacklist();
         },
         
         toggleFormatDropdown() {
@@ -1122,6 +1181,23 @@ export default {
     margin: 0;
     font-size: 12px;
     line-height: 1.5;
+}
+
+.blacklist-warning {
+    width: 100%;
+    margin-top: 10px;
+    padding: 12px;
+    background: #fff5f5;
+    border: 1px solid #f5c2c7;
+    border-radius: 10px;
+    display: flex;
+    gap: 12px;
+    align-items: flex-start;
+}
+
+.blacklist-warning .warning-title,
+.blacklist-warning .warning-details {
+    color: #b02a37;
 }
 
 .format__dropdown {

--- a/internal/handlers/application_unread_permission_test.go
+++ b/internal/handlers/application_unread_permission_test.go
@@ -68,7 +68,9 @@ func TestApplicationService_GetUnreadCount_PermissionCheck(t *testing.T) {
 
 	permSvc := services.NewPermissionService(db)
 	notifSvc := services.NewNotificationService(db)
-	appSvc := services.NewApplicationService(db, permSvc, notifSvc)
+	vblSvc := services.NewVehicleBlacklistService(db, services.NewVehicleBlacklistHistoryService(db))
+	pblSvc := services.NewPersonBlacklistService(db, services.NewPersonBlacklistHistoryService(db))
+	appSvc := services.NewApplicationService(db, permSvc, notifSvc, vblSvc, pblSvc)
 
 	// outsider не должен видеть эту заявку в счётчике.
 	resOutsider, err := appSvc.GetUnreadCount(context.Background(), outsider.Username)

--- a/internal/handlers/applications_blacklist_test.go
+++ b/internal/handlers/applications_blacklist_test.go
@@ -1,0 +1,118 @@
+package handlers_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"systemburo/internal/models"
+	"systemburo/internal/testutil"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// submitCarApp подаёт полную заявку с одной машиной (номер + mark_id) и возвращает recorder.
+func submitCarApp(t *testing.T, e *echo.Echo, db *gorm.DB, token, orgName, tag, carNumber string, markID int) *httptest.ResponseRecorder {
+	t.Helper()
+	uaID := seedUniqueAttachment(t, db, "cars", fmt.Sprintf("car_tmpl_%s_%s", t.Name(), tag), "Car Template")
+	body := fmt.Sprintf(`{
+		"message": "blacklist guard",
+		"organization": "%s",
+		"responsible_person": "Test",
+		"contact_phone": "+79001234567",
+		"data_approval": true,
+		"attachments": [{
+			"attachment_type": "cars",
+			"attachment_name": "car_tmpl",
+			"attachment_display_name": "Car Template",
+			"unique_attachment_id": %d,
+			"entry_date_from": "2026-04-01",
+			"entry_date_to": "2099-12-31",
+			"entry_time_from": "08:00",
+			"entry_time_to": "18:00",
+			"data": {"vehicles": [{"car_number": "%s", "car_brand": "Kamaz", "mark_id": %d}]}
+		}]
+	}`, orgName, uaID, carNumber, markID)
+	return testutil.POST(t, e, "/applications/submit-complete-application", body, testutil.AuthHeader(token))
+}
+
+// submitPersonApp подаёт полную заявку с одним человеком (ФИО) и возвращает recorder.
+func submitPersonApp(t *testing.T, e *echo.Echo, db *gorm.DB, token, orgName, tag, last, first, middle string, citizenshipID, tableID int) *httptest.ResponseRecorder {
+	t.Helper()
+	uaID := seedUniqueAttachment(t, db, "people", fmt.Sprintf("emp_tmpl_%s_%s", t.Name(), tag), "Employee Template")
+	body := fmt.Sprintf(`{
+		"message": "blacklist guard",
+		"organization": "%s",
+		"responsible_person": "Test",
+		"contact_phone": "+79001234567",
+		"data_approval": true,
+		"attachments": [{
+			"attachment_type": "people",
+			"attachment_name": "people_tmpl",
+			"attachment_display_name": "People Template",
+			"unique_attachment_id": %d,
+			"entry_date_from": "2026-04-01",
+			"entry_date_to": "2099-12-31",
+			"entry_time_from": "08:00",
+			"entry_time_to": "18:00",
+			"data": {"employees": [{"last_name": "%s", "first_name": "%s", "middle_name": "%s", "citizenship_id": %d, "position": "Worker", "passport_series_number": "1234 567890", "target_tables": [%d]}]}
+		}]
+	}`, orgName, uaID, last, first, middle, citizenshipID, tableID)
+	return testutil.POST(t, e, "/applications/submit-complete-application", body, testutil.AuthHeader(token))
+}
+
+// TestSubmitCompleteApplication_BlacklistGuard проверяет серверный гард ЧС (#443):
+// заявку с заблокированной машиной/человеком отклоняем 409 (на случай обхода фронта),
+// а чистую - пропускаем.
+func TestSubmitCompleteApplication_BlacklistGuard(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	ctx := context.Background()
+
+	const orgName = "Test Organization"
+	token := testutil.RegisterAndLogin(t, e, "bl_guard_user", "pass123", 1, td.OrgID, td.CompanyID)
+	userID := getUserID(t, db, "bl_guard_user")
+
+	mark := seedMark(t, db, "BL_Guard_Mark")
+	citizenshipID := seedCitizenship(t, db)
+	tableID := seedSystemTable(t, db)
+
+	_, err := newVehicleBlacklistService(db).Create(ctx, models.CreateVehicleBlacklistRequest{
+		CarNumber: "C777CC799", MarkID: mark.ID, Reason: "угон",
+	}, userID)
+	require.NoError(t, err)
+
+	_, err = newPersonBlacklistService(db).Create(ctx, models.CreatePersonBlacklistRequest{
+		LastName: "Petrov", FirstName: "Petr", MiddleName: "Petrovich", Reason: "нарушение",
+	}, userID)
+	require.NoError(t, err)
+
+	t.Run("заблокированную машину нельзя подать", func(t *testing.T) {
+		rec := submitCarApp(t, e, db, token, orgName, "blocked", "C777CC799", mark.ID)
+		require.Equal(t, http.StatusConflict, rec.Code, "body: %s", rec.Body.String())
+		assert.Contains(t, rec.Body.String(), "чёрном списке")
+	})
+
+	t.Run("машину не из ЧС подать можно", func(t *testing.T) {
+		rec := submitCarApp(t, e, db, token, orgName, "clean", "D888DD799", mark.ID)
+		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+	})
+
+	t.Run("заблокированного человека нельзя подать", func(t *testing.T) {
+		rec := submitPersonApp(t, e, db, token, orgName, "blocked", "Petrov", "Petr", "Petrovich", citizenshipID, tableID)
+		require.Equal(t, http.StatusConflict, rec.Code, "body: %s", rec.Body.String())
+		assert.Contains(t, rec.Body.String(), "чёрном списке")
+	})
+
+	t.Run("человека не из ЧС подать можно", func(t *testing.T) {
+		rec := submitPersonApp(t, e, db, token, orgName, "clean", "Sidorov", "Sidr", "Sidorovich", citizenshipID, tableID)
+		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+	})
+}

--- a/internal/handlers/applications_expiry_test.go
+++ b/internal/handlers/applications_expiry_test.go
@@ -22,7 +22,9 @@ func TestCheckExpiredAttachments(t *testing.T) {
 	// Create the service directly for calling CheckExpiredAttachments.
 	permSvc := services.NewPermissionService(db)
 	notifSvc := services.NewNotificationService(db)
-	appSvc := services.NewApplicationService(db, permSvc, notifSvc)
+	vblSvc := services.NewVehicleBlacklistService(db, services.NewVehicleBlacklistHistoryService(db))
+	pblSvc := services.NewPersonBlacklistService(db, services.NewPersonBlacklistHistoryService(db))
+	appSvc := services.NewApplicationService(db, permSvc, notifSvc, vblSvc, pblSvc)
 
 	tests := []struct {
 		name string

--- a/internal/handlers/employees_history_actions_test.go
+++ b/internal/handlers/employees_history_actions_test.go
@@ -113,7 +113,9 @@ func TestCheckExpiredAttachments_CreatesEmployeeDeactivateHistory(t *testing.T) 
 
 	permSvc := services.NewPermissionService(db)
 	notifSvc := services.NewNotificationService(db)
-	appSvc := services.NewApplicationService(db, permSvc, notifSvc)
+	vblSvc := services.NewVehicleBlacklistService(db, services.NewVehicleBlacklistHistoryService(db))
+	pblSvc := services.NewPersonBlacklistService(db, services.NewPersonBlacklistHistoryService(db))
+	appSvc := services.NewApplicationService(db, permSvc, notifSvc, vblSvc, pblSvc)
 
 	token := testutil.RegisterAndLogin(t, e, "emphist_expiry1", "pass123", 1, td.OrgID, td.CompanyID)
 	appID, attID, empID := seedEmployeeViaCompleteApp(t, e, db, token, "Test Organization")

--- a/internal/services/application_service.go
+++ b/internal/services/application_service.go
@@ -178,6 +178,7 @@ type AttachmentContentData struct {
 type VehicleInput struct {
 	CarNumber    string  `json:"car_number"`
 	CarBrand     string  `json:"car_brand"`
+	MarkID       *int    `json:"mark_id"`
 	UnloadPlace  *string `json:"unload_place"`
 	UnloadPlaces []int   `json:"unload_places"`
 }
@@ -465,11 +466,19 @@ type applicationService struct {
 	db                  *gorm.DB
 	permissionService   PermissionService
 	notificationService NotificationService
+	vehicleBlacklist    VehicleBlacklistService
+	personBlacklist     PersonBlacklistService
 }
 
 // NewApplicationService создаёт экземпляр сервиса заявок.
-func NewApplicationService(db *gorm.DB, permSvc PermissionService, notifSvc NotificationService) ApplicationService {
-	return &applicationService{db: db, permissionService: permSvc, notificationService: notifSvc}
+func NewApplicationService(db *gorm.DB, permSvc PermissionService, notifSvc NotificationService, vehicleBL VehicleBlacklistService, personBL PersonBlacklistService) ApplicationService {
+	return &applicationService{
+		db:                  db,
+		permissionService:   permSvc,
+		notificationService: notifSvc,
+		vehicleBlacklist:    vehicleBL,
+		personBlacklist:     personBL,
+	}
 }
 
 // --- Основные методы ---
@@ -929,6 +938,48 @@ func (s *applicationService) CreateApplication(ctx context.Context, username str
 	}, nil
 }
 
+// validateBlacklist проверяет машины и людей заявки против активного ЧС (#443).
+// Машины матчатся по номеру + mark_id (как и фронтовый /check); машины без mark_id
+// ("по факту"/свободная марка) пропускаем - по mark_id в ЧС они попасть не могут.
+// Люди - строгое совпадение ФИО. Возвращает 409 при первом совпадении.
+func (s *applicationService) validateBlacklist(ctx context.Context, req CompleteApplicationRequest) error {
+	for _, att := range req.Attachments {
+		if att.Data.Vehicles != nil {
+			for _, v := range *att.Data.Vehicles {
+				if v.MarkID == nil {
+					continue
+				}
+				res, err := s.vehicleBlacklist.Check(ctx, v.CarNumber, *v.MarkID)
+				if err != nil {
+					return err
+				}
+				if res.IsBlacklisted {
+					return echo.NewHTTPError(http.StatusConflict,
+						fmt.Sprintf("Машина %s %s в чёрном списке: %s", v.CarNumber, v.CarBrand, res.Reason))
+				}
+			}
+		}
+		if att.Data.Employees != nil {
+			for _, e := range *att.Data.Employees {
+				middleName := ""
+				if e.MiddleName != nil {
+					middleName = *e.MiddleName
+				}
+				res, err := s.personBlacklist.Check(ctx, e.LastName, e.FirstName, middleName)
+				if err != nil {
+					return err
+				}
+				if res.IsBlacklisted {
+					fio := strings.TrimSpace(fmt.Sprintf("%s %s %s", e.LastName, e.FirstName, middleName))
+					return echo.NewHTTPError(http.StatusConflict,
+						fmt.Sprintf("Человек %s в чёрном списке: %s", fio, res.Reason))
+				}
+			}
+		}
+	}
+	return nil
+}
+
 // SubmitCompleteApplication создаёт полную заявку с вложениями, машинами и сотрудниками.
 func (s *applicationService) SubmitCompleteApplication(ctx context.Context, username string, req CompleteApplicationRequest) (*CompleteApplicationResponse, error) {
 	user, err := s.getUserByUsername(ctx, username)
@@ -941,6 +992,12 @@ func (s *applicationService) SubmitCompleteApplication(ctx context.Context, user
 	}
 	if len(req.Attachments) == 0 {
 		return nil, echo.NewHTTPError(http.StatusBadRequest, "At least one attachment is required")
+	}
+
+	// Серверный гард ЧС (#443): отклоняем заявку с заблокированной машиной/человеком
+	// до старта транзакции - на случай обхода фронтовой проверки.
+	if err := s.validateBlacklist(ctx, req); err != nil {
+		return nil, err
 	}
 
 	tx := s.db.WithContext(ctx).Begin()

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -120,7 +120,6 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	notificationService := notificationServiceEarly
 	requestLogsService := services.NewRequestLogsService(db)
 	employeesHistoryService := services.NewEmployeesHistoryService(db)
-	applicationService := services.NewApplicationService(db, permissionService, notificationService)
 	approverService := services.NewApproverService(db)
 	consentService := services.NewConsentService(db)
 	settingsService := services.NewSettingsService(db, &config.Config{
@@ -137,6 +136,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	vehicleBlacklistService := services.NewVehicleBlacklistService(db, vehicleBlacklistHistoryService)
 	personBlacklistHistoryService := services.NewPersonBlacklistHistoryService(db)
 	personBlacklistService := services.NewPersonBlacklistService(db, personBlacklistHistoryService)
+	applicationService := services.NewApplicationService(db, permissionService, notificationService, vehicleBlacklistService, personBlacklistService)
 	attachmentTemplateService := services.NewAttachmentTemplateService(db, "./uploads")
 	attachmentBlankService := services.NewAttachmentBlankService(db)
 	trashService := services.NewTrashService(db)


### PR DESCRIPTION
Финальный срез **C** эпика #443 - интеграция чёрного списка в подачу заявки.

## Что сделано
- **Frontend.** VehicleForm и EmployeeForm при заполнении номер+марка / ФИО дёргают `/vehicle-blacklist/check` и `/person-blacklist/check` (debounce 500мс). При совпадении - красный баннер с причиной и блокировка кнопки "Добавить" (через существующий `useFormValidation`, по образцу баннера активной заявки).
- **API-клиент.** `checkVehicleBlacklist` / `checkPersonBlacklist` в `api/blacklist.js`.
- **Серверный гард.** `validateBlacklist` в `SubmitCompleteApplication` отклоняет заявку с заблокированной машиной (номер+mark_id) или человеком (ФИО) с **409** до старта транзакции. Бэкстоп на обход фронта; итерирует все вложения payload, поэтому покрывает и ручной ввод, и выбор существующих машин/людей.
- `VehicleInput` получил `MarkID *int` - фронт уже слал `mark_id` в submit-payload, серверная проверка теперь зеркалит клиентскую (номер+mark_id). Конструктор `NewApplicationService` прокинут через все вызовы (main, testutil, 3 теста).

## Тесты
- Go integration `TestSubmitCompleteApplication_BlacklistGuard`: заблокированная машина/человек -> 409, чистые -> 200.
- Go full suite + vitest (335) + eslint + build - зелёные.

## Ревью
Adversarial multi-dimension review. Один подтверждённый баг: stale-баннер при `editVehicle` для "по факту" (watcher numberParts не срабатывал) - исправлен (`checkBlacklist` в editVehicle + сброс `blacklistInfo` в clear-методах + очистка `blacklistTimeout` в beforeUnmount). Прочие findings отклонены как out-of-scope/non-issue (токены/радиус/DRY - pre-existing; 409 vs 400 - конвенция пакета; /check-доступ - не в диффе).

## Верификация в браузере
Оба баннера проверены локально (Playwright, реальный браузер + реальный `/check`): баннер с причиной + disabled "Добавить" для машины и человека. Скриншоты отправлены в чат до мержа.

## Заметки
- E2E гарда - Go integration-тест через полный стек handler->service->DB. Playwright-спеки создания заявки в репо скипнуты из-за seed-требований; гард надёжнее покрывается интеграционным тестом.
- Выбор существующих машин/людей фронт-баннером не подсвечивается (нет инлайн-поля под выбор из модалки), но серверный гард ловит их при submit.
