### PR TITLE
feat(number-format): backend история форматов номеров - аудит (#414)

### DIFF
--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -23,6 +23,7 @@ func AllModels() []interface{} {
 		&models.CompanyHistory{},
 		&models.Citizenship{},
 		&models.LicensePlateFormat{},
+		&models.LicensePlateFormatHistory{},
 		&models.Mark{},
 		&models.MarkHistory{},
 		&models.VehicleBlacklist{},

--- a/internal/handlers/license_formats.go
+++ b/internal/handlers/license_formats.go
@@ -57,7 +57,8 @@ func (h *LicensePlateFormatHandler) Create(c echo.Context) error {
 		return err
 	}
 
-	id, err := h.service.Create(c.Request().Context(), req)
+	userID, _ := c.Get("user_id").(int)
+	id, err := h.service.Create(c.Request().Context(), userID, req)
 	if err != nil {
 		return err
 	}
@@ -92,7 +93,8 @@ func (h *LicensePlateFormatHandler) Update(c echo.Context) error {
 		return err
 	}
 
-	if err := h.service.Update(c.Request().Context(), id, req); err != nil {
+	userID, _ := c.Get("user_id").(int)
+	if err := h.service.Update(c.Request().Context(), userID, id, req); err != nil {
 		return err
 	}
 
@@ -119,7 +121,8 @@ func (h *LicensePlateFormatHandler) Delete(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
 	}
 
-	if err := h.service.Delete(c.Request().Context(), id); err != nil {
+	userID, _ := c.Get("user_id").(int)
+	if err := h.service.Delete(c.Request().Context(), userID, id); err != nil {
 		return err
 	}
 
@@ -146,9 +149,36 @@ func (h *LicensePlateFormatHandler) Restore(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
 	}
 
-	if err := h.service.Restore(c.Request().Context(), id); err != nil {
+	userID, _ := c.Get("user_id").(int)
+	if err := h.service.Restore(c.Request().Context(), userID, id); err != nil {
 		return err
 	}
 
 	return RespondMessage(c, "Формат номеров восстановлен из архива")
+}
+
+// GetHistory godoc
+// @Summary      История изменений формата номерного знака
+// @Description  Возвращает аудит создания/изменения/архивации/восстановления формата (новые сверху)
+// @Tags         license-formats
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID формата"
+// @Success      200 {array} models.LicensePlateFormatHistoryItem
+// @Failure      400 {object} models.HTTPError
+// @Failure      401 {object} models.HTTPError
+// @Failure      500 {object} models.HTTPError
+// @Router       /license-plate-formats/{id}/history [get]
+func (h *LicensePlateFormatHandler) GetHistory(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+
+	items, err := h.service.GetHistory(c.Request().Context(), id)
+	if err != nil {
+		return err
+	}
+
+	return RespondSuccess(c, items)
 }

--- a/internal/handlers/license_formats_test.go
+++ b/internal/handlers/license_formats_test.go
@@ -338,3 +338,101 @@ func TestLicenseFormats_Restore_NotFound(t *testing.T) {
 	rec := testutil.POST(t, e, "/license-plate-formats/99999/restore", "", h)
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
+
+// Полный цикл аудита: create/update/archive/restore попадают в историю (новые сверху)
+// с именем актора; update пишет diff изменённых полей и ячеек.
+func TestLicenseFormats_History_FullCycle(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	createBody := `{"name":"История RU","country_code":"RU","is_default":false,"cells":[
+		{"cell_order":1,"cell_type":"letter","min_length":1,"max_length":1}
+	]}`
+	created := testutil.ParseMap(t, testutil.POST(t, e, "/license-plate-formats", createBody, h))
+	id := int(created["id"].(float64))
+
+	// Меняем имя, страну и ячейку - все три должны попасть в diff.
+	updateBody := `{"name":"История KZ","country_code":"KZ","is_default":false,"cells":[
+		{"cell_order":1,"cell_type":"digit","min_length":3,"max_length":3}
+	]}`
+	require.Equal(t, http.StatusOK, testutil.PUT(t, e, fmt.Sprintf("/license-plate-formats/%d", id), updateBody, h).Code)
+	require.Equal(t, http.StatusOK, testutil.DELETE(t, e, fmt.Sprintf("/license-plate-formats/%d", id), h).Code)
+	require.Equal(t, http.StatusOK, testutil.POST(t, e, fmt.Sprintf("/license-plate-formats/%d/restore", id), "", h).Code)
+
+	hist := testutil.ParseSlice(t, testutil.GET(t, e, fmt.Sprintf("/license-plate-formats/%d/history", id), h))
+	require.Len(t, hist, 4)
+	assert.Equal(t, "restored", hist[0]["action_type"])
+	assert.Equal(t, "archived", hist[1]["action_type"])
+	assert.Equal(t, "updated", hist[2]["action_type"])
+	assert.Equal(t, "created", hist[3]["action_type"])
+	assert.NotEmpty(t, hist[0]["actor_name"], "actor_name должен резолвиться в зарегистрированного админа")
+	assert.NotEmpty(t, hist[3]["actor_name"])
+
+	// created хранит имя формата.
+	assert.Equal(t, "История RU", hist[3]["details"].(map[string]interface{})["name"])
+
+	// updated: diff name + country_code + cells как {old,new}; is_default не менялся - его нет.
+	upd := hist[2]["details"].(map[string]interface{})
+	assert.Equal(t, "История RU", upd["name"].(map[string]interface{})["old"])
+	assert.Equal(t, "История KZ", upd["name"].(map[string]interface{})["new"])
+	assert.Equal(t, "RU", upd["country_code"].(map[string]interface{})["old"])
+	assert.Equal(t, "KZ", upd["country_code"].(map[string]interface{})["new"])
+	assert.Contains(t, upd, "cells", "изменение ячеек должно фиксироваться")
+	assert.NotContains(t, upd, "is_default", "неизменённое поле не должно попадать в diff")
+}
+
+// Update без реальных изменений не плодит запись "updated" в истории.
+func TestLicenseFormats_History_NoopUpdate_NotLogged(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	body := `{"name":"Без изменений","country_code":"RU","is_default":false,"cells":[
+		{"cell_order":1,"cell_type":"digit","min_length":3,"max_length":3}
+	]}`
+	id := int(testutil.ParseMap(t, testutil.POST(t, e, "/license-plate-formats", body, h))["id"].(float64))
+
+	// Тот же payload - diff пустой, "updated" логироваться не должен.
+	require.Equal(t, http.StatusOK, testutil.PUT(t, e, fmt.Sprintf("/license-plate-formats/%d", id), body, h).Code)
+
+	hist := testutil.ParseSlice(t, testutil.GET(t, e, fmt.Sprintf("/license-plate-formats/%d/history", id), h))
+	require.Len(t, hist, 1)
+	assert.Equal(t, "created", hist[0]["action_type"])
+}
+
+// Перестановка ячеек без изменения данных не должна давать ложный diff "cells".
+func TestLicenseFormats_History_CellReorder_NoFalseDiff(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	createBody := `{"name":"Порядок","country_code":"RU","is_default":false,"cells":[
+		{"cell_order":1,"cell_type":"letter","min_length":1,"max_length":1},
+		{"cell_order":2,"cell_type":"digit","min_length":3,"max_length":3}
+	]}`
+	id := int(testutil.ParseMap(t, testutil.POST(t, e, "/license-plate-formats", createBody, h))["id"].(float64))
+
+	// Те же ячейки, но в обратном порядке и без других изменений.
+	reorderBody := `{"name":"Порядок","country_code":"RU","is_default":false,"cells":[
+		{"cell_order":2,"cell_type":"digit","min_length":3,"max_length":3},
+		{"cell_order":1,"cell_type":"letter","min_length":1,"max_length":1}
+	]}`
+	require.Equal(t, http.StatusOK, testutil.PUT(t, e, fmt.Sprintf("/license-plate-formats/%d", id), reorderBody, h).Code)
+
+	hist := testutil.ParseSlice(t, testutil.GET(t, e, fmt.Sprintf("/license-plate-formats/%d/history", id), h))
+	require.Len(t, hist, 1, "перестановка ячеек без изменений не должна логировать updated")
+	assert.Equal(t, "created", hist[0]["action_type"])
+}

--- a/internal/models/license_plate_format_history.go
+++ b/internal/models/license_plate_format_history.go
@@ -1,0 +1,39 @@
+package models
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// LicensePlateFormatHistory логирует действия над форматом номеров: создание,
+// изменение, архивацию и восстановление. Нужна для аудита (#414): изменение
+// ячеек меняет правила валидации номеров, важно знать кто и когда.
+//
+// FormatID - над каким форматом действие, ActorUserID - кто его совершил.
+// FK намеренно без constraint: аудит должен пережить архивацию/удаление формата.
+type LicensePlateFormatHistory struct {
+	ID          int             `json:"id"`
+	FormatID    int             `gorm:"index;not null" json:"format_id"`
+	ActorUserID *int            `gorm:"index" json:"actor_user_id,omitempty"`
+	ActionType  string          `gorm:"size:32;index" json:"action_type"`
+	Details     json.RawMessage `gorm:"type:jsonb" json:"details,omitempty"`
+	CreatedAt   time.Time       `json:"created_at"`
+}
+
+// LicensePlateFormatActionType - константы для LicensePlateFormatHistory.ActionType.
+const (
+	LicensePlateFormatActionCreated  = "created"
+	LicensePlateFormatActionUpdated  = "updated"
+	LicensePlateFormatActionArchived = "archived"
+	LicensePlateFormatActionRestored = "restored"
+)
+
+// LicensePlateFormatHistoryItem - запись истории с именем актора для API (LEFT JOIN users).
+type LicensePlateFormatHistoryItem struct {
+	ID          int             `json:"id"`
+	ActionType  string          `json:"action_type"`
+	Details     json.RawMessage `json:"details,omitempty" swaggerignore:"true"`
+	ActorUserID *int            `json:"actor_user_id,omitempty"`
+	ActorName   string          `json:"actor_name"`
+	CreatedAt   time.Time       `json:"created_at"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -184,6 +184,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	lpfGroup.PUT("/:id", lpf.Update)
 	lpfGroup.DELETE("/:id", lpf.Delete)
 	lpfGroup.POST("/:id/restore", lpf.Restore)
+	lpfGroup.GET("/:id/history", lpf.GetHistory)
 
 	// Марки автомобилей (#185) - справочник с историчностью.
 	marksGroup := protected.Group("/marks")

--- a/internal/services/license_format_history_service.go
+++ b/internal/services/license_format_history_service.go
@@ -1,0 +1,88 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"systemburo/internal/models"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+// LicensePlateFormatHistoryService - аудит действий над форматами номеров (#414).
+type LicensePlateFormatHistoryService interface {
+	// Log пишет запись аудита. Ошибка не возвращается: аудит не ломает основное действие.
+	Log(ctx context.Context, formatID int, actorUserID *int, actionType string, details interface{})
+	// GetHistory возвращает историю по формату номеров (новые сверху).
+	GetHistory(ctx context.Context, formatID int) ([]models.LicensePlateFormatHistoryItem, error)
+}
+
+type licensePlateFormatHistoryService struct {
+	db *gorm.DB
+}
+
+// NewLicensePlateFormatHistoryService создаёт реализацию LicensePlateFormatHistoryService.
+func NewLicensePlateFormatHistoryService(db *gorm.DB) LicensePlateFormatHistoryService {
+	return &licensePlateFormatHistoryService{db: db}
+}
+
+func (s *licensePlateFormatHistoryService) Log(ctx context.Context, formatID int, actorUserID *int, actionType string, details interface{}) {
+	var raw json.RawMessage
+	if details != nil {
+		b, err := json.Marshal(details)
+		if err != nil {
+			slog.Error("license_format_history: marshal details", "format", formatID, "error", err)
+		} else {
+			raw = b
+		}
+	}
+	entry := models.LicensePlateFormatHistory{
+		FormatID:    formatID,
+		ActorUserID: actorUserID,
+		ActionType:  actionType,
+		Details:     raw,
+	}
+	if err := s.db.WithContext(ctx).Create(&entry).Error; err != nil {
+		slog.Error("license_format_history: insert", "format", formatID, "action", actionType, "error", err)
+	}
+}
+
+func (s *licensePlateFormatHistoryService) GetHistory(ctx context.Context, formatID int) ([]models.LicensePlateFormatHistoryItem, error) {
+	type row struct {
+		ID          int             `gorm:"column:id"`
+		ActionType  string          `gorm:"column:action_type"`
+		Details     json.RawMessage `gorm:"column:details"`
+		ActorUserID *int            `gorm:"column:actor_user_id"`
+		ActorName   string          `gorm:"column:actor_name"`
+		CreatedAt   time.Time       `gorm:"column:created_at"`
+	}
+	var rows []row
+	if err := s.db.WithContext(ctx).
+		Table("license_plate_format_histories AS h").
+		Select(`h.id, h.action_type, h.details, h.actor_user_id,
+			COALESCE(NULLIF(TRIM(BOTH ' ' FROM CONCAT_WS(' ', u.last_name, u.first_name)), ''), u.username, '') AS actor_name,
+			h.created_at`).
+		Joins("LEFT JOIN users u ON u.id = h.actor_user_id").
+		Where("h.format_id = ?", formatID).
+		Order("h.created_at DESC").
+		Scan(&rows).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching license plate format history")
+	}
+
+	items := make([]models.LicensePlateFormatHistoryItem, 0, len(rows))
+	for _, r := range rows {
+		items = append(items, models.LicensePlateFormatHistoryItem{
+			ID:          r.ID,
+			ActionType:  r.ActionType,
+			Details:     r.Details,
+			ActorUserID: r.ActorUserID,
+			ActorName:   r.ActorName,
+			CreatedAt:   r.CreatedAt,
+		})
+	}
+	return items, nil
+}

--- a/internal/services/license_format_service.go
+++ b/internal/services/license_format_service.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"reflect"
+	"sort"
 
 	"systemburo/internal/models"
 
@@ -15,19 +17,21 @@ import (
 // LicensePlateFormatService определяет интерфейс бизнес-логики форматов номерных знаков.
 type LicensePlateFormatService interface {
 	GetAll(ctx context.Context, includeArchived bool) ([]models.LicensePlateFormatWithCells, error)
-	Create(ctx context.Context, req models.CreateLicensePlateFormatRequest) (int, error)
-	Update(ctx context.Context, id int, req models.UpdateLicensePlateFormatRequest) error
-	Delete(ctx context.Context, id int) error
-	Restore(ctx context.Context, id int) error
+	Create(ctx context.Context, callerUserID int, req models.CreateLicensePlateFormatRequest) (int, error)
+	Update(ctx context.Context, callerUserID, id int, req models.UpdateLicensePlateFormatRequest) error
+	Delete(ctx context.Context, callerUserID, id int) error
+	Restore(ctx context.Context, callerUserID, id int) error
+	GetHistory(ctx context.Context, id int) ([]models.LicensePlateFormatHistoryItem, error)
 }
 
 type licensePlateFormatService struct {
-	db *gorm.DB
+	db      *gorm.DB
+	history LicensePlateFormatHistoryService
 }
 
 // NewLicensePlateFormatService создаёт сервис для управления форматами номерных знаков.
 func NewLicensePlateFormatService(db *gorm.DB) LicensePlateFormatService {
-	return &licensePlateFormatService{db: db}
+	return &licensePlateFormatService{db: db, history: NewLicensePlateFormatHistoryService(db)}
 }
 
 // GetAll возвращает форматы номерных знаков с ячейками.
@@ -61,7 +65,7 @@ func (s *licensePlateFormatService) GetAll(ctx context.Context, includeArchived 
 }
 
 // Create создаёт формат номерного знака с ячейками в транзакции.
-func (s *licensePlateFormatService) Create(ctx context.Context, req models.CreateLicensePlateFormatRequest) (int, error) {
+func (s *licensePlateFormatService) Create(ctx context.Context, callerUserID int, req models.CreateLicensePlateFormatRequest) (int, error) {
 	var formatID int
 
 	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
@@ -112,12 +116,29 @@ func (s *licensePlateFormatService) Create(ctx context.Context, req models.Creat
 		return 0, err
 	}
 	slog.Info("формат номеров создан", "id", formatID)
+	s.history.Log(ctx, formatID, &callerUserID, models.LicensePlateFormatActionCreated, map[string]any{"name": req.Name})
 	return formatID, nil
 }
 
 // Update обновляет формат номерного знака и пересоздаёт ячейки.
-func (s *licensePlateFormatService) Update(ctx context.Context, id int, req models.UpdateLicensePlateFormatRequest) error {
-	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+func (s *licensePlateFormatService) Update(ctx context.Context, callerUserID, id int, req models.UpdateLicensePlateFormatRequest) error {
+	var details map[string]any
+
+	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// Снимок до изменений - для diff в истории. First даёт чистый 404,
+		// если формата нет (вместо проверки RowsAffected ниже).
+		var prev models.LicensePlateFormat
+		if err := tx.First(&prev, id).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return echo.NewHTTPError(http.StatusNotFound, "Формат номеров не найден")
+			}
+			return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения формата номеров")
+		}
+		var prevCells []models.LicensePlateFormatCell
+		if err := tx.Where("format_id = ?", id).Order("cell_order").Find(&prevCells).Error; err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "Error fetching format cells")
+		}
+
 		if req.IsDefault != nil && *req.IsDefault {
 			if err := tx.Model(&models.LicensePlateFormat{}).
 				Where("is_default = ? AND id != ?", true, id).
@@ -127,20 +148,16 @@ func (s *licensePlateFormatService) Update(ctx context.Context, id int, req mode
 		}
 
 		isDefault := req.IsDefault != nil && *req.IsDefault
-		result := tx.Model(&models.LicensePlateFormat{}).
+		if err := tx.Model(&models.LicensePlateFormat{}).
 			Where("id = ?", id).
 			Updates(map[string]interface{}{
 				"name":         req.Name,
 				"country_code": req.CountryCode,
 				"icon":         req.Icon,
 				"is_default":   isDefault,
-			})
-		if result.Error != nil {
-			slog.Error("не удалось обновить формат номеров", "id", id, "error", result.Error)
+			}).Error; err != nil {
+			slog.Error("не удалось обновить формат номеров", "id", id, "error", err)
 			return echo.NewHTTPError(http.StatusInternalServerError, "Error updating license plate format")
-		}
-		if result.RowsAffected == 0 {
-			return echo.NewHTTPError(http.StatusNotFound, "Формат номеров не найден")
 		}
 		slog.Info("формат номеров обновлён", "id", id)
 
@@ -167,15 +184,25 @@ func (s *licensePlateFormatService) Update(ctx context.Context, id int, req mode
 			}
 		}
 
+		details = buildFormatUpdateDetails(prev, prevCells, req)
 		return nil
 	})
+	if err != nil {
+		return err
+	}
+
+	// Логируем только если что-то реально изменилось - иначе спам "Изменены данные" без диффа.
+	if len(details) > 0 {
+		s.history.Log(ctx, id, &callerUserID, models.LicensePlateFormatActionUpdated, details)
+	}
+	return nil
 }
 
 // Delete архивирует формат номерного знака (soft-delete через is_active=false).
 // Формат по умолчанию архивировать нельзя - сначала нужно назначить другой дефолтный.
 // Формат, используемый машинами (unique_cars.format_id), архивировать можно: машины уже
 // созданы и валидацию прошли, архивный формат лишь скрывается из выбора новых.
-func (s *licensePlateFormatService) Delete(ctx context.Context, id int) error {
+func (s *licensePlateFormatService) Delete(ctx context.Context, callerUserID, id int) error {
 	var format models.LicensePlateFormat
 	if err := s.db.WithContext(ctx).First(&format, id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -194,11 +221,12 @@ func (s *licensePlateFormatService) Delete(ctx context.Context, id int) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка архивации формата номеров")
 	}
 	slog.Info("формат номеров архивирован", "id", id)
+	s.history.Log(ctx, id, &callerUserID, models.LicensePlateFormatActionArchived, nil)
 	return nil
 }
 
 // Restore восстанавливает формат номерного знака из архива (is_active=true).
-func (s *licensePlateFormatService) Restore(ctx context.Context, id int) error {
+func (s *licensePlateFormatService) Restore(ctx context.Context, callerUserID, id int) error {
 	var format models.LicensePlateFormat
 	if err := s.db.WithContext(ctx).First(&format, id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -216,7 +244,13 @@ func (s *licensePlateFormatService) Restore(ctx context.Context, id int) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка восстановления формата номеров")
 	}
 	slog.Info("формат номеров восстановлен", "id", id)
+	s.history.Log(ctx, id, &callerUserID, models.LicensePlateFormatActionRestored, nil)
 	return nil
+}
+
+// GetHistory возвращает историю изменений формата номеров (новые сверху).
+func (s *licensePlateFormatService) GetHistory(ctx context.Context, id int) ([]models.LicensePlateFormatHistoryItem, error) {
+	return s.history.GetHistory(ctx, id)
 }
 
 // ptrOrDefault возвращает указатель на значение или значение по умолчанию.
@@ -225,4 +259,90 @@ func ptrOrDefault(p *string, def string) *string {
 		return p
 	}
 	return &def
+}
+
+// formatCellSnapshot - компактный снимок ячейки для аудита: сравнение old/new
+// при Update, чтобы зафиксировать изменение правил валидации номера.
+type formatCellSnapshot struct {
+	CellOrder      int     `json:"cell_order"`
+	CellType       string  `json:"cell_type"`
+	MinLength      *int    `json:"min_length,omitempty"`
+	MaxLength      *int    `json:"max_length,omitempty"`
+	AllowedLetters *string `json:"allowed_letters,omitempty"`
+	AlphabetType   *string `json:"alphabet_type,omitempty"`
+	Language       *string `json:"language,omitempty"`
+	PaddingChar    *string `json:"padding_char,omitempty"`
+	PaddingSide    *string `json:"padding_side,omitempty"`
+}
+
+// buildFormatUpdateDetails собирает diff изменённых полей формата как {old, new}.
+// В результат попадают только реально изменившиеся поля - иначе история засоряется
+// "пустыми" записями (см. ui-history: фильтр nil/неизменённого обязателен).
+func buildFormatUpdateDetails(prev models.LicensePlateFormat, prevCells []models.LicensePlateFormatCell, req models.UpdateLicensePlateFormatRequest) map[string]any {
+	details := map[string]any{}
+
+	if req.Name != prev.Name {
+		details["name"] = map[string]any{"old": prev.Name, "new": req.Name}
+	}
+	if strPtrVal(prev.CountryCode) != strPtrVal(req.CountryCode) {
+		details["country_code"] = map[string]any{"old": strPtrVal(prev.CountryCode), "new": strPtrVal(req.CountryCode)}
+	}
+	if strPtrVal(prev.Icon) != strPtrVal(req.Icon) {
+		details["icon"] = map[string]any{"old": strPtrVal(prev.Icon), "new": strPtrVal(req.Icon)}
+	}
+	newDefault := req.IsDefault != nil && *req.IsDefault
+	if newDefault != prev.IsDefault {
+		details["is_default"] = map[string]any{"old": prev.IsDefault, "new": newDefault}
+	}
+
+	// Нормализуем порядок по cell_order перед сравнением: клиент может прислать
+	// ячейки не по порядку, а reflect.DeepEqual слайсов чувствителен к позиции -
+	// иначе простая перестановка без изменения данных дала бы ложный diff в истории.
+	oldCells := cellSnapshotsFromModel(prevCells)
+	newCells := cellSnapshotsFromRequest(req.Cells)
+	sort.Slice(oldCells, func(i, j int) bool { return oldCells[i].CellOrder < oldCells[j].CellOrder })
+	sort.Slice(newCells, func(i, j int) bool { return newCells[i].CellOrder < newCells[j].CellOrder })
+	if !reflect.DeepEqual(oldCells, newCells) {
+		details["cells"] = map[string]any{"old": oldCells, "new": newCells}
+	}
+
+	return details
+}
+
+func cellSnapshotsFromModel(cells []models.LicensePlateFormatCell) []formatCellSnapshot {
+	out := make([]formatCellSnapshot, 0, len(cells))
+	for _, c := range cells {
+		out = append(out, formatCellSnapshot{
+			CellOrder: c.CellOrder, CellType: c.CellType,
+			MinLength: c.MinLength, MaxLength: c.MaxLength,
+			AllowedLetters: c.AllowedLetters, AlphabetType: c.AlphabetType,
+			Language: c.Language, PaddingChar: c.PaddingChar, PaddingSide: c.PaddingSide,
+		})
+	}
+	return out
+}
+
+// cellSnapshotsFromRequest применяет те же дефолты padding, что и при записи в БД,
+// чтобы сравнение old (из БД) и new (из запроса) не давало ложных диффов.
+func cellSnapshotsFromRequest(cells []models.UpdateFormatCellRequest) []formatCellSnapshot {
+	out := make([]formatCellSnapshot, 0, len(cells))
+	for _, c := range cells {
+		out = append(out, formatCellSnapshot{
+			CellOrder: c.CellOrder, CellType: c.CellType,
+			MinLength: c.MinLength, MaxLength: c.MaxLength,
+			AllowedLetters: c.AllowedLetters, AlphabetType: c.AlphabetType,
+			Language:    c.Language,
+			PaddingChar: ptrOrDefault(c.PaddingChar, "0"), PaddingSide: ptrOrDefault(c.PaddingSide, "left"),
+		})
+	}
+	return out
+}
+
+// strPtrVal разыменовывает *string, трактуя nil как "" - чтобы nil и пустая строка
+// считались одним значением и не плодили ложные диффы в истории.
+func strPtrVal(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -59,7 +59,7 @@ var tables = []string{
 	"table_fields", "table_field_facts", "companies_tables", "organization_tables",
 	"system_table_trash_histories", "system_table_histories",
 	"system_table_time_slots", "system_table_photos", "system_tables",
-	"license_plate_format_cells", "license_plate_formats",
+	"license_plate_format_histories", "license_plate_format_cells", "license_plate_formats",
 	"citizenships",
 	"companies_users", "organization_users",
 	"user_histories", "user_type_histories", "organization_histories", "company_histories",


### PR DESCRIPTION
Срез 414-2 эпика #406 (приведение к эталону): backend-аудит форматов номеров. Продолжение 414-1 (архив, #469).

## Что сделано
- Модель `LicensePlateFormatHistory` (FK без constraint - аудит переживает архивацию формата) + регистрация в `migrate.go` AutoMigrate (OK владельца дан в decisions.md).
- Сервис `LicensePlateFormatHistoryService` (`Log`/`GetHistory`) по образцу `unload_place_history_service`: COALESCE actor_name через LEFT JOIN users, сортировка новые-сверху.
- Логирование в `license_format_service`: `created`/`updated`/`archived`/`restored` с актором (`c.Get("user_id")`). Update пишет diff `{old,new}` только по реально изменившимся полям (фильтр неизменённого, как требует ui-history) - имя, страна, иконка, is_default и ячейки.
- Endpoint `GET /license-plate-formats/{id}/history` + роут.
- Тесты: полный цикл аудита, no-op update без записи, перестановка ячеек без ложного diff.
- Фикс `testutil.CleanDB`: новая таблица `license_plate_format_histories` в список очистки (иначе течёт между тестами).

## Ревью
Прогнан адверсариальный multi-lens разбор (конвенции/корректность/целостность аудита) + верификация-опровержение каждой находки. Из 3 сырых находок подтверждены 2 (обе low):
1. **Позиционное сравнение ячеек** давало ложный `cells changed` при перестановке ячеек без изменения данных - **исправлено**: нормализация порядка по `cell_order` перед `reflect.DeepEqual` + тест.
2. **Демоция is_default у сиблингов не логируется в их историю** - осознанно НЕ реализовано в этом срезе: каскадного логирования побочных эффектов на другие сущности нет нигде в кодовой базе, decisions.md скоупил #414 на diff полей редактируемого формата, а событие восстановимо кросс-референсом историй. Если владелец захочет - отдельный polish-срез.

## Проверки
- `go test ./...` зелёный (worktree, Docker).
- `go vet ./...` (=`make lint`) чист, gofmt по изменённым файлам чист.

Pure-backend срез, фронт (master-detail + модалка истории) идёт в 414-3/414-4.