### PR TITLE
feat(blacklist): добавление машины в ЧС из карточки Т/С (#443)

### DIFF
--- a/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
@@ -15,25 +15,42 @@
             @mousedown.stop
           >
             <div class="modal-header">
-              <h3 class="modal-title">
-                {{ modalTitle }}
-              </h3>
+              <div class="modal-title-row">
+                <h3 class="modal-title">
+                  {{ modalTitle }}
+                </h3>
+                <span
+                  v-if="isBlacklisted"
+                  class="blacklist-plashka"
+                  :title="blacklistReason || 'В чёрном списке'"
+                >
+                  В ЧС
+                </span>
+              </div>
               <div
-                v-if="showCarFeatures"
+                v-if="showCarFeatures || (canManageBlacklist && hasVehicleIdentity)"
                 class="header-actions"
               >
                 <button
+                  v-if="showCarFeatures"
                   class="history-btn"
                   @click="openCarHistory"
                 >
                   <span>Полная история</span>
                 </button>
                 <button
-                  v-if="source !== 'application'"
+                  v-if="showCarFeatures && source !== 'application'"
                   class="application-btn"
                   @click="openApplication"
                 >
                   <span>Открыть заявку</span>
+                </button>
+                <button
+                  v-if="canManageBlacklist && hasVehicleIdentity && !isBlacklisted"
+                  class="blacklist-add-btn"
+                  @click="openAddBlacklist"
+                >
+                  <span>Добавить в ЧС</span>
                 </button>
               </div>
               <button
@@ -319,6 +336,16 @@
     :current-user-name="currentUserName"
     @close="showCarHistoryModal = false"
   />
+
+  <AddToBlacklistModal
+    :show="showAddBlacklist"
+    type="vehicle"
+    :entity-label="vehicleLabel"
+    :saving="savingBlacklist"
+    :error="blacklistError"
+    @close="closeAddBlacklist"
+    @confirm="submitAddBlacklist"
+  />
 </template>
 
 <script>
@@ -326,7 +353,12 @@ import { apiRequest } from '@/api/client'
 import UnloadPlaceModal from './UnloadPlaceModal.vue';
 import CarHistoryModal from '../CarHistoryModal.vue';
 import LoaderSpinner from '@/components/ui/LoaderSpinner.vue';
+import AddToBlacklistModal from '@/components/admin/blacklist/AddToBlacklistModal.vue';
 import { useOverlayClose } from '@/composables/useOverlayClose';
+import { usePermissionsStore } from '@/stores/permissions';
+import { useDeletionsStore } from '@/stores/deletions';
+import { listVehicleBlacklist, createVehicleBlacklist } from '@/api/blacklist';
+import { listMarks } from '@/api/marks';
 import ExcelJS from 'exceljs';
 
 export default {
@@ -334,7 +366,8 @@ export default {
     components: {
         UnloadPlaceModal,
         CarHistoryModal,
-        LoaderSpinner
+        LoaderSpinner,
+        AddToBlacklistModal
     },
     props: {
         show: {
@@ -390,7 +423,12 @@ export default {
             isExporting: false,
             showCarHistoryModal: false,
             entryChecked: false,
-            exitChecked: false
+            exitChecked: false,
+            isBlacklisted: false,
+            blacklistReason: '',
+            showAddBlacklist: false,
+            savingBlacklist: false,
+            blacklistError: ''
         }
     },
     computed: {
@@ -420,6 +458,23 @@ export default {
         // Только события въезда/выезда
         entryExitHistory() {
             return this.history.filter(item => item.action_type === 'entry' || item.action_type === 'exit');
+        },
+        canManageBlacklist() {
+            return usePermissionsStore().hasPermission('page.admin.blacklist');
+        },
+        vehicleNumber() {
+            return (this.vehicle?.plateNumber || this.vehicle?.car_number || '').trim();
+        },
+        vehicleMark() {
+            return (this.vehicle?.mark || this.vehicle?.car_brand || '').trim();
+        },
+        vehicleLabel() {
+            return [this.vehicleNumber, this.vehicleMark].filter(Boolean).join(' ');
+        },
+        // Добавить в ЧС можно только реальную машину с номером и маркой (не "по факту").
+        hasVehicleIdentity() {
+            const n = this.vehicleNumber.toLowerCase();
+            return !!this.vehicleNumber && !!this.vehicleMark && n !== 'по факту';
         }
     },
     watch: {
@@ -428,6 +483,7 @@ export default {
             handler(newVal) {
                 if (newVal) {
                     this.loadCarStatus();
+                    this.checkBlacklist();
                     if (this.showCarFeatures && this.vehicle?.id) {
                         this.loadCarHistory();
                     }
@@ -445,9 +501,12 @@ export default {
         vehicle: {
             deep: true,
             handler(newVal) {
-                if (newVal && this.show && this.showCarFeatures) {
-                    this.loadCarStatus();
-                    this.loadCarHistory();
+                if (newVal && this.show) {
+                    this.checkBlacklist();
+                    if (this.showCarFeatures) {
+                        this.loadCarStatus();
+                        this.loadCarHistory();
+                    }
                 }
             }
         }
@@ -467,6 +526,62 @@ export default {
             }
             this.isMainShifted = false;
             this.selectedUnloadPlace = null;
+        },
+
+        // Статус ЧС: матч активного списка по номеру+марке (зеркалит серверный CheckByName).
+        async checkBlacklist() {
+            this.isBlacklisted = false;
+            this.blacklistReason = '';
+            if (!this.hasVehicleIdentity) return;
+            try {
+                const list = await listVehicleBlacklist();
+                const arr = Array.isArray(list) ? list : [];
+                const key = (n, m) => `${(n || '').trim().toLowerCase()}|${(m || '').trim().toLowerCase()}`;
+                const want = key(this.vehicleNumber, this.vehicleMark);
+                const hit = arr.find((e) => key(e.car_number, e.mark_name) === want);
+                if (hit) {
+                    this.isBlacklisted = true;
+                    this.blacklistReason = hit.reason || '';
+                }
+            } catch {
+                // Молча: статус ЧС - вспомогательная плашка, не критична для карточки.
+            }
+        },
+
+        openAddBlacklist() {
+            this.blacklistError = '';
+            this.showAddBlacklist = true;
+        },
+
+        closeAddBlacklist() {
+            if (this.savingBlacklist) return;
+            this.showAddBlacklist = false;
+        },
+
+        async submitAddBlacklist(reason) {
+            if (this.savingBlacklist) return;
+            this.savingBlacklist = true;
+            this.blacklistError = '';
+            try {
+                // includeArchived: марка машины могла быть заархивирована, но как ключ
+                // для создания записи ЧС она валидна (сервер резолвит mark_id без фильтра).
+                const marks = await listMarks({ includeArchived: true });
+                const arr = Array.isArray(marks) ? marks : [];
+                const mark = arr.find((m) => (m.name || '').trim().toLowerCase() === this.vehicleMark.toLowerCase());
+                if (!mark) {
+                    this.blacklistError = `Марка "${this.vehicleMark}" не найдена в справочнике. Добавьте через раздел Чёрный список.`;
+                    return;
+                }
+                await createVehicleBlacklist({ car_number: this.vehicleNumber, mark_id: mark.id, reason });
+                this.isBlacklisted = true;
+                this.blacklistReason = reason;
+                this.showAddBlacklist = false;
+                useDeletionsStore().notify({ prefix: 'Машина ', bold: this.vehicleLabel, suffix: ' добавлена в чёрный список' });
+            } catch (e) {
+                this.blacklistError = e?.message || 'Не удалось добавить в чёрный список';
+            } finally {
+                this.savingBlacklist = false;
+            }
         },
 
         showUnloadPlaceDetails(placeId) {
@@ -936,6 +1051,43 @@ export default {
 .history-btn:hover, .application-btn:hover {
   background: #f5f5f5;
   border-color: #4F5BDF;
+}
+
+.blacklist-add-btn {
+  padding: 6px 12px;
+  background: white;
+  border: 1px solid #fecaca;
+  border-radius: 20px;
+  font-size: 12px;
+  color: #dc2626;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+  white-space: nowrap;
+}
+
+.blacklist-add-btn:hover {
+  background: #fee2e2;
+  border-color: #dc2626;
+}
+
+.modal-title-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.blacklist-plashka {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  background: #fee2e2;
+  color: #991b1b;
+  border: 1px solid #fecaca;
+  white-space: nowrap;
 }
 
 .modal-title {

--- a/frontend/src/components/admin/blacklist/AddToBlacklistModal.vue
+++ b/frontend/src/components/admin/blacklist/AddToBlacklistModal.vue
@@ -1,0 +1,145 @@
+<template>
+  <BaseModal
+    :show="show"
+    :title="title"
+    width="480px"
+    :z-index="zIndex"
+    @close="close"
+  >
+    <div class="atb">
+      <div class="atb-entity">
+        <span class="atb-entity-label">{{ entityCaption }}</span>
+        <span class="atb-entity-value">{{ entityLabel }}</span>
+      </div>
+
+      <FormField
+        label="Причина"
+        :required="true"
+      >
+        <textarea
+          ref="reasonInput"
+          v-model="reason"
+          class="lk-textarea"
+          rows="3"
+          placeholder="Опишите причину добавления в чёрный список"
+        />
+      </FormField>
+
+      <div
+        v-if="error"
+        class="atb-error"
+      >
+        {{ error }}
+      </div>
+    </div>
+
+    <template #actions>
+      <button
+        class="lk-button lk-button--ghost"
+        :disabled="saving"
+        @click="close"
+      >
+        Отмена
+      </button>
+      <button
+        class="lk-button lk-button--danger"
+        :disabled="!reason.trim() || saving"
+        @click="confirm"
+      >
+        {{ saving ? 'Добавление...' : 'Добавить в ЧС' }}
+      </button>
+    </template>
+  </BaseModal>
+</template>
+
+<script>
+import BaseModal from '@/components/ui/BaseModal.vue';
+import FormField from '@/components/ui/FormField.vue';
+
+/**
+ * Модалка-подтверждение добавления в чёрный список из карточки сущности (#443).
+ * Сущность уже известна (показывается read-only), оператору остаётся ввести причину.
+ * Само создание (резолв mark_id для машин, вызов API) - на стороне родителя: модалка
+ * только собирает причину и эмитит confirm(reason). error/saving контролирует родитель.
+ */
+export default {
+  name: 'AddToBlacklistModal',
+  components: { BaseModal, FormField },
+  props: {
+    show: { type: Boolean, default: false },
+    type: { type: String, required: true, validator: (v) => ['vehicle', 'person'].includes(v) },
+    entityLabel: { type: String, default: '' },
+    saving: { type: Boolean, default: false },
+    error: { type: String, default: '' },
+    // Открывается из карточки Т/С/сотрудника (z-index 10001) - перекрываем её. Ниже
+    // DirtyConfirmModal (11000).
+    zIndex: { type: Number, default: 10500 },
+  },
+  emits: ['close', 'confirm'],
+  data() {
+    return { reason: '' };
+  },
+  computed: {
+    title() {
+      return this.type === 'vehicle' ? 'Добавить машину в чёрный список' : 'Добавить человека в чёрный список';
+    },
+    entityCaption() {
+      return this.type === 'vehicle' ? 'Машина' : 'Человек';
+    },
+  },
+  watch: {
+    show(open) {
+      if (open) {
+        this.reason = '';
+        this.$nextTick(() => this.$refs.reasonInput?.focus());
+      }
+    },
+  },
+  methods: {
+    close() {
+      if (this.saving) return;
+      this.$emit('close');
+    },
+    confirm() {
+      const reason = this.reason.trim();
+      if (!reason || this.saving) return;
+      this.$emit('confirm', reason);
+    },
+  },
+};
+</script>
+
+<style scoped>
+.atb {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.atb-entity {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 10px 14px;
+  background: var(--color-bg, #f8f9ff);
+  border-radius: var(--radius-md, 15px);
+}
+
+.atb-entity-label {
+  font-size: 12px;
+  color: var(--color-text-muted, #999);
+}
+
+.atb-entity-value {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--color-text, #333);
+  word-break: break-word;
+}
+
+.atb-error {
+  color: var(--color-danger, #dc3545);
+  font-size: 13px;
+}
+</style>

--- a/frontend/src/components/admin/blacklist/__tests__/AddToBlacklistModal.spec.js
+++ b/frontend/src/components/admin/blacklist/__tests__/AddToBlacklistModal.spec.js
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import AddToBlacklistModal from '../AddToBlacklistModal.vue';
+
+// BaseModal рендерит через Teleport - стабим, чтобы контент был в обёртке для запросов.
+const stubs = {
+  BaseModal: { template: '<div class="base-modal"><slot /><slot name="actions" /></div>' },
+  FormField: { template: '<div class="form-field"><slot /></div>' },
+};
+
+function mountModal(props = {}) {
+  return mount(AddToBlacklistModal, {
+    props: { show: true, type: 'vehicle', entityLabel: 'А777АА777 BMW', ...props },
+    global: { stubs },
+  });
+}
+
+describe('AddToBlacklistModal', () => {
+  it('заголовок и подпись зависят от типа', () => {
+    const veh = mountModal({ type: 'vehicle' });
+    expect(veh.vm.title).toBe('Добавить машину в чёрный список');
+    expect(veh.vm.entityCaption).toBe('Машина');
+    const per = mountModal({ type: 'person', entityLabel: 'Иванов Иван' });
+    expect(per.vm.title).toBe('Добавить человека в чёрный список');
+    expect(per.vm.entityCaption).toBe('Человек');
+  });
+
+  it('показывает entityLabel', () => {
+    const wrapper = mountModal({ entityLabel: 'А777АА777 BMW' });
+    expect(wrapper.text()).toContain('А777АА777 BMW');
+  });
+
+  it('кнопка добавления заблокирована без причины', async () => {
+    const wrapper = mountModal();
+    const addBtn = wrapper.findAll('button').find((b) => b.text().includes('Добавить'));
+    expect(addBtn.attributes('disabled')).toBeDefined();
+    await wrapper.find('textarea').setValue('угон');
+    expect(addBtn.attributes('disabled')).toBeUndefined();
+  });
+
+  it('confirm эмитит trimmed причину', async () => {
+    const wrapper = mountModal();
+    await wrapper.find('textarea').setValue('  нарушение режима  ');
+    await wrapper.findAll('button').find((b) => b.text().includes('Добавить')).trigger('click');
+    expect(wrapper.emitted('confirm')).toBeTruthy();
+    expect(wrapper.emitted('confirm')[0]).toEqual(['нарушение режима']);
+  });
+
+  it('не эмитит confirm и close при saving', async () => {
+    const wrapper = mountModal({ saving: true });
+    await wrapper.find('textarea').setValue('причина');
+    wrapper.vm.confirm();
+    wrapper.vm.close();
+    expect(wrapper.emitted('confirm')).toBeFalsy();
+    expect(wrapper.emitted('close')).toBeFalsy();
+  });
+
+  it('сбрасывает причину при повторном открытии', async () => {
+    const wrapper = mountModal({ show: false });
+    await wrapper.setProps({ show: true });
+    wrapper.vm.reason = 'старое';
+    await wrapper.setProps({ show: false });
+    await wrapper.setProps({ show: true });
+    expect(wrapper.vm.reason).toBe('');
+  });
+});

--- a/frontend/src/components/ui/BaseModal.vue
+++ b/frontend/src/components/ui/BaseModal.vue
@@ -4,6 +4,7 @@
       <div
         v-if="show"
         class="base-modal-overlay"
+        :style="{ zIndex }"
         @mousedown="handleOverlayMousedown"
         @mouseup="handleOverlayMouseup"
       >
@@ -80,6 +81,12 @@ export default {
       type: String,
       default: '',
     },
+    // z-index оверлея. Дефолт 1000 (базовый слой модалок). Поднимать, когда модалка
+    // открывается ПОВЕРХ другой модалки с высоким z-index (напр. из карточки Т/С).
+    zIndex: {
+      type: Number,
+      default: 1000,
+    },
   },
   emits: ['close'],
   data() {
@@ -155,7 +162,7 @@ export default {
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1000;
+  /* z-index задаётся через prop zIndex (:style), дефолт 1000 - базовый слой модалок. */
   backdrop-filter: blur(0.1px);
   -webkit-backdrop-filter: blur(0.1px);
 }

--- a/frontend/src/generated/permission-keys.json
+++ b/frontend/src/generated/permission-keys.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-06-08T09:53:25.669Z",
+  "generated": "2026-06-08T11:06:22.736Z",
   "keys": [
     "action.delete.employee",
     "permission.audit.manage"


### PR DESCRIPTION
## Что

Срез P5a эпика ЧС (#443). В карточке Т/С (`VehicleDetailsModal`, используется в /table, ApplicationDetail, форме создания):

- **Плашка «В ЧС»** у заголовка, если машина в активном чёрном списке. Статус - матч активного списка по номеру + имени марки (зеркалит серверный `CheckByName`).
- **Кнопка «Добавить в ЧС»** (по праву `page.admin.blacklist`, только для реальной машины с номером и маркой, не «по факту», и не уже-в-ЧС). Открывает компактную модалку причины (сущность read-only), резолвит mark_id из `/marks` по имени (включая архивные марки) и создаёт запись. После добавления - плашка обновляется, кнопка скрывается, уведомление.
- Новая общая `AddToBlacklistModal` (причина + показ сущности) - будет переиспользована для людей (P5b).
- `BaseModal`: добавлен опциональный проп `zIndex` (дефолт 1000, обратносовместимо). Нужен, т.к. карточка Т/С имеет `z-index: 10001` и модалка причины на дефолтном 1000 уходила под неё.

## Проверка
- eslint, vitest 350 (+ `AddToBlacklistModal.spec.js`, 6 кейсов), build.
- Локально через Playwright (полный флоу через карточку Т/С): кнопка -> модалка причины поверх карточки -> подтверждение -> плашка «В ЧС», кнопка скрыта.

## Заметки
- Уведомление об успехе (стек z-9999) перекрывается оверлеем карточки (10001) - это давний z-index карточки; основное подтверждение - плашка в самой карточке.
- P5b (то же для `EmployeeDetailsModal`) - отдельный следующий срез, переиспользует `AddToBlacklistModal`.