### PR TITLE
feat(blacklist): hard-delete архивной записи ЧС (#443)

### DIFF
--- a/frontend/src/api/blacklist.js
+++ b/frontend/src/api/blacklist.js
@@ -46,6 +46,10 @@ export function restoreVehicleBlacklist(id) {
   return mutate(`/vehicle-blacklist/${id}/restore`);
 }
 
+export function purgeVehicleBlacklist(id) {
+  return mutate(`/vehicle-blacklist/${id}/purge`, { method: 'DELETE' });
+}
+
 export function createPersonBlacklist({ last_name, first_name, middle_name, reason }) {
   return mutate('/person-blacklist', { body: { last_name, first_name, middle_name, reason } });
 }
@@ -60,6 +64,10 @@ export function archivePersonBlacklist(id) {
 
 export function restorePersonBlacklist(id) {
   return mutate(`/person-blacklist/${id}/restore`);
+}
+
+export function purgePersonBlacklist(id) {
+  return mutate(`/person-blacklist/${id}/purge`, { method: 'DELETE' });
 }
 
 export async function getVehicleBlacklistHistory(id) {

--- a/frontend/src/components/admin/blacklist/BlacklistTabBase.vue
+++ b/frontend/src/components/admin/blacklist/BlacklistTabBase.vue
@@ -132,6 +132,13 @@
             >
               Вернуть в ЧС
             </button>
+            <button
+              v-if="!selected.is_active"
+              class="lk-button lk-button--danger"
+              @click="$emit('purge', selected)"
+            >
+              Удалить навсегда
+            </button>
           </div>
         </div>
         <div class="bl-details-body">
@@ -210,7 +217,7 @@ export default {
     // "Открыть карточку" (disabled, пока запись в реестре не найдена).
     lookupCard: { type: Function, default: null },
   },
-  emits: ['count', 'create', 'archive', 'restore', 'history', 'open-card', 'edit'],
+  emits: ['count', 'create', 'archive', 'restore', 'history', 'open-card', 'edit', 'purge'],
   data() {
     return {
       items: [],

--- a/frontend/src/components/admin/blacklist/PersonBlacklistTab.vue
+++ b/frontend/src/components/admin/blacklist/PersonBlacklistTab.vue
@@ -15,6 +15,7 @@
       @history="historyItem = $event"
       @open-card="openCard"
       @edit="onEdit"
+      @purge="askPurge"
     >
       <template #header-left>
         <slot name="header-left" />
@@ -55,6 +56,16 @@
       @confirm="doArchive"
       @cancel="archiveItem = null"
     />
+    <ConfirmationModal
+      :show="!!purgeItem"
+      title="Удалить навсегда"
+      :message="purgeMessage"
+      confirm-text="Удалить навсегда"
+      cancel-text="Отмена"
+      :confirm-button-style="{ background: '#dc3545', borderColor: '#dc3545' }"
+      @confirm="doPurge"
+      @cancel="purgeItem = null"
+    />
     <EmployeeDetailsModal
       :show="showDetails"
       :employee="detailsEmployee"
@@ -78,6 +89,7 @@ import {
   updatePersonBlacklist,
   archivePersonBlacklist,
   restorePersonBlacklist,
+  purgePersonBlacklist,
 } from '@/api/blacklist';
 import { lookupUniqueEmployee } from '@/api/employees';
 import { formatDateTime } from '@/utils/datetime';
@@ -98,13 +110,18 @@ export default {
   data() {
     return {
       showCreate: false, archiveItem: null, historyItem: null, userIcon, detailsEmployee: null, showDetails: false,
-      editItem: null, savingEdit: false, editError: '',
+      editItem: null, savingEdit: false, editError: '', purgeItem: null,
     };
   },
   computed: {
     archiveMessage() {
       return this.archiveItem
         ? `Убрать «${this.primaryText(this.archiveItem)}» из чёрного списка? Совпадающие сотрудники с активной заявкой снова станут активными.`
+        : '';
+    },
+    purgeMessage() {
+      return this.purgeItem
+        ? `Удалить «${this.primaryText(this.purgeItem)}» из архива навсегда? Запись и её история будут удалены безвозвратно.`
         : '';
     },
   },
@@ -199,6 +216,21 @@ export default {
         await this.$refs.base.fetchData();
       } catch (e) {
         useDeletionsStore().notify({ prefix: 'Не удалось вернуть: ', bold: e?.message || 'ошибка', type: 'error' });
+      }
+    },
+    askPurge(item) {
+      this.purgeItem = item;
+    },
+    async doPurge() {
+      const item = this.purgeItem;
+      this.purgeItem = null;
+      if (!item) return;
+      try {
+        await purgePersonBlacklist(item.id);
+        useDeletionsStore().notify({ prefix: 'Запись ', bold: this.primaryText(item), suffix: ' удалена безвозвратно' });
+        await this.$refs.base.fetchData();
+      } catch (e) {
+        useDeletionsStore().notify({ prefix: 'Не удалось удалить: ', bold: e?.message || 'ошибка', type: 'error' });
       }
     },
   },

--- a/frontend/src/components/admin/blacklist/VehicleBlacklistTab.vue
+++ b/frontend/src/components/admin/blacklist/VehicleBlacklistTab.vue
@@ -15,6 +15,7 @@
       @history="historyItem = $event"
       @open-card="openCard"
       @edit="onEdit"
+      @purge="askPurge"
     >
       <template #header-left>
         <slot name="header-left" />
@@ -55,6 +56,16 @@
       @confirm="doArchive"
       @cancel="archiveItem = null"
     />
+    <ConfirmationModal
+      :show="!!purgeItem"
+      title="Удалить навсегда"
+      :message="purgeMessage"
+      confirm-text="Удалить навсегда"
+      cancel-text="Отмена"
+      :confirm-button-style="{ background: '#dc3545', borderColor: '#dc3545' }"
+      @confirm="doPurge"
+      @cancel="purgeItem = null"
+    />
     <VehicleDetailsModal
       :show="showDetails"
       :vehicle="detailsVehicle"
@@ -79,6 +90,7 @@ import {
   updateVehicleBlacklist,
   archiveVehicleBlacklist,
   restoreVehicleBlacklist,
+  purgeVehicleBlacklist,
 } from '@/api/blacklist';
 import { lookupUniqueCar } from '@/api/cars';
 import { formatDateTime } from '@/utils/datetime';
@@ -99,13 +111,18 @@ export default {
   data() {
     return {
       showCreate: false, archiveItem: null, historyItem: null, carIcon, detailsVehicle: null, showDetails: false,
-      editItem: null, savingEdit: false, editError: '',
+      editItem: null, savingEdit: false, editError: '', purgeItem: null,
     };
   },
   computed: {
     archiveMessage() {
       return this.archiveItem
         ? `Убрать «${this.primaryText(this.archiveItem)}» из чёрного списка? Совпадающие машины с активной заявкой снова станут активными.`
+        : '';
+    },
+    purgeMessage() {
+      return this.purgeItem
+        ? `Удалить «${this.primaryText(this.purgeItem)}» из архива навсегда? Запись и её история будут удалены безвозвратно.`
         : '';
     },
   },
@@ -194,6 +211,21 @@ export default {
         await this.$refs.base.fetchData();
       } catch (e) {
         useDeletionsStore().notify({ prefix: 'Не удалось вернуть: ', bold: e?.message || 'ошибка', type: 'error' });
+      }
+    },
+    askPurge(item) {
+      this.purgeItem = item;
+    },
+    async doPurge() {
+      const item = this.purgeItem;
+      this.purgeItem = null;
+      if (!item) return;
+      try {
+        await purgeVehicleBlacklist(item.id);
+        useDeletionsStore().notify({ prefix: 'Запись ', bold: this.primaryText(item), suffix: ' удалена безвозвратно' });
+        await this.$refs.base.fetchData();
+      } catch (e) {
+        useDeletionsStore().notify({ prefix: 'Не удалось удалить: ', bold: e?.message || 'ошибка', type: 'error' });
       }
     },
   },

--- a/internal/handlers/person_blacklist.go
+++ b/internal/handlers/person_blacklist.go
@@ -86,6 +86,25 @@ func (h *PersonBlacklistHandler) Update(c echo.Context) error {
 	return RespondSuccess(c, entry)
 }
 
+// Purge godoc
+// @Summary      Безвозвратно удалить архивную запись чёрного списка
+// @Tags         person-blacklist
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID записи"
+// @Success      200 {string} string "Запись удалена"
+// @Router       /person-blacklist/{id}/purge [delete]
+func (h *PersonBlacklistHandler) Purge(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	if err := h.service.Purge(c.Request().Context(), id); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Запись удалена")
+}
+
 // Delete godoc
 // @Summary      Снять человека с чёрного списка (архивация)
 // @Tags         person-blacklist

--- a/internal/handlers/person_blacklist_test.go
+++ b/internal/handlers/person_blacklist_test.go
@@ -2,6 +2,7 @@ package handlers_test
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"systemburo/internal/models"
@@ -186,4 +187,38 @@ func TestPersonBlacklist_UnblacklistSkipsExpiredPass(t *testing.T) {
 	require.NoError(t, db.First(&after, empID).Error)
 	require.NotNil(t, after.Status)
 	assert.Equal(t, 0, *after.Status, "сотрудник с истёкшим пропуском не должен возрождаться")
+}
+
+// TestPersonBlacklist_Purge покрывает hard-delete архивной записи + запрет на активную.
+func TestPersonBlacklist_Purge(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	userID, _, userCleanup := setupMWUser(t, db, true, false)
+	defer userCleanup()
+	svc := newPersonBlacklistService(db)
+	ctx := context.Background()
+
+	entry, err := svc.Create(ctx, models.CreatePersonBlacklistRequest{
+		LastName: "Удаляев", FirstName: "Удал", MiddleName: "Удалович", Reason: "к удалению",
+	}, userID)
+	require.NoError(t, err)
+
+	t.Run("активную удалять нельзя - 400", func(t *testing.T) {
+		assertHTTPStatus(t, svc.Purge(ctx, entry.ID), http.StatusBadRequest)
+	})
+
+	require.NoError(t, svc.Archive(ctx, entry.ID, userID))
+
+	t.Run("архивную удаляет вместе с историей", func(t *testing.T) {
+		require.NoError(t, svc.Purge(ctx, entry.ID))
+
+		_, err := svc.GetByID(ctx, entry.ID)
+		assertHTTPStatus(t, err, http.StatusNotFound)
+
+		var histCount int64
+		require.NoError(t, db.Model(&models.PersonBlacklistHistory{}).Where("entity_id = ?", entry.ID).Count(&histCount).Error)
+		assert.Zero(t, histCount, "история записи должна быть удалена")
+	})
 }

--- a/internal/handlers/vehicle_blacklist.go
+++ b/internal/handlers/vehicle_blacklist.go
@@ -86,6 +86,25 @@ func (h *VehicleBlacklistHandler) Update(c echo.Context) error {
 	return RespondSuccess(c, entry)
 }
 
+// Purge godoc
+// @Summary      Безвозвратно удалить архивную запись чёрного списка
+// @Tags         vehicle-blacklist
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID записи"
+// @Success      200 {string} string "Запись удалена"
+// @Router       /vehicle-blacklist/{id}/purge [delete]
+func (h *VehicleBlacklistHandler) Purge(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	if err := h.service.Purge(c.Request().Context(), id); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Запись удалена")
+}
+
 // Delete godoc
 // @Summary      Снять машину с чёрного списка (архивация)
 // @Tags         vehicle-blacklist

--- a/internal/handlers/vehicle_blacklist_test.go
+++ b/internal/handlers/vehicle_blacklist_test.go
@@ -297,3 +297,38 @@ func TestVehicleBlacklist_UpdateReason(t *testing.T) {
 		assertHTTPStatus(t, err, http.StatusBadRequest)
 	})
 }
+
+// TestVehicleBlacklist_Purge покрывает hard-delete архивной записи + запрет на активную.
+func TestVehicleBlacklist_Purge(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	userID, _, userCleanup := setupMWUser(t, db, true, false)
+	defer userCleanup()
+	mark := seedMark(t, db, "BL_Purge")
+	svc := newVehicleBlacklistService(db)
+	ctx := context.Background()
+
+	entry, err := svc.Create(ctx, models.CreateVehicleBlacklistRequest{
+		CarNumber: "P222PP799", MarkID: mark.ID, Reason: "к удалению",
+	}, userID)
+	require.NoError(t, err)
+
+	t.Run("активную удалять нельзя - 400", func(t *testing.T) {
+		assertHTTPStatus(t, svc.Purge(ctx, entry.ID), http.StatusBadRequest)
+	})
+
+	require.NoError(t, svc.Archive(ctx, entry.ID, userID))
+
+	t.Run("архивную удаляет вместе с историей", func(t *testing.T) {
+		require.NoError(t, svc.Purge(ctx, entry.ID))
+
+		_, err := svc.GetByID(ctx, entry.ID)
+		assertHTTPStatus(t, err, http.StatusNotFound)
+
+		var histCount int64
+		require.NoError(t, db.Model(&models.VehicleBlacklistHistory{}).Where("entity_id = ?", entry.ID).Count(&histCount).Error)
+		assert.Zero(t, histCount, "история записи должна быть удалена")
+	})
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -209,6 +209,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	vblGroup.POST("", vehicleBlacklist.Create, requireBlacklist)
 	vblGroup.PUT("/:id", vehicleBlacklist.Update, requireBlacklist)
 	vblGroup.DELETE("/:id", vehicleBlacklist.Delete, requireBlacklist)
+	vblGroup.DELETE("/:id/purge", vehicleBlacklist.Purge, requireBlacklist)
 	vblGroup.POST("/:id/restore", vehicleBlacklist.Restore, requireBlacklist)
 
 	// Чёрный список людей (#443). Та же permission page.admin.blacklist (одна страница).
@@ -219,6 +220,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	pblGroup.POST("", personBlacklist.Create, requireBlacklist)
 	pblGroup.PUT("/:id", personBlacklist.Update, requireBlacklist)
 	pblGroup.DELETE("/:id", personBlacklist.Delete, requireBlacklist)
+	pblGroup.DELETE("/:id/purge", personBlacklist.Purge, requireBlacklist)
 	pblGroup.POST("/:id/restore", personBlacklist.Restore, requireBlacklist)
 
 	// Attachment Excel-templates (#183) - вложенные ручки под /attachments/:id/...

--- a/internal/services/person_blacklist_service.go
+++ b/internal/services/person_blacklist_service.go
@@ -28,6 +28,8 @@ type PersonBlacklistService interface {
 	Check(ctx context.Context, lastName, firstName, middleName string) (models.PersonBlacklistCheckResult, error)
 	// UpdateReason - редактирование причины записи + лог в историю (updated).
 	UpdateReason(ctx context.Context, id int, reason string, userID int) (*models.PersonBlacklist, error)
+	// Purge - безвозвратное удаление архивной записи вместе с её историей (только is_active=false).
+	Purge(ctx context.Context, id int) error
 	GetHistory(ctx context.Context, id int) ([]models.PersonBlacklistHistoryItem, error)
 }
 
@@ -202,6 +204,28 @@ func (s *personBlacklistService) UpdateReason(ctx context.Context, id int, reaso
 	}
 	e.Reason = newReason
 	return e, nil
+}
+
+// Purge безвозвратно удаляет архивную запись и её историю в одной транзакции. Активную
+// удалять нельзя - сперва "Убрать из ЧС". Каскадную историю самих сотрудников не трогаем.
+func (s *personBlacklistService) Purge(ctx context.Context, id int) error {
+	e, err := s.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	if e.IsActive {
+		return echo.NewHTTPError(http.StatusBadRequest, "Сначала уберите запись из чёрного списка")
+	}
+	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("entity_id = ?", e.ID).Delete(&models.PersonBlacklistHistory{}).Error; err != nil {
+			return err
+		}
+		return tx.Delete(&models.PersonBlacklist{}, e.ID).Error
+	})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка удаления записи")
+	}
+	return nil
 }
 
 func (s *personBlacklistService) GetHistory(ctx context.Context, id int) ([]models.PersonBlacklistHistoryItem, error) {

--- a/internal/services/vehicle_blacklist_service.go
+++ b/internal/services/vehicle_blacklist_service.go
@@ -37,6 +37,8 @@ type VehicleBlacklistService interface {
 	CheckByName(ctx context.Context, carNumber, markName string) (models.VehicleBlacklistCheckResult, error)
 	// UpdateReason - редактирование причины записи + лог в историю (updated).
 	UpdateReason(ctx context.Context, id int, reason string, userID int) (*models.VehicleBlacklist, error)
+	// Purge - безвозвратное удаление архивной записи вместе с её историей (только is_active=false).
+	Purge(ctx context.Context, id int) error
 	GetHistory(ctx context.Context, id int) ([]models.VehicleBlacklistHistoryItem, error)
 }
 
@@ -173,6 +175,28 @@ func (s *vehicleBlacklistService) UpdateReason(ctx context.Context, id int, reas
 	}
 	e.Reason = newReason
 	return e, nil
+}
+
+// Purge безвозвратно удаляет архивную запись и её историю в одной транзакции. Активную
+// запись удалять нельзя - сперва "Убрать из ЧС". Каскадную историю самих машин не трогаем.
+func (s *vehicleBlacklistService) Purge(ctx context.Context, id int) error {
+	e, err := s.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	if e.IsActive {
+		return echo.NewHTTPError(http.StatusBadRequest, "Сначала уберите запись из чёрного списка")
+	}
+	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("entity_id = ?", e.ID).Delete(&models.VehicleBlacklistHistory{}).Error; err != nil {
+			return err
+		}
+		return tx.Delete(&models.VehicleBlacklist{}, e.ID).Error
+	})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка удаления записи")
+	}
+	return nil
 }
 
 func (s *vehicleBlacklistService) Restore(ctx context.Context, id int, userID int) error {


### PR DESCRIPTION
Полировка ЧС, раунд 2, срез S5 (issue #5) - последний срез раунда.

### Backend
- `Purge(id)` в vehicle/person сервисах: только архивные (400 на активной - сперва «Убрать из ЧС»); транзакция: удаление истории записи + самой записи. Каскадная история на машинах/сотрудниках (cars_history/employees_history) НЕ трогается.
- `DELETE /vehicle-blacklist/:id/purge` и `/person-blacklist/:id/purge` под `requireBlacklist`.
- Тесты `TestVehicleBlacklist_Purge` и `TestPersonBlacklist_Purge`: активную -> 400; архивную -> запись (404) + история (count 0).

### Frontend
- `BlacklistTabBase`: кнопка «Удалить навсегда» (danger) только для архивных -> emit `purge`.
- Vehicle/PersonBlacklistTab: `ConfirmationModal` «Запись и её история будут удалены безвозвратно» -> purge + refresh + уведомление.
- api: `purgeVehicleBlacklist`/`purgePersonBlacklist`.

## Проверка
- Go: vet + оба Purge-теста на изолированной БД + полный пакет handlers/services.
- Front: eslint, vitest 388, build.
- Локально: архив-режим - кнопка «Удалить навсегда» + модалка подтверждения. Сам purge на :8090 (main-бэк без нового эндпоинта) 404 - покрыто Go-тестами.

С этим срезом закрыты #1-7 раунда полировки. #8 (фаззи-детект обхода ЧС) - отдельный issue #481.