### PR TITLE
feat(blacklist): пометка похожих на ЧС элементов заявки при подаче (#481)

### DIFF
--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -100,6 +100,10 @@ func AllModels() []interface{} {
 		&models.EmployeeFile{},
 		&models.EmployeeTargetTable{},
 
+		// Per-element флаги возможного обхода ЧС (#481): ссылается на cars.id/employees.id
+		// без FK (снимок момента подачи, переживает изменение/удаление элемента и записи ЧС).
+		&models.ApplicationBlacklistFlag{},
+
 		// Items (depends on Attachment)
 		&models.Item{},
 		&models.ApplicationItem{},

--- a/internal/handlers/applications_blacklist_similarity_test.go
+++ b/internal/handlers/applications_blacklist_similarity_test.go
@@ -1,0 +1,134 @@
+package handlers_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"systemburo/internal/models"
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// latestElementID возвращает id последней вставленной строки таблицы по WHERE-условию.
+func latestElementID(t *testing.T, db *gorm.DB, table, where string, args ...interface{}) int {
+	t.Helper()
+	var id int
+	q := fmt.Sprintf("SELECT id FROM %s WHERE %s ORDER BY id DESC LIMIT 1", table, where)
+	require.NoError(t, db.Raw(q, args...).Scan(&id).Error)
+	require.NotZero(t, id, "элемент не найден: %s / %s", table, where)
+	return id
+}
+
+// blacklistFlagFor возвращает per-element флаг обхода ЧС (#481), если он есть.
+func blacklistFlagFor(t *testing.T, db *gorm.DB, elementType string, elementID int) (models.ApplicationBlacklistFlag, bool) {
+	t.Helper()
+	var f models.ApplicationBlacklistFlag
+	err := db.Where("element_type = ? AND element_id = ?", elementType, elementID).First(&f).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return f, false
+	}
+	require.NoError(t, err)
+	return f, true
+}
+
+// TestSubmitCompleteApplication_BlacklistSimilarity проверяет мягкий слой #481: похожий
+// (не точный) элемент НЕ блокируется как точный 409, а помечается per-element флагом и
+// отдаётся в детали заявки. Далёкие элементы остаются без флага.
+func TestSubmitCompleteApplication_BlacklistSimilarity(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	ctx := context.Background()
+
+	const orgName = "Test Organization"
+	token := testutil.RegisterAndLogin(t, e, "bl_sim_user", "pass123", 1, td.OrgID, td.CompanyID)
+	userID := getUserID(t, db, "bl_sim_user")
+
+	mark := seedMark(t, db, "BL_Sim_Mark")
+	citizenshipID := seedCitizenship(t, db)
+	tableID := seedSystemTable(t, db)
+
+	_, err := newVehicleBlacklistService(db).Create(ctx, models.CreateVehicleBlacklistRequest{
+		CarNumber: "C777CC799", MarkID: mark.ID, Reason: "угон",
+	}, userID)
+	require.NoError(t, err)
+	_, err = newPersonBlacklistService(db).Create(ctx, models.CreatePersonBlacklistRequest{
+		LastName: "Petrov", FirstName: "Petr", MiddleName: "Petrovich", Reason: "нарушение",
+	}, userID)
+	require.NoError(t, err)
+
+	t.Run("похожая машина (опечатка в номере) подаётся и помечается", func(t *testing.T) {
+		rec := submitCarApp(t, e, db, token, orgName, "sim", "C777CC798", mark.ID)
+		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+		carID := latestElementID(t, db, "cars", "car_number = ?", "C777CC798")
+		flag, ok := blacklistFlagFor(t, db, models.BlacklistElementCar, carID)
+		require.True(t, ok, "ожидался флаг похожести для машины")
+		assert.GreaterOrEqual(t, flag.Similarity, 0.7)
+		assert.Contains(t, flag.MatchedValue, "C777CC799")
+		assert.Equal(t, "угон", flag.MatchedReason)
+
+		var attID int
+		require.NoError(t, db.Raw("SELECT attachment_id FROM cars WHERE id = ?", carID).Scan(&attID).Error)
+		det := testutil.GET(t, e, fmt.Sprintf("/attachments/%d/cars", attID), testutil.AuthHeader(token))
+		require.Equal(t, http.StatusOK, det.Code, "body: %s", det.Body.String())
+		assert.Contains(t, det.Body.String(), "blacklist_similar")
+		assert.Contains(t, det.Body.String(), "угон")
+	})
+
+	t.Run("точная машина по-прежнему 409 и не создаёт флаг", func(t *testing.T) {
+		countCarFlags := func() int64 {
+			var n int64
+			require.NoError(t, db.Model(&models.ApplicationBlacklistFlag{}).
+				Where("element_type = ?", models.BlacklistElementCar).Count(&n).Error)
+			return n
+		}
+		before := countCarFlags()
+		rec := submitCarApp(t, e, db, token, orgName, "exact", "C777CC799", mark.ID)
+		require.Equal(t, http.StatusConflict, rec.Code, "body: %s", rec.Body.String())
+		assert.Equal(t, before, countCarFlags(), "409 (точное совпадение) не должен создавать флаг")
+	})
+
+	t.Run("далёкая машина без флага", func(t *testing.T) {
+		rec := submitCarApp(t, e, db, token, orgName, "far", "X123XX111", mark.ID)
+		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+		carID := latestElementID(t, db, "cars", "car_number = ?", "X123XX111")
+		_, ok := blacklistFlagFor(t, db, models.BlacklistElementCar, carID)
+		assert.False(t, ok, "далёкая машина не должна помечаться")
+	})
+
+	t.Run("похожий человек (без отчества) подаётся и помечается", func(t *testing.T) {
+		rec := submitPersonApp(t, e, db, token, orgName, "sim", "Petrov", "Petr", "", citizenshipID, tableID)
+		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+		empID := latestElementID(t, db, "employees", "last_name = ? AND first_name = ?", "Petrov", "Petr")
+		flag, ok := blacklistFlagFor(t, db, models.BlacklistElementEmployee, empID)
+		require.True(t, ok, "ожидался флаг похожести для человека")
+		assert.GreaterOrEqual(t, flag.Similarity, 0.7)
+		assert.Contains(t, flag.MatchedValue, "Petrov")
+		assert.Equal(t, "нарушение", flag.MatchedReason)
+
+		var attID int
+		require.NoError(t, db.Raw("SELECT attachment_id FROM employees WHERE id = ?", empID).Scan(&attID).Error)
+		det := testutil.GET(t, e, fmt.Sprintf("/attachments/%d/employees", attID), testutil.AuthHeader(token))
+		require.Equal(t, http.StatusOK, det.Code, "body: %s", det.Body.String())
+		assert.Contains(t, det.Body.String(), "blacklist_similar")
+	})
+
+	t.Run("далёкий человек без флага", func(t *testing.T) {
+		rec := submitPersonApp(t, e, db, token, orgName, "far", "Sidorov", "Sidr", "Sidorovich", citizenshipID, tableID)
+		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+		empID := latestElementID(t, db, "employees", "last_name = ? AND first_name = ?", "Sidorov", "Sidr")
+		_, ok := blacklistFlagFor(t, db, models.BlacklistElementEmployee, empID)
+		assert.False(t, ok, "далёкий человек не должен помечаться")
+	})
+}

--- a/internal/models/application_blacklist.go
+++ b/internal/models/application_blacklist.go
@@ -1,0 +1,32 @@
+package models
+
+import "time"
+
+// Типы элементов заявки для ApplicationBlacklistFlag.
+const (
+	BlacklistElementCar      = "car"
+	BlacklistElementEmployee = "employee"
+)
+
+// ApplicationBlacklistFlag - per-element предупреждение о возможном обходе ЧС (#481).
+//
+// Создаётся при сабмите заявки, когда элемент (машина/человек) НЕ точно совпадает с
+// активным ЧС (точное совпадение ловит validateBlacklist -> 409), но близок по
+// нормализованной форме (FindSimilar: гомоглиф/опечатка/0<->О/без отчества). Подачу
+// НЕ блокирует - это мягкое предупреждение; помеченный элемент блокирует согласование
+// заявки до явного override (срез 4).
+//
+// ElementID ссылается на cars.id / employees.id без внешнего ключа - как и история ЧС:
+// флаг это снимок момента подачи (matched_value/reason фиксируются), он должен пережить
+// изменение/удаление записи ЧС и не каскадиться при удалении элемента.
+type ApplicationBlacklistFlag struct {
+	ID                 int       `json:"id"`
+	ApplicationID      int       `gorm:"index" json:"application_id"`
+	ElementType        string    `gorm:"size:20;index:idx_app_blacklist_flag_element,priority:1" json:"element_type"`
+	ElementID          int       `gorm:"index:idx_app_blacklist_flag_element,priority:2" json:"element_id"`
+	MatchedBlacklistID int       `json:"matched_blacklist_id"`
+	MatchedValue       string    `gorm:"size:300" json:"matched_value"`
+	MatchedReason      string    `gorm:"size:500" json:"matched_reason"`
+	Similarity         float64   `json:"similarity"`
+	CreatedAt          time.Time `json:"created_at"`
+}

--- a/internal/services/application_attachment_service.go
+++ b/internal/services/application_attachment_service.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"systemburo/internal/crypto"
+	"systemburo/internal/models"
 
 	"github.com/labstack/echo/v4"
 )
