### PR TITLE
fix(blacklist): русские тексты истории, иконка без обрезки, «Убрать из ЧС» (#443)

### DIFF
--- a/frontend/src/components/CarHistoryModal.vue
+++ b/frontend/src/components/CarHistoryModal.vue
@@ -437,7 +437,9 @@ export default {
         'update': 'dot-update',
         'delete': 'dot-delete',
         'activate': 'dot-activate',
-        'deactivate': 'dot-deactivate'
+        'deactivate': 'dot-deactivate',
+        'blacklisted': 'dot-delete',
+        'unblacklisted': 'dot-activate'
       };
       return classes[actionType] || 'dot-default';
     },
@@ -455,7 +457,9 @@ export default {
         'delete': 'Автомобиль удалён',
         'activate': 'Автомобиль введён в работу',
         'deactivate': 'Автомобиль выведен из работы',
-        'restore': 'Автомобиль восстановлен'
+        'restore': 'Автомобиль восстановлен',
+        'blacklisted': 'Добавлен в чёрный список',
+        'unblacklisted': 'Снят с чёрного списка'
       };
       
       let text = texts[item.action_type] || item.action_type;

--- a/frontend/src/components/CreateApplication/EmployeeHistoryModal.vue
+++ b/frontend/src/components/CreateApplication/EmployeeHistoryModal.vue
@@ -455,7 +455,9 @@ export default {
         'delete': 'dot-delete',
         'activate': 'dot-activate',
         'deactivate': 'dot-deactivate',
-        'restore': 'dot-restore'
+        'restore': 'dot-restore',
+        'blacklisted': 'dot-delete',
+        'unblacklisted': 'dot-activate'
       };
       return classes[actionType] || 'dot-default';
     },
@@ -473,7 +475,9 @@ export default {
         'delete': 'Сотрудник удалён',
         'activate': 'Сотрудник введён в работу',
         'deactivate': 'Сотрудник выведен из работы',
-        'restore': 'Сотрудник восстановлен'
+        'restore': 'Сотрудник восстановлен',
+        'blacklisted': 'Добавлен в чёрный список',
+        'unblacklisted': 'Снят с чёрного списка'
       };
       
       let text = texts[item.action_type] || item.action_type;

--- a/frontend/src/components/admin/blacklist/BlacklistTabBase.vue
+++ b/frontend/src/components/admin/blacklist/BlacklistTabBase.vue
@@ -81,12 +81,16 @@
       >
         <div class="bl-details-header">
           <div class="bl-details-heading">
-            <img
+            <div
               v-if="entityIcon"
-              :src="entityIcon"
-              alt=""
               class="bl-details-icon"
             >
+              <img
+                :src="entityIcon"
+                alt=""
+                class="bl-details-icon-img"
+              >
+            </div>
             <h3 class="bl-details-title">
               {{ getPrimaryText(selected) }}
             </h3>
@@ -112,7 +116,7 @@
               class="lk-button lk-button--danger"
               @click="$emit('archive', selected)"
             >
-              Снять с ЧС
+              Убрать из ЧС
             </button>
             <button
               v-else
