### PR TITLE
feat(blacklist): открытие карточки сотрудника со страницы ЧС (#443)

### DIFF
--- a/frontend/src/api/employees.js
+++ b/frontend/src/api/employees.js
@@ -12,3 +12,15 @@ export async function getActiveEmployeesForTable(tableId) {
   const res = await apiRequest(`/employees/active-for-table/${tableId}`);
   return res.json();
 }
+
+/**
+ * Поиск сотрудника в реестре по ФИО (для открытия карточки со страницы ЧС).
+ * Возвращает запись unique_employee или null, если совпадения нет (404).
+ */
+export async function lookupUniqueEmployee({ last_name, first_name, middle_name = '' }) {
+  const qs = new URLSearchParams({ last_name, first_name, middle_name: middle_name || '' });
+  const res = await apiRequest(`/unique-employees/lookup?${qs.toString()}`);
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`Ошибка поиска сотрудника (${res.status})`);
+  return res.json();
+}

--- a/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
@@ -684,7 +684,9 @@ export default {
             this.loadingHistory = true;
             try {
                 let res;
-                if (this.source === 'employeesview') {
+                // employeesview и blacklist открывают карточку по реестру (unique_employee id),
+                // поэтому история - по ФИО (unified), а не по id реальной записи employees.
+                if (this.source === 'employeesview' || this.source === 'blacklist') {
                     const params = new URLSearchParams({
                         last_name: this.employee.last_name || '',
                         first_name: this.employee.first_name || ''

--- a/frontend/src/components/admin/blacklist/PersonBlacklistTab.vue
+++ b/frontend/src/components/admin/blacklist/PersonBlacklistTab.vue
@@ -7,11 +7,13 @@
       :api-list="listPersonBlacklist"
       :get-primary-text="primaryText"
       :get-detail-rows="detailRows"
+      :lookup-card="lookupPerson"
       @count="$emit('count', $event)"
       @create="showCreate = true"
       @archive="askArchive"
       @restore="doRestore"
       @history="historyItem = $event"
+      @open-card="openCard"
     >
       <template #header-left>
         <slot name="header-left" />
@@ -40,6 +42,13 @@
       @confirm="doArchive"
       @cancel="archiveItem = null"
     />
+    <EmployeeDetailsModal
+      :show="showDetails"
+      :employee="detailsEmployee"
+      source="blacklist"
+      :current-user-name="currentUserName"
+      @close="showDetails = false"
+    />
   </div>
 </template>
 
@@ -48,12 +57,14 @@ import BlacklistTabBase from './BlacklistTabBase.vue';
 import BlacklistCreateModal from './BlacklistCreateModal.vue';
 import PersonBlacklistHistoryModal from './PersonBlacklistHistoryModal.vue';
 import ConfirmationModal from '@/components/ConfirmationModal.vue';
+import EmployeeDetailsModal from '@/components/CreateApplication/EmployeeDetailsModal.vue';
 import {
   listPersonBlacklist,
   createPersonBlacklist,
   archivePersonBlacklist,
   restorePersonBlacklist,
 } from '@/api/blacklist';
+import { lookupUniqueEmployee } from '@/api/employees';
 import { formatDateTime } from '@/utils/datetime';
 import { useDeletionsStore } from '@/stores/deletions';
 import userIcon from '@/assets/icons/user.png';
@@ -64,13 +75,13 @@ import userIcon from '@/assets/icons/user.png';
  */
 export default {
   name: 'PersonBlacklistTab',
-  components: { BlacklistTabBase, BlacklistCreateModal, PersonBlacklistHistoryModal, ConfirmationModal },
+  components: { BlacklistTabBase, BlacklistCreateModal, PersonBlacklistHistoryModal, ConfirmationModal, EmployeeDetailsModal },
   props: {
     currentUserName: { type: String, default: '' },
   },
   emits: ['count'],
   data() {
-    return { showCreate: false, archiveItem: null, historyItem: null, userIcon };
+    return { showCreate: false, archiveItem: null, historyItem: null, userIcon, detailsEmployee: null, showDetails: false };
   },
   computed: {
     archiveMessage() {
@@ -93,6 +104,35 @@ export default {
         { label: 'Причина', value: item.reason, kind: 'reason' },
         { label: 'Добавлен', value: formatDateTime(item.created_at) },
       ];
+    },
+    // Лукап сотрудника в реестре по ФИО записи ЧС -> объект для EmployeeDetailsModal
+    // (как EmployeeView.openEmployeeDetails). null, если в реестре нет (кнопка disabled).
+    async lookupPerson(item) {
+      const emp = await lookupUniqueEmployee({
+        last_name: item.last_name,
+        first_name: item.first_name,
+        middle_name: item.middle_name || '',
+      });
+      if (!emp) return null;
+      return {
+        id: emp.id,
+        last_name: emp.last_name,
+        first_name: emp.first_name,
+        middle_name: emp.middle_name,
+        position: emp.position,
+        citizenshipName: emp.citizenship_name,
+        passport_series_number: emp.passport_series_number,
+        patent_number: emp.patent_number,
+        other_permission: emp.other_permission,
+        organization: emp.organization_name || null,
+        company: emp.company_name || null,
+        target_tables: [],
+      };
+    },
+    openCard(employee) {
+      if (!employee) return;
+      this.detailsEmployee = employee;
+      this.showDetails = true;
     },
     async onCreated(name) {
       this.showCreate = false;

--- a/internal/handlers/unique_employees.go
+++ b/internal/handlers/unique_employees.go
@@ -154,6 +154,35 @@ func (h *UniqueEmployeeHandler) GetHistory(c echo.Context) error {
 	return RespondSuccess(c, items)
 }
 
+// Lookup godoc
+// @Summary      Найти сотрудника по ФИО
+// @Description  Поиск сотрудника (LOWER/TRIM) для открытия карточки со страницы ЧС. 404 если нет.
+// @Tags         unique-employees
+// @Produce      json
+// @Security     BearerAuth
+// @Param        last_name query string true "Фамилия"
+// @Param        first_name query string true "Имя"
+// @Param        middle_name query string false "Отчество"
+// @Success      200 {object} services.UniqueEmployeeWithRelations
+// @Failure      400 {object} models.HTTPError
+// @Failure      404 {object} models.HTTPError
+// @Router       /unique-employees/lookup [get]
+func (h *UniqueEmployeeHandler) Lookup(c echo.Context) error {
+	lastName := c.QueryParam("last_name")
+	firstName := c.QueryParam("first_name")
+	if lastName == "" || firstName == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "last_name и first_name обязательны")
+	}
+	emp, err := h.service.LookupByFIO(c.Request().Context(), lastName, firstName, c.QueryParam("middle_name"))
+	if err != nil {
+		return err
+	}
+	if emp == nil {
+		return echo.NewHTTPError(http.StatusNotFound, "Сотрудник не найден")
+	}
+	return RespondSuccess(c, emp)
+}
+
 // GetOwnershipInfo godoc
 // @Summary      Информация о владельце для сотрудников
 // @Description  Возвращает данные о привязке пользователя к организации/компании

--- a/internal/handlers/unique_employees_test.go
+++ b/internal/handlers/unique_employees_test.go
@@ -171,3 +171,38 @@ func TestUniqueEmployees_Update_NotFound(t *testing.T) {
 	rec := testutil.PUT(t, e, "/unique-employees/99999", `{"last_name":"X"}`, h)
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
+
+func TestUniqueEmployees_Lookup(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	body := fmt.Sprintf(`{"last_name":"Сидоров","first_name":"Семён","middle_name":"Семёнович","passport_series_number":"9999 888777","organization_id":%d}`, td.OrgID)
+	require.Equal(t, http.StatusOK, testutil.POST(t, e, "/unique-employees", body, h).Code)
+
+	t.Run("находит по ФИО без учёта регистра/пробелов", func(t *testing.T) {
+		rec := testutil.GET(t, e, "/unique-employees/lookup?last_name=%20сидоров%20&first_name=семён&middle_name=Семёнович", h)
+		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+		resp := testutil.ParseMap(t, rec)
+		assert.Equal(t, "Сидоров", resp["last_name"])
+		assert.Greater(t, int(resp["id"].(float64)), 0)
+	})
+
+	t.Run("404 при несовпадении отчества", func(t *testing.T) {
+		rec := testutil.GET(t, e, "/unique-employees/lookup?last_name=Сидоров&first_name=Семён&middle_name=Петрович", h)
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+	})
+
+	t.Run("400 без имени", func(t *testing.T) {
+		rec := testutil.GET(t, e, "/unique-employees/lookup?last_name=Сидоров", h)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("400 без фамилии", func(t *testing.T) {
+		rec := testutil.GET(t, e, "/unique-employees/lookup?first_name=Семён", h)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -380,6 +380,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	ueg.PUT("/:id", ue.Update)
 	ueg.DELETE("/:id", ue.Delete)
 	ueg.GET("/ownership-info", ue.GetOwnershipInfo)
+	ueg.GET("/lookup", ue.Lookup, requireBlacklist)
 	ueg.GET("/:id/history", ue.GetHistory)
 
 	// Обратная связь

--- a/internal/services/unique_employee_service.go
+++ b/internal/services/unique_employee_service.go
@@ -142,6 +142,9 @@ type UniqueEmployeeHistoryItem struct {
 type UniqueEmployeeService interface {
 	GetOwnerInfo(ctx context.Context, username string) (*EmployeeOwnerInfo, error)
 	GetAll(ctx context.Context, username string, filterType string) ([]UniqueEmployeeWithRelations, error)
+	// LookupByFIO ищет сотрудника по ФИО (LOWER(TRIM), как ЧС) для открытия карточки со
+	// страницы чёрного списка. Возвращает nil, nil если совпадения нет.
+	LookupByFIO(ctx context.Context, lastName, firstName, middleName string) (*UniqueEmployeeWithRelations, error)
 	Create(ctx context.Context, username string, req NewUniqueEmployeeRequest) (*UniqueEmployeeResponse, error)
 	Update(ctx context.Context, username string, id int, req NewUniqueEmployeeRequest) (*UniqueEmployeeResponse, error)
 	Delete(ctx context.Context, username string, id int) error
@@ -192,6 +195,37 @@ func (s *uniqueEmployeeService) getEmployeeOwnerInfo(ctx context.Context, userna
 // GetOwnerInfo возвращает информацию о владельце для фильтрации сотрудников.
 func (s *uniqueEmployeeService) GetOwnerInfo(ctx context.Context, username string) (*EmployeeOwnerInfo, error) {
 	return s.getEmployeeOwnerInfo(ctx, username)
+}
+
+// LookupByFIO ищет сотрудника по ФИО без скоупинга по владельцу (вызывается из админ-
+// страницы ЧС). Самый свежий при нескольких совпадениях. nil,nil если нет.
+func (s *uniqueEmployeeService) LookupByFIO(ctx context.Context, lastName, firstName, middleName string) (*UniqueEmployeeWithRelations, error) {
+	rows := make([]UniqueEmployeeWithRelations, 0, 1)
+	err := s.db.WithContext(ctx).
+		Table("unique_employees ue").
+		Select(`ue.id, ue.last_name, ue.first_name, ue.middle_name,
+			ue.organization_id, ue.company_id, ue.citizenship_id, ue.user_id,
+			ue."position", ue.passport_series_number, ue.patent_number, ue.other_permission, ue.created_at,
+			o.name as organization_name, c.name as company_name, cit.name as citizenship_name`).
+		Joins("LEFT JOIN organizations o ON ue.organization_id = o.id").
+		Joins("LEFT JOIN companies c ON ue.company_id = c.id").
+		Joins("LEFT JOIN citizenships cit ON ue.citizenship_id = cit.id").
+		Where("LOWER(TRIM(ue.last_name)) = LOWER(TRIM(?))", lastName).
+		Where("LOWER(TRIM(ue.first_name)) = LOWER(TRIM(?))", firstName).
+		Where("LOWER(TRIM(COALESCE(ue.middle_name, ''))) = LOWER(TRIM(?))", middleName).
+		Order("ue.id DESC").
+		Limit(1).
+		Scan(&rows).Error
+	if err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка поиска сотрудника")
+	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	// Паспорт/патент хранятся зашифрованными - расшифровываем, как в GetAll.
+	rows[0].PassportSeriesNumber = crypto.DecryptOptional(rows[0].PassportSeriesNumber)
+	rows[0].PatentNumber = crypto.DecryptOptional(rows[0].PatentNumber)
+	return &rows[0], nil
 }
 
 // GetAll возвращает список уникальных сотрудников с фильтрацией по типу владельца.


### PR DESCRIPTION
## Что

Финальный срез P6b эпика ЧС (#443) - зеркало P6a для людей. В панели деталей ЧС (вкладка Люди) - кнопка «Открыть карточку», открывающая полную `EmployeeDetailsModal` с историей.

### Backend
- `UniqueEmployeeService.LookupByFIO(last, first, middle)` - матч по `LOWER(TRIM)` ФИО (`COALESCE(middle,'')`, зеркалит person_blacklist Check), LEFT JOIN org/company/citizenship, самый свежий при нескольких. Расшифровывает паспорт/патент (как GetAll). nil если нет.
- `GET /unique-employees/lookup` под `requireBlacklist`. 400 без ФИО, 404 если нет.
- Тест `TestUniqueEmployees_Lookup` (match без регистра/пробелов, 404, 400 x2).

### Frontend
- `api/employees.js`: `lookupUniqueEmployee` (null на 404).
- `PersonBlacklistTab`: `lookup-card` -> маппинг записи в объект сотрудника (как `EmployeeView.openEmployeeDetails`), открывает `EmployeeDetailsModal` (`source='blacklist'`).
- `EmployeeDetailsModal`: для `source='blacklist'` история грузится по ФИО (unified), а не по id (lookup даёт id реестра, не реальной employees-записи). «Открыть заявку» уже скрыта (нет applicationId). Человек в ЧС -> плашка «В ЧС» (из P5b).
- Кнопка «Открыть карточку» + инфра lookup-card - из P6a (BlacklistTabBase), здесь переиспользованы.

## Проверка
- Go: vet + `TestUniqueEmployees_Lookup` + полный пакет handlers/services на изолированной БД.
- Front: eslint, vitest 361, build.
- Локально через Playwright (страница ЧС, Люди): кнопка активна при наличии записи в реестре, disabled без неё, карточка открывается с историей и плашкой «В ЧС». Лукап в кадрах мокнут (эндпоинта нет в running-бэкенде :8090; покрыт Go-тестом).

Закрывает #443 - эпик «Чёрный список» завершён (P1-P6b).