### PR TITLE
feat(blacklist): редактирование причины записи ЧС с историей (#443)

### DIFF
--- a/frontend/src/api/blacklist.js
+++ b/frontend/src/api/blacklist.js
@@ -34,6 +34,10 @@ export function createVehicleBlacklist({ car_number, mark_id, reason }) {
   return mutate('/vehicle-blacklist', { body: { car_number, mark_id, reason } });
 }
 
+export function updateVehicleBlacklist(id, { reason }) {
+  return mutate(`/vehicle-blacklist/${id}`, { method: 'PUT', body: { reason } });
+}
+
 export function archiveVehicleBlacklist(id) {
   return mutate(`/vehicle-blacklist/${id}`, { method: 'DELETE' });
 }
@@ -44,6 +48,10 @@ export function restoreVehicleBlacklist(id) {
 
 export function createPersonBlacklist({ last_name, first_name, middle_name, reason }) {
   return mutate('/person-blacklist', { body: { last_name, first_name, middle_name, reason } });
+}
+
+export function updatePersonBlacklist(id, { reason }) {
+  return mutate(`/person-blacklist/${id}`, { method: 'PUT', body: { reason } });
 }
 
 export function archivePersonBlacklist(id) {

--- a/frontend/src/components/admin/blacklist/AddToBlacklistModal.vue
+++ b/frontend/src/components/admin/blacklist/AddToBlacklistModal.vue
@@ -21,7 +21,7 @@
           v-model="reason"
           class="lk-textarea"
           rows="3"
-          placeholder="Опишите причину добавления в чёрный список"
+          placeholder="Опишите причину попадания в чёрный список"
         />
       </FormField>
 
@@ -42,11 +42,12 @@
         Отмена
       </button>
       <button
-        class="lk-button lk-button--danger"
+        class="lk-button"
+        :class="isEdit ? 'lk-button--primary' : 'lk-button--danger'"
         :disabled="!reason.trim() || saving"
         @click="confirm"
       >
-        {{ saving ? 'Добавление...' : 'Добавить в ЧС' }}
+        {{ confirmText }}
       </button>
     </template>
   </BaseModal>
@@ -68,7 +69,10 @@ export default {
   props: {
     show: { type: Boolean, default: false },
     type: { type: String, required: true, validator: (v) => ['vehicle', 'person'].includes(v) },
+    // 'add' - добавление из карточки; 'edit' - редактирование причины из страницы ЧС.
+    mode: { type: String, default: 'add', validator: (v) => ['add', 'edit'].includes(v) },
     entityLabel: { type: String, default: '' },
+    initialReason: { type: String, default: '' },
     saving: { type: Boolean, default: false },
     error: { type: String, default: '' },
     // Открывается из карточки Т/С/сотрудника (z-index 10001) - перекрываем её. Ниже
@@ -80,17 +84,25 @@ export default {
     return { reason: '' };
   },
   computed: {
+    isEdit() {
+      return this.mode === 'edit';
+    },
     title() {
+      if (this.isEdit) return 'Редактировать причину';
       return this.type === 'vehicle' ? 'Добавить машину в чёрный список' : 'Добавить человека в чёрный список';
     },
     entityCaption() {
       return this.type === 'vehicle' ? 'Машина' : 'Человек';
     },
+    confirmText() {
+      if (this.isEdit) return this.saving ? 'Сохранение...' : 'Сохранить';
+      return this.saving ? 'Добавление...' : 'Добавить в ЧС';
+    },
   },
   watch: {
     show(open) {
       if (open) {
-        this.reason = '';
+        this.reason = this.initialReason || '';
         this.$nextTick(() => this.$refs.reasonInput?.focus());
       }
     },

--- a/frontend/src/components/admin/blacklist/BlacklistHistoryModalBase.vue
+++ b/frontend/src/components/admin/blacklist/BlacklistHistoryModalBase.vue
@@ -193,6 +193,7 @@ const ACTION_DOT_CLASS = {
   created: 'dot-create',
   archived: 'dot-deactivate',
   restored: 'dot-activate',
+  updated: 'dot-update',
 };
 
 /**
@@ -377,8 +378,11 @@ export default {
       const d = item.details;
       if (!d || typeof d !== 'object') return '';
       const parts = [];
-      for (const [key, raw] of Object.entries(d)) {
-        if (!(key in this.fieldLabels)) continue;
+      // Порядок - по объявлению в fieldLabels (а не по ключам details: jsonb не хранит
+      // порядок, иначе "Стало/Было" показывались бы в произвольном порядке).
+      for (const key of Object.keys(this.fieldLabels)) {
+        if (!(key in d)) continue;
+        const raw = d[key];
         if (raw === null || raw === undefined || raw === '') continue;
         if (typeof raw === 'number' && raw === 0) continue;
         parts.push(`${this.fieldLabels[key]}: ${this.formatFieldValue(raw)}`);

--- a/frontend/src/components/admin/blacklist/BlacklistTabBase.vue
+++ b/frontend/src/components/admin/blacklist/BlacklistTabBase.vue
@@ -113,6 +113,13 @@
             </button>
             <button
               v-if="selected.is_active"
+              class="lk-button lk-button--secondary"
+              @click="$emit('edit', selected)"
+            >
+              Редактировать
+            </button>
+            <button
+              v-if="selected.is_active"
               class="lk-button lk-button--danger"
               @click="$emit('archive', selected)"
             >
@@ -203,7 +210,7 @@ export default {
     // "Открыть карточку" (disabled, пока запись в реестре не найдена).
     lookupCard: { type: Function, default: null },
   },
-  emits: ['count', 'create', 'archive', 'restore', 'history', 'open-card'],
+  emits: ['count', 'create', 'archive', 'restore', 'history', 'open-card', 'edit'],
   data() {
     return {
       items: [],

--- a/frontend/src/components/admin/blacklist/PersonBlacklistHistoryModal.vue
+++ b/frontend/src/components/admin/blacklist/PersonBlacklistHistoryModal.vue
@@ -18,10 +18,13 @@ const ACTION_TEXTS = {
   created: 'Добавлен в чёрный список',
   archived: 'Снят с чёрного списка',
   restored: 'Возвращён в чёрный список',
+  updated: 'Изменена причина',
 };
 
 const FIELD_LABELS = {
   reason: 'Причина',
+  reason_old: 'Было',
+  reason_new: 'Стало',
   employees_deactivated: 'Деактивировано сотрудников',
   employees_reactivated: 'Возвращено сотрудников',
 };

--- a/frontend/src/components/admin/blacklist/PersonBlacklistTab.vue
+++ b/frontend/src/components/admin/blacklist/PersonBlacklistTab.vue
@@ -14,11 +14,24 @@
       @restore="doRestore"
       @history="historyItem = $event"
       @open-card="openCard"
+      @edit="onEdit"
     >
       <template #header-left>
         <slot name="header-left" />
       </template>
     </BlacklistTabBase>
+    <AddToBlacklistModal
+      :show="!!editItem"
+      type="person"
+      mode="edit"
+      :entity-label="editItem ? primaryText(editItem) : ''"
+      :initial-reason="editItem ? editItem.reason : ''"
+      :saving="savingEdit"
+      :error="editError"
+      :z-index="1000"
+      @close="editItem = null"
+      @confirm="saveEdit"
+    />
     <BlacklistCreateModal
       :show="showCreate"
       type="person"
@@ -56,11 +69,13 @@
 import BlacklistTabBase from './BlacklistTabBase.vue';
 import BlacklistCreateModal from './BlacklistCreateModal.vue';
 import PersonBlacklistHistoryModal from './PersonBlacklistHistoryModal.vue';
+import AddToBlacklistModal from './AddToBlacklistModal.vue';
 import ConfirmationModal from '@/components/ConfirmationModal.vue';
 import EmployeeDetailsModal from '@/components/CreateApplication/EmployeeDetailsModal.vue';
 import {
   listPersonBlacklist,
   createPersonBlacklist,
+  updatePersonBlacklist,
   archivePersonBlacklist,
   restorePersonBlacklist,
 } from '@/api/blacklist';
@@ -75,13 +90,16 @@ import userIcon from '@/assets/icons/user.png';
  */
 export default {
   name: 'PersonBlacklistTab',
-  components: { BlacklistTabBase, BlacklistCreateModal, PersonBlacklistHistoryModal, ConfirmationModal, EmployeeDetailsModal },
+  components: { BlacklistTabBase, BlacklistCreateModal, PersonBlacklistHistoryModal, AddToBlacklistModal, ConfirmationModal, EmployeeDetailsModal },
   props: {
     currentUserName: { type: String, default: '' },
   },
   emits: ['count'],
   data() {
-    return { showCreate: false, archiveItem: null, historyItem: null, userIcon, detailsEmployee: null, showDetails: false };
+    return {
+      showCreate: false, archiveItem: null, historyItem: null, userIcon, detailsEmployee: null, showDetails: false,
+      editItem: null, savingEdit: false, editError: '',
+    };
   },
   computed: {
     archiveMessage() {
@@ -138,6 +156,26 @@ export default {
       this.showCreate = false;
       useDeletionsStore().notify({ prefix: 'Человек ', bold: name, suffix: ' добавлен в чёрный список' });
       await this.$refs.base.fetchData();
+    },
+    onEdit(item) {
+      this.editError = '';
+      this.editItem = item;
+    },
+    async saveEdit(reason) {
+      const item = this.editItem;
+      if (!item || this.savingEdit) return;
+      this.savingEdit = true;
+      this.editError = '';
+      try {
+        await updatePersonBlacklist(item.id, { reason });
+        useDeletionsStore().notify({ prefix: 'Причина обновлена для ', bold: this.primaryText(item) });
+        this.editItem = null;
+        await this.$refs.base.fetchData();
+      } catch (e) {
+        this.editError = e?.message || 'Не удалось сохранить причину';
+      } finally {
+        this.savingEdit = false;
+      }
     },
     askArchive(item) {
       this.archiveItem = item;

--- a/frontend/src/components/admin/blacklist/VehicleBlacklistHistoryModal.vue
+++ b/frontend/src/components/admin/blacklist/VehicleBlacklistHistoryModal.vue
@@ -18,10 +18,13 @@ const ACTION_TEXTS = {
   created: 'Добавлена в чёрный список',
   archived: 'Снята с чёрного списка',
   restored: 'Возвращена в чёрный список',
+  updated: 'Изменена причина',
 };
 
 const FIELD_LABELS = {
   reason: 'Причина',
+  reason_old: 'Было',
+  reason_new: 'Стало',
   cars_deactivated: 'Деактивировано машин',
   cars_reactivated: 'Возвращено машин в оборот',
 };

--- a/frontend/src/components/admin/blacklist/VehicleBlacklistTab.vue
+++ b/frontend/src/components/admin/blacklist/VehicleBlacklistTab.vue
@@ -14,11 +14,24 @@
       @restore="doRestore"
       @history="historyItem = $event"
       @open-card="openCard"
+      @edit="onEdit"
     >
       <template #header-left>
         <slot name="header-left" />
       </template>
     </BlacklistTabBase>
+    <AddToBlacklistModal
+      :show="!!editItem"
+      type="vehicle"
+      mode="edit"
+      :entity-label="editItem ? primaryText(editItem) : ''"
+      :initial-reason="editItem ? editItem.reason : ''"
+      :saving="savingEdit"
+      :error="editError"
+      :z-index="1000"
+      @close="editItem = null"
+      @confirm="saveEdit"
+    />
     <BlacklistCreateModal
       :show="showCreate"
       type="vehicle"
@@ -57,11 +70,13 @@
 import BlacklistTabBase from './BlacklistTabBase.vue';
 import BlacklistCreateModal from './BlacklistCreateModal.vue';
 import VehicleBlacklistHistoryModal from './VehicleBlacklistHistoryModal.vue';
+import AddToBlacklistModal from './AddToBlacklistModal.vue';
 import ConfirmationModal from '@/components/ConfirmationModal.vue';
 import VehicleDetailsModal from '@/components/CreateApplication/VehicleDetailsModal.vue';
 import {
   listVehicleBlacklist,
   createVehicleBlacklist,
+  updateVehicleBlacklist,
   archiveVehicleBlacklist,
   restoreVehicleBlacklist,
 } from '@/api/blacklist';
@@ -76,13 +91,16 @@ import carIcon from '@/assets/icons/car.png';
  */
 export default {
   name: 'VehicleBlacklistTab',
-  components: { BlacklistTabBase, BlacklistCreateModal, VehicleBlacklistHistoryModal, ConfirmationModal, VehicleDetailsModal },
+  components: { BlacklistTabBase, BlacklistCreateModal, VehicleBlacklistHistoryModal, AddToBlacklistModal, ConfirmationModal, VehicleDetailsModal },
   props: {
     currentUserName: { type: String, default: '' },
   },
   emits: ['count'],
   data() {
-    return { showCreate: false, archiveItem: null, historyItem: null, carIcon, detailsVehicle: null, showDetails: false };
+    return {
+      showCreate: false, archiveItem: null, historyItem: null, carIcon, detailsVehicle: null, showDetails: false,
+      editItem: null, savingEdit: false, editError: '',
+    };
   },
   computed: {
     archiveMessage() {
@@ -133,6 +151,26 @@ export default {
       this.showCreate = false;
       useDeletionsStore().notify({ prefix: 'Машина ', bold: name, suffix: ' добавлена в чёрный список' });
       await this.$refs.base.fetchData();
+    },
+    onEdit(item) {
+      this.editError = '';
+      this.editItem = item;
+    },
+    async saveEdit(reason) {
+      const item = this.editItem;
+      if (!item || this.savingEdit) return;
+      this.savingEdit = true;
+      this.editError = '';
+      try {
+        await updateVehicleBlacklist(item.id, { reason });
+        useDeletionsStore().notify({ prefix: 'Причина обновлена для ', bold: this.primaryText(item) });
+        this.editItem = null;
+        await this.$refs.base.fetchData();
+      } catch (e) {
+        this.editError = e?.message || 'Не удалось сохранить причину';
+      } finally {
+        this.savingEdit = false;
+      }
     },
     askArchive(item) {
       this.archiveItem = item;

--- a/frontend/src/components/admin/blacklist/__tests__/AddToBlacklistModal.spec.js
+++ b/frontend/src/components/admin/blacklist/__tests__/AddToBlacklistModal.spec.js
@@ -63,4 +63,27 @@ describe('AddToBlacklistModal', () => {
     await wrapper.setProps({ show: true });
     expect(wrapper.vm.reason).toBe('');
   });
+
+  describe('режим редактирования (mode=edit)', () => {
+    it('заголовок и кнопка - для редактирования', () => {
+      const wrapper = mountModal({ mode: 'edit', type: 'person' });
+      expect(wrapper.vm.title).toBe('Редактировать причину');
+      const btn = wrapper.findAll('button').find((b) => b.text().includes('Сохранить'));
+      expect(btn).toBeTruthy();
+    });
+
+    it('предзаполняет причину из initialReason при открытии', async () => {
+      const wrapper = mountModal({ show: false, mode: 'edit', initialReason: 'прежняя причина' });
+      await wrapper.setProps({ show: true });
+      expect(wrapper.vm.reason).toBe('прежняя причина');
+    });
+
+    it('confirm эмитит изменённую причину', async () => {
+      const wrapper = mountModal({ show: false, mode: 'edit', initialReason: 'старая' });
+      await wrapper.setProps({ show: true });
+      await wrapper.find('textarea').setValue('новая причина');
+      await wrapper.findAll('button').find((b) => b.text().includes('Сохранить')).trigger('click');
+      expect(wrapper.emitted('confirm')[0]).toEqual(['новая причина']);
+    });
+  });
 });

--- a/frontend/src/components/admin/blacklist/__tests__/BlacklistHistoryModalBase.spec.js
+++ b/frontend/src/components/admin/blacklist/__tests__/BlacklistHistoryModalBase.spec.js
@@ -80,6 +80,16 @@ describe('BlacklistHistoryModalBase', () => {
     expect(wrapper.vm.getActionComment(history[2])).toBe('Деактивировано машин: 1');
   });
 
+  it('updated: порядок Было -> Стало детерминирован по fieldLabels, не по порядку details', async () => {
+    const wrapper = mountModal({
+      fieldLabels: { reason_old: 'Было', reason_new: 'Стало' },
+    });
+    await flushPromises();
+    // details сознательно в обратном порядке (reason_new раньше) - вывод всё равно "Было / Стало"
+    const item = { action_type: 'updated', details: { reason_new: 'новая', reason_old: 'старая' } };
+    expect(wrapper.vm.getActionComment(item)).toBe('Было: старая / Стало: новая');
+  });
+
   it('цвет точки маппится по типу действия', async () => {
     const wrapper = mountModal();
     await flushPromises();

--- a/frontend/src/generated/permission-keys.json
+++ b/frontend/src/generated/permission-keys.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-06-08T12:11:53.945Z",
+  "generated": "2026-06-08T17:14:06.189Z",
   "keys": [
     "action.delete.employee",
     "permission.audit.manage"

--- a/internal/handlers/person_blacklist.go
+++ b/internal/handlers/person_blacklist.go
@@ -59,6 +59,33 @@ func (h *PersonBlacklistHandler) Create(c echo.Context) error {
 	return RespondCreated(c, entry)
 }
 
+// Update godoc
+// @Summary      Редактировать причину записи чёрного списка
+// @Tags         person-blacklist
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID записи"
+// @Param        request body models.UpdateBlacklistReasonRequest true "Новая причина"
+// @Success      200 {object} models.PersonBlacklist
+// @Router       /person-blacklist/{id} [put]
+func (h *PersonBlacklistHandler) Update(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	var req models.UpdateBlacklistReasonRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	userID, _ := c.Get("user_id").(int)
+	entry, err := h.service.UpdateReason(c.Request().Context(), id, req.Reason, userID)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, entry)
+}
+
 // Delete godoc
 // @Summary      Снять человека с чёрного списка (архивация)
 // @Tags         person-blacklist

--- a/internal/handlers/vehicle_blacklist.go
+++ b/internal/handlers/vehicle_blacklist.go
@@ -59,6 +59,33 @@ func (h *VehicleBlacklistHandler) Create(c echo.Context) error {
 	return RespondCreated(c, entry)
 }
 
+// Update godoc
+// @Summary      Редактировать причину записи чёрного списка
+// @Tags         vehicle-blacklist
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID записи"
+// @Param        request body models.UpdateBlacklistReasonRequest true "Новая причина"
+// @Success      200 {object} models.VehicleBlacklist
+// @Router       /vehicle-blacklist/{id} [put]
+func (h *VehicleBlacklistHandler) Update(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	var req models.UpdateBlacklistReasonRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	userID, _ := c.Get("user_id").(int)
+	entry, err := h.service.UpdateReason(c.Request().Context(), id, req.Reason, userID)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, entry)
+}
+
 // Delete godoc
 // @Summary      Снять машину с чёрного списка (архивация)
 // @Tags         vehicle-blacklist

--- a/internal/handlers/vehicle_blacklist_test.go
+++ b/internal/handlers/vehicle_blacklist_test.go
@@ -3,6 +3,7 @@ package handlers_test
 import (
 	"context"
 	"errors"
+	"net/http"
 	"testing"
 
 	"systemburo/internal/models"
@@ -240,4 +241,59 @@ func TestVehicleBlacklist_UnblacklistSkipsExpiredPass(t *testing.T) {
 	require.NoError(t, db.First(&after, carID).Error)
 	require.NotNil(t, after.Status)
 	assert.Equal(t, 0, *after.Status, "машина с истёкшим пропуском не должна возрождаться")
+}
+
+// TestVehicleBlacklist_UpdateReason покрывает редактирование причины + лог в историю.
+func TestVehicleBlacklist_UpdateReason(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	userID, _, userCleanup := setupMWUser(t, db, true, false)
+	defer userCleanup()
+	mark := seedMark(t, db, "BL_UpdReason")
+	svc := newVehicleBlacklistService(db)
+	ctx := context.Background()
+
+	entry, err := svc.Create(ctx, models.CreateVehicleBlacklistRequest{
+		CarNumber: "U111UU799", MarkID: mark.ID, Reason: "старая причина",
+	}, userID)
+	require.NoError(t, err)
+
+	updated, err := svc.UpdateReason(ctx, entry.ID, "  новая причина  ", userID)
+	require.NoError(t, err)
+	assert.Equal(t, "новая причина", updated.Reason)
+
+	stored, err := svc.GetByID(ctx, entry.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "новая причина", stored.Reason)
+
+	hist, err := svc.GetHistory(ctx, entry.ID)
+	require.NoError(t, err)
+	hasUpdated := false
+	for _, h := range hist {
+		if h.ActionType == models.BlacklistActionUpdated {
+			hasUpdated = true
+		}
+	}
+	assert.True(t, hasUpdated, "ожидали запись истории 'updated'")
+
+	t.Run("пустая причина - 400", func(t *testing.T) {
+		_, err := svc.UpdateReason(ctx, entry.ID, "   ", userID)
+		assertHTTPStatus(t, err, http.StatusBadRequest)
+	})
+
+	t.Run("та же причина - без новой записи истории", func(t *testing.T) {
+		before, _ := svc.GetHistory(ctx, entry.ID)
+		_, err := svc.UpdateReason(ctx, entry.ID, "новая причина", userID)
+		require.NoError(t, err)
+		after, _ := svc.GetHistory(ctx, entry.ID)
+		assert.Equal(t, len(before), len(after), "идентичная причина не должна писать историю")
+	})
+
+	t.Run("нельзя редактировать архивную запись - 400", func(t *testing.T) {
+		require.NoError(t, svc.Archive(ctx, entry.ID, userID))
+		_, err := svc.UpdateReason(ctx, entry.ID, "после архива", userID)
+		assertHTTPStatus(t, err, http.StatusBadRequest)
+	})
 }

--- a/internal/models/blacklist.go
+++ b/internal/models/blacklist.go
@@ -46,6 +46,7 @@ const (
 	BlacklistActionCreated  = "created"
 	BlacklistActionArchived = "archived"
 	BlacklistActionRestored = "restored"
+	BlacklistActionUpdated  = "updated"
 )
 
 // CreateVehicleBlacklistRequest - тело POST /vehicle-blacklist.
@@ -53,6 +54,11 @@ type CreateVehicleBlacklistRequest struct {
 	CarNumber string `json:"car_number" validate:"required,min=1,max=50"`
 	MarkID    int    `json:"mark_id" validate:"required"`
 	Reason    string `json:"reason" validate:"required,min=1"`
+}
+
+// UpdateBlacklistReasonRequest - тело PUT /<entity>-blacklist/{id} (редактирование причины).
+type UpdateBlacklistReasonRequest struct {
+	Reason string `json:"reason" validate:"required,min=1"`
 }
 
 // VehicleBlacklistHistoryItem - элемент истории для API (с именем пользователя).

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -207,6 +207,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	vblGroup.GET("/check", vehicleBlacklist.Check)
 	vblGroup.GET("/:id/history", vehicleBlacklist.GetHistory)
 	vblGroup.POST("", vehicleBlacklist.Create, requireBlacklist)
+	vblGroup.PUT("/:id", vehicleBlacklist.Update, requireBlacklist)
 	vblGroup.DELETE("/:id", vehicleBlacklist.Delete, requireBlacklist)
 	vblGroup.POST("/:id/restore", vehicleBlacklist.Restore, requireBlacklist)
 
@@ -216,6 +217,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	pblGroup.GET("/check", personBlacklist.Check)
 	pblGroup.GET("/:id/history", personBlacklist.GetHistory)
 	pblGroup.POST("", personBlacklist.Create, requireBlacklist)
+	pblGroup.PUT("/:id", personBlacklist.Update, requireBlacklist)
 	pblGroup.DELETE("/:id", personBlacklist.Delete, requireBlacklist)
 	pblGroup.POST("/:id/restore", personBlacklist.Restore, requireBlacklist)
 

--- a/internal/services/person_blacklist_service.go
+++ b/internal/services/person_blacklist_service.go
@@ -26,6 +26,8 @@ type PersonBlacklistService interface {
 	Archive(ctx context.Context, id int, userID int) error
 	Restore(ctx context.Context, id int, userID int) error
 	Check(ctx context.Context, lastName, firstName, middleName string) (models.PersonBlacklistCheckResult, error)
+	// UpdateReason - редактирование причины записи + лог в историю (updated).
+	UpdateReason(ctx context.Context, id int, reason string, userID int) (*models.PersonBlacklist, error)
 	GetHistory(ctx context.Context, id int) ([]models.PersonBlacklistHistoryItem, error)
 }
 
@@ -170,6 +172,36 @@ func (s *personBlacklistService) Check(ctx context.Context, lastName, firstName,
 		return models.PersonBlacklistCheckResult{}, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка проверки чёрного списка")
 	}
 	return models.PersonBlacklistCheckResult{IsBlacklisted: true, Reason: e.Reason}, nil
+}
+
+func (s *personBlacklistService) UpdateReason(ctx context.Context, id int, reason string, userID int) (*models.PersonBlacklist, error) {
+	e, err := s.GetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if !e.IsActive {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "Нельзя редактировать причину архивной записи")
+	}
+	newReason := strings.TrimSpace(reason)
+	if newReason == "" {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "Причина обязательна")
+	}
+	if newReason == e.Reason {
+		return e, nil // без изменений - не пишем историю
+	}
+	oldReason := e.Reason
+	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&models.PersonBlacklist{}).Where("id = ?", e.ID).Update("reason", newReason).Error; err != nil {
+			return err
+		}
+		details := map[string]interface{}{"reason_old": oldReason, "reason_new": newReason}
+		return s.history.Log(ctx, tx, e.ID, &userID, models.BlacklistActionUpdated, details)
+	})
+	if err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка обновления причины")
+	}
+	e.Reason = newReason
+	return e, nil
 }
 
 func (s *personBlacklistService) GetHistory(ctx context.Context, id int) ([]models.PersonBlacklistHistoryItem, error) {

--- a/internal/services/vehicle_blacklist_service.go
+++ b/internal/services/vehicle_blacklist_service.go
@@ -35,6 +35,8 @@ type VehicleBlacklistService interface {
 	// CheckByName - проверка по номеру и имени марки (для машин без mark_id, например
 	// выбранных из существующих unique_cars). Совпадение по mark_name, как в каскаде.
 	CheckByName(ctx context.Context, carNumber, markName string) (models.VehicleBlacklistCheckResult, error)
+	// UpdateReason - редактирование причины записи + лог в историю (updated).
+	UpdateReason(ctx context.Context, id int, reason string, userID int) (*models.VehicleBlacklist, error)
 	GetHistory(ctx context.Context, id int) ([]models.VehicleBlacklistHistoryItem, error)
 }
 
@@ -141,6 +143,36 @@ func (s *vehicleBlacklistService) Archive(ctx context.Context, id int, userID in
 		return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка снятия из чёрного списка")
 	}
 	return nil
+}
+
+func (s *vehicleBlacklistService) UpdateReason(ctx context.Context, id int, reason string, userID int) (*models.VehicleBlacklist, error) {
+	e, err := s.GetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if !e.IsActive {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "Нельзя редактировать причину архивной записи")
+	}
+	newReason := strings.TrimSpace(reason)
+	if newReason == "" {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "Причина обязательна")
+	}
+	if newReason == e.Reason {
+		return e, nil // без изменений - не пишем историю
+	}
+	oldReason := e.Reason
+	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&models.VehicleBlacklist{}).Where("id = ?", e.ID).Update("reason", newReason).Error; err != nil {
+			return err
+		}
+		details := map[string]interface{}{"reason_old": oldReason, "reason_new": newReason}
+		return s.history.Log(ctx, tx, e.ID, &userID, models.BlacklistActionUpdated, details)
+	})
+	if err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка обновления причины")
+	}
+	e.Reason = newReason
+	return e, nil
 }
 
 func (s *vehicleBlacklistService) Restore(ctx context.Context, id int, userID int) error {


### PR DESCRIPTION
Полировка ЧС, раунд 2, срез S4 (issue #6).

### Backend
- `UpdateReason` в vehicle/person blacklist сервисах: trim, 400 на пустую, no-op при той же причине (без истории), иначе tx: update reason + лог истории `updated` ({reason_old, reason_new}). **Отказ 400 для архивных записей** (parity с фронтом).
- `PUT /vehicle-blacklist/:id` и `/person-blacklist/:id` под `requireBlacklist`. Модель `UpdateBlacklistReasonRequest`.
- Тест `TestVehicleBlacklist_UpdateReason`: смена причины + лог; 400 пустая; no-op идентичная; 400 архивная.

### Frontend
- `AddToBlacklistModal` обобщён: `mode` ('add'|'edit') + `initialReason`. Edit -> заголовок «Редактировать причину», primary «Сохранить» (add без изменений).
- `BlacklistTabBase`: кнопка «Редактировать» для активных записей -> emit `edit`.
- Vehicle/PersonBlacklistTab: правка через модалку -> `updateXBlacklist` -> refresh + уведомление.
- История: `updated` -> «Изменена причина», `reason_old/new` -> «Было/Стало». `getActionComment` рендерит детали в порядке `fieldLabels` (детерминированный «Было -> Стало», jsonb порядок ключей не сохраняет).

## Проверка
- Go: vet + `TestVehicleBlacklist_UpdateReason` на изолированной БД.
- Front: eslint, vitest 378 (+ edit-mode тесты модалки, тест порядка истории), build.
- Локально: модалка правки (предзаполнена, «Сохранить»), история «Изменена причина / Было / Стало». Живой сейв не персистил на :8090 (main-бэк без нового PUT) - покрыто Go-тестом.