### PR TITLE
feat(blacklist): общий журнал ЧС + удаление навсегда (#443)

### DIFF
--- a/frontend/src/api/blacklist.js
+++ b/frontend/src/api/blacklist.js
@@ -46,6 +46,10 @@ export function restoreVehicleBlacklist(id) {
   return mutate(`/vehicle-blacklist/${id}/restore`);
 }
 
+export function purgeVehicleBlacklist(id) {
+  return mutate(`/vehicle-blacklist/${id}/purge`, { method: 'DELETE' });
+}
+
 export function createPersonBlacklist({ last_name, first_name, middle_name, reason }) {
   return mutate('/person-blacklist', { body: { last_name, first_name, middle_name, reason } });
 }
@@ -62,6 +66,10 @@ export function restorePersonBlacklist(id) {
   return mutate(`/person-blacklist/${id}/restore`);
 }
 
+export function purgePersonBlacklist(id) {
+  return mutate(`/person-blacklist/${id}/purge`, { method: 'DELETE' });
+}
+
 export async function getVehicleBlacklistHistory(id) {
   const res = await apiRequest(`/vehicle-blacklist/${id}/history`);
   return res.json();
@@ -69,6 +77,18 @@ export async function getVehicleBlacklistHistory(id) {
 
 export async function getPersonBlacklistHistory(id) {
   const res = await apiRequest(`/person-blacklist/${id}/history`);
+  return res.json();
+}
+
+/** Весь журнал ЧС машин (все события всех записей, включая удалённые). */
+export async function getAllVehicleBlacklistHistory() {
+  const res = await apiRequest('/vehicle-blacklist/history');
+  return res.json();
+}
+
+/** Весь журнал ЧС людей (все события всех записей, включая удалённые). */
+export async function getAllPersonBlacklistHistory() {
+  const res = await apiRequest('/person-blacklist/history');
   return res.json();
 }
 

--- a/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
@@ -1000,7 +1000,7 @@ export default {
     padding: 12px 16px;
     background: #fdeaea;
     border: 1px solid #f5b5b5;
-    border-radius: 12px;
+    border-radius: 20px;
 }
 
 .bl-section-head {

--- a/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
@@ -1084,7 +1084,7 @@ export default {
   padding: 12px 16px;
   background: #fdeaea;
   border: 1px solid #f5b5b5;
-  border-radius: 12px;
+  border-radius: 20px;
 }
 
 .bl-section-head {

--- a/frontend/src/components/admin/blacklist/BlacklistHistoryModalBase.vue
+++ b/frontend/src/components/admin/blacklist/BlacklistHistoryModalBase.vue
@@ -158,6 +158,13 @@
               />
 
               <div class="history-content">
+                <div
+                  v-if="getEntityLabel(item)"
+                  class="history-entity"
+                >
+                  {{ getEntityLabel(item) }}
+                </div>
+
                 <div class="history-header">
                   <span class="user-name">{{ item.user_name || 'Система' }}</span>
                   <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
@@ -168,7 +175,31 @@
                 </div>
 
                 <div
-                  v-if="getActionComment(item)"
+                  v-if="getReasonDiff(item)"
+                  class="action-diff"
+                >
+                  <span class="diff-old">{{ getReasonDiff(item).from }}</span>
+                  <svg
+                    class="diff-arrow"
+                    viewBox="0 0 24 24"
+                    width="16"
+                    height="16"
+                    aria-hidden="true"
+                  >
+                    <path
+                      d="M4 12h14M13 6l6 6-6 6"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </svg>
+                  <span class="diff-new">{{ getReasonDiff(item).to }}</span>
+                </div>
+
+                <div
+                  v-else-if="getActionComment(item)"
                   class="action-comment"
                 >
                   {{ getActionComment(item) }}
@@ -194,6 +225,7 @@ const ACTION_DOT_CLASS = {
   archived: 'dot-deactivate',
   restored: 'dot-activate',
   updated: 'dot-update',
+  purged: 'dot-delete',
 };
 
 /**
@@ -215,6 +247,13 @@ export default {
     actionTexts: { type: Object, required: true },
     /** ключ поля details -> лейбл; показываются только присутствующие тут ключи. */
     fieldLabels: { type: Object, default: () => ({}) },
+    /**
+     * Опц. (item) => string - лейбл сущности (номер+марка / ФИО) для общего журнала ЧС.
+     * Берётся из item.details, поэтому показывается и для физически удалённых записей.
+     */
+    entityLabelFn: { type: Function, default: null },
+    /** ключи details, которые НЕ показывать в комментарии (рендерятся отдельно - лейбл, diff). */
+    commentExcludeKeys: { type: Array, default: () => [] },
     currentUserName: { type: String, default: '' },
   },
   emits: ['close'],
@@ -261,7 +300,11 @@ export default {
           const userName = (item.user_name || '').toLowerCase();
           const actionText = this.getActionText(item).toLowerCase();
           const comment = this.getActionComment(item).toLowerCase();
-          return userName.includes(query) || actionText.includes(query) || comment.includes(query);
+          const entity = this.getEntityLabel(item).toLowerCase();
+          const diff = this.getReasonDiff(item);
+          const diffText = diff ? `${diff.from} ${diff.to}`.toLowerCase() : '';
+          return userName.includes(query) || actionText.includes(query)
+            || comment.includes(query) || entity.includes(query) || diffText.includes(query);
         });
       }
 
@@ -312,14 +355,19 @@ export default {
     },
 
     exportData() {
-      return this.filteredHistory.map((item) => ({
-        'Дата и время': this.formatDateTime(item.created_at),
-        Пользователь: item.user_name || 'Система',
-        Действие: this.getActionText(item),
-        Детали: this.getActionComment(item),
-        'Тип действия': item.action_type,
-        'ID записи': item.id,
-      }));
+      const hasEntity = !!this.entityLabelFn;
+      return this.filteredHistory.map((item) => {
+        const row = {
+          'Дата и время': this.formatDateTime(item.created_at),
+          Пользователь: item.user_name || 'Система',
+        };
+        if (hasEntity) row['Объект'] = this.getEntityLabel(item) || '-';
+        row['Действие'] = this.getActionText(item);
+        row['Детали'] = this.getDetailText(item);
+        row['Тип действия'] = item.action_type;
+        row['ID записи'] = item.id;
+        return row;
+      });
     },
   },
   mounted() {
@@ -370,17 +418,44 @@ export default {
       return this.actionTexts[item.action_type] || item.action_type;
     },
 
+    /** Лейбл сущности (номер+марка / ФИО) для строки общего журнала. */
+    getEntityLabel(item) {
+      if (!this.entityLabelFn) return '';
+      try {
+        return this.entityLabelFn(item) || '';
+      } catch {
+        return '';
+      }
+    },
+
+    /**
+     * Диф причины для action=updated: { from, to }. Рендерится отдельной строкой со
+     * стрелкой (#1) вместо текстового "Было: / Стало:". null - если это не правка причины.
+     */
+    getReasonDiff(item) {
+      if (item.action_type !== 'updated') return null;
+      const d = item.details;
+      if (!d || typeof d !== 'object') return null;
+      if (!('reason_old' in d) && !('reason_new' in d)) return null;
+      return {
+        from: d.reason_old ? String(d.reason_old) : '-',
+        to: d.reason_new ? String(d.reason_new) : '-',
+      };
+    },
+
     /**
      * Читаемые детали для timeline. Показываем только ключи из fieldLabels,
-     * пропуская пустые значения и нулевые счётчики (иначе "Деактивировано: 0" - шум).
+     * пропуская пустые значения, нулевые счётчики (иначе "Деактивировано: 0" - шум) и
+     * ключи из commentExcludeKeys (лейбл сущности и причина-диф рендерятся отдельно).
      */
     getActionComment(item) {
       const d = item.details;
       if (!d || typeof d !== 'object') return '';
       const parts = [];
       // Порядок - по объявлению в fieldLabels (а не по ключам details: jsonb не хранит
-      // порядок, иначе "Стало/Было" показывались бы в произвольном порядке).
+      // порядок, иначе поля показывались бы в произвольном порядке).
       for (const key of Object.keys(this.fieldLabels)) {
+        if (this.commentExcludeKeys.includes(key)) continue;
         if (!(key in d)) continue;
         const raw = d[key];
         if (raw === null || raw === undefined || raw === '') continue;
@@ -394,6 +469,17 @@ export default {
       if (typeof value === 'boolean') return value ? 'да' : 'нет';
       const s = String(value);
       return s.length > 80 ? `${s.slice(0, 80)}...` : s;
+    },
+
+    /** Детали для экспорта: комментарий + причина-диф (в Excel стрелку рисовать нечем). */
+    getDetailText(item) {
+      const diff = this.getReasonDiff(item);
+      const comment = this.getActionComment(item);
+      if (diff) {
+        const d = `Причина: ${diff.from} -> ${diff.to}`;
+        return comment ? `${comment} / ${d}` : d;
+      }
+      return comment;
     },
 
     toggleSortOrder() {
@@ -416,7 +502,7 @@ export default {
         const workbook = new ExcelJS.Workbook();
         const worksheet = workbook.addWorksheet('История');
 
-        const headers = ['Дата и время', 'Пользователь', 'Действие', 'Детали', 'Тип действия', 'ID записи'];
+        const headers = Object.keys(this.exportData[0]);
         const headerRow = worksheet.addRow(headers);
         headerRow.height = 25;
         headerRow.eachCell((cell) => {
@@ -432,14 +518,7 @@ export default {
         });
 
         this.exportData.forEach((item, index) => {
-          const row = worksheet.addRow([
-            item['Дата и время'],
-            item.Пользователь,
-            item.Действие,
-            item.Детали,
-            item['Тип действия'],
-            item['ID записи'],
-          ]);
+          const row = worksheet.addRow(headers.map((h) => item[h]));
           row.height = 20;
           const fillColor = index % 2 === 0 ? 'FFF0F5FF' : 'FFE0E9FF';
           row.eachCell((cell) => {
@@ -486,14 +565,16 @@ export default {
           });
         });
 
-        worksheet.columns = [
-          { width: 22 },
-          { width: 30 },
-          { width: 30 },
-          { width: 60 },
-          { width: 22 },
-          { width: 12 },
-        ];
+        const colWidths = {
+          'Дата и время': 22,
+          Пользователь: 30,
+          Объект: 32,
+          Действие: 26,
+          Детали: 60,
+          'Тип действия': 18,
+          'ID записи': 12,
+        };
+        worksheet.columns = headers.map((h) => ({ width: colWidths[h] || 20 }));
 
         const buffer = await workbook.xlsx.writeBuffer();
         const blob = new Blob([buffer], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
@@ -863,13 +944,23 @@ export default {
 }
 
 .dot-create { background: #4F5BDF; }
+.dot-update { background: #f59e0b; }
 .dot-activate { background: #10b981; }
 .dot-deactivate { background: #6b7280; }
+.dot-delete { background: #dc2626; }
 .dot-default { background: #9ca3af; }
 
 .history-content {
   flex: 1;
   min-width: 0;
+}
+
+.history-entity {
+  font-size: 13px;
+  font-weight: 600;
+  color: #1f2937;
+  margin-bottom: 4px;
+  word-break: break-word;
 }
 
 .history-header {
@@ -904,6 +995,39 @@ export default {
   padding-left: 6px;
   border-left: 2px solid #e6e6e6;
   word-break: break-word;
+}
+
+.action-diff {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 6px;
+  font-size: 12px;
+}
+
+.diff-old,
+.diff-new {
+  padding: 3px 10px;
+  border-radius: var(--radius-pill);
+  word-break: break-word;
+}
+
+.diff-old {
+  background: #f1f3f5;
+  color: #6b7280;
+  text-decoration: line-through;
+}
+
+.diff-new {
+  background: #e7f6ec;
+  color: #15803d;
+  font-weight: 500;
+}
+
+.diff-arrow {
+  flex-shrink: 0;
+  color: #9ca3af;
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/components/admin/blacklist/BlacklistTabBase.vue
+++ b/frontend/src/components/admin/blacklist/BlacklistTabBase.vue
@@ -23,6 +23,12 @@
         >
           Создать запись
         </button>
+        <button
+          class="lk-button lk-button--ghost"
+          @click="$emit('history-all')"
+        >
+          История
+        </button>
         <RefreshButton
           :loading="isLoading"
           @refresh="fetchData"
@@ -106,11 +112,37 @@
               Открыть карточку
             </button>
             <button
-              class="lk-button lk-button--ghost"
-              @click="$emit('history', selected)"
+              v-if="selected.is_active"
+              class="lk-button lk-button--danger"
+              @click="$emit('archive', selected)"
             >
-              История
+              Убрать из ЧС
             </button>
+            <template v-else>
+              <button
+                class="lk-button lk-button--secondary"
+                @click="$emit('restore', selected)"
+              >
+                Вернуть в ЧС
+              </button>
+              <button
+                class="lk-button lk-button--danger"
+                @click="$emit('purge', selected)"
+              >
+                Удалить навсегда
+              </button>
+            </template>
+          </div>
+        </div>
+        <div class="bl-details-body">
+          <div class="bl-status-row">
+            <div
+              class="bl-status-banner"
+              :class="selected.is_active ? 'is-active' : 'is-archived'"
+            >
+              <span class="bl-status-dot" />
+              {{ selected.is_active ? 'В чёрном списке' : 'Снято с ЧС - в архиве' }}
+            </div>
             <button
               v-if="selected.is_active"
               class="lk-button lk-button--secondary"
@@ -118,29 +150,6 @@
             >
               Редактировать
             </button>
-            <button
-              v-if="selected.is_active"
-              class="lk-button lk-button--danger"
-              @click="$emit('archive', selected)"
-            >
-              Убрать из ЧС
-            </button>
-            <button
-              v-else
-              class="lk-button lk-button--secondary"
-              @click="$emit('restore', selected)"
-            >
-              Вернуть в ЧС
-            </button>
-          </div>
-        </div>
-        <div class="bl-details-body">
-          <div
-            class="bl-status-banner"
-            :class="selected.is_active ? 'is-active' : 'is-archived'"
-          >
-            <span class="bl-status-dot" />
-            {{ selected.is_active ? 'В чёрном списке' : 'Снято с ЧС - в архиве' }}
           </div>
 
           <div
@@ -210,7 +219,7 @@ export default {
     // "Открыть карточку" (disabled, пока запись в реестре не найдена).
     lookupCard: { type: Function, default: null },
   },
-  emits: ['count', 'create', 'archive', 'restore', 'history', 'open-card', 'edit'],
+  emits: ['count', 'create', 'archive', 'restore', 'history-all', 'open-card', 'edit', 'purge'],
   data() {
     return {
       items: [],
@@ -492,11 +501,17 @@ export default {
   gap: 16px;
 }
 
+.bl-status-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
 .bl-status-banner {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  align-self: flex-start;
   padding: 6px 14px;
   border-radius: var(--radius-pill);
   font-size: 13px;

--- a/frontend/src/components/admin/blacklist/PersonBlacklistHistoryModal.vue
+++ b/frontend/src/components/admin/blacklist/PersonBlacklistHistoryModal.vue
@@ -1,10 +1,12 @@
 <template>
   <BlacklistHistoryModalBase
-    :title="title"
-    :entity-label="entityLabel"
+    title="История чёрного списка людей"
+    entity-label="lyudi"
     :load-fn="loadFn"
     :action-texts="actionTexts"
     :field-labels="fieldLabels"
+    :entity-label-fn="entityLabelFn"
+    :comment-exclude-keys="commentExcludeKeys"
     :current-user-name="currentUserName"
     @close="$emit('close')"
   />
@@ -12,13 +14,14 @@
 
 <script>
 import BlacklistHistoryModalBase from './BlacklistHistoryModalBase.vue';
-import { getPersonBlacklistHistory } from '@/api/blacklist';
+import { getAllPersonBlacklistHistory } from '@/api/blacklist';
 
 const ACTION_TEXTS = {
   created: 'Добавлен в чёрный список',
   archived: 'Снят с чёрного списка',
   restored: 'Возвращён в чёрный список',
   updated: 'Изменена причина',
+  purged: 'Удалён навсегда',
 };
 
 const FIELD_LABELS = {
@@ -29,15 +32,18 @@ const FIELD_LABELS = {
   employees_reactivated: 'Возвращено сотрудников',
 };
 
+// ФИО и причина-диф рендерятся отдельными блоками - не дублируем их в комментарии.
+const COMMENT_EXCLUDE_KEYS = ['full_name', 'reason_old', 'reason_new'];
+
 /**
- * Модалка истории записи ЧС людей (#443). Тонкая обёртка над
- * BlacklistHistoryModalBase: задаёт заголовок, словари действий/полей и загрузчик.
+ * Модалка общего журнала ЧС людей (#443): все события всех записей, включая физически
+ * удалённые (ФИО берётся из details, а не из самой записи). Тонкая обёртка над
+ * BlacklistHistoryModalBase.
  */
 export default {
   name: 'PersonBlacklistHistoryModal',
   components: { BlacklistHistoryModalBase },
   props: {
-    item: { type: Object, required: true },
     currentUserName: { type: String, default: '' },
   },
   emits: ['close'],
@@ -48,16 +54,17 @@ export default {
     fieldLabels() {
       return FIELD_LABELS;
     },
-    entityLabel() {
-      return [this.item.last_name, this.item.first_name, this.item.middle_name].filter(Boolean).join(' ');
-    },
-    title() {
-      return `История человека «${this.entityLabel}»`;
+    commentExcludeKeys() {
+      return COMMENT_EXCLUDE_KEYS;
     },
   },
   methods: {
     loadFn() {
-      return getPersonBlacklistHistory(this.item.id);
+      return getAllPersonBlacklistHistory();
+    },
+    entityLabelFn(historyItem) {
+      const d = historyItem.details || {};
+      return d.full_name || '';
     },
   },
 };

--- a/frontend/src/components/admin/blacklist/PersonBlacklistTab.vue
+++ b/frontend/src/components/admin/blacklist/PersonBlacklistTab.vue
@@ -12,7 +12,8 @@
       @create="showCreate = true"
       @archive="askArchive"
       @restore="doRestore"
-      @history="historyItem = $event"
+      @purge="askPurge"
+      @history-all="showHistory = true"
       @open-card="openCard"
       @edit="onEdit"
     >
@@ -40,10 +41,9 @@
       @created="onCreated"
     />
     <PersonBlacklistHistoryModal
-      v-if="historyItem"
-      :item="historyItem"
+      v-if="showHistory"
       :current-user-name="currentUserName"
-      @close="historyItem = null"
+      @close="showHistory = false"
     />
     <ConfirmationModal
       :show="!!archiveItem"
@@ -54,6 +54,16 @@
       :confirm-button-style="{ background: '#dc3545', borderColor: '#dc3545' }"
       @confirm="doArchive"
       @cancel="archiveItem = null"
+    />
+    <ConfirmationModal
+      :show="!!purgeItem"
+      title="Удалить запись навсегда"
+      :message="purgeMessage"
+      confirm-text="Удалить навсегда"
+      cancel-text="Отмена"
+      :confirm-button-style="{ background: '#dc3545', borderColor: '#dc3545' }"
+      @confirm="doPurge"
+      @cancel="purgeItem = null"
     />
     <EmployeeDetailsModal
       :show="showDetails"
@@ -78,6 +88,7 @@ import {
   updatePersonBlacklist,
   archivePersonBlacklist,
   restorePersonBlacklist,
+  purgePersonBlacklist,
 } from '@/api/blacklist';
 import { lookupUniqueEmployee } from '@/api/employees';
 import { formatDateTime } from '@/utils/datetime';
@@ -97,14 +108,19 @@ export default {
   emits: ['count'],
   data() {
     return {
-      showCreate: false, archiveItem: null, historyItem: null, userIcon, detailsEmployee: null, showDetails: false,
-      editItem: null, savingEdit: false, editError: '',
+      showCreate: false, archiveItem: null, showHistory: false, userIcon, detailsEmployee: null, showDetails: false,
+      editItem: null, savingEdit: false, editError: '', purgeItem: null,
     };
   },
   computed: {
     archiveMessage() {
       return this.archiveItem
         ? `Убрать «${this.primaryText(this.archiveItem)}» из чёрного списка? Совпадающие сотрудники с активной заявкой снова станут активными.`
+        : '';
+    },
+    purgeMessage() {
+      return this.purgeItem
+        ? `Удалить «${this.primaryText(this.purgeItem)}» из архива навсегда? Запись исчезнет, но событие останется в общей истории чёрного списка.`
         : '';
     },
   },
@@ -199,6 +215,21 @@ export default {
         await this.$refs.base.fetchData();
       } catch (e) {
         useDeletionsStore().notify({ prefix: 'Не удалось вернуть: ', bold: e?.message || 'ошибка', type: 'error' });
+      }
+    },
+    askPurge(item) {
+      this.purgeItem = item;
+    },
+    async doPurge() {
+      const item = this.purgeItem;
+      this.purgeItem = null;
+      if (!item) return;
+      try {
+        await purgePersonBlacklist(item.id);
+        useDeletionsStore().notify({ prefix: 'Человек ', bold: this.primaryText(item), suffix: ' удалён навсегда' });
+        await this.$refs.base.fetchData();
+      } catch (e) {
+        useDeletionsStore().notify({ prefix: 'Не удалось удалить: ', bold: e?.message || 'ошибка', type: 'error' });
       }
     },
   },

--- a/frontend/src/components/admin/blacklist/VehicleBlacklistHistoryModal.vue
+++ b/frontend/src/components/admin/blacklist/VehicleBlacklistHistoryModal.vue
@@ -1,10 +1,12 @@
 <template>
   <BlacklistHistoryModalBase
-    :title="title"
-    :entity-label="entityLabel"
+    title="История чёрного списка машин"
+    entity-label="mashiny"
     :load-fn="loadFn"
     :action-texts="actionTexts"
     :field-labels="fieldLabels"
+    :entity-label-fn="entityLabelFn"
+    :comment-exclude-keys="commentExcludeKeys"
     :current-user-name="currentUserName"
     @close="$emit('close')"
   />
@@ -12,13 +14,14 @@
 
 <script>
 import BlacklistHistoryModalBase from './BlacklistHistoryModalBase.vue';
-import { getVehicleBlacklistHistory } from '@/api/blacklist';
+import { getAllVehicleBlacklistHistory } from '@/api/blacklist';
 
 const ACTION_TEXTS = {
   created: 'Добавлена в чёрный список',
   archived: 'Снята с чёрного списка',
   restored: 'Возвращена в чёрный список',
   updated: 'Изменена причина',
+  purged: 'Удалена навсегда',
 };
 
 const FIELD_LABELS = {
@@ -29,15 +32,18 @@ const FIELD_LABELS = {
   cars_reactivated: 'Возвращено машин в оборот',
 };
 
+// Лейбл машины и причина-диф рендерятся отдельными блоками - не дублируем их в комментарии.
+const COMMENT_EXCLUDE_KEYS = ['car_number', 'mark_name', 'reason_old', 'reason_new'];
+
 /**
- * Модалка истории записи ЧС машин (#443). Тонкая обёртка над
- * BlacklistHistoryModalBase: задаёт заголовок, словари действий/полей и загрузчик.
+ * Модалка общего журнала ЧС машин (#443): все события всех записей, включая физически
+ * удалённые (лейбл машины берётся из details, а не из самой записи). Тонкая обёртка над
+ * BlacklistHistoryModalBase.
  */
 export default {
   name: 'VehicleBlacklistHistoryModal',
   components: { BlacklistHistoryModalBase },
   props: {
-    item: { type: Object, required: true },
     currentUserName: { type: String, default: '' },
   },
   emits: ['close'],
@@ -48,16 +54,17 @@ export default {
     fieldLabels() {
       return FIELD_LABELS;
     },
-    entityLabel() {
-      return [this.item.car_number, this.item.mark_name].filter(Boolean).join(' ');
-    },
-    title() {
-      return `История машины «${this.entityLabel}»`;
+    commentExcludeKeys() {
+      return COMMENT_EXCLUDE_KEYS;
     },
   },
   methods: {
     loadFn() {
-      return getVehicleBlacklistHistory(this.item.id);
+      return getAllVehicleBlacklistHistory();
+    },
+    entityLabelFn(historyItem) {
+      const d = historyItem.details || {};
+      return [d.car_number, d.mark_name].filter(Boolean).join(' ');
     },
   },
 };

--- a/frontend/src/components/admin/blacklist/VehicleBlacklistTab.vue
+++ b/frontend/src/components/admin/blacklist/VehicleBlacklistTab.vue
@@ -12,7 +12,8 @@
       @create="showCreate = true"
       @archive="askArchive"
       @restore="doRestore"
-      @history="historyItem = $event"
+      @purge="askPurge"
+      @history-all="showHistory = true"
       @open-card="openCard"
       @edit="onEdit"
     >
@@ -40,10 +41,9 @@
       @created="onCreated"
     />
     <VehicleBlacklistHistoryModal
-      v-if="historyItem"
-      :item="historyItem"
+      v-if="showHistory"
       :current-user-name="currentUserName"
-      @close="historyItem = null"
+      @close="showHistory = false"
     />
     <ConfirmationModal
       :show="!!archiveItem"
@@ -54,6 +54,16 @@
       :confirm-button-style="{ background: '#dc3545', borderColor: '#dc3545' }"
       @confirm="doArchive"
       @cancel="archiveItem = null"
+    />
+    <ConfirmationModal
+      :show="!!purgeItem"
+      title="Удалить запись навсегда"
+      :message="purgeMessage"
+      confirm-text="Удалить навсегда"
+      cancel-text="Отмена"
+      :confirm-button-style="{ background: '#dc3545', borderColor: '#dc3545' }"
+      @confirm="doPurge"
+      @cancel="purgeItem = null"
     />
     <VehicleDetailsModal
       :show="showDetails"
@@ -79,6 +89,7 @@ import {
   updateVehicleBlacklist,
   archiveVehicleBlacklist,
   restoreVehicleBlacklist,
+  purgeVehicleBlacklist,
 } from '@/api/blacklist';
 import { lookupUniqueCar } from '@/api/cars';
 import { formatDateTime } from '@/utils/datetime';
@@ -98,14 +109,19 @@ export default {
   emits: ['count'],
   data() {
     return {
-      showCreate: false, archiveItem: null, historyItem: null, carIcon, detailsVehicle: null, showDetails: false,
-      editItem: null, savingEdit: false, editError: '',
+      showCreate: false, archiveItem: null, showHistory: false, carIcon, detailsVehicle: null, showDetails: false,
+      editItem: null, savingEdit: false, editError: '', purgeItem: null,
     };
   },
   computed: {
     archiveMessage() {
       return this.archiveItem
         ? `Убрать «${this.primaryText(this.archiveItem)}» из чёрного списка? Совпадающие машины с активной заявкой снова станут активными.`
+        : '';
+    },
+    purgeMessage() {
+      return this.purgeItem
+        ? `Удалить «${this.primaryText(this.purgeItem)}» из архива навсегда? Запись исчезнет, но событие останется в общей истории чёрного списка.`
         : '';
     },
   },
@@ -194,6 +210,21 @@ export default {
         await this.$refs.base.fetchData();
       } catch (e) {
         useDeletionsStore().notify({ prefix: 'Не удалось вернуть: ', bold: e?.message || 'ошибка', type: 'error' });
+      }
+    },
+    askPurge(item) {
+      this.purgeItem = item;
+    },
+    async doPurge() {
+      const item = this.purgeItem;
+      this.purgeItem = null;
+      if (!item) return;
+      try {
+        await purgeVehicleBlacklist(item.id);
+        useDeletionsStore().notify({ prefix: 'Машина ', bold: this.primaryText(item), suffix: ' удалена навсегда' });
+        await this.$refs.base.fetchData();
+      } catch (e) {
+        useDeletionsStore().notify({ prefix: 'Не удалось удалить: ', bold: e?.message || 'ошибка', type: 'error' });
       }
     },
   },

--- a/frontend/src/components/admin/blacklist/__tests__/BlacklistHistoryModalBase.spec.js
+++ b/frontend/src/components/admin/blacklist/__tests__/BlacklistHistoryModalBase.spec.js
@@ -96,7 +96,52 @@ describe('BlacklistHistoryModalBase', () => {
     expect(wrapper.vm.getActionClass('created')).toBe('dot-create');
     expect(wrapper.vm.getActionClass('archived')).toBe('dot-deactivate');
     expect(wrapper.vm.getActionClass('restored')).toBe('dot-activate');
+    expect(wrapper.vm.getActionClass('updated')).toBe('dot-update');
+    expect(wrapper.vm.getActionClass('purged')).toBe('dot-delete');
     expect(wrapper.vm.getActionClass('unknown')).toBe('dot-default');
+  });
+
+  it('commentExcludeKeys убирает ключи из комментария (рендерятся отдельно)', async () => {
+    const wrapper = mountModal({
+      fieldLabels: { reason: 'Причина', reason_old: 'Было', reason_new: 'Стало' },
+      commentExcludeKeys: ['reason_old', 'reason_new'],
+    });
+    await flushPromises();
+    const item = { action_type: 'updated', details: { reason_old: 'старая', reason_new: 'новая' } };
+    expect(wrapper.vm.getActionComment(item)).toBe('');
+  });
+
+  it('getReasonDiff: для updated возвращает from/to, для прочих - null', async () => {
+    const wrapper = mountModal();
+    await flushPromises();
+    expect(wrapper.vm.getReasonDiff({ action_type: 'updated', details: { reason_old: 'a', reason_new: 'b' } }))
+      .toEqual({ from: 'a', to: 'b' });
+    expect(wrapper.vm.getReasonDiff({ action_type: 'created', details: { reason: 'x' } })).toBe(null);
+  });
+
+  it('updated рендерит diff со стрелкой (.action-diff), а не текст "Стало:"', async () => {
+    const updated = [{
+      id: 9,
+      action_type: 'updated',
+      user_id: 7,
+      user_name: 'Иванов Иван',
+      created_at: '2026-06-04T10:00:00Z',
+      details: { car_number: 'A1', mark_name: 'BMW', reason_old: 'старая', reason_new: 'новая' },
+    }];
+    const wrapper = mountModal({
+      loadFn: vi.fn().mockResolvedValue(updated),
+      actionTexts: { updated: 'Изменена причина' },
+      fieldLabels: { reason_old: 'Было', reason_new: 'Стало' },
+      commentExcludeKeys: ['car_number', 'mark_name', 'reason_old', 'reason_new'],
+      entityLabelFn: (it) => `${it.details.car_number} ${it.details.mark_name}`,
+    });
+    await flushPromises();
+    expect(wrapper.find('.action-diff').exists()).toBe(true);
+    expect(wrapper.find('.diff-old').text()).toBe('старая');
+    expect(wrapper.find('.diff-new').text()).toBe('новая');
+    expect(wrapper.find('.diff-arrow').exists()).toBe(true);
+    expect(wrapper.find('.history-entity').text()).toBe('A1 BMW');
+    expect(wrapper.text()).not.toContain('Стало:');
   });
 
   it('по умолчанию сортировка desc (новые сверху), toggle переключает на asc', async () => {

--- a/frontend/src/components/admin/blacklist/__tests__/BlacklistTabBase.spec.js
+++ b/frontend/src/components/admin/blacklist/__tests__/BlacklistTabBase.spec.js
@@ -134,13 +134,49 @@ describe('BlacklistTabBase', () => {
     expect(wrapper.emitted('restore')[0][0].id).toBe(3);
   });
 
-  it('кнопка "История" эмитит history с выбранной записью', async () => {
+  it('кнопка "История" в шапке эмитит history-all (общий журнал)', async () => {
+    const wrapper = mountBase();
+    await flushPromises();
+    const btn = wrapper.findAll('button').find((b) => b.text() === 'История');
+    await btn.trigger('click');
+    expect(wrapper.emitted('history-all')).toBeTruthy();
+  });
+
+  it('в панели деталей нет кнопки "История" (она глобальная в шапке)', async () => {
     const wrapper = mountBase();
     await flushPromises();
     await wrapper.findAll('.bl-row')[0].trigger('click');
-    const btn = wrapper.findAll('button').find((b) => b.text() === 'История');
+    const inActions = wrapper.findAll('.bl-details-actions button').find((b) => b.text() === 'История');
+    expect(inActions).toBeUndefined();
+  });
+
+  it('кнопка "Удалить навсегда" эмитит purge для архивной записи', async () => {
+    const wrapper = mountBase();
+    await flushPromises();
+    wrapper.vm.onArchiveModeChange('archive');
+    await flushPromises();
+    await wrapper.findAll('.bl-row')[0].trigger('click');
+    const btn = wrapper.findAll('button').find((b) => b.text() === 'Удалить навсегда');
     await btn.trigger('click');
-    expect(wrapper.emitted('history')[0][0].id).toBe(1);
+    expect(wrapper.emitted('purge')[0][0].id).toBe(3);
+  });
+
+  it('у активной записи нет кнопки "Удалить навсегда"', async () => {
+    const wrapper = mountBase();
+    await flushPromises();
+    await wrapper.findAll('.bl-row')[0].trigger('click');
+    const btn = wrapper.findAll('button').find((b) => b.text() === 'Удалить навсегда');
+    expect(btn).toBeUndefined();
+  });
+
+  it('кнопка "Редактировать" в строке статуса эмитит edit для активной записи', async () => {
+    const wrapper = mountBase();
+    await flushPromises();
+    await wrapper.findAll('.bl-row')[0].trigger('click');
+    const btn = wrapper.findAll('.bl-status-row button').find((b) => b.text() === 'Редактировать');
+    expect(btn).toBeTruthy();
+    await btn.trigger('click');
+    expect(wrapper.emitted('edit')[0][0].id).toBe(1);
   });
 
   it('пустой список показывает empty-state', async () => {

--- a/internal/handlers/person_blacklist.go
+++ b/internal/handlers/person_blacklist.go
@@ -168,3 +168,38 @@ func (h *PersonBlacklistHandler) GetHistory(c echo.Context) error {
 	}
 	return RespondSuccess(c, history)
 }
+
+// GetAllHistory godoc
+// @Summary      Весь журнал чёрного списка людей
+// @Tags         person-blacklist
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200 {array} models.PersonBlacklistHistoryItem
+// @Router       /person-blacklist/history [get]
+func (h *PersonBlacklistHandler) GetAllHistory(c echo.Context) error {
+	history, err := h.service.GetAllHistory(c.Request().Context())
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, history)
+}
+
+// Purge godoc
+// @Summary      Удалить запись чёрного списка людей навсегда
+// @Tags         person-blacklist
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID записи"
+// @Success      200 {string} string "Запись удалена навсегда"
+// @Router       /person-blacklist/{id}/purge [delete]
+func (h *PersonBlacklistHandler) Purge(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	userID, _ := c.Get("user_id").(int)
+	if err := h.service.Purge(c.Request().Context(), id, userID); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Запись удалена навсегда")
+}

--- a/internal/handlers/person_blacklist_test.go
+++ b/internal/handlers/person_blacklist_test.go
@@ -187,3 +187,84 @@ func TestPersonBlacklist_UnblacklistSkipsExpiredPass(t *testing.T) {
 	require.NotNil(t, after.Status)
 	assert.Equal(t, 0, *after.Status, "сотрудник с истёкшим пропуском не должен возрождаться")
 }
+
+// TestPersonBlacklist_Purge: удаление архивной записи навсегда стирает запись, но
+// сохраняет историю и пишет событие purged; активную удалять нельзя.
+func TestPersonBlacklist_Purge(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	userID, _, userCleanup := setupMWUser(t, db, true, false)
+	defer userCleanup()
+	svc := newPersonBlacklistService(db)
+	ctx := context.Background()
+
+	entry, err := svc.Create(ctx, models.CreatePersonBlacklistRequest{
+		LastName: "Удалённый", FirstName: "Иван", MiddleName: "Иванович", Reason: "на удаление",
+	}, userID)
+	require.NoError(t, err)
+
+	assertHTTPStatus(t, svc.Purge(ctx, entry.ID, userID), 400)
+
+	require.NoError(t, svc.Archive(ctx, entry.ID, userID))
+	require.NoError(t, svc.Purge(ctx, entry.ID, userID))
+
+	_, err = svc.GetByID(ctx, entry.ID)
+	assertHTTPStatus(t, err, 404)
+
+	hist, err := svc.GetHistory(ctx, entry.ID)
+	require.NoError(t, err)
+	actions := make([]string, 0, len(hist))
+	for _, h := range hist {
+		actions = append(actions, h.ActionType)
+	}
+	assert.Contains(t, actions, models.BlacklistActionCreated)
+	assert.Contains(t, actions, models.BlacklistActionArchived)
+	assert.Contains(t, actions, models.BlacklistActionPurged)
+}
+
+// TestPersonBlacklist_GetAllHistory: общий журнал отдаёт события всех записей (включая
+// удалённую) с именем пользователя, новые сверху.
+func TestPersonBlacklist_GetAllHistory(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	userID, _, userCleanup := setupMWUser(t, db, true, false)
+	defer userCleanup()
+	svc := newPersonBlacklistService(db)
+	ctx := context.Background()
+
+	e1, err := svc.Create(ctx, models.CreatePersonBlacklistRequest{
+		LastName: "Первый", FirstName: "Один", Reason: "первая",
+	}, userID)
+	require.NoError(t, err)
+	e2, err := svc.Create(ctx, models.CreatePersonBlacklistRequest{
+		LastName: "Второй", FirstName: "Два", Reason: "вторая",
+	}, userID)
+	require.NoError(t, err)
+	require.NoError(t, svc.Archive(ctx, e2.ID, userID))
+	require.NoError(t, svc.Purge(ctx, e2.ID, userID))
+
+	all, err := svc.GetAllHistory(ctx)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(all), 4)
+
+	var sawE1Created, sawE2Purged bool
+	for _, h := range all {
+		assert.NotEmpty(t, h.UserName, "должно подтягиваться имя пользователя")
+		if h.EntityID == e1.ID && h.ActionType == models.BlacklistActionCreated {
+			sawE1Created = true
+		}
+		if h.EntityID == e2.ID && h.ActionType == models.BlacklistActionPurged {
+			sawE2Purged = true
+		}
+	}
+	assert.True(t, sawE1Created, "журнал должен содержать created первой записи")
+	assert.True(t, sawE2Purged, "журнал должен содержать purged удалённой записи")
+
+	for i := 1; i < len(all); i++ {
+		assert.False(t, all[i].CreatedAt.After(all[i-1].CreatedAt), "события должны идти от новых к старым")
+	}
+}

--- a/internal/handlers/vehicle_blacklist.go
+++ b/internal/handlers/vehicle_blacklist.go
@@ -167,3 +167,38 @@ func (h *VehicleBlacklistHandler) GetHistory(c echo.Context) error {
 	}
 	return RespondSuccess(c, history)
 }
+
+// GetAllHistory godoc
+// @Summary      Весь журнал чёрного списка машин
+// @Tags         vehicle-blacklist
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200 {array} models.VehicleBlacklistHistoryItem
+// @Router       /vehicle-blacklist/history [get]
+func (h *VehicleBlacklistHandler) GetAllHistory(c echo.Context) error {
+	history, err := h.service.GetAllHistory(c.Request().Context())
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, history)
+}
+
+// Purge godoc
+// @Summary      Удалить запись чёрного списка машин навсегда
+// @Tags         vehicle-blacklist
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID записи"
+// @Success      200 {string} string "Запись удалена навсегда"
+// @Router       /vehicle-blacklist/{id}/purge [delete]
+func (h *VehicleBlacklistHandler) Purge(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	userID, _ := c.Get("user_id").(int)
+	if err := h.service.Purge(c.Request().Context(), id, userID); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Запись удалена навсегда")
+}

--- a/internal/handlers/vehicle_blacklist_test.go
+++ b/internal/handlers/vehicle_blacklist_test.go
@@ -297,3 +297,91 @@ func TestVehicleBlacklist_UpdateReason(t *testing.T) {
 		assertHTTPStatus(t, err, http.StatusBadRequest)
 	})
 }
+
+// TestVehicleBlacklist_Purge: удаление архивной записи навсегда стирает саму запись, но
+// сохраняет историю и пишет событие purged в общий журнал; активную удалять нельзя.
+func TestVehicleBlacklist_Purge(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	userID, _, userCleanup := setupMWUser(t, db, true, false)
+	defer userCleanup()
+	mark := seedMark(t, db, "BL_Purge")
+	svc := newVehicleBlacklistService(db)
+	ctx := context.Background()
+
+	entry, err := svc.Create(ctx, models.CreateVehicleBlacklistRequest{
+		CarNumber: "P777PP799", MarkID: mark.ID, Reason: "на удаление",
+	}, userID)
+	require.NoError(t, err)
+
+	// Активную удалять нельзя.
+	assertHTTPStatus(t, svc.Purge(ctx, entry.ID, userID), http.StatusBadRequest)
+
+	require.NoError(t, svc.Archive(ctx, entry.ID, userID))
+	require.NoError(t, svc.Purge(ctx, entry.ID, userID))
+
+	// Сама запись физически удалена.
+	_, err = svc.GetByID(ctx, entry.ID)
+	assertHTTPStatus(t, err, http.StatusNotFound)
+
+	// История по entity_id сохранилась и содержит событие purged.
+	hist, err := svc.GetHistory(ctx, entry.ID)
+	require.NoError(t, err)
+	actions := make([]string, 0, len(hist))
+	for _, h := range hist {
+		actions = append(actions, h.ActionType)
+	}
+	assert.Contains(t, actions, models.BlacklistActionCreated)
+	assert.Contains(t, actions, models.BlacklistActionArchived)
+	assert.Contains(t, actions, models.BlacklistActionPurged)
+}
+
+// TestVehicleBlacklist_GetAllHistory: общий журнал отдаёт события всех записей (включая
+// удалённую) с именем пользователя, новые сверху.
+func TestVehicleBlacklist_GetAllHistory(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	userID, _, userCleanup := setupMWUser(t, db, true, false)
+	defer userCleanup()
+	mark := seedMark(t, db, "BL_AllHist")
+	svc := newVehicleBlacklistService(db)
+	ctx := context.Background()
+
+	e1, err := svc.Create(ctx, models.CreateVehicleBlacklistRequest{
+		CarNumber: "H100HH799", MarkID: mark.ID, Reason: "первая",
+	}, userID)
+	require.NoError(t, err)
+	e2, err := svc.Create(ctx, models.CreateVehicleBlacklistRequest{
+		CarNumber: "H200HH799", MarkID: mark.ID, Reason: "вторая",
+	}, userID)
+	require.NoError(t, err)
+	require.NoError(t, svc.Archive(ctx, e2.ID, userID))
+	require.NoError(t, svc.Purge(ctx, e2.ID, userID))
+
+	all, err := svc.GetAllHistory(ctx)
+	require.NoError(t, err)
+	// created x2, archived x1, purged x1 = минимум 4 события обеих записей.
+	require.GreaterOrEqual(t, len(all), 4)
+
+	var sawE1Created, sawE2Purged bool
+	for _, h := range all {
+		assert.NotEmpty(t, h.UserName, "должно подтягиваться имя пользователя")
+		if h.EntityID == e1.ID && h.ActionType == models.BlacklistActionCreated {
+			sawE1Created = true
+		}
+		if h.EntityID == e2.ID && h.ActionType == models.BlacklistActionPurged {
+			sawE2Purged = true
+		}
+	}
+	assert.True(t, sawE1Created, "журнал должен содержать created первой записи")
+	assert.True(t, sawE2Purged, "журнал должен содержать purged удалённой записи")
+
+	// Новые сверху.
+	for i := 1; i < len(all); i++ {
+		assert.False(t, all[i].CreatedAt.After(all[i-1].CreatedAt), "события должны идти от новых к старым")
+	}
+}

--- a/internal/models/blacklist.go
+++ b/internal/models/blacklist.go
@@ -47,6 +47,9 @@ const (
 	BlacklistActionArchived = "archived"
 	BlacklistActionRestored = "restored"
 	BlacklistActionUpdated  = "updated"
+	// BlacklistActionPurged - запись удалена из архива навсегда. Сама запись удаляется
+	// физически, но событие (с лейблом сущности в details) остаётся в общем журнале ЧС.
+	BlacklistActionPurged = "purged"
 )
 
 // CreateVehicleBlacklistRequest - тело POST /vehicle-blacklist.

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -205,20 +205,24 @@ func Setup(e *echo.Echo, d Dependencies) {
 	vblGroup := protected.Group("/vehicle-blacklist")
 	vblGroup.GET("", vehicleBlacklist.GetAll)
 	vblGroup.GET("/check", vehicleBlacklist.Check)
+	vblGroup.GET("/history", vehicleBlacklist.GetAllHistory)
 	vblGroup.GET("/:id/history", vehicleBlacklist.GetHistory)
 	vblGroup.POST("", vehicleBlacklist.Create, requireBlacklist)
 	vblGroup.PUT("/:id", vehicleBlacklist.Update, requireBlacklist)
 	vblGroup.DELETE("/:id", vehicleBlacklist.Delete, requireBlacklist)
+	vblGroup.DELETE("/:id/purge", vehicleBlacklist.Purge, requireBlacklist)
 	vblGroup.POST("/:id/restore", vehicleBlacklist.Restore, requireBlacklist)
 
 	// Чёрный список людей (#443). Та же permission page.admin.blacklist (одна страница).
 	pblGroup := protected.Group("/person-blacklist")
 	pblGroup.GET("", personBlacklist.GetAll)
 	pblGroup.GET("/check", personBlacklist.Check)
+	pblGroup.GET("/history", personBlacklist.GetAllHistory)
 	pblGroup.GET("/:id/history", personBlacklist.GetHistory)
 	pblGroup.POST("", personBlacklist.Create, requireBlacklist)
 	pblGroup.PUT("/:id", personBlacklist.Update, requireBlacklist)
 	pblGroup.DELETE("/:id", personBlacklist.Delete, requireBlacklist)
+	pblGroup.DELETE("/:id/purge", personBlacklist.Purge, requireBlacklist)
 	pblGroup.POST("/:id/restore", personBlacklist.Restore, requireBlacklist)
 
 	// Attachment Excel-templates (#183) - вложенные ручки под /attachments/:id/...

--- a/internal/services/person_blacklist_history_service.go
+++ b/internal/services/person_blacklist_history_service.go
@@ -19,6 +19,8 @@ type PersonBlacklistHistoryService interface {
 	// Ошибку возвращает: запись - часть транзакции, провал откатывает операцию.
 	Log(ctx context.Context, exec *gorm.DB, entityID int, userID *int, actionType string, details interface{}) error
 	GetHistory(ctx context.Context, entityID int) ([]models.PersonBlacklistHistoryItem, error)
+	// GetAllHistory - весь журнал ЧС людей (все записи, включая удалённые), новые сверху.
+	GetAllHistory(ctx context.Context) ([]models.PersonBlacklistHistoryItem, error)
 }
 
 type personBlacklistHistoryService struct {
@@ -52,6 +54,15 @@ func (s *personBlacklistHistoryService) Log(ctx context.Context, exec *gorm.DB, 
 }
 
 func (s *personBlacklistHistoryService) GetHistory(ctx context.Context, entityID int) ([]models.PersonBlacklistHistoryItem, error) {
+	return s.query(ctx, &entityID)
+}
+
+func (s *personBlacklistHistoryService) GetAllHistory(ctx context.Context) ([]models.PersonBlacklistHistoryItem, error) {
+	return s.query(ctx, nil)
+}
+
+// query читает журнал ЧС людей (новые сверху). entityID == nil - весь журнал.
+func (s *personBlacklistHistoryService) query(ctx context.Context, entityID *int) ([]models.PersonBlacklistHistoryItem, error) {
 	type row struct {
 		ID         int             `gorm:"column:id"`
 		EntityID   int             `gorm:"column:entity_id"`
@@ -61,16 +72,18 @@ func (s *personBlacklistHistoryService) GetHistory(ctx context.Context, entityID
 		UserName   string          `gorm:"column:user_name"`
 		CreatedAt  time.Time       `gorm:"column:created_at"`
 	}
-	var rows []row
-	if err := s.db.WithContext(ctx).
+	q := s.db.WithContext(ctx).
 		Table("person_blacklist_histories AS h").
 		Select(`h.id, h.entity_id, h.action_type, h.details, h.user_id,
 			COALESCE(NULLIF(TRIM(BOTH ' ' FROM CONCAT_WS(' ', u.last_name, u.first_name)), ''), u.username, '') AS user_name,
 			h.created_at`).
-		Joins("LEFT JOIN users u ON u.id = h.user_id").
-		Where("h.entity_id = ?", entityID).
-		Order("h.created_at DESC").
-		Scan(&rows).Error; err != nil {
+		Joins("LEFT JOIN users u ON u.id = h.user_id")
+	if entityID != nil {
+		q = q.Where("h.entity_id = ?", *entityID)
+	}
+
+	var rows []row
+	if err := q.Order("h.created_at DESC").Scan(&rows).Error; err != nil {
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения истории чёрного списка")
 	}
 

--- a/internal/services/person_blacklist_service.go
+++ b/internal/services/person_blacklist_service.go
@@ -28,7 +28,12 @@ type PersonBlacklistService interface {
 	Check(ctx context.Context, lastName, firstName, middleName string) (models.PersonBlacklistCheckResult, error)
 	// UpdateReason - редактирование причины записи + лог в историю (updated).
 	UpdateReason(ctx context.Context, id int, reason string, userID int) (*models.PersonBlacklist, error)
+	// Purge - удаление архивной записи навсегда: запись удаляется физически, но событие
+	// purged (с ФИО) остаётся в общем журнале ЧС. Активную удалять нельзя.
+	Purge(ctx context.Context, id int, userID int) error
 	GetHistory(ctx context.Context, id int) ([]models.PersonBlacklistHistoryItem, error)
+	// GetAllHistory - весь журнал ЧС людей (все события всех записей, включая удалённые).
+	GetAllHistory(ctx context.Context) ([]models.PersonBlacklistHistoryItem, error)
 }
 
 type personBlacklistService struct {
@@ -194,7 +199,11 @@ func (s *personBlacklistService) UpdateReason(ctx context.Context, id int, reaso
 		if err := tx.Model(&models.PersonBlacklist{}).Where("id = ?", e.ID).Update("reason", newReason).Error; err != nil {
 			return err
 		}
-		details := map[string]interface{}{"reason_old": oldReason, "reason_new": newReason}
+		details := map[string]interface{}{
+			"full_name":  personFullName(*e),
+			"reason_old": oldReason,
+			"reason_new": newReason,
+		}
 		return s.history.Log(ctx, tx, e.ID, &userID, models.BlacklistActionUpdated, details)
 	})
 	if err != nil {
@@ -204,8 +213,38 @@ func (s *personBlacklistService) UpdateReason(ctx context.Context, id int, reaso
 	return e, nil
 }
 
+// Purge удаляет архивную запись навсегда. Логируем purged-событие (с ФИО в details),
+// затем физически удаляем запись - в одной транзакции. История по entity_id остаётся.
+func (s *personBlacklistService) Purge(ctx context.Context, id int, userID int) error {
+	e, err := s.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	if e.IsActive {
+		return echo.NewHTTPError(http.StatusBadRequest, "Нельзя удалить навсегда активную запись - сначала уберите из чёрного списка")
+	}
+	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		details := map[string]interface{}{
+			"full_name": personFullName(*e),
+			"reason":    e.Reason,
+		}
+		if err := s.history.Log(ctx, tx, e.ID, &userID, models.BlacklistActionPurged, details); err != nil {
+			return err
+		}
+		return tx.Where("id = ?", e.ID).Delete(&models.PersonBlacklist{}).Error
+	})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка удаления записи чёрного списка")
+	}
+	return nil
+}
+
 func (s *personBlacklistService) GetHistory(ctx context.Context, id int) ([]models.PersonBlacklistHistoryItem, error) {
 	return s.history.GetHistory(ctx, id)
+}
+
+func (s *personBlacklistService) GetAllHistory(ctx context.Context) ([]models.PersonBlacklistHistoryItem, error) {
+	return s.history.GetAllHistory(ctx)
 }
 
 // deactivateMatchingEmployees гасит (status 1 -> 0, date_deleted) активных employees,

--- a/internal/services/vehicle_blacklist_history_service.go
+++ b/internal/services/vehicle_blacklist_history_service.go
@@ -22,6 +22,8 @@ type VehicleBlacklistHistoryService interface {
 	Log(ctx context.Context, exec *gorm.DB, entityID int, userID *int, actionType string, details interface{}) error
 	// GetHistory возвращает историю по записи (новые сверху) с именем пользователя.
 	GetHistory(ctx context.Context, entityID int) ([]models.VehicleBlacklistHistoryItem, error)
+	// GetAllHistory - весь журнал ЧС машин (все записи, включая удалённые), новые сверху.
+	GetAllHistory(ctx context.Context) ([]models.VehicleBlacklistHistoryItem, error)
 }
 
 type vehicleBlacklistHistoryService struct {
@@ -55,6 +57,15 @@ func (s *vehicleBlacklistHistoryService) Log(ctx context.Context, exec *gorm.DB,
 }
 
 func (s *vehicleBlacklistHistoryService) GetHistory(ctx context.Context, entityID int) ([]models.VehicleBlacklistHistoryItem, error) {
+	return s.query(ctx, &entityID)
+}
+
+func (s *vehicleBlacklistHistoryService) GetAllHistory(ctx context.Context) ([]models.VehicleBlacklistHistoryItem, error) {
+	return s.query(ctx, nil)
+}
+
+// query читает журнал ЧС машин (новые сверху). entityID == nil - весь журнал.
+func (s *vehicleBlacklistHistoryService) query(ctx context.Context, entityID *int) ([]models.VehicleBlacklistHistoryItem, error) {
 	type row struct {
 		ID         int             `gorm:"column:id"`
 		EntityID   int             `gorm:"column:entity_id"`
@@ -64,16 +75,18 @@ func (s *vehicleBlacklistHistoryService) GetHistory(ctx context.Context, entityI
 		UserName   string          `gorm:"column:user_name"`
 		CreatedAt  time.Time       `gorm:"column:created_at"`
 	}
-	var rows []row
-	if err := s.db.WithContext(ctx).
+	q := s.db.WithContext(ctx).
 		Table("vehicle_blacklist_histories AS h").
 		Select(`h.id, h.entity_id, h.action_type, h.details, h.user_id,
 			COALESCE(NULLIF(TRIM(BOTH ' ' FROM CONCAT_WS(' ', u.last_name, u.first_name)), ''), u.username, '') AS user_name,
 			h.created_at`).
-		Joins("LEFT JOIN users u ON u.id = h.user_id").
-		Where("h.entity_id = ?", entityID).
-		Order("h.created_at DESC").
-		Scan(&rows).Error; err != nil {
+		Joins("LEFT JOIN users u ON u.id = h.user_id")
+	if entityID != nil {
+		q = q.Where("h.entity_id = ?", *entityID)
+	}
+
+	var rows []row
+	if err := q.Order("h.created_at DESC").Scan(&rows).Error; err != nil {
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения истории чёрного списка")
 	}
 

--- a/internal/services/vehicle_blacklist_service.go
+++ b/internal/services/vehicle_blacklist_service.go
@@ -37,7 +37,12 @@ type VehicleBlacklistService interface {
 	CheckByName(ctx context.Context, carNumber, markName string) (models.VehicleBlacklistCheckResult, error)
 	// UpdateReason - редактирование причины записи + лог в историю (updated).
 	UpdateReason(ctx context.Context, id int, reason string, userID int) (*models.VehicleBlacklist, error)
+	// Purge - удаление архивной записи навсегда: запись удаляется физически, но событие
+	// purged (с лейблом машины) остаётся в общем журнале ЧС. Активную удалять нельзя.
+	Purge(ctx context.Context, id int, userID int) error
 	GetHistory(ctx context.Context, id int) ([]models.VehicleBlacklistHistoryItem, error)
+	// GetAllHistory - весь журнал ЧС машин (все события всех записей, включая удалённые).
+	GetAllHistory(ctx context.Context) ([]models.VehicleBlacklistHistoryItem, error)
 }
 
 type vehicleBlacklistService struct {
@@ -165,7 +170,12 @@ func (s *vehicleBlacklistService) UpdateReason(ctx context.Context, id int, reas
 		if err := tx.Model(&models.VehicleBlacklist{}).Where("id = ?", e.ID).Update("reason", newReason).Error; err != nil {
 			return err
 		}
-		details := map[string]interface{}{"reason_old": oldReason, "reason_new": newReason}
+		details := map[string]interface{}{
+			"car_number": e.CarNumber,
+			"mark_name":  e.MarkName,
+			"reason_old": oldReason,
+			"reason_new": newReason,
+		}
 		return s.history.Log(ctx, tx, e.ID, &userID, models.BlacklistActionUpdated, details)
 	})
 	if err != nil {
@@ -173,6 +183,34 @@ func (s *vehicleBlacklistService) UpdateReason(ctx context.Context, id int, reas
 	}
 	e.Reason = newReason
 	return e, nil
+}
+
+// Purge удаляет архивную запись навсегда. Сначала логируем purged-событие (с лейблом
+// машины в details), затем физически удаляем запись - в одной транзакции. История по
+// entity_id остаётся (FK нет), общий журнал ЧС сохраняет весь жизненный цикл записи.
+func (s *vehicleBlacklistService) Purge(ctx context.Context, id int, userID int) error {
+	e, err := s.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	if e.IsActive {
+		return echo.NewHTTPError(http.StatusBadRequest, "Нельзя удалить навсегда активную запись - сначала уберите из чёрного списка")
+	}
+	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		details := map[string]interface{}{
+			"car_number": e.CarNumber,
+			"mark_name":  e.MarkName,
+			"reason":     e.Reason,
+		}
+		if err := s.history.Log(ctx, tx, e.ID, &userID, models.BlacklistActionPurged, details); err != nil {
+			return err
+		}
+		return tx.Where("id = ?", e.ID).Delete(&models.VehicleBlacklist{}).Error
+	})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка удаления записи чёрного списка")
+	}
+	return nil
 }
 
 func (s *vehicleBlacklistService) Restore(ctx context.Context, id int, userID int) error {
@@ -243,6 +281,10 @@ func (s *vehicleBlacklistService) CheckByName(ctx context.Context, carNumber, ma
 
 func (s *vehicleBlacklistService) GetHistory(ctx context.Context, id int) ([]models.VehicleBlacklistHistoryItem, error) {
 	return s.history.GetHistory(ctx, id)
+}
+
+func (s *vehicleBlacklistService) GetAllHistory(ctx context.Context) ([]models.VehicleBlacklistHistoryItem, error) {
+	return s.history.GetAllHistory(ctx)
 }
 
 // deactivateMatchingCars деактивирует (status 1 -> 0) активные cars, совпадающие с записью


### PR DESCRIPTION
## Что и зачем

Редизайн истории чёрного списка по запросу пользователя: вместо истории по конкретной записи теперь **один общий журнал на весь ЧС** (все события всех записей, включая физически удалённые). Это закрывает вопрос «как узнать, кто и когда удалил запись из архива» - событие остаётся в журнале, даже когда самой записи уже нет.

## Backend
- `GET /vehicle-blacklist/history` и `GET /person-blacklist/history` - весь журнал (все события, новые сверху, с именем пользователя). Открыты любому авторизованному, как остальные GET группы.
- `DELETE /:id/purge` (под `requireBlacklist`) - удаление архивной записи навсегда. В одной транзакции: пишем событие `purged` (с лейблом сущности в details), затем физически удаляем запись. История по `entity_id` остаётся (FK нет). Активную удалять нельзя (400).
- Во все `updated`-события и в `purged` кладётся лейбл сущности (номер+марка / ФИО), чтобы журнал отображал объект даже после удаления записи.
- Константа `BlacklistActionPurged`.

## Frontend
- Историю по отдельной записи убрал. Кнопка **«История»** теперь глобальная - в шапке вкладки, открывает общий журнал.
- Модалка журнала: лейбл сущности на каждой строке; для `updated` - diff причины **SVG-стрелкой «было → стало»** вместо текста «Стало:»; событие `purged` красной точкой; экспорт в Excel с колонкой «Объект».
- Кнопка **«Удалить навсегда»** для архивных записей с `ConfirmationModal`.
- Кнопка **«Редактировать»** перенесена в строку статуса (`flex; justify-content: space-between`).
- `bl-section` в Vehicle/EmployeeDetailsModal - `border-radius: 20px`.

## Проверки
- Go: `go vet` + `gofmt` чисто; тесты `internal/handlers` + `internal/services` зелёные (добавлены `TestVehicleBlacklist_Purge/_GetAllHistory`, `TestPersonBlacklist_Purge/_GetAllHistory`).
- FE: vitest 60/60 по компонентам ЧС, eslint чисто.
- code-reviewer: GO, блокеров нет.
- Скриншоты сняты локально (активная карточка, журнал, архив) и согласованы с пользователем до мержа.

Закрывает раунд 2 полировки #443 (пункты: общий журнал, удаление навсегда, стрелка diff, перенос «Редактировать», радиус секции).