### PR TITLE
refactor(unload-places): общий timeSlotStore вместо дубля CRUD слотов (#413)

### DIFF
--- a/internal/models/system_table.go
+++ b/internal/models/system_table.go
@@ -20,8 +20,8 @@ type SystemTable struct {
 
 	// Оформление таблицы (#345). FontSize - размер шрифта строк (px, 10-24).
 	// RowDensity - плотность строк: compact|normal|spacious.
-	FontSize    int    `gorm:"default:14" json:"font_size"`
-	RowDensity  string `gorm:"size:20;default:'normal'" json:"row_density"`
+	FontSize   int    `gorm:"default:14" json:"font_size"`
+	RowDensity string `gorm:"size:20;default:'normal'" json:"row_density"`
 	// То же самое, но для FactTable (отдельные настройки).
 	FontSizeFact   int    `gorm:"default:14" json:"font_size_fact"`
 	RowDensityFact string `gorm:"size:20;default:'normal'" json:"row_density_fact"`
@@ -57,6 +57,9 @@ type SystemTableTimeSlot struct {
 	CreatedAt time.Time   `json:"created_at"`
 	UpdatedAt time.Time   `json:"updated_at"`
 }
+
+// GetID возвращает идентификатор слота (контракт timeSlotModel для общего стора).
+func (s SystemTableTimeSlot) GetID() int { return s.ID }
 
 type OrganizationTable struct {
 	ID             int          `json:"id"`
@@ -161,11 +164,11 @@ type UpdateSystemTableRequest struct {
 
 // CreateTimeSlotRequest -- запрос на создание временного слота.
 type CreateTimeSlotRequest struct {
-	DayOfWeek int     `json:"day_of_week" validate:"min=0,max=6"`
-	OpenTime  string  `json:"open_time" validate:"required"`
-	CloseTime string  `json:"close_time" validate:"required"`
-	IsNextDay *bool   `json:"is_next_day"`
-	IsActive  *bool   `json:"is_active"`
+	DayOfWeek int    `json:"day_of_week" validate:"min=0,max=6"`
+	OpenTime  string `json:"open_time" validate:"required"`
+	CloseTime string `json:"close_time" validate:"required"`
+	IsNextDay *bool  `json:"is_next_day"`
+	IsActive  *bool  `json:"is_active"`
 }
 
 // UpdateTimeSlotRequest -- запрос на обновление временного слота (все поля опциональные).

--- a/internal/models/unload_place.go
+++ b/internal/models/unload_place.go
@@ -40,6 +40,9 @@ type UnloadPlaceTimeSlot struct {
 	UpdatedAt     time.Time   `json:"updated_at"`
 }
 
+// GetID возвращает идентификатор слота (контракт timeSlotModel для общего стора).
+func (s UnloadPlaceTimeSlot) GetID() int { return s.ID }
+
 type OrganizationUnloadPlace struct {
 	ID             int          `json:"id"`
 	OrganizationID int          `gorm:"index" json:"organization_id"`

--- a/internal/services/system_table_timeslot_service.go
+++ b/internal/services/system_table_timeslot_service.go
@@ -3,137 +3,60 @@ package services
 import (
 	"context"
 	"net/http"
-	"time"
 
 	"systemburo/internal/models"
 
 	"github.com/labstack/echo/v4"
-	"gorm.io/gorm"
 )
+
+// timeSlots -- общий стор временных слотов для системных таблиц. Слот можно
+// добавить только к активной таблице.
+func (s *systemTableService) timeSlots() timeSlotStore[models.SystemTableTimeSlot] {
+	return timeSlotStore[models.SystemTableTimeSlot]{
+		db:       s.db,
+		entity:   "system_table",
+		fkColumn: "table_id",
+		checkParent: func(ctx context.Context, tableID int) error {
+			var count int64
+			if err := s.db.WithContext(ctx).Model(&models.SystemTable{}).
+				Where("id = ? AND is_active = ?", tableID, true).
+				Count(&count).Error; err != nil {
+				return echo.NewHTTPError(http.StatusInternalServerError, "Error checking system table")
+			}
+			if count == 0 {
+				return echo.NewHTTPError(http.StatusNotFound, "Системная таблица не найдена")
+			}
+			return nil
+		},
+		newSlot: func(tableID int, req models.CreateTimeSlotRequest) models.SystemTableTimeSlot {
+			return models.SystemTableTimeSlot{
+				TableID:   tableID,
+				DayOfWeek: req.DayOfWeek,
+				OpenTime:  req.OpenTime,
+				CloseTime: req.CloseTime,
+				IsNextDay: req.IsNextDay != nil && *req.IsNextDay,
+				IsActive:  req.IsActive == nil || *req.IsActive,
+			}
+		},
+	}
+}
 
 // GetTimeSlots возвращает временные слоты системной таблицы.
 func (s *systemTableService) GetTimeSlots(ctx context.Context, tableID int) ([]models.SystemTableTimeSlot, error) {
-	slots := make([]models.SystemTableTimeSlot, 0)
-	if err := s.db.WithContext(ctx).
-		Where("table_id = ?", tableID).
-		Order("day_of_week, open_time").
-		Find(&slots).Error; err != nil {
-		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching time slots")
-	}
-	return slots, nil
+	return s.timeSlots().list(ctx, tableID)
 }
 
 // AddTimeSlot добавляет временной слот к системной таблице.
 func (s *systemTableService) AddTimeSlot(ctx context.Context, tableID int, req models.CreateTimeSlotRequest) (int, error) {
-	// Проверяем существование таблицы
-	var count int64
-	if err := s.db.WithContext(ctx).Model(&models.SystemTable{}).
-		Where("id = ? AND is_active = ?", tableID, true).
-		Count(&count).Error; err != nil {
-		return 0, echo.NewHTTPError(http.StatusInternalServerError, "Error checking system table")
-	}
-	if count == 0 {
-		return 0, echo.NewHTTPError(http.StatusNotFound, "Системная таблица не найдена")
-	}
-
-	// Валидация времени (формат HH:MM)
-	if _, err := time.Parse("15:04", req.OpenTime); err != nil {
-		return 0, echo.NewHTTPError(http.StatusBadRequest, "Неверный формат времени открытия. Используйте ЧЧ:ММ")
-	}
-	if _, err := time.Parse("15:04", req.CloseTime); err != nil {
-		return 0, echo.NewHTTPError(http.StatusBadRequest, "Неверный формат времени закрытия. Используйте ЧЧ:ММ")
-	}
-
-	if req.DayOfWeek < 0 || req.DayOfWeek > 6 {
-		return 0, echo.NewHTTPError(http.StatusBadRequest, "День недели должен быть от 0 (Пн) до 6 (Вс)")
-	}
-
-	isNextDay := req.IsNextDay != nil && *req.IsNextDay
-	isActive := req.IsActive == nil || *req.IsActive
-
-	slot := models.SystemTableTimeSlot{
-		TableID:   tableID,
-		DayOfWeek: req.DayOfWeek,
-		OpenTime:  req.OpenTime,
-		CloseTime: req.CloseTime,
-		IsNextDay: isNextDay,
-		IsActive:  isActive,
-	}
-
-	if err := s.db.WithContext(ctx).Create(&slot).Error; err != nil {
-		return 0, echo.NewHTTPError(http.StatusInternalServerError, "Error adding time slot")
-	}
-
-	return slot.ID, nil
+	return s.timeSlots().add(ctx, tableID, req)
 }
 
 // UpdateTimeSlot обновляет временной слот системной таблицы.
 func (s *systemTableService) UpdateTimeSlot(ctx context.Context, tableID, slotID int, req models.UpdateTimeSlotRequest) error {
-	var slot models.SystemTableTimeSlot
-	if err := s.db.WithContext(ctx).
-		Where("id = ? AND table_id = ?", slotID, tableID).
-		First(&slot).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
-			return echo.NewHTTPError(http.StatusNotFound, "Временной слот не найден")
-		}
-		return echo.NewHTTPError(http.StatusInternalServerError, "Error fetching time slot")
-	}
-
-	if req.DayOfWeek != nil {
-		if *req.DayOfWeek < 0 || *req.DayOfWeek > 6 {
-			return echo.NewHTTPError(http.StatusBadRequest, "День недели должен быть от 0 (Пн) до 6 (Вс)")
-		}
-		slot.DayOfWeek = *req.DayOfWeek
-	}
-	if req.OpenTime != nil {
-		if _, err := time.Parse("15:04", *req.OpenTime); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Неверный формат времени открытия")
-		}
-		slot.OpenTime = *req.OpenTime
-	}
-	if req.CloseTime != nil {
-		if _, err := time.Parse("15:04", *req.CloseTime); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Неверный формат времени закрытия")
-		}
-		slot.CloseTime = *req.CloseTime
-	}
-	if req.IsNextDay != nil {
-		slot.IsNextDay = *req.IsNextDay
-	}
-	if req.IsActive != nil {
-		slot.IsActive = *req.IsActive
-	}
-
-	result := s.db.WithContext(ctx).
-		Model(&models.SystemTableTimeSlot{}).
-		Where("id = ? AND table_id = ?", slotID, tableID).
-		Updates(map[string]interface{}{
-			"day_of_week": slot.DayOfWeek,
-			"open_time":   slot.OpenTime,
-			"close_time":  slot.CloseTime,
-			"is_next_day": slot.IsNextDay,
-			"is_active":   slot.IsActive,
-			"updated_at":  time.Now().UTC(),
-		})
-	if result.Error != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "Error updating time slot")
-	}
-	if result.RowsAffected == 0 {
-		return echo.NewHTTPError(http.StatusNotFound, "Временной слот не найден")
-	}
-	return nil
+	return s.timeSlots().update(ctx, tableID, slotID, req)
 }
 
 // DeleteTimeSlot удаляет временной слот системной таблицы.
 func (s *systemTableService) DeleteTimeSlot(ctx context.Context, tableID, slotID int) error {
-	result := s.db.WithContext(ctx).
-		Where("id = ? AND table_id = ?", slotID, tableID).
-		Delete(&models.SystemTableTimeSlot{})
-	if result.Error != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "Error deleting time slot")
-	}
-	if result.RowsAffected == 0 {
-		return echo.NewHTTPError(http.StatusNotFound, "Временной слот не найден")
-	}
-	return nil
+	return s.timeSlots().remove(ctx, tableID, slotID)
 }