@@ -102,6 +103,41 @@ func (s *applicationService) GetApplicationAttachments(ctx context.Context, appl
 	return attachments, nil
 }
 
+// fetchBlacklistFlags возвращает per-element предупреждения о возможном обходе ЧС (#481)
+// по типу элемента и его id; ключ результата - element_id. Best-effort overlay для детали
+// заявки: ошибку чтения логируем и возвращаем пустую карту - деталь должна отрисоваться и
+// без предупреждений, а не падать. При нескольких флагах на элемент берём последний по id.
+// Фильтр по application_id не нужен: element_id это глобальный PK cars/employees, флаг
+// не может относиться к чужой заявке.
+func (s *applicationService) fetchBlacklistFlags(ctx context.Context, elementType string, ids []int) map[int]*BlacklistFlagInfo {
+	out := make(map[int]*BlacklistFlagInfo)
+	if len(ids) == 0 {
+		return out
+	}
+	var rows []struct {
+		ElementID     int     `gorm:"column:element_id"`
+		MatchedValue  string  `gorm:"column:matched_value"`
+		MatchedReason string  `gorm:"column:matched_reason"`
+		Similarity    float64 `gorm:"column:similarity"`
+	}
+	if err := s.db.WithContext(ctx).Raw(`
+		SELECT element_id, matched_value, matched_reason, similarity
+		FROM application_blacklist_flags
+		WHERE element_type = ? AND element_id IN ?
+		ORDER BY id`, elementType, ids).Scan(&rows).Error; err != nil {
+		slog.Warn("fetch blacklist flags failed", "err", err, "element_type", elementType)
+		return out
+	}
+	for _, r := range rows {
+		out[r.ElementID] = &BlacklistFlagInfo{
+			MatchedValue:  r.MatchedValue,
+			MatchedReason: r.MatchedReason,
+			Similarity:    r.Similarity,
+		}
+	}
+	return out
+}
+
 // GetAttachmentCars возвращает автомобили вложения с привязанными местами разгрузки.
 func (s *applicationService) GetAttachmentCars(ctx context.Context, attachmentID int) ([]CarWithPlaces, error) {
 	type carRow struct {
@@ -143,6 +179,12 @@ func (s *applicationService) GetAttachmentCars(ctx context.Context, attachmentID
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching cars")
 	}
 
+	carIDs := make([]int, 0, len(cars))
+	for _, car := range cars {
+		carIDs = append(carIDs, car.ID)
+	}
+	flags := s.fetchBlacklistFlags(ctx, models.BlacklistElementCar, carIDs)
+
 	result := make([]CarWithPlaces, 0)
 	for _, car := range cars {
 		places := make([]UnloadPlaceRef, 0)
@@ -155,19 +197,20 @@ func (s *applicationService) GetAttachmentCars(ctx context.Context, attachmentID
 		`, car.ID).Scan(&places)
 
 		result = append(result, CarWithPlaces{
-			ID:             car.ID,
-			CarNumber:      car.CarNumber,
-			CarBrand:       car.CarBrand,
-			UnloadPlace:    car.UnloadPlace,
-			EntryDateFrom:  car.EntryDateFrom,
-			EntryTimeFrom:  car.EntryTimeFrom,
-			EntryDateTo:    car.EntryDateTo,
-			EntryTimeTo:    car.EntryTimeTo,
-			Organization:   car.Organization,
-			OrganizationID: car.OrganizationID,
-			Company:        car.Company,
-			CompanyID:      car.CompanyID,
-			UnloadPlaces:   places,
+			ID:               car.ID,
+			CarNumber:        car.CarNumber,
+			CarBrand:         car.CarBrand,
+			UnloadPlace:      car.UnloadPlace,
+			EntryDateFrom:    car.EntryDateFrom,
+			EntryTimeFrom:    car.EntryTimeFrom,
+			EntryDateTo:      car.EntryDateTo,
+			EntryTimeTo:      car.EntryTimeTo,
+			Organization:     car.Organization,
+			OrganizationID:   car.OrganizationID,
+			Company:          car.Company,
+			CompanyID:        car.CompanyID,
+			UnloadPlaces:     places,
+			BlacklistSimilar: flags[car.ID],
 		})
 	}
 
@@ -228,6 +271,12 @@ func (s *applicationService) GetAttachmentEmployees(ctx context.Context, attachm
 		employees[i].PatentNumber = crypto.DecryptOptional(employees[i].PatentNumber)
 	}
 
+	empIDs := make([]int, 0, len(employees))
+	for _, emp := range employees {
+		empIDs = append(empIDs, emp.ID)
+	}
+	flags := s.fetchBlacklistFlags(ctx, models.BlacklistElementEmployee, empIDs)
+
 	result := make([]EmployeeWithTables, 0)
 	for _, emp := range employees {
 		tables := make([]TableInfoRef, 0)
@@ -257,6 +306,7 @@ func (s *applicationService) GetAttachmentEmployees(ctx context.Context, attachm
 			Company:              emp.Company,
 			CompanyID:            emp.CompanyID,
 			TargetTables:         tables,
+			BlacklistSimilar:     flags[emp.ID],
 		})
 	}
 

--- a/internal/services/application_service.go
+++ b/internal/services/application_service.go
@@ -415,6 +415,17 @@ type CarWithPlaces struct {
 	Company        *string          `json:"company"`
 	CompanyID      *int             `json:"company_id"`
 	UnloadPlaces   []UnloadPlaceRef `json:"unload_places"`
+	// BlacklistSimilar - предупреждение о возможном обходе ЧС (#481): заполнено, если
+	// номер близок к активной записи ЧС (но не точное совпадение). nil - элемент чист.
+	BlacklistSimilar *BlacklistFlagInfo `json:"blacklist_similar,omitempty"`
+}
+
+// BlacklistFlagInfo - данные per-element предупреждения о возможном обходе ЧС (#481)
+// для детали заявки: что в ЧС похоже, причина записи и степень близости [0..1].
+type BlacklistFlagInfo struct {
+	MatchedValue  string  `json:"matched_value"`
+	MatchedReason string  `json:"matched_reason"`
+	Similarity    float64 `json:"similarity"`
 }
 
 // UnloadPlaceRef ссылка на место разгрузки.
@@ -443,6 +454,9 @@ type EmployeeWithTables struct {
 	Company              *string        `json:"company"`
 	CompanyID            *int           `json:"company_id"`
 	TargetTables         []TableInfoRef `json:"target_tables"`
+	// BlacklistSimilar - предупреждение о возможном обходе ЧС (#481): заполнено, если
+	// ФИО близко к активной записи ЧС (но не точное совпадение). nil - элемент чист.
+	BlacklistSimilar *BlacklistFlagInfo `json:"blacklist_similar,omitempty"`
 }
 
 // TableInfoRef ссылка на системную таблицу.
@@ -991,6 +1005,68 @@ func (s *applicationService) validateBlacklist(ctx context.Context, req Complete
 	return nil
 }
 
+// pendingVehicleFlag - вставленная машина заявки, по которой нужно проверить близость к ЧС
+// после коммита (id + номер; FindSimilar матчит по нормализованному номеру, марка не нужна).
+type pendingVehicleFlag struct {
+	carID     int
+	carNumber string
+}
+
+// pendingEmployeeFlag - вставленный сотрудник заявки для пост-коммит проверки близости к ЧС.
+type pendingEmployeeFlag struct {
+	empID      int
+	lastName   string
+	firstName  string
+	middleName string
+}
+
+// detectBlacklistSimilarity - мягкий слой предупреждения о возможном обходе ЧС (#481).
+// Запускается ПОСЛЕ коммита сабмита и намеренно best-effort: это не блокирующая проверка
+// (точное совпадение уже отклонено в validateBlacklist -> 409), а предупреждение. Любая
+// ошибка поиска/записи флага логируется и проглатывается - неудача warning-слоя НЕ должна
+// валить уже созданную заявку. Вне транзакции сабмита: ошибка здесь не отравит и не откатит её.
+func (s *applicationService) detectBlacklistSimilarity(ctx context.Context, appID int, vehicles []pendingVehicleFlag, employees []pendingEmployeeFlag) {
+	for _, v := range vehicles {
+		matches, err := s.vehicleBlacklist.FindSimilar(ctx, v.carNumber)
+		if err != nil {
+			slog.Warn("blacklist similarity check failed (vehicle)", "err", err, "app_id", appID, "car_id", v.carID)
+			continue
+		}
+		s.saveBlacklistFlag(ctx, appID, models.BlacklistElementCar, v.carID, matches)
+	}
+	for _, e := range employees {
+		matches, err := s.personBlacklist.FindSimilar(ctx, e.lastName, e.firstName, e.middleName)
+		if err != nil {
+			slog.Warn("blacklist similarity check failed (person)", "err", err, "app_id", appID, "employee_id", e.empID)
+			continue
+		}
+		s.saveBlacklistFlag(ctx, appID, models.BlacklistElementEmployee, e.empID, matches)
+	}
+}
+
+// saveBlacklistFlag сохраняет ЛУЧШЕЕ совпадение как флаг элемента: matches приходят
+// отсортированными по убыванию близости (контракт FindSimilar). Пустой срез - элемент
+// чист, флаг не пишем. Ошибку записи логируем и проглатываем (best-effort warning-слой).
+func (s *applicationService) saveBlacklistFlag(ctx context.Context, appID int, elementType string, elementID int, matches []models.BlacklistSimilarMatch) {
+	if len(matches) == 0 {
+		return
+	}
+	best := matches[0]
+	flag := models.ApplicationBlacklistFlag{
+		ApplicationID:      appID,
+		ElementType:        elementType,
+		ElementID:          elementID,
+		MatchedBlacklistID: best.ID,
+		MatchedValue:       best.MatchedValue,
+		MatchedReason:      best.Reason,
+		Similarity:         best.Similarity,
+		CreatedAt:          time.Now().UTC(),
+	}
+	if err := s.db.WithContext(ctx).Create(&flag).Error; err != nil {
+		slog.Warn("blacklist flag save failed", "err", err, "app_id", appID, "element_type", elementType, "element_id", elementID)
+	}
+}
+
 // SubmitCompleteApplication создаёт полную заявку с вложениями, машинами и сотрудниками.
 func (s *applicationService) SubmitCompleteApplication(ctx context.Context, username string, req CompleteApplicationRequest) (*CompleteApplicationResponse, error) {
 	user, err := s.getUserByUsername(ctx, username)
@@ -1152,6 +1228,10 @@ func (s *applicationService) SubmitCompleteApplication(ctx context.Context, user
 		`, appID, ru.UserID, string(meta), historyTime)
 	}
 
+	// Вставленные машины/сотрудники для пост-коммит проверки близости к ЧС (#481).
+	var pendingVehicleFlags []pendingVehicleFlag
+	var pendingEmployeeFlags []pendingEmployeeFlag
+
 	// Создаём вложения
 	for _, att := range req.Attachments {
 		var attID int
@@ -1181,6 +1261,8 @@ func (s *applicationService) SubmitCompleteApplication(ctx context.Context, user
 						tx.Rollback()
 						return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error creating car")
 					}
+
+					pendingVehicleFlags = append(pendingVehicleFlags, pendingVehicleFlag{carID: carID, carNumber: v.CarNumber})
 
 					carHistoryTime := baseTime.Add(time.Millisecond)
 					tx.Exec(`
@@ -1226,6 +1308,9 @@ func (s *applicationService) SubmitCompleteApplication(ctx context.Context, user
 					if e.MiddleName != nil {
 						empMiddle = *e.MiddleName
 					}
+					pendingEmployeeFlags = append(pendingEmployeeFlags, pendingEmployeeFlag{
+						empID: empID, lastName: lastName, firstName: firstName, middleName: empMiddle,
+					})
 					empComment := fmt.Sprintf("Сотрудник %s создан", strings.TrimSpace(strings.Join([]string{lastName, firstName, empMiddle}, " ")))
 					tx.Exec(`
 						INSERT INTO employees_history (employee_id, user_id, action_type, comment, created_at)
@@ -1273,6 +1358,12 @@ func (s *applicationService) SubmitCompleteApplication(ctx context.Context, user
 	if err := tx.Commit().Error; err != nil {
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Failed to commit transaction")
 	}
+
+	// Мягкая проверка возможного обхода ЧС по похожему номеру/ФИО (#481): помечает
+	// элементы флагом для предупреждения согласующим. Best-effort, заявку не блокирует.
+	// Синхронно (не в горутине) намеренно: флаги должны быть готовы сразу для детали
+	// заявки и детерминированны для тестов; сабмит не hot-path, элементов в заявке мало.
+	s.detectBlacklistSimilarity(ctx, appID, pendingVehicleFlags, pendingEmployeeFlags)
 
 	// Уведомление отправителю о создании заявки
 	if s.notificationService != nil {

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -44,6 +44,7 @@ var tables = []string{
 	"bug_reports",
 	"request_log", "request_logs", "notifications", "news", "announcements",
 	"feedback", "application_items", "items",
+	"application_blacklist_flags",
 	"employee_target_tables", "employee_files", "application_employees", "employees_history", "employees",
 	"car_unload_places", "cars_history", "cars",
 	"vehicle_blacklist_histories", "vehicle_blacklists",


### PR DESCRIPTION
Срез 3 эпика #481 (мягкое предупреждение о возможном обходе ЧС).

## Что делает
При подаче заявки, помимо точного гарда (точное совпадение с активным ЧС -> 409, не тронут), теперь ищем ПОХОЖИЕ совпадения по номеру/ФИО (движок FindSimilar из среза 2a, порог 0.7) и помечаем конкретную машину/человека per-element флагом. Это мягкое предупреждение согласующим - подачу НЕ блокирует. Точное совпадение по-прежнему жёсткий 409. Гомоглиф (латиница vs кириллица), который точный гард пропускает, ловится как похожий (sim 1.0 на нормализованной форме).

## Реализация
- Новая таблица `application_blacklist_flags` (отдельная модель, не колонки на cars/employees - концерн ЧС изолирован). `element_type`+`element_id` -> cars.id/employees.id без FK: флаг это снимок момента подачи, переживает изменение/удаление элемента и записи ЧС.
- `detectBlacklistSimilarity` запускается ПОСЛЕ коммита сабмит-транзакции, best-effort: ошибки поиска/записи логируются и проглатываются - неудача warning-слоя не должна валить уже созданную заявку. Вне tx намеренно (ошибка внутри откатила бы валидную заявку).
- Флаг отдаётся в детали заявки: `GetAttachmentCars`/`GetAttachmentEmployees` -> поле `blacklist_similar` (matched_value/reason/similarity).
- `migrate.go`: одна аддитивная строка в AllModels() (под стоящее разрешение на аддитивный AutoMigrate в этом эпике).
- `CleanDB`: новая таблица добавлена в список очистки (иначе флаги протекали между тестами).

## Проверка
- Новый интеграционный тест `TestSubmitCompleteApplication_BlacklistSimilarity`: похожая машина/человек (опечатка, без отчества) -> 200 + флаг + оверлей в детали; точное совпадение -> 409 без флага; далёкие -> без флага.
- Полный `./internal/...` зелёный в изолированной БД, регрессий нет.
- code-reviewer: GO, замечания (синхронность/комментарии/хрупкий ассерт) исправлены.

Следующий срез 4: блокировка согласования помеченной заявки до явного override с аудитом.