### PR TITLE
feat(blacklist): открытие карточки Т/С со страницы ЧС (#443)

### DIFF
--- a/frontend/src/api/cars.js
+++ b/frontend/src/api/cars.js
@@ -45,3 +45,15 @@ export async function getCarsCurrentStatus() {
   const res = await apiRequest('/cars/history/current-status');
   return res.json();
 }
+
+/**
+ * Поиск машины в реестре по номеру и марке (для открытия карточки со страницы ЧС).
+ * Возвращает запись unique_car или null, если совпадения нет (404).
+ */
+export async function lookupUniqueCar({ number, mark }) {
+  const qs = new URLSearchParams({ number, mark: mark || '' });
+  const res = await apiRequest(`/unique-cars/lookup?${qs.toString()}`);
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`Ошибка поиска машины (${res.status})`);
+  return res.json();
+}

--- a/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
@@ -39,7 +39,7 @@
                   <span>Полная история</span>
                 </button>
                 <button
-                  v-if="showCarFeatures && source !== 'application'"
+                  v-if="showCarFeatures && source !== 'application' && source !== 'blacklist'"
                   class="application-btn"
                   @click="openApplication"
                 >
@@ -436,7 +436,7 @@ export default {
         // "Открыть заявку" - при showCarFeatures и source !== 'application'.
         visibleActionsCount() {
             const history = this.showCarFeatures ? 1 : 0;
-            const application = (this.showCarFeatures && this.source !== 'application') ? 1 : 0;
+            const application = (this.showCarFeatures && this.source !== 'application' && this.source !== 'blacklist') ? 1 : 0;
             return history + application;
         },
         modalTitle() {

--- a/frontend/src/components/admin/blacklist/BlacklistTabBase.vue
+++ b/frontend/src/components/admin/blacklist/BlacklistTabBase.vue
@@ -93,6 +93,15 @@
           </div>
           <div class="bl-details-actions">
             <button
+              v-if="lookupCard"
+              class="lk-button lk-button--secondary"
+              :disabled="cardLoading || !cardEntity"
+              :title="cardButtonTitle"
+              @click="$emit('open-card', cardEntity)"
+            >
+              Открыть карточку
+            </button>
+            <button
               class="lk-button lk-button--ghost"
               @click="$emit('history', selected)"
             >
@@ -186,8 +195,11 @@ export default {
     apiList: { type: Function, required: true },
     getPrimaryText: { type: Function, required: true },
     getDetailRows: { type: Function, required: true },
+    // Опц. async (item) => entity|null. Если задан - в панели появляется кнопка
+    // "Открыть карточку" (disabled, пока запись в реестре не найдена).
+    lookupCard: { type: Function, default: null },
   },
-  emits: ['count', 'create', 'archive', 'restore', 'history'],
+  emits: ['count', 'create', 'archive', 'restore', 'history', 'open-card'],
   data() {
     return {
       items: [],
@@ -195,6 +207,9 @@ export default {
       showArchive: false,
       isLoading: false,
       selected: null,
+      cardEntity: null,
+      cardLoading: false,
+      cardReqId: 0,
       archiveOptions: [
         { label: 'Активные', value: 'active' },
         { label: 'Архив', value: 'archive' },
@@ -224,6 +239,11 @@ export default {
     metaRows() {
       return this.detailData.filter((r) => r.kind !== 'reason');
     },
+    cardButtonTitle() {
+      if (this.cardLoading) return 'Поиск записи в реестре...';
+      if (!this.cardEntity) return 'Запись в реестре не найдена';
+      return 'Открыть карточку с историей';
+    },
   },
   mounted() {
     this.fetchData();
@@ -247,9 +267,37 @@ export default {
     onArchiveModeChange(value) {
       this.showArchive = value === 'archive';
       this.selected = null;
+      this.cardEntity = null;
+      this.cardLoading = false;
+      this.cardReqId++; // инвалидируем in-flight лукап
     },
     selectItem(item) {
       this.selected = item;
+      this.resolveCard(item);
+    },
+    async resolveCard(item) {
+      this.cardEntity = null;
+      if (!this.lookupCard || !item) {
+        this.cardLoading = false;
+        return;
+      }
+      // Счётчик запросов: применяем результат только последнего лукапа (защита от гонки
+      // при быстром переключении строк - устаревший ответ не сбросит loading и не подставит
+      // чужую запись).
+      const reqId = ++this.cardReqId;
+      this.cardLoading = true;
+      try {
+        const entity = await this.lookupCard(item);
+        if (reqId === this.cardReqId) {
+          this.cardEntity = entity || null;
+          this.cardLoading = false;
+        }
+      } catch {
+        if (reqId === this.cardReqId) {
+          this.cardEntity = null;
+          this.cardLoading = false;
+        }
+      }
     },
   },
 };

--- a/frontend/src/components/admin/blacklist/VehicleBlacklistTab.vue
+++ b/frontend/src/components/admin/blacklist/VehicleBlacklistTab.vue
@@ -7,11 +7,13 @@
       :api-list="listVehicleBlacklist"
       :get-primary-text="primaryText"
       :get-detail-rows="detailRows"
+      :lookup-card="lookupCar"
       @count="$emit('count', $event)"
       @create="showCreate = true"
       @archive="askArchive"
       @restore="doRestore"
       @history="historyItem = $event"
+      @open-card="openCard"
     >
       <template #header-left>
         <slot name="header-left" />
@@ -40,6 +42,14 @@
       @confirm="doArchive"
       @cancel="archiveItem = null"
     />
+    <VehicleDetailsModal
+      :show="showDetails"
+      :vehicle="detailsVehicle"
+      :show-car-features="true"
+      source="blacklist"
+      :current-user-name="currentUserName"
+      @close="showDetails = false"
+    />
   </div>
 </template>
 
@@ -48,12 +58,14 @@ import BlacklistTabBase from './BlacklistTabBase.vue';
 import BlacklistCreateModal from './BlacklistCreateModal.vue';
 import VehicleBlacklistHistoryModal from './VehicleBlacklistHistoryModal.vue';
 import ConfirmationModal from '@/components/ConfirmationModal.vue';
+import VehicleDetailsModal from '@/components/CreateApplication/VehicleDetailsModal.vue';
 import {
   listVehicleBlacklist,
   createVehicleBlacklist,
   archiveVehicleBlacklist,
   restoreVehicleBlacklist,
 } from '@/api/blacklist';
+import { lookupUniqueCar } from '@/api/cars';
 import { formatDateTime } from '@/utils/datetime';
 import { useDeletionsStore } from '@/stores/deletions';
 import carIcon from '@/assets/icons/car.png';
@@ -64,13 +76,13 @@ import carIcon from '@/assets/icons/car.png';
  */
 export default {
   name: 'VehicleBlacklistTab',
-  components: { BlacklistTabBase, BlacklistCreateModal, VehicleBlacklistHistoryModal, ConfirmationModal },
+  components: { BlacklistTabBase, BlacklistCreateModal, VehicleBlacklistHistoryModal, ConfirmationModal, VehicleDetailsModal },
   props: {
     currentUserName: { type: String, default: '' },
   },
   emits: ['count'],
   data() {
-    return { showCreate: false, archiveItem: null, historyItem: null, carIcon };
+    return { showCreate: false, archiveItem: null, historyItem: null, carIcon, detailsVehicle: null, showDetails: false };
   },
   computed: {
     archiveMessage() {
@@ -92,6 +104,30 @@ export default {
         { label: 'Причина', value: item.reason, kind: 'reason' },
         { label: 'Добавлена', value: formatDateTime(item.created_at) },
       ];
+    },
+    // Лукап машины в реестре по номеру+марке записи ЧС -> объект для VehicleDetailsModal
+    // (как CarsView.openCarDetails). null, если машины в реестре нет (кнопка останется disabled).
+    async lookupCar(item) {
+      const car = await lookupUniqueCar({ number: item.car_number, mark: item.mark_name });
+      if (!car) return null;
+      return {
+        id: car.id,
+        plateNumber: car.number,
+        mark: car.mark,
+        formatId: car.format_id || null,
+        organization: car.organization_name || null,
+        organizationId: car.organization_id || null,
+        company: car.company_name || null,
+        companyId: car.company_id || null,
+        isExisting: true,
+        unloadPlaces: [],
+        isActive: car.status,
+      };
+    },
+    openCard(vehicle) {
+      if (!vehicle) return;
+      this.detailsVehicle = vehicle;
+      this.showDetails = true;
     },
     async onCreated(name) {
       this.showCreate = false;

--- a/frontend/src/components/admin/blacklist/__tests__/BlacklistTabBase.spec.js
+++ b/frontend/src/components/admin/blacklist/__tests__/BlacklistTabBase.spec.js
@@ -148,4 +148,58 @@ describe('BlacklistTabBase', () => {
     await flushPromises();
     expect(wrapper.find('.bl-empty').exists()).toBe(true);
   });
+
+  it('без lookupCard кнопки "Открыть карточку" нет', async () => {
+    const wrapper = mountBase();
+    await flushPromises();
+    await wrapper.findAll('.bl-row')[0].trigger('click');
+    const btn = wrapper.findAll('button').find((b) => b.text() === 'Открыть карточку');
+    expect(btn).toBeUndefined();
+  });
+
+  it('с lookupCard: кнопка disabled пока запись не найдена, потом активна и эмитит open-card', async () => {
+    const entity = { id: 99, plateNumber: 'A1' };
+    const lookupCard = vi.fn().mockResolvedValue(entity);
+    const wrapper = mountBase({ lookupCard });
+    await flushPromises();
+    await wrapper.findAll('.bl-row')[0].trigger('click');
+    await flushPromises();
+    expect(lookupCard).toHaveBeenCalledWith(items[0]);
+    const btn = wrapper.findAll('button').find((b) => b.text() === 'Открыть карточку');
+    expect(btn).toBeTruthy();
+    expect(btn.attributes('disabled')).toBeUndefined();
+    await btn.trigger('click');
+    expect(wrapper.emitted('open-card')[0]).toEqual([entity]);
+  });
+
+  it('с lookupCard: кнопка disabled, если записи в реестре нет (null)', async () => {
+    const lookupCard = vi.fn().mockResolvedValue(null);
+    const wrapper = mountBase({ lookupCard });
+    await flushPromises();
+    await wrapper.findAll('.bl-row')[0].trigger('click');
+    await flushPromises();
+    const btn = wrapper.findAll('button').find((b) => b.text() === 'Открыть карточку');
+    expect(btn.attributes('disabled')).toBeDefined();
+  });
+
+  it('гонка: при быстром переключении строк применяется только последний лукап', async () => {
+    // Первый лукап (item1) разрешается ПОЗЖЕ второго (item2) - не должен затереть результат.
+    let resolveFirst;
+    const lookupCard = vi.fn()
+      .mockImplementationOnce(() => new Promise((r) => { resolveFirst = r; }))
+      .mockResolvedValueOnce({ id: 2, plateNumber: 'B2' });
+    const wrapper = mountBase({ lookupCard });
+    await flushPromises();
+    await wrapper.findAll('.bl-row')[0].trigger('click'); // item1 - висит
+    await wrapper.findAll('.bl-row')[1].trigger('click'); // item2 - резолвится
+    await flushPromises();
+    // item2 разрешён -> cardEntity = item2, loading сброшен
+    expect(wrapper.vm.cardEntity).toEqual({ id: 2, plateNumber: 'B2' });
+    expect(wrapper.vm.cardLoading).toBe(false);
+    // теперь поздно разрешаем item1 - он устарел, не должен затереть cardEntity/loading
+    resolveFirst({ id: 1, plateNumber: 'B1' });
+    await flushPromises();
+    expect(wrapper.vm.cardEntity).toEqual({ id: 2, plateNumber: 'B2' });
+    expect(wrapper.vm.cardLoading).toBe(false);
+  });
 });

--- a/internal/handlers/unique_cars.go
+++ b/internal/handlers/unique_cars.go
@@ -207,6 +207,32 @@ func (h *UniqueCarHandler) GetHistory(c echo.Context) error {
 	return RespondSuccess(c, items)
 }
 
+// Lookup godoc
+// @Summary      Найти машину по номеру и марке
+// @Description  Поиск машины (LOWER/TRIM) для открытия карточки со страницы ЧС. 404 если нет.
+// @Tags         unique-cars
+// @Produce      json
+// @Security     BearerAuth
+// @Param        number query string true "Номер машины"
+// @Param        mark query string false "Марка"
+// @Success      200 {object} services.UniqueCarWithRelations
+// @Failure      404 {object} models.HTTPError
+// @Router       /unique-cars/lookup [get]
+func (h *UniqueCarHandler) Lookup(c echo.Context) error {
+	number := c.QueryParam("number")
+	if number == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "number обязателен")
+	}
+	car, err := h.service.LookupByNumberMark(c.Request().Context(), number, c.QueryParam("mark"))
+	if err != nil {
+		return err
+	}
+	if car == nil {
+		return echo.NewHTTPError(http.StatusNotFound, "Машина не найдена")
+	}
+	return RespondSuccess(c, car)
+}
+
 // GetOwnershipInfo godoc
 // @Summary      Информация о владельце для машин
 // @Description  Возвращает данные о привязке пользователя к организации/компании

--- a/internal/handlers/unique_cars_test.go
+++ b/internal/handlers/unique_cars_test.go
@@ -222,3 +222,34 @@ func TestUniqueCars_FilterTypes(t *testing.T) {
 		assert.Equal(t, http.StatusOK, rec.Code, "filter_type=%s should return 200", f)
 	}
 }
+
+func TestUniqueCars_Lookup(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	body := fmt.Sprintf(`{"number":"Х999ХХ77","mark":"Lada","organization_id":%d}`, td.OrgID)
+	require.Equal(t, http.StatusOK, testutil.POST(t, e, "/unique-cars", body, h).Code)
+
+	t.Run("находит по номеру и марке без учёта регистра/пробелов", func(t *testing.T) {
+		rec := testutil.GET(t, e, "/unique-cars/lookup?number=%20х999хх77%20&mark=lada", h)
+		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+		resp := testutil.ParseMap(t, rec)
+		assert.Equal(t, "Х999ХХ77", resp["number"])
+		assert.Equal(t, "Lada", resp["mark"])
+		assert.Greater(t, int(resp["id"].(float64)), 0)
+	})
+
+	t.Run("404 если нет совпадения по марке", func(t *testing.T) {
+		rec := testutil.GET(t, e, "/unique-cars/lookup?number=Х999ХХ77&mark=BMW", h)
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+	})
+
+	t.Run("400 без номера", func(t *testing.T) {
+		rec := testutil.GET(t, e, "/unique-cars/lookup?mark=Lada", h)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -370,6 +370,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	ucg.PUT("/by-number", uc.UpdateByNumber)
 	ucg.DELETE("/:id", uc.Delete)
 	ucg.GET("/ownership-info", uc.GetOwnershipInfo)
+	ucg.GET("/lookup", uc.Lookup, requireBlacklist)
 	ucg.GET("/:id/history", uc.GetHistory)
 
 	// Реестр сотрудников (unique_employees)

--- a/internal/services/unique_car_service.go
+++ b/internal/services/unique_car_service.go
@@ -125,6 +125,9 @@ type UniqueCarHistoryItem struct {
 type UniqueCarService interface {
 	GetOwnerInfo(ctx context.Context, username string) (*CarOwnerInfo, error)
 	GetAll(ctx context.Context, username string, filterType string) ([]UniqueCarWithRelations, error)
+	// LookupByNumberMark ищет машину по номеру и марке (LOWER(TRIM), как ЧС) для открытия
+	// карточки со страницы чёрного списка. Возвращает nil, nil если совпадения нет.
+	LookupByNumberMark(ctx context.Context, number, mark string) (*UniqueCarWithRelations, error)
 	Create(ctx context.Context, username string, req NewUniqueCarRequest) (*UniqueCarResponse, error)
 	CreateBatch(ctx context.Context, username string, reqs []NewUniqueCarRequest) (*BatchCreateCarsResponse, int, error)
 	Update(ctx context.Context, username string, id int, req NewUniqueCarRequest) (*UniqueCarResponse, error)
@@ -177,6 +180,32 @@ func (s *uniqueCarService) getCarOwnerInfo(ctx context.Context, username string)
 // GetOwnerInfo возвращает информацию о владельце для фильтрации машин.
 func (s *uniqueCarService) GetOwnerInfo(ctx context.Context, username string) (*CarOwnerInfo, error) {
 	return s.getCarOwnerInfo(ctx, username)
+}
+
+// LookupByNumberMark ищет машину по номеру+марке без скоупинга по владельцу (вызывается
+// из админ-страницы ЧС). Берёт самую свежую при нескольких совпадениях. nil,nil если нет.
+func (s *uniqueCarService) LookupByNumberMark(ctx context.Context, number, mark string) (*UniqueCarWithRelations, error) {
+	rows := make([]UniqueCarWithRelations, 0, 1)
+	err := s.db.WithContext(ctx).
+		Table("unique_cars uc").
+		Select(`uc.id, uc.number, uc.mark, uc.organization_id, uc.company_id, uc.format_id, uc.user_id,
+			uc.status, uc.created_at,
+			o.name as organization_name, c.name as company_name, lpf.name as format_name`).
+		Joins("LEFT JOIN organizations o ON uc.organization_id = o.id").
+		Joins("LEFT JOIN companies c ON uc.company_id = c.id").
+		Joins("LEFT JOIN license_plate_formats lpf ON uc.format_id = lpf.id").
+		Where("LOWER(TRIM(uc.number)) = LOWER(TRIM(?))", number).
+		Where("LOWER(TRIM(COALESCE(uc.mark, ''))) = LOWER(TRIM(?))", mark).
+		Order("uc.id DESC").
+		Limit(1).
+		Scan(&rows).Error
+	if err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка поиска машины")
+	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	return &rows[0], nil
 }
 
 // GetAll возвращает список уникальных автомобилей с фильтрацией по типу владельца.


### PR DESCRIPTION
## Что

Срез P6a эпика ЧС (#443). В панели деталей чёрного списка (вкладка Машины) - кнопка «Открыть карточку», открывающая полную `VehicleDetailsModal` с историей въездов/выездов.

### Backend
Запись ЧС знает только номер+марку (без id), поэтому нужен лукап:
- `UniqueCarService.LookupByNumberMark(number, mark)` - матч по `LOWER(TRIM)` номера и марки (зеркалит нормализацию ЧС), LEFT JOIN org/company/format, самая свежая при нескольких. nil если нет.
- `GET /unique-cars/lookup` под `requireBlacklist` (лукап обходит per-user скоупинг списка - гейтим правом ЧС). 400 без номера, 404 если нет.
- Тест `TestUniqueCars_Lookup` (match без учёта регистра/пробелов, 404, 400).

### Frontend
- `api/cars.js`: `lookupUniqueCar` (null на 404).
- `BlacklistTabBase`: опц. function-prop `lookupCard`; при его наличии в панели кнопка «Открыть карточку», disabled пока запись в реестре не найдена. Лукап на выборе строки со счётчиком запросов (защита от гонки при быстром переключении). Эмитит `open-card`.
- `VehicleBlacklistTab`: маппит запись -> объект машины (как `CarsView.openCarDetails`), открывает `VehicleDetailsModal` (`source='blacklist'`).
- `VehicleDetailsModal`: для `source='blacklist'` скрыта нерелевантная «Открыть заявку» (+ учтено в `visibleActionsCount`/заголовке). Машина в ЧС -> плашка «В ЧС» (из P5a).

## Проверка
- Go: vet + `TestUniqueCars_Lookup` + полный пакет handlers/services на изолированной БД.
- Front: eslint, vitest 354 (+ тесты lookup-card, вкл. гонку), build.
- Локально через Playwright (страница ЧС): кнопка активна при наличии записи в реестре, disabled без неё, карточка открывается с историей и плашкой «В ЧС». Лукап в кадрах мокнут (эндпоинт не в running-бэкенде :8090; покрыт Go-тестом).

## Заметки
- Статус въезда в карточке из ЧС показывает «не въезжал» (current-status матчится по реальному car_id, а unique_car id иной) - то же поведение, что при открытии из CarsView/EmployeeView.
- «Действует до»/«Время пребывания» = «-» (lookup не тянет active-app поля) - приемлемо для контекста ЧС.
- P6b (то же для людей) - финальный срез эпика.