### PR TITLE
fix(blacklist): шапка ЧС с табами-бейджами и плейсхолдером Поиск (#443)

### DIFF
--- a/frontend/src/components/admin/blacklist/BlacklistTabBase.vue
+++ b/frontend/src/components/admin/blacklist/BlacklistTabBase.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="bl-tab">
     <div class="bl-header">
+      <div class="bl-header-left">
+        <slot name="header-left" />
+      </div>
       <div class="bl-header-controls">
         <BaseDropdown
           class="bl-archive-dropdown"
@@ -219,7 +222,7 @@ export default {
 
 .bl-header {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   align-items: center;
   padding: 0 20px;
   height: 50px;
@@ -227,10 +230,18 @@ export default {
   gap: 12px;
 }
 
+.bl-header-left {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  min-width: 0;
+}
+
 .bl-header-controls {
   display: flex;
   gap: 10px;
   align-items: center;
+  flex-shrink: 0;
 }
 
 .bl-content {

--- a/frontend/src/components/admin/blacklist/PersonBlacklistTab.vue
+++ b/frontend/src/components/admin/blacklist/PersonBlacklistTab.vue
@@ -2,7 +2,6 @@
   <div>
     <BlacklistTabBase
       ref="base"
-      search-placeholder="Поиск по ФИО..."
       empty-noun="людей"
       :api-list="listPersonBlacklist"
       :get-primary-text="primaryText"
@@ -12,7 +11,11 @@
       @archive="askArchive"
       @restore="doRestore"
       @history="historyItem = $event"
-    />
+    >
+      <template #header-left>
+        <slot name="header-left" />
+      </template>
+    </BlacklistTabBase>
     <BlacklistCreateModal
       :show="showCreate"
       type="person"

--- a/frontend/src/components/admin/blacklist/VehicleBlacklistTab.vue
+++ b/frontend/src/components/admin/blacklist/VehicleBlacklistTab.vue
@@ -2,7 +2,6 @@
   <div>
     <BlacklistTabBase
       ref="base"
-      search-placeholder="Поиск по номеру или марке..."
       empty-noun="машины"
       :api-list="listVehicleBlacklist"
       :get-primary-text="primaryText"
@@ -12,7 +11,11 @@
       @archive="askArchive"
       @restore="doRestore"
       @history="historyItem = $event"
-    />
+    >
+      <template #header-left>
+        <slot name="header-left" />
+      </template>
+    </BlacklistTabBase>
     <BlacklistCreateModal
       :show="showCreate"
       type="vehicle"

--- a/frontend/src/components/ui/FilterTabs.vue
+++ b/frontend/src/components/ui/FilterTabs.vue
@@ -8,14 +8,23 @@
       :data-testid="`filter-tab-${tab.key}`"
       @click="$emit('update:modelValue', tab.key)"
     >
-      {{ tab.label }}
+      <span class="filter-tab__label">{{ tab.label }}</span>
+      <Badge
+        v-if="tab.count != null"
+        :label="String(tab.count)"
+        size="sm"
+        variant="neutral"
+      />
     </button>
   </div>
 </template>
 
 <script>
+import Badge from '@/components/ui/Badge.vue';
+
 export default {
   name: 'FilterTabs',
+  components: { Badge },
   props: {
     tabs: {
       type: Array,
@@ -43,7 +52,10 @@ export default {
 }
 
 .filter-tab {
-  padding: 0 16px;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 0 14px;
   height: 30px;
   border: 1px solid #e6e6e6;
   background: white;

--- a/frontend/src/generated/permission-keys.json
+++ b/frontend/src/generated/permission-keys.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-05-06T16:57:42.792Z",
+  "generated": "2026-06-08T07:50:17.300Z",
   "keys": [
     "action.delete.employee",
     "permission.audit.manage"

--- a/frontend/src/views/admin/BlacklistView.vue
+++ b/frontend/src/views/admin/BlacklistView.vue
@@ -1,27 +1,40 @@
 <template>
   <section class="blacklist-page">
-    <header class="page-header">
-      <h2 class="page-title">
-        Чёрный список
-      </h2>
-    </header>
-
-    <FilterTabs
-      v-model="activeTab"
-      :tabs="tabs"
-    />
-
     <div class="blacklist-card">
       <VehicleBlacklistTab
         v-show="activeTab === 'vehicles'"
         :current-user-name="currentUserName"
         @count="vehicleCount = $event"
-      />
+      >
+        <template #header-left>
+          <div class="bl-head-left">
+            <h2 class="bl-page-title">
+              Чёрный список
+            </h2>
+            <FilterTabs
+              v-model="activeTab"
+              :tabs="tabs"
+            />
+          </div>
+        </template>
+      </VehicleBlacklistTab>
       <PersonBlacklistTab
         v-show="activeTab === 'persons'"
         :current-user-name="currentUserName"
         @count="personCount = $event"
-      />
+      >
+        <template #header-left>
+          <div class="bl-head-left">
+            <h2 class="bl-page-title">
+              Чёрный список
+            </h2>
+            <FilterTabs
+              v-model="activeTab"
+              :tabs="tabs"
+            />
+          </div>
+        </template>
+      </PersonBlacklistTab>
     </div>
   </section>
 </template>
@@ -52,8 +65,8 @@ export default {
   computed: {
     tabs() {
       return [
-        { key: 'vehicles', label: `Машины (${this.vehicleCount})` },
-        { key: 'persons', label: `Люди (${this.personCount})` },
+        { key: 'vehicles', label: 'Машины', count: this.vehicleCount },
+        { key: 'persons', label: 'Люди', count: this.personCount },
       ];
     },
   },
@@ -78,21 +91,20 @@ export default {
 <style scoped>
 .blacklist-page {
   padding: 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
 }
 
-.page-header {
+.bl-head-left {
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  gap: 16px;
+  min-width: 0;
 }
 
-.page-title {
+.bl-page-title {
   margin: 0;
-  font-size: 18px;
+  font-size: 16px;
   font-weight: 600;
+  white-space: nowrap;
 }
 
 .blacklist-card {

--- a/frontend/src/views/admin/__tests__/BlacklistView.spec.js
+++ b/frontend/src/views/admin/__tests__/BlacklistView.spec.js
@@ -2,36 +2,40 @@ import { describe, it, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
 import BlacklistView from '../BlacklistView.vue';
 
+// Вкладки теперь рендерят заголовок + FilterTabs через слот #header-left, поэтому
+// стабы пробрасывают слот. Обе вкладки смонтированы (v-show) - слот рендерится дважды.
 const stubs = {
-  VehicleBlacklistTab: { name: 'VehicleBlacklistTab', template: '<div class="veh-tab" />' },
-  PersonBlacklistTab: { name: 'PersonBlacklistTab', template: '<div class="per-tab" />' },
+  VehicleBlacklistTab: { name: 'VehicleBlacklistTab', template: '<div class="veh-tab"><slot name="header-left" /></div>' },
+  PersonBlacklistTab: { name: 'PersonBlacklistTab', template: '<div class="per-tab"><slot name="header-left" /></div>' },
   FilterTabs: {
     name: 'FilterTabs',
     props: ['tabs', 'modelValue'],
-    template: '<div class="tabs">{{ tabs.map(t => t.label).join("|") }}</div>',
+    template: '<div class="tabs">{{ tabs.map(t => `${t.label}=${t.count}`).join("|") }}</div>',
   },
 };
 
 describe('BlacklistView', () => {
-  it('строит ярлыки вкладок со счётчиками', () => {
+  it('строит ярлыки вкладок с отдельными счётчиками', () => {
     const wrapper = mount(BlacklistView, { global: { stubs } });
-    expect(wrapper.find('.tabs').text()).toContain('Машины (0)');
-    expect(wrapper.find('.tabs').text()).toContain('Люди (0)');
+    const tabsText = wrapper.findAll('.tabs')[0].text();
+    expect(tabsText).toContain('Машины=0');
+    expect(tabsText).toContain('Люди=0');
   });
 
-  it('рендерит обе вкладки (v-show) и заголовок страницы', () => {
+  it('рендерит обе вкладки (v-show) и заголовок в шапке', () => {
     const wrapper = mount(BlacklistView, { global: { stubs } });
-    expect(wrapper.find('.page-title').text()).toBe('Чёрный список');
+    expect(wrapper.findAll('.bl-page-title')[0].text()).toBe('Чёрный список');
     expect(wrapper.find('.veh-tab').exists()).toBe(true);
     expect(wrapper.find('.per-tab').exists()).toBe(true);
   });
 
-  it('ярлык реактивно обновляется при изменении счётчика', async () => {
+  it('счётчик реактивно обновляется', async () => {
     const wrapper = mount(BlacklistView, { global: { stubs } });
     wrapper.vm.vehicleCount = 5;
     wrapper.vm.personCount = 3;
     await wrapper.vm.$nextTick();
-    expect(wrapper.find('.tabs').text()).toContain('Машины (5)');
-    expect(wrapper.find('.tabs').text()).toContain('Люди (3)');
+    const tabsText = wrapper.findAll('.tabs')[0].text();
+    expect(tabsText).toContain('Машины=5');
+    expect(tabsText).toContain('Люди=3');
   });
 });


### PR DESCRIPTION
## Что

Полировка UI чёрного списка (срез P2 из 6) по итогам ручного теста.

- **Шапка унифицирована.** Заголовок «Чёрный список» и переключатель Машины/Люди переехали в шапку таблицы (`#header-left` слот в `BlacklistTabBase`), вместо отдельной полосы над карточкой.
- **Счётчики табов** — компонент `Badge` (variant neutral, size sm) вместо текстовых `(0)`. Читается и на белом неактивном, и на синем активном табе.
- **Плейсхолдер поиска** сокращён до «Поиск…» в обеих вкладках — длинный «Поиск по номеру или марке…» обрезался.

## Заметки

- `FilterTabs` шарится с `ApplicationsCenter` — Badge рендерится только при `tab.count != null`, для вызовов без `count` поведение прежнее (проверено).
- Известный tradeoff: слот `#header-left` рендерится дважды (обе вкладки смонтированы через v-show) — функционально корректно, видна одна; чистка вне scope этого среза.

## Проверка

- eslint чист по затронутым файлам.
- vitest: 335 passed (`BlacklistView.spec.js` обновлён под новую структуру).
- build ок.
- Локально через Playwright сняты обе вкладки: шапка с бейджами, плейсхолдер «Поиск…», master-detail и футер не тронуты.