### PR TITLE
feat(number-format): фронт форматов номеров под эталон - архив, уведомления, модалки (#414)

### DIFF
--- a/frontend/src/components/NumberFormat.vue
+++ b/frontend/src/components/NumberFormat.vue
@@ -5,29 +5,35 @@
         Управление форматами номеров
       </h3>
       <div class="header-controls">
+        <BaseDropdown
+          class="archive-dropdown"
+          :model-value="showArchive ? 'archive' : 'active'"
+          :options="archiveOptions"
+          label-key="label"
+          value-key="value"
+          @update:model-value="onArchiveModeChange"
+        />
         <SearchComponent
           v-model="searchQuery"
           :title="'Поиск форматов...'"
         />
         <button
           class="add-header-button"
-          @click="showAddModal = true"
+          data-testid="nf-add-btn"
+          @click="openAddModal"
         >
           Добавить
         </button>
         <RefreshButton
-          :loading="refreshing"
-          @refresh="refreshData"
+          :loading="isLoading"
+          @refresh="refresh"
         />
       </div>
     </div>
 
     <div class="content-container">
-      <!-- Левая часть - таблица форматов -->
-      <div
-        class="table-section"
-        :class="{'with-details': selectedFormat}"
-      >
+      <!-- Левая часть - список форматов -->
+      <div class="table-section">
         <div class="table-container">
           <div class="table-header">
             <div
@@ -37,13 +43,10 @@
               <p :class="{ 'active-sort': sortField === 'id' }">
                 ID
               </p>
-              <img 
-                src="@/assets/icons/sort.png" 
-                class="sort-icon" 
-                :class="{ 
-                  'sorted': sortField === 'id',
-                  'desc': sortField === 'id' && sortDirection === 'desc'
-                }" 
+              <img
+                src="@/assets/icons/sort.png"
+                class="sort-icon"
+                :class="{ sorted: sortField === 'id', desc: sortField === 'id' && sortDirection === 'desc' }"
               >
             </div>
             <div
@@ -53,41 +56,65 @@
               <p :class="{ 'active-sort': sortField === 'name' }">
                 Наименование
               </p>
-              <img 
-                src="@/assets/icons/sort.png" 
-                class="sort-icon" 
-                :class="{ 
-                  'sorted': sortField === 'name',
-                  'desc': sortField === 'name' && sortDirection === 'desc'
-                }" 
+              <img
+                src="@/assets/icons/sort.png"
+                class="sort-icon"
+                :class="{ sorted: sortField === 'name', desc: sortField === 'name' && sortDirection === 'desc' }"
               >
             </div>
           </div>
 
           <div class="table-body">
-            <div 
-              v-for="format in sortedFormats" 
-              :key="format.format.id" 
+            <div
+              v-for="item in filteredFormats"
+              :key="item.format.id"
               class="table-row"
-              :class="{'selected': selectedFormat && selectedFormat.format.id === format.format.id}"
-              @click="selectFormat(format)"
+              data-testid="nf-row"
+              :class="{
+                selected: selectedFormat && selectedFormat.format.id === item.format.id,
+                inactive: !item.format.is_active,
+              }"
+              @click="selectFormat(item)"
             >
               <div class="table-col id-col">
-                <span class="cell-content id-value">{{ format.format.id }}</span>
+                <span class="cell-content id-value">{{ item.format.id }}</span>
               </div>
               <div class="table-col name-col">
                 <span
                   class="truncate-text"
-                  :title="format.format.name"
+                  :title="item.format.name"
                 >
-                  {{ format.format.name }}
+                  {{ item.format.name }}
+                  <span
+                    v-if="item.format.is_default"
+                    class="default-badge"
+                  >по умолчанию</span>
+                  <span
+                    v-if="!item.format.is_active"
+                    class="inactive-badge"
+                  >(архив)</span>
                 </span>
               </div>
+            </div>
+
+            <div
+              v-if="!filteredFormats.length && !isLoading"
+              class="no-results"
+            >
+              {{ emptyText }}
+            </div>
+            <div
+              v-if="isLoading && !formats.length"
+              class="nf-loading"
+            >
+              <LoaderSpinner label="Загрузка форматов..." />
             </div>
           </div>
 
           <div class="table-footer">
-            <span class="items-count">Всего форматов: {{ filteredFormats.length }}</span>
+            <span class="items-count">
+              {{ showArchive ? 'В архиве' : 'Всего форматов' }}: {{ filteredFormats.length }}
+            </span>
           </div>
         </div>
       </div>
@@ -96,8 +123,9 @@
       <div
         v-if="selectedFormat"
         class="details-section"
+        data-testid="nf-details"
       >
-        <div class="details-content">
+        <div class="tab-content">
           <div class="details-header">
             <div class="details-title-wrapper">
               <h3 class="details-title">
@@ -106,100 +134,133 @@
               <span class="format-preview">{{ getFormatPreview(selectedFormat) }}</span>
             </div>
             <div class="details-header-actions">
+              <span
+                v-if="!selectedFormat.format.is_active"
+                class="archive-badge"
+              >В архиве</span>
               <button
-                class="delete-icon-btn"
-                @click="confirmDeleteFormat(selectedFormat.format)"
+                v-if="selectedFormat.format.is_active"
+                class="action-btn archive-action-btn"
+                data-testid="nf-archive"
+                @click="onArchiveClick(selectedFormat)"
               >
-                <img
-                  src="@/assets/icons/delete.png"
-                  class="delete-icon"
-                >
+                В архив
+              </button>
+              <button
+                v-else
+                class="action-btn restore-btn"
+                data-testid="nf-restore"
+                @click="onRestore(selectedFormat)"
+              >
+                Восстановить
               </button>
             </div>
           </div>
-          
+
           <div class="details-body">
-            <div class="compact-form">
-              <div class="form-row">
-                <div class="form-group compact">
-                  <label class="detail-label">Наименование:</label>
-                  <input 
-                    v-model="selectedFormat.format.name" 
-                    class="form-input-sm"
-                    placeholder="Название формата"
-                    autocomplete="off"
-                    @change="updateFormat(selectedFormat)"
-                  >
-                </div>
-                <div class="form-group compact">
-                  <label class="detail-label">Код страны:</label>
-                  <input 
-                    v-model="selectedFormat.format.country_code" 
-                    class="form-input-sm"
-                    placeholder="RU, AZ, KZ"
-                    autocomplete="off"
-                    @change="updateFormat(selectedFormat)"
-                  >
-                </div>
+            <div class="form-row">
+              <div class="field">
+                <label class="field-label">Наименование</label>
+                <input
+                  v-model.trim="selectedFormat.format.name"
+                  type="text"
+                  class="lk-input"
+                  maxlength="100"
+                  placeholder="Название формата"
+                  :disabled="!selectedFormat.format.is_active"
+                  data-testid="nf-detail-name"
+                >
               </div>
-
-              <div class="default-checkbox-section">
-                <label class="default-checkbox-label">
-                  <input 
-                    v-model="selectedFormat.format.is_default" 
-                    type="checkbox"
-                    class="default-checkbox"
-                    @change="handleDefaultFormatChange"
-                  >
-                  <span class="default-checkbox-text">Формат по умолчанию</span>
-                </label>
-                <span class="default-checkbox-hint">
-                  Этот формат будет выбран по умолчанию при создании нового Т/С
-                </span>
+              <div class="field">
+                <label class="field-label">Код страны</label>
+                <input
+                  v-model.trim="selectedFormat.format.country_code"
+                  type="text"
+                  class="lk-input"
+                  maxlength="10"
+                  placeholder="RU, AZ, KZ"
+                  :disabled="!selectedFormat.format.is_active"
+                  data-testid="nf-detail-country"
+                >
               </div>
+            </div>
 
-              <div class="cells-section">
-                <label class="section-label">Клетки формата номера:</label>
-                <div class="cells-horizontal">
-                  <div 
-                    v-for="(cell, index) in selectedFormat.cells" 
-                    :key="index"
-                    class="cell-horizontal-card"
-                    @click="editCell(index)"
-                  >
-                    <div class="cell-horizontal-header">
-                      <span class="cell-badge">Клетка №{{ index + 1 }}</span>
-                      <span
-                        class="cell-type-badge"
-                        :class="cell.cell_type"
-                      >
-                        {{ getCellTypeLabel(cell.cell_type) }}
-                      </span>
-                    </div>
-                    <div class="cell-horizontal-details">
-                      <span class="cell-length">{{ cell.min_length }}-{{ cell.max_length }} симв.</span>
-                      <span
-                        v-if="cell.allowed_letters"
-                        class="cell-letters"
-                        :title="cell.allowed_letters"
-                      >
-                        {{ truncateLetters(cell.allowed_letters) }}
-                      </span>
-                      <span
-                        v-if="cell.cell_type === 'numbers'"
-                        class="cell-padding"
-                      >
-                        Дополнение: {{ cell.padding_side === 'left' ? 'слева' : 'справа' }}
-                      </span>
-                    </div>
+            <label class="default-checkbox-section">
+              <input
+                v-model="selectedFormat.format.is_default"
+                type="checkbox"
+                class="default-checkbox"
+                :disabled="!selectedFormat.format.is_active"
+                data-testid="nf-detail-default"
+              >
+              <span class="default-checkbox-body">
+                <span class="default-checkbox-text">Формат по умолчанию</span>
+                <span class="default-checkbox-hint">Выбирается по умолчанию при создании нового Т/С</span>
+              </span>
+            </label>
+
+            <div class="cells-section">
+              <label class="field-label">Клетки формата номера</label>
+              <div class="cells-horizontal">
+                <button
+                  v-for="(cell, index) in selectedFormat.cells"
+                  :key="index"
+                  type="button"
+                  class="cell-card"
+                  :disabled="!selectedFormat.format.is_active"
+                  @click="editCell(index)"
+                >
+                  <div class="cell-card-header">
+                    <span class="cell-badge">Клетка №{{ index + 1 }}</span>
+                    <span
+                      class="cell-type-badge"
+                      :class="cell.cell_type"
+                    >{{ getCellTypeLabel(cell.cell_type) }}</span>
                   </div>
-                </div>
+                  <div class="cell-card-details">
+                    <span class="cell-length">{{ cell.min_length }}-{{ cell.max_length }} симв.</span>
+                    <span
+                      v-if="cell.cell_type !== 'numbers' && cell.allowed_letters"
+                      class="cell-letters"
+                      :title="cell.allowed_letters"
+                    >{{ truncateLetters(cell.allowed_letters) }}</span>
+                    <span
+                      v-if="cell.cell_type === 'numbers'"
+                      class="cell-padding"
+                    >Дополнение: {{ cell.padding_side === 'left' ? 'слева' : 'справа' }}</span>
+                  </div>
+                </button>
               </div>