@@ -445,9 +449,16 @@ export default {
   width: 36px;
   height: 36px;
   flex-shrink: 0;
-  padding: 7px;
   border-radius: 50%;
   background: var(--color-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.bl-details-icon-img {
+  width: 20px;
+  height: 20px;
   object-fit: contain;
 }
 

--- a/frontend/src/components/admin/blacklist/PersonBlacklistTab.vue
+++ b/frontend/src/components/admin/blacklist/PersonBlacklistTab.vue
@@ -34,9 +34,9 @@
     />
     <ConfirmationModal
       :show="!!archiveItem"
-      title="Снятие с чёрного списка"
+      title="Убрать из чёрного списка"
       :message="archiveMessage"
-      confirm-text="Снять"
+      confirm-text="Убрать"
       cancel-text="Отмена"
       :confirm-button-style="{ background: '#dc3545', borderColor: '#dc3545' }"
       @confirm="doArchive"
@@ -86,7 +86,7 @@ export default {
   computed: {
     archiveMessage() {
       return this.archiveItem
-        ? `Снять «${this.primaryText(this.archiveItem)}» с чёрного списка? Совпадающие сотрудники с активной заявкой снова станут активными.`
+        ? `Убрать «${this.primaryText(this.archiveItem)}» из чёрного списка? Совпадающие сотрудники с активной заявкой снова станут активными.`
         : '';
     },
   },
@@ -148,10 +148,10 @@ export default {
       if (!item) return;
       try {
         await archivePersonBlacklist(item.id);
-        useDeletionsStore().notify({ prefix: 'Человек ', bold: this.primaryText(item), suffix: ' снят с чёрного списка' });
+        useDeletionsStore().notify({ prefix: 'Человек ', bold: this.primaryText(item), suffix: ' убран из чёрного списка' });
         await this.$refs.base.fetchData();
       } catch (e) {
-        useDeletionsStore().notify({ prefix: 'Не удалось снять: ', bold: e?.message || 'ошибка', type: 'error' });
+        useDeletionsStore().notify({ prefix: 'Не удалось убрать: ', bold: e?.message || 'ошибка', type: 'error' });
       }
     },
     async doRestore(item) {

--- a/frontend/src/components/admin/blacklist/VehicleBlacklistTab.vue
+++ b/frontend/src/components/admin/blacklist/VehicleBlacklistTab.vue
@@ -34,9 +34,9 @@
     />
     <ConfirmationModal
       :show="!!archiveItem"
-      title="Снятие с чёрного списка"
+      title="Убрать из чёрного списка"
       :message="archiveMessage"
-      confirm-text="Снять"
+      confirm-text="Убрать"
       cancel-text="Отмена"
       :confirm-button-style="{ background: '#dc3545', borderColor: '#dc3545' }"
       @confirm="doArchive"
@@ -87,7 +87,7 @@ export default {
   computed: {
     archiveMessage() {
       return this.archiveItem
-        ? `Снять «${this.primaryText(this.archiveItem)}» с чёрного списка? Совпадающие машины с активной заявкой снова станут активными.`
+        ? `Убрать «${this.primaryText(this.archiveItem)}» из чёрного списка? Совпадающие машины с активной заявкой снова станут активными.`
         : '';
     },
   },
@@ -143,10 +143,10 @@ export default {
       if (!item) return;
       try {
         await archiveVehicleBlacklist(item.id);
-        useDeletionsStore().notify({ prefix: 'Машина ', bold: this.primaryText(item), suffix: ' снята с чёрного списка' });
+        useDeletionsStore().notify({ prefix: 'Машина ', bold: this.primaryText(item), suffix: ' убрана из чёрного списка' });
         await this.$refs.base.fetchData();
       } catch (e) {
-        useDeletionsStore().notify({ prefix: 'Не удалось снять: ', bold: e?.message || 'ошибка', type: 'error' });
+        useDeletionsStore().notify({ prefix: 'Не удалось убрать: ', bold: e?.message || 'ошибка', type: 'error' });
       }
     },
     async doRestore(item) {

--- a/frontend/src/components/admin/blacklist/__tests__/BlacklistTabBase.spec.js
+++ b/frontend/src/components/admin/blacklist/__tests__/BlacklistTabBase.spec.js
@@ -103,7 +103,7 @@ describe('BlacklistTabBase', () => {
     await flushPromises();
     await wrapper.findAll('.bl-row')[0].trigger('click');
     expect(wrapper.find('.bl-details-icon').exists()).toBe(true);
-    expect(wrapper.find('.bl-details-icon').attributes('src')).toBe('/icons/car.png');
+    expect(wrapper.find('.bl-details-icon-img').attributes('src')).toBe('/icons/car.png');
   });
 
   it('кнопка "Создать запись" эмитит create', async () => {
@@ -114,11 +114,11 @@ describe('BlacklistTabBase', () => {
     expect(wrapper.emitted('create')).toBeTruthy();
   });
 
-  it('кнопка "Снять с ЧС" эмитит archive с активной записью', async () => {
+  it('кнопка "Убрать из ЧС" эмитит archive с активной записью', async () => {
     const wrapper = mountBase();
     await flushPromises();
     await wrapper.findAll('.bl-row')[0].trigger('click');
-    const btn = wrapper.findAll('button').find((b) => b.text() === 'Снять с ЧС');
+    const btn = wrapper.findAll('button').find((b) => b.text() === 'Убрать из ЧС');
     await btn.trigger('click');
     expect(wrapper.emitted('archive')[0][0].id).toBe(1);
   });


### PR DESCRIPTION
Полировка ЧС, раунд 2, срез S1 (быстрые фиксы по итогам ручного теста).

- **#1** История машин/сотрудников показывала `blacklisted`/`unblacklisted` сырьём -> русский маппинг «Добавлен в чёрный список» / «Снят с чёрного списка» в Car/EmployeeHistoryModal + цвет точки (красный/зелёный).
- **#3** Иконка `bl-details-icon` обрезалась скруглением -> круглый фон на обёртке, иконка отдельным `<img>` (20px) по центру.
- **#7** «Снять с ЧС» -> «Убрать из ЧС» (кнопка панели + модалка подтверждения + уведомления, оба таба).

## Проверка
- eslint, vitest 362 (обновил 2 теста под новую разметку иконки и текст кнопки), build.
- Локально: панель ЧС - иконка чистая, кнопка «Убрать из ЧС». unified-история возвращает blacklisted-строку, маппинг рендерит её по-русски (живую модалку истории конкретной машины в dev не открыть - нет cars-таблицы; фикс детерминированный, покрыт тестами модалок).