### PR TITLE
feat(blacklist): нечёткий поиск возможного обхода ЧС - движок (#481)

### DIFF
--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -145,6 +145,9 @@ func AllModels() []interface{} {
 // AutoMigrate creates/updates all tables from GORM models.
 func AutoMigrate(db *gorm.DB) error {
 	slog.Info("running AutoMigrate for all models")
+	if err := installExtensions(db); err != nil {
+		return err
+	}
 	if err := db.AutoMigrate(AllModels()...); err != nil {
 		return err
 	}
@@ -276,6 +279,23 @@ $$ LANGUAGE plpgsql IMMUTABLE;
 		return err
 	}
 	slog.Info("SQL functions installed: format_short_name, format_full_name")
+	return nil
+}
+
+// installExtensions включает Postgres-расширения для нечёткого поиска возможного обхода
+// ЧС (#481): pg_trgm (триграммные similarity/word_similarity по ФИО) и fuzzystrmatch
+// (levenshtein по госномерам). CREATE EXTENSION IF NOT EXISTS идемпотентен и безопасен при
+// каждом старте; оба расширения trusted в PG13+, поэтому ставятся владельцем БД без
+// суперпользователя. Ставим до AutoMigrate: инфраструктура не зависит от таблиц, а
+// FindSimilar-запросы сервисов зависят от расширений.
+func installExtensions(db *gorm.DB) error {
+	if err := db.Exec(`CREATE EXTENSION IF NOT EXISTS pg_trgm`).Error; err != nil {
+		return fmt.Errorf("failed to install pg_trgm extension: %w", err)
+	}
+	if err := db.Exec(`CREATE EXTENSION IF NOT EXISTS fuzzystrmatch`).Error; err != nil {
+		return fmt.Errorf("failed to install fuzzystrmatch extension: %w", err)
+	}
+	slog.Info("SQL extensions installed: pg_trgm, fuzzystrmatch")
 	return nil
 }
 

--- a/internal/handlers/person_blacklist_test.go
+++ b/internal/handlers/person_blacklist_test.go
@@ -268,3 +268,76 @@ func TestPersonBlacklist_GetAllHistory(t *testing.T) {
 		assert.False(t, all[i].CreatedAt.After(all[i-1].CreatedAt), "события должны идти от новых к старым")
 	}
 }
+
+// TestPersonBlacklist_FindSimilar: нечёткий поиск (#481) ловит латиничный гомоглиф, опечатку
+// и отсутствие отчества; не ловит постороннее ФИО; игнорирует архивные.
+func TestPersonBlacklist_FindSimilar(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	userID, _, userCleanup := setupMWUser(t, db, true, false)
+	defer userCleanup()
+	svc := newPersonBlacklistService(db)
+	ctx := context.Background()
+
+	target, err := svc.Create(ctx, models.CreatePersonBlacklistRequest{
+		LastName: "Иванов", FirstName: "Иван", MiddleName: "Иванович", Reason: "обход",
+	}, userID)
+	require.NoError(t, err)
+	_, err = svc.Create(ctx, models.CreatePersonBlacklistRequest{
+		LastName: "Сидоров", FirstName: "Сидор", MiddleName: "Сидорович", Reason: "фон",
+	}, userID)
+	require.NoError(t, err)
+
+	containsTarget := func(t *testing.T, res []models.BlacklistSimilarMatch) models.BlacklistSimilarMatch {
+		t.Helper()
+		for _, m := range res {
+			if m.ID == target.ID {
+				return m
+			}
+		}
+		t.Fatalf("ожидали эталон id=%d среди похожих, получили %+v", target.ID, res)
+		return models.BlacklistSimilarMatch{}
+	}
+
+	t.Run("латиница-гомоглиф в фамилии (обход) -> sim ~1.0", func(t *testing.T) {
+		// "Ивaнов" с латинской 'a' нормализуется в "иванов" - сырой Check бы не сматчил.
+		res, err := svc.FindSimilar(ctx, "Ивaнов", "Иван", "Иванович")
+		require.NoError(t, err)
+		m := containsTarget(t, res)
+		assert.InDelta(t, 1.0, m.Similarity, 1e-9)
+		assert.Equal(t, "обход", m.Reason)
+		assert.Contains(t, m.MatchedValue, "Иванов")
+	})
+
+	t.Run("без отчества (обход) -> похоже, >=0.7", func(t *testing.T) {
+		res, err := svc.FindSimilar(ctx, "Иванов", "Иван", "")
+		require.NoError(t, err)
+		m := containsTarget(t, res)
+		assert.GreaterOrEqual(t, m.Similarity, 0.7)
+	})
+
+	t.Run("опечатка в имени -> похоже", func(t *testing.T) {
+		res, err := svc.FindSimilar(ctx, "Иванов", "Иваи", "Иванович")
+		require.NoError(t, err)
+		_ = containsTarget(t, res)
+	})
+
+	t.Run("постороннее ФИО -> эталон не матчится", func(t *testing.T) {
+		res, err := svc.FindSimilar(ctx, "Кузнецов", "Алексей", "Петрович")
+		require.NoError(t, err)
+		for _, m := range res {
+			assert.NotEqual(t, target.ID, m.ID)
+		}
+	})
+
+	t.Run("архивная запись не находится", func(t *testing.T) {
+		require.NoError(t, svc.Archive(ctx, target.ID, userID))
+		res, err := svc.FindSimilar(ctx, "Иванов", "Иван", "Иванович")
+		require.NoError(t, err)
+		for _, m := range res {
+			assert.NotEqual(t, target.ID, m.ID)
+		}
+	})
+}

