### PR TITLE
feat(blacklist): насыщенная панель деталей ЧС (#443)

### DIFF
--- a/frontend/src/components/admin/blacklist/BlacklistTabBase.vue
+++ b/frontend/src/components/admin/blacklist/BlacklistTabBase.vue
@@ -80,14 +80,18 @@
         class="bl-details"
       >
         <div class="bl-details-header">
-          <h3 class="bl-details-title">
-            {{ getPrimaryText(selected) }}
-          </h3>
+          <div class="bl-details-heading">
+            <img
+              v-if="entityIcon"
+              :src="entityIcon"
+              alt=""
+              class="bl-details-icon"
+            >
+            <h3 class="bl-details-title">
+              {{ getPrimaryText(selected) }}
+            </h3>
+          </div>
           <div class="bl-details-actions">
-            <span
-              v-if="!selected.is_active"
-              class="bl-archive-pill"
-            >В архиве</span>
             <button
               class="lk-button lk-button--ghost"
               @click="$emit('history', selected)"
@@ -112,13 +116,40 @@
         </div>
         <div class="bl-details-body">
           <div
-            v-for="(row, idx) in getDetailRows(selected)"
-            :key="idx"
-            class="bl-field"
+            class="bl-status-banner"
+            :class="selected.is_active ? 'is-active' : 'is-archived'"
           >
-            <span class="bl-field-label">{{ row.label }}</span>
-            <span class="bl-field-value">{{ row.value || '-' }}</span>
+            <span class="bl-status-dot" />
+            {{ selected.is_active ? 'В чёрном списке' : 'Снято с ЧС - в архиве' }}
           </div>
+
+          <div
+            v-if="reasonRow"
+            class="bl-reason"
+          >
+            <span class="bl-reason-label">{{ reasonRow.label }}</span>
+            <p class="bl-reason-text">
+              {{ reasonRow.value || '-' }}
+            </p>
+          </div>
+
+          <dl
+            v-if="metaRows.length"
+            class="bl-def-list"
+          >
+            <div
+              v-for="(row, idx) in metaRows"
+              :key="idx"
+              class="bl-def-row"
+            >
+              <dt class="bl-def-label">
+                {{ row.label }}
+              </dt>
+              <dd class="bl-def-value">
+                {{ row.value || '-' }}
+              </dd>
+            </div>
+          </dl>
         </div>
       </div>
       <div
@@ -151,6 +182,7 @@ export default {
   props: {
     searchPlaceholder: { type: String, default: 'Поиск...' },
     emptyNoun: { type: String, default: 'записей' },
+    entityIcon: { type: String, default: '' },
     apiList: { type: Function, required: true },
     getPrimaryText: { type: Function, required: true },
     getDetailRows: { type: Function, required: true },
@@ -182,6 +214,15 @@ export default {
     emptyText() {
       if (this.searchQuery.trim()) return 'Ничего не найдено по фильтру';
       return this.showArchive ? 'В архиве пусто' : `Записей нет`;
+    },
+    detailData() {
+      return this.selected ? this.getDetailRows(this.selected) : [];
+    },
+    reasonRow() {
+      return this.detailData.find((r) => r.kind === 'reason') || null;
+    },
+    metaRows() {
+      return this.detailData.filter((r) => r.kind !== 'reason');
     },
   },
   mounted() {
@@ -345,20 +386,30 @@ export default {
   border-bottom: 1px solid #e6e6e6;
 }
 
+.bl-details-heading {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.bl-details-icon {
+  width: 36px;
+  height: 36px;
+  flex-shrink: 0;
+  padding: 7px;
+  border-radius: 50%;
+  background: var(--color-bg);
+  object-fit: contain;
+}
+
 .bl-details-title {
   margin: 0;
   font-size: 16px;
   font-weight: 600;
   color: #000;
-}
-
-.bl-archive-pill {
-  background: #6b7280;
-  color: #fff;
-  padding: 4px 10px;
-  border-radius: 50px;
-  font-size: 0.75em;
-  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -372,23 +423,95 @@ export default {
   padding: 16px 20px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 16px;
 }
 
-.bl-field {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
+.bl-status-banner {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  align-self: flex-start;
+  padding: 6px 14px;
+  border-radius: var(--radius-pill);
+  font-size: 13px;
+  font-weight: 500;
 }
 
-.bl-field-label {
+.bl-status-banner.is-active {
+  background: #fdeaea;
+  color: #b91c1c;
+}
+
+.bl-status-banner.is-archived {
+  background: #f1f3f5;
+  color: #475569;
+}
+
+.bl-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.bl-status-banner.is-active .bl-status-dot {
+  background: var(--color-danger);
+}
+
+.bl-status-banner.is-archived .bl-status-dot {
+  background: #94a3b8;
+}
+
+.bl-reason {
+  padding: 12px 16px;
+  background: #fdf3f3;
+  border-radius: var(--radius-md);
+  border-left: 3px solid var(--color-danger);
+}
+
+.bl-reason-label {
+  display: block;
+  margin-bottom: 4px;
   font-size: 12px;
-  color: #a2a2a2;
+  font-weight: 600;
+  color: #b91c1c;
 }
 
-.bl-field-value {
+.bl-reason-text {
+  margin: 0;
   font-size: 14px;
-  color: #333;
+  line-height: 1.5;
+  color: var(--color-text);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.bl-def-list {
+  margin: 0;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.bl-def-row {
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  gap: 12px;
+  padding: 11px 16px;
+}
+
+.bl-def-row:not(:last-child) {
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.bl-def-label {
+  font-size: 13px;
+  color: var(--color-text-muted);
+}
+
+.bl-def-value {
+  margin: 0;
+  font-size: 14px;
+  color: var(--color-text);
   white-space: pre-wrap;
   word-break: break-word;
 }

--- a/frontend/src/components/admin/blacklist/PersonBlacklistTab.vue
+++ b/frontend/src/components/admin/blacklist/PersonBlacklistTab.vue
@@ -3,6 +3,7 @@
     <BlacklistTabBase
       ref="base"
       empty-noun="людей"
+      :entity-icon="userIcon"
       :api-list="listPersonBlacklist"
       :get-primary-text="primaryText"
       :get-detail-rows="detailRows"
@@ -55,6 +56,7 @@ import {
 } from '@/api/blacklist';
 import { formatDateTime } from '@/utils/datetime';
 import { useDeletionsStore } from '@/stores/deletions';
+import userIcon from '@/assets/icons/user.png';
 
 /**
  * Вкладка "Люди" чёрного списка (#443). Конфигурирует BlacklistTabBase под людей
@@ -68,7 +70,7 @@ export default {
   },
   emits: ['count'],
   data() {
-    return { showCreate: false, archiveItem: null, historyItem: null };
+    return { showCreate: false, archiveItem: null, historyItem: null, userIcon };
   },
   computed: {
     archiveMessage() {
@@ -88,7 +90,7 @@ export default {
         { label: 'Фамилия', value: item.last_name },
         { label: 'Имя', value: item.first_name },
         { label: 'Отчество', value: item.middle_name },
-        { label: 'Причина', value: item.reason },
+        { label: 'Причина', value: item.reason, kind: 'reason' },
         { label: 'Добавлен', value: formatDateTime(item.created_at) },
       ];
     },

--- a/frontend/src/components/admin/blacklist/VehicleBlacklistTab.vue
+++ b/frontend/src/components/admin/blacklist/VehicleBlacklistTab.vue
@@ -3,6 +3,7 @@
     <BlacklistTabBase
       ref="base"
       empty-noun="машины"
+      :entity-icon="carIcon"
       :api-list="listVehicleBlacklist"
       :get-primary-text="primaryText"
       :get-detail-rows="detailRows"
@@ -55,6 +56,7 @@ import {
 } from '@/api/blacklist';
 import { formatDateTime } from '@/utils/datetime';
 import { useDeletionsStore } from '@/stores/deletions';
+import carIcon from '@/assets/icons/car.png';
 
 /**
  * Вкладка "Машины" чёрного списка (#443). Конфигурирует BlacklistTabBase под машины
@@ -68,7 +70,7 @@ export default {
   },
   emits: ['count'],
   data() {
-    return { showCreate: false, archiveItem: null, historyItem: null };
+    return { showCreate: false, archiveItem: null, historyItem: null, carIcon };
   },
   computed: {
     archiveMessage() {
@@ -87,7 +89,7 @@ export default {
       return [
         { label: 'Номер', value: item.car_number },
         { label: 'Марка', value: item.mark_name },
-        { label: 'Причина', value: item.reason },
+        { label: 'Причина', value: item.reason, kind: 'reason' },
         { label: 'Добавлена', value: formatDateTime(item.created_at) },
       ];
     },

--- a/frontend/src/components/admin/blacklist/__tests__/BlacklistTabBase.spec.js
+++ b/frontend/src/components/admin/blacklist/__tests__/BlacklistTabBase.spec.js
@@ -68,6 +68,44 @@ describe('BlacklistTabBase', () => {
     expect(wrapper.find('.bl-details-title').text()).toBe('Запись 1');
   });
 
+  it('строка kind=reason рендерится отдельным callout, остальные - в def-list', async () => {
+    const wrapper = mountBase({
+      getDetailRows: (i) => [
+        { label: 'Номер', value: `N${i.id}` },
+        { label: 'Причина', value: i.reason, kind: 'reason' },
+      ],
+    });
+    await flushPromises();
+    await wrapper.findAll('.bl-row')[0].trigger('click');
+    expect(wrapper.find('.bl-reason').exists()).toBe(true);
+    expect(wrapper.find('.bl-reason-text').text()).toBe('причина1');
+    const defRows = wrapper.findAll('.bl-def-row');
+    expect(defRows).toHaveLength(1);
+    expect(defRows[0].text()).toContain('Номер');
+    expect(wrapper.find('.bl-def-list').text()).not.toContain('причина1');
+  });
+
+  it('статус-баннер: активная - is-active, архивная - is-archived', async () => {
+    const wrapper = mountBase();
+    await flushPromises();
+    await wrapper.findAll('.bl-row')[0].trigger('click');
+    expect(wrapper.find('.bl-status-banner.is-active').exists()).toBe(true);
+    expect(wrapper.find('.bl-status-banner').text()).toContain('В чёрном списке');
+
+    wrapper.vm.onArchiveModeChange('archive');
+    await flushPromises();
+    await wrapper.findAll('.bl-row')[0].trigger('click');
+    expect(wrapper.find('.bl-status-banner.is-archived').exists()).toBe(true);
+  });
+
+  it('иконка сущности рендерится при entity-icon', async () => {
+    const wrapper = mountBase({ entityIcon: '/icons/car.png' });
+    await flushPromises();
+    await wrapper.findAll('.bl-row')[0].trigger('click');
+    expect(wrapper.find('.bl-details-icon').exists()).toBe(true);
+    expect(wrapper.find('.bl-details-icon').attributes('src')).toBe('/icons/car.png');
+  });
+
   it('кнопка "Создать запись" эмитит create', async () => {
     const wrapper = mountBase();
     await flushPromises();


### PR DESCRIPTION
## Что

Полировка UI чёрного списка (срез P3 из 6). Панель деталей (правая часть master-detail) была плоским стеком `label/value` и выглядела пустой - переработал.

- **Иконка сущности** в шапке панели (авто/человек) — новый prop `entityIcon` на `BlacklistTabBase`, передаётся из вкладок.
- **Статус-баннер** в теле: красный «В чёрном списке» (активная) / серый «Снято с ЧС - в архиве» (архив). Раньше статус в теле не отображался.
- **Причина** вынесена в акцентный callout (красная полоса + лёгкая заливка) — ключевое для ЧС поле больше не теряется рядовой строкой. Реализовано через `kind: 'reason'` в `detailRows()`, `BlacklistTabBase` делит строки на `reasonRow` + `metaRows`.
- **Метаданные** — в `<dl>` definition-карточке с рамкой и разделителями вместо плоского стека.
- Убрал дублирующий header-пилл «В архиве» (статус теперь в баннере).

## Проверка

- eslint чист.
- vitest: 338 passed (4 новых теста: callout reason, status-banner active/archived, entity-icon).
- build ок.
- Локально через Playwright сняты три состояния: машина, человек, архивная запись.

## Заметки

- `#b91c1c` (тёмно-красный текст) — намеренно как тональный текст на светлом фоне (токена danger-text в проекте нет, паттерн в духе бейджей).
- `<dl>` под `v-if="metaRows.length"` — защита от пустой карточки, если все строки окажутся reason.