### PR TITLE
feat(blacklist): гард ЧС в выборе существующих машин/людей (#443)

### DIFF
--- a/frontend/src/components/CreateApplication/ExistingCarsModal.vue
+++ b/frontend/src/components/CreateApplication/ExistingCarsModal.vue
@@ -97,8 +97,10 @@
                 class="table-row"
                 :class="{
                   'table-row--disabled': isCarDisabled(car),
+                  'table-row--blacklisted': isCarBlacklisted(car),
                   'table-row--selected': isCarSelected(car)
                 }"
+                :title="carRowTitle(car)"
                 @click="handleRowClick(car)"
               >
                 <div
@@ -123,6 +125,14 @@
                 </div>
                 <div class="table-cell status-cell">
                   <span
+                    v-if="isCarBlacklisted(car)"
+                    class="status-badge status-blacklisted"
+                    title="В чёрном списке"
+                  >
+                    В ЧС
+                  </span>
+                  <span
+                    v-else
                     class="status-badge"
                     :class="{
                       'status-active': car.status,
@@ -176,6 +186,7 @@
 import { apiRequest } from '@/api/client'
 import SearchComponent from '@/components/SearchComponent.vue'
 import LoaderSpinner from '@/components/ui/LoaderSpinner.vue'
+import { listVehicleBlacklist } from '@/api/blacklist'
 
 export default {
     name: 'ExistingCarsModal',
@@ -213,15 +224,19 @@ export default {
             tempSelectedCars: [],
             currentFilter: 'all',
             loadingCars: false,
-            searchQuery: ''
+            searchQuery: '',
+            blacklistKeys: new Set()
         }
     },
     watch: {
-        visible(newVal) {
+        async visible(newVal) {
             if (newVal) {
                 this.tempSelectedCars = [...this.initialSelectedCars]
                 this.currentFilter = 'all'
                 this.searchQuery = ''
+                // Грузим ЧС до списка, чтобы строки сразу рисовались с бейджем "В ЧС"
+                // (иначе строка на миг отрисуется выбираемой, пока blacklistKeys пуст).
+                await this.loadBlacklist()
                 this.loadCarsByFilter('all')
             } else {
                 this.tempSelectedCars = []
@@ -337,7 +352,36 @@ export default {
             return this.tempSelectedCars.some(selectedCar => selectedCar.id === car.id)
         },
 
+        async loadBlacklist() {
+            try {
+                const items = await listVehicleBlacklist()
+                const list = Array.isArray(items) ? items : []
+                this.blacklistKeys = new Set(
+                    list.map(e => this.blacklistKey(e.car_number, e.mark_name))
+                )
+            } catch (error) {
+                // Не блокируем модалку при сбое ЧС - серверный гард всё равно отклонит подачу.
+                console.error('Не удалось загрузить чёрный список машин:', error)
+                this.blacklistKeys = new Set()
+            }
+        },
+
+        // Ключ совпадения зеркалит серверный CheckByName: LOWER(TRIM(номер)) + LOWER(TRIM(марка)).
+        blacklistKey(number, mark) {
+            return `${(number || '').trim().toLowerCase()}|${(mark || '').trim().toLowerCase()}`
+        },
+
+        isCarBlacklisted(car) {
+            return this.blacklistKeys.has(this.blacklistKey(car.number, car.mark))
+        },
+
+        carRowTitle(car) {
+            if (this.isCarBlacklisted(car)) return 'Машина в чёрном списке - выбрать нельзя'
+            return ''
+        },
+
         isCarDisabled(car) {
+            if (this.isCarBlacklisted(car)) return true
             return this.alreadyAddedVehicles.some(vehicle =>
                 (vehicle.isExisting && vehicle.existingCarId === car.id) ||
                 (!vehicle.isExisting && vehicle.plateNumber === car.number && vehicle.mark === car.mark)
@@ -633,6 +677,17 @@ export default {
     background-color: #fef2f2;
     color: #991b1b;
     border: 1px solid #fecaca;
+}
+
+.status-blacklisted {
+    background-color: #fee2e2;
+    color: #991b1b;
+    border: 1px solid #fecaca;
+    font-weight: 700;
+}
+
+.table-row--blacklisted .status-badge.status-blacklisted {
+    opacity: 1;
 }
 
 .table-row--disabled .status-badge {

--- a/frontend/src/components/CreateApplication/ExistingEmployeesModal.vue
+++ b/frontend/src/components/CreateApplication/ExistingEmployeesModal.vue
@@ -87,8 +87,10 @@
                 class="table-row"
                 :class="{
                   'table-row--disabled': isEmployeeDisabled(employee),
+                  'table-row--blacklisted': isEmployeeBlacklisted(employee),
                   'table-row--selected': isEmployeeSelected(employee)
                 }"
+                :title="employeeRowTitle(employee)"
                 @click="handleRowClick(employee)"
               >
                 <div
@@ -116,6 +118,14 @@
                 </div>
                 <div class="table-cell status-cell">
                   <span
+                    v-if="isEmployeeBlacklisted(employee)"
+                    class="status-badge status-blacklisted"
+                    title="В чёрном списке"
+                  >
+                    В ЧС
+                  </span>
+                  <span
+                    v-else
                     class="status-badge"
                     :class="{
                       'status-active': employee.status,
@@ -167,6 +177,7 @@
 import { apiRequest } from '@/api/client'
 import SearchComponent from '@/components/SearchComponent.vue'
 import LoaderSpinner from '@/components/ui/LoaderSpinner.vue'
+import { listPersonBlacklist } from '@/api/blacklist'
 
 export default {
     name: 'ExistingEmployeesModal',
@@ -200,15 +211,18 @@ export default {
             tempSelectedEmployees: [],
             currentFilter: 'all',
             loadingEmployees: false,
-            searchQuery: ''
+            searchQuery: '',
+            blacklistKeys: new Set()
         }
     },
     watch: {
-        visible(newVal) {
+        async visible(newVal) {
             if (newVal) {
                 this.tempSelectedEmployees = [...this.initialSelectedEmployees]
                 this.currentFilter = 'all'
                 this.searchQuery = ''
+                // Грузим ЧС до списка, чтобы строки сразу рисовались с бейджем "В ЧС".
+                await this.loadBlacklist()
                 this.loadEmployeesByFilter('all')
             } else {
                 this.tempSelectedEmployees = []
@@ -295,7 +309,39 @@ export default {
             return this.tempSelectedEmployees.some(sel => sel.id === employee.id)
         },
 
+        async loadBlacklist() {
+            try {
+                const items = await listPersonBlacklist()
+                const list = Array.isArray(items) ? items : []
+                this.blacklistKeys = new Set(
+                    list.map(e => this.blacklistKey(e.last_name, e.first_name, e.middle_name))
+                )
+            } catch (error) {
+                // Не блокируем модалку при сбое ЧС - серверный гард всё равно отклонит подачу.
+                console.error('Не удалось загрузить чёрный список людей:', error)
+                this.blacklistKeys = new Set()
+            }
+        },
+
+        // Ключ зеркалит серверный Check: LOWER(TRIM) по ФИО, пустое отчество матчит пустое.
+        blacklistKey(last, first, middle) {
+            const norm = (v) => (v || '').trim().toLowerCase()
+            return `${norm(last)}|${norm(first)}|${norm(middle)}`
+        },
+
+        isEmployeeBlacklisted(employee) {
+            return this.blacklistKeys.has(
+                this.blacklistKey(employee.last_name, employee.first_name, employee.middle_name)
+            )
+        },
+
+        employeeRowTitle(employee) {
+            if (this.isEmployeeBlacklisted(employee)) return 'Человек в чёрном списке - выбрать нельзя'
+            return ''
+        },
+
         isEmployeeDisabled(employee) {
+            if (this.isEmployeeBlacklisted(employee)) return true
             return this.alreadyAddedEmployees.some(emp =>
                 (emp.isExisting && emp.existingEmployeeId === employee.id) ||
                 (!emp.isExisting && emp.passportSeriesNumber === employee.passport_series_number)
@@ -596,6 +642,17 @@ export default {
     background-color: #fef2f2;
     color: #991b1b;
     border: 1px solid #fecaca;
+}
+
+.status-blacklisted {
+    background-color: #fee2e2;
+    color: #991b1b;
+    border: 1px solid #fecaca;
+    font-weight: 700;
+}
+
+.table-row--blacklisted .status-badge.status-blacklisted {
+    opacity: 1;
 }
 
 .table-row--disabled .status-badge {

--- a/frontend/src/components/CreateApplication/__tests__/ExistingModalsBlacklist.spec.js
+++ b/frontend/src/components/CreateApplication/__tests__/ExistingModalsBlacklist.spec.js
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import ExistingCarsModal from '../ExistingCarsModal.vue';
+import ExistingEmployeesModal from '../ExistingEmployeesModal.vue';
+
+// Модалки на visible=false не дёргают API (watcher не срабатывает) - тестируем чистую
+// логику матчинга ЧС, выставляя blacklistKeys напрямую. Зеркалирование серверной
+// нормализации (LOWER+TRIM) - ключевое, что проверяем.
+vi.mock('@/api/client', () => ({ apiRequest: vi.fn() }));
+vi.mock('@/api/blacklist', () => ({
+  listVehicleBlacklist: vi.fn().mockResolvedValue([]),
+  listPersonBlacklist: vi.fn().mockResolvedValue([]),
+}));
+
+const stubs = { SearchComponent: true, LoaderSpinner: true };
+
+describe('ExistingCarsModal - гард ЧС', () => {
+  it('blacklistKey нормализует номер и марку (LOWER+TRIM)', () => {
+    const wrapper = mount(ExistingCarsModal, { props: { visible: false }, global: { stubs } });
+    expect(wrapper.vm.blacklistKey('  A777AA  ', '  BMW ')).toBe('a777aa|bmw');
+  });
+
+  it('isCarBlacklisted матчит по номеру+марке без учёта регистра/пробелов по краям', () => {
+    const wrapper = mount(ExistingCarsModal, { props: { visible: false }, global: { stubs } });
+    wrapper.vm.blacklistKeys = new Set(['a777aa777|bmw']);
+    expect(wrapper.vm.isCarBlacklisted({ number: 'A777AA777', mark: 'BMW' })).toBe(true);
+    expect(wrapper.vm.isCarBlacklisted({ number: ' a777aa777 ', mark: ' bmw ' })).toBe(true);
+    expect(wrapper.vm.isCarBlacklisted({ number: 'A777AA777', mark: 'Toyota' })).toBe(false);
+    expect(wrapper.vm.isCarBlacklisted({ number: 'B111BB111', mark: 'BMW' })).toBe(false);
+  });
+
+  it('isCarDisabled = true для машины из ЧС даже без already-added', () => {
+    const wrapper = mount(ExistingCarsModal, { props: { visible: false }, global: { stubs } });
+    wrapper.vm.blacklistKeys = new Set(['a777aa777|bmw']);
+    expect(wrapper.vm.isCarDisabled({ id: 1, number: 'A777AA777', mark: 'BMW' })).toBe(true);
+    expect(wrapper.vm.isCarDisabled({ id: 2, number: 'C999CC999', mark: 'Toyota' })).toBe(false);
+  });
+});
+
+describe('ExistingEmployeesModal - гард ЧС', () => {
+  it('blacklistKey по ФИО, пустое отчество нормализуется', () => {
+    const wrapper = mount(ExistingEmployeesModal, { props: { visible: false }, global: { stubs } });
+    expect(wrapper.vm.blacklistKey(' Иванов ', 'Иван', '')).toBe('иванов|иван|');
+    expect(wrapper.vm.blacklistKey('Иванов', 'Иван', 'Иванович')).toBe('иванов|иван|иванович');
+  });
+
+  it('isEmployeeBlacklisted матчит по ФИО, пустое отчество матчит пустое', () => {
+    const wrapper = mount(ExistingEmployeesModal, { props: { visible: false }, global: { stubs } });
+    wrapper.vm.blacklistKeys = new Set(['иванов|иван|']);
+    expect(wrapper.vm.isEmployeeBlacklisted({ last_name: 'Иванов', first_name: 'Иван', middle_name: '' })).toBe(true);
+    expect(wrapper.vm.isEmployeeBlacklisted({ last_name: 'Иванов', first_name: 'Иван', middle_name: null })).toBe(true);
+    expect(wrapper.vm.isEmployeeBlacklisted({ last_name: 'Иванов', first_name: 'Иван', middle_name: 'Петрович' })).toBe(false);
+  });
+
+  it('isEmployeeDisabled = true для человека из ЧС', () => {
+    const wrapper = mount(ExistingEmployeesModal, { props: { visible: false }, global: { stubs } });
+    wrapper.vm.blacklistKeys = new Set(['иванов|иван|иванович']);
+    expect(wrapper.vm.isEmployeeDisabled({ id: 1, last_name: 'Иванов', first_name: 'Иван', middle_name: 'Иванович' })).toBe(true);
+    expect(wrapper.vm.isEmployeeDisabled({ id: 2, last_name: 'Сидоров', first_name: 'Сидр', middle_name: '' })).toBe(false);
+  });
+});

--- a/frontend/src/generated/permission-keys.json
+++ b/frontend/src/generated/permission-keys.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-06-08T07:50:17.300Z",
+  "generated": "2026-06-08T09:53:25.669Z",
   "keys": [
     "action.delete.employee",
     "permission.audit.manage"

--- a/internal/handlers/applications_blacklist_test.go
+++ b/internal/handlers/applications_blacklist_test.go
@@ -41,6 +41,32 @@ func submitCarApp(t *testing.T, e *echo.Echo, db *gorm.DB, token, orgName, tag, 
 	return testutil.POST(t, e, "/applications/submit-complete-application", body, testutil.AuthHeader(token))
 }
 
+// submitCarAppNoMark подаёт заявку с машиной БЕЗ mark_id (как при выборе из существующих
+// unique_cars) - только номер и car_brand. Проверяет name-fallback серверного гарда.
+func submitCarAppNoMark(t *testing.T, e *echo.Echo, db *gorm.DB, token, orgName, tag, carNumber, carBrand string) *httptest.ResponseRecorder {
+	t.Helper()
+	uaID := seedUniqueAttachment(t, db, "cars", fmt.Sprintf("car_tmpl_%s_%s", t.Name(), tag), "Car Template")
+	body := fmt.Sprintf(`{
+		"message": "blacklist guard",
+		"organization": "%s",
+		"responsible_person": "Test",
+		"contact_phone": "+79001234567",
+		"data_approval": true,
+		"attachments": [{
+			"attachment_type": "cars",
+			"attachment_name": "car_tmpl",
+			"attachment_display_name": "Car Template",
+			"unique_attachment_id": %d,
+			"entry_date_from": "2026-04-01",
+			"entry_date_to": "2099-12-31",
+			"entry_time_from": "08:00",
+			"entry_time_to": "18:00",
+			"data": {"vehicles": [{"car_number": "%s", "car_brand": "%s"}]}
+		}]
+	}`, orgName, uaID, carNumber, carBrand)
+	return testutil.POST(t, e, "/applications/submit-complete-application", body, testutil.AuthHeader(token))
+}
+
 // submitPersonApp подаёт полную заявку с одним человеком (ФИО) и возвращает recorder.
 func submitPersonApp(t *testing.T, e *echo.Echo, db *gorm.DB, token, orgName, tag, last, first, middle string, citizenshipID, tableID int) *httptest.ResponseRecorder {
 	t.Helper()
@@ -102,6 +128,17 @@ func TestSubmitCompleteApplication_BlacklistGuard(t *testing.T) {
 
 	t.Run("машину не из ЧС подать можно", func(t *testing.T) {
 		rec := submitCarApp(t, e, db, token, orgName, "clean", "D888DD799", mark.ID)
+		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+	})
+
+	t.Run("заблокированную машину без mark_id ловит name-fallback", func(t *testing.T) {
+		rec := submitCarAppNoMark(t, e, db, token, orgName, "blocked_noid", "C777CC799", mark.Name)
+		require.Equal(t, http.StatusConflict, rec.Code, "body: %s", rec.Body.String())
+		assert.Contains(t, rec.Body.String(), "чёрном списке")
+	})
+
+	t.Run("без mark_id и без совпадения по имени - можно", func(t *testing.T) {
+		rec := submitCarAppNoMark(t, e, db, token, orgName, "clean_noid", "C777CC799", "Другая марка")
 		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
 	})
 

--- a/internal/services/application_service.go
+++ b/internal/services/application_service.go
@@ -946,10 +946,21 @@ func (s *applicationService) validateBlacklist(ctx context.Context, req Complete
 	for _, att := range req.Attachments {
 		if att.Data.Vehicles != nil {
 			for _, v := range *att.Data.Vehicles {
-				if v.MarkID == nil {
+				// Машины из mark-дропдауна приходят с mark_id (строгий матч), выбранные из
+				// существующих unique_cars - без mark_id, но с car_brand (имя марки): для них
+				// fallback на матч по имени, иначе заблокированная машина прошла бы гард.
+				var (
+					res models.VehicleBlacklistCheckResult
+					err error
+				)
+				switch {
+				case v.MarkID != nil:
+					res, err = s.vehicleBlacklist.Check(ctx, v.CarNumber, *v.MarkID)
+				case strings.TrimSpace(v.CarBrand) != "":
+					res, err = s.vehicleBlacklist.CheckByName(ctx, v.CarNumber, v.CarBrand)
+				default:
 					continue
 				}
-				res, err := s.vehicleBlacklist.Check(ctx, v.CarNumber, *v.MarkID)
 				if err != nil {
 					return err
 				}

--- a/internal/services/vehicle_blacklist_service.go
+++ b/internal/services/vehicle_blacklist_service.go
@@ -32,6 +32,9 @@ type VehicleBlacklistService interface {
 	Restore(ctx context.Context, id int, userID int) error
 	// Check - заблокирована ли машина (number+mark) активной записью.
 	Check(ctx context.Context, carNumber string, markID int) (models.VehicleBlacklistCheckResult, error)
+	// CheckByName - проверка по номеру и имени марки (для машин без mark_id, например
+	// выбранных из существующих unique_cars). Совпадение по mark_name, как в каскаде.
+	CheckByName(ctx context.Context, carNumber, markName string) (models.VehicleBlacklistCheckResult, error)
 	GetHistory(ctx context.Context, id int) ([]models.VehicleBlacklistHistoryItem, error)
 }
 
@@ -178,6 +181,24 @@ func (s *vehicleBlacklistService) Check(ctx context.Context, carNumber string, m
 		Where("is_active = ?", true).
 		Where("LOWER(TRIM(car_number)) = LOWER(TRIM(?))", carNumber).
 		Where("mark_id = ?", markID).
+		First(&e).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return models.VehicleBlacklistCheckResult{IsBlacklisted: false}, nil
+		}
+		return models.VehicleBlacklistCheckResult{}, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка проверки чёрного списка")
+	}
+	return models.VehicleBlacklistCheckResult{IsBlacklisted: true, Reason: e.Reason}, nil
+}
+
+func (s *vehicleBlacklistService) CheckByName(ctx context.Context, carNumber, markName string) (models.VehicleBlacklistCheckResult, error) {
+	// .First: при нескольких активных записях с одним номером+именем марки (разные mark_id
+	// после пересоздания марки) берём любую - для блокировки достаточно факта совпадения.
+	var e models.VehicleBlacklist
+	err := s.db.WithContext(ctx).
+		Where("is_active = ?", true).
+		Where("LOWER(TRIM(car_number)) = LOWER(TRIM(?))", carNumber).
+		Where("LOWER(TRIM(mark_name)) = LOWER(TRIM(?))", markName).
 		First(&e).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {


### PR DESCRIPTION
## Что

Срез P4 эпика ЧС (#443): заблокированную машину/человека нельзя добавить в заявку через «Добавить существующего».

### Backend (закрыта реальная дыра)
Существующие машины из `/unique-cars` уходили на submit с `mark_id: null` (у UniqueCar нет mark_id), а серверный гард `validateBlacklist` их пропускал (`if v.MarkID == nil { continue }`) - заблокированная машина проходила. Люди блокировались всегда (ФИО шлётся).
- `VehicleBlacklistService.CheckByName(carNumber, markName)` - матч активной записи по номеру + имени марки (зеркалит каскадный name-match).
- `validateBlacklist`: `mark_id != nil` -> `Check` (по id, как было); иначе `car_brand` непустой -> `CheckByName`; иначе скип.

### Frontend (UX-гард)
- `ExistingCarsModal` / `ExistingEmployeesModal`: при открытии тянут активный ЧС, строит Set ключей. Матч зеркалит серверную нормализацию (`trim().toLowerCase()`, без удаления внутренних пробелов - как SQL `LOWER(TRIM())`). Строки из ЧС: серые, недоступны для выбора (чекбокс+клик), бейдж «В ЧС» + тултип.
- Сбой загрузки ЧС не блокирует модалку (серверный гард всё равно отклонит подачу).

## Проверка
- Go: `go vet` + `TestSubmitCompleteApplication_BlacklistGuard` (новые подтесты: машина без mark_id с совпадающим car_brand -> 409; без совпадения -> 200) - зелёные на изолированной test-БД.
- Front: eslint, vitest 344 (+ новый `ExistingModalsBlacklist.spec.js` на логику матчинга), build.
- Локально через Playwright: обе модалки - заблокированная строка серая, disabled, бейдж «В ЧС», кнопка добавления неактивна.