### PR TITLE
feat(citizenship): архив + история гражданств (#415)

### DIFF
--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -22,6 +22,7 @@ func AllModels() []interface{} {
 		&models.Company{},
 		&models.CompanyHistory{},
 		&models.Citizenship{},
+		&models.CitizenshipHistory{},
 		&models.LicensePlateFormat{},
 		&models.LicensePlateFormatHistory{},
 		&models.Mark{},

--- a/internal/handlers/citizenships.go
+++ b/internal/handlers/citizenships.go
@@ -22,17 +22,19 @@ func NewCitizenshipHandler(service services.CitizenshipService) *CitizenshipHand
 
 // GetAll godoc
 // @Summary      Получить все гражданства
-// @Description  Возвращает список всех гражданств в системе
+// @Description  Возвращает список гражданств. По умолчанию только активные; include_archived=true добавляет архивные.
 // @Tags         citizenships
 // @Accept       json
 // @Produce      json
 // @Security     BearerAuth
+// @Param        include_archived query bool false "Включить архивные гражданства"
 // @Success      200 {array} models.Citizenship
 // @Failure      401 {object} models.HTTPError
 // @Failure      500 {object} models.HTTPError
 // @Router       /citizenships [get]
 func (h *CitizenshipHandler) GetAll(c echo.Context) error {
-	citizenships, err := h.service.GetAll(c.Request().Context())
+	includeArchived := c.QueryParam("include_archived") == "true"
+	citizenships, err := h.service.GetAll(c.Request().Context(), includeArchived)
 	if err != nil {
 		return err
 	}
@@ -54,11 +56,12 @@ func (h *CitizenshipHandler) GetAll(c echo.Context) error {
 // @Router       /citizenships [post]
 func (h *CitizenshipHandler) Create(c echo.Context) error {
 	typeID := c.Get("type_id").(int)
+	userID, _ := c.Get("user_id").(int)
 	var req models.CreateCitizenshipRequest
 	if err := BindAndValidate(c, &req); err != nil {
 		return err
 	}
-	id, err := h.service.Create(c.Request().Context(), typeID, req)
+	id, err := h.service.Create(c.Request().Context(), typeID, userID, req)
 	if err != nil {
 		return err
 	}
@@ -84,6 +87,7 @@ func (h *CitizenshipHandler) Create(c echo.Context) error {
 // @Router       /citizenships/{id} [put]
 func (h *CitizenshipHandler) Update(c echo.Context) error {
 	typeID := c.Get("type_id").(int)
+	userID, _ := c.Get("user_id").(int)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
@@ -92,35 +96,90 @@ func (h *CitizenshipHandler) Update(c echo.Context) error {
 	if err := BindAndValidate(c, &req); err != nil {
 		return err
 	}
-	if err := h.service.Update(c.Request().Context(), typeID, id, req); err != nil {
+	if err := h.service.Update(c.Request().Context(), typeID, userID, id, req); err != nil {
 		return err
 	}
 	return RespondMessage(c, "Гражданство успешно обновлено")
 }
 
 // Delete godoc
-// @Summary      Удалить гражданство
-// @Description  Удаляет гражданство по указанному ID
+// @Summary      Архивировать гражданство
+// @Description  Архивирует гражданство (soft-delete, is_active=false). Гражданство по умолчанию архивировать нельзя.
 // @Tags         citizenships
 // @Accept       json
 // @Produce      json
 // @Security     BearerAuth
 // @Param        id path int true "ID гражданства"
-// @Success      200 {string} string "Гражданство успешно удалено"
+// @Success      200 {string} string "Гражданство архивировано"
 // @Failure      400 {object} models.HTTPError
 // @Failure      401 {object} models.HTTPError
 // @Failure      403 {object} models.HTTPError
+// @Failure      404 {object} models.HTTPError
+// @Failure      409 {object} models.HTTPError
 // @Router       /citizenships/{id} [delete]
 func (h *CitizenshipHandler) Delete(c echo.Context) error {
 	typeID := c.Get("type_id").(int)
+	userID, _ := c.Get("user_id").(int)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
 	}
-	if err := h.service.Delete(c.Request().Context(), typeID, id); err != nil {
+	if err := h.service.Delete(c.Request().Context(), typeID, userID, id); err != nil {
 		return err
 	}
-	return RespondMessage(c, "Гражданство успешно удалено")
+	return RespondMessage(c, "Гражданство архивировано")
+}
+
+// Restore godoc
+// @Summary      Восстановить гражданство из архива
+// @Description  Возвращает гражданство из архива (is_active=true)
+// @Tags         citizenships
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID гражданства"
+// @Success      200 {string} string "Гражданство восстановлено из архива"
+// @Failure      400 {object} models.HTTPError
+// @Failure      401 {object} models.HTTPError
+// @Failure      403 {object} models.HTTPError
+// @Failure      404 {object} models.HTTPError
+// @Failure      500 {object} models.HTTPError
+// @Router       /citizenships/{id}/restore [post]
+func (h *CitizenshipHandler) Restore(c echo.Context) error {
+	typeID := c.Get("type_id").(int)
+	userID, _ := c.Get("user_id").(int)
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	if err := h.service.Restore(c.Request().Context(), typeID, userID, id); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Гражданство восстановлено из архива")
+}
+
+// GetHistory godoc
+// @Summary      История изменений гражданства
+// @Description  Возвращает аудит создания/изменения/архивации/восстановления гражданства (новые сверху)
+// @Tags         citizenships
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID гражданства"
+// @Success      200 {array} models.CitizenshipHistoryItem
+// @Failure      400 {object} models.HTTPError
+// @Failure      401 {object} models.HTTPError
+// @Failure      500 {object} models.HTTPError
+// @Router       /citizenships/{id}/history [get]
+func (h *CitizenshipHandler) GetHistory(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	items, err := h.service.GetHistory(c.Request().Context(), id)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, items)
 }
 
 // ClearDefaults godoc

--- a/internal/handlers/citizenships_test.go
+++ b/internal/handlers/citizenships_test.go
@@ -68,8 +68,7 @@ func TestCitizenships_CRUD_Cycle(t *testing.T) {
 	assert.Equal(t, false, list[0]["patent_required"])
 
 	// --- Update ---
-	updateBody := fmt.Sprintf(
-		`{"name":"РФ обновлённое","icon":"🏳️","is_active":true,"is_default":false,"patent_required":true}`)
+	updateBody := `{"name":"РФ обновлённое","icon":"🏳️","is_default":false,"patent_required":true}`
 	rec = testutil.PUT(t, e, fmt.Sprintf("/citizenships/%d", citizenshipID), updateBody, h)
 	require.Equal(t, http.StatusOK, rec.Code)
 
@@ -86,14 +85,14 @@ func TestCitizenships_CRUD_Cycle(t *testing.T) {
 	assert.Equal(t, false, list[0]["is_default"])
 	assert.Equal(t, true, list[0]["patent_required"])
 
-	// --- Delete ---
+	// --- Delete (архив, soft-delete) ---
 	rec = testutil.DELETE(t, e, fmt.Sprintf("/citizenships/%d", citizenshipID), h)
 	require.Equal(t, http.StatusOK, rec.Code)
 
 	deleteResp := testutil.ParseMessage(t, rec)
-	assert.Equal(t, "Гражданство успешно удалено", deleteResp)
+	assert.Equal(t, "Гражданство архивировано", deleteResp)
 
-	// --- Read (verify gone) ---
+	// --- Read (активные не показывают архивное) ---
 	rec = testutil.GET(t, e, "/citizenships", h)
 	require.Equal(t, http.StatusOK, rec.Code)
 
@@ -249,4 +248,112 @@ func TestCitizenships_Create_DefaultClears_Previous(t *testing.T) {
 		}
 	}
 	assert.Equal(t, 1, defaultCount)
+}
+
+func TestCitizenships_Archive_Restore_Cycle(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	rec := testutil.POST(t, e, "/citizenships", `{"name":"Узбекистан"}`, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	id := int(testutil.ParseMap(t, rec)["id"].(float64))
+
+	// Архив (soft-delete)
+	rec = testutil.DELETE(t, e, fmt.Sprintf("/citizenships/%d", id), h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "Гражданство архивировано", testutil.ParseMessage(t, rec))
+
+	// Активные - пусто, архив виден через include_archived
+	rec = testutil.GET(t, e, "/citizenships", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Empty(t, testutil.ParseSlice(t, rec))
+
+	rec = testutil.GET(t, e, "/citizenships?include_archived=true", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	list := testutil.ParseSlice(t, rec)
+	require.Len(t, list, 1)
+	assert.Equal(t, false, list[0]["is_active"])
+
+	// Восстановление
+	rec = testutil.POST(t, e, fmt.Sprintf("/citizenships/%d/restore", id), "", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "Гражданство восстановлено из архива", testutil.ParseMessage(t, rec))
+
+	rec = testutil.GET(t, e, "/citizenships", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	list = testutil.ParseSlice(t, rec)
+	require.Len(t, list, 1)
+	assert.Equal(t, true, list[0]["is_active"])
+}
+
+func TestCitizenships_Archive_Default_Conflict(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	rec := testutil.POST(t, e, "/citizenships", `{"name":"РФ","is_default":true}`, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	id := int(testutil.ParseMap(t, rec)["id"].(float64))
+
+	// Дефолтное гражданство архивировать нельзя - 409.
+	rec = testutil.DELETE(t, e, fmt.Sprintf("/citizenships/%d", id), h)
+	assert.Equal(t, http.StatusConflict, rec.Code)
+}
+
+func TestCitizenships_History(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	rec := testutil.POST(t, e, "/citizenships", `{"name":"Таджикистан","patent_required":false}`, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	id := int(testutil.ParseMap(t, rec)["id"].(float64))
+
+	// Изменение имени + патента -> запись updated с diff.
+	rec = testutil.PUT(t, e, fmt.Sprintf("/citizenships/%d", id),
+		`{"name":"Республика Таджикистан","patent_required":true}`, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Архив + восстановление.
+	rec = testutil.DELETE(t, e, fmt.Sprintf("/citizenships/%d", id), h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	rec = testutil.POST(t, e, fmt.Sprintf("/citizenships/%d/restore", id), "", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = testutil.GET(t, e, fmt.Sprintf("/citizenships/%d/history", id), h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	hist := testutil.ParseSlice(t, rec)
+	require.Len(t, hist, 4)
+
+	// Новые сверху: restored, archived, updated, created.
+	assert.Equal(t, "restored", hist[0]["action_type"])
+	assert.Equal(t, "archived", hist[1]["action_type"])
+	assert.Equal(t, "updated", hist[2]["action_type"])
+	assert.Equal(t, "created", hist[3]["action_type"])
+
+	// created - имя в details.
+	created := hist[3]["details"].(map[string]interface{})
+	assert.Equal(t, "Таджикистан", created["name"])
+
+	// updated - diff по name и patent_required.
+	updated := hist[2]["details"].(map[string]interface{})
+	name := updated["name"].(map[string]interface{})
+	assert.Equal(t, "Таджикистан", name["old"])
+	assert.Equal(t, "Республика Таджикистан", name["new"])
+	patent := updated["patent_required"].(map[string]interface{})
+	assert.Equal(t, false, patent["old"])
+	assert.Equal(t, true, patent["new"])
 }

--- a/internal/models/citizenship.go
+++ b/internal/models/citizenship.go
@@ -22,10 +22,12 @@ type CreateCitizenshipRequest struct {
 }
 
 // UpdateCitizenshipRequest -- запрос на обновление гражданства.
+// is_active намеренно отсутствует: архивацией/восстановлением управляют
+// DELETE (архив) и POST /restore, чтобы действие логировалось в историю и
+// проходило проверку дефолта, а не менялось молча через PUT.
 type UpdateCitizenshipRequest struct {
 	Name           string  `json:"name" validate:"required,min=1,max=100"`
 	Icon           *string `json:"icon"`
-	IsActive       *bool   `json:"is_active"`
 	IsDefault      *bool   `json:"is_default"`
 	PatentRequired *bool   `json:"patent_required"`
 }

--- a/internal/models/citizenship_history.go
+++ b/internal/models/citizenship_history.go
@@ -1,0 +1,37 @@
+package models
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// CitizenshipHistory логирует действия над гражданством: создание, изменение,
+// архивацию и восстановление. Нужна для аудита (#415): гражданство влияет на
+// требование патента у сотрудников, важно знать кто и когда менял.
+// FK (CitizenshipID) намеренно без constraint: аудит должен пережить удаление гражданства.
+type CitizenshipHistory struct {
+	ID            int             `json:"id"`
+	CitizenshipID int             `gorm:"index;not null" json:"citizenship_id"`
+	ActorUserID   *int            `gorm:"index" json:"actor_user_id,omitempty"`
+	ActionType    string          `gorm:"size:32;index" json:"action_type"`
+	Details       json.RawMessage `gorm:"type:jsonb" json:"details,omitempty"`
+	CreatedAt     time.Time       `json:"created_at"`
+}
+
+// CitizenshipActionType - константы для CitizenshipHistory.ActionType.
+const (
+	CitizenshipActionCreated  = "created"
+	CitizenshipActionUpdated  = "updated"
+	CitizenshipActionArchived = "archived"
+	CitizenshipActionRestored = "restored"
+)
+
+// CitizenshipHistoryItem - запись истории с именем актора для API (LEFT JOIN users).
+type CitizenshipHistoryItem struct {
+	ID          int             `json:"id"`
+	ActionType  string          `json:"action_type"`
+	Details     json.RawMessage `json:"details,omitempty" swaggerignore:"true"`
+	ActorUserID *int            `json:"actor_user_id,omitempty"`
+	ActorName   string          `json:"actor_name"`
+	CreatedAt   time.Time       `json:"created_at"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -175,6 +175,8 @@ func Setup(e *echo.Echo, d Dependencies) {
 	csg.POST("", cs.Create)
 	csg.PUT("/:id", cs.Update)
 	csg.DELETE("/:id", cs.Delete)
+	csg.POST("/:id/restore", cs.Restore)
+	csg.GET("/:id/history", cs.GetHistory)
 	csg.POST("/clear-default", cs.ClearDefaults)
 
 	// Форматы номерных знаков

--- a/internal/services/citizenship_history_service.go
+++ b/internal/services/citizenship_history_service.go
@@ -1,0 +1,88 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"systemburo/internal/models"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+// CitizenshipHistoryService - аудит действий над гражданствами (#415).
+type CitizenshipHistoryService interface {
+	// Log пишет запись аудита. Ошибка не возвращается: аудит не ломает основное действие.
+	Log(ctx context.Context, citizenshipID int, actorUserID *int, actionType string, details interface{})
+	// GetHistory возвращает историю по гражданству (новые сверху).
+	GetHistory(ctx context.Context, citizenshipID int) ([]models.CitizenshipHistoryItem, error)
+}
+
+type citizenshipHistoryService struct {
+	db *gorm.DB
+}
+
+// NewCitizenshipHistoryService создаёт реализацию CitizenshipHistoryService.
+func NewCitizenshipHistoryService(db *gorm.DB) CitizenshipHistoryService {
+	return &citizenshipHistoryService{db: db}
+}
+
+func (s *citizenshipHistoryService) Log(ctx context.Context, citizenshipID int, actorUserID *int, actionType string, details interface{}) {
+	var raw json.RawMessage
+	if details != nil {
+		b, err := json.Marshal(details)
+		if err != nil {
+			slog.Error("citizenship_history: marshal details", "citizenship", citizenshipID, "error", err)
+		} else {
+			raw = b
+		}
+	}
+	entry := models.CitizenshipHistory{
+		CitizenshipID: citizenshipID,
+		ActorUserID:   actorUserID,
+		ActionType:    actionType,
+		Details:       raw,
+	}
+	if err := s.db.WithContext(ctx).Create(&entry).Error; err != nil {
+		slog.Error("citizenship_history: insert", "citizenship", citizenshipID, "action", actionType, "error", err)
+	}
+}
+
+func (s *citizenshipHistoryService) GetHistory(ctx context.Context, citizenshipID int) ([]models.CitizenshipHistoryItem, error) {
+	type row struct {
+		ID          int             `gorm:"column:id"`
+		ActionType  string          `gorm:"column:action_type"`
+		Details     json.RawMessage `gorm:"column:details"`
+		ActorUserID *int            `gorm:"column:actor_user_id"`
+		ActorName   string          `gorm:"column:actor_name"`
+		CreatedAt   time.Time       `gorm:"column:created_at"`
+	}
+	var rows []row
+	if err := s.db.WithContext(ctx).
+		Table("citizenship_histories AS h").
+		Select(`h.id, h.action_type, h.details, h.actor_user_id,
+			COALESCE(NULLIF(TRIM(BOTH ' ' FROM CONCAT_WS(' ', u.last_name, u.first_name)), ''), u.username, '') AS actor_name,
+			h.created_at`).
+		Joins("LEFT JOIN users u ON u.id = h.actor_user_id").
+		Where("h.citizenship_id = ?", citizenshipID).
+		Order("h.created_at DESC").
+		Scan(&rows).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching citizenship history")
+	}
+
+	items := make([]models.CitizenshipHistoryItem, 0, len(rows))
+	for _, r := range rows {
+		items = append(items, models.CitizenshipHistoryItem{
+			ID:          r.ID,
+			ActionType:  r.ActionType,
+			Details:     r.Details,
+			ActorUserID: r.ActorUserID,
+			ActorName:   r.ActorName,
+			CreatedAt:   r.CreatedAt,
+		})
+	}
+	return items, nil
+}

--- a/internal/services/citizenship_service.go
+++ b/internal/services/citizenship_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 
@@ -13,20 +14,23 @@ import (
 
 // CitizenshipService -- интерфейс бизнес-логики гражданств.
 type CitizenshipService interface {
-	GetAll(ctx context.Context) ([]models.Citizenship, error)
-	Create(ctx context.Context, typeID int, req models.CreateCitizenshipRequest) (int, error)
-	Update(ctx context.Context, typeID int, id int, req models.UpdateCitizenshipRequest) error
-	Delete(ctx context.Context, typeID int, id int) error
+	GetAll(ctx context.Context, includeArchived bool) ([]models.Citizenship, error)
+	Create(ctx context.Context, typeID, userID int, req models.CreateCitizenshipRequest) (int, error)
+	Update(ctx context.Context, typeID, userID, id int, req models.UpdateCitizenshipRequest) error
+	Delete(ctx context.Context, typeID, userID, id int) error
+	Restore(ctx context.Context, typeID, userID, id int) error
+	GetHistory(ctx context.Context, id int) ([]models.CitizenshipHistoryItem, error)
 	ClearDefaults(ctx context.Context, typeID int) error
 }
 
 type citizenshipService struct {
-	db *gorm.DB
+	db      *gorm.DB
+	history CitizenshipHistoryService
 }
 
 // NewCitizenshipService создаёт реализацию CitizenshipService.
 func NewCitizenshipService(db *gorm.DB) CitizenshipService {
-	return &citizenshipService{db: db}
+	return &citizenshipService{db: db, history: NewCitizenshipHistoryService(db)}
 }
 
 // checkAdmin проверяет, что пользователь с данным type_id является администратором
@@ -48,17 +52,22 @@ func (s *citizenshipService) checkAdmin(ctx context.Context, typeID int) error {
 	return nil
 }
 
-// GetAll возвращает список всех гражданств.
-func (s *citizenshipService) GetAll(ctx context.Context) ([]models.Citizenship, error) {
+// GetAll возвращает список гражданств.
+// По умолчанию только активные; includeArchived=true добавляет архивные.
+func (s *citizenshipService) GetAll(ctx context.Context, includeArchived bool) ([]models.Citizenship, error) {
 	citizenships := make([]models.Citizenship, 0)
-	if err := s.db.WithContext(ctx).Order("name").Find(&citizenships).Error; err != nil {
+	q := s.db.WithContext(ctx).Order("name")
+	if !includeArchived {
+		q = q.Where("is_active = ?", true)
+	}
+	if err := q.Find(&citizenships).Error; err != nil {
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching citizenships")
 	}
 	return citizenships, nil
 }
 
 // Create создаёт новое гражданство с опциональной установкой по умолчанию.
-func (s *citizenshipService) Create(ctx context.Context, typeID int, req models.CreateCitizenshipRequest) (int, error) {
+func (s *citizenshipService) Create(ctx context.Context, typeID, userID int, req models.CreateCitizenshipRequest) (int, error) {
 	if err := s.checkAdmin(ctx, typeID); err != nil {
 		return 0, err
 	}
@@ -69,6 +78,7 @@ func (s *citizenshipService) Create(ctx context.Context, typeID int, req models.
 	citizenship := models.Citizenship{
 		Name:           req.Name,
 		Icon:           req.Icon,
+		IsActive:       true,
 		IsDefault:      isDefault,
 		PatentRequired: patentRequired,
 	}
@@ -95,20 +105,31 @@ func (s *citizenshipService) Create(ctx context.Context, typeID int, req models.
 	}
 
 	slog.Info("гражданство создано", "id", citizenship.ID)
+	s.history.Log(ctx, citizenship.ID, &userID, models.CitizenshipActionCreated, map[string]any{"name": req.Name})
 	return citizenship.ID, nil
 }
 
-// Update обновляет гражданство по ID.
-func (s *citizenshipService) Update(ctx context.Context, typeID int, id int, req models.UpdateCitizenshipRequest) error {
+// Update обновляет гражданство по ID. is_active не трогает - архивацией/восстановлением
+// управляют Delete/Restore (отдельные действия в истории).
+func (s *citizenshipService) Update(ctx context.Context, typeID, userID, id int, req models.UpdateCitizenshipRequest) error {
 	if err := s.checkAdmin(ctx, typeID); err != nil {
 		return err
 	}
 
-	isActive := req.IsActive == nil || *req.IsActive
 	isDefault := req.IsDefault != nil && *req.IsDefault
 	patentRequired := req.PatentRequired != nil && *req.PatentRequired
 
-	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	var details map[string]any
+	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// Снимок до изменений - для diff в истории. First даёт чистый 404, если нет.
+		var prev models.Citizenship
+		if err := tx.First(&prev, id).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return echo.NewHTTPError(http.StatusNotFound, "Гражданство не найдено")
+			}
+			return echo.NewHTTPError(http.StatusInternalServerError, "Error fetching citizenship")
+		}
+
 		// Если выбран как гражданство по умолчанию, снимаем флаг у остальных
 		if isDefault {
 			if err := tx.Model(&models.Citizenship{}).
@@ -119,43 +140,92 @@ func (s *citizenshipService) Update(ctx context.Context, typeID int, id int, req
 			}
 		}
 
-		result := tx.Model(&models.Citizenship{}).
+		if err := tx.Model(&models.Citizenship{}).
 			Where("id = ?", id).
 			Updates(map[string]interface{}{
 				"name":            req.Name,
 				"icon":            req.Icon,
-				"is_active":       isActive,
 				"is_default":      isDefault,
 				"patent_required": patentRequired,
-			})
-		if result.Error != nil {
-			slog.Error("не удалось обновить гражданство", "id", id, "error", result.Error)
+			}).Error; err != nil {
+			slog.Error("не удалось обновить гражданство", "id", id, "error", err)
 			return echo.NewHTTPError(http.StatusInternalServerError, "Error updating citizenship")
 		}
-		if result.RowsAffected == 0 {
-			return echo.NewHTTPError(http.StatusNotFound, "Гражданство не найдено")
-		}
 		slog.Info("гражданство обновлено", "id", id)
+		details = buildCitizenshipUpdateDetails(prev, req.Name, req.Icon, isDefault, patentRequired)
 		return nil
 	})
+	if err != nil {
+		return err
+	}
+
+	// Логируем только если что-то реально изменилось - иначе спам "Изменены данные".
+	if len(details) > 0 {
+		s.history.Log(ctx, id, &userID, models.CitizenshipActionUpdated, details)
+	}
+	return nil
 }
 
-// Delete удаляет гражданство по ID.
-func (s *citizenshipService) Delete(ctx context.Context, typeID int, id int) error {
+// Delete архивирует гражданство (soft-delete через is_active=false).
+// Гражданство по умолчанию архивировать нельзя - сначала нужно назначить другое.
+// Гражданство, используемое сотрудниками (employees.citizenship_id), архивировать
+// можно: сотрудники уже созданы, архивное гражданство лишь скрывается из выбора новых.
+func (s *citizenshipService) Delete(ctx context.Context, typeID, userID, id int) error {
 	if err := s.checkAdmin(ctx, typeID); err != nil {
 		return err
 	}
 
-	result := s.db.WithContext(ctx).Delete(&models.Citizenship{}, id)
-	if result.Error != nil {
-		slog.Error("не удалось удалить гражданство", "id", id, "error", result.Error)
-		return echo.NewHTTPError(http.StatusInternalServerError, "Error deleting citizenship")
+	var citizenship models.Citizenship
+	if err := s.db.WithContext(ctx).First(&citizenship, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "Гражданство не найдено")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Error fetching citizenship")
 	}
-	if result.RowsAffected == 0 {
-		return echo.NewHTTPError(http.StatusNotFound, "Гражданство не найдено")
+	if !citizenship.IsActive {
+		return nil // уже в архиве - идемпотентно; проверяем до is_default, иначе архивный дефолт залип бы на 409
 	}
-	slog.Info("гражданство удалено", "id", id)
+	if citizenship.IsDefault {
+		return echo.NewHTTPError(http.StatusConflict, "Нельзя архивировать гражданство по умолчанию. Сначала назначьте другое гражданство по умолчанию")
+	}
+	if err := s.db.WithContext(ctx).Model(&citizenship).Update("is_active", false).Error; err != nil {
+		slog.Error("не удалось архивировать гражданство", "id", id, "error", err)
+		return echo.NewHTTPError(http.StatusInternalServerError, "Error archiving citizenship")
+	}
+	slog.Info("гражданство архивировано", "id", id)
+	s.history.Log(ctx, id, &userID, models.CitizenshipActionArchived, nil)
 	return nil
+}
+
+// Restore восстанавливает гражданство из архива (is_active=true).
+func (s *citizenshipService) Restore(ctx context.Context, typeID, userID, id int) error {
+	if err := s.checkAdmin(ctx, typeID); err != nil {
+		return err
+	}
+
+	var citizenship models.Citizenship
+	if err := s.db.WithContext(ctx).First(&citizenship, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "Гражданство не найдено")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Error fetching citizenship")
+	}
+	if citizenship.IsActive {
+		return nil // уже активно - идемпотентно
+	}
+	// У гражданств нет уникального индекса по name, конфликт имени при восстановлении невозможен.
+	if err := s.db.WithContext(ctx).Model(&citizenship).Update("is_active", true).Error; err != nil {
+		slog.Error("не удалось восстановить гражданство", "id", id, "error", err)
+		return echo.NewHTTPError(http.StatusInternalServerError, "Error restoring citizenship")
+	}
+	slog.Info("гражданство восстановлено", "id", id)
+	s.history.Log(ctx, id, &userID, models.CitizenshipActionRestored, nil)
+	return nil
+}
+
+// GetHistory возвращает историю изменений гражданства (новые сверху).
+func (s *citizenshipService) GetHistory(ctx context.Context, id int) ([]models.CitizenshipHistoryItem, error) {
+	return s.history.GetHistory(ctx, id)
 }
 
 // ClearDefaults сбрасывает флаг «по умолчанию» у всех гражданств.
@@ -173,4 +243,25 @@ func (s *citizenshipService) ClearDefaults(ctx context.Context, typeID int) erro
 	}
 	slog.Info("гражданства по умолчанию сброшены")
 	return nil
+}
+
+// buildCitizenshipUpdateDetails собирает diff изменённых полей гражданства как {old, new}.
+// В результат попадают только реально изменившиеся поля - иначе история засоряется
+// "пустыми" записями (см. ui-history: фильтр неизменённого обязателен). strPtrVal
+// определён в license_format_service.go (тот же пакет).
+func buildCitizenshipUpdateDetails(prev models.Citizenship, name string, icon *string, isDefault, patentRequired bool) map[string]any {
+	details := map[string]any{}
+	if name != prev.Name {
+		details["name"] = map[string]any{"old": prev.Name, "new": name}
+	}
+	if strPtrVal(prev.Icon) != strPtrVal(icon) {
+		details["icon"] = map[string]any{"old": strPtrVal(prev.Icon), "new": strPtrVal(icon)}
+	}
+	if isDefault != prev.IsDefault {
+		details["is_default"] = map[string]any{"old": prev.IsDefault, "new": isDefault}
+	}
+	if patentRequired != prev.PatentRequired {
+		details["patent_required"] = map[string]any{"old": prev.PatentRequired, "new": patentRequired}
+	}
+	return details
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -60,7 +60,7 @@ var tables = []string{
 	"system_table_trash_histories", "system_table_histories",
 	"system_table_time_slots", "system_table_photos", "system_tables",
 	"license_plate_format_histories", "license_plate_format_cells", "license_plate_formats",
-	"citizenships",
+	"citizenship_histories", "citizenships",
 	"companies_users", "organization_users",
 	"user_histories", "user_type_histories", "organization_histories", "company_histories",
 	"refresh_tokens", "users",


### PR DESCRIPTION
Срез 415-backend эпика #406. Backend для архива и истории гражданств - по образцу форматов номеров (#414). Дальше отдельным PR пойдёт фронт (CitizenshipManagement под эталон + модалка истории).

## Что внутри
- **Архив (soft-delete):** `Delete` теперь ставит `is_active=false` вместо hard-delete; дефолтное гражданство архивировать нельзя (409); `POST /citizenships/{id}/restore`. `GetAll` по умолчанию отдаёт только активные, `?include_archived=true` - с архивом.
- **История:** модель `CitizenshipHistory` (jsonb-details) + сервис + `GET /citizenships/{id}/history`; логирование create/update/archive/restore со структурным diff (`{field:{old,new}}`) по name/icon/is_default/patent_required.
- Регистрация модели в AutoMigrate (владелец дал OK); добавлен `citizenship_histories` в CleanDB.

## Решения
- Гражданство, используемое сотрудниками (`employees.citizenship_id`), архивировать **можно** - по паритету с #414 (формат, используемый машинами, архивируется). Блокируется только архив дефолтного. Сотрудник сохраняет ссылку на архивное гражданство.
- `is_active` убран из `UpdateCitizenshipRequest`: архив/восстановление идут через DELETE/restore (логируются + проверка дефолта), а не молча через PUT. Bind нестрогий, старый фронт с `is_active` в теле не упадёт (поле игнорируется). Фронт переведём на archive/restore следующим срезом.
- Авторизация без изменений: сервис как и раньше делает `checkAdmin(typeID)`; `userID` добавлен отдельно только как актор в аудите.

## Проверено
- `go build ./...`, `go vet ./...`, gofmt - чисто.
- Тесты гражданств зелёные: архив->soft + `include_archived`, restore-цикл, блок архива дефолта (409), история (4 записи created/updated/archived/restored с diff по name/patent_required). Обновлён CRUD-тест (сообщение "архивировано").
- Ревью code-reviewer: пофикшен блокер (отсутствие `citizenship_histories` в CleanDB), убрано вводящее в заблуждение `IsActive` из UpdateRequest, подчищен docblock. GetHistory-404 и index на is_active оставлены по паритету с эталоном #414 (осознанно).

Фронт (управление под эталон + история-модалка + кнопка) - следующим PR в этой серии.