--- a/internal/services/timeslot_store.go
+++ b/internal/services/timeslot_store.go
@@ -1,0 +1,161 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"systemburo/internal/models"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+// timeSlotModel -- контракт модели временного слота: общий стор читает ID после
+// создания. Реализуют SystemTableTimeSlot и UnloadPlaceTimeSlot.
+type timeSlotModel interface {
+	GetID() int
+}
+
+// timeSlotStore -- generic-CRUD временных слотов поверх произвольной модели слота.
+// Раньше эта логика была продублирована в system_table и unload_place сервисах;
+// специфика таблицы (имя FK-колонки, проверка родителя, конструктор слота) задаётся
+// полями, остальное общее.
+type timeSlotStore[T timeSlotModel] struct {
+	db          *gorm.DB
+	entity      string                                                 // для логов: "system_table" | "unload_place"
+	fkColumn    string                                                 // "table_id" | "unload_place_id"
+	checkParent func(ctx context.Context, parentID int) error          // существование родителя + текст 404
+	newSlot     func(parentID int, req models.CreateTimeSlotRequest) T // конструктор слота с FK и полями
+}
+
+// list возвращает слоты родителя, отсортированные по дню и времени открытия.
+func (st timeSlotStore[T]) list(ctx context.Context, parentID int) ([]T, error) {
+	slots := make([]T, 0)
+	if err := st.db.WithContext(ctx).
+		Where(st.fkColumn+" = ?", parentID).
+		Order("day_of_week, open_time").
+		Find(&slots).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching time slots")
+	}
+	return slots, nil
+}
+
+// add валидирует и создаёт слот после проверки существования родителя.
+func (st timeSlotStore[T]) add(ctx context.Context, parentID int, req models.CreateTimeSlotRequest) (int, error) {
+	if err := st.checkParent(ctx, parentID); err != nil {
+		return 0, err
+	}
+	if err := validateClock(req.OpenTime, "открытия"); err != nil {
+		return 0, err
+	}
+	if err := validateClock(req.CloseTime, "закрытия"); err != nil {
+		return 0, err
+	}
+	if err := validateDayOfWeek(req.DayOfWeek); err != nil {
+		return 0, err
+	}
+
+	slot := st.newSlot(parentID, req)
+	if err := st.db.WithContext(ctx).Create(&slot).Error; err != nil {
+		slog.Error("не удалось добавить временной слот", "entity", st.entity, "parent_id", parentID, "error", err)
+		return 0, echo.NewHTTPError(http.StatusInternalServerError, "Error adding time slot")
+	}
+	slog.Info("временной слот добавлен", "entity", st.entity, "id", slot.GetID(), "parent_id", parentID)
+	return slot.GetID(), nil
+}
+
+// update применяет переданные поля к существующему слоту (404, если слота нет).
+func (st timeSlotStore[T]) update(ctx context.Context, parentID, slotID int, req models.UpdateTimeSlotRequest) error {
+	var existing T
+	if err := st.db.WithContext(ctx).
+		Where("id = ? AND "+st.fkColumn+" = ?", slotID, parentID).
+		First(&existing).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return errTimeSlotNotFound()
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Error fetching time slot")
+	}
+
+	// updated_at всегда в наборе -> RowsAffected отражает реальное наличие строки,
+	// а не "значения не изменились".
+	updates := map[string]interface{}{"updated_at": time.Now().UTC()}
+	if req.DayOfWeek != nil {
+		if err := validateDayOfWeek(*req.DayOfWeek); err != nil {
+			return err
+		}
+		updates["day_of_week"] = *req.DayOfWeek
+	}
+	if req.OpenTime != nil {
+		if err := validateClock(*req.OpenTime, "открытия"); err != nil {
+			return err
+		}
+		updates["open_time"] = *req.OpenTime
+	}
+	if req.CloseTime != nil {
+		if err := validateClock(*req.CloseTime, "закрытия"); err != nil {
+			return err
+		}
+		updates["close_time"] = *req.CloseTime
+	}
+	if req.IsNextDay != nil {
+		updates["is_next_day"] = *req.IsNextDay
+	}
+	if req.IsActive != nil {
+		updates["is_active"] = *req.IsActive
+	}
+
+	result := st.db.WithContext(ctx).
+		Model(new(T)).
+		Where("id = ? AND "+st.fkColumn+" = ?", slotID, parentID).
+		Updates(updates)
+	if result.Error != nil {
+		slog.Error("не удалось обновить временной слот", "entity", st.entity, "slot_id", slotID, "parent_id", parentID, "error", result.Error)
+		return echo.NewHTTPError(http.StatusInternalServerError, "Error updating time slot")
+	}
+	if result.RowsAffected == 0 {
+		return errTimeSlotNotFound()
+	}
+	slog.Info("временной слот обновлён", "entity", st.entity, "slot_id", slotID, "parent_id", parentID)
+	return nil
+}
+
+// remove удаляет слот родителя (404, если слота нет).
+func (st timeSlotStore[T]) remove(ctx context.Context, parentID, slotID int) error {
+	result := st.db.WithContext(ctx).
+		Where("id = ? AND "+st.fkColumn+" = ?", slotID, parentID).
+		Delete(new(T))
+	if result.Error != nil {
+		slog.Error("не удалось удалить временной слот", "entity", st.entity, "slot_id", slotID, "parent_id", parentID, "error", result.Error)
+		return echo.NewHTTPError(http.StatusInternalServerError, "Error deleting time slot")
+	}
+	if result.RowsAffected == 0 {
+		return errTimeSlotNotFound()
+	}
+	slog.Info("временной слот удалён", "entity", st.entity, "slot_id", slotID, "parent_id", parentID)
+	return nil
+}
+
+// errTimeSlotNotFound -- 404 для отсутствующего слота. Функция, а не общая
+// переменная: echo может проставлять Internal на *HTTPError, делиться экземпляром нельзя.
+func errTimeSlotNotFound() error {
+	return echo.NewHTTPError(http.StatusNotFound, "Временной слот не найден")
+}
+
+// validateClock проверяет формат времени ЧЧ:ММ. label -- "открытия"/"закрытия".
+func validateClock(value, label string) error {
+	if _, err := time.Parse("15:04", value); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Неверный формат времени "+label+". Используйте ЧЧ:ММ")
+	}
+	return nil
+}
+
+// validateDayOfWeek проверяет день недели в диапазоне 0 (Пн) -- 6 (Вс).
+func validateDayOfWeek(day int) error {
+	if day < 0 || day > 6 {
+		return echo.NewHTTPError(http.StatusBadRequest, "День недели должен быть от 0 (Пн) до 6 (Вс)")
+	}
+	return nil
+}