--- a/internal/handlers/vehicle_blacklist_test.go
+++ b/internal/handlers/vehicle_blacklist_test.go
@@ -444,3 +444,67 @@ func TestBlacklistNormalized_CreateAndBackfill(t *testing.T) {
 	require.NoError(t, db.First(&pBackfilled, pOld.ID).Error)
 	assert.Equal(t, "петров петр", pBackfilled.NormalizedFIO, "бэкфилл нормализует ФИО старой записи (ё->е)")
 }
+
+// TestVehicleBlacklist_FindSimilar: нечёткий поиск возможного обхода (#481) ловит латиничный
+// гомоглиф (тот же нормализованный номер при разных сырых) и опечатку, не ловит далёкий номер,
+// игнорирует архивные. Точную форму ловит Check (409) - здесь только "похожее".
+func TestVehicleBlacklist_FindSimilar(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	userID, _, userCleanup := setupMWUser(t, db, true, false)
+	defer userCleanup()
+	mark := seedMark(t, db, "BL_Sim")
+	svc := newVehicleBlacklistService(db)
+	ctx := context.Background()
+
+	// Эталон в ЧС: кириллический "А123ВС799".
+	target, err := svc.Create(ctx, models.CreateVehicleBlacklistRequest{
+		CarNumber: "А123ВС799", MarkID: mark.ID, Reason: "обход",
+	}, userID)
+	require.NoError(t, err)
+	// Далёкая запись - фон, не должна матчить эталонный запрос.
+	_, err = svc.Create(ctx, models.CreateVehicleBlacklistRequest{
+		CarNumber: "Х999ХХ111", MarkID: mark.ID, Reason: "другая",
+	}, userID)
+	require.NoError(t, err)
+
+	t.Run("латиница-гомоглиф = тот же нормализованный номер (обход) -> sim 1.0 сверху", func(t *testing.T) {
+		// Сырой "A123BC799" латиницей != сырого кириллического эталона (Check бы не сматчил),
+		// но нормализованные формы совпадают - это и есть обход.
+		res, err := svc.FindSimilar(ctx, "A123BC799")
+		require.NoError(t, err)
+		require.NotEmpty(t, res)
+		assert.Equal(t, target.ID, res[0].ID)
+		assert.InDelta(t, 1.0, res[0].Similarity, 1e-9)
+		assert.Equal(t, "обход", res[0].Reason)
+		assert.Contains(t, res[0].MatchedValue, "А123ВС799")
+	})
+
+	t.Run("опечатка в одну цифру -> похоже (>=0.7, <1.0)", func(t *testing.T) {
+		res, err := svc.FindSimilar(ctx, "А124ВС799")
+		require.NoError(t, err)
+		require.NotEmpty(t, res)
+		assert.Equal(t, target.ID, res[0].ID)
+		assert.GreaterOrEqual(t, res[0].Similarity, 0.7)
+		assert.Less(t, res[0].Similarity, 1.0)
+	})
+
+	t.Run("далёкий номер -> эталон не матчится", func(t *testing.T) {
+		res, err := svc.FindSimilar(ctx, "К555КК12")
+		require.NoError(t, err)
+		for _, m := range res {
+			assert.NotEqual(t, target.ID, m.ID)
+		}
+	})
+
+	t.Run("архивная запись не находится", func(t *testing.T) {
+		require.NoError(t, svc.Archive(ctx, target.ID, userID))
+		res, err := svc.FindSimilar(ctx, "A123BC799")
+		require.NoError(t, err)
+		for _, m := range res {
+			assert.NotEqual(t, target.ID, m.ID)
+		}
+	})
+}