+            </div>
+
+            <div
+              v-if="detailError"
+              class="form-error"
+            >
+              {{ detailError }}
+            </div>
+
+            <div
+              v-if="selectedFormat.format.is_active"
+              class="details-actions"
+            >
+              <button
+                class="lk-button lk-button--primary"
+                :disabled="!isDetailsDirty || isSaving"
+                data-testid="nf-detail-save"
+                @click="saveDetails"
+              >
+                Сохранить
+              </button>
+            </div>
+
+            <div class="details-meta">
+              <span>ID: {{ selectedFormat.format.id }}</span>
+              <span v-if="selectedFormat.format.created_at">Создан: {{ formatDate(selectedFormat.format.created_at) }}</span>
             </div>
           </div>
         </div>
       </div>
-      
       <div
         v-else
         class="no-selection-message"
@@ -208,111 +269,105 @@
       </div>
     </div>
 
-    <div
-      v-if="filteredFormats.length === 0"
-      class="no-results"
-    >
-      <div class="no-results-icon">
-        🚗
-      </div>
-      <p>Форматы номеров не найдены</p>
-    </div>
-
-    <!-- Модальное окно добавления формата -->
+    <!-- Модалка добавления формата -->
     <Teleport to="body">
-      <div
-        v-if="showAddModal"
-        class="modal-overlay"
-        @click.self="showAddModal = false"
-      >
-        <div class="modal-content horizontal-modal">
-          <div class="modal-header">
-            <h3>Добавить формат номеров</h3>
-            <button
-              class="modal-close"
-              @click="showAddModal = false"
-            >
-              ×
-            </button>
-          </div>
-        
-          <div class="modal-body-horizontal">
-            <!-- Левая часть - основная информация -->
-            <div class="modal-main-info">
-              <div class="main-fields">
-                <div class="form-group-compact">
-                  <label class="form-label-compact">Название формата</label>
-                  <input
-                    v-model="newFormat.name"
-                    placeholder="Российские номера"
-                    class="input-compact"
-                  >
-                </div>
-              
-                <div class="form-group-compact">
-                  <label class="form-label-compact">Код страны</label>
-                  <input
-                    v-model="newFormat.country_code"
-                    placeholder="RU"
-                    class="input-compact"
-                  >
-                </div>
-
-                <div class="default-checkbox-modal">
-                  <label class="default-checkbox-label-modal">
-                    <input 
-                      v-model="newFormat.is_default" 
-                      type="checkbox"
-                      class="default-checkbox"
-                    >
-                    <span class="default-checkbox-text-modal">Формат по умолчанию</span>
-                  </label>
-                  <span class="default-checkbox-hint-modal">
-                    Этот формат будет выбран по умолчанию при создании нового Т/С
-                  </span>
-                </div>
-              </div>
+      <transition name="modal-fade">
+        <div
+          v-if="showAddModal"
+          class="modal-overlay"
+          data-testid="nf-modal"
+          @mousedown="onAddOverlayMousedown"
+          @mouseup="onAddOverlayMouseup"
+        >
+          <div
+            class="nf-modal"
+            @mousedown.stop
+          >
+            <div class="modal-header">
+              <h3>Новый формат номеров</h3>
+              <button
+                class="modal-close"
+                aria-label="Закрыть"
+                data-testid="nf-modal-close"
+                @click="requestCloseAdd"
+              >
+                ×
+              </button>
             </div>
 
-            <!-- Правая часть - клетки -->
-            <div class="modal-cells-section">
-              <div class="cells-header-compact">
-                <h4 class="cells-title-compact">
-                  Клетки формата
-                </h4>
-                <button
-                  class="add-cell-btn-header"
-                  @click="addCell"
-                >
-                  + Добавить клетку
-                </button>
-              </div>
-            
-              <div class="cells-scroll-container">
-                <div class="cells-grid-compact">
-                  <div 
-                    v-for="(cell, index) in newFormat.cells" 
-                    :key="index"
-                    class="cell-card-compact"
+            <div class="modal-body">
+              <div class="form-row">
+                <div class="field">
+                  <label class="field-label">Название формата</label>
+                  <input
+                    v-model.trim="addForm.name"
+                    type="text"
+                    class="lk-input"
+                    maxlength="100"
+                    placeholder="Российские номера"
+                    data-testid="nf-input-name"
                   >
-                    <div class="cell-header-mini">
-                      <span class="cell-number-mini">Клетка №{{ index + 1 }}</span>
-                      <button 
-                        v-if="newFormat.cells.length > 1"
-                        class="remove-cell-btn-mini"
+                </div>
+                <div class="field">
+                  <label class="field-label">Код страны</label>
+                  <input
+                    v-model.trim="addForm.country_code"
+                    type="text"
+                    class="lk-input"
+                    maxlength="10"
+                    placeholder="RU"
+                  >
+                </div>
+              </div>
+
+              <label class="default-checkbox-section">
+                <input
+                  v-model="addForm.is_default"
+                  type="checkbox"
+                  class="default-checkbox"
+                >
+                <span class="default-checkbox-body">
+                  <span class="default-checkbox-text">Формат по умолчанию</span>
+                  <span class="default-checkbox-hint">Выбирается по умолчанию при создании нового Т/С</span>
+                </span>
+              </label>
+
+              <div class="cells-edit-section">
+                <div class="cells-edit-header">
+                  <label class="field-label">Клетки формата</label>
+                  <button
+                    type="button"
+                    class="lk-button lk-button--secondary add-cell-btn"
+                    @click="addCell"
+                  >
+                    + Добавить клетку
+                  </button>
+                </div>
+
+                <div class="cells-edit-list">
+                  <div
+                    v-for="(cell, index) in addForm.cells"
+                    :key="index"
+                    class="cell-edit-card"
+                  >
+                    <div class="cell-edit-card-header">
+                      <span class="cell-number">Клетка №{{ index + 1 }}</span>
+                      <button
+                        v-if="addForm.cells.length > 1"
+                        type="button"
+                        class="cell-remove-btn"
                         title="Удалить клетку"
                         @click="removeCell(index)"
                       >
                         ×
                       </button>
                     </div>
-                  
-                    <div class="cell-config-mini">
-                      <div class="config-group-mini">
-                        <label>Тип</label>
+                    <div class="cell-edit-fields">
+                      <div class="field">
+                        <label class="field-label">Тип</label>
                         <select
                           v-model="cell.cell_type"
-                          class="select-mini"
+                          class="lk-select"
                         >
                           <option value="letters">
                             Буквы
@@ -325,38 +380,36 @@
                           </option>
                         </select>
                       </div>
-                    
-                      <div class="config-group-mini">
-                        <label>Длина</label>
-                        <div class="length-controls-mini">
-                          <input 
-                            v-model.number="cell.min_length" 
-                            type="number" 
-                            min="1" 
+                      <div class="field length-field">
+                        <label class="field-label">Длина</label>
+                        <div class="length-controls">
+                          <input
+                            v-model.number="cell.min_length"
+                            type="number"
+                            min="1"
                             max="10"
-                            class="input-micro"
+                            class="lk-input length-input"
                             placeholder="мин"
                           >
                           <span class="length-dash">-</span>
-                          <input 
-                            v-model.number="cell.max_length" 
-                            type="number" 
-                            min="1" 
+                          <input
+                            v-model.number="cell.max_length"
+                            type="number"
+                            min="1"
                             max="10"
-                            class="input-micro"
+                            class="lk-input length-input"
                             placeholder="макс"
                           >
                         </div>
                       </div>
-
                       <div
                         v-if="cell.cell_type !== 'numbers'"
-                        class="config-group-mini"
+                        class="field"
                       >
-                        <label>Алфавит</label>
+                        <label class="field-label">Алфавит</label>
                         <select
                           v-model="cell.alphabet_type"
-                          class="select-mini"
+                          class="lk-select"
                         >
                           <option value="cyrillic">
                             Кириллица
@@ -369,15 +422,14 @@
                           </option>
                         </select>
                       </div>
-                    
                       <div
                         v-if="cell.cell_type === 'numbers'"
-                        class="config-group-mini"
+                        class="field"
                       >
-                        <label>Дополнение</label>
+                        <label class="field-label">Дополнение</label>
                         <select
                           v-model="cell.padding_side"
-                          class="select-mini"
+                          class="lk-select"
                         >
                           <option value="left">
                             Слева
@@ -387,70 +439,88 @@
                           </option>
                         </select>
                       </div>
-
                       <div
                         v-if="cell.cell_type !== 'numbers'"
-                        class="config-group-full-mini"
+                        class="field field-full"
                       >
-                        <label>Разрешенные буквы</label>
-                        <input 
+                        <label class="field-label">Разрешённые буквы</label>
+                        <input
                           v-model="cell.allowed_letters"
+                          type="text"
+                          class="lk-input"
                           placeholder="АВЕКМНОРСТУХ"
-                          class="input-compact"
                         >
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
+
+              <div
+                v-if="addError"
+                class="form-error"
+              >
+                {{ addError }}
+              </div>
+            </div>
+
+            <div class="modal-footer">
+              <button
+                class="lk-button lk-button--ghost"
+                data-testid="nf-modal-cancel"
+                @click="requestCloseAdd"
+              >
+                Отмена
+              </button>
+              <button
+                class="lk-button lk-button--primary"
+                :disabled="!addForm.name || isAdding"
+                data-testid="nf-modal-save"
+                @click="submitAdd"
+              >
+                Добавить
+              </button>
             </div>
           </div>
-        
-          <div class="modal-footer">
-            <button
-              class="modal-cancel"
-              @click="showAddModal = false"
-            >
-              Отмена
-            </button>
-            <button
-              class="modal-confirm"
-              @click="addFormat"
-            >
-              Добавить
-            </button>
-          </div>
         </div>
-      </div>
+      </transition>
     </Teleport>
 
-    <!-- Модальное окно редактирования клетки -->
+    <!-- Модалка редактирования клетки -->
     <Teleport to="body">
