### PR TITLE
fix(history): дропдаун фильтра не закрывался по клику снаружи при Teleport (#406)

### DIFF
--- a/frontend/src/components/CarHistoryModal.vue
+++ b/frontend/src/components/CarHistoryModal.vue
@@ -57,6 +57,7 @@
               <div class="user-filter">
                 <span class="filter-label">Пользователь:</span>
                 <div
+                  ref="userSelect"
                   class="custom-select"
                   @click="toggleUserDropdown"
                 >
@@ -571,7 +572,9 @@ export default {
     applyFilters() {},
 
     handleClickOutside(event) {
-      const select = this.$el.querySelector('.custom-select');
+      // ref, не this.$el.querySelector: при <Teleport> $el - это якорный комментарий
+      // без querySelector, и дропдаун фильтра не закрывался бы по клику снаружи.
+      const select = this.$refs.userSelect;
       if (select && !select.contains(event.target)) {
         this.userDropdownOpen = false;
       }

--- a/frontend/src/components/CarsTableHistoryModal.vue
+++ b/frontend/src/components/CarsTableHistoryModal.vue
@@ -57,6 +57,7 @@
               <div class="user-filter">
                 <span class="filter-label">Пользователь:</span>
                 <div
+                  ref="userSelect"
                   class="custom-select"
                   @click="toggleUserDropdown"
                 >
@@ -97,6 +98,7 @@
               <div class="car-filter">
                 <span class="filter-label">Автомобиль:</span>
                 <div
+                  ref="carSelect"
                   class="custom-select"
                   @click="toggleCarDropdown"
                 >
@@ -530,12 +532,12 @@ export default {
     applyFilters() {},
 
     handleClickOutside(event) {
-      const selects = this.$el.querySelectorAll('.custom-select');
-      let clickedInside = false;
-      selects.forEach(select => {
-        if (select.contains(event.target)) clickedInside = true;
-      });
-      
+      // refs, не this.$el.querySelectorAll: при <Teleport> $el - это якорный комментарий
+      // без querySelector, и дропдауны фильтров не закрывались бы по клику снаружи.
+      const selects = [this.$refs.userSelect, this.$refs.carSelect];
+      const clickedInside = selects.some(
+        (select) => select && select.contains(event.target),
+      );
       if (!clickedInside) {
         this.userDropdownOpen = false;
         this.carDropdownOpen = false;

--- a/frontend/src/components/CreateApplication/EmployeeHistoryModal.vue
+++ b/frontend/src/components/CreateApplication/EmployeeHistoryModal.vue
@@ -57,6 +57,7 @@
               <div class="user-filter">
                 <span class="filter-label">Пользователь:</span>
                 <div
+                  ref="userSelect"
                   class="custom-select"
                   @click="toggleUserDropdown"
                 >
@@ -97,6 +98,7 @@
               <div class="place-filter">
                 <span class="filter-label">Место прохода:</span>
                 <div
+                  ref="placeSelect"
                   class="custom-select"
                   @click="togglePlaceDropdown"
                 >
@@ -585,12 +587,12 @@ export default {
     applyFilters() {},
 
     handleClickOutside(event) {
-      const selects = this.$el.querySelectorAll('.custom-select');
-      let clickedInside = false;
-      selects.forEach(select => {
-        if (select.contains(event.target)) clickedInside = true;
-      });
-      
+      // refs, не this.$el.querySelectorAll: при <Teleport> $el - это якорный комментарий
+      // без querySelector, и дропдауны фильтров не закрывались бы по клику снаружи.
+      const selects = [this.$refs.userSelect, this.$refs.placeSelect];
+      const clickedInside = selects.some(
+        (select) => select && select.contains(event.target),
+      );
       if (!clickedInside) {
         this.userDropdownOpen = false;
         this.placeDropdownOpen = false;

--- a/frontend/src/components/CreateApplication/EmployeesTableHistoryModal.vue
+++ b/frontend/src/components/CreateApplication/EmployeesTableHistoryModal.vue
@@ -57,6 +57,7 @@
               <div class="user-filter">
                 <span class="filter-label">Пользователь:</span>
                 <div
+                  ref="userSelect"
                   class="custom-select"
                   @click="toggleUserDropdown"
                 >
@@ -97,6 +98,7 @@
               <div class="employee-filter">
                 <span class="filter-label">Сотрудник:</span>
                 <div
+                  ref="employeeSelect"
                   class="custom-select"
                   @click="toggleEmployeeDropdown"
                 >
@@ -498,12 +500,12 @@ export default {
     applyFilters() {},
 
     handleClickOutside(event) {
-      const selects = this.$el.querySelectorAll('.custom-select');
-      let clickedInside = false;
-      selects.forEach(select => {
-        if (select.contains(event.target)) clickedInside = true;
-      });
-      
+      // refs, не this.$el.querySelectorAll: при <Teleport> $el - это якорный комментарий
+      // без querySelector, и дропдауны фильтров не закрывались бы по клику снаружи.
+      const selects = [this.$refs.userSelect, this.$refs.employeeSelect];
+      const clickedInside = selects.some(
+        (select) => select && select.contains(event.target),
+      );
       if (!clickedInside) {
         this.userDropdownOpen = false;
         this.employeeDropdownOpen = false;

--- a/frontend/src/components/LicensePlateFormatHistoryModal.vue
+++ b/frontend/src/components/LicensePlateFormatHistoryModal.vue
@@ -61,6 +61,7 @@
                 <!-- Кастомный select, не BaseDropdown: повторяет фильтр-строку эталона
                      SystemTableHistoryModal (32px-контролы поиск/период/сортировка в ряд). -->
                 <div
+                  ref="userSelect"
                   class="custom-select"
                   @click="toggleUserDropdown"
                 >
@@ -413,7 +414,9 @@ export default {
       if (e.key === 'Escape') this.requestClose();
     },
     handleClickOutside(event) {
-      const select = this.$el && this.$el.querySelector ? this.$el.querySelector('.custom-select') : null;
+      // ref, не this.$el.querySelector: при <Teleport> $el - это якорный комментарий
+      // без querySelector, и дропдаун фильтра не закрывался бы по клику снаружи.
+      const select = this.$refs.userSelect;
       if (select && !select.contains(event.target)) {
         this.userDropdownOpen = false;
       }

--- a/frontend/src/components/MarkHistoryModal.vue
+++ b/frontend/src/components/MarkHistoryModal.vue
@@ -61,6 +61,7 @@
                 <!-- Кастомный select, не BaseDropdown: повторяет фильтр-строку эталона
                      SystemTableHistoryModal (32px-контролы поиск/период/сортировка в ряд). -->
                 <div
+                  ref="userSelect"
                   class="custom-select"
                   @click="toggleUserDropdown"
                 >
@@ -349,7 +350,9 @@ export default {
       if (e.key === 'Escape') this.requestClose();
     },
     handleClickOutside(event) {
-      const select = this.$el && this.$el.querySelector ? this.$el.querySelector('.custom-select') : null;
+      // ref, не this.$el.querySelector: при <Teleport> $el - это якорный комментарий
+      // без querySelector, и дропдаун фильтра не закрывался бы по клику снаружи.
+      const select = this.$refs.userSelect;
       if (select && !select.contains(event.target)) {
         this.userDropdownOpen = false;
       }

--- a/frontend/src/components/SystemTableHistoryModal.vue
+++ b/frontend/src/components/SystemTableHistoryModal.vue
@@ -59,6 +59,7 @@
               <div class="user-filter">
                 <span class="filter-label">Пользователь:</span>
                 <div
+                  ref="userSelect"
                   class="custom-select"
                   @click="toggleUserDropdown"
                 >
@@ -384,7 +385,9 @@ export default {
       if (e.key === 'Escape') this.requestClose();
     },
     handleClickOutside(event) {
-      const select = this.$el && this.$el.querySelector ? this.$el.querySelector('.custom-select') : null;
+      // ref, не this.$el.querySelector: при <Teleport> $el - это якорный комментарий
+      // без querySelector, и дропдаун фильтра не закрывался бы по клику снаружи.
+      const select = this.$refs.userSelect;
       if (select && !select.contains(event.target)) {
         this.userDropdownOpen = false;
       }

--- a/frontend/src/components/UnloadPlaces/UnloadPlaceHistoryModal.vue
+++ b/frontend/src/components/UnloadPlaces/UnloadPlaceHistoryModal.vue
@@ -62,6 +62,7 @@
                 <!-- Кастомный select, не BaseDropdown: повторяет фильтр-строку эталона
                    MarkHistoryModal (32px-контролы поиск/период/сортировка в ряд). -->
                 <div
+                  ref="userSelect"
                   class="custom-select"
                   @click="toggleUserDropdown"
                 >
@@ -348,7 +349,9 @@ export default {
       if (e.key === 'Escape') this.close();
     },
     handleClickOutside(event) {
-      const select = this.$el && this.$el.querySelector ? this.$el.querySelector('.custom-select') : null;
+      // ref, не this.$el.querySelector: при <Teleport> $el - это якорный комментарий
+      // без querySelector, и дропдаун фильтра не закрывался бы по клику снаружи.
+      const select = this.$refs.userSelect;
       if (select && !select.contains(event.target)) {
         this.userDropdownOpen = false;
       }

--- a/frontend/src/components/__tests__/HistoryModalsClickOutside.spec.js
+++ b/frontend/src/components/__tests__/HistoryModalsClickOutside.spec.js
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+
+// Все модалки грузят историю по-разному: 6 через apiRequest(@/api/client),
+// LPF через @/api/licenseFormats, Mark через @/api/marks. Контракт закрытия
+// дропдаунов-фильтров от данных не зависит - моки отдают пустую историю.
+vi.mock('@/api/client', () => ({
+  apiRequest: vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve([]) })),
+}));
+vi.mock('@/api/licenseFormats', () => ({
+  getLicenseFormatHistory: vi.fn(() => Promise.resolve([])),
+}));
+vi.mock('@/api/marks', () => ({
+  getMarkHistory: vi.fn(() => Promise.resolve([])),
+}));
+// exceljs тяжёлый и для теста закрытия дропдауна не нужен.
+vi.mock('exceljs', () => ({ default: { Workbook: class {} } }));
+
+import CarHistoryModal from '../CarHistoryModal.vue';
+import CarsTableHistoryModal from '../CarsTableHistoryModal.vue';
+import LicensePlateFormatHistoryModal from '../LicensePlateFormatHistoryModal.vue';
+import MarkHistoryModal from '../MarkHistoryModal.vue';
+import SystemTableHistoryModal from '../SystemTableHistoryModal.vue';
+import UnloadPlaceHistoryModal from '../UnloadPlaces/UnloadPlaceHistoryModal.vue';
+import EmployeeHistoryModal from '../CreateApplication/EmployeeHistoryModal.vue';
+import EmployeesTableHistoryModal from '../CreateApplication/EmployeesTableHistoryModal.vue';
+
+// Срез D-clickoutside (#406): handleClickOutside во всех history-модалках переведён
+// с this.$el.querySelector('.custom-select') на this.$refs.<select>. При <Teleport>
+// $el - якорный комментарий без querySelector, поэтому дропдаун фильтра не закрывался
+// бы по клику снаружи (баг найден как Y-1 в #484 на CitizenshipHistoryModal).
+const MODALS = [
+  { name: 'CarHistoryModal', component: CarHistoryModal, props: { carId: 1, carNumber: 'A123AA' }, refs: ['userSelect'] },
+  { name: 'CarsTableHistoryModal', component: CarsTableHistoryModal, props: { cars: [] }, refs: ['userSelect', 'carSelect'] },
+  { name: 'LicensePlateFormatHistoryModal', component: LicensePlateFormatHistoryModal, props: { format: { id: 7, name: 'Российские номера' } }, refs: ['userSelect'] },
+  { name: 'MarkHistoryModal', component: MarkHistoryModal, props: { mark: { id: 3, name: 'BMW' } }, refs: ['userSelect'] },
+  { name: 'SystemTableHistoryModal', component: SystemTableHistoryModal, props: { table: { id: 1 } }, refs: ['userSelect'] },
+  { name: 'UnloadPlaceHistoryModal', component: UnloadPlaceHistoryModal, props: { unloadPlace: { id: 1 } }, refs: ['userSelect'] },
+  { name: 'EmployeeHistoryModal', component: EmployeeHistoryModal, props: { lastName: 'Иванов', firstName: 'Иван' }, refs: ['userSelect', 'placeSelect'] },
+  { name: 'EmployeesTableHistoryModal', component: EmployeesTableHistoryModal, props: { tableId: 1 }, refs: ['userSelect', 'employeeSelect'] },
+];
+
+async function mountModal(component, props) {
+  const wrapper = mount(component, {
+    props,
+    global: { stubs: { teleport: true } },
+    attachTo: document.body,
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+describe('История-модалки: закрытие дропдаунов-фильтров по клику снаружи (refs при Teleport)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  MODALS.forEach(({ name, component, props, refs }) => {
+    describe(name, () => {
+      it('фильтр-селекты подключены через ref (а не this.$el.querySelector)', async () => {
+        const wrapper = await mountModal(component, props);
+        // Регресс-защита на сам факт наличия ref-атрибута: с teleport-stub реальный
+        // баг ($el = якорный комментарий) не воспроизводится, но если ref случайно
+        // удалят при рефакторинге - $refs.<select> станет undefined и тест упадёт.
+        refs.forEach((r) => expect(wrapper.vm.$refs[r]).toBeTruthy());
+        wrapper.unmount();
+      });
+
+      it('дропдаун закрывается по клику снаружи', async () => {
+        const wrapper = await mountModal(component, props);
+
+        await wrapper.find('.custom-select').trigger('click');
+        expect(wrapper.find('.select-dropdown').exists()).toBe(true);
+
+        document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        await wrapper.vm.$nextTick();
+        expect(wrapper.find('.select-dropdown').exists()).toBe(false);
+
+        wrapper.unmount();
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Что и зачем

Срез **D-clickoutside** эпика #406 (полиш-очередь). Латентный баг во всех history-модалках: `handleClickOutside` искал `.custom-select` через `this.$el.querySelector(...)`, но под `<Teleport to="body">` `this.$el` — якорный комментарий-плейсхолдер, а не корневой DOM-узел. querySelector ничего не находил, и дропдаун фильтра (пользователь/объект) **не закрывался по клику снаружи** — оставался открытым.

Найден как Y-1 в #484 (CitizenshipHistoryModal), помечен в `tasks.json` как кандидат на polish-синк. Здесь добиваю все остальные модалки тем же фиксом: `ref` на `.custom-select` + `this.$refs.<select>`.

## Файлы (8 модалок)

1 дропдаун (`userSelect`): `CarHistoryModal`, `LicensePlateFormatHistoryModal`, `MarkHistoryModal`, `SystemTableHistoryModal`, `UnloadPlaces/UnloadPlaceHistoryModal`.

2 дропдауна (массив refs): `CarsTableHistoryModal` (user+car), `CreateApplication/EmployeeHistoryModal` (user+place), `CreateApplication/EmployeesTableHistoryModal` (user+employee).

Эталон — `CitizenshipHistoryModal`/`UniqueAttachmentHistoryModal` (уже на `$refs`, не трогал).

## Тесты

Новый `HistoryModalsClickOutside.spec.js` — 8 модалок × 2 кейса (ref подключён + дропдаун закрывается по клику снаружи). vitest **462 зелёных** (+16), eslint/build чисто.

Примечание про тест: с `stubs: { teleport: true }` сам Teleport-баг ($el = комментарий) в jsdom не воспроизводится, поэтому регресс-защита — на факт наличия `ref`-атрибута (`$refs.<select>` truthy). Реальное Teleport-поведение совпадает с уже верифицированным вживую #484.

## Ревью

code-reviewer: **GO**. Корректность подтверждена (имена ref↔$refs совпадают во всех 8, `$el.querySelector` убран везде, логика `.some()` эквивалентна старой). Y-1 (комментарий в тесте) — добавлен. Y-2 (контракт мока `apiRequest`) — проверен: модалки используют сырой `apiRequest` через `response.ok`/`response.json()`, мок `{ ok, json }` корректен.

## Верификация

Однотипный bugfix-батч (класс D-1 #493 / D-2 #495) — merge-when-green, визуальная проверка после деплоя на staging. Без MCP по `feedback_skip_mcp_for_small_fixes`.