--- a/internal/services/unload_place_timeslot_service.go
+++ b/internal/services/unload_place_timeslot_service.go
@@ -2,153 +2,61 @@ package services
 
 import (
 	"context"
-	"log/slog"
 	"net/http"
-	"time"
 
 	"systemburo/internal/models"
 
 	"github.com/labstack/echo/v4"
-	"gorm.io/gorm"
 )
+
+// timeSlots -- общий стор временных слотов для мест разгрузки. В отличие от
+// системных таблиц, слот можно добавить и к архивному месту (is_active не
+// проверяется -- сохранение расписания при архивации).
+func (s *unloadPlaceService) timeSlots() timeSlotStore[models.UnloadPlaceTimeSlot] {
+	return timeSlotStore[models.UnloadPlaceTimeSlot]{
+		db:       s.db,
+		entity:   "unload_place",
+		fkColumn: "unload_place_id",
+		checkParent: func(ctx context.Context, placeID int) error {
+			var count int64
+			if err := s.db.WithContext(ctx).Model(&models.UnloadPlace{}).
+				Where("id = ?", placeID).Count(&count).Error; err != nil {
+				return echo.NewHTTPError(http.StatusInternalServerError, "Error checking unload place")
+			}
+			if count == 0 {
+				return echo.NewHTTPError(http.StatusNotFound, "Место разгрузки не найдено")
+			}
+			return nil
+		},
+		newSlot: func(placeID int, req models.CreateTimeSlotRequest) models.UnloadPlaceTimeSlot {
+			return models.UnloadPlaceTimeSlot{
+				UnloadPlaceID: placeID,
+				DayOfWeek:     req.DayOfWeek,
+				OpenTime:      req.OpenTime,
+				CloseTime:     req.CloseTime,
+				IsNextDay:     req.IsNextDay != nil && *req.IsNextDay,
+				IsActive:      req.IsActive == nil || *req.IsActive,
+			}
+		},
+	}
+}
 
 // GetTimeSlots возвращает временные слоты места разгрузки.
 func (s *unloadPlaceService) GetTimeSlots(ctx context.Context, placeID int) ([]models.UnloadPlaceTimeSlot, error) {
-	slots := make([]models.UnloadPlaceTimeSlot, 0)
-	if err := s.db.WithContext(ctx).
-		Where("unload_place_id = ?", placeID).
-		Order("day_of_week, open_time").
-		Find(&slots).Error; err != nil {
-		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching time slots")
-	}
-	return slots, nil
+	return s.timeSlots().list(ctx, placeID)
 }
 
 // AddTimeSlot добавляет временной слот к месту разгрузки.
 func (s *unloadPlaceService) AddTimeSlot(ctx context.Context, placeID int, req CreateTimeSlotRequest) (int, error) {
-	// Проверяем существование места
-	var count int64
-	if err := s.db.WithContext(ctx).Model(&models.UnloadPlace{}).Where("id = ?", placeID).Count(&count).Error; err != nil {
-		return 0, echo.NewHTTPError(http.StatusInternalServerError, "Error checking unload place")
-	}
-	if count == 0 {
-		return 0, echo.NewHTTPError(http.StatusNotFound, "Место разгрузки не найдено")
-	}
-
-	// Валидируем формат времени
-	if _, err := time.Parse("15:04", req.OpenTime); err != nil {
-		return 0, echo.NewHTTPError(http.StatusBadRequest, "Неверный формат времени открытия. Используйте ЧЧ:ММ")
-	}
-	if _, err := time.Parse("15:04", req.CloseTime); err != nil {
-		return 0, echo.NewHTTPError(http.StatusBadRequest, "Неверный формат времени закрытия. Используйте ЧЧ:ММ")
-	}
-
-	if req.DayOfWeek < 0 || req.DayOfWeek > 6 {
-		return 0, echo.NewHTTPError(http.StatusBadRequest, "День недели должен быть от 0 (Пн) до 6 (Вс)")
-	}
-
-	isNextDay := req.IsNextDay != nil && *req.IsNextDay
-	isActive := req.IsActive == nil || *req.IsActive
-
-	slot := models.UnloadPlaceTimeSlot{
-		UnloadPlaceID: placeID,
-		DayOfWeek:     req.DayOfWeek,
-		OpenTime:      req.OpenTime,
-		CloseTime:     req.CloseTime,
-		IsNextDay:     isNextDay,
-		IsActive:      isActive,
-		UpdatedAt:     time.Now().UTC(),
-	}
-
-	if err := s.db.WithContext(ctx).Create(&slot).Error; err != nil {
-		slog.Error("не удалось добавить временной слот", "place_id", placeID, "error", err)
-		return 0, echo.NewHTTPError(http.StatusInternalServerError, "Error adding time slot")
-	}
-	slog.Info("временной слот добавлен", "id", slot.ID, "place_id", placeID)
-	return slot.ID, nil
+	return s.timeSlots().add(ctx, placeID, models.CreateTimeSlotRequest(req))
 }
 
 // UpdateTimeSlot обновляет временной слот места разгрузки.
 func (s *unloadPlaceService) UpdateTimeSlot(ctx context.Context, placeID, slotID int, req UpdateTimeSlotRequest) error {
-	var slot models.UnloadPlaceTimeSlot
-	if err := s.db.WithContext(ctx).
-		Where("id = ? AND unload_place_id = ?", slotID, placeID).
-		First(&slot).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
-			return echo.NewHTTPError(http.StatusNotFound, "Временной слот не найден")
-		}
-		return echo.NewHTTPError(http.StatusInternalServerError, "Error fetching time slot")
-	}
-
-	// Определяем новые значения с fallback на текущие
-	dayOfWeek := slot.DayOfWeek
-	if req.DayOfWeek != nil {
-		dayOfWeek = *req.DayOfWeek
-	}
-	if dayOfWeek < 0 || dayOfWeek > 6 {
-		return echo.NewHTTPError(http.StatusBadRequest, "День недели должен быть от 0 (Пн) до 6 (Вс)")
-	}
-
-	openTime := slot.OpenTime
-	if req.OpenTime != nil {
-		if _, err := time.Parse("15:04", *req.OpenTime); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Неверный формат времени открытия")
-		}
-		openTime = *req.OpenTime
-	}
-
-	closeTime := slot.CloseTime
-	if req.CloseTime != nil {
-		if _, err := time.Parse("15:04", *req.CloseTime); err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "Неверный формат времени закрытия")
-		}
-		closeTime = *req.CloseTime
-	}
-
-	isNextDay := slot.IsNextDay
-	if req.IsNextDay != nil {
-		isNextDay = *req.IsNextDay
-	}
-
-	isActive := slot.IsActive
-	if req.IsActive != nil {
-		isActive = *req.IsActive
-	}
-
-	result := s.db.WithContext(ctx).
-		Model(&models.UnloadPlaceTimeSlot{}).
-		Where("id = ? AND unload_place_id = ?", slotID, placeID).
-		Updates(map[string]interface{}{
-			"day_of_week": dayOfWeek,
-			"open_time":   openTime,
-			"close_time":  closeTime,
-			"is_next_day": isNextDay,
-			"is_active":   isActive,
-			"updated_at":  time.Now().UTC(),
-		})
-	if result.Error != nil {
-		slog.Error("не удалось обновить временной слот", "slot_id", slotID, "place_id", placeID, "error", result.Error)
-		return echo.NewHTTPError(http.StatusInternalServerError, "Error updating time slot")
-	}
-	if result.RowsAffected == 0 {
-		return echo.NewHTTPError(http.StatusNotFound, "Временной слот не найден")
-	}
-	slog.Info("временной слот обновлён", "slot_id", slotID, "place_id", placeID)
-	return nil
+	return s.timeSlots().update(ctx, placeID, slotID, models.UpdateTimeSlotRequest(req))
 }
 
 // DeleteTimeSlot удаляет временной слот места разгрузки.
 func (s *unloadPlaceService) DeleteTimeSlot(ctx context.Context, placeID, slotID int) error {
-	result := s.db.WithContext(ctx).
-		Where("id = ? AND unload_place_id = ?", slotID, placeID).
-		Delete(&models.UnloadPlaceTimeSlot{})
-	if result.Error != nil {
-		slog.Error("не удалось удалить временной слот", "slot_id", slotID, "place_id", placeID, "error", result.Error)
-		return echo.NewHTTPError(http.StatusInternalServerError, "Error deleting time slot")
-	}
-	if result.RowsAffected == 0 {
-		return echo.NewHTTPError(http.StatusNotFound, "Временной слот не найден")
-	}
-	slog.Info("временной слот удалён", "slot_id", slotID, "place_id", placeID)
-	return nil
+	return s.timeSlots().remove(ctx, placeID, slotID)
 }


### PR DESCRIPTION
## Что

Логика CRUD временных слотов была почти побайтово продублирована в `system_table_timeslot_service.go` и `unload_place_timeslot_service.go` (валидация времени/дня, GORM Find/Create/Updates/Delete, обработка 404). Свёл её в generic `timeSlotStore[T timeSlotModel]` (`internal/services/timeslot_store.go`).

Различия таблиц остались параметрами стора:
- `fkColumn` (`table_id` / `unload_place_id`),
- `checkParent` - проверка родителя (system-table требует `is_active=true`, место разгрузки - нет, чтобы расписание сохранялось у архивных мест),
- `newSlot` - конструктор типизированного слота.

Сервисы стали тонкими обёртками, `GetID()` добавлен на обе модели слотов (контракт `timeSlotModel`).

## Поведение

Не меняется. Сигнатуры публичных методов те же - хендлеры и роутер не тронуты. Тексты ошибок сохранены, hard-delete сохранён (у моделей нет `gorm.DeletedAt`). Партиал-апдейт-мапа эквивалентна прежнему чтению-слиянию по итоговому состоянию строки; `updated_at` всегда в наборе, поэтому `RowsAffected` остаётся надёжным индикатором наличия строки. Порядок 404-перед-400 сохранён.

Побочно: логирование мутаций слотов унифицировано на оба раздела (раньше slog был только у мест разгрузки).

## Не входит в скоуп

Дубль типов `services.*TimeSlotRequest` vs `models.*TimeSlotRequest` оставлен: унификация затронула бы swagger-аннотацию unload-хендлера + регенерацию `docs/*`, а в рабочем дереве уже висит несвязанный крупный регенер docs. Конверсия делается на границе сервиса (`models.CreateTimeSlotRequest(req)`). Долг отмечен, отдельной задачей.

## Проверки

- `go build` / `go vet` / `gofmt` чисто.
- Полный `make test` зелёный; TimeSlots-тесты обоих разделов проходят.
- code-reviewer: GO.