-      <div
-        v-if="showCellEditModal"
-        class="modal-overlay"
-        @click.self="showCellEditModal = false"
-      >
-        <div class="modal-content horizontal-modal cell-edit-modal">
-          <div class="modal-header">
-            <h3>Редактировать клетку {{ editingCellIndex + 1 }}</h3>
-            <button
-              class="modal-close"
-              @click="showCellEditModal = false"
+      <transition name="modal-fade">
+        <div
+          v-if="showCellEditModal"
+          class="modal-overlay"
+          data-testid="nf-cell-modal"
+          @mousedown="onCellOverlayMousedown"
+          @mouseup="onCellOverlayMouseup"
+        >
+          <div
+            class="nf-modal nf-modal--narrow"
+            @mousedown.stop
+          >
+            <div class="modal-header">
+              <h3>Редактирование клетки {{ editingCellIndex + 1 }}</h3>
+              <button
+                class="modal-close"
+                aria-label="Закрыть"
+                @click="showCellEditModal = false"
+              >
+                ×
+              </button>
+            </div>
+
+            <div
+              v-if="editingCell"
+              class="modal-body"
             >
-              ×
-            </button>
-          </div>
-        
-          <div class="modal-body-horizontal">
-            <!-- Левая часть - основные настройки -->
-            <div class="modal-main-info">
-              <div class="main-fields">
-                <div class="form-group-compact">
-                  <label class="form-label-compact">Тип клетки</label>
+              <div class="cell-edit-fields">
+                <div class="field">
+                  <label class="field-label">Тип клетки</label>
                   <select
                     v-model="editingCell.cell_type"
-                    class="select-mini"
+                    class="lk-select"
                   >
                     <option value="letters">
                       Буквы
@@ -463,38 +533,36 @@
                     </option>
                   </select>
                 </div>
-              
-                <div class="form-row-horizontal">
-                  <div class="form-group-compact">
-                    <label class="form-label-compact">Мин. длина</label>
-                    <input 
-                      v-model.number="editingCell.min_length" 
-                      type="number" 
-                      min="1" 
+                <div class="field length-field">
+                  <label class="field-label">Длина</label>
+                  <div class="length-controls">
+                    <input
+                      v-model.number="editingCell.min_length"
+                      type="number"
+                      min="1"
                       max="10"
-                      class="input-compact"
+                      class="lk-input length-input"
+                      placeholder="мин"
                     >
-                  </div>
-                  <div class="form-group-compact">
-                    <label class="form-label-compact">Макс. длина</label>
-                    <input 
-                      v-model.number="editingCell.max_length" 
-                      type="number" 
-                      min="1" 
+                    <span class="length-dash">-</span>
+                    <input
+                      v-model.number="editingCell.max_length"
+                      type="number"
+                      min="1"
                       max="10"
-                      class="input-compact"
+                      class="lk-input length-input"
+                      placeholder="макс"
                     >
                   </div>
                 </div>
-
                 <div
                   v-if="editingCell.cell_type !== 'numbers'"
-                  class="form-group-compact"
+                  class="field"
                 >
-                  <label class="form-label-compact">Алфавит</label>
+                  <label class="field-label">Алфавит</label>
                   <select
                     v-model="editingCell.alphabet_type"
-                    class="select-mini"
+                    class="lk-select"
                   >
                     <option value="cyrillic">
                       Кириллица
@@ -507,15 +575,14 @@
                     </option>
                   </select>
                 </div>
-              
                 <div
                   v-if="editingCell.cell_type === 'numbers'"
-                  class="form-group-compact"
+                  class="field"
                 >
-                  <label class="form-label-compact">Дополнение нулями</label>
+                  <label class="field-label">Дополнение нулями</label>
                   <select
                     v-model="editingCell.padding_side"
-                    class="select-mini"
+                    class="lk-select"
                   >
                     <option value="left">
                       Слева
@@ -525,406 +592,211 @@
                     </option>
                   </select>
                 </div>
+                <div
+                  v-if="editingCell.cell_type !== 'numbers'"
+                  class="field field-full"
+                >
+                  <label class="field-label">Разрешённые буквы</label>
+                  <input
+                    v-model="editingCell.allowed_letters"
+                    type="text"
+                    class="lk-input"
+                    placeholder="АВЕКМНОРСТУХ"
+                  >
+                  <span class="field-hint">Пусто - используются все буквы выбранного алфавита</span>
+                </div>
+              </div>
+
+              <div class="cell-preview">
+                <span class="cell-preview-label">Предпросмотр</span>
+                <span class="cell-preview-value">{{ getCellPreview(editingCell) }}</span>
+              </div>
+
+              <div
+                v-if="cellEditError"
+                class="form-error"
+              >
+                {{ cellEditError }}
               </div>
             </div>
 
-            <!-- Правая часть - дополнительные настройки -->
-            <div class="modal-cells-section">
-              <div class="cells-header-compact">
-                <h4 class="cells-title-compact">
-                  Дополнительные настройки
-                </h4>
-              </div>
-            
-              <div class="cells-scroll-container">
-                <div class="cell-edit-details">
-                  <div
-                    v-if="editingCell.cell_type !== 'numbers'"
-                    class="form-group-compact"
-                  >
-                    <label class="form-label-compact">Разрешенные буквы</label>
-                    <input 
-                      v-model="editingCell.allowed_letters"
-                      placeholder="АВЕКМНОРСТУХ"
-                      class="input-compact"
-                    >
-                    <span class="form-hint">
-                      Оставьте пустым для использования всех букв выбранного алфавита
-                    </span>
-                  </div>
-                
-                  <div class="cell-preview-section">
-                    <h5 class="preview-title">
-                      Предпросмотр клетки
-                    </h5>
-                    <div class="preview-content">
-                      <div class="preview-example">
-                        {{ getCellPreview(editingCell) }}
-                      </div>
-                      <div class="preview-info">
-                        <span class="preview-length">
-                          Длина: {{ editingCell.min_length }}-{{ editingCell.max_length }} символов
-                        </span>
-                        <span
-                          v-if="editingCell.allowed_letters"
-                          class="preview-letters"
-                        >
-                          Разрешённые символы: {{ editingCell.allowed_letters }}
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
+            <div class="modal-footer">
+              <button
+                class="lk-button lk-button--ghost"
+                @click="showCellEditModal = false"
+              >
+                Отмена
+              </button>
+              <button
+                class="lk-button lk-button--primary"
+                @click="saveCellEdit"
+              >
+                Применить
+              </button>
             </div>
           </div>
-        
-          <div class="modal-footer">
-            <button
-              class="modal-cancel"
-              @click="showCellEditModal = false"
-            >
-              Отмена
-            </button>
-            <button
-              class="modal-confirm"
-              @click="saveCellEdit"
-            >
-              Сохранить
-            </button>
-          </div>
         </div>
-      </div>
+      </transition>
     </Teleport>
+
+    <ConfirmationModal
+      :show="!!archiveConfirmFormat"
+      title="Архивация формата"
+      :message="archiveConfirmFormat ? `Архивировать формат «${archiveConfirmFormat.name}»? Его можно будет восстановить из архива.` : ''"
+      confirm-text="В архив"
+      cancel-text="Отмена"
+      :confirm-button-style="{ background: '#c62828', borderColor: '#c62828' }"
+      @confirm="performArchive"
+      @cancel="archiveConfirmFormat = null"
+    />
   </div>
 </template>
 
 <script>
-import { apiRequest } from '@/api/client'
-import RefreshButton from './RefreshButton.vue';
 import SearchComponent from './SearchComponent.vue';
