### PR TITLE
fix(history): анимация закрытия модалок истории машин и сотрудников (#406)

### DIFF
--- a/frontend/src/components/CarHistoryModal.vue
+++ b/frontend/src/components/CarHistoryModal.vue
@@ -1,220 +1,227 @@
 <template>
   <Teleport to="body">
-    <div
-      class="modal-overlay"
-      @mousedown="onOverlayMousedown"
-      @mouseup="onOverlayMouseup"
+    <transition
+      name="modal-fade"
+      @after-leave="onAfterLeave"
     >
       <div
-        class="car-history-modal"
-        @mousedown.stop
+        v-if="visible"
+        class="modal-overlay"
+        @mousedown="onOverlayMousedown"
+        @mouseup="onOverlayMouseup"
       >
-        <div class="modal-header">
-          <h3>История автомобиля {{ carNumber }}</h3>
-          <div class="header-actions">
-            <button
-              class="export-btn"
-              :disabled="filteredHistory.length === 0 || isExporting"
-              @click="exportToExcel"
-            >
-              <img
-                v-if="!isExporting"
-                src="@/assets/icons/export.png"
-                class="export-icon"
-              >
-              <span v-if="!isExporting">Экспорт</span>
-              <div
-                v-else
-                class="export-loader"
-              />
-            </button>
-            <button
-              class="close-btn"
-              @click="close"
-            >
-              ×
-            </button>
-          </div>
-        </div>
-
-        <div class="history-filters">
-          <div class="filter-row">
-            <div class="search-filter">
-              <span class="filter-label">Поиск:</span>
-              <input 
-                v-model="searchQuery" 
-                type="text" 
-                class="search-input" 
-                placeholder="Поиск по пользователю, действию..."
-                @input="applyFilters"
-              >
-            </div>
-            <div class="user-filter">
-              <span class="filter-label">Пользователь:</span>
-              <div
-                class="custom-select"
-                @click="toggleUserDropdown"
-              >
-                <div class="select-trigger">
-                  <span class="selected-value">{{ selectedUserName }}</span>
-                  <img 
-                    src="@/assets/icons/arrow.png" 
-                    class="select-arrow" 
-                    :class="{ 'arrow-open': userDropdownOpen }"
-                  >
-                </div>
-                <transition name="fade">
-                  <div
-                    v-if="userDropdownOpen"
-                    class="select-dropdown"
-                  >
-                    <div 
-                      class="select-option"
-                      :class="{ 'selected': selectedUserId === null }"
-                      @click="selectUser(null)"
-                    >
-                      Все пользователи
-                    </div>
-                    <div 
-                      v-for="user in uniqueUsers" 
-                      :key="user.id"
-                      class="select-option"
-                      :class="{ 'selected': selectedUserId === user.id }"
-                      @click="selectUser(user.id)"
-                    >
-                      {{ user.name }}
-                    </div>
-                  </div>
-                </transition>
-              </div>
-            </div>
-          
-            <div class="date-filter">
-              <span class="filter-label">Период:</span>
-              <input 
-                v-model="dateFrom" 
-                type="date" 
-                class="date-input"
-                @change="applyFilters"
-              >
-              <span class="date-separator">—</span>
-              <input 
-                v-model="dateTo" 
-                type="date" 
-                class="date-input"
-                @change="applyFilters"
-              >
-            </div>
-          
-            <div class="sort-filter">
-              <span class="filter-label">Сортировка:</span>
+        <div
+          class="car-history-modal"
+          @mousedown.stop
+        >
+          <div class="modal-header">
+            <h3>История автомобиля {{ carNumber }}</h3>
+            <div class="header-actions">
               <button
-                class="sort-btn"
-                @click="toggleSortOrder"
+                class="export-btn"
+                :disabled="filteredHistory.length === 0 || isExporting"
+                @click="exportToExcel"
               >
                 <img
-                  src="@/assets/icons/sort.png"
-                  class="sort-icon"
-                  :class="{ 'sort-asc': sortOrder === 'asc' }"
+                  v-if="!isExporting"
+                  src="@/assets/icons/export.png"
+                  class="export-icon"
                 >
-                <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
+                <span v-if="!isExporting">Экспорт</span>
+                <div
+                  v-else
+                  class="export-loader"
+                />
+              </button>
+              <button
+                class="close-btn"
+                @click="requestClose"
+              >
+                ×
               </button>
             </div>
           </div>
-        </div>
 
-        <div
-          ref="scrollContainer"
-          class="modal-content"
-        >
-          <div
-            v-if="loading"
-            class="history-loading"
-          >
-            <LoaderSpinner label="Загрузка истории…" />
+          <div class="history-filters">
+            <div class="filter-row">
+              <div class="search-filter">
+                <span class="filter-label">Поиск:</span>
+                <input 
+                  v-model="searchQuery" 
+                  type="text" 
+                  class="search-input" 
+                  placeholder="Поиск по пользователю, действию..."
+                  @input="applyFilters"
+                >
+              </div>
+              <div class="user-filter">
+                <span class="filter-label">Пользователь:</span>
+                <div
+                  class="custom-select"
+                  @click="toggleUserDropdown"
+                >
+                  <div class="select-trigger">
+                    <span class="selected-value">{{ selectedUserName }}</span>
+                    <img 
+                      src="@/assets/icons/arrow.png" 
+                      class="select-arrow" 
+                      :class="{ 'arrow-open': userDropdownOpen }"
+                    >
+                  </div>
+                  <transition name="fade">
+                    <div
+                      v-if="userDropdownOpen"
+                      class="select-dropdown"
+                    >
+                      <div 
+                        class="select-option"
+                        :class="{ 'selected': selectedUserId === null }"
+                        @click="selectUser(null)"
+                      >
+                        Все пользователи
+                      </div>
+                      <div 
+                        v-for="user in uniqueUsers" 
+                        :key="user.id"
+                        class="select-option"
+                        :class="{ 'selected': selectedUserId === user.id }"
+                        @click="selectUser(user.id)"
+                      >
+                        {{ user.name }}
+                      </div>
+                    </div>
+                  </transition>
+                </div>
+              </div>
+          
+              <div class="date-filter">
+                <span class="filter-label">Период:</span>
+                <input 
+                  v-model="dateFrom" 
+                  type="date" 
+                  class="date-input"
+                  @change="applyFilters"
+                >
+                <span class="date-separator">—</span>
+                <input 
+                  v-model="dateTo" 
+                  type="date" 
+                  class="date-input"
+                  @change="applyFilters"
+                >
+              </div>
+          
+              <div class="sort-filter">
+                <span class="filter-label">Сортировка:</span>
+                <button
+                  class="sort-btn"
+                  @click="toggleSortOrder"
+                >
+                  <img
+                    src="@/assets/icons/sort.png"
+                    class="sort-icon"
+                    :class="{ 'sort-asc': sortOrder === 'asc' }"
+                  >
+                  <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
+                </button>
+              </div>
+            </div>
           </div>
-        
+
           <div
-            v-else-if="filteredHistory.length === 0"
-            class="history-empty"
+            ref="scrollContainer"
+            class="modal-content"
           >
-            История пуста
-          </div>
-        
-          <div
-            v-else
-            class="history-timeline"
-          >
-            <div 
-              v-for="(item, index) in filteredHistory" 
-              :key="item.id" 
-              class="history-item"
+            <div
+              v-if="loading"
+              class="history-loading"
             >
-              <div
-                class="timeline-dot"
-                :class="getActionClass(item.action_type)"
-              />
-              <div
-                v-if="index < filteredHistory.length - 1"
-                class="timeline-line"
-              />
+              <LoaderSpinner label="Загрузка истории…" />
+            </div>
+        
+            <div
+              v-else-if="filteredHistory.length === 0"
+              class="history-empty"
+            >
+              История пуста
+            </div>
+        
+            <div
+              v-else
+              class="history-timeline"
+            >
+              <div 
+                v-for="(item, index) in filteredHistory" 
+                :key="item.id" 
+                class="history-item"
+              >
+                <div
+                  class="timeline-dot"
+                  :class="getActionClass(item.action_type)"
+                />
+                <div
+                  v-if="index < filteredHistory.length - 1"
+                  class="timeline-line"
+                />
             
-              <div class="history-content">
-                <div class="history-header">
-                  <span class="user-name">{{ item.user_name || 'Система' }}</span>
-                  <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
-                </div>
+                <div class="history-content">
+                  <div class="history-header">
+                    <span class="user-name">{{ item.user_name || 'Система' }}</span>
+                    <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                  </div>
               
-                <div class="action-text">
-                  {{ getActionText(item) }}
-                </div>
+                  <div class="action-text">
+                    {{ getActionText(item) }}
+                  </div>
               
-                <div
-                  v-if="item.action_type === 'entry' || item.action_type === 'exit'"
-                  class="action-comment"
-                >
-                  {{ getActionComment(item) }}
-                </div>
+                  <div
+                    v-if="item.action_type === 'entry' || item.action_type === 'exit'"
+                    class="action-comment"
+                  >
+                    {{ getActionComment(item) }}
+                  </div>
               
-                <div
-                  v-if="item.comment && item.action_type !== 'entry' && item.action_type !== 'exit'"
-                  class="action-comment"
-                >
-                  {{ item.comment }}
-                </div>
+                  <div
+                    v-if="item.comment && item.action_type !== 'entry' && item.action_type !== 'exit'"
+                    class="action-comment"
+                  >
+                    {{ item.comment }}
+                  </div>
               
-                <div
-                  v-if="item.old_value && item.new_value && item.old_value !== item.new_value"
-                  class="value-change"
-                >
-                  <span class="old-value">{{ item.old_value }}</span>
-                  <span class="arrow">→</span>
-                  <span class="new-value">{{ item.new_value }}</span>
-                </div>
+                  <div
+                    v-if="item.old_value && item.new_value && item.old_value !== item.new_value"
+                    class="value-change"
+                  >
+                    <span class="old-value">{{ item.old_value }}</span>
+                    <span class="arrow">→</span>
+                    <span class="new-value">{{ item.new_value }}</span>
+                  </div>
               
-                <div
-                  v-if="item.field_name"
-                  class="field-name"
-                >
-                  Поле: {{ item.field_name }}
-                </div>
+                  <div
+                    v-if="item.field_name"
+                    class="field-name"
+                  >
+                    Поле: {{ item.field_name }}
+                  </div>
               
-                <div
-                  v-if="item.table_name"
-                  class="place-name"
-                >
-                  {{ item.table_name }}
+                  <div
+                    v-if="item.table_name"
+                    class="place-name"
+                  >
+                    {{ item.table_name }}
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    </transition>
   </Teleport>
 </template>
 
 <script>
+import { ref } from 'vue';
 import { apiRequest } from '@/api/client'
 import { useOverlayClose } from '@/composables/useOverlayClose';
 import LoaderSpinner from './ui/LoaderSpinner.vue';
@@ -263,8 +270,14 @@ export default {
   },
   emits: ['close'],
   setup(_, { emit }) {
-    const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(() => emit('close'));
-    return { onOverlayMousedown, onOverlayMouseup };
+    // Анимация закрытия: внутренний visible (enter по mounted, leave по requestClose),
+    // emit('close') только ПОСЛЕ leave-перехода (@after-leave) - иначе родитель
+    // размонтирует мгновенно и анимация не проиграется.
+    const visible = ref(false);
+    const requestClose = () => { visible.value = false; };
+    const onAfterLeave = () => emit('close');
+    const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(requestClose);
+    return { visible, requestClose, onAfterLeave, onOverlayMousedown, onOverlayMouseup };
   },
   data() {
     return {
@@ -391,17 +404,14 @@ export default {
     }
   },
   mounted() {
+    this.visible = true;
     this.loadHistory();
-    console.log('CarHistoryModal получил пропсы:', {
-      carNumber: this.carNumber,
-      carBrand: this.carBrand,
-      organizationId: this.organizationId,
-      companyId: this.companyId
-    });
     document.addEventListener('click', this.handleClickOutside);
+    document.addEventListener('keydown', this.onKeydown);
   },
   beforeUnmount() {
     document.removeEventListener('click', this.handleClickOutside);
+    document.removeEventListener('keydown', this.onKeydown);
   },
   methods: {
     async loadHistory() {
@@ -730,9 +740,9 @@ export default {
       }
     },
 
-    close() {
-      this.$emit('close');
-    }
+    onKeydown(e) {
+      if (e.key === 'Escape') this.requestClose();
+    },
   }
 };
 </script>
@@ -758,12 +768,38 @@ export default {
   z-index: 12000;
   backdrop-filter: blur(0.1px);
   -webkit-backdrop-filter: blur(0.1px);
-  animation: fadeIn 0.2s ease-out;
 }
 
-@keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
+/* Анимация открытия/закрытия (паттерн BaseModal): overlay fade + контент scale */
+.modal-fade-enter-active {
+  transition: opacity 0.25s ease;
+}
+
+.modal-fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+  opacity: 0;
+}
+
+.modal-fade-enter-active .car-history-modal {
+  animation: modal-scale-in 0.25s ease;
+}
+
+.modal-fade-leave-active .car-history-modal {
+  animation: modal-scale-out 0.2s ease;
+}
+
+@keyframes modal-scale-in {
+  from { transform: scale(0.95); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
+}
+
+@keyframes modal-scale-out {
+  from { transform: scale(1); opacity: 1; }
+  to { transform: scale(0.95); opacity: 0; }
 }
 
 .car-history-modal {
@@ -775,18 +811,6 @@ export default {
   display: flex;
   flex-direction: column;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
-  animation: slideUp 0.2s ease-out;
-}
-
-@keyframes slideUp {
-  from {
-    transform: translateY(20px);
-    opacity: 0;
-  }
-  to {
-    transform: translateY(0);
-    opacity: 1;
-  }
 }
 
 .modal-header {

--- a/frontend/src/components/CarsTableHistoryModal.vue
+++ b/frontend/src/components/CarsTableHistoryModal.vue
@@ -1,242 +1,254 @@
 <template>
   <Teleport to="body">
-    <div
-      class="modal-overlay"
-      @click.self="close"
+    <transition
+      name="modal-fade"
+      @after-leave="onAfterLeave"
     >
-      <div class="cars-history-modal">
-        <div class="modal-header">
-          <h3>История въездов и выездов всех автомобилей</h3>
-          <div class="header-actions">
-            <button
-              class="export-btn"
-              :disabled="filteredHistory.length === 0 || isExporting"
-              @click="exportToExcel"
-            >
-              <img
-                v-if="!isExporting"
-                src="@/assets/icons/export.png"
-                class="export-icon"
-              >
-              <span v-if="!isExporting">Экспорт</span>
-              <div
-                v-else
-                class="export-loader"
-              />
-            </button>
-            <button
-              class="close-btn"
-              @click="close"
-            >
-              ×
-            </button>
-          </div>
-        </div>
-
-        <div class="history-filters">
-          <div class="filter-row">
-            <div class="search-filter">
-              <span class="filter-label">Поиск:</span>
-              <input 
-                v-model="searchQuery" 
-                type="text" 
-                class="search-input" 
-                placeholder="Поиск по автомобилю, номеру, организации..."
-                @input="applyFilters"
-              >
-            </div>
-            <div class="user-filter">
-              <span class="filter-label">Пользователь:</span>
-              <div
-                class="custom-select"
-                @click="toggleUserDropdown"
-              >
-                <div class="select-trigger">
-                  <span class="selected-value">{{ selectedUserName }}</span>
-                  <img 
-                    src="@/assets/icons/arrow.png" 
-                    class="select-arrow" 
-                    :class="{ 'arrow-open': userDropdownOpen }"
-                  >
-                </div>
-                <transition name="fade">
-                  <div
-                    v-if="userDropdownOpen"
-                    class="select-dropdown"
-                  >
-                    <div 
-                      class="select-option"
-                      :class="{ 'selected': selectedUserId === null }"
-                      @click="selectUser(null)"
-                    >
-                      Все пользователи
-                    </div>
-                    <div 
-                      v-for="user in uniqueUsers" 
-                      :key="user.id"
-                      class="select-option"
-                      :class="{ 'selected': selectedUserId === user.id }"
-                      @click="selectUser(user.id)"
-                    >
-                      {{ user.name }}
-                    </div>
-                  </div>
-                </transition>
-              </div>
-            </div>
-          
-            <div class="car-filter">
-              <span class="filter-label">Автомобиль:</span>
-              <div
-                class="custom-select"
-                @click="toggleCarDropdown"
-              >
-                <div class="select-trigger">
-                  <span class="selected-value">{{ selectedCarName }}</span>
-                  <img 
-                    src="@/assets/icons/arrow.png" 
-                    class="select-arrow" 
-                    :class="{ 'arrow-open': carDropdownOpen }"
-                  >
-                </div>
-                <transition name="fade">
-                  <div
-                    v-if="carDropdownOpen"
-                    class="select-dropdown"
-                  >
-                    <div 
-                      class="select-option"
-                      :class="{ 'selected': selectedCarId === null }"
-                      @click="selectCar(null)"
-                    >
-                      Все автомобили
-                    </div>
-                    <div 
-                      v-for="car in cars" 
-                      :key="car.id"
-                      class="select-option"
-                      :class="{ 'selected': selectedCarId === car.id }"
-                      @click="selectCar(car.id)"
-                    >
-                      {{ formatCarName(car) }}
-                    </div>
-                  </div>
-                </transition>
-              </div>
-            </div>
-          
-            <div class="date-filter">
-              <span class="filter-label">Период:</span>
-              <input 
-                v-model="dateFrom" 
-                type="date" 
-                class="date-input"
-                @change="applyFilters"
-              >
-              <span class="date-separator">—</span>
-              <input 
-                v-model="dateTo" 
-                type="date" 
-                class="date-input"
-                @change="applyFilters"
-              >
-            </div>
-          
-            <div class="sort-filter">
-              <span class="filter-label">Сортировка:</span>
+      <div
+        v-if="visible"
+        class="modal-overlay"
+        @mousedown="onOverlayMousedown"
+        @mouseup="onOverlayMouseup"
+      >
+        <div
+          class="cars-history-modal"
+          @mousedown.stop
+        >
+          <div class="modal-header">
+            <h3>История въездов и выездов всех автомобилей</h3>
+            <div class="header-actions">
               <button
-                class="sort-btn"
-                @click="toggleSortOrder"
+                class="export-btn"
+                :disabled="filteredHistory.length === 0 || isExporting"
+                @click="exportToExcel"
               >
                 <img
-                  src="@/assets/icons/sort.png"
-                  class="sort-icon"
-                  :class="{ 'sort-asc': sortOrder === 'asc' }"
+                  v-if="!isExporting"
+                  src="@/assets/icons/export.png"
+                  class="export-icon"
                 >
-                <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
+                <span v-if="!isExporting">Экспорт</span>
+                <div
+                  v-else
+                  class="export-loader"
+                />
+              </button>
+              <button
+                class="close-btn"
+                @click="requestClose"
+              >
+                ×
               </button>
             </div>
           </div>
-        </div>
 
-        <div
-          ref="scrollContainer"
-          class="modal-content"
-        >
-          <div
-            v-if="loading"
-            class="history-loading"
-          >
-            <LoaderSpinner label="Загрузка истории…" />
+          <div class="history-filters">
+            <div class="filter-row">
+              <div class="search-filter">
+                <span class="filter-label">Поиск:</span>
+                <input 
+                  v-model="searchQuery" 
+                  type="text" 
+                  class="search-input" 
+                  placeholder="Поиск по автомобилю, номеру, организации..."
+                  @input="applyFilters"
+                >
+              </div>
+              <div class="user-filter">
+                <span class="filter-label">Пользователь:</span>
+                <div
+                  class="custom-select"
+                  @click="toggleUserDropdown"
+                >
+                  <div class="select-trigger">
+                    <span class="selected-value">{{ selectedUserName }}</span>
+                    <img 
+                      src="@/assets/icons/arrow.png" 
+                      class="select-arrow" 
+                      :class="{ 'arrow-open': userDropdownOpen }"
+                    >
+                  </div>
+                  <transition name="fade">
+                    <div
+                      v-if="userDropdownOpen"
+                      class="select-dropdown"
+                    >
+                      <div 
+                        class="select-option"
+                        :class="{ 'selected': selectedUserId === null }"
+                        @click="selectUser(null)"
+                      >
+                        Все пользователи
+                      </div>
+                      <div 
+                        v-for="user in uniqueUsers" 
+                        :key="user.id"
+                        class="select-option"
+                        :class="{ 'selected': selectedUserId === user.id }"
+                        @click="selectUser(user.id)"
+                      >
+                        {{ user.name }}
+                      </div>
+                    </div>
+                  </transition>
+                </div>
+              </div>
+          
+              <div class="car-filter">
+                <span class="filter-label">Автомобиль:</span>
+                <div
+                  class="custom-select"
+                  @click="toggleCarDropdown"
+                >
+                  <div class="select-trigger">
+                    <span class="selected-value">{{ selectedCarName }}</span>
+                    <img 
+                      src="@/assets/icons/arrow.png" 
+                      class="select-arrow" 
+                      :class="{ 'arrow-open': carDropdownOpen }"
+                    >
+                  </div>
+                  <transition name="fade">
+                    <div
+                      v-if="carDropdownOpen"
+                      class="select-dropdown"
+                    >
+                      <div 
+                        class="select-option"
+                        :class="{ 'selected': selectedCarId === null }"
+                        @click="selectCar(null)"
+                      >
+                        Все автомобили
+                      </div>
+                      <div 
+                        v-for="car in cars" 
+                        :key="car.id"
+                        class="select-option"
+                        :class="{ 'selected': selectedCarId === car.id }"
+                        @click="selectCar(car.id)"
+                      >
+                        {{ formatCarName(car) }}
+                      </div>
+                    </div>
+                  </transition>
+                </div>
+              </div>
+          
+              <div class="date-filter">
+                <span class="filter-label">Период:</span>
+                <input 
+                  v-model="dateFrom" 
+                  type="date" 
+                  class="date-input"
+                  @change="applyFilters"
+                >
+                <span class="date-separator">—</span>
+                <input 
+                  v-model="dateTo" 
+                  type="date" 
+                  class="date-input"
+                  @change="applyFilters"
+                >
+              </div>
+          
+              <div class="sort-filter">
+                <span class="filter-label">Сортировка:</span>
+                <button
+                  class="sort-btn"
+                  @click="toggleSortOrder"
+                >
+                  <img
+                    src="@/assets/icons/sort.png"
+                    class="sort-icon"
+                    :class="{ 'sort-asc': sortOrder === 'asc' }"
+                  >
+                  <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
+                </button>
+              </div>
+            </div>
           </div>
-        
+
           <div
-            v-else-if="filteredHistory.length === 0"
-            class="history-empty"
+            ref="scrollContainer"
+            class="modal-content"
           >
-            История пуста
-          </div>
-        
-          <div
-            v-else
-            class="history-timeline"
-          >
-            <div 
-              v-for="(item, index) in filteredHistory" 
-              :key="item.id" 
-              class="history-item"
+            <div
+              v-if="loading"
+              class="history-loading"
             >
-              <div
-                class="timeline-dot"
-                :class="getActionClass(item.action_type)"
-              />
-              <div
-                v-if="index < filteredHistory.length - 1"
-                class="timeline-line"
-              />
+              <LoaderSpinner label="Загрузка истории…" />
+            </div>
+        
+            <div
+              v-else-if="filteredHistory.length === 0"
+              class="history-empty"
+            >
+              История пуста
+            </div>
+        
+            <div
+              v-else
+              class="history-timeline"
+            >
+              <div 
+                v-for="(item, index) in filteredHistory" 
+                :key="item.id" 
+                class="history-item"
+              >
+                <div
+                  class="timeline-dot"
+                  :class="getActionClass(item.action_type)"
+                />
+                <div
+                  v-if="index < filteredHistory.length - 1"
+                  class="timeline-line"
+                />
             
-              <div class="history-content">
-                <div class="history-header">
-                  <span class="car-info">{{ getCarInfo(item) }}</span>
-                  <span class="user-name">{{ item.user_name || 'Система' }}</span>
-                  <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
-                </div>
+                <div class="history-content">
+                  <div class="history-header">
+                    <span class="car-info">{{ getCarInfo(item) }}</span>
+                    <span class="user-name">{{ item.user_name || 'Система' }}</span>
+                    <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                  </div>
               
-                <div class="action-text">
-                  {{ getActionText(item) }}
-                </div>
+                  <div class="action-text">
+                    {{ getActionText(item) }}
+                  </div>
               
-                <div
-                  v-if="item.action_type === 'entry' || item.action_type === 'exit'"
-                  class="action-comment"
-                >
-                  {{ getActionComment(item) }}
-                </div>
+                  <div
+                    v-if="item.action_type === 'entry' || item.action_type === 'exit'"
+                    class="action-comment"
+                  >
+                    {{ getActionComment(item) }}
+                  </div>
               
-                <div
-                  v-if="item.comment && item.action_type !== 'entry' && item.action_type !== 'exit'"
-                  class="action-comment"
-                >
-                  {{ item.comment }}
-                </div>
+                  <div
+                    v-if="item.comment && item.action_type !== 'entry' && item.action_type !== 'exit'"
+                    class="action-comment"
+                  >
+                    {{ item.comment }}
+                  </div>
 
-                <div
-                  v-if="item.table_name"
-                  class="place-name"
-                >
-                  {{ item.table_name }}
+                  <div
+                    v-if="item.table_name"
+                    class="place-name"
+                  >
+                    {{ item.table_name }}
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    </transition>
   </Teleport>
 </template>
 
 <script>
+import { ref } from 'vue';
 import { apiRequest } from '@/api/client'
+import { useOverlayClose } from '@/composables/useOverlayClose';
 import LoaderSpinner from '@/components/ui/LoaderSpinner.vue';
 import ExcelJS from 'exceljs';
 
@@ -258,6 +270,16 @@ export default {
     }
   },
   emits: ['close'],
+  setup(_, { emit }) {
+    // Анимация закрытия: внутренний visible (enter по mounted, leave по requestClose),
+    // emit('close') только ПОСЛЕ leave-перехода (@after-leave) - иначе родитель
+    // размонтирует мгновенно и анимация не проиграется.
+    const visible = ref(false);
+    const requestClose = () => { visible.value = false; };
+    const onAfterLeave = () => emit('close');
+    const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(requestClose);
+    return { visible, requestClose, onAfterLeave, onOverlayMousedown, onOverlayMouseup };
+  },
   data() {
     return {
       loading: false,
@@ -380,15 +402,18 @@ export default {
     }
   },
   mounted() {
+    this.visible = true;
     this.loadHistory();
     document.addEventListener('click', this.handleClickOutside);
-    
+    document.addEventListener('keydown', this.onKeydown);
+
     this.cars.forEach(car => {
       this.carsMap[car.id] = this.formatCarName(car);
     });
   },
   beforeUnmount() {
     document.removeEventListener('click', this.handleClickOutside);
+    document.removeEventListener('keydown', this.onKeydown);
   },
   methods: {
     formatCarName(car) {
@@ -656,9 +681,9 @@ export default {
       }
     },
 
-    close() {
-      this.$emit('close');
-    }
+    onKeydown(e) {
+      if (e.key === 'Escape') this.requestClose();
+    },
   }
 };
 </script>
@@ -685,12 +710,38 @@ export default {
   z-index: 13000;
   backdrop-filter: blur(0.1px);
   -webkit-backdrop-filter: blur(0.1px);
-  animation: fadeIn 0.2s ease-out;
 }
 
-@keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
+/* Анимация открытия/закрытия (паттерн BaseModal): overlay fade + контент scale */
+.modal-fade-enter-active {
+  transition: opacity 0.25s ease;
+}
+
+.modal-fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+  opacity: 0;
+}
+
+.modal-fade-enter-active .cars-history-modal {
+  animation: modal-scale-in 0.25s ease;
+}
+
+.modal-fade-leave-active .cars-history-modal {
+  animation: modal-scale-out 0.2s ease;
+}
+
+@keyframes modal-scale-in {
+  from { transform: scale(0.95); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
+}
+
+@keyframes modal-scale-out {
+  from { transform: scale(1); opacity: 1; }
+  to { transform: scale(0.95); opacity: 0; }
 }
 
 .cars-history-modal {
@@ -702,18 +753,6 @@ export default {
   display: flex;
   flex-direction: column;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
-  animation: slideUp 0.2s ease-out;
-}
-
-@keyframes slideUp {
-  from {
-    transform: translateY(20px);
-    opacity: 0;
-  }
-  to {
-    transform: translateY(0);
-    opacity: 1;
-  }
 }
 
 .modal-header {

--- a/frontend/src/components/CreateApplication/EmployeeHistoryModal.vue
+++ b/frontend/src/components/CreateApplication/EmployeeHistoryModal.vue
@@ -1,256 +1,268 @@
 <template>
   <Teleport to="body">
-    <div
-      class="modal-overlay"
-      @click.self="close"
+    <transition
+      name="modal-fade"
+      @after-leave="onAfterLeave"
     >
-      <div class="employee-history-modal">
-        <div class="modal-header">
-          <h3>История сотрудника {{ fullName }}</h3>
-          <div class="header-actions">
-            <button
-              class="export-btn"
-              :disabled="filteredHistory.length === 0 || isExporting"
-              @click="exportToExcel"
-            >
-              <img
-                v-if="!isExporting"
-                src="@/assets/icons/export.png"
-                class="export-icon"
-              >
-              <span v-if="!isExporting">Экспорт</span>
-              <div
-                v-else
-                class="export-loader"
-              />
-            </button>
-            <button
-              class="close-btn"
-              @click="close"
-            >
-              ×
-            </button>
-          </div>
-        </div>
-
-        <div class="history-filters">
-          <div class="filter-row">
-            <div class="search-filter">
-              <span class="filter-label">Поиск:</span>
-              <input 
-                v-model="searchQuery" 
-                type="text" 
-                class="search-input" 
-                placeholder="Поиск по пользователю, действию..."
-                @input="applyFilters"
-              >
-            </div>
-            <div class="user-filter">
-              <span class="filter-label">Пользователь:</span>
-              <div
-                class="custom-select"
-                @click="toggleUserDropdown"
-              >
-                <div class="select-trigger">
-                  <span class="selected-value">{{ selectedUserName }}</span>
-                  <img 
-                    src="@/assets/icons/arrow.png" 
-                    class="select-arrow" 
-                    :class="{ 'arrow-open': userDropdownOpen }"
-                  >
-                </div>
-                <transition name="fade">
-                  <div
-                    v-if="userDropdownOpen"
-                    class="select-dropdown"
-                  >
-                    <div 
-                      class="select-option"
-                      :class="{ 'selected': selectedUserId === null }"
-                      @click="selectUser(null)"
-                    >
-                      Все пользователи
-                    </div>
-                    <div 
-                      v-for="user in uniqueUsers" 
-                      :key="user.id"
-                      class="select-option"
-                      :class="{ 'selected': selectedUserId === user.id }"
-                      @click="selectUser(user.id)"
-                    >
-                      {{ user.name }}
-                    </div>
-                  </div>
-                </transition>
-              </div>
-            </div>
-          
-            <div class="place-filter">
-              <span class="filter-label">Место прохода:</span>
-              <div
-                class="custom-select"
-                @click="togglePlaceDropdown"
-              >
-                <div class="select-trigger">
-                  <span class="selected-value">{{ selectedPlaceName }}</span>
-                  <img 
-                    src="@/assets/icons/arrow.png" 
-                    class="select-arrow" 
-                    :class="{ 'arrow-open': placeDropdownOpen }"
-                  >
-                </div>
-                <transition name="fade">
-                  <div
-                    v-if="placeDropdownOpen"
-                    class="select-dropdown"
-                  >
-                    <div 
-                      class="select-option"
-                      :class="{ 'selected': selectedPlaceId === null }"
-                      @click="selectPlace(null)"
-                    >
-                      Все места
-                    </div>
-                    <div 
-                      v-for="place in uniquePlaces" 
-                      :key="place.id"
-                      class="select-option"
-                      :class="{ 'selected': selectedPlaceId === place.id }"
-                      @click="selectPlace(place.id)"
-                    >
-                      {{ place.name }}
-                    </div>
-                  </div>
-                </transition>
-              </div>
-            </div>
-          
-            <div class="date-filter">
-              <span class="filter-label">Период:</span>
-              <input 
-                v-model="dateFrom" 
-                type="date" 
-                class="date-input"
-                @change="applyFilters"
-              >
-              <span class="date-separator">—</span>
-              <input 
-                v-model="dateTo" 
-                type="date" 
-                class="date-input"
-                @change="applyFilters"
-              >
-            </div>
-          
-            <div class="sort-filter">
-              <span class="filter-label">Сортировка:</span>
+      <div
+        v-if="visible"
+        class="modal-overlay"
+        @mousedown="onOverlayMousedown"
+        @mouseup="onOverlayMouseup"
+      >
+        <div
+          class="employee-history-modal"
+          @mousedown.stop
+        >
+          <div class="modal-header">
+            <h3>История сотрудника {{ fullName }}</h3>
+            <div class="header-actions">
               <button
-                class="sort-btn"
-                @click="toggleSortOrder"
+                class="export-btn"
+                :disabled="filteredHistory.length === 0 || isExporting"
+                @click="exportToExcel"
               >
                 <img
-                  src="@/assets/icons/sort.png"
-                  class="sort-icon"
-                  :class="{ 'sort-asc': sortOrder === 'asc' }"
+                  v-if="!isExporting"
+                  src="@/assets/icons/export.png"
+                  class="export-icon"
                 >
-                <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
+                <span v-if="!isExporting">Экспорт</span>
+                <div
+                  v-else
+                  class="export-loader"
+                />
+              </button>
+              <button
+                class="close-btn"
+                @click="requestClose"
+              >
+                ×
               </button>
             </div>
           </div>
-        </div>
 
-        <div
-          ref="scrollContainer"
-          class="modal-content"
-        >
-          <div
-            v-if="loading"
-            class="history-loading"
-          >
-            <div class="loader" />
+          <div class="history-filters">
+            <div class="filter-row">
+              <div class="search-filter">
+                <span class="filter-label">Поиск:</span>
+                <input 
+                  v-model="searchQuery" 
+                  type="text" 
+                  class="search-input" 
+                  placeholder="Поиск по пользователю, действию..."
+                  @input="applyFilters"
+                >
+              </div>
+              <div class="user-filter">
+                <span class="filter-label">Пользователь:</span>
+                <div
+                  class="custom-select"
+                  @click="toggleUserDropdown"
+                >
+                  <div class="select-trigger">
+                    <span class="selected-value">{{ selectedUserName }}</span>
+                    <img 
+                      src="@/assets/icons/arrow.png" 
+                      class="select-arrow" 
+                      :class="{ 'arrow-open': userDropdownOpen }"
+                    >
+                  </div>
+                  <transition name="fade">
+                    <div
+                      v-if="userDropdownOpen"
+                      class="select-dropdown"
+                    >
+                      <div 
+                        class="select-option"
+                        :class="{ 'selected': selectedUserId === null }"
+                        @click="selectUser(null)"
+                      >
+                        Все пользователи
+                      </div>
+                      <div 
+                        v-for="user in uniqueUsers" 
+                        :key="user.id"
+                        class="select-option"
+                        :class="{ 'selected': selectedUserId === user.id }"
+                        @click="selectUser(user.id)"
+                      >
+                        {{ user.name }}
+                      </div>
+                    </div>
+                  </transition>
+                </div>
+              </div>
+          
+              <div class="place-filter">
+                <span class="filter-label">Место прохода:</span>
+                <div
+                  class="custom-select"
+                  @click="togglePlaceDropdown"
+                >
+                  <div class="select-trigger">
+                    <span class="selected-value">{{ selectedPlaceName }}</span>
+                    <img 
+                      src="@/assets/icons/arrow.png" 
+                      class="select-arrow" 
+                      :class="{ 'arrow-open': placeDropdownOpen }"
+                    >
+                  </div>
+                  <transition name="fade">
+                    <div
+                      v-if="placeDropdownOpen"
+                      class="select-dropdown"
+                    >
+                      <div 
+                        class="select-option"
+                        :class="{ 'selected': selectedPlaceId === null }"
+                        @click="selectPlace(null)"
+                      >
+                        Все места
+                      </div>
+                      <div 
+                        v-for="place in uniquePlaces" 
+                        :key="place.id"
+                        class="select-option"
+                        :class="{ 'selected': selectedPlaceId === place.id }"
+                        @click="selectPlace(place.id)"
+                      >
+                        {{ place.name }}
+                      </div>
+                    </div>
+                  </transition>
+                </div>
+              </div>
+          
+              <div class="date-filter">
+                <span class="filter-label">Период:</span>
+                <input 
+                  v-model="dateFrom" 
+                  type="date" 
+                  class="date-input"
+                  @change="applyFilters"
+                >
+                <span class="date-separator">—</span>
+                <input 
+                  v-model="dateTo" 
+                  type="date" 
+                  class="date-input"
+                  @change="applyFilters"
+                >
+              </div>
+          
+              <div class="sort-filter">
+                <span class="filter-label">Сортировка:</span>
+                <button
+                  class="sort-btn"
+                  @click="toggleSortOrder"
+                >
+                  <img
+                    src="@/assets/icons/sort.png"
+                    class="sort-icon"
+                    :class="{ 'sort-asc': sortOrder === 'asc' }"
+                  >
+                  <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
+                </button>
+              </div>
+            </div>
           </div>
-        
+
           <div
-            v-else-if="filteredHistory.length === 0"
-            class="history-empty"
+            ref="scrollContainer"
+            class="modal-content"
           >
-            История пуста
-          </div>
-        
-          <div
-            v-else
-            class="history-timeline"
-          >
-            <div 
-              v-for="(item, index) in filteredHistory" 
-              :key="item.id" 
-              class="history-item"
+            <div
+              v-if="loading"
+              class="history-loading"
             >
-              <div
-                class="timeline-dot"
-                :class="getActionClass(item.action_type)"
-              />
-              <div
-                v-if="index < filteredHistory.length - 1"
-                class="timeline-line"
-              />
+              <div class="loader" />
+            </div>
+        
+            <div
+              v-else-if="filteredHistory.length === 0"
+              class="history-empty"
+            >
+              История пуста
+            </div>
+        
+            <div
+              v-else
+              class="history-timeline"
+            >
+              <div 
+                v-for="(item, index) in filteredHistory" 
+                :key="item.id" 
+                class="history-item"
+              >
+                <div
+                  class="timeline-dot"
+                  :class="getActionClass(item.action_type)"
+                />
+                <div
+                  v-if="index < filteredHistory.length - 1"
+                  class="timeline-line"
+                />
             
-              <div class="history-content">
-                <div class="history-header">
-                  <span class="user-name">{{ item.user_name || 'Система' }}</span>
-                  <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
-                </div>
+                <div class="history-content">
+                  <div class="history-header">
+                    <span class="user-name">{{ item.user_name || 'Система' }}</span>
+                    <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                  </div>
               
-                <div class="action-text">
-                  {{ getActionText(item) }}
-                </div>
+                  <div class="action-text">
+                    {{ getActionText(item) }}
+                  </div>
               
-                <div
-                  v-if="item.action_type === 'entry' || item.action_type === 'exit'"
-                  class="action-comment"
-                >
-                  {{ getActionComment(item) }}
-                </div>
+                  <div
+                    v-if="item.action_type === 'entry' || item.action_type === 'exit'"
+                    class="action-comment"
+                  >
+                    {{ getActionComment(item) }}
+                  </div>
               
-                <div
-                  v-if="item.comment && item.action_type !== 'entry' && item.action_type !== 'exit'"
-                  class="action-comment"
-                >
-                  {{ item.comment }}
-                </div>
+                  <div
+                    v-if="item.comment && item.action_type !== 'entry' && item.action_type !== 'exit'"
+                    class="action-comment"
+                  >
+                    {{ item.comment }}
+                  </div>
               
-                <div
-                  v-if="item.old_value && item.new_value && item.old_value !== item.new_value"
-                  class="value-change"
-                >
-                  <span class="old-value">{{ item.old_value }}</span>
-                  <span class="arrow">→</span>
-                  <span class="new-value">{{ item.new_value }}</span>
-                </div>
+                  <div
+                    v-if="item.old_value && item.new_value && item.old_value !== item.new_value"
+                    class="value-change"
+                  >
+                    <span class="old-value">{{ item.old_value }}</span>
+                    <span class="arrow">→</span>
+                    <span class="new-value">{{ item.new_value }}</span>
+                  </div>
               
-                <div
-                  v-if="item.field_name"
-                  class="field-name"
-                >
-                  Поле: {{ item.field_name }}
-                </div>
-                <div
-                  v-if="item.table_name"
-                  class="place-name"
-                >
-                  {{ item.table_name }}
+                  <div
+                    v-if="item.field_name"
+                    class="field-name"
+                  >
+                    Поле: {{ item.field_name }}
+                  </div>
+                  <div
+                    v-if="item.table_name"
+                    class="place-name"
+                  >
+                    {{ item.table_name }}
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    </transition>
   </Teleport>
 </template>
 
 <script>
+import { ref } from 'vue';
 import { apiRequest } from '@/api/client';
+import { useOverlayClose } from '@/composables/useOverlayClose';
 import ExcelJS from 'exceljs';
 
 export default {
@@ -278,6 +290,16 @@ export default {
     }
   },
   emits: ['close'],
+  setup(_, { emit }) {
+    // Анимация закрытия: внутренний visible (enter по mounted, leave по requestClose),
+    // emit('close') только ПОСЛЕ leave-перехода (@after-leave) - иначе родитель
+    // размонтирует мгновенно и анимация не проиграется.
+    const visible = ref(false);
+    const requestClose = () => { visible.value = false; };
+    const onAfterLeave = () => emit('close');
+    const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(requestClose);
+    return { visible, requestClose, onAfterLeave, onOverlayMousedown, onOverlayMouseup };
+  },
   data() {
     return {
       loading: false,
@@ -417,11 +439,14 @@ export default {
     }
   },
   mounted() {
+    this.visible = true;
     this.loadHistory();
     document.addEventListener('click', this.handleClickOutside);
+    document.addEventListener('keydown', this.onKeydown);
   },
   beforeUnmount() {
     document.removeEventListener('click', this.handleClickOutside);
+    document.removeEventListener('keydown', this.onKeydown);
   },
   methods: {
     async loadHistory() {
@@ -723,9 +748,9 @@ export default {
       }
     },
 
-    close() {
-      this.$emit('close');
-    }
+    onKeydown(e) {
+      if (e.key === 'Escape') this.requestClose();
+    },
   }
 };
 </script>
@@ -745,12 +770,38 @@ export default {
   z-index: 12000;
   backdrop-filter: blur(0.1px);
   -webkit-backdrop-filter: blur(0.1px);
-  animation: fadeIn 0.2s ease-out;
 }
 
-@keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
+/* Анимация открытия/закрытия (паттерн BaseModal): overlay fade + контент scale */
+.modal-fade-enter-active {
+  transition: opacity 0.25s ease;
+}
+
+.modal-fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+  opacity: 0;
+}
+
+.modal-fade-enter-active .employee-history-modal {
+  animation: modal-scale-in 0.25s ease;
+}
+
+.modal-fade-leave-active .employee-history-modal {
+  animation: modal-scale-out 0.2s ease;
+}
+
+@keyframes modal-scale-in {
+  from { transform: scale(0.95); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
+}
+
+@keyframes modal-scale-out {
+  from { transform: scale(1); opacity: 1; }
+  to { transform: scale(0.95); opacity: 0; }
 }
 
 .employee-history-modal {
@@ -762,18 +813,6 @@ export default {
   display: flex;
   flex-direction: column;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
-  animation: slideUp 0.2s ease-out;
-}
-
-@keyframes slideUp {
-  from {
-    transform: translateY(20px);
-    opacity: 0;
-  }
-  to {
-    transform: translateY(0);
-    opacity: 1;
-  }
 }
 
 .modal-header {

--- a/frontend/src/components/CreateApplication/EmployeesTableHistoryModal.vue
+++ b/frontend/src/components/CreateApplication/EmployeesTableHistoryModal.vue
@@ -1,229 +1,241 @@
 <template>
   <Teleport to="body">
-    <div
-      class="modal-overlay"
-      @click.self="close"
+    <transition
+      name="modal-fade"
+      @after-leave="onAfterLeave"
     >
-      <div class="employees-history-modal">
-        <div class="modal-header">
-          <h3>История проходов сотрудников (таблица)</h3>
-          <div class="header-actions">
-            <button
-              class="export-btn"
-              :disabled="filteredHistory.length === 0 || isExporting"
-              @click="exportToExcel"
-            >
-              <img
-                v-if="!isExporting"
-                src="@/assets/icons/export.png"
-                class="export-icon"
-              >
-              <span v-if="!isExporting">Экспорт</span>
-              <div
-                v-else
-                class="export-loader"
-              />
-            </button>
-            <button
-              class="close-btn"
-              @click="close"
-            >
-              ×
-            </button>
-          </div>
-        </div>
-
-        <div class="history-filters">
-          <div class="filter-row">
-            <div class="search-filter">
-              <span class="filter-label">Поиск:</span>
-              <input 
-                v-model="searchQuery" 
-                type="text" 
-                class="search-input" 
-                placeholder="Поиск по сотруднику, пользователю..."
-                @input="applyFilters"
-              >
-            </div>
-            <div class="user-filter">
-              <span class="filter-label">Пользователь:</span>
-              <div
-                class="custom-select"
-                @click="toggleUserDropdown"
-              >
-                <div class="select-trigger">
-                  <span class="selected-value">{{ selectedUserName }}</span>
-                  <img 
-                    src="@/assets/icons/arrow.png" 
-                    class="select-arrow" 
-                    :class="{ 'arrow-open': userDropdownOpen }"
-                  >
-                </div>
-                <transition name="fade">
-                  <div
-                    v-if="userDropdownOpen"
-                    class="select-dropdown"
-                  >
-                    <div 
-                      class="select-option"
-                      :class="{ 'selected': selectedUserId === null }"
-                      @click="selectUser(null)"
-                    >
-                      Все пользователи
-                    </div>
-                    <div 
-                      v-for="user in uniqueUsers" 
-                      :key="user.id"
-                      class="select-option"
-                      :class="{ 'selected': selectedUserId === user.id }"
-                      @click="selectUser(user.id)"
-                    >
-                      {{ user.name }}
-                    </div>
-                  </div>
-                </transition>
-              </div>
-            </div>
-          
-            <div class="employee-filter">
-              <span class="filter-label">Сотрудник:</span>
-              <div
-                class="custom-select"
-                @click="toggleEmployeeDropdown"
-              >
-                <div class="select-trigger">
-                  <span class="selected-value">{{ selectedEmployeeName }}</span>
-                  <img 
-                    src="@/assets/icons/arrow.png" 
-                    class="select-arrow" 
-                    :class="{ 'arrow-open': employeeDropdownOpen }"
-                  >
-                </div>
-                <transition name="fade">
-                  <div
-                    v-if="employeeDropdownOpen"
-                    class="select-dropdown"
-                  >
-                    <div 
-                      class="select-option"
-                      :class="{ 'selected': selectedEmployeeId === null }"
-                      @click="selectEmployee(null)"
-                    >
-                      Все сотрудники
-                    </div>
-                    <div 
-                      v-for="emp in uniqueEmployees" 
-                      :key="emp.id"
-                      class="select-option"
-                      :class="{ 'selected': selectedEmployeeId === emp.id }"
-                      @click="selectEmployee(emp.id)"
-                    >
-                      {{ emp.name }}
-                    </div>
-                  </div>
-                </transition>
-              </div>
-            </div>
-          
-            <div class="date-filter">
-              <span class="filter-label">Период:</span>
-              <input 
-                v-model="dateFrom" 
-                type="date" 
-                class="date-input"
-                @change="applyFilters"
-              >
-              <span class="date-separator">—</span>
-              <input 
-                v-model="dateTo" 
-                type="date" 
-                class="date-input"
-                @change="applyFilters"
-              >
-            </div>
-          
-            <div class="sort-filter">
-              <span class="filter-label">Сортировка:</span>
+      <div
+        v-if="visible"
+        class="modal-overlay"
+        @mousedown="onOverlayMousedown"
+        @mouseup="onOverlayMouseup"
+      >
+        <div
+          class="employees-history-modal"
+          @mousedown.stop
+        >
+          <div class="modal-header">
+            <h3>История проходов сотрудников (таблица)</h3>
+            <div class="header-actions">
               <button
-                class="sort-btn"
-                @click="toggleSortOrder"
+                class="export-btn"
+                :disabled="filteredHistory.length === 0 || isExporting"
+                @click="exportToExcel"
               >
                 <img
-                  src="@/assets/icons/sort.png"
-                  class="sort-icon"
-                  :class="{ 'sort-asc': sortOrder === 'asc' }"
+                  v-if="!isExporting"
+                  src="@/assets/icons/export.png"
+                  class="export-icon"
                 >
-                <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
+                <span v-if="!isExporting">Экспорт</span>
+                <div
+                  v-else
+                  class="export-loader"
+                />
+              </button>
+              <button
+                class="close-btn"
+                @click="requestClose"
+              >
+                ×
               </button>
             </div>
           </div>
-        </div>
 
-        <div
-          ref="scrollContainer"
-          class="modal-content"
-        >
-          <div
-            v-if="loading"
-            class="history-loading"
-          >
-            <div class="loader" />
+          <div class="history-filters">
+            <div class="filter-row">
+              <div class="search-filter">
+                <span class="filter-label">Поиск:</span>
+                <input 
+                  v-model="searchQuery" 
+                  type="text" 
+                  class="search-input" 
+                  placeholder="Поиск по сотруднику, пользователю..."
+                  @input="applyFilters"
+                >
+              </div>
+              <div class="user-filter">
+                <span class="filter-label">Пользователь:</span>
+                <div
+                  class="custom-select"
+                  @click="toggleUserDropdown"
+                >
+                  <div class="select-trigger">
+                    <span class="selected-value">{{ selectedUserName }}</span>
+                    <img 
+                      src="@/assets/icons/arrow.png" 
+                      class="select-arrow" 
+                      :class="{ 'arrow-open': userDropdownOpen }"
+                    >
+                  </div>
+                  <transition name="fade">
+                    <div
+                      v-if="userDropdownOpen"
+                      class="select-dropdown"
+                    >
+                      <div 
+                        class="select-option"
+                        :class="{ 'selected': selectedUserId === null }"
+                        @click="selectUser(null)"
+                      >
+                        Все пользователи
+                      </div>
+                      <div 
+                        v-for="user in uniqueUsers" 
+                        :key="user.id"
+                        class="select-option"
+                        :class="{ 'selected': selectedUserId === user.id }"
+                        @click="selectUser(user.id)"
+                      >
+                        {{ user.name }}
+                      </div>
+                    </div>
+                  </transition>
+                </div>
+              </div>
+          
+              <div class="employee-filter">
+                <span class="filter-label">Сотрудник:</span>
+                <div
+                  class="custom-select"
+                  @click="toggleEmployeeDropdown"
+                >
+                  <div class="select-trigger">
+                    <span class="selected-value">{{ selectedEmployeeName }}</span>
+                    <img 
+                      src="@/assets/icons/arrow.png" 
+                      class="select-arrow" 
+                      :class="{ 'arrow-open': employeeDropdownOpen }"
+                    >
+                  </div>
+                  <transition name="fade">
+                    <div
+                      v-if="employeeDropdownOpen"
+                      class="select-dropdown"
+                    >
+                      <div 
+                        class="select-option"
+                        :class="{ 'selected': selectedEmployeeId === null }"
+                        @click="selectEmployee(null)"
+                      >
+                        Все сотрудники
+                      </div>
+                      <div 
+                        v-for="emp in uniqueEmployees" 
+                        :key="emp.id"
+                        class="select-option"
+                        :class="{ 'selected': selectedEmployeeId === emp.id }"
+                        @click="selectEmployee(emp.id)"
+                      >
+                        {{ emp.name }}
+                      </div>
+                    </div>
+                  </transition>
+                </div>
+              </div>
+          
+              <div class="date-filter">
+                <span class="filter-label">Период:</span>
+                <input 
+                  v-model="dateFrom" 
+                  type="date" 
+                  class="date-input"
+                  @change="applyFilters"
+                >
+                <span class="date-separator">—</span>
+                <input 
+                  v-model="dateTo" 
+                  type="date" 
+                  class="date-input"
+                  @change="applyFilters"
+                >
+              </div>
+          
+              <div class="sort-filter">
+                <span class="filter-label">Сортировка:</span>
+                <button
+                  class="sort-btn"
+                  @click="toggleSortOrder"
+                >
+                  <img
+                    src="@/assets/icons/sort.png"
+                    class="sort-icon"
+                    :class="{ 'sort-asc': sortOrder === 'asc' }"
+                  >
+                  <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
+                </button>
+              </div>
+            </div>
           </div>
-        
+
           <div
-            v-else-if="filteredHistory.length === 0"
-            class="history-empty"
+            ref="scrollContainer"
+            class="modal-content"
           >
-            История пуста
-          </div>
-        
-          <div
-            v-else
-            class="history-timeline"
-          >
-            <div 
-              v-for="(item, index) in filteredHistory" 
-              :key="item.id" 
-              class="history-item"
+            <div
+              v-if="loading"
+              class="history-loading"
             >
-              <div
-                class="timeline-dot"
-                :class="getActionClass(item.action_type)"
-              />
-              <div
-                v-if="index < filteredHistory.length - 1"
-                class="timeline-line"
-              />
+              <div class="loader" />
+            </div>
+        
+            <div
+              v-else-if="filteredHistory.length === 0"
+              class="history-empty"
+            >
+              История пуста
+            </div>
+        
+            <div
+              v-else
+              class="history-timeline"
+            >
+              <div 
+                v-for="(item, index) in filteredHistory" 
+                :key="item.id" 
+                class="history-item"
+              >
+                <div
+                  class="timeline-dot"
+                  :class="getActionClass(item.action_type)"
+                />
+                <div
+                  v-if="index < filteredHistory.length - 1"
+                  class="timeline-line"
+                />
             
-              <div class="history-content">
-                <div class="history-header">
-                  <span class="employee-info">{{ getEmployeeName(item) }}</span>
-                  <span
-                    v-if="item.table_name"
-                    class="table-name"
-                  >{{ item.table_name }}</span>
-                  <span class="user-name">{{ item.user_name || 'Система' }}</span>
-                  <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
-                </div>
+                <div class="history-content">
+                  <div class="history-header">
+                    <span class="employee-info">{{ getEmployeeName(item) }}</span>
+                    <span
+                      v-if="item.table_name"
+                      class="table-name"
+                    >{{ item.table_name }}</span>
+                    <span class="user-name">{{ item.user_name || 'Система' }}</span>
+                    <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                  </div>
               
-                <div class="action-text">
-                  {{ getActionText(item) }}
-                </div>
+                  <div class="action-text">
+                    {{ getActionText(item) }}
+                  </div>
               
-                <div class="action-comment">
-                  {{ item.comment || getActionComment(item) }}
+                  <div class="action-comment">
+                    {{ item.comment || getActionComment(item) }}
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    </transition>
   </Teleport>
 </template>
 
 <script>
+import { ref } from 'vue';
 import { apiRequest } from '@/api/client';
+import { useOverlayClose } from '@/composables/useOverlayClose';
 import ExcelJS from 'exceljs';
 
 export default {
@@ -243,6 +255,16 @@ export default {
     }
   },
   emits: ['close'],
+  setup(_, { emit }) {
+    // Анимация закрытия: внутренний visible (enter по mounted, leave по requestClose),
+    // emit('close') только ПОСЛЕ leave-перехода (@after-leave) - иначе родитель
+    // размонтирует мгновенно и анимация не проиграется.
+    const visible = ref(false);
+    const requestClose = () => { visible.value = false; };
+    const onAfterLeave = () => emit('close');
+    const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(requestClose);
+    return { visible, requestClose, onAfterLeave, onOverlayMousedown, onOverlayMouseup };
+  },
   data() {
     return {
       loading: false,
@@ -373,11 +395,14 @@ export default {
     }
   },
   mounted() {
+    this.visible = true;
     this.loadHistory();
     document.addEventListener('click', this.handleClickOutside);
+    document.addEventListener('keydown', this.onKeydown);
   },
   beforeUnmount() {
     document.removeEventListener('click', this.handleClickOutside);
+    document.removeEventListener('keydown', this.onKeydown);
   },
   methods: {
     async loadHistory() {
@@ -624,9 +649,9 @@ export default {
       }
     },
 
-    close() {
-      this.$emit('close');
-    }
+    onKeydown(e) {
+      if (e.key === 'Escape') this.requestClose();
+    },
   }
 };
 </script>
@@ -645,12 +670,38 @@ export default {
   z-index: 13000;
   backdrop-filter: blur(0.1px);
   -webkit-backdrop-filter: blur(0.1px);
-  animation: fadeIn 0.2s ease-out;
 }
 
-@keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
+/* Анимация открытия/закрытия (паттерн BaseModal): overlay fade + контент scale */
+.modal-fade-enter-active {
+  transition: opacity 0.25s ease;
+}
+
+.modal-fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+  opacity: 0;
+}
+
+.modal-fade-enter-active .employees-history-modal {
+  animation: modal-scale-in 0.25s ease;
+}
+
+.modal-fade-leave-active .employees-history-modal {
+  animation: modal-scale-out 0.2s ease;
+}
+
+@keyframes modal-scale-in {
+  from { transform: scale(0.95); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
+}
+
+@keyframes modal-scale-out {
+  from { transform: scale(1); opacity: 1; }
+  to { transform: scale(0.95); opacity: 0; }
 }
 
 .employees-history-modal {
@@ -662,18 +713,6 @@ export default {
   display: flex;
   flex-direction: column;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
-  animation: slideUp 0.2s ease-out;
-}
-
-@keyframes slideUp {
-  from {
-    transform: translateY(20px);
-    opacity: 0;
-  }
-  to {
-    transform: translateY(0);
-    opacity: 1;
-  }
 }
 
 .modal-header {

--- a/frontend/src/components/__tests__/HistoryModalsCloseAnimation.spec.js
+++ b/frontend/src/components/__tests__/HistoryModalsCloseAnimation.spec.js
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+
+// Все 4 модалки грузят историю через apiRequest(path).ok -> json().
+// Контракт закрытия (visible/requestClose/onAfterLeave/Escape/overlay) от истории
+// не зависит - мок отдаёт пустую историю, чтобы mounted не падал.
+vi.mock('@/api/client', () => ({
+  apiRequest: vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve([]) })),
+}));
+// exceljs тяжёлый и для теста закрытия не нужен.
+vi.mock('exceljs', () => ({ default: { Workbook: class {} } }));
+
+import CarHistoryModal from '../CarHistoryModal.vue';
+import CarsTableHistoryModal from '../CarsTableHistoryModal.vue';
+import EmployeeHistoryModal from '../CreateApplication/EmployeeHistoryModal.vue';
+import EmployeesTableHistoryModal from '../CreateApplication/EmployeesTableHistoryModal.vue';
+
+// Срез D-2 (#406): открытие/закрытие 4 истории-модалок переведено на self-contained
+// паттерн visible+<transition @after-leave>. Тест фиксирует контракт закрытия, единый
+// для всех (эталон - CitizenshipHistoryModal из D-1).
+const MODALS = [
+  { name: 'CarHistoryModal', component: CarHistoryModal, props: { carId: 1, carNumber: 'A123AA' } },
+  { name: 'CarsTableHistoryModal', component: CarsTableHistoryModal, props: { cars: [] } },
+  { name: 'EmployeeHistoryModal', component: EmployeeHistoryModal, props: { lastName: 'Иванов', firstName: 'Иван' } },
+  { name: 'EmployeesTableHistoryModal', component: EmployeesTableHistoryModal, props: { tableId: 1 } },
+];
+
+async function mountModal(component, props) {
+  const wrapper = mount(component, {
+    props,
+    global: { stubs: { teleport: true } },
+    attachTo: document.body,
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+describe('История-модалки: анимация закрытия (D-паттерн)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  MODALS.forEach(({ name, component, props }) => {
+    describe(name, () => {
+      it('visible=true по mounted, overlay отрендерен', async () => {
+        const wrapper = await mountModal(component, props);
+        expect(wrapper.vm.visible).toBe(true);
+        expect(wrapper.find('.modal-overlay').exists()).toBe(true);
+        wrapper.unmount();
+      });
+
+      it('requestClose прячет overlay (visible=false), но НЕ эмитит close сразу', async () => {
+        const wrapper = await mountModal(component, props);
+        wrapper.vm.requestClose();
+        expect(wrapper.vm.visible).toBe(false);
+        // close эмитится только ПОСЛЕ leave-перехода (@after-leave), не моментально.
+        expect(wrapper.emitted('close')).toBeFalsy();
+        wrapper.unmount();
+      });
+
+      it('close эмитится по завершении leave-перехода (onAfterLeave)', async () => {
+        const wrapper = await mountModal(component, props);
+        wrapper.vm.onAfterLeave();
+        expect(wrapper.emitted('close')).toHaveLength(1);
+        wrapper.unmount();
+      });
+
+      it('Escape запускает закрытие через requestClose (visible=false)', async () => {
+        const wrapper = await mountModal(component, props);
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+        expect(wrapper.vm.visible).toBe(false);
+        wrapper.unmount();
+      });
+
+      it('клик по overlay (mousedown+mouseup) закрывает через useOverlayClose', async () => {
+        const wrapper = await mountModal(component, props);
+        const overlay = wrapper.find('.modal-overlay');
+        await overlay.trigger('mousedown');
+        await overlay.trigger('mouseup');
+        expect(wrapper.vm.visible).toBe(false);
+        wrapper.unmount();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Срез D-2 эпика #406 (etalon-refactor). Продолжение D-1 (#493) — тот же self-contained паттерн закрытия с анимацией, применённый к оставшимся истории-модалкам.

## Что меняется
Модалки `CarHistoryModal`, `CarsTableHistoryModal`, `CreateApplication/EmployeeHistoryModal`, `CreateApplication/EmployeesTableHistoryModal` закрывались мгновенно: родитель убирал их по `v-if` без leave-перехода (была только open-only `fadeIn`/`slideUp`). Перевёл на паттерн эталона `CitizenshipHistoryModal` (D-1):

- `setup()` -> `visible=ref(false)` + `requestClose()` (снимает visible) + `onAfterLeave(()=>emit('close'))` + `useOverlayClose(requestClose)`;
- `<Teleport><transition name="modal-fade" @after-leave="onAfterLeave"><div v-if="visible" class="modal-overlay">`;
- `mounted` ставит `visible=true` и вешает Escape; крестик/Escape/клик по overlay -> `requestClose`;
- CSS `modal-fade-enter/leave` + `modal-scale-in/out`, старые `fadeIn`/`slideUp` keyframes удалены; метод `close()` удалён.

Три модалки (`CarsTable`/оба `Employee`) заодно получили drag-защиту overlay-закрытия (`@click.self` -> `useOverlayClose`).

Родители всех 4 (`CarDetailsModal`, `VehicleDetailsModal`, `CarsTable`, `EmployeeDetailsModal`, `PeopleTable`) показывают модалки через `v-if` + `@close` — что обязательно для паттерна, проверено.

Большой дифф — на ~90% whitespace-переотступ шаблона под новый `<transition>` (как в #493).

## Тесты
Новый общий спек `HistoryModalsCloseAnimation.spec.js` — контракт закрытия для всех 4 (visible по mounted, requestClose без преждевременного emit, emit по onAfterLeave, Escape, overlay-close). 20 кейсов зелёные.

- `vitest run`: 446 passed (38 файлов), включая 20 новых.
- `eslint`: чисто на всех 4 + спеке.
- `vite build`: успешно.

Анимация-полиш без новой структуры/API — по практике #493 без MCP/ship-check, проверяется визуально после деплоя.

## Координация
Из исходного списка D-2 исключена blacklist-модалка `BlacklistHistoryModalBase` — её ведёт параллельная сессия (#443/#481, переработана в #492). Чтобы не трогать одни файлы, blacklist-модалку оставляю той сессии.

## Вне scope (пре-существующее, отдельные задачи)
- `alert()` в `exportToExcel` и `console.log` в `loadHistory` CarHistoryModal — долг #407.
- Латентный баг `handleClickOutside` через `this.$el.querySelector` под Teleport — отдельный полиш-пункт.

Ревью `code-reviewer`: GO (единственный блокер — приложить вывод тестов — закрыт: 446 vitest зелёные).