### PR TITLE
feat(number-format): история форматов номеров - модалка с timeline и Excel (#414)

### DIFF
--- a/frontend/src/api/licenseFormats.js
+++ b/frontend/src/api/licenseFormats.js
@@ -1,0 +1,11 @@
+import { apiRequest } from './client';
+
+// apiRequest разворачивает envelope, поэтому res.json() даёт уже сам массив истории.
+// res.ok проверяем явно: на 4xx wrapJsonUnwrap вернул бы {message}, а не массив,
+// и без throw модалка молча показала бы "История пуста" вместо ошибки.
+
+export async function getLicenseFormatHistory(id) {
+  const res = await apiRequest(`/license-plate-formats/${id}/history`);
+  if (!res.ok) throw new Error('Не удалось загрузить историю формата');
+  return res.json();
+}

--- a/frontend/src/components/LicensePlateFormatHistoryModal.vue
+++ b/frontend/src/components/LicensePlateFormatHistoryModal.vue
@@ -1,0 +1,1052 @@
+<template>
+  <Teleport to="body">
+    <div
+      class="modal-overlay"
+      data-testid="lpf-history-modal"
+      @mousedown="onOverlayMousedown"
+      @mouseup="onOverlayMouseup"
+    >
+      <div
+        class="lpf-history-modal"
+        @mousedown.stop
+      >
+        <div class="modal-header">
+          <h3>История формата «{{ format.name }}»</h3>
+          <div class="header-actions">
+            <button
+              class="export-btn"
+              :disabled="filteredHistory.length === 0 || isExporting"
+              @click="exportToExcel"
+            >
+              <img
+                v-if="!isExporting"
+                src="@/assets/icons/export.png"
+                class="export-icon"
+              >
+              <span v-if="!isExporting">Экспорт</span>
+              <div
+                v-else
+                class="export-loader"
+              />
+            </button>
+            <button
+              class="close-btn"
+              aria-label="Закрыть"
+              @click="close"
+            >
+              ×
+            </button>
+          </div>
+        </div>
+
+        <div class="history-filters">
+          <div class="filter-row">
+            <div class="search-filter">
+              <span class="filter-label">Поиск:</span>
+              <input
+                v-model="searchQuery"
+                type="text"
+                class="search-input"
+                placeholder="Поиск по пользователю, действию..."
+              >
+            </div>
+
+            <div class="user-filter">
+              <span class="filter-label">Пользователь:</span>
+              <!-- Кастомный select, не BaseDropdown: повторяет фильтр-строку эталона
+                   SystemTableHistoryModal (32px-контролы поиск/период/сортировка в ряд). -->
+              <div
+                class="custom-select"
+                @click="toggleUserDropdown"
+              >
+                <div class="select-trigger">
+                  <span class="selected-value">{{ selectedUserName }}</span>
+                  <img
+                    src="@/assets/icons/arrow.png"
+                    class="select-arrow"
+                    :class="{ 'arrow-open': userDropdownOpen }"
+                  >
+                </div>
+                <transition name="fade">
+                  <div
+                    v-if="userDropdownOpen"
+                    class="select-dropdown"
+                  >
+                    <div
+                      class="select-option"
+                      :class="{ 'selected': selectedUserId === null }"
+                      @click.stop="selectUser(null)"
+                    >
+                      Все пользователи
+                    </div>
+                    <div
+                      v-for="user in uniqueUsers"
+                      :key="user.id"
+                      class="select-option"
+                      :class="{ 'selected': selectedUserId === user.id }"
+                      @click.stop="selectUser(user.id)"
+                    >
+                      {{ user.name }}
+                    </div>
+                  </div>
+                </transition>
+              </div>
+            </div>
+
+            <div class="date-filter">
+              <span class="filter-label">Период:</span>
+              <input
+                v-model="dateFrom"
+                type="date"
+                class="date-input"
+              >
+              <span class="date-separator">-</span>
+              <input
+                v-model="dateTo"
+                type="date"
+                class="date-input"
+              >
+            </div>
+
+            <div class="sort-filter">
+              <span class="filter-label">Сортировка:</span>
+              <button
+                class="sort-btn"
+                @click="toggleSortOrder"
+              >
+                <img
+                  src="@/assets/icons/sort.png"
+                  class="sort-icon"
+                  :class="{ 'sort-asc': sortOrder === 'asc' }"
+                >
+                <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div class="modal-content">
+          <div
+            v-if="loading"
+            class="history-loading"
+          >
+            <LoaderSpinner label="Загрузка истории..." />
+          </div>
+
+          <div
+            v-else-if="filteredHistory.length === 0"
+            class="history-empty"
+          >
+            История пуста
+          </div>
+
+          <div
+            v-else
+            class="history-timeline"
+          >
+            <div
+              v-for="(item, index) in displayHistory"
+              :key="item.id"
+              class="history-item"
+            >
+              <div
+                class="timeline-dot"
+                :class="getActionClass(item.action_type)"
+              />
+              <div
+                v-if="index < displayHistory.length - 1"
+                class="timeline-line"
+              />
+
+              <div class="history-content">
+                <div class="history-header">
+                  <span class="user-name">{{ item.actor_name || 'Система' }}</span>
+                  <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                </div>
+
+                <div class="action-text">
+                  {{ getActionText(item) }}
+                </div>
+
+                <div
+                  v-if="item.changes.length"
+                  class="change-list"
+                >
+                  <div
+                    v-for="(change, ci) in item.changes"
+                    :key="ci"
+                    class="change-row"
+                  >
+                    <span class="change-label">{{ change.label }}:</span>
+                    <template v-if="change.kind === 'single'">
+                      <span class="change-new">{{ change.value }}</span>
+                    </template>
+                    <template v-else>
+                      <span class="change-old">{{ change.old }}</span>
+                      <span class="change-arrow">→</span>
+                      <span class="change-new">{{ change.new }}</span>
+                    </template>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script>
+import { getLicenseFormatHistory } from '@/api/licenseFormats';
+import { useDeletionsStore } from '@/stores/deletions';
+import { useOverlayClose } from '@/composables/useOverlayClose';
+import LoaderSpinner from './ui/LoaderSpinner.vue';
+import ExcelJS from 'exceljs';
+
+const ACTION_TEXTS = {
+  created: 'Формат создан',
+  updated: 'Изменены данные формата',
+  archived: 'Формат архивирован',
+  restored: 'Формат восстановлен из архива',
+};
+
+const ACTION_DOT_CLASS = {
+  created: 'dot-create',
+  updated: 'dot-update',
+  archived: 'dot-deactivate',
+  restored: 'dot-activate',
+};
+
+// Порядок и подписи полей формата для diff в истории (см. backend buildFormatUpdateDetails).
+const FIELD_LABELS = {
+  name: 'Наименование',
+  country_code: 'Код страны',
+  icon: 'Иконка',
+  is_default: 'По умолчанию',
+  cells: 'Клетки формата',
+};
+const FIELD_ORDER = ['name', 'country_code', 'icon', 'is_default', 'cells'];
+
+const CELL_TYPE_LABELS = {
+  letters: 'Буквы',
+  numbers: 'Цифры',
+  mixed: 'Смеш.',
+};
+
+// formatCell - короткая человекочитаемая подпись одной ячейки для diff истории.
+function formatCell(c) {
+  const type = CELL_TYPE_LABELS[c.cell_type] || c.cell_type;
+  const min = c.min_length ?? '?';
+  const max = c.max_length ?? '?';
+  let s = `№${(c.cell_order ?? 0) + 1} ${type} ${min}-${max}`;
+  if (c.cell_type !== 'numbers' && c.allowed_letters) {
+    s += ` [${c.allowed_letters}]`;
+  }
+  if (c.cell_type === 'numbers' && c.padding_side) {
+    s += ` (доп. ${c.padding_side === 'left' ? 'слева' : 'справа'})`;
+  }
+  return s;
+}
+
+// formatCells - собирает массив снапшотов ячеек в строку, отсортированную по порядку.
+function formatCells(cells) {
+  if (!Array.isArray(cells) || cells.length === 0) return '—';
+  return [...cells]
+    .sort((a, b) => (a.cell_order ?? 0) - (b.cell_order ?? 0))
+    .map(formatCell)
+    .join('; ');
+}
+
+function emptyOr(value) {
+  return value === '' || value === null || value === undefined ? '—' : String(value);
+}
+
+export default {
+  name: 'LicensePlateFormatHistoryModal',
+  components: { LoaderSpinner },
+  props: {
+    format: { type: Object, required: true },
+    currentUserName: { type: String, default: '' },
+  },
+  emits: ['close'],
+  setup(_, { emit }) {
+    const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(() => emit('close'));
+    return { onOverlayMousedown, onOverlayMouseup };
+  },
+  data() {
+    return {
+      loading: false,
+      history: [],
+      sortOrder: 'desc',
+      searchQuery: '',
+      selectedUserId: null,
+      dateFrom: '',
+      dateTo: '',
+      userDropdownOpen: false,
+      isExporting: false,
+    };
+  },
+  computed: {
+    uniqueUsers() {
+      const users = new Map();
+      this.history.forEach((item) => {
+        if (item.actor_user_id && !users.has(item.actor_user_id)) {
+          users.set(item.actor_user_id, {
+            id: item.actor_user_id,
+            name: item.actor_name || 'Система',
+          });
+        }
+      });
+      return Array.from(users.values()).sort((a, b) => a.name.localeCompare(b.name));
+    },
+
+    selectedUserName() {
+      if (this.selectedUserId === null) return 'Все пользователи';
+      const user = this.uniqueUsers.find((u) => u.id === this.selectedUserId);
+      return user ? user.name : 'Все пользователи';
+    },
+
+    filteredHistory() {
+      let filtered = [...this.history];
+
+      if (this.searchQuery && this.searchQuery.trim() !== '') {
+        const query = this.searchQuery.toLowerCase().trim();
+        filtered = filtered.filter((item) => {
+          const userName = (item.actor_name || '').toLowerCase();
+          const actionText = this.getActionText(item).toLowerCase();
+          const changes = this.getChangesText(item).toLowerCase();
+          return userName.includes(query)
+            || actionText.includes(query)
+            || changes.includes(query);
+        });
+      }
+
+      if (this.selectedUserId) {
+        filtered = filtered.filter((item) => item.actor_user_id === this.selectedUserId);
+      }
+
+      if (this.dateFrom) {
+        const fromDate = new Date(this.dateFrom);
+        fromDate.setHours(0, 0, 0, 0);
+        filtered = filtered.filter((item) => new Date(item.created_at) >= fromDate);
+      }
+
+      if (this.dateTo) {
+        const toDate = new Date(this.dateTo);
+        toDate.setHours(23, 59, 59, 999);
+        filtered = filtered.filter((item) => new Date(item.created_at) <= toDate);
+      }
+
+      return filtered.sort((a, b) => {
+        const timeA = new Date(a.created_at).getTime();
+        const timeB = new Date(b.created_at).getTime();
+        return this.sortOrder === 'desc' ? timeB - timeA : timeA - timeB;
+      });
+    },
+
+    // Предвычисляем changes один раз на запись - иначе getChanges дёргался бы в
+    // шаблоне дважды на item (v-if + v-for).
+    displayHistory() {
+      return this.filteredHistory.map((item) => ({ ...item, changes: this.getChanges(item) }));
+    },
+
+    formattedCurrentDateTime() {
+      const now = new Date();
+      return now.toLocaleString('ru-RU', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+      }).replace(',', '');
+    },
+
+    currentUserDisplayName() {
+      if (!this.currentUserName) return 'Пользователь';
+      const parts = this.currentUserName.split(' ').filter((p) => p && p !== 'null' && p !== 'undefined');
+      return parts.length > 0 ? parts.join(' ') : 'Пользователь';
+    },
+
+    safeFormatName() {
+      const name = this.format.name || `id_${this.format.id}`;
+      return name.replace(/[\\/:"*?<>|]/g, '_').replace(/\s+/g, '_');
+    },
+
+    exportData() {
+      return this.filteredHistory.map((item) => ({
+        'Дата и время': this.formatDateTime(item.created_at),
+        'Пользователь': item.actor_name || 'Система',
+        'Действие': this.getActionText(item),
+        'Детали': this.getChangesText(item),
+        'Тип действия': item.action_type,
+        'ID записи': item.id,
+      }));
+    },
+  },
+  mounted() {
+    this.loadHistory();
+    document.addEventListener('click', this.handleClickOutside);
+    document.addEventListener('keydown', this.onKeydown);
+  },
+  beforeUnmount() {
+    document.removeEventListener('click', this.handleClickOutside);
+    document.removeEventListener('keydown', this.onKeydown);
+  },
+  methods: {
+    onKeydown(e) {
+      if (e.key === 'Escape') this.close();
+    },
+    close() {
+      this.$emit('close');
+    },
+    handleClickOutside(event) {
+      const select = this.$el && this.$el.querySelector ? this.$el.querySelector('.custom-select') : null;
+      if (select && !select.contains(event.target)) {
+        this.userDropdownOpen = false;
+      }
+    },
+
+    async loadHistory() {
+      this.loading = true;
+      try {
+        const data = await getLicenseFormatHistory(this.format.id);
+        this.history = Array.isArray(data) ? data : [];
+      } catch (error) {
+        console.error('Error loading license plate format history:', error);
+        useDeletionsStore().notify({ prefix: 'Не удалось загрузить ', bold: 'историю формата', type: 'error' });
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    getActionClass(actionType) {
+      return ACTION_DOT_CLASS[actionType] || 'dot-default';
+    },
+
+    getActionText(item) {
+      return ACTION_TEXTS[item.action_type] || item.action_type;
+    },
+
+    /**
+     * Структурированные изменения для timeline. created - исходное имя;
+     * updated - diff {old, new} по каждому изменённому полю (клетки сводятся
+     * в короткую подпись); архив/восстановление деталей не имеют.
+     */
+    getChanges(item) {
+      const d = item.details;
+      if (!d || typeof d !== 'object') return [];
+
+      if (item.action_type === 'created') {
+        if (!d.name) return [];
+        return [{ label: FIELD_LABELS.name, kind: 'single', value: d.name }];
+      }
+
+      if (item.action_type !== 'updated') return [];
+
+      const changes = [];
+      FIELD_ORDER.forEach((field) => {
+        const diff = d[field];
+        if (!diff || typeof diff !== 'object') return;
+        if (field === 'cells') {
+          changes.push({
+            label: FIELD_LABELS.cells,
+            old: formatCells(diff.old),
+            new: formatCells(diff.new),
+          });
+        } else if (field === 'is_default') {
+          changes.push({
+            label: FIELD_LABELS.is_default,
+            old: diff.old ? 'Да' : 'Нет',
+            new: diff.new ? 'Да' : 'Нет',
+          });
+        } else {
+          changes.push({
+            label: FIELD_LABELS[field],
+            old: emptyOr(diff.old),
+            new: emptyOr(diff.new),
+          });
+        }
+      });
+      return changes;
+    },
+
+    // getChangesText - плоский текст изменений для поиска и Excel-экспорта.
+    getChangesText(item) {
+      return this.getChanges(item)
+        .map((c) => (c.kind === 'single' ? `${c.label}: ${c.value}` : `${c.label}: ${c.old} → ${c.new}`))
+        .join('; ');
+    },
+
+    formatDateTime(s) {
+      if (!s) return '';
+      const d = new Date(s);
+      return d.toLocaleString('ru-RU', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+      }).replace(',', '');
+    },
+
+    toggleSortOrder() {
+      this.sortOrder = this.sortOrder === 'desc' ? 'asc' : 'desc';
+    },
+
+    toggleUserDropdown() {
+      this.userDropdownOpen = !this.userDropdownOpen;
+    },
+
+    selectUser(userId) {
+      this.selectedUserId = userId;
+      this.userDropdownOpen = false;
+    },
+
+    async exportToExcel() {
+      if (this.filteredHistory.length === 0) return;
+      this.isExporting = true;
+      try {
+        const workbook = new ExcelJS.Workbook();
+        const worksheet = workbook.addWorksheet(`Istoriya_${this.safeFormatName}`);
+
+        const headers = ['Дата и время', 'Пользователь', 'Действие', 'Детали', 'Тип действия', 'ID записи'];
+        const headerRow = worksheet.addRow(headers);
+        headerRow.height = 25;
+        headerRow.eachCell((cell) => {
+          cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FF4F5BDF' } };
+          cell.font = { name: 'Verdana', size: 11, bold: true, color: { argb: 'FFFFFFFF' } };
+          cell.alignment = { vertical: 'middle', horizontal: 'center' };
+          cell.border = {
+            top: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+            bottom: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+            left: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+            right: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+          };
+        });
+
+        this.exportData.forEach((item, index) => {
+          const row = worksheet.addRow([
+            item['Дата и время'],
+            item['Пользователь'],
+            item['Действие'],
+            item['Детали'],
+            item['Тип действия'],
+            item['ID записи'],
+          ]);
+          row.height = 20;
+          const fillColor = index % 2 === 0 ? 'FFF0F5FF' : 'FFE0E9FF';
+          row.eachCell((cell) => {
+            cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: fillColor } };
+            cell.font = { name: 'Verdana', size: 9, color: { argb: 'FF333333' } };
+            cell.alignment = { vertical: 'middle', wrapText: true };
+            cell.border = {
+              top: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+              bottom: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+              left: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+              right: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+            };
+          });
+        });
+
+        const lastDataRow = this.exportData.length;
+        const cols = headers.length;
+        for (let row = 1; row <= lastDataRow + 1; row++) {
+          const rightCell = worksheet.getCell(row, cols);
+          rightCell.border = { ...rightCell.border, right: { style: 'medium', color: { argb: 'FF000000' } } };
+          const leftCell = worksheet.getCell(row, 1);
+          leftCell.border = { ...leftCell.border, left: { style: 'medium', color: { argb: 'FF000000' } } };
+        }
+        for (let col = 1; col <= cols; col++) {
+          const topCell = worksheet.getCell(1, col);
+          topCell.border = { ...topCell.border, top: { style: 'medium', color: { argb: 'FF000000' } } };
+          const bottomCell = worksheet.getCell(lastDataRow + 1, col);
+          bottomCell.border = { ...bottomCell.border, bottom: { style: 'medium', color: { argb: 'FF000000' } } };
+        }
+
+        worksheet.addRow([]);
+        const infoRow1 = worksheet.addRow(['Отчёт сформировал:', this.currentUserDisplayName]);
+        const infoRow2 = worksheet.addRow(['Дата формирования:', this.formattedCurrentDateTime]);
+        [infoRow1, infoRow2].forEach((row) => {
+          row.eachCell((cell) => {
+            cell.font = { name: 'Verdana', size: 10, color: { argb: 'FF333333' } };
+            cell.alignment = { vertical: 'middle' };
+            cell.border = {
+              top: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+              bottom: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+              left: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+              right: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+            };
+          });
+        });
+
+        worksheet.columns = [
+          { width: 22 },
+          { width: 30 },
+          { width: 30 },
+          { width: 60 },
+          { width: 22 },
+          { width: 12 },
+        ];
+
+        const buffer = await workbook.xlsx.writeBuffer();
+        const blob = new Blob([buffer], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.download = `Istoriya_formata_${this.safeFormatName}_${this.formattedCurrentDateTime.replace(/[.:,]/g, '-')}.xlsx`;
+        a.href = url;
+        a.click();
+        window.URL.revokeObjectURL(url);
+      } catch (error) {
+        console.error('Error exporting license plate format history to Excel:', error);
+        useDeletionsStore().notify({ prefix: 'Не удалось ', bold: 'выгрузить историю', type: 'error' });
+      } finally {
+        this.isExporting = false;
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 12000;
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
+  animation: fadeIn 0.2s ease-out;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.lpf-history-modal {
+  background: white;
+  border-radius: 30px;
+  width: 900px;
+  max-width: 95%;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+  animation: slideUp 0.2s ease-out;
+}
+
+@keyframes slideUp {
+  from { transform: translateY(20px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 15px 25px;
+  border-bottom: 1px solid #e6e6e6;
+}
+
+.modal-header h3 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: #333;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.export-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 6px 16px;
+  background: white;
+  border: 1px solid #e6e6e6;
+  border-radius: 20px;
+  font-size: 13px;
+  color: #000;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  height: 32px;
+}
+
+.export-btn:hover:not(:disabled) {
+  background: #f5f5f5;
+  border-color: #4F5BDF;
+}
+
+.export-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.export-icon {
+  width: 14px;
+  height: 14px;
+}
+
+.export-loader {
+  width: 16px;
+  height: 16px;
+  border: 2px solid #e6e6e6;
+  border-top: 2px solid #4F5BDF;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  font-size: 24px;
+  color: #a2a2a2;
+  cursor: pointer;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  transition: all 0.2s ease;
+}
+
+.close-btn:hover {
+  background: #f5f5f5;
+  color: #333;
+}
+
+.history-filters {
+  padding: 15px 25px;
+  border-bottom: 1px solid #e6e6e6;
+  background-color: #fafafa;
+}
+
+.filter-row {
+  display: flex;
+  gap: 15px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.search-filter,
+.user-filter,
+.date-filter,
+.sort-filter {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.filter-label {
+  font-size: 12px;
+  color: #a2a2a2;
+  white-space: nowrap;
+}
+
+.search-input {
+  padding: 6px 12px;
+  border: 1px solid #e6e6e6;
+  border-radius: 15px;
+  font-size: 12px;
+  width: 200px;
+  height: 32px;
+  transition: all 0.2s ease;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: #4F5BDF;
+  box-shadow: 0 0 0 3px rgba(79, 91, 223, 0.1);
+}
+
+.custom-select {
+  position: relative;
+  width: 200px;
+  cursor: pointer;
+}
+
+.select-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 12px;
+  background: white;
+  border: 1px solid #e6e6e6;
+  border-radius: 15px;
+  transition: all 0.2s ease;
+  height: 32px;
+}
+
+.select-trigger:hover {
+  border-color: #4F5BDF;
+  background: #f5f5f5;
+}
+
+.selected-value {
+  font-size: 12px;
+  color: #000;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+}
+
+.select-arrow {
+  width: 8px;
+  height: 8px;
+  transition: transform 0.2s ease;
+}
+
+.select-arrow.arrow-open {
+  transform: rotate(90deg);
+}
+
+.fade-enter-active, .fade-leave-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.fade-enter-from, .fade-leave-to {
+  opacity: 0;
+  transform: translateY(-10px);
+}
+
+.select-dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  max-height: 300px;
+  overflow-y: auto;
+  background: white;
+  border: 1px solid #e6e6e6;
+  border-radius: 15px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  z-index: 1000;
+}
+
+.select-option {
+  padding: 10px 14px;
+  font-size: 12px;
+  color: #000;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.select-option:hover {
+  background-color: #f0f3ff;
+}
+
+.select-option.selected {
+  background-color: #f0f3ff;
+  font-weight: 500;
+}
+
+.date-input {
+  padding: 6px 8px;
+  border: 1px solid #e6e6e6;
+  border-radius: 15px;
+  font-size: 12px;
+  width: 120px;
+  height: 32px;
+}
+
+.date-separator {
+  color: #a2a2a2;
+  font-size: 12px;
+}
+
+.sort-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  background: white;
+  border: 1px solid #e6e6e6;
+  border-radius: 20px;
+  font-size: 12px;
+  color: #000;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  height: 32px;
+  width: 170px;
+}
+
+.sort-btn:hover {
+  background: #f5f5f5;
+  border-color: #4F5BDF;
+}
+
+.sort-icon {
+  width: 14px;
+  height: 14px;
+  transition: transform 0.2s ease;
+}
+
+.sort-icon.sort-asc {
+  transform: rotate(180deg);
+}
+
+.modal-content {
+  padding: 20px 25px;
+  overflow-y: auto;
+  max-height: calc(80vh - 180px);
+  position: relative;
+}
+
+.history-loading,
+.history-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px;
+  color: #a2a2a2;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.history-timeline {
+  position: relative;
+  padding-left: 20px;
+  min-height: 100px;
+}
+
+.history-item {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 20px;
+  position: relative;
+}
+
+.history-item:last-child {
+  margin-bottom: 0;
+}
+
+.timeline-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  margin-top: 4px;
+  z-index: 1;
+  position: relative;
+}
+
+.timeline-line {
+  position: absolute;
+  left: 4px;
+  top: 18px;
+  width: 2px;
+  height: calc(100% + 2px);
+  background: #e6e6e6;
+}
+
+.dot-create { background: #4F5BDF; }
+.dot-update { background: #f59e0b; }
+.dot-activate { background: #10b981; }
+.dot-deactivate { background: #6b7280; }
+.dot-default { background: #9ca3af; }
+
+.history-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.history-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 4px;
+}
+
+.user-name {
+  font-weight: 500;
+  color: #333;
+  font-size: 13px;
+}
+
+.action-time {
+  color: #a2a2a2;
+  font-size: 11px;
+}
+
+.action-text {
+  color: #666;
+  font-size: 12px;
+  margin-bottom: 2px;
+}
+
+.change-list {
+  margin-top: 6px;
+  padding-left: 6px;
+  border-left: 2px solid #e6e6e6;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.change-row {
+  font-size: 11px;
+  color: #666;
+  line-height: 1.5;
+  word-break: break-word;
+}
+
+.change-label {
+  font-weight: 500;
+  color: #555;
+  margin-right: 4px;
+}
+
+.change-old {
+  color: #b91c1c;
+}
+
+.change-arrow {
+  color: #a2a2a2;
+  margin: 0 4px;
+}
+
+.change-new {
+  color: #15803d;
+}
+
+@media (max-width: 768px) {
+  .filter-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .search-filter,
+  .user-filter,
+  .date-filter,
+  .sort-filter {
+    width: 100%;
+  }
+  .custom-select,
+  .search-input,
+  .date-input,
+  .sort-btn {
+    width: 100%;
+  }
+  .date-input {
+    width: calc(50% - 20px);
+  }
+}
+</style>

--- a/frontend/src/components/NumberFormat.vue
+++ b/frontend/src/components/NumberFormat.vue
@@ -139,6 +139,13 @@
                 class="archive-badge"
               >В архиве</span>
               <button
+                class="action-btn history-btn"
+                data-testid="nf-history"
+                @click="openHistory(selectedFormat)"
+              >
+                История
+              </button>
+              <button
                 v-if="selectedFormat.format.is_active"
                 class="action-btn archive-action-btn"
                 data-testid="nf-archive"
@@ -649,6 +656,13 @@
       @confirm="performArchive"
       @cancel="archiveConfirmFormat = null"
     />
+
+    <LicensePlateFormatHistoryModal
+      v-if="historyForFormat"
+      :format="historyForFormat"
+      :current-user-name="currentUserName"
+      @close="historyForFormat = null"
+    />
   </div>
 </template>
 
@@ -658,6 +672,7 @@ import RefreshButton from './RefreshButton.vue';
 import ConfirmationModal from './ConfirmationModal.vue';
 import BaseDropdown from './ui/BaseDropdown.vue';
 import LoaderSpinner from './ui/LoaderSpinner.vue';
+import LicensePlateFormatHistoryModal from './LicensePlateFormatHistoryModal.vue';
 import { useDeletionsStore } from '@/stores/deletions';
 import { registerDirtyTracker, confirmIfAnyDirty } from '@/utils/dirtyTracker';
 import { useOverlayClose } from '@/composables/useOverlayClose';
@@ -683,7 +698,7 @@ const CELL_TYPE_LABELS = {
 
 export default {
   name: 'NumberFormat',
-  components: { SearchComponent, RefreshButton, ConfirmationModal, BaseDropdown, LoaderSpinner },
+  components: { SearchComponent, RefreshButton, ConfirmationModal, BaseDropdown, LoaderSpinner, LicensePlateFormatHistoryModal },
   setup() {
     // Колбэки закрытия присваиваются в created - нужен доступ к this (проверка dirty).
     const addOverlay = { close: () => {} };
@@ -720,6 +735,8 @@ export default {
       editingCell: null,
       cellEditError: '',
       archiveConfirmFormat: null,
+      historyForFormat: null,
+      currentUserName: '',
       archiveOptions: [
         { label: 'Активные', value: 'active' },
         { label: 'Архив', value: 'archive' },
@@ -761,6 +778,7 @@ export default {
   },
   mounted() {
     this.refresh();
+    this.fetchCurrentUser();
     this._stopGuard = registerDirtyTracker({
       isDirty: () => this.isDirty,
       getChanges: () => {
@@ -1049,6 +1067,21 @@ export default {
         await this.refresh();
       } catch (e) {
         useDeletionsStore().notify({ prefix: 'Не удалось восстановить: ', bold: e?.message || 'ошибка', type: 'error' });
+      }
+    },
+    openHistory(item) {
+      this.historyForFormat = item.format;
+    },
+    async fetchCurrentUser() {
+      // Имя нужно для футера Excel-экспорта истории ("Отчёт сформировал").
+      try {
+        const res = await apiRequest('/users/me');
+        if (!res.ok) return;
+        const u = await res.json();
+        const parts = [u.last_name, u.first_name, u.middle_name].filter(Boolean);
+        this.currentUserName = parts.join(' ') || u.username || '';
+      } catch {
+        // Имя - необязательная деталь экспорта, молчим (footer покажет дефолт).
       }
     },
     getCellTypeLabel(type) {
@@ -1395,6 +1428,16 @@ export default {
   font-weight: 500;
   transition: background 0.2s;
   white-space: nowrap;
+}
+
+.history-btn {
+  background: #fff;
+  color: #4F5BDF;
+  border: 1px solid #4F5BDF;
+}
+
+.history-btn:hover {
+  background: #eef0ff;
 }
 
 .archive-action-btn {

--- a/frontend/src/components/__tests__/LicensePlateFormatHistoryModal.spec.js
+++ b/frontend/src/components/__tests__/LicensePlateFormatHistoryModal.spec.js
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+
+const getLicenseFormatHistory = vi.fn();
+vi.mock('@/api/licenseFormats', () => ({
+  getLicenseFormatHistory: (...args) => getLicenseFormatHistory(...args),
+}));
+// exceljs тяжёлый и нужен только для экспорта - экспорт здесь не тестируем.
+vi.mock('exceljs', () => ({ default: { Workbook: class {} } }));
+
+import LicensePlateFormatHistoryModal from '../LicensePlateFormatHistoryModal.vue';
+
+async function mountWith(history) {
+  getLicenseFormatHistory.mockResolvedValue(history);
+  const wrapper = mount(LicensePlateFormatHistoryModal, {
+    props: {
+      format: { id: 7, name: 'Российские номера' },
+      currentUserName: 'Иванов Иван',
+    },
+    global: { stubs: { teleport: true } },
+    attachTo: document.body,
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+function entry(over = {}) {
+  return {
+    id: 1,
+    action_type: 'created',
+    details: { name: 'Российские номера' },
+    actor_user_id: 3,
+    actor_name: 'Петров П.П.',
+    created_at: '2026-05-01T10:00:00Z',
+    ...over,
+  };
+}
+
+describe('LicensePlateFormatHistoryModal', () => {
+  beforeEach(() => {
+    getLicenseFormatHistory.mockReset();
+    document.body.innerHTML = '';
+  });
+
+  it('created: "Формат создан" + "Наименование: <имя>"', async () => {
+    const wrapper = await mountWith([entry()]);
+
+    expect(wrapper.find('.action-text').text()).toBe('Формат создан');
+    const rows = wrapper.findAll('.change-row');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].text()).toContain('Наименование:');
+    expect(rows[0].text()).toContain('Российские номера');
+    expect(rows[0].find('.change-arrow').exists()).toBe(false);
+  });
+
+  it('updated: скалярные поля выводятся как old → new, is_default как Да/Нет', async () => {
+    const wrapper = await mountWith([
+      entry({
+        id: 2,
+        action_type: 'updated',
+        details: {
+          name: { old: 'Старое', new: 'Новое' },
+          country_code: { old: '', new: 'RU' },
+          is_default: { old: false, new: true },
+        },
+      }),
+    ]);
+
+    expect(wrapper.find('.action-text').text()).toBe('Изменены данные формата');
+    const rows = wrapper.findAll('.change-row');
+    expect(rows).toHaveLength(3);
+    // Порядок полей фиксирован: name, country_code, is_default.
+    expect(rows[0].text()).toContain('Наименование:');
+    expect(rows[0].find('.change-old').text()).toBe('Старое');
+    expect(rows[0].find('.change-new').text()).toBe('Новое');
+    // Пустой код страны рендерится как "—".
+    expect(rows[1].find('.change-old').text()).toBe('—');
+    expect(rows[1].find('.change-new').text()).toBe('RU');
+    expect(rows[2].text()).toContain('По умолчанию:');
+    expect(rows[2].find('.change-old').text()).toBe('Нет');
+    expect(rows[2].find('.change-new').text()).toBe('Да');
+  });
+
+  it('updated: diff ячеек сводится в читаемую подпись', async () => {
+    const wrapper = await mountWith([
+      entry({
+        id: 3,
+        action_type: 'updated',
+        details: {
+          cells: {
+            old: [
+              { cell_order: 0, cell_type: 'letters', min_length: 1, max_length: 1, allowed_letters: 'АВ' },
+              { cell_order: 1, cell_type: 'numbers', min_length: 3, max_length: 3, padding_side: 'left' },
+            ],
+            new: [
+              { cell_order: 0, cell_type: 'letters', min_length: 1, max_length: 2, allowed_letters: 'АВЕ' },
+            ],
+          },
+        },
+      }),
+    ]);
+
+    const row = wrapper.find('.change-row');
+    expect(row.text()).toContain('Клетки формата:');
+    expect(row.find('.change-old').text()).toBe('№1 Буквы 1-1 [АВ]; №2 Цифры 3-3 (доп. слева)');
+    expect(row.find('.change-new').text()).toBe('№1 Буквы 1-2 [АВЕ]');
+  });
+
+  it('archived/restored: деталей нет (null и undefined), только текст действия', async () => {
+    // Бэк опускает details для archived/restored - на фронт может прийти null или undefined.
+    const wrapper = await mountWith([
+      entry({ id: 4, action_type: 'archived', details: null }),
+      entry({ id: 5, action_type: 'restored', details: undefined, created_at: '2026-05-01T09:00:00Z' }),
+    ]);
+
+    const items = wrapper.findAll('.history-item');
+    expect(items[0].find('.action-text').text()).toBe('Формат архивирован');
+    expect(items[1].find('.action-text').text()).toBe('Формат восстановлен из архива');
+    expect(wrapper.find('.change-list').exists()).toBe(false);
+    expect(items[0].find('.timeline-dot').classes()).toContain('dot-deactivate');
+    expect(items[1].find('.timeline-dot').classes()).toContain('dot-activate');
+  });
+
+  it('поиск фильтрует по имени актора и тексту изменений', async () => {
+    const wrapper = await mountWith([
+      entry({ id: 1, actor_name: 'Сидоров С.С.', details: { name: 'Казахстан' } }),
+      entry({ id: 2, actor_name: 'Петров П.П.', details: { name: 'Беларусь' } }),
+    ]);
+
+    expect(wrapper.findAll('.history-item')).toHaveLength(2);
+
+    await wrapper.find('.search-input').setValue('сидоров');
+    expect(wrapper.findAll('.history-item')).toHaveLength(1);
+
+    await wrapper.find('.search-input').setValue('беларусь');
+    expect(wrapper.findAll('.history-item')).toHaveLength(1);
+    expect(wrapper.find('.change-row').text()).toContain('Беларусь');
+  });
+
+  it('фильтр пользователей собирает уникальных акторов', async () => {
+    const wrapper = await mountWith([
+      entry({ id: 1, actor_user_id: 3, actor_name: 'Петров П.П.' }),
+      entry({ id: 2, actor_user_id: 5, actor_name: 'Сидоров С.С.' }),
+      entry({ id: 3, actor_user_id: 3, actor_name: 'Петров П.П.' }),
+    ]);
+
+    await wrapper.find('.custom-select').trigger('click');
+    // 2 уникальных пользователя + опция "Все пользователи".
+    expect(wrapper.findAll('.select-option')).toHaveLength(3);
+  });
+
+  it('пустая история показывает "История пуста"', async () => {
+    const wrapper = await mountWith([]);
+    expect(wrapper.find('.history-empty').text()).toBe('История пуста');
+  });
+});


### PR DESCRIPTION
Закрывает срез 414-4 эпика #406 (история форматов номерных знаков). Backend аудита (endpoint + логирование create/update/archive/restore) был добавлен ранее в #471 - тут только фронт.

## Что внутри
- `LicensePlateFormatHistoryModal.vue` - модалка истории по образцу `MarkHistoryModal`/`SystemTableHistoryModal`: Teleport, фильтры (пользователь/период/поиск), сортировка, timeline с цветными точками, выгрузка в Excel (ExcelJS).
- Кнопка «История» в карточке формата (видна и для архивных), проброс модалки в `NumberFormat.vue`.
- Тонкая обёртка `api/licenseFormats.js` (`getLicenseFormatHistory`).

## Читаемый diff
- `created` -> «Наименование: <имя>».
- `updated` -> по каждому изменённому полю «Поле: было → стало»; для клеток - короткая подпись `№N Тип min-max [буквы]` старой и новой раскладки.
- `archived`/`restored` - без деталей.
Словари `ACTION_TEXTS`/`FIELD_LABELS` дают человеческий текст вместо сырого JSON.

## Проверено
- vitest: новый спек (7 кейсов: created/updated-скаляры/updated-клетки/archived+restored/поиск/уникальные акторы/пусто) + полный сьют 357 зелёный; eslint + build чистые.
- Реальный round-trip на живом бэке (:8090): создание -> обновление (имя+страна+клетки) -> архив, история открывается и рендерит все три записи с корректным diff клеток; форма ответа API сверена с фронт-парсингом; Excel-экспорт скачивается; 0 console-ошибок.
- Ревью code-reviewer: применены res.ok в обёртке (молчаливый провал на 4xx), предвычисление changes в computed (двойной вызов в шаблоне), тест на null-details. Отклонены как ложные с проверкой по эталону: «нет анимации закрытия» (все *HistoryModal open-only, MarkHistoryModal в MarksManagement вызван голым v-if без transition) и «кнопка не lk-button» (эталонная кнопка История в MarksManagement.vue:140 - ровно `action-btn history-btn`, копия один-в-один).

Эталон по чек-листу управленческих компонентов соблюдён для истории. Архив/уведомления/master-detail закрыты в #469/#473.