+import RefreshButton from './RefreshButton.vue';
+import ConfirmationModal from './ConfirmationModal.vue';
+import BaseDropdown from './ui/BaseDropdown.vue';
+import LoaderSpinner from './ui/LoaderSpinner.vue';
+import { useDeletionsStore } from '@/stores/deletions';
+import { registerDirtyTracker, confirmIfAnyDirty } from '@/utils/dirtyTracker';
+import { useOverlayClose } from '@/composables/useOverlayClose';
+import { apiRequest } from '@/api/client';
+
+function defaultCell() {
+  return {
+    cell_order: 0,
+    cell_type: 'letters',
+    min_length: 1,
+    max_length: 1,
+    alphabet_type: 'cyrillic',
+    allowed_letters: '',
+    padding_side: 'left',
+  };
+}
+
+const CELL_TYPE_LABELS = {
+  letters: 'Буквы',
+  numbers: 'Цифры',
+  mixed: 'Смешанный',
+};
 
 export default {
-  components: {
-    SearchComponent,
-    RefreshButton
+  name: 'NumberFormat',
+  components: { SearchComponent, RefreshButton, ConfirmationModal, BaseDropdown, LoaderSpinner },
+  setup() {
+    // Колбэки закрытия присваиваются в created - нужен доступ к this (проверка dirty).
+    const addOverlay = { close: () => {} };
+    const cellOverlay = { close: () => {} };
+    const a = useOverlayClose(() => addOverlay.close());
+    const c = useOverlayClose(() => cellOverlay.close());
+    return {
+      addOverlay,
+      cellOverlay,
+      onAddOverlayMousedown: a.onOverlayMousedown,
+      onAddOverlayMouseup: a.onOverlayMouseup,
+      onCellOverlayMousedown: c.onOverlayMousedown,
+      onCellOverlayMouseup: c.onOverlayMouseup,
+    };
   },
   data() {
     return {
-      searchQuery: '',
-      refreshing: false,
-      newFormat: {
-        name: '',
-        country_code: '',
-        is_default: false,
-        cells: [
-          {
-            cell_order: 0,
-            cell_type: 'letters',
-            min_length: 1,
-            max_length: 1,
-            alphabet_type: 'cyrillic',
-            allowed_letters: '',
-            padding_side: 'left'
-          }
-        ]
-      },
       formats: [],
-      showAddModal: false,
-      showCellEditModal: false,
+      searchQuery: '',
+      showArchive: false,
+      sortField: null,
+      sortDirection: 'asc',
+      isLoading: false,
       selectedFormat: null,
+      originalSnapshot: '',
+      detailError: '',
+      isSaving: false,
+      showAddModal: false,
+      addForm: { name: '', country_code: '', is_default: false, cells: [defaultCell()] },
+      addError: '',
+      isAdding: false,
+      showCellEditModal: false,
       editingCellIndex: null,
       editingCell: null,
-      sortField: null,
-      sortDirection: 'asc'
+      cellEditError: '',
+      archiveConfirmFormat: null,
+      archiveOptions: [
+        { label: 'Активные', value: 'active' },
+        { label: 'Архив', value: 'archive' },
+      ],
     };
   },
   computed: {
     filteredFormats() {
-      if (!this.searchQuery) return this.formats;
-      const query = this.searchQuery.toLowerCase();
-      return this.formats.filter(format => 
-        format.format.name.toLowerCase().includes(query) || 
-        format.format.id.toString().includes(query) ||
-        (format.format.country_code && format.format.country_code.toLowerCase().includes(query))
-      );
-    },
-    sortedFormats() {
-      const formats = [...this.filteredFormats];
-      
-      if (!this.sortField) {
-        return formats.sort((a, b) => a.format.name.localeCompare(b.format.name));
+      const q = this.searchQuery.trim().toLowerCase();
+      let list = this.formats.filter(item =>
+        this.showArchive ? !item.format.is_active : item.format.is_active);
+      if (q) {
+        list = list.filter(item =>
+          item.format.name.toLowerCase().includes(q)
+          || String(item.format.id).includes(q)
+          || (item.format.country_code && item.format.country_code.toLowerCase().includes(q)));
       }
-      
-      return formats.sort((a, b) => {
-        let valueA, valueB;
-        
-        switch (this.sortField) {
-          case 'id':
-            valueA = a.format.id;
-            valueB = b.format.id;
-            break;
-          case 'name':
-            valueA = a.format.name;
-            valueB = b.format.name;
-            break;
-          default:
-            return 0;
-        }
-        
-        if (valueA < valueB) {
-          return this.sortDirection === 'asc' ? -1 : 1;
-        }
-        if (valueA > valueB) {
-          return this.sortDirection === 'asc' ? 1 : -1;
-        }
-        return 0;
-      });
-    }
+      return this.sortList(list);
+    },
+    emptyText() {
+      if (this.searchQuery.trim()) return 'Ничего не найдено по запросу';
+      return this.showArchive ? 'В архиве пусто' : 'Форматов пока нет';
+    },
+    isAddDirty() {
+      return this.showAddModal && this.addForm.name.trim() !== '';
+    },
+    isDetailsDirty() {
+      return !!this.selectedFormat
+        && this.selectedFormat.format.is_active
+        && this.detailSnapshot(this.selectedFormat) !== this.originalSnapshot;
+    },
+    isDirty() {
+      return this.isAddDirty || this.isDetailsDirty;
+    },
+  },
+  created() {
+    this.addOverlay.close = () => { this.requestCloseAdd(); };
+    this.cellOverlay.close = () => { this.showCellEditModal = false; };
   },
   mounted() {
-    this.refreshData();
+    this.refresh();
+    this._stopGuard = registerDirtyTracker({
+      isDirty: () => this.isDirty,
+      getChanges: () => {
+        if (this.isAddDirty) return [`Новый формат: "${this.addForm.name.trim()}"`];
+        if (this.isDetailsDirty) return [`Изменения формата "${this.selectedFormat.format.name}"`];
+        return [];
+      },
+      save: async () => {
+        if (this.isAddDirty) await this.submitAdd();
+        if (this.isDetailsDirty) await this.saveDetails();
+      },
+    });
+    document.addEventListener('keydown', this.onKeydown);
+  },
+  beforeUnmount() {
+    this._stopGuard?.();
+    document.removeEventListener('keydown', this.onKeydown);
   },
   methods: {
-    async refreshData() {
-      this.refreshing = true;
-      try {
-        await this.fetchFormats();
-      } finally {
-        this.refreshing = false;
-      }
+    onKeydown(e) {
+      if (e.key !== 'Escape') return;
+      if (this.showCellEditModal) this.showCellEditModal = false;
+      else if (this.showAddModal) this.requestCloseAdd();
     },
-    async fetchFormats() {
-      try {
-        const response = await apiRequest("/license-plate-formats", {
-        });
-        if (response.ok) {
-          const data = await response.json();
-          this.formats = data;
+    sortList(list) {
+      const arr = [...list];
+      if (!this.sortField) {
+        return arr.sort((a, b) => a.format.name.localeCompare(b.format.name));
+      }
+      return arr.sort((a, b) => {
+        if (this.sortField === 'id') {
+          return this.sortDirection === 'asc' ? a.format.id - b.format.id : b.format.id - a.format.id;
         }
-      } catch (error) {
-        console.error("Error fetching license plate formats:", error);
-        this.showNotification("Ошибка при загрузке форматов номеров", "error");
-      }
-    },
-    async addFormat() {
-      if (!this.newFormat.name.trim()) {
-        this.showNotification("Введите название формата", "warning");
-        return;
-      }
-      
-      if (this.newFormat.cells.length === 0) {
-        this.showNotification("Добавьте хотя бы одну клетку", "warning");
-        return;
-      }
-      
-      // Подготавливаем данные для отправки
-      const formatData = {
-        name: this.newFormat.name,
-        country_code: this.newFormat.country_code || null,
-        is_default: this.newFormat.is_default,
-        icon: null,
-        cells: this.newFormat.cells.map((cell, index) => ({
-          cell_order: index,
-          cell_type: cell.cell_type,
-          min_length: cell.min_length,
-          max_length: cell.max_length,
-          allowed_letters: cell.allowed_letters || null,
-          alphabet_type: cell.cell_type !== 'numbers' ? cell.alphabet_type : null,
-          language: 'ru',
-          padding_char: '0',
-          padding_side: cell.cell_type === 'numbers' ? cell.padding_side : null
-        }))
-      };
-      
-      try {
-        const response = await apiRequest("/license-plate-formats", {
-          method: "POST",
-          body: JSON.stringify(formatData),
-        });
-        
-        if (response.ok) {
-          this.newFormat = {
-            name: '',
-            country_code: '',
-            is_default: false,
-            cells: [{
-              cell_order: 0,
-              cell_type: 'letters',
-              min_length: 1,
-              max_length: 1,
-              alphabet_type: 'cyrillic',
-              allowed_letters: '',
-              padding_side: 'left'
-            }]
-          };
-          this.showAddModal = false;
-          await this.refreshData();
-          this.showNotification("Формат номеров успешно добавлен", "success");
-        } else {
-          const errorText = await response.text();
-          this.showNotification(errorText || "Ошибка при добавлении формата", "error");
-        }
-      } catch (error) {
-        console.error("Error adding license plate format:", error);
-        this.showNotification("Ошибка сети", "error");
-      }
-    },
-    async updateFormat(format) {
-      try {
-        const formatData = {
-          name: format.format.name,
-          country_code: format.format.country_code || null,
-          is_default: format.format.is_default,
-          icon: null,
-          cells: format.cells.map((cell, index) => ({
-            id: cell.id,
-            cell_order: index,
-            cell_type: cell.cell_type,
-            min_length: cell.min_length,
-            max_length: cell.max_length,
-            allowed_letters: cell.allowed_letters || null,
-            alphabet_type: cell.cell_type !== 'numbers' ? cell.alphabet_type : null,
-            language: 'ru',
-            padding_char: '0',
-            padding_side: cell.cell_type === 'numbers' ? cell.padding_side : null
-          }))
-        };
-        const response = await apiRequest(`/license-plate-formats/${format.format.id}`, {
-          method: "PUT",
-          body: JSON.stringify(formatData),
-        });
-        
-        if (response.ok) {
-          this.showNotification("Формат номеров успешно обновлен", "success");
-        } else {
-          const errorText = await response.text();
-          this.showNotification(errorText || "Ошибка при обновлении формата", "error");
-          await this.refreshData(); // Перезагружаем данные чтобы откатить изменения
-        }
-      } catch (error) {
-        console.error("Error updating license plate format:", error);
-        this.showNotification("Ошибка сети", "error");
-        await this.refreshData();
-      }
-    },
-    async handleDefaultFormatChange() {
-      // Сохраняем текущее состояние чекбокса
-      const isDefault = this.selectedFormat.format.is_default;
-      
-      try {
-        // Если чекбокс выбран - устанавливаем формат по умолчанию
-        if (isDefault) {
-          await this.setDefaultFormat(this.selectedFormat);
-        } else {
-          // Если чекбокс снят - обновляем формат без установки по умолчанию
-          await this.updateFormat(this.selectedFormat);
-          this.showNotification("Формат больше не является форматом по умолчанию", "success");
-          
-          // После успешного обновления, обновляем данные в формате
-          // чтобы избежать рассинхронизации
-          await this.refreshData();
-          
-          // Обновляем selectedFormat актуальными данными из базы
-          const updatedFormat = this.formats.find(f => f.format.id === this.selectedFormat.format.id);
-          if (updatedFormat) {
-            this.selectedFormat = JSON.parse(JSON.stringify(updatedFormat));
-          }
-        }
-      } catch (error) {
-        // В случае ошибки откатываем состояние чекбокса
-        this.selectedFormat.format.is_default = !isDefault;
-        console.error("Error handling default format change:", error);
-      }
-    },
-    async setDefaultFormat(format) {
-      try {
-        // Сначала снимаем статус по умолчанию со всех форматов
-        await this.clearDefaultFormats();
-        
-        // Устанавливаем новый формат по умолчанию
-        const formatData = {
-          name: format.format.name,
-          country_code: format.format.country_code || null,
-          is_default: true,
-          icon: null,
-          cells: format.cells.map((cell, index) => ({
-            id: cell.id,
-            cell_order: index,
-            cell_type: cell.cell_type,
-            min_length: cell.min_length,
-            max_length: cell.max_length,
-            allowed_letters: cell.allowed_letters || null,
-            alphabet_type: cell.cell_type !== 'numbers' ? cell.alphabet_type : null,
-            language: 'ru',
-            padding_char: '0',
-            padding_side: cell.cell_type === 'numbers' ? cell.padding_side : null
-          }))
-        };
-        const response = await apiRequest(`/license-plate-formats/${format.format.id}`, {
-          method: "PUT",
-          body: JSON.stringify(formatData),
-        });
-        
-        if (response.ok) {
-          await this.refreshData();
-          this.showNotification("Формат по умолчанию успешно установлен", "success");
-        } else {
-          const errorText = await response.text();
-          this.showNotification(errorText || "Ошибка при установке формата по умолчанию", "error");
-        }
-      } catch (error) {
-        console.error("Error setting default format:", error);
-        this.showNotification("Ошибка сети", "error");
-      }
-    },
-    async clearDefaultFormats() {
-      try {
-        // Снимаем статус default со всех форматов
-        await apiRequest("/license-plate-formats/clear-default", {
-          method: "POST",
-        });
-      } catch (error) {
-        console.error("Error clearing default formats:", error);
-      }
-    },
-    async confirmDeleteFormat(format) {
-      if (!confirm(`Вы уверены, что хотите удалить формат "${format.name}"?`)) return;
-      
-      try {
-        const response = await apiRequest(`/license-plate-formats/${format.id}`, {
-          method: "DELETE",
-        });
-        
-        if (response.ok) {
-          this.selectedFormat = null;
-          await this.refreshData();
-          this.showNotification("Формат номеров успешно удален", "success");
-        } else {
-          const error = await response.json();
-          this.showNotification(error.message || "Ошибка при удалении формата", "error");
-        }
-      } catch (error) {
-        console.error("Error deleting license plate format:", error);
-        this.showNotification("Ошибка сети", "error");
-      }
-    },
-    selectFormat(format) {
-      this.selectedFormat = JSON.parse(JSON.stringify(format));
-    },
-    editCell(index) {
-      this.editingCellIndex = index;
-      this.editingCell = JSON.parse(JSON.stringify(this.selectedFormat.cells[index]));
-      this.showCellEditModal = true;
-    },
-    saveCellEdit() {
-      if (this.selectedFormat && this.editingCellIndex !== null) {
-        this.selectedFormat.cells[this.editingCellIndex] = this.editingCell;
-        this.updateFormat(this.selectedFormat);
-        this.showCellEditModal = false;
-        this.editingCellIndex = null;
-        this.editingCell = null;
-      }
+        const r = a.format.name.localeCompare(b.format.name);
+        return this.sortDirection === 'asc' ? r : -r;
+      });
     },
     sortBy(field) {
       if (this.sortField === field) {
@@ -934,80 +806,270 @@ export default {
         this.sortDirection = 'asc';
       }
     },
-    addCell() {
-      this.newFormat.cells.push({
-        cell_order: this.newFormat.cells.length,
-        cell_type: 'letters',
-        min_length: 1,
-        max_length: 1,
-        alphabet_type: 'cyrillic',
-        allowed_letters: '',
-        padding_side: 'left'
+    formatDate(s) {
+      if (!s) return '';
+      return new Date(s).toLocaleDateString('ru-RU', { day: '2-digit', month: '2-digit', year: 'numeric' });
+    },
+    // Поля, нерелевантные текущему типу клетки, обнуляются перед сравнением,
+    // чтобы скрытые значения не давали ложного dirty.
+    detailSnapshot(item) {
+      return JSON.stringify({
+        name: (item.format.name || '').trim(),
+        country_code: (item.format.country_code || '').trim(),
+        is_default: !!item.format.is_default,
+        cells: item.cells.map(c => ({
+          cell_type: c.cell_type,
+          min_length: c.min_length,
+          max_length: c.max_length,
+          allowed_letters: c.cell_type !== 'numbers' ? (c.allowed_letters || '') : '',
+          alphabet_type: c.cell_type !== 'numbers' ? (c.alphabet_type || 'cyrillic') : '',
+          padding_side: c.cell_type === 'numbers' ? (c.padding_side || 'left') : '',
+        })),
       });
+    },
+    // validateCells - дружелюбная проверка длин до отправки на сервер: иначе ошибка
+    // прилетела бы как сетевая 4xx без понятного пользователю текста.
+    validateCells(cells) {
+      for (let i = 0; i < cells.length; i += 1) {
+        const min = Number(cells[i].min_length);
+        const max = Number(cells[i].max_length);
+        if (!Number.isInteger(min) || !Number.isInteger(max) || min < 1 || max < 1) {
+          return `Клетка №${i + 1}: длина должна быть целым числом не меньше 1`;
+        }
+        if (min > max) {
+          return `Клетка №${i + 1}: мин. длина не может превышать макс.`;
+        }
+      }
+      return '';
+    },
+    buildCellPayload(cell, index, withId) {
+      const payload = {
+        cell_order: index,
+        cell_type: cell.cell_type,
+        min_length: cell.min_length,
+        max_length: cell.max_length,
+        allowed_letters: cell.cell_type !== 'numbers' ? (cell.allowed_letters || null) : null,
+        alphabet_type: cell.cell_type !== 'numbers' ? (cell.alphabet_type || 'cyrillic') : null,
+        language: 'ru',
+        padding_char: '0',
+        padding_side: cell.cell_type === 'numbers' ? (cell.padding_side || 'left') : null,
+      };
+      if (withId && cell.id) payload.id = cell.id;
+      return payload;
+    },
+    async refresh() {
+      this.isLoading = true;
+      try {
+        const res = await apiRequest('/license-plate-formats?include_archived=true');
+        if (!res.ok) throw new Error('fetch failed');
+        const data = await res.json();
+        this.formats = Array.isArray(data) ? data : [];
+        if (this.selectedFormat) {
+          const fresh = this.formats.find(f => f.format.id === this.selectedFormat.format.id);
+          const visible = fresh && (this.showArchive ? !fresh.format.is_active : fresh.format.is_active);
+          if (fresh && visible && !this.isDetailsDirty) {
+            this.applySelection(fresh);
+          } else if (!visible) {
+            this.selectedFormat = null;
+          }
+        }
+      } catch {
+        useDeletionsStore().notify({ prefix: 'Не удалось загрузить ', bold: 'форматы номеров', type: 'error' });
+      } finally {
+        this.isLoading = false;
+      }
+    },
+    applySelection(item) {
+      this.selectedFormat = JSON.parse(JSON.stringify(item));
+      this.originalSnapshot = this.detailSnapshot(this.selectedFormat);
+      this.detailError = '';
+    },
+    async onArchiveModeChange(value) {
+      if (this.isDetailsDirty && !(await confirmIfAnyDirty())) return;
+      this.showArchive = value === 'archive';
+      this.selectedFormat = null;
+      this.detailError = '';
+    },
+    async selectFormat(item) {
+      if (this.selectedFormat && this.selectedFormat.format.id === item.format.id) return;
+      if (this.isDetailsDirty && !(await confirmIfAnyDirty())) return;
+      this.applySelection(item);
+    },
+    async saveDetails() {
+      if (!this.isDetailsDirty || this.isSaving) return;
+      const f = this.selectedFormat;
+      const name = (f.format.name || '').trim();
+      if (!name) {
+        this.detailError = 'Введите название формата';
+        return;
+      }
+      const cellErr = this.validateCells(f.cells);
+      if (cellErr) {
+        this.detailError = cellErr;
+        return;
+      }
+      this.isSaving = true;
+      this.detailError = '';
+      try {
+        const body = {
+          name,
+          country_code: (f.format.country_code || '').trim() || null,
+          icon: f.format.icon || null,
+          is_default: !!f.format.is_default,
+          cells: f.cells.map((c, i) => this.buildCellPayload(c, i, true)),
+        };
+        const res = await apiRequest(`/license-plate-formats/${f.format.id}`, {
+          method: 'PUT',
+          body: JSON.stringify(body),
+        });
+        if (!res.ok) {
+          const err = await res.json();
+          throw new Error(err?.message || 'Ошибка сохранения');
+        }
+        useDeletionsStore().notify({ prefix: 'Изменения сохранены в ', bold: name });
+        await this.refresh();
+      } catch (e) {
+        this.detailError = e?.message || 'Не удалось сохранить';
+      } finally {
+        this.isSaving = false;
+      }
+    },
+    openAddModal() {
+      this.showAddModal = true;
+      this.addForm = { name: '', country_code: '', is_default: false, cells: [defaultCell()] };
+      this.addError = '';
+    },
+    async requestCloseAdd() {
+      if (this.isAddDirty && !(await confirmIfAnyDirty())) return;
+      this.forceCloseAdd();
+    },
+    forceCloseAdd() {
+      this.showAddModal = false;
+      this.addForm = { name: '', country_code: '', is_default: false, cells: [defaultCell()] };
+      this.addError = '';
+    },
+    addCell() {
+      this.addForm.cells.push(defaultCell());
     },
     removeCell(index) {
-      this.newFormat.cells.splice(index, 1);
-      // Обновляем порядок клеток
-      this.newFormat.cells.forEach((cell, idx) => {
-        cell.cell_order = idx;
-      });
+      this.addForm.cells.splice(index, 1);
+    },
+    async submitAdd() {
+      const name = this.addForm.name.trim();
+      if (!name || this.isAdding) return;
+      if (!this.addForm.cells.length) {
+        this.addError = 'Добавьте хотя бы одну клетку';
+        return;
+      }
+      const cellErr = this.validateCells(this.addForm.cells);
+      if (cellErr) {
+        this.addError = cellErr;
+        return;
+      }
+      this.isAdding = true;
+      this.addError = '';
+      try {
+        const body = {
+          name,
+          country_code: (this.addForm.country_code || '').trim() || null,
+          icon: null,
+          is_default: !!this.addForm.is_default,
+          cells: this.addForm.cells.map((c, i) => this.buildCellPayload(c, i, false)),
+        };
+        const res = await apiRequest('/license-plate-formats', {
+          method: 'POST',
+          body: JSON.stringify(body),
+        });
+        if (!res.ok) {
+          const err = await res.json();
+          throw new Error(err?.message || 'Ошибка создания');
+        }
+        useDeletionsStore().notify({ prefix: 'Формат ', bold: name, suffix: ' создан' });
+        this.forceCloseAdd();
+        await this.refresh();
+      } catch (e) {
+        this.addError = e?.message || 'Не удалось создать формат';
+      } finally {
+        this.isAdding = false;
+      }
+    },
+    editCell(index) {
+      if (!this.selectedFormat.format.is_active) return;
+      this.editingCellIndex = index;
+      this.editingCell = JSON.parse(JSON.stringify(this.selectedFormat.cells[index]));
+      this.cellEditError = '';
+      this.showCellEditModal = true;
+    },
+    saveCellEdit() {
+      if (this.editingCellIndex === null || !this.editingCell) return;
+      const err = this.validateCells([this.editingCell]);
+      if (err) {
+        this.cellEditError = err;
+        return;
+      }
+      this.selectedFormat.cells.splice(this.editingCellIndex, 1, this.editingCell);
+      this.showCellEditModal = false;
+      this.editingCellIndex = null;
+      this.editingCell = null;
+    },
+    onArchiveClick(item) {
+      this.archiveConfirmFormat = item.format;
+    },
+    async performArchive() {
+      const fmt = this.archiveConfirmFormat;
+      this.archiveConfirmFormat = null;
+      if (!fmt) return;
+      try {
+        const res = await apiRequest(`/license-plate-formats/${fmt.id}`, { method: 'DELETE' });
+        if (!res.ok) {
+          const err = await res.json();
+          throw new Error(err?.message || 'Ошибка архивации');
+        }
+        useDeletionsStore().notify({ prefix: 'Формат ', bold: fmt.name, suffix: ' архивирован' });
+        if (this.selectedFormat && this.selectedFormat.format.id === fmt.id && !this.showArchive) {
+          this.selectedFormat = null;
+        }
+        await this.refresh();
+      } catch (e) {
+        useDeletionsStore().notify({ prefix: 'Не удалось архивировать: ', bold: e?.message || 'ошибка', type: 'error' });
+      }
+    },
+    async onRestore(item) {
+      const fmt = item.format;
+      try {
+        const res = await apiRequest(`/license-plate-formats/${fmt.id}/restore`, { method: 'POST' });
+        if (!res.ok) {
+          const err = await res.json();
+          throw new Error(err?.message || 'Ошибка восстановления');
+        }
+        useDeletionsStore().notify({ prefix: 'Формат ', bold: fmt.name, suffix: ' восстановлен из архива' });
+        if (this.selectedFormat && this.selectedFormat.format.id === fmt.id && this.showArchive) {
+          this.selectedFormat = null;
+        }
+        await this.refresh();
+      } catch (e) {
+        useDeletionsStore().notify({ prefix: 'Не удалось восстановить: ', bold: e?.message || 'ошибка', type: 'error' });
+      }
     },
     getCellTypeLabel(type) {
-      const labels = {
-        'letters': 'Буквы',
-        'numbers': 'Цифры',
-        'mixed': 'Смешанный'
-      };
-      return labels[type] || type;
+      return CELL_TYPE_LABELS[type] || type;
     },
-    getFormatPreview(format) {
-      return format.cells.map(cell => {
-        if (cell.cell_type === 'numbers') {
-          return '0'.repeat(cell.max_length);
-        } else {
-          return 'A'.repeat(cell.max_length);
-        }
+    getFormatPreview(item) {
+      return item.cells.map((cell) => {
+        const len = cell.max_length || 1;
+        return cell.cell_type === 'numbers' ? '0'.repeat(len) : 'A'.repeat(len);
       }).join(' ');
     },
     getCellPreview(cell) {
-      if (cell.cell_type === 'numbers') {
-        return '0'.repeat(cell.max_length);
-      } else if (cell.allowed_letters) {
-        return cell.allowed_letters.charAt(0).repeat(cell.max_length);
-      } else {
-        return 'A'.repeat(cell.max_length);
-      }
+      const len = cell.max_length || 1;
+      if (cell.cell_type === 'numbers') return '0'.repeat(len);
+      if (cell.allowed_letters) return cell.allowed_letters.charAt(0).repeat(len);
+      return 'A'.repeat(len);
     },
     truncateLetters(letters, maxLength = 12) {
       if (!letters) return '';
-      return letters.length > maxLength ? letters.substring(0, maxLength) + '...' : letters;
+      return letters.length > maxLength ? `${letters.substring(0, maxLength)}...` : letters;
     },
-    showNotification(message, type = 'info') {
-      const notification = document.createElement('div');
-      notification.className = `notification ${type}`;
-      notification.textContent = message;
-      notification.style.cssText = `
-        position: fixed;
-        top: 20px;
-        right: 20px;
-        padding: 12px 20px;
-        border-radius: 8px;
-        color: white;
-        font-weight: 500;
-        z-index: 1000;
-      `;
-      
-      if (type === 'success') notification.style.backgroundColor = '#10b981';
-      if (type === 'error') notification.style.backgroundColor = '#ef4444';
-      if (type === 'warning') notification.style.backgroundColor = '#f59e0b';
-      if (type === 'info') notification.style.backgroundColor = '#3b82f6';
-      
-      document.body.appendChild(notification);
-      
-      setTimeout(() => {
-        notification.remove();
-      }, 3000);
-    }
   },
 };
 </script>
@@ -1018,8 +1080,6 @@ export default {
   border-radius: 16px;
   border: 1px solid #e6e6e6;
   overflow: hidden;
-  width: 100%;
-  height: 400px;
 }
 
 .management-header {
@@ -1029,19 +1089,24 @@ export default {
   padding: 0 20px;
   border-bottom: 1px solid #e6e6e6;
   height: 50px;
+  gap: 12px;
 }
 
 .management-title {
-  font-size: 1.2em;
   margin: 0;
+  font-size: 1.2em;
   font-weight: 600;
   color: #000;
 }
 
 .header-controls {
   display: flex;
+  gap: 10px;
   align-items: center;
-  gap: 12px;
+}
+
+.archive-dropdown {
+  min-width: 130px;
 }
 
 .add-header-button {
@@ -1053,9 +1118,6 @@ export default {
   cursor: pointer;
   font-size: 0.9em;
   transition: background-color 0.2s ease;
-  display: flex;
-  align-items: center;
-  gap: 6px;
   white-space: nowrap;
 }
 
@@ -1063,22 +1125,20 @@ export default {
   background: #3a45b2;
 }
 
+/* Master-detail layout (эталон TableConstructor / MarksManagement) */
 .content-container {
   display: flex;
-  height: 350px;
+  height: 500px;
   width: 100%;
+  overflow: hidden;
 }
 
-/* Левая часть - таблица */
 .table-section {
   width: 40%;
   display: flex;
   flex-direction: column;
   border-right: 1px solid #e6e6e6;
-}
-
-.table-section.with-details {
-  width: 40%;
+  background: #fff;
 }
 
 .table-container {
@@ -1107,13 +1167,17 @@ export default {
   display: flex;
   align-items: center;
   gap: 5px;
-  transition: .2s;
+  transition: 0.2s;
   cursor: pointer;
   user-select: none;
 }
 
+.header-col p {
+  margin: 0;
+}
+
 .header-col:hover {
-  color: #333;
+  color: #000;
 }
 
 .header-col:hover .sort-icon {
@@ -1123,7 +1187,7 @@ export default {
 .sort-icon {
   width: 12px;
   height: 12px;
-  transition: .2s;
+  transition: 0.2s;
 }
 
 .sort-icon.sorted {
@@ -1135,22 +1199,23 @@ export default {
 }
 
 .active-sort {
-  color: #333 !important;
+  color: #000 !important;
   font-weight: 600 !important;
 }
 
 .id-col {
-  width: 20%;
+  width: 25%;
   min-width: 60px;
 }
 
 .name-col {
-  width: 80%;
-  min-width: 250px;
+  width: 75%;
+  min-width: 160px;
 }
 
 .table-body {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
 }
 
@@ -1173,6 +1238,11 @@ export default {
   background-color: #f8f9ff;
 }
 
+.table-row.inactive {
+  background: #fafafa;
+  color: #6b7280;
+}
+
 .table-row:last-child {
   border-bottom: none;
 }
@@ -1191,6 +1261,10 @@ export default {
   color: #000;
 }
 
+.table-row.inactive .id-value {
+  color: #6b7280;
+}
+
 .truncate-text {
   white-space: nowrap;
   overflow: hidden;
@@ -1199,11 +1273,42 @@ export default {
   display: block;
 }
 
+.default-badge {
+  margin-left: 6px;
+  font-size: 0.7em;
+  padding: 1px 8px;
+  border-radius: 999px;
+  background: #e8eafe;
+  color: #4F5BDF;
+  font-weight: 600;
+  vertical-align: middle;
+}
+
+.inactive-badge {
+  margin-left: 6px;
+  font-size: 0.75em;
+  color: #a2a2a2;
+  font-style: italic;
+}
+
+.no-results {
+  text-align: center;
+  padding: 40px 20px;
+  color: #a2a2a2;
+  width: 100%;
+}
+
+.nf-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 0;
+}
+
 .table-footer {
-  margin-top: auto;
   padding: 6px 20px;
   border-top: 1px solid #e6e6e6;
-  text-align: end;
+  text-align: right;
   background: #f8fafc;
 }
 
@@ -1213,29 +1318,37 @@ export default {
   font-weight: 500;
 }
 
-/* Правая часть - детали */
+/* Details */
 .details-section {
   width: 60%;
-  padding: 15px;
-  overflow-y: auto;
-  background: #fafafa;
+  display: flex;
+  flex-direction: column;
+  background: #fff;
+  overflow: hidden;
 }
 
-.details-content {
-  height: 100%;
+.tab-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px;
+  background: #fff;
+  line-height: 1.5;
 }
 
 .details-header {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 15px;
+  margin-bottom: 20px;
+  gap: 12px;
 }
 
 .details-title-wrapper {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
+  flex-wrap: wrap;
+  min-width: 0;
 }
 
 .details-title {
@@ -1243,16 +1356,16 @@ export default {
   color: #000;
   font-size: 1.2em;
   font-weight: 600;
-  padding-bottom: 5px;
+  word-break: break-word;
 }
 
 .format-preview {
   font-family: monospace;
   font-size: 0.9em;
-  color: #666;
-  background: #fff;
-  padding: 4px 8px;
-  border-radius: 10px;
+  color: #475569;
+  background: #f8fafc;
+  padding: 4px 10px;
+  border-radius: 15px;
   border: 1px solid #e6e6e6;
 }
 
@@ -1260,40 +1373,51 @@ export default {
   display: flex;
   align-items: center;
   gap: 10px;
+  flex-shrink: 0;
 }
 
-.delete-icon-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
+.archive-badge {
+  background: #6b7280;
+  color: #fff;
+  padding: 4px 10px;
+  border-radius: 50px;
+  font-size: 0.75em;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.action-btn {
+  padding: 8px 16px;
   border: none;
-  background: none;
+  border-radius: 30px;
   cursor: pointer;
-  padding: 0;
-  transition: opacity 0.2s;
-  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  transition: background 0.2s;
+  white-space: nowrap;
 }
 
-.delete-icon-btn:hover {
-  background-color: #fee;
-  opacity: 0.8;
+.archive-action-btn {
+  background: #fff;
+  color: #dc3545;
+  border: 1px solid #fecaca;
 }
 
-.delete-icon {
-  width: 20px;
-  height: 20px;
+.archive-action-btn:hover {
+  background: #fff1f2;
+  border-color: #dc3545;
+}
+
+.restore-btn {
+  background: #10b981;
+  color: #fff;
+}
+
+.restore-btn:hover {
+  background: #0da271;
 }
 
 .details-body {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-/* Компактная форма */
-.compact-form {
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -1304,51 +1428,54 @@ export default {
   gap: 16px;
 }
 
-.form-group.compact {
+.field {
   display: flex;
   flex-direction: column;
   gap: 6px;
   flex: 1;
+  min-width: 0;
 }
 
-.detail-label {
+.field-full {
+  flex-basis: 100%;
+}
+
+.field-label {
   font-size: 0.85em;
-  color: #a2a2a2;
-  font-weight:400;
+  color: #666;
+  font-weight: 500;
 }
 
-.form-input-sm {
-  padding: 8px 12px;
-  border: 1px solid #e6e6e6;
-  border-radius: 10px;
-  font-size: 0.95em;
-  height: 35px;
-  transition: border-color 0.2s ease;
-  background: #fff;
-  width: 100%;
-}
-
-.form-input-sm:focus {
-  border-color: #4F5BDF;
-  outline: none;
+.field-hint {
+  font-size: 0.75em;
+  color: #999;
+  line-height: 1.3;
 }
 
 /* Чекбокс по умолчанию */
 .default-checkbox-section {
   display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 6px 12px;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px 14px;
   background: #f8f9ff;
   border-radius: 15px;
   border: 1px solid #e6e6e6;
+  cursor: pointer;
 }
 
-.default-checkbox-label {
-  display: flex;
-  align-items: center;
-  gap: 8px;
+.default-checkbox {
+  margin-top: 2px;
+  width: 16px;
+  height: 16px;
   cursor: pointer;
+  accent-color: #4F5BDF;
+}
+
+.default-checkbox-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 
 .default-checkbox-text {
@@ -1363,49 +1490,49 @@ export default {
   line-height: 1.4;
 }
 
-/* Горизонтальная секция клеток */
+/* Клетки в деталях */
 .cells-section {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-}
-
-.section-label {
-  font-size: 0.9em;
-  color: #666;
-  font-weight: 500;
+  gap: 10px;
 }
 
 .cells-horizontal {
   display: flex;
-  gap: 8px;
+  gap: 10px;
   flex-wrap: wrap;
-  padding-bottom: 15px;
 }
 
-.cell-horizontal-card {
+.cell-card {
+  text-align: left;
   background: #fff;
   border: 1px solid #e6e6e6;
-  border-radius: 20px;
-  padding: 10px;
+  border-radius: 15px;
+  padding: 10px 12px;
   transition: all 0.2s ease;
   cursor: pointer;
-  min-width: 230px;
+  min-width: 200px;
   max-width: 230px;
   flex: 1;
+  font: inherit;
 }
 
-.cell-horizontal-card:hover {
+.cell-card:hover:not(:disabled) {
   border-color: #4F5BDF;
   box-shadow: 0 2px 4px rgba(79, 91, 223, 0.1);
   background: #f8f9ff;
 }
 
-.cell-horizontal-header {
+.cell-card:disabled {
+  cursor: default;
+  opacity: 0.7;
+}
+
+.cell-card-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 4px;
+  margin-bottom: 6px;
 }
 
 .cell-badge {
@@ -1416,8 +1543,8 @@ export default {
 
 .cell-type-badge {
   font-size: 0.7em;
-  padding: 2px 6px;
-  border-radius: 4px;
+  padding: 2px 8px;
+  border-radius: 999px;
   font-weight: 500;
 }
 
@@ -1427,8 +1554,8 @@ export default {
 }
 
 .cell-type-badge.numbers {
-  background: #f0fdf4;
-  color: #166534;
+  background: #d1fae5;
+  color: #059669;
 }
 
 .cell-type-badge.mixed {
@@ -1436,10 +1563,10 @@ export default {
   color: #92400e;
 }
 
-.cell-horizontal-details {
+.cell-card-details {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 3px;
   font-size: 0.8em;
 }
 
@@ -1451,10 +1578,9 @@ export default {
 .cell-letters {
   font-family: monospace;
   background: #f8fafc;
-  padding: 2px 4px;
+  padding: 2px 6px;
   border-radius: 10px;
   color: #475569;
-  font-size: 0.8em;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1462,7 +1588,23 @@ export default {
 
 .cell-padding {
   color: #666;
-  font-size: 0.8em;
+}
+
+.details-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.details-meta {
+  display: flex;
+  gap: 16px;
+  font-size: 12px;
+  color: #a2a2a2;
+}
+
+.form-error {
+  color: #d73a3a;
+  font-size: 0.85em;
 }
 
 .no-selection-message {
@@ -1475,25 +1617,7 @@ export default {
   font-size: 14px;
 }
 
-.no-results {
-  text-align: center;
-  padding: 40px 20px;
-  color: #a2a2a2;
-  width: 100%;
-}
-
-.no-results-icon {
-  font-size: 3em;
-  margin-bottom: 16px;
-  opacity: 0.5;
-}
-
-.no-results p {
-  margin: 0;
-  font-size: 1.1em;
-}
-
-/* ГОРИЗОНТАЛЬНОЕ МОДАЛЬНОЕ ОКНО */
+/* Модалки */
 .modal-overlay {
   position: fixed;
   top: 0;
@@ -1510,9 +1634,10 @@ export default {
   -webkit-backdrop-filter: blur(0.1px);
 }
 
-.horizontal-modal {
+.nf-modal {
   width: 100%;
-  max-height: 350px;
+  max-width: 680px;
+  max-height: 88vh;
   display: flex;
   flex-direction: column;
   background: #fff;
@@ -1521,13 +1646,16 @@ export default {
   overflow: hidden;
 }
 
+.nf-modal--narrow {
+  max-width: 460px;
+}
+
 .modal-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 12px 16px;
+  padding: 18px 24px;
   border-bottom: 1px solid #e6e6e6;
-  background: #fff;
   flex-shrink: 0;
 }
 
@@ -1539,486 +1667,214 @@ export default {
 }
 
 .modal-close {
-  background: none;
-  border: none;
-  font-size: 18px;
-  cursor: pointer;
-  color: #999;
-  padding: 0;
-  width: 24px;
-  height: 24px;
+  width: 30px;
+  height: 30px;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: color 0.2s;
+  font-size: 24px;
+  line-height: 1;
+  color: #999;
+  background: none;
+  border: none;
+  cursor: pointer;
+  border-radius: 50%;
+  transition: all 0.2s;
 }
 
 .modal-close:hover {
   color: #333;
+  background: #f5f5f5;
 }
 
-.modal-body-horizontal {
-  display: flex;
-  flex: 1;
-  overflow: hidden;
-  padding: 0;
-}
-
-/* Левая часть - основная информация */
-.modal-main-info {
-  width: 30%;
-  padding: 16px;
-  border-right: 1px solid #e6e6e6;
-  background: #fafafa;
+.modal-body {
+  padding: 22px 24px;
   display: flex;
   flex-direction: column;
+  gap: 16px;
+  overflow-y: auto;
 }
 
-.main-fields {
+.modal-footer {
   display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.form-group-compact {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.form-label-compact {
-  font-size: 0.8em;
-  color: #666;
-  font-weight: 500;
-}
-
-.input-compact {
-  padding: 8px 10px;
-  border: 1px solid #e6e6e6;
-  border-radius: 6px;
-  font-size: 0.85em;
-  background: #fff;
-  transition: border-color 0.2s;
-  height: 28px;
-}
-
-.input-compact:focus {
-  border-color: #4F5BDF;
-  outline: none;
-}
-
-.form-row-horizontal {
-  display: flex;
+  justify-content: flex-end;
   gap: 10px;
-}
-
-.form-row-horizontal .form-group-compact {
-  flex: 1;
-}
-
-/* Чекбокс по умолчанию в модальном окне */
-.default-checkbox-modal {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 12px;
-  background: #f8f9ff;
-  border-radius: 8px;
-  border: 1px solid #e6e6e6;
-}
-
-.default-checkbox-label-modal {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  cursor: pointer;
-}
-
-.default-checkbox-text-modal {
-  font-size: 0.85em;
-  font-weight: 500;
-  color: #333;
-}
-
-.default-checkbox-hint-modal {
-  font-size: 0.75em;
-  color: #666;
-  line-height: 1.4;
-}
-
-/* Правая часть - клетки */
-.modal-cells-section {
-  width: 70%;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-}
-
-.cells-header-compact {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 12px 16px;
-  border-bottom: 1px solid #e6e6e6;
-  background: #fff;
+  padding: 16px 24px;
+  border-top: 1px solid #e6e6e6;
   flex-shrink: 0;
 }
 
-.cells-title-compact {
-  margin: 0;
-  font-size: 1em;
-  font-weight: 600;
-  color: #333;
-}
-
-.add-cell-btn-header {
-  padding: 6px 12px;
-  background: #4F5BDF;
-  color: white;
-  border: none;
-  border-radius: 6px;
-  cursor: pointer;
-  font-size: 0.8em;
-  font-weight: 500;
-  transition: background-color 0.2s ease;
-  white-space: nowrap;
-}
-
-.add-cell-btn-header:hover {
-  background: #3a45b2;
-}
-
-.cells-scroll-container {
-  flex: 1;
-  overflow-y: auto;
-  padding: 12px;
-  min-height: 175px;
-  max-height: 175px;
-}
-
-.cells-grid-compact {
+/* Редактор клеток в модалке */
+.cells-edit-section {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  align-content: start;
+  gap: 10px;
 }
 
-.cell-card-compact {
-  background: #f8f9fa;
-  border: 1px solid #e6e6e6;
-  border-radius: 8px;
-  padding: 10px;
-  min-height: 140px;
-}
-
-.cell-header-mini {
+.cells-edit-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 8px;
-  padding-bottom: 6px;
-  border-bottom: 1px solid #e6e6e6;
 }
 
-.cell-number-mini {
+.cells-edit-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.cell-edit-card {
+  background: #f8f9fa;
+  border: 1px solid #e6e6e6;
+  border-radius: 15px;
+  padding: 12px;
+}
+
+.cell-edit-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.cell-number {
   font-size: 0.8em;
   font-weight: 600;
   color: #333;
 }
 
-.remove-cell-btn-mini {
-  background: #ef4444;
-  color: white;
-  border: none;
-  border-radius: 3px;
-  width: 16px;
-  height: 16px;
+.cell-remove-btn {
+  background: #fff;
+  color: #dc3545;
+  border: 1px solid #fecaca;
+  border-radius: 50%;
+  width: 22px;
+  height: 22px;
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  font-size: 10px;
+  font-size: 14px;
   line-height: 1;
-  transition: background-color 0.2s;
+  transition: all 0.2s;
 }
 
-.remove-cell-btn-mini:hover {
-  background: #dc2626;
+.cell-remove-btn:hover {
+  background: #fff1f2;
+  border-color: #dc3545;
 }
 
-.cell-config-mini {
+.cell-edit-fields {
   display: flex;
   flex-wrap: wrap;
-  gap: 15px;
-  row-gap: 5px;
+  gap: 12px;
 }
 
-.config-group-mini {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
+.cell-edit-fields .field {
+  flex: 1;
+  min-width: 130px;
 }
 
-.config-group-mini label {
-  font-size: 0.7em;
-  color: #666;
-  font-weight: 500;
+.length-field {
+  flex: 0 0 auto;
 }
 
-.select-mini {
-  padding: 5px 8px;
-  border: 1px solid #e6e6e6;
-  border-radius: 4px;
-  font-size: 0.75em;
-  background: #fff;
-  height: 28px;
-  width: 300px;
-}
-
-.length-controls-mini {
+.length-controls {
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: 6px;
 }
 
-.input-micro {
-  width: 45px;
-  padding: 5px;
-  border: 1px solid #e6e6e6;
-  border-radius: 4px;
-  font-size: 0.75em;
+.length-input {
+  width: 64px;
   text-align: center;
-  height: 28px;
 }
 
 .length-dash {
   color: #666;
   font-weight: 500;
-  margin: 0 2px;
-  font-size: 0.8em;
 }
 
-.config-group-full-mini {
+.add-cell-btn {
+  padding: 6px 14px;
+  font-size: 12px;
+}
+
+.cell-preview {
   display: flex;
-  flex-direction: column;
-  gap: 3px;
-}
-
-.config-group-full-mini label {
-  font-size: 0.7em;
-  color: #666;
-  font-weight: 500;
-}
-
-.select-mini:focus,
-.input-micro:focus,
-.input-compact:focus {
-  border-color: #4F5BDF;
-  outline: none;
-}
-
-/* Футер модального окна */
-.modal-footer {
-  display: flex;
-  justify-content: flex-end;
+  align-items: center;
   gap: 10px;
-  padding: 12px 16px;
-  border-top: 1px solid #e6e6e6;
-  background: #fff;
-  flex-shrink: 0;
-}
-
-.modal-cancel {
-  padding: 8px 16px;
-  background: #f8f9fa;
-  color: #666;
-  border: 1px solid #e6e6e6;
-  border-radius: 6px;
-  cursor: pointer;
-  font-size: 0.85em;
-  font-weight: 500;
-  transition: all 0.2s ease;
-}
-
-.modal-cancel:hover {
-  background: #e9ecef;
-}
-
-.modal-confirm {
-  padding: 8px 16px;
-  background: #4F5BDF;
-  color: white;
-  border: none;
-  border-radius: 6px;
-  cursor: pointer;
-  font-size: 0.85em;
-  font-weight: 600;
-  transition: background-color 0.2s ease;
-}
-
-.modal-confirm:hover {
-  background: #3a45b2;
-}
-
-/* СТИЛИ ДЛЯ МОДАЛЬНОГО ОКНА РЕДАКТИРОВАНИЯ КЛЕТКИ */
-.cell-edit-modal {
-  max-height: 320px;
-}
-
-.cell-edit-details {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  padding: 8px 0;
-}
-
-.form-hint {
-  font-size: 0.7em;
-  color: #999;
-  margin-top: 4px;
-  line-height: 1.3;
-}
-
-.cell-preview-section {
+  padding: 12px 14px;
   background: #f8f9ff;
   border: 1px solid #e6e6e6;
-  border-radius: 8px;
-  padding: 12px;
+  border-radius: 15px;
 }
 
-.preview-title {
-  margin: 0 0 8px 0;
-  font-size: 0.85em;
-  font-weight: 600;
-  color: #333;
+.cell-preview-label {
+  font-size: 0.8em;
+  color: #666;
+  font-weight: 500;
 }
 
-.preview-content {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.preview-example {
+.cell-preview-value {
   font-family: monospace;
-  font-size: 1.2em;
+  font-size: 1.1em;
   font-weight: 600;
   color: #4F5BDF;
-  text-align: center;
-  padding: 8px;
-  background: #fff;
-  border-radius: 6px;
-  border: 1px solid #e6e6e6;
 }
 
-.preview-info {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+/* Анимация открытия/закрытия */
+.modal-fade-enter-active,
+.modal-fade-leave-active {
+  transition: all 0.25s ease;
 }
 
-.preview-length,
-.preview-letters {
-  font-size: 0.75em;
-  color: #666;
+.modal-fade-enter-active .nf-modal,
+.modal-fade-leave-active .nf-modal {
+  transition: all 0.25s ease;
 }
 
-/* Адаптивность */
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+  background: rgba(0, 0, 0, 0);
+}
+
+.modal-fade-enter-from .nf-modal,
+.modal-fade-leave-to .nf-modal {
+  opacity: 0;
+  transform: translateY(20px);
+}
+
 @media (max-width: 768px) {
-  .content-container {
-    flex-direction: column;
-    height: auto;
-  }
-  
-  .table-section,
-  .details-section,
-  .no-selection-message {
-    width: 100% !important;
-  }
-  
-  .table-section.with-details {
-    border-right: none;
-    border-bottom: 1px solid #e6e6e6;
-    height: 255px;
-  }
-  
-  .horizontal-modal {
-    max-height: 80vh;
-  }
-  
-  .modal-body-horizontal {
-    flex-direction: column;
-  }
-  
-  .modal-main-info,
-  .modal-cells-section {
-    width: 100%;
-  }
-  
-  .modal-main-info {
-    border-right: none;
-    border-bottom: 1px solid #e6e6e6;
-    padding: 12px;
-  }
-  
-  .cells-grid-compact {
-    grid-template-columns: 1fr;
-  }
-
-  .cell-edit-modal {
-    width: 95%;
-    margin: 10px;
-  }
-
-  .form-row-horizontal {
-    flex-direction: column;
-    gap: 12px;
-  }
-}
-
-@media (max-width: 480px) {
   .management-header {
     flex-direction: column;
     align-items: flex-start;
-    gap: 12px;
     height: auto;
     padding: 16px;
   }
-  
   .header-controls {
     width: 100%;
     flex-direction: column;
     align-items: stretch;
   }
-  
-  .add-header-button {
-    justify-content: center;
-  }
-  
-  .cells-horizontal {
+  .content-container {
     flex-direction: column;
+    height: auto;
   }
-  
-  .cell-horizontal-card {
-    min-width: auto;
+  .table-section,
+  .details-section,
+  .no-selection-message {
+    width: 100%;
   }
-  
-  .cells-header-compact {
+  .table-section {
+    border-right: none;
+    border-bottom: 1px solid #e6e6e6;
+  }
+  .table-body {
+    max-height: 300px;
+  }
+  .form-row {
     flex-direction: column;
-    gap: 8px;
-    align-items: stretch;
-  }
-  
-  .add-cell-btn-header {
-    align-self: flex-end;
-  }
-
-  .cell-edit-modal .modal-body {
-    padding: 16px;
-  }
-
-  .cell-edit-details {
-    gap: 12px;
   }
 }
 </style>


### PR DESCRIPTION
Срез 414-3 эпика #406. Привёл `NumberFormat.vue` (управление форматами номерных знаков) к UI-эталону `TableConstructor`/`MarksManagement`. Бэкенд (архив + история) уже смержен в #469/#471 — здесь только фронт.

## Что сделано
- **Архив**: переключатель «Активные/Архив» через `BaseDropdown`, загрузка с `?include_archived=true`, фильтрация на клиенте, бейдж `(архив)` + серый стиль на архивных строках, кнопки «В архив»/«Восстановить» в шапке деталей.
- **Уведомления**: самодельный DOM-toast заменён на `useDeletionsStore.notify()` с конкретными формулировками («Формат X создан/архивирован/восстановлен»).
- **Подтверждение**: `ConfirmationModal` вместо браузерного `confirm()` при архивации.
- **Модалки** (добавление формата, редактирование клетки): `<Teleport>`, анимация открытия/закрытия (`modal-fade`), закрытие по overlay через `useOverlayClose` и по Escape, корневой radius 30px, инпуты/селекты 15px (`lk-input`/`lk-select`), кнопки `lk-button`.
- **Защита изменений**: `registerDirtyTracker` на форму добавления и редактирование деталей; детали сохраняются явной кнопкой «Сохранить» (раньше был авто-сейв на `@change`).
- **Убрал** вызов несуществующего `POST /license-plate-formats/clear-default` — бэкенд сам снимает прежний дефолт в Create/Update (транзакционно).

## Ревью (code-reviewer) — обработка находок
- **Y1 (валидация длин)** — добавил `validateCells`: блокирует сохранение при `min>max` или длине < 1 с понятным текстом (в форме добавления, деталях и модалке клетки).
- **Y3 (`lk-button--sm`)** — переименовал локальный модификатор в `.add-cell-btn`, чтобы не маскировать под глобальный lk-вариант.
- **Y4 (мёртвый `.with-details`)** — убрал неиспользуемый binding и dead CSS.
- **N1** — подчистил комментарий.
- **R1 (кнопки «В архив»/«Восстановить» не `lk-button`)** — осознанно оставил как в эталоне `MarksManagement` (детальная шапка использует те же `.action-btn`-классы; `.archive-action-btn` визуально совпадает с `lk-button--danger` по токенам). Дивергенция сделала бы компонент непохожим на утверждённый эталон.
- **Y2 (dirty не покрывает открытую модалку клетки)** — модалка клетки транзиентная, закрытие = discard (как у любой вложенной модалки); по «Применить» изменения попадают в `selectedFormat.cells` и уже отслеживаются. Принято осознанно.

## Проверки
- `npm run test:run` — 344 теста зелёные; `vite build` зелёный; `eslint` чистый.
- Локальный рендер (Playwright): master-detail layout соответствует эталону, обе модалки открываются с анимацией и закрываются по Escape/overlay, **0 console-ошибок**.
- API round-trip через эндпоинты фронта на свежем бэкенде: create -> DELETE даёт soft-archive (`is_active=false`, отфильтрован из активных) -> restore возвращает в активные. История сохранена.

## Не входит в срез
- 414-4: модалка истории `LicensePlateFormatHistoryModal` + кнопка «История» + ExcelJS — отдельный срез.

Связано с #406. Бэкенд-контракт: #469, #471.