### PR TITLE
feat(number-format): архив форматов номеров - soft-delete + restore (#414)

### DIFF
--- a/internal/handlers/license_formats.go
+++ b/internal/handlers/license_formats.go
@@ -20,17 +20,19 @@ func NewLicensePlateFormatHandler(service services.LicensePlateFormatService) *L
 
 // GetAll godoc
 // @Summary      Получить все форматы номерных знаков
-// @Description  Возвращает список всех форматов номерных знаков с их ячейками
+// @Description  Возвращает список форматов номерных знаков с их ячейками. По умолчанию только активные; include_archived=true добавляет архивные.
 // @Tags         license-formats
 // @Accept       json
 // @Produce      json
 // @Security     BearerAuth
+// @Param        include_archived query bool false "Включить архивные форматы"
 // @Success      200 {array} models.LicensePlateFormatWithCells
 // @Failure      401 {object} models.HTTPError
 // @Failure      500 {object} models.HTTPError
 // @Router       /license-plate-formats [get]
 func (h *LicensePlateFormatHandler) GetAll(c echo.Context) error {
-	formats, err := h.service.GetAll(c.Request().Context())
+	includeArchived := c.QueryParam("include_archived") == "true"
+	formats, err := h.service.GetAll(c.Request().Context(), includeArchived)
 	if err != nil {
 		return err
 	}
@@ -98,16 +100,18 @@ func (h *LicensePlateFormatHandler) Update(c echo.Context) error {
 }
 
 // Delete godoc
-// @Summary      Удалить формат номерного знака
-// @Description  Удаляет формат номерного знака по указанному ID
+// @Summary      Архивировать формат номерного знака
+// @Description  Архивирует формат (soft-delete, is_active=false). Формат по умолчанию архивировать нельзя.
 // @Tags         license-formats
 // @Accept       json
 // @Produce      json
 // @Security     BearerAuth
 // @Param        id path int true "ID формата"
-// @Success      200 {string} string "Формат номеров успешно удален"
+// @Success      200 {string} string "Формат номеров архивирован"
 // @Failure      400 {object} models.HTTPError
 // @Failure      401 {object} models.HTTPError
+// @Failure      404 {object} models.HTTPError
+// @Failure      409 {object} models.HTTPError
 // @Router       /license-plate-formats/{id} [delete]
 func (h *LicensePlateFormatHandler) Delete(c echo.Context) error {
 	id, err := strconv.Atoi(c.Param("id"))
@@ -119,5 +123,32 @@ func (h *LicensePlateFormatHandler) Delete(c echo.Context) error {
 		return err
 	}
 
-	return RespondMessage(c, "Формат номеров успешно удален")
+	return RespondMessage(c, "Формат номеров архивирован")
+}
+
+// Restore godoc
+// @Summary      Восстановить формат номерного знака из архива
+// @Description  Возвращает формат из архива (is_active=true)
+// @Tags         license-formats
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID формата"
+// @Success      200 {string} string "Формат номеров восстановлен из архива"
+// @Failure      400 {object} models.HTTPError
+// @Failure      401 {object} models.HTTPError
+// @Failure      404 {object} models.HTTPError
+// @Failure      500 {object} models.HTTPError
+// @Router       /license-plate-formats/{id}/restore [post]
+func (h *LicensePlateFormatHandler) Restore(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+
+	if err := h.service.Restore(c.Request().Context(), id); err != nil {
+		return err
+	}
+
+	return RespondMessage(c, "Формат номеров восстановлен из архива")
 }

--- a/internal/handlers/license_formats_test.go
+++ b/internal/handlers/license_formats_test.go
@@ -139,14 +139,14 @@ func TestLicenseFormats_CRUD_Cycle(t *testing.T) {
 	assert.Equal(t, false, format["is_default"])
 	assert.Len(t, cells, 1, "update should replace cells")
 
-	// --- Delete ---
+	// --- Delete (архив) ---
 	rec = testutil.DELETE(t, e, fmt.Sprintf("/license-plate-formats/%d", formatID), h)
 	require.Equal(t, http.StatusOK, rec.Code)
 
 	deleteMsg := testutil.ParseMessage(t, rec)
-	assert.Equal(t, "Формат номеров успешно удален", deleteMsg)
+	assert.Equal(t, "Формат номеров архивирован", deleteMsg)
 
-	// --- Read (verify gone) ---
+	// --- Read (архивный формат скрыт из активного списка) ---
 	rec = testutil.GET(t, e, "/license-plate-formats", h)
 	require.Equal(t, http.StatusOK, rec.Code)
 	list = testutil.ParseSlice(t, rec)
@@ -249,4 +249,92 @@ func TestLicenseFormats_Create_WithCellDefaults(t *testing.T) {
 	cell := cells[0].(map[string]interface{})
 	assert.Equal(t, "0", cell["padding_char"])
 	assert.Equal(t, "left", cell["padding_side"])
+}
+
+// Архивировать формат по умолчанию нельзя - сначала нужно назначить другой дефолтный.
+func TestLicenseFormats_Archive_BlocksDefault(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	body := `{"name":"Дефолтный","country_code":"RU","is_default":true,"cells":[]}`
+	rec := testutil.POST(t, e, "/license-plate-formats", body, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	formatID := int(testutil.ParseMap(t, rec)["id"].(float64))
+
+	rec = testutil.DELETE(t, e, fmt.Sprintf("/license-plate-formats/%d", formatID), h)
+	assert.Equal(t, http.StatusConflict, rec.Code, "архив дефолтного формата должен вернуть 409")
+
+	// Формат остался активным.
+	rec = testutil.GET(t, e, "/license-plate-formats", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	list := testutil.ParseSlice(t, rec)
+	require.Len(t, list, 1)
+}
+
+// Архив скрывает формат из активного списка, но возвращается с include_archived;
+// restore возвращает его в активные.
+func TestLicenseFormats_Archive_And_Restore(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	body := `{"name":"Архивируемый","country_code":"KZ","is_default":false,"cells":[]}`
+	rec := testutil.POST(t, e, "/license-plate-formats", body, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	formatID := int(testutil.ParseMap(t, rec)["id"].(float64))
+
+	// Архивируем.
+	rec = testutil.DELETE(t, e, fmt.Sprintf("/license-plate-formats/%d", formatID), h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "Формат номеров архивирован", testutil.ParseMessage(t, rec))
+
+	// Повторный архив - идемпотентный no-op (200), а не ошибка.
+	rec = testutil.DELETE(t, e, fmt.Sprintf("/license-plate-formats/%d", formatID), h)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Активный список пуст.
+	rec = testutil.GET(t, e, "/license-plate-formats", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Empty(t, testutil.ParseSlice(t, rec))
+
+	// С include_archived формат виден и помечен is_active=false.
+	rec = testutil.GET(t, e, "/license-plate-formats?include_archived=true", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	list := testutil.ParseSlice(t, rec)
+	require.Len(t, list, 1)
+	assert.Equal(t, false, list[0]["format"].(map[string]interface{})["is_active"])
+
+	// Восстанавливаем.
+	rec = testutil.POST(t, e, fmt.Sprintf("/license-plate-formats/%d/restore", formatID), "", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "Формат номеров восстановлен из архива", testutil.ParseMessage(t, rec))
+
+	// Снова в активном списке.
+	rec = testutil.GET(t, e, "/license-plate-formats", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	list = testutil.ParseSlice(t, rec)
+	require.Len(t, list, 1)
+	assert.Equal(t, true, list[0]["format"].(map[string]interface{})["is_active"])
+}
+
+func TestLicenseFormats_Restore_NotFound(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	rec := testutil.POST(t, e, "/license-plate-formats/99999/restore", "", h)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -183,6 +183,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	lpfGroup.POST("", lpf.Create)
 	lpfGroup.PUT("/:id", lpf.Update)
 	lpfGroup.DELETE("/:id", lpf.Delete)
+	lpfGroup.POST("/:id/restore", lpf.Restore)
 
 	// Марки автомобилей (#185) - справочник с историчностью.
 	marksGroup := protected.Group("/marks")

--- a/internal/services/license_format_service.go
+++ b/internal/services/license_format_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 
@@ -13,10 +14,11 @@ import (
 
 // LicensePlateFormatService определяет интерфейс бизнес-логики форматов номерных знаков.
 type LicensePlateFormatService interface {
-	GetAll(ctx context.Context) ([]models.LicensePlateFormatWithCells, error)
+	GetAll(ctx context.Context, includeArchived bool) ([]models.LicensePlateFormatWithCells, error)
 	Create(ctx context.Context, req models.CreateLicensePlateFormatRequest) (int, error)
 	Update(ctx context.Context, id int, req models.UpdateLicensePlateFormatRequest) error
 	Delete(ctx context.Context, id int) error
+	Restore(ctx context.Context, id int) error
 }
 
 type licensePlateFormatService struct {
@@ -28,13 +30,15 @@ func NewLicensePlateFormatService(db *gorm.DB) LicensePlateFormatService {
 	return &licensePlateFormatService{db: db}
 }
 
-// GetAll возвращает все активные форматы номерных знаков с ячейками.
-func (s *licensePlateFormatService) GetAll(ctx context.Context) ([]models.LicensePlateFormatWithCells, error) {
+// GetAll возвращает форматы номерных знаков с ячейками.
+// По умолчанию только активные; includeArchived=true добавляет архивные.
+func (s *licensePlateFormatService) GetAll(ctx context.Context, includeArchived bool) ([]models.LicensePlateFormatWithCells, error) {
 	formats := make([]models.LicensePlateFormat, 0)
-	if err := s.db.WithContext(ctx).
-		Where("is_active = ?", true).
-		Order("name").
-		Find(&formats).Error; err != nil {
+	q := s.db.WithContext(ctx).Order("name")
+	if !includeArchived {
+		q = q.Where("is_active = ?", true)
+	}
+	if err := q.Find(&formats).Error; err != nil {
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching license plate formats")
 	}
 
@@ -167,17 +171,51 @@ func (s *licensePlateFormatService) Update(ctx context.Context, id int, req mode
 	})
 }
 
-// Delete удаляет формат номерного знака по ID.
+// Delete архивирует формат номерного знака (soft-delete через is_active=false).
+// Формат по умолчанию архивировать нельзя - сначала нужно назначить другой дефолтный.
+// Формат, используемый машинами (unique_cars.format_id), архивировать можно: машины уже
+// созданы и валидацию прошли, архивный формат лишь скрывается из выбора новых.
 func (s *licensePlateFormatService) Delete(ctx context.Context, id int) error {
-	result := s.db.WithContext(ctx).Delete(&models.LicensePlateFormat{}, id)
-	if result.Error != nil {
-		slog.Error("не удалось удалить формат номеров", "id", id, "error", result.Error)
-		return echo.NewHTTPError(http.StatusInternalServerError, "Error deleting license plate format")
+	var format models.LicensePlateFormat
+	if err := s.db.WithContext(ctx).First(&format, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "Формат номеров не найден")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения формата номеров")
 	}
-	if result.RowsAffected == 0 {
-		return echo.NewHTTPError(http.StatusNotFound, "Формат номеров не найден")
+	if !format.IsActive {
+		return nil // уже в архиве - идемпотентно; проверяем до is_default, иначе архивный дефолт залип бы на 409
 	}
-	slog.Info("формат номеров удалён", "id", id)
+	if format.IsDefault {
+		return echo.NewHTTPError(http.StatusConflict, "Нельзя архивировать формат по умолчанию. Сначала назначьте другой формат по умолчанию")
+	}
+	if err := s.db.WithContext(ctx).Model(&format).Update("is_active", false).Error; err != nil {
+		slog.Error("не удалось архивировать формат номеров", "id", id, "error", err)
+		return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка архивации формата номеров")
+	}
+	slog.Info("формат номеров архивирован", "id", id)
+	return nil
+}
+
+// Restore восстанавливает формат номерного знака из архива (is_active=true).
+func (s *licensePlateFormatService) Restore(ctx context.Context, id int) error {
+	var format models.LicensePlateFormat
+	if err := s.db.WithContext(ctx).First(&format, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "Формат номеров не найден")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения формата номеров")
+	}
+	if format.IsActive {
+		return nil // уже активен - идемпотентно
+	}
+	// У форматов нет уникального индекса по name (в отличие от marks/organizations),
+	// поэтому при восстановлении проверка конфликта имени не нужна.
+	if err := s.db.WithContext(ctx).Model(&format).Update("is_active", true).Error; err != nil {
+		slog.Error("не удалось восстановить формат номеров", "id", id, "error", err)
+		return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка восстановления формата номеров")
+	}
+	slog.Info("формат номеров восстановлен", "id", id)
 	return nil
 }
 


### PR DESCRIPTION
## Что и зачем
Срез 414-1 эпика etalon-refactor (#406, sub-issue #414 «Управление форматами номеров»). Backend форматов номерных знаков переведён на архив (soft-delete) по эталону `system_tables`/`marks`. Раньше `DELETE` физически удалял формат вместе с ячейками по каскаду — теперь архивирует через `is_active=false`.

## Изменения
- `GetAll(includeArchived)` + handler читает `?include_archived=true` (по умолчанию только активные).
- `Delete` -> soft (is_active=false). **Блок только is_default**: дефолтный формат архивировать нельзя (409), пока не назначен другой. Формат, используемый машинами (`unique_cars.format_id`), архивировать **можно** — машины уже созданы и валидацию прошли, архивный формат лишь скрывается из выбора новых (LEFT JOIN не фильтрует is_active — машины не сиротеют, ячейки не теряются).
- `POST /:id/restore` — возврат из архива, идемпотентно.
- Тесты: блок-is_default (409), archive+restore цикл, идемпотентный повторный archive, restore-not-found; обновлён CRUD-тест под новое сообщение.

## Решение владельца (08.06)
Архив с блоком **только is_default** (не «любой используемый формат») — иначе популярный формат стал бы неудаляемым навсегда. История форматов (`LicensePlateFormatHistory`) — отдельный срез 414-2.

## Что НЕ входит (следующие срезы)
- 414-2: backend история + AutoMigrate (OK владельца получен).
- 414-3/414-4: frontend `NumberFormat.vue` под эталон + история-модалка.
- Известный долг (вне скоупа, отмечен в ревью): N+1 в `GetAll` (cells по одному запросу на формат) — был до PR, закрыть отдельно.

## Проверка
- `go build -buildvcs=false ./...` чистый.
- `go test ./internal/handlers/` (весь пакет) зелёный; license-тесты зелёные.
- Миграция не нужна (поле IsActive уже было в модели). migrate.go не тронут.

Closes #414 частично (backend-архив). Эпик #406.