### PR TITLE
feat(attachments): история шаблонов вложений - аудит create/update/archive/restore (#416)

### DIFF
--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -72,6 +72,7 @@ func AllModels() []interface{} {
 
 		// Unique records
 		&models.UniqueAttachment{},
+		&models.UniqueAttachmentHistory{},
 		&models.UniqueCar{},
 		&models.UniqueCarHistory{},
 		&models.UniqueEmployee{},

--- a/internal/handlers/attachments.go
+++ b/internal/handlers/attachments.go
@@ -96,11 +96,12 @@ func (h *AttachmentHandler) GetByID(c echo.Context) error {
 // @Failure      401 {object} models.HTTPError
 // @Router       /attachments [post]
 func (h *AttachmentHandler) Create(c echo.Context) error {
+	userID := GetUserID(c)
 	var req models.CreateUniqueAttachmentRequest
 	if err := BindAndValidate(c, &req); err != nil {
 		return err
 	}
-	resp, err := h.service.Create(c.Request().Context(), req)
+	resp, err := h.service.Create(c.Request().Context(), userID, req)
 	if err != nil {
 		return err
 	}
@@ -121,6 +122,7 @@ func (h *AttachmentHandler) Create(c echo.Context) error {
 // @Failure      401 {object} models.HTTPError
 // @Router       /attachments/{id} [put]
 func (h *AttachmentHandler) Update(c echo.Context) error {
+	userID := GetUserID(c)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid attachment ID")
@@ -129,7 +131,7 @@ func (h *AttachmentHandler) Update(c echo.Context) error {
 	if err := BindAndValidate(c, &req); err != nil {
 		return err
 	}
-	if err := h.service.Update(c.Request().Context(), id, req); err != nil {
+	if err := h.service.Update(c.Request().Context(), userID, id, req); err != nil {
 		return err
 	}
 	return RespondMessage(c, "Вложение успешно обновлено")
@@ -148,11 +150,12 @@ func (h *AttachmentHandler) Update(c echo.Context) error {
 // @Failure      401 {object} models.HTTPError
 // @Router       /attachments/{id} [delete]
 func (h *AttachmentHandler) Delete(c echo.Context) error {
+	userID := GetUserID(c)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid attachment ID")
 	}
-	if err := h.service.Delete(c.Request().Context(), id); err != nil {
+	if err := h.service.Delete(c.Request().Context(), userID, id); err != nil {
 		return err
 	}
 	return RespondMessage(c, "Вложение успешно удалено")
@@ -171,12 +174,37 @@ func (h *AttachmentHandler) Delete(c echo.Context) error {
 // @Failure      401 {object} models.HTTPError
 // @Router       /attachments/{id}/restore [put]
 func (h *AttachmentHandler) Restore(c echo.Context) error {
+	userID := GetUserID(c)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid attachment ID")
 	}
-	if err := h.service.Restore(c.Request().Context(), id); err != nil {
+	if err := h.service.Restore(c.Request().Context(), userID, id); err != nil {
 		return err
 	}
 	return RespondMessage(c, "Вложение успешно восстановлено")
+}
+
+// GetHistory godoc
+// @Summary      История изменений шаблона вложения
+// @Description  Возвращает аудит создания/изменения/архивации/восстановления шаблона вложения (новые сверху)
+// @Tags         attachments
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID шаблона вложения"
+// @Success      200 {array} models.UniqueAttachmentHistoryItem
+// @Failure      400 {object} models.HTTPError
+// @Failure      401 {object} models.HTTPError
+// @Failure      500 {object} models.HTTPError
+// @Router       /attachments/{id}/history [get]
+func (h *AttachmentHandler) GetHistory(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid attachment ID")
+	}
+	items, err := h.service.GetHistory(c.Request().Context(), id)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, items)
 }

--- a/internal/handlers/attachments_test.go
+++ b/internal/handlers/attachments_test.go
@@ -371,6 +371,133 @@ func TestAttachments_InvalidID(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+// findHistoryByAction возвращает первую запись истории с указанным action_type (или nil).
+// Поиск по action_type, а не по индексу: при близких created_at порядок одинаковых
+// меток нестабилен, поэтому тесты проверяют наличие действия, а не его позицию.
+func findHistoryByAction(items []map[string]interface{}, action string) map[string]interface{} {
+	for _, it := range items {
+		if it["action_type"] == action {
+			return it
+		}
+	}
+	return nil
+}
+
+func TestAttachments_History_Created(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	body := `{"attachment_type":"cars","name":"hist-created","display_name":"История Created","title":"T"}`
+	createRec := testutil.POST(t, e, "/attachments", body, testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, createRec.Code)
+	id := int(testutil.ParseMap(t, createRec)["id"].(float64))
+
+	rec := testutil.GET(t, e, fmt.Sprintf("/attachments/%d/history", id), testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	items := testutil.ParseSlice(t, rec)
+	require.Len(t, items, 1)
+	assert.Equal(t, "created", items[0]["action_type"])
+	details, ok := items[0]["details"].(map[string]interface{})
+	require.True(t, ok, "created details should be an object")
+	assert.Equal(t, "История Created", details["display_name"])
+}
+
+func TestAttachments_History_UpdatedDiff(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	createBody := `{"attachment_type":"cars","name":"hist-upd","display_name":"Было","title":"A"}`
+	createRec := testutil.POST(t, e, "/attachments", createBody, testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, createRec.Code)
+	id := int(testutil.ParseMap(t, createRec)["id"].(float64))
+
+	// Меняем display_name и attachment_type; title и name оставляем прежними.
+	updateBody := `{"attachment_type":"people","name":"hist-upd","display_name":"Стало","title":"A"}`
+	updRec := testutil.PUT(t, e, fmt.Sprintf("/attachments/%d", id), updateBody, testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, updRec.Code)
+
+	rec := testutil.GET(t, e, fmt.Sprintf("/attachments/%d/history", id), testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	items := testutil.ParseSlice(t, rec)
+	require.Len(t, items, 2)
+
+	upd := findHistoryByAction(items, "updated")
+	require.NotNil(t, upd)
+	d, ok := upd["details"].(map[string]interface{})
+	require.True(t, ok)
+
+	dn, ok := d["display_name"].(map[string]interface{})
+	require.True(t, ok, "changed display_name must be in diff")
+	assert.Equal(t, "Было", dn["old"])
+	assert.Equal(t, "Стало", dn["new"])
+
+	at, ok := d["attachment_type"].(map[string]interface{})
+	require.True(t, ok, "changed attachment_type must be in diff")
+	assert.Equal(t, "cars", at["old"])
+	assert.Equal(t, "people", at["new"])
+
+	_, hasTitle := d["title"]
+	assert.False(t, hasTitle, "unchanged title must not appear in diff")
+	_, hasName := d["name"]
+	assert.False(t, hasName, "unchanged name must not appear in diff")
+}
+
+func TestAttachments_History_NoChangeNotLogged(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	createBody := `{"attachment_type":"cars","name":"hist-nochange","display_name":"X","title":"Y"}`
+	createRec := testutil.POST(t, e, "/attachments", createBody, testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, createRec.Code)
+	id := int(testutil.ParseMap(t, createRec)["id"].(float64))
+
+	// Обновляем теми же значениями - diff пустой, история не должна расти.
+	updRec := testutil.PUT(t, e, fmt.Sprintf("/attachments/%d", id), createBody, testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, updRec.Code)
+
+	rec := testutil.GET(t, e, fmt.Sprintf("/attachments/%d/history", id), testutil.AuthHeader(token))
+	items := testutil.ParseSlice(t, rec)
+	require.Len(t, items, 1)
+	assert.Equal(t, "created", items[0]["action_type"])
+}
+
+func TestAttachments_History_ArchiveRestore(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	createBody := `{"attachment_type":"items","name":"hist-arch","display_name":"Архивный","title":"Z"}`
+	createRec := testutil.POST(t, e, "/attachments", createBody, testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, createRec.Code)
+	id := int(testutil.ParseMap(t, createRec)["id"].(float64))
+
+	delRec := testutil.DELETE(t, e, fmt.Sprintf("/attachments/%d", id), testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, delRec.Code)
+	restoreRec := testutil.PUT(t, e, fmt.Sprintf("/attachments/%d/restore", id), "", testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, restoreRec.Code)
+
+	rec := testutil.GET(t, e, fmt.Sprintf("/attachments/%d/history", id), testutil.AuthHeader(token))
+	items := testutil.ParseSlice(t, rec)
+	require.Len(t, items, 3)
+	assert.NotNil(t, findHistoryByAction(items, "created"))
+	require.NotNil(t, findHistoryByAction(items, "archived"))
+	require.NotNil(t, findHistoryByAction(items, "restored"))
+	// archived/restored без details - omitempty убирает поле из JSON.
+	assert.Nil(t, findHistoryByAction(items, "archived")["details"])
+	assert.Nil(t, findHistoryByAction(items, "restored")["details"])
+}
+
 func TestAttachments_CRUD_FullCycle(t *testing.T) {
 	e, db, cleanup := testutil.SetupTestApp(t)
 	defer cleanup()

--- a/internal/models/attachment_history.go
+++ b/internal/models/attachment_history.go
@@ -1,0 +1,37 @@
+package models
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// UniqueAttachmentHistory логирует действия над шаблоном вложения: создание,
+// изменение, архивацию и восстановление. Нужна для аудита (#416): шаблоны вложений
+// привязаны к Excel-бланкам и заявкам, важно знать кто и когда менял.
+// FK (UniqueAttachmentID) намеренно без constraint: аудит должен пережить удаление шаблона.
+type UniqueAttachmentHistory struct {
+	ID                 int             `json:"id"`
+	UniqueAttachmentID int             `gorm:"index;not null" json:"unique_attachment_id"`
+	ActorUserID        *int            `gorm:"index" json:"actor_user_id,omitempty"`
+	ActionType         string          `gorm:"size:32;index" json:"action_type"`
+	Details            json.RawMessage `gorm:"type:jsonb" json:"details,omitempty"`
+	CreatedAt          time.Time       `json:"created_at"`
+}
+
+// UniqueAttachmentActionType - константы для UniqueAttachmentHistory.ActionType.
+const (
+	UniqueAttachmentActionCreated  = "created"
+	UniqueAttachmentActionUpdated  = "updated"
+	UniqueAttachmentActionArchived = "archived"
+	UniqueAttachmentActionRestored = "restored"
+)
+
+// UniqueAttachmentHistoryItem - запись истории с именем актора для API (LEFT JOIN users).
+type UniqueAttachmentHistoryItem struct {
+	ID          int             `json:"id"`
+	ActionType  string          `json:"action_type"`
+	Details     json.RawMessage `json:"details,omitempty" swaggerignore:"true"`
+	ActorUserID *int            `json:"actor_user_id,omitempty"`
+	ActorName   string          `json:"actor_name"`
+	CreatedAt   time.Time       `json:"created_at"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -159,6 +159,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	att.PUT("/:id", attachments.Update)
 	att.DELETE("/:id", attachments.Delete)
 	att.PUT("/:id/restore", attachments.Restore)
+	att.GET("/:id/history", attachments.GetHistory)
 	att.GET("/:id", attachments.GetByID)
 
 	// Управление типами пользователей (admin-only)

--- a/internal/services/attachment_history_service.go
+++ b/internal/services/attachment_history_service.go
@@ -1,0 +1,88 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"systemburo/internal/models"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+// AttachmentHistoryService - аудит действий над шаблонами вложений (#416).
+type AttachmentHistoryService interface {
+	// Log пишет запись аудита. Ошибка не возвращается: аудит не ломает основное действие.
+	Log(ctx context.Context, attachmentID int, actorUserID *int, actionType string, details interface{})
+	// GetHistory возвращает историю по шаблону вложения (новые сверху).
+	GetHistory(ctx context.Context, attachmentID int) ([]models.UniqueAttachmentHistoryItem, error)
+}
+
+type attachmentHistoryService struct {
+	db *gorm.DB
+}
+
+// NewAttachmentHistoryService создаёт реализацию AttachmentHistoryService.
+func NewAttachmentHistoryService(db *gorm.DB) AttachmentHistoryService {
+	return &attachmentHistoryService{db: db}
+}
+
+func (s *attachmentHistoryService) Log(ctx context.Context, attachmentID int, actorUserID *int, actionType string, details interface{}) {
+	var raw json.RawMessage
+	if details != nil {
+		b, err := json.Marshal(details)
+		if err != nil {
+			slog.Error("attachment_history: marshal details", "attachment", attachmentID, "error", err)
+		} else {
+			raw = b
+		}
+	}
+	entry := models.UniqueAttachmentHistory{
+		UniqueAttachmentID: attachmentID,
+		ActorUserID:        actorUserID,
+		ActionType:         actionType,
+		Details:            raw,
+	}
+	if err := s.db.WithContext(ctx).Create(&entry).Error; err != nil {
+		slog.Error("attachment_history: insert", "attachment", attachmentID, "action", actionType, "error", err)
+	}
+}
+
+func (s *attachmentHistoryService) GetHistory(ctx context.Context, attachmentID int) ([]models.UniqueAttachmentHistoryItem, error) {
+	type row struct {
+		ID          int             `gorm:"column:id"`
+		ActionType  string          `gorm:"column:action_type"`
+		Details     json.RawMessage `gorm:"column:details"`
+		ActorUserID *int            `gorm:"column:actor_user_id"`
+		ActorName   string          `gorm:"column:actor_name"`
+		CreatedAt   time.Time       `gorm:"column:created_at"`
+	}
+	var rows []row
+	if err := s.db.WithContext(ctx).
+		Table("unique_attachment_histories AS h").
+		Select(`h.id, h.action_type, h.details, h.actor_user_id,
+			COALESCE(NULLIF(TRIM(BOTH ' ' FROM CONCAT_WS(' ', u.last_name, u.first_name)), ''), u.username, '') AS actor_name,
+			h.created_at`).
+		Joins("LEFT JOIN users u ON u.id = h.actor_user_id").
+		Where("h.unique_attachment_id = ?", attachmentID).
+		Order("h.created_at DESC").
+		Scan(&rows).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching attachment history")
+	}
+
+	items := make([]models.UniqueAttachmentHistoryItem, 0, len(rows))
+	for _, r := range rows {
+		items = append(items, models.UniqueAttachmentHistoryItem{
+			ID:          r.ID,
+			ActionType:  r.ActionType,
+			Details:     r.Details,
+			ActorUserID: r.ActorUserID,
+			ActorName:   r.ActorName,
+			CreatedAt:   r.CreatedAt,
+		})
+	}
+	return items, nil
+}

--- a/internal/services/attachment_service.go
+++ b/internal/services/attachment_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -21,22 +22,25 @@ type AttachmentService interface {
 	// GetByID возвращает активный шаблон вложения по ID.
 	GetByID(ctx context.Context, id int) (*models.UniqueAttachment, error)
 	// Create создаёт новый шаблон вложения.
-	Create(ctx context.Context, req models.CreateUniqueAttachmentRequest) (*models.CreateUniqueAttachmentResponse, error)
+	Create(ctx context.Context, userID int, req models.CreateUniqueAttachmentRequest) (*models.CreateUniqueAttachmentResponse, error)
 	// Update обновляет существующий шаблон вложения.
-	Update(ctx context.Context, id int, req models.UpdateUniqueAttachmentRequest) error
+	Update(ctx context.Context, userID, id int, req models.UpdateUniqueAttachmentRequest) error
 	// Delete выполняет мягкое удаление шаблона вложения.
-	Delete(ctx context.Context, id int) error
+	Delete(ctx context.Context, userID, id int) error
 	// Restore восстанавливает ранее удалённый шаблон вложения.
-	Restore(ctx context.Context, id int) error
+	Restore(ctx context.Context, userID, id int) error
+	// GetHistory возвращает историю изменений шаблона вложения (новые сверху).
+	GetHistory(ctx context.Context, id int) ([]models.UniqueAttachmentHistoryItem, error)
 }
 
 type attachmentService struct {
-	db *gorm.DB
+	db      *gorm.DB
+	history AttachmentHistoryService
 }
 
 // NewAttachmentService создаёт новый экземпляр AttachmentService.
 func NewAttachmentService(db *gorm.DB) AttachmentService {
-	return &attachmentService{db: db}
+	return &attachmentService{db: db, history: NewAttachmentHistoryService(db)}
 }
 
 // GetActive возвращает все активные шаблоны вложений.
@@ -71,7 +75,7 @@ func (s *attachmentService) GetByID(ctx context.Context, id int) (*models.Unique
 		Where("id = ? AND is_active = ?", id, true).
 		First(&attachment).Error
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, echo.NewHTTPError(http.StatusNotFound, "Attachment not found")
 		}
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching attachment")
@@ -80,7 +84,7 @@ func (s *attachmentService) GetByID(ctx context.Context, id int) (*models.Unique
 }
 
 // Create создаёт новый шаблон вложения с проверкой уникальности имени.
-func (s *attachmentService) Create(ctx context.Context, req models.CreateUniqueAttachmentRequest) (*models.CreateUniqueAttachmentResponse, error) {
+func (s *attachmentService) Create(ctx context.Context, userID int, req models.CreateUniqueAttachmentRequest) (*models.CreateUniqueAttachmentResponse, error) {
 	// Проверяем уникальность имени среди активных
 	var count int64
 	err := s.db.WithContext(ctx).
@@ -109,73 +113,115 @@ func (s *attachmentService) Create(ctx context.Context, req models.CreateUniqueA
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка при создании вложения")
 	}
 
+	s.history.Log(ctx, attachment.ID, &userID, models.UniqueAttachmentActionCreated, map[string]any{"display_name": req.DisplayName})
 	return &models.CreateUniqueAttachmentResponse{
 		ID:      attachment.ID,
 		Message: "Вложение успешно создано",
 	}, nil
 }
 
-// Update обновляет существующий шаблон вложения.
-func (s *attachmentService) Update(ctx context.Context, id int, req models.UpdateUniqueAttachmentRequest) error {
-	// Проверяем существование среди активных
-	var count int64
-	err := s.db.WithContext(ctx).
-		Model(&models.UniqueAttachment{}).
-		Where("id = ? AND is_active = ?", id, true).
-		Count(&count).Error
+// Update обновляет существующий шаблон вложения и логирует diff изменённых полей.
+func (s *attachmentService) Update(ctx context.Context, userID, id int, req models.UpdateUniqueAttachmentRequest) error {
+	titleUpper := strings.ToUpper(req.Title)
+	var details map[string]any
+	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// Снимок до изменений - для diff в истории. First даёт чистый 404, если нет.
+		var prev models.UniqueAttachment
+		if err := tx.Where("id = ? AND is_active = ?", id, true).First(&prev).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return echo.NewHTTPError(http.StatusNotFound, "Вложение не найдено")
+			}
+			return echo.NewHTTPError(http.StatusInternalServerError, "Error fetching attachment")
+		}
+
+		if err := tx.Model(&models.UniqueAttachment{}).
+			Where("id = ?", id).
+			Updates(map[string]interface{}{
+				"attachment_type": req.AttachmentType,
+				"name":            req.Name,
+				"display_name":    req.DisplayName,
+				"title":           titleUpper,
+				"instruction":     req.Instruction,
+			}).Error; err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "Error updating attachment")
+		}
+		details = buildAttachmentUpdateDetails(prev, req, titleUpper)
+		return nil
+	})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "Error checking attachment existence")
-	}
-	if count == 0 {
-		return echo.NewHTTPError(http.StatusNotFound, "Attachment not found")
+		return err
 	}
 
-	titleUpper := strings.ToUpper(req.Title)
-	result := s.db.WithContext(ctx).
-		Model(&models.UniqueAttachment{}).
-		Where("id = ?", id).
-		Updates(map[string]interface{}{
-			"attachment_type": req.AttachmentType,
-			"name":           req.Name,
-			"display_name":   req.DisplayName,
-			"title":          titleUpper,
-			"instruction":    req.Instruction,
-		})
-	if result.Error != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "Error updating attachment")
-	}
-	if result.RowsAffected == 0 {
-		return echo.NewHTTPError(http.StatusNotFound, "Вложение не найдено")
+	// Логируем только если что-то реально изменилось - иначе спам "Изменены данные".
+	if len(details) > 0 {
+		s.history.Log(ctx, id, &userID, models.UniqueAttachmentActionUpdated, details)
 	}
 	return nil
 }
 
-// Delete выполняет мягкое удаление шаблона вложения.
-func (s *attachmentService) Delete(ctx context.Context, id int) error {
-	result := s.db.WithContext(ctx).
-		Model(&models.UniqueAttachment{}).
-		Where("id = ?", id).
-		Update("is_active", false)
-	if result.Error != nil {
+// Delete архивирует шаблон вложения (soft-delete через is_active=false).
+func (s *attachmentService) Delete(ctx context.Context, userID, id int) error {
+	var attachment models.UniqueAttachment
+	if err := s.db.WithContext(ctx).First(&attachment, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "Вложение не найдено")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Error fetching attachment")
+	}
+	if !attachment.IsActive {
+		return nil // уже в архиве - идемпотентно, не дублируем запись истории
+	}
+	if err := s.db.WithContext(ctx).Model(&attachment).Update("is_active", false).Error; err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "Error deleting attachment")
 	}
-	if result.RowsAffected == 0 {
-		return echo.NewHTTPError(http.StatusNotFound, "Вложение не найдено")
-	}
+	s.history.Log(ctx, id, &userID, models.UniqueAttachmentActionArchived, nil)
 	return nil
 }
 
-// Restore восстанавливает ранее удалённый шаблон вложения.
-func (s *attachmentService) Restore(ctx context.Context, id int) error {
-	result := s.db.WithContext(ctx).
-		Model(&models.UniqueAttachment{}).
-		Where("id = ?", id).
-		Update("is_active", true)
-	if result.Error != nil {
+// Restore восстанавливает ранее удалённый шаблон вложения (is_active=true).
+func (s *attachmentService) Restore(ctx context.Context, userID, id int) error {
+	var attachment models.UniqueAttachment
+	if err := s.db.WithContext(ctx).First(&attachment, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "Вложение не найдено")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Error fetching attachment")
+	}
+	if attachment.IsActive {
+		return nil // уже активно - идемпотентно
+	}
+	if err := s.db.WithContext(ctx).Model(&attachment).Update("is_active", true).Error; err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "Error restoring attachment")
 	}
-	if result.RowsAffected == 0 {
-		return echo.NewHTTPError(http.StatusNotFound, "Вложение не найдено")
-	}
+	s.history.Log(ctx, id, &userID, models.UniqueAttachmentActionRestored, nil)
 	return nil
+}
+
+// GetHistory возвращает историю изменений шаблона вложения (новые сверху).
+func (s *attachmentService) GetHistory(ctx context.Context, id int) ([]models.UniqueAttachmentHistoryItem, error) {
+	return s.history.GetHistory(ctx, id)
+}
+
+// buildAttachmentUpdateDetails собирает diff изменённых полей шаблона вложения как {old, new}.
+// В результат попадают только реально изменившиеся поля - иначе история засоряется
+// "пустыми" записями (см. ui-history: фильтр неизменённого обязателен). Title сравнивается
+// с уже приведённым к верхнему регистру значением (titleUpper), как его пишет Update.
+func buildAttachmentUpdateDetails(prev models.UniqueAttachment, req models.UpdateUniqueAttachmentRequest, titleUpper string) map[string]any {
+	details := map[string]any{}
+	if prev.AttachmentType != req.AttachmentType {
+		details["attachment_type"] = map[string]any{"old": prev.AttachmentType, "new": req.AttachmentType}
+	}
+	if strPtrVal(prev.Name) != req.Name {
+		details["name"] = map[string]any{"old": strPtrVal(prev.Name), "new": req.Name}
+	}
+	if strPtrVal(prev.DisplayName) != req.DisplayName {
+		details["display_name"] = map[string]any{"old": strPtrVal(prev.DisplayName), "new": req.DisplayName}
+	}
+	if strPtrVal(prev.Title) != titleUpper {
+		details["title"] = map[string]any{"old": strPtrVal(prev.Title), "new": titleUpper}
+	}
+	if strPtrVal(prev.Instruction) != strPtrVal(req.Instruction) {
+		details["instruction"] = map[string]any{"old": strPtrVal(prev.Instruction), "new": strPtrVal(req.Instruction)}
+	}
+	return details
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -50,7 +50,7 @@ var tables = []string{
 	"person_blacklist_histories", "person_blacklists",
 	"attachments",
 	"unique_employees_history", "unique_cars_history",
-	"unique_employees", "unique_cars", "unique_attachments",
+	"unique_employees", "unique_cars", "unique_attachment_histories", "unique_attachments",
 	"application_reads", "application_viewers", "application_approvers", "application_responsible_users",
 	"application_status_history", "application_history", "applications",
 	"companies_unload_places", "organization_unload_places",


### PR DESCRIPTION
Срез **416-1** эпика #406 (sub-issue #416 «Вложения заявок / бланки»). Чисто-backend: добавляет аудит-историю для шаблонов вложений `UniqueAttachment` по образцу уже смерженных #414 (форматы номеров) и #415 (гражданства).

## Что сделано
- Модель `UniqueAttachmentHistory` (jsonb `details`, FK `unique_attachment_id` намеренно без constraint — аудит должен пережить удаление шаблона).
- Сервис `AttachmentHistoryService` (`Log`/`GetHistory`, LEFT JOIN users для имени актора).
- Логирование `created` / `updated` / `archived` / `restored` из `attachment_service`; `userID` протянут из JWT-контекста в Create/Update/Delete/Restore.
- Diff изменённых полей `buildAttachmentUpdateDetails` — в историю попадают только реально изменившиеся поля (title сравнивается с уже uppercased-значением; nil-указатели через `strPtrVal`).
- Идемпотентность Delete/Restore — повторный архив/восстановление не плодят дублей истории.
- Эндпоинт `GET /attachments/{id}/history`.
- `AutoMigrate(UniqueAttachmentHistory)` — владелец дал явный OK на касание migrate.go.

## Решения владельца (08.06)
- История ДА (как у марок: «по значимости управление вложениями = управление справочниками с историей»).
- FK **не блокирует** архив (паритет #414/#415): архивный шаблон лишь скрывается из выбора новых, уже поданные вложения в заявках остаются. FK-проверка в Delete не добавлялась осознанно.

## Вне скоупа (осознанно)
- `include_archived` query-param и перевод фронта на новый контракт `GetAll` — в срезе 416-2 (фронт), чтобы не рассинхронить текущий фронт, который грузит `/all`.
- Фронт-модалка истории — срез 416-3.

## Проверено
- `go build` / `go vet` / `gofmt` чисто.
- `go test ./internal/handlers/ ./internal/services/ -count=1` зелёные (включая новые тесты истории: created, updated-diff с проверкой фильтра неизменённого, archive+restore, no-change-not-logged).
- Ревью code-reviewer: GO, паритет с эталоном #414/#415 подтверждён; MINOR (использовать helper `GetUserID` вместо сырого type-assert) применён.