--- a/internal/models/blacklist.go
+++ b/internal/models/blacklist.go
@@ -85,6 +85,19 @@ type VehicleBlacklistCheckResult struct {
 	Reason        string `json:"reason,omitempty"`
 }
 
+// BlacklistSimilarMatch - похожая (но не точная) активная запись ЧС, найденная нечётким
+// поиском возможного обхода (#481). Точные совпадения сюда НЕ относятся - их ловит жёсткий
+// гард Check (409); здесь кандидаты на предупреждение: опечатка, латинский гомоглиф, ё/е,
+// подмена 0<->О, отсутствие отчества. Similarity - близость [0..1] нормализованного
+// значения записи к нормализованному запросу (1 - совпавшая нормализованная форма).
+// Общий тип vehicle- и person-сервисов; MatchedValue несёт "номер марка" или ФИО.
+type BlacklistSimilarMatch struct {
+	ID           int     `json:"id"`
+	Similarity   float64 `json:"similarity"`
+	MatchedValue string  `json:"matched_value"`
+	Reason       string  `json:"reason,omitempty"`
+}
+
 // PersonBlacklist - запись чёрного списка людей (#443).
 //
 // Совпадение строгое по всем трём полям ФИО; отсутствие отчества (NULL/пусто) считается

--- a/internal/services/person_blacklist_service.go
+++ b/internal/services/person_blacklist_service.go
@@ -27,6 +27,11 @@ type PersonBlacklistService interface {
 	Archive(ctx context.Context, id int, userID int) error
 	Restore(ctx context.Context, id int, userID int) error
 	Check(ctx context.Context, lastName, firstName, middleName string) (models.PersonBlacklistCheckResult, error)
+	// FindSimilar - активные записи ЧС, чьё нормализованное ФИО БЛИЗКО (но не обязательно
+	// равно) нормализованному ФИО заявки: триграммная similarity + word_similarity (учёт
+	// отсутствия отчества), порог 0.7. Слой предупреждения о возможном обходе (#481): точное
+	// совпадение ловит Check (409). Пустой срез - похожих нет.
+	FindSimilar(ctx context.Context, lastName, firstName, middleName string) ([]models.BlacklistSimilarMatch, error)
 	// UpdateReason - редактирование причины записи + лог в историю (updated).
 	UpdateReason(ctx context.Context, id int, reason string, userID int) (*models.PersonBlacklist, error)
 	// Purge - удаление архивной записи навсегда: запись удаляется физически, но событие
@@ -182,6 +187,64 @@ func (s *personBlacklistService) Check(ctx context.Context, lastName, firstName,
 		return models.PersonBlacklistCheckResult{}, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка проверки чёрного списка")
 	}
 	return models.PersonBlacklistCheckResult{IsBlacklisted: true, Reason: e.Reason}, nil
+}
+
+// FindSimilar ищет активные записи, чьё нормализованное ФИО близко к нормализованному ФИО
+// заявки. Метрика - GREATEST из триграммной similarity и word_similarity в обе стороны:
+//   - similarity ловит опечатку/гомоглиф (нормализованные формы почти равны);
+//   - word_similarity(@q, normalized_fio) ловит "без отчества" в заявке (запрос - подстрока эталона);
+//   - word_similarity(normalized_fio, @q) ловит обратное (отчество добавлено в заявке).
+//
+// Сравниваем по normalized_fio (канон-форма из Create/бэкфилла), порог 0.7. Нормализованно-
+// точную форму не исключаем: совпадение в нормали при различии в сырых данных (латиница) -
+// это и есть обход (Check его не сматчит). Результат - по убыванию близости.
+func (s *personBlacklistService) FindSimilar(ctx context.Context, lastName, firstName, middleName string) ([]models.BlacklistSimilarMatch, error) {
+	q := normalize.Name(lastName, firstName, middleName)
+	if q == "" {
+		return []models.BlacklistSimilarMatch{}, nil
+	}
+	type simRow struct {
+		ID         int
+		LastName   string
+		FirstName  string
+		MiddleName *string
+		Reason     string
+		Sim        float64
+	}
+	var rows []simRow
+	err := s.db.WithContext(ctx).Raw(`
+		SELECT id, last_name, first_name, middle_name, reason, sim FROM (
+			SELECT id, last_name, first_name, middle_name, reason,
+			       GREATEST(
+			         similarity(normalized_fio, @q),
+			         word_similarity(@q, normalized_fio),
+			         word_similarity(normalized_fio, @q)
+			       ) AS sim
+			FROM person_blacklists
+			WHERE is_active = true AND normalized_fio <> ''
+		) t
+		WHERE sim >= @threshold
+		ORDER BY sim DESC, id`,
+		map[string]interface{}{"q": q, "threshold": blacklistSimilarityThreshold},
+	).Scan(&rows).Error
+	if err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка поиска похожих записей чёрного списка")
+	}
+	matches := make([]models.BlacklistSimilarMatch, 0, len(rows))
+	for _, r := range rows {
+		middle := ""
+		if r.MiddleName != nil {
+			middle = *r.MiddleName
+		}
+		label := strings.Join(strings.Fields(r.LastName+" "+r.FirstName+" "+middle), " ")
+		matches = append(matches, models.BlacklistSimilarMatch{
+			ID:           r.ID,
+			Similarity:   r.Sim,
+			MatchedValue: label,
+			Reason:       r.Reason,
+		})
+	}
+	return matches, nil
 }
 
 func (s *personBlacklistService) UpdateReason(ctx context.Context, id int, reason string, userID int) (*models.PersonBlacklist, error) {

--- a/internal/services/vehicle_blacklist_service.go
+++ b/internal/services/vehicle_blacklist_service.go
@@ -16,6 +16,12 @@ import (
 	"gorm.io/gorm"
 )
 
+// blacklistSimilarityThreshold - порог [0..1] нечёткого совпадения для предупреждения о
+// возможном обходе ЧС (#481). Дефолт 0.7 (решение владельца). Общий для машин (Левенштейн
+// по номеру) и людей (similarity/word_similarity по ФИО). Может стать настройкой админки
+// отдельным срезом - пока фиксированная константа (YAGNI).
+const blacklistSimilarityThreshold = 0.7
+
 // VehicleBlacklistService - бизнес-логика чёрного списка автомобилей (#443).
 //
 // Create/Restore каскадно деактивируют совпадающие cars (status 1 -> 0) в одной
@@ -36,6 +42,11 @@ type VehicleBlacklistService interface {
 	// CheckByName - проверка по номеру и имени марки (для машин без mark_id, например
 	// выбранных из существующих unique_cars). Совпадение по mark_name, как в каскаде.
 	CheckByName(ctx context.Context, carNumber, markName string) (models.VehicleBlacklistCheckResult, error)
+	// FindSimilar - активные записи ЧС, чьи нормализованные номера БЛИЗКИ (но не обязательно
+	// равны) нормализованному номеру заявки: Левенштейн по normalized_number, порог 0.7.
+	// Слой предупреждения о возможном обходе (#481): точное совпадение ловит Check (409),
+	// сюда попадают опечатка/гомоглиф/подмена 0<->О. Пустой срез - похожих нет.
+	FindSimilar(ctx context.Context, carNumber string) ([]models.BlacklistSimilarMatch, error)
 	// UpdateReason - редактирование причины записи + лог в историю (updated).
 	UpdateReason(ctx context.Context, id int, reason string, userID int) (*models.VehicleBlacklist, error)
 	// Purge - удаление архивной записи навсегда: запись удаляется физически, но событие
@@ -280,6 +291,58 @@ func (s *vehicleBlacklistService) CheckByName(ctx context.Context, carNumber, ma
 		return models.VehicleBlacklistCheckResult{}, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка проверки чёрного списка")
 	}
 	return models.VehicleBlacklistCheckResult{IsBlacklisted: true, Reason: e.Reason}, nil
+}
+
+// FindSimilar ищет активные записи, чей нормализованный номер близок к нормализованному
+// номеру заявки. Метрика - 1 - levenshtein/max(len): расстояние редактирования fuzzystrmatch,
+// приведённое к [0..1]. Сравниваем по normalized_number (та же канон-форма, что при Create/
+// бэкфилле), чтобы гомоглиф/0<->О/пробелы не давали ложного расхождения. Нормализованно-точную
+// форму НЕ исключаем: совпадение в нормали при различии в сырых данных (латиница) - и есть
+// обход (Check его не сматчит). Результат - по убыванию близости.
+func (s *vehicleBlacklistService) FindSimilar(ctx context.Context, carNumber string) ([]models.BlacklistSimilarMatch, error) {
+	q := normalize.Plate(carNumber)
+	if q == "" {
+		return []models.BlacklistSimilarMatch{}, nil
+	}
+	// levenshtein (fuzzystrmatch) падает на аргументе >255 байт, а FindSimilar зовётся с
+	// пользовательским вводом (normalize.Plate длину не ограничивает). Реальные номера
+	// короткие - обрезаем по рунам, чтобы мусорный ввод не ронял запрос (64 руны <= 128 байт).
+	if r := []rune(q); len(r) > 64 {
+		q = string(r[:64])
+	}
+	type simRow struct {
+		ID        int
+		CarNumber string
+		MarkName  string
+		Reason    string
+		Sim       float64
+	}
+	var rows []simRow
+	err := s.db.WithContext(ctx).Raw(`
+		SELECT id, car_number, mark_name, reason, sim FROM (
+			SELECT id, car_number, mark_name, reason,
+			       1 - levenshtein(normalized_number, @q)::float
+			           / GREATEST(LENGTH(normalized_number), LENGTH(@q), 1) AS sim
+			FROM vehicle_blacklists
+			WHERE is_active = true AND normalized_number <> ''
+		) t
+		WHERE sim >= @threshold
+		ORDER BY sim DESC, id`,
+		map[string]interface{}{"q": q, "threshold": blacklistSimilarityThreshold},
+	).Scan(&rows).Error
+	if err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка поиска похожих записей чёрного списка")
+	}
+	matches := make([]models.BlacklistSimilarMatch, 0, len(rows))
+	for _, r := range rows {
+		matches = append(matches, models.BlacklistSimilarMatch{
+			ID:           r.ID,
+			Similarity:   r.Sim,
+			MatchedValue: strings.TrimSpace(r.CarNumber + " " + r.MarkName),
+			Reason:       r.Reason,
+		})
+	}
+	return matches, nil
 }
 
 func (s *vehicleBlacklistService) GetHistory(ctx context.Context, id int) ([]models.VehicleBlacklistHistoryItem, error) {


### PR DESCRIPTION
Срез 2a эпика #481 (мягкое предупреждение о возможном обходе ЧС по похожему ФИО/номеру). Backend-only, движок нечёткого поиска - подключается к сабмиту в следующих срезах.

## Что сделано
- Включил Postgres-расширения pg_trgm и fuzzystrmatch (installExtensions в AutoMigrate, до db.AutoMigrate; идемпотентно, CREATE EXTENSION IF NOT EXISTS).
- Метод FindSimilar в vehicle- и person-blacklist сервисах:
  - машины: 1 - levenshtein(normalized_number, q) / max(len), порог 0.7;
  - люди: GREATEST(similarity, word_similarity(q,fio), word_similarity(fio,q)) по normalized_fio, порог 0.7 (word_similarity ловит ФИО без отчества).
- Общий тип models.BlacklistSimilarMatch (id, similarity, matched_value, reason).
- Сравнение по нормализованным колонкам из среза 1 (та же функция normalize, что при записи) - гомоглиф/0<->О/пробелы не дают ложного расхождения.
- Точное совпадение по-прежнему ловит существующий Check (409). FindSimilar - слой предупреждения, не блокировки; архивные записи игнорируются.

## Вынесено в срез 2b
Учёт форматов номеров (парсинг по ячейкам LicensePlateFormat) - отдельный PR feat/481-fuzzy-format-refine, чтобы не раздувать этот срез. Здесь только Левенштейн по полному номеру.

## Ревью (code-reviewer, GO без блокеров) - исправлено
- nil,nil при пустом запросе -> пустой slice.
- vehicle: обрезка q по рунам (levenshtein падает на >255 байт при мусорном вводе).
- person/vehicle: sim вычисляется один раз через подзапрос вместо дубля SELECT+WHERE.
- GIN-индексы под триграммы - отложены (ЧС малого размера, open-question, отдельный polish при росте).

## Проверка
- gofmt/build/vet чисто.
- Интеграционные тесты против реального PG16 (расширения встают через AutoMigrate): TestVehicleBlacklist_FindSimilar и TestPersonBlacklist_FindSimilar - гомоглиф/опечатка/без-отчества ловятся, далёкое не ловится, архивные игнорируются.
- Существующая blacklist-сюита зелёная (без регрессий), пакеты services/database зелёные.

migrate.go - off-limits: изменение аддитивное и идемпотентное (только CREATE EXTENSION IF NOT EXISTS), дифф согласуется с владельцем перед мержем.