### PR TITLE
feat(unload-places): зачистка выбора места разгрузки - мёртвый is_active + toast->notify (#413)

### DIFF
--- a/frontend/src/components/SelectUnloadPlaces.vue
+++ b/frontend/src/components/SelectUnloadPlaces.vue
@@ -30,10 +30,7 @@
             v-for="place in allUnloadPlaces" 
             :key="place.id"
             class="place-item"
-            :class="{
-              'selected': isPlaceSelected(place.id),
-              'disabled': !place.is_active
-            }"
+            :class="{ 'selected': isPlaceSelected(place.id) }"
             @click="toggleUnloadPlace(place)"
           >
             {{ place.name }}
@@ -53,6 +50,7 @@
 
 <script>
 import { apiRequest } from '@/api/client'
+import { useDeletionsStore } from '@/stores/deletions'
 export default {
   name: 'SelectUnloadPlaces',
   props: {
@@ -152,16 +150,16 @@ export default {
         
         if (response.ok) {
           this.originalSelectedPlaces = [...this.selectedUnloadPlaces];
-          this.showNotification("Места разгрузки успешно обновлены", "success");
+          useDeletionsStore().notify({ prefix: 'Места разгрузки сохранены для ', bold: this.entity.name, type: 'success' });
           this.$emit('places-updated');
         } else {
           const error = await response.json();
-          this.showNotification(error.message || "Ошибка при обновлении мест разгрузки", "error");
+          useDeletionsStore().notify({ prefix: 'Не удалось сохранить места разгрузки: ', bold: error.message || 'ошибка сервера', type: 'error' });
           await this.fetchEntityUnloadPlaces(this.entity.id);
         }
       } catch (error) {
         console.error("Error updating unload places:", error);
-        this.showNotification("Ошибка сети", "error");
+        useDeletionsStore().notify({ prefix: 'Не удалось сохранить места разгрузки: ', bold: 'ошибка сети', type: 'error' });
         await this.fetchEntityUnloadPlaces(this.entity.id);
       } finally {
         this.isSaving = false;
@@ -173,8 +171,6 @@ export default {
     },
 
     toggleUnloadPlace(place) {
-      if (!place.is_active) return;
-      
       const index = this.selectedUnloadPlaces.findIndex(p => p.id === place.id);
       if (index > -1) {
         this.selectedUnloadPlaces.splice(index, 1);
@@ -185,33 +181,6 @@ export default {
 
     isPlaceSelected(placeId) {
       return this.selectedUnloadPlaces.some(p => p.id === placeId);
-    },
-
-    showNotification(message, type = 'info') {
-      const notification = document.createElement('div');
-      notification.className = `notification ${type}`;
-      notification.textContent = message;
-      notification.style.cssText = `
-        position: fixed;
-        top: 20px;
-        right: 20px;
-        padding: 12px 20px;
-        border-radius: 8px;
-        color: white;
-        font-weight: 500;
-        z-index: 1000;
-      `;
-      
-      if (type === 'success') notification.style.backgroundColor = '#10b981';
-      if (type === 'error') notification.style.backgroundColor = '#ef4444';
-      if (type === 'warning') notification.style.backgroundColor = '#f59e0b';
-      if (type === 'info') notification.style.backgroundColor = '#3b82f6';
-      
-      document.body.appendChild(notification);
-      
-      setTimeout(() => {
-        notification.remove();
-      }, 3000);
     }
   },
 };
@@ -270,15 +239,6 @@ export default {
 .place-item.selected {
   background: #4F5BDF;
   color: #FFF;
-}
-
-.place-item.disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.place-item.disabled:hover {
-  background: #f2f2f2;
 }
 
 .no-places-message {

--- a/frontend/src/components/UnloadingPlaceFilter.vue
+++ b/frontend/src/components/UnloadingPlaceFilter.vue
@@ -146,7 +146,7 @@ export default {
 
                 if (response.ok) {
                     const data = await response.json();
-                    this.unloadingPlaces = data.filter(place => place.is_active !== false);
+                    this.unloadingPlaces = data;
                     this.updateSelectedName();
                 } else {
                     console.error("Ошибка при загрузке мест разгрузки");
@@ -307,7 +307,7 @@ export default {
     width: 100%;
     padding: 8px 12px;
     border: 1px solid #e6e6e6;
-    border-radius: 8px;
+    border-radius: var(--radius-md);
     font-size: 14px;
     outline: none;
     transition: border-color 0.2s;


### PR DESCRIPTION
Финальный срез **3f** эпика #413 (приведение управления местами разгрузки к эталону). Низкий риск, ~25 строк нетто, без нового layout.

## Что сделано
- **SelectUnloadPlaces.vue** (выбор мест по умолчанию для орг/компании):
  - Убрал мёртвый `'disabled': !place.is_active` (класс) и `if (!place.is_active) return;` (guard в `toggleUnloadPlace`). Backend `GetAll /unload-places` отдаёт только активные по умолчанию (`unload_place_service.go:180-181`, компонент зовёт без `include_archived`) - `is_active` всегда `true`, проверки не срабатывали. Удалил осиротевший CSS `.place-item.disabled`.
  - Самодельный `showNotification` (toast через `document.createElement`) -> `useDeletionsStore().notify(...)` в 3 ветках save (success/ошибка сервера/ошибка сети). Паттерн 1:1 с сиблингом `UnloadPlacesContainer.vue` из этого же эпика.
- **UnloadingPlaceFilter.vue** (фильтр места в таблице заявок):
  - Убрал мёртвый `data.filter(place => place.is_active !== false)` (та же причина).
  - `border-radius` инпута поиска `8px` -> `var(--radius-md)` (15px) по [[ui-inputs]].

## Проверки
- eslint clean, vitest 335/335, `vite build` OK.
- code-reviewer: **GO** (1 YELLOW по стилю формулировки notify - закрыт, приведено к единому виду с соседними notify и контейнером).
- Мёртвость is_active-проверок подтверждена чтением backend (фильтр `WHERE is_active = true` по умолчанию).

## Остаётся долгом (вне скоупа 3f)
- `UnloadingPlaceFilter.vue`: focus инпута поиска `box-shadow` сырой rgba вместо `var(--shadow-focus)`; меню `.custom-dropdown` radius 10px - мелкий polish, отдельно.
- `UnloadPlaceModal.vue` намеренно НЕ тронут (там `is_active` слот-уровня в CreateApplication-флоу - регрессия заявок).

Браузер-смок локально не выполнен (профиль MCP занят фоновым агентом); FE-гейт - `/ship-check` после деплоя на staging.