### PR TITLE
feat(blacklist): блокировка согласования помеченной заявки до override (#481)

### DIFF
--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -103,6 +103,8 @@ func AllModels() []interface{} {
 		// Per-element флаги возможного обхода ЧС (#481): ссылается на cars.id/employees.id
 		// без FK (снимок момента подачи, переживает изменение/удаление элемента и записи ЧС).
 		&models.ApplicationBlacklistFlag{},
+		// Аудит override помеченных элементов (#481, срез 4): кто/когда/коммент "всё равно пропустить".
+		&models.ApplicationBlacklistOverride{},
 
 		// Items (depends on Attachment)
 		&models.Item{},

--- a/internal/handlers/applications_blacklist_override_test.go
+++ b/internal/handlers/applications_blacklist_override_test.go
@@ -1,0 +1,132 @@
+package handlers_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"systemburo/internal/models"
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBlacklistOverride_BlocksApprovalUntilConfirmed: помеченную заявку нельзя согласовать,
+// пока ответственный не подтвердит пропуск каждого элемента (override) - тогда разблокируется.
+func TestBlacklistOverride_BlocksApprovalUntilConfirmed(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	ctx := context.Background()
+
+	const orgName = "Test Organization"
+	senderToken := testutil.RegisterAndLogin(t, e, "bo_sender", "pass123", 1, td.OrgID, td.CompanyID)
+	senderID := getUserID(t, db, "bo_sender")
+	mark := seedMark(t, db, "BO_Mark")
+
+	_, err := newVehicleBlacklistService(db).Create(ctx, models.CreateVehicleBlacklistRequest{
+		CarNumber: "C777CC799", MarkID: mark.ID, Reason: "угон",
+	}, senderID)
+	require.NoError(t, err)
+
+	rec := submitCarApp(t, e, db, senderToken, orgName, "ovr", "C777CC798", mark.ID)
+	require.Equal(t, http.StatusOK, rec.Code, "submit: %s", rec.Body.String())
+	carID := latestElementID(t, db, "cars", "car_number = ?", "C777CC798")
+	flag, ok := blacklistFlagFor(t, db, models.BlacklistElementCar, carID)
+	require.True(t, ok, "ожидался флаг похожести")
+	appID := flag.ApplicationID
+
+	testutil.RegisterUser(t, e, "bo_appr", "pass123", 1, td.OrgID, td.CompanyID)
+	apprID := getUserID(t, db, "bo_appr")
+	fwd := fmt.Sprintf(`{"users":[{"user_id":%d,"required_approval":true,"can_view":false}]}`, apprID)
+	rec = testutil.POST(t, e, fmt.Sprintf("/applications/%d/forward", appID), fwd, testutil.AuthHeader(senderToken))
+	require.Equal(t, http.StatusOK, rec.Code, "forward: %s", rec.Body.String())
+	apprToken, _ := testutil.LoginUser(t, e, "bo_appr", "pass123")
+	approveBody := fmt.Sprintf(`{"user_id":%d,"status":"approved","comment":"ok"}`, apprID)
+	overridePath := fmt.Sprintf("/applications/%d/blacklist-overrides", appID)
+
+	t.Run("согласование заблокировано до override", func(t *testing.T) {
+		rec := testutil.POST(t, e, fmt.Sprintf("/applications/%d/approve", appID), approveBody, testutil.AuthHeader(apprToken))
+		require.Equal(t, http.StatusConflict, rec.Code, "body: %s", rec.Body.String())
+		assert.Contains(t, rec.Body.String(), "чёрн")
+	})
+
+	t.Run("прямой PUT confirmation=Согласовано тоже заблокирован", func(t *testing.T) {
+		rec := testutil.PUT(t, e, fmt.Sprintf("/applications/%d", appID), `{"confirmation":"Согласовано"}`, testutil.AuthHeader(apprToken))
+		require.Equal(t, http.StatusConflict, rec.Code, "обход гейта через PUT не должен проходить: %s", rec.Body.String())
+	})
+
+	t.Run("override без комментария отклоняется", func(t *testing.T) {
+		rec := testutil.POST(t, e, overridePath, fmt.Sprintf(`{"flag_id":%d,"comment":""}`, flag.ID), testutil.AuthHeader(apprToken))
+		require.Equal(t, http.StatusBadRequest, rec.Code, "body: %s", rec.Body.String())
+	})
+
+	t.Run("override от не-ответственного запрещён", func(t *testing.T) {
+		outsiderToken := testutil.RegisterAndLogin(t, e, "bo_outsider", "pass123", 1, td.OrgID, td.CompanyID)
+		rec := testutil.POST(t, e, overridePath, fmt.Sprintf(`{"flag_id":%d,"comment":"чужой"}`, flag.ID), testutil.AuthHeader(outsiderToken))
+		require.Equal(t, http.StatusForbidden, rec.Code, "body: %s", rec.Body.String())
+	})
+
+	t.Run("override фиксирует аудит и разблокирует согласование", func(t *testing.T) {
+		rec := testutil.POST(t, e, overridePath, fmt.Sprintf(`{"flag_id":%d,"comment":"проверено лично"}`, flag.ID), testutil.AuthHeader(apprToken))
+		require.Equal(t, http.StatusOK, rec.Code, "override: %s", rec.Body.String())
+
+		var ovr models.ApplicationBlacklistOverride
+		require.NoError(t, db.Where("flag_id = ?", flag.ID).First(&ovr).Error)
+		assert.Equal(t, apprID, ovr.OverriddenByUserID)
+		assert.Equal(t, "проверено лично", ovr.Comment)
+		assert.Equal(t, flag.MatchedValue, ovr.MatchedValue, "снимок совпавшего значения для аудита")
+
+		// Оверлей детали теперь помечает элемент как подтверждённый.
+		var attID int
+		require.NoError(t, db.Raw("SELECT attachment_id FROM cars WHERE id = ?", carID).Scan(&attID).Error)
+		det := testutil.GET(t, e, fmt.Sprintf("/attachments/%d/cars", attID), testutil.AuthHeader(apprToken))
+		require.Equal(t, http.StatusOK, det.Code, "body: %s", det.Body.String())
+		assert.Contains(t, det.Body.String(), `"overridden":true`)
+
+		// После override согласование проходит.
+		rec = testutil.POST(t, e, fmt.Sprintf("/applications/%d/approve", appID), approveBody, testutil.AuthHeader(apprToken))
+		require.Equal(t, http.StatusOK, rec.Code, "approve after override: %s", rec.Body.String())
+	})
+}
+
+// TestBlacklistOverride_RejectionNotBlocked: отказ ('rejected') помеченной заявки не требует
+// override - отклонить подозрительную заявку можно сразу.
+func TestBlacklistOverride_RejectionNotBlocked(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	ctx := context.Background()
+
+	const orgName = "Test Organization"
+	senderToken := testutil.RegisterAndLogin(t, e, "br_sender", "pass123", 1, td.OrgID, td.CompanyID)
+	senderID := getUserID(t, db, "br_sender")
+	mark := seedMark(t, db, "BR_Mark")
+
+	_, err := newVehicleBlacklistService(db).Create(ctx, models.CreateVehicleBlacklistRequest{
+		CarNumber: "C777CC799", MarkID: mark.ID, Reason: "угон",
+	}, senderID)
+	require.NoError(t, err)
+
+	rec := submitCarApp(t, e, db, senderToken, orgName, "rej", "C777CC798", mark.ID)
+	require.Equal(t, http.StatusOK, rec.Code, "submit: %s", rec.Body.String())
+	carID := latestElementID(t, db, "cars", "car_number = ?", "C777CC798")
+	flag, ok := blacklistFlagFor(t, db, models.BlacklistElementCar, carID)
+	require.True(t, ok)
+	appID := flag.ApplicationID
+
+	testutil.RegisterUser(t, e, "br_appr", "pass123", 1, td.OrgID, td.CompanyID)
+	apprID := getUserID(t, db, "br_appr")
+	fwd := fmt.Sprintf(`{"users":[{"user_id":%d,"required_approval":true,"can_view":false}]}`, apprID)
+	rec = testutil.POST(t, e, fmt.Sprintf("/applications/%d/forward", appID), fwd, testutil.AuthHeader(senderToken))
+	require.Equal(t, http.StatusOK, rec.Code, "forward: %s", rec.Body.String())
+
+	apprToken, _ := testutil.LoginUser(t, e, "br_appr", "pass123")
+	rec = testutil.POST(t, e, fmt.Sprintf("/applications/%d/approve", appID),
+		fmt.Sprintf(`{"user_id":%d,"status":"rejected","comment":"подозрительно"}`, apprID), testutil.AuthHeader(apprToken))
+	require.Equal(t, http.StatusOK, rec.Code, "reject не должен блокироваться: %s", rec.Body.String())
+}

--- a/internal/handlers/applications_workflow.go
+++ b/internal/handlers/applications_workflow.go
@@ -76,6 +76,39 @@ func (h *ApplicationHandler) ApproveApplicationByUser(c echo.Context) error {
 	return RespondMessage(c, "Approval status updated successfully")
 }
 
+// OverrideBlacklistFlag godoc
+// @Summary      Подтвердить пропуск похожего на ЧС элемента
+// @Description  Ответственный фиксирует "всё равно пропустить" по конкретному предупреждению (#481), снимая блокировку согласования по нему.
+// @Tags         applications
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id      path int                                    true "ID заявки"
+// @Param        request body services.OverrideBlacklistFlagRequest  true "flag_id + комментарий"
+// @Success      200 {object} map[string]interface{} "success + message"
+// @Failure      400 {object} models.HTTPError
+// @Failure      403 {object} models.HTTPError
+// @Failure      404 {object} models.HTTPError
+// @Failure      500 {object} models.HTTPError
+// @Router       /applications/{id}/blacklist-overrides [post]
+func (h *ApplicationHandler) OverrideBlacklistFlag(c echo.Context) error {
+	username := c.Get("username").(string)
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid application ID")
+	}
+
+	var req services.OverrideBlacklistFlagRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+
+	if err := h.service.OverrideBlacklistFlag(c.Request().Context(), username, id, req); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Пропуск подтверждён")
+}
+
 // CheckApprovalStatus godoc
 // @Summary      Проверка статуса согласования
 // @Description  Возвращает текущие confirmation и status заявки.

--- a/internal/models/application_blacklist.go
+++ b/internal/models/application_blacklist.go
@@ -30,3 +30,20 @@ type ApplicationBlacklistFlag struct {
 	Similarity         float64   `json:"similarity"`
 	CreatedAt          time.Time `json:"created_at"`
 }
+
+// ApplicationBlacklistOverride - аудит явного решения "всё равно пропустить" по помеченному
+// элементу заявки (#481). Согласование помеченной заявки заблокировано, пока по каждому
+// флагу нет override. Отдельная таблица аудита (НЕ pd_audit, off-limits): фиксирует кто/когда/
+// комментарий и снимок совпавшего значения - запись неизменяема и переживает удаление флага.
+// FlagID уникален (один override на флаг) и без FK - это исторический след, а не живая связь.
+type ApplicationBlacklistOverride struct {
+	ID                 int       `json:"id"`
+	FlagID             int       `gorm:"uniqueIndex" json:"flag_id"`
+	ApplicationID      int       `gorm:"index" json:"application_id"`
+	ElementType        string    `gorm:"size:20" json:"element_type"`
+	ElementID          int       `json:"element_id"`
+	MatchedValue       string    `gorm:"size:300" json:"matched_value"`
+	OverriddenByUserID int       `json:"overridden_by_user_id"`
+	Comment            string    `gorm:"size:1000" json:"comment"`
+	CreatedAt          time.Time `json:"created_at"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -417,6 +417,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	apg.POST("/:id/update-items-status", app.UpdateApplicationItemsStatus)
 	apg.POST("/:id/forward", app.ForwardApplication)
 	apg.POST("/:id/approve", app.ApproveApplicationByUser)
+	apg.POST("/:id/blacklist-overrides", app.OverrideBlacklistFlag) // #481 - "всё равно пропустить"
 	apg.GET("/:id/check-approval-status", app.CheckApprovalStatus)
 	apg.POST("/:id/take-to-work", app.TakeApplicationToWork)
 	apg.POST("/:id/revoke-from-work", app.RevokeApplicationFromWork)

--- a/internal/services/application_approval_service.go
+++ b/internal/services/application_approval_service.go
@@ -275,6 +275,22 @@ func (s *applicationService) ApproveApplicationByUser(ctx context.Context, usern
 		return echo.NewHTTPError(http.StatusBadRequest, "You have already voted on this application")
 	}
 
+	// Гейт обхода ЧС (#481): согласовать ('approved') нельзя, пока по всем помеченным
+	// похожими на ЧС элементам не подтверждён пропуск (override). Отказ ('rejected') не
+	// блокируем - отклонить подозрительную заявку можно сразу.
+	if req.Status == "approved" {
+		blocked, err := hasUnoverriddenBlacklistFlags(ctx, tx, applicationID)
+		if err != nil {
+			tx.Rollback()
+			return err
+		}
+		if blocked {
+			tx.Rollback()
+			return echo.NewHTTPError(http.StatusConflict,
+				"Заявка содержит элементы, похожие на чёрный список. Подтвердите пропуск каждого ('Всё равно пропустить') перед согласованием")
+		}
+	}
+
 	// Сохраняем старый confirmation
 	var oldConfirmation *string
 	tx.Raw("SELECT confirmation FROM applications WHERE id = ?", applicationID).Scan(&oldConfirmation)

--- a/internal/services/application_attachment_service.go
+++ b/internal/services/application_attachment_service.go
@@ -104,35 +104,44 @@ func (s *applicationService) GetApplicationAttachments(ctx context.Context, appl
 }
 
 // fetchBlacklistFlags возвращает per-element предупреждения о возможном обходе ЧС (#481)
-// по типу элемента и его id; ключ результата - element_id. Best-effort overlay для детали
-// заявки: ошибку чтения логируем и возвращаем пустую карту - деталь должна отрисоваться и
-// без предупреждений, а не падать. При нескольких флагах на элемент берём последний по id.
-// Фильтр по application_id не нужен: element_id это глобальный PK cars/employees, флаг
-// не может относиться к чужой заявке.
-func (s *applicationService) fetchBlacklistFlags(ctx context.Context, elementType string, ids []int) map[int]*BlacklistFlagInfo {
+// по типу элемента и его id в рамках заявки; ключ результата - element_id. Best-effort
+// overlay для детали: ошибку чтения логируем и возвращаем пустую карту - деталь должна
+// отрисоваться и без предупреждений, а не падать.
+// Фильтр по application_id - защита-в-глубину: cars/employees сейчас создаются свежими на
+// каждый сабмит (element_id уникален на заявку), но завязываться на этот инвариант в
+// security-оверлее не хочется - иначе будущий рефактор с переиспользованием строк тихо
+// показал бы чужой override.
+func (s *applicationService) fetchBlacklistFlags(ctx context.Context, elementType string, applicationID int, ids []int) map[int]*BlacklistFlagInfo {
 	out := make(map[int]*BlacklistFlagInfo)
 	if len(ids) == 0 {
 		return out
 	}
 	var rows []struct {
+		FlagID        int     `gorm:"column:flag_id"`
 		ElementID     int     `gorm:"column:element_id"`
 		MatchedValue  string  `gorm:"column:matched_value"`
 		MatchedReason string  `gorm:"column:matched_reason"`
 		Similarity    float64 `gorm:"column:similarity"`
+		Overridden    bool    `gorm:"column:overridden"`
 	}
+	// LEFT JOIN на override: overridden=true, если по флагу подтверждён пропуск (срез 4).
 	if err := s.db.WithContext(ctx).Raw(`
-		SELECT element_id, matched_value, matched_reason, similarity
-		FROM application_blacklist_flags
-		WHERE element_type = ? AND element_id IN ?
-		ORDER BY id`, elementType, ids).Scan(&rows).Error; err != nil {
+		SELECT f.id AS flag_id, f.element_id, f.matched_value, f.matched_reason, f.similarity,
+		       (o.id IS NOT NULL) AS overridden
+		FROM application_blacklist_flags f
+		LEFT JOIN application_blacklist_overrides o ON o.flag_id = f.id
+		WHERE f.application_id = ? AND f.element_type = ? AND f.element_id IN ?
+		ORDER BY f.id`, applicationID, elementType, ids).Scan(&rows).Error; err != nil {
 		slog.Warn("fetch blacklist flags failed", "err", err, "element_type", elementType)
 		return out
 	}
 	for _, r := range rows {
 		out[r.ElementID] = &BlacklistFlagInfo{
+			FlagID:        r.FlagID,
 			MatchedValue:  r.MatchedValue,
 			MatchedReason: r.MatchedReason,
 			Similarity:    r.Similarity,
+			Overridden:    r.Overridden,
 		}
 	}
 	return out
@@ -183,7 +192,8 @@ func (s *applicationService) GetAttachmentCars(ctx context.Context, attachmentID
 	for _, car := range cars {
 		carIDs = append(carIDs, car.ID)
 	}
-	flags := s.fetchBlacklistFlags(ctx, models.BlacklistElementCar, carIDs)
+	appID, _ := s.GetApplicationIDByAttachment(ctx, attachmentID)
+	flags := s.fetchBlacklistFlags(ctx, models.BlacklistElementCar, appID, carIDs)
 
 	result := make([]CarWithPlaces, 0)
 	for _, car := range cars {
@@ -275,7 +285,8 @@ func (s *applicationService) GetAttachmentEmployees(ctx context.Context, attachm
 	for _, emp := range employees {
 		empIDs = append(empIDs, emp.ID)
 	}
-	flags := s.fetchBlacklistFlags(ctx, models.BlacklistElementEmployee, empIDs)
+	appID, _ := s.GetApplicationIDByAttachment(ctx, attachmentID)
+	flags := s.fetchBlacklistFlags(ctx, models.BlacklistElementEmployee, appID, empIDs)
 
 	result := make([]EmployeeWithTables, 0)
 	for _, emp := range employees {

--- a/internal/services/application_blacklist_override_service.go
+++ b/internal/services/application_blacklist_override_service.go
@@ -1,0 +1,101 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"systemburo/internal/models"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+// OverrideBlacklistFlagRequest - запрос "всё равно пропустить" по конкретному флагу (#481).
+type OverrideBlacklistFlagRequest struct {
+	FlagID  int    `json:"flag_id" validate:"gte=1"`
+	Comment string `json:"comment" validate:"required,min=1,max=1000"`
+}
+
+// OverrideBlacklistFlag фиксирует решение ответственного "всё равно пропустить" по
+// помеченному элементу заявки (#481, срез 4): пишет аудит-запись (кто/когда/коммент +
+// снимок совпавшего значения) и тем самым снимает блокировку согласования по этому флагу.
+// Только ответственный по заявке. Идемпотентно: повторный override того же флага не
+// плодит дубль (uniqueIndex на flag_id) и возвращает успех.
+func (s *applicationService) OverrideBlacklistFlag(ctx context.Context, username string, applicationID int, req OverrideBlacklistFlagRequest) error {
+	user, err := s.getUserByUsername(ctx, username)
+	if err != nil {
+		return err
+	}
+	comment := strings.TrimSpace(req.Comment)
+	if comment == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "Комментарий к пропуску обязателен")
+	}
+
+	// Подтвердить пропуск может только ответственный по заявке (как и голосовать).
+	var responsibleID int
+	if err := s.db.WithContext(ctx).Raw(
+		"SELECT id FROM application_responsible_users WHERE application_id = ? AND user_id = ?",
+		applicationID, user.ID,
+	).Scan(&responsibleID).Error; err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка проверки прав на заявку")
+	}
+	if responsibleID == 0 {
+		return echo.NewHTTPError(http.StatusForbidden, "Вы не ответственный по этой заявке")
+	}
+
+	// Флаг должен существовать и принадлежать этой заявке.
+	var flag models.ApplicationBlacklistFlag
+	err = s.db.WithContext(ctx).Where("id = ? AND application_id = ?", req.FlagID, applicationID).First(&flag).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "Предупреждение не найдено для этой заявки")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения предупреждения")
+	}
+
+	var existing int64
+	if err := s.db.WithContext(ctx).Model(&models.ApplicationBlacklistOverride{}).
+		Where("flag_id = ?", flag.ID).Count(&existing).Error; err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка проверки подтверждения пропуска")
+	}
+	if existing > 0 {
+		return nil // уже подтверждён - идемпотентно
+	}
+
+	override := models.ApplicationBlacklistOverride{
+		FlagID:             flag.ID,
+		ApplicationID:      flag.ApplicationID,
+		ElementType:        flag.ElementType,
+		ElementID:          flag.ElementID,
+		MatchedValue:       flag.MatchedValue,
+		OverriddenByUserID: user.ID,
+		Comment:            comment,
+		CreatedAt:          time.Now().UTC(),
+	}
+	if err := s.db.WithContext(ctx).Create(&override).Error; err != nil {
+		if isUniqueViolation(err) {
+			return nil // гонка двух параллельных override одного флага - не ошибка
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка сохранения подтверждения пропуска")
+	}
+	return nil
+}
+
+// hasUnoverriddenBlacklistFlags - есть ли у заявки помеченные элементы без override (#481).
+// Гейт согласования: пока true, голос "approved" запрещён. Принимает *gorm.DB, чтобы
+// вызываться и внутри транзакции согласования, и отдельно.
+func hasUnoverriddenBlacklistFlags(ctx context.Context, db *gorm.DB, applicationID int) (bool, error) {
+	var cnt int64
+	err := db.WithContext(ctx).
+		Table("application_blacklist_flags f").
+		Where("f.application_id = ?", applicationID).
+		Where("NOT EXISTS (SELECT 1 FROM application_blacklist_overrides o WHERE o.flag_id = f.id)").
+		Count(&cnt).Error
+	if err != nil {
+		return false, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка проверки предупреждений ЧС")
+	}
+	return cnt > 0, nil
+}

--- a/internal/services/application_service.go
+++ b/internal/services/application_service.go
@@ -56,6 +56,9 @@ type ApplicationService interface {
 
 	// ApproveApplicationByUser согласование/отказ заявки пользователем.
 	ApproveApplicationByUser(ctx context.Context, username string, applicationID int, req UserApprovalRequest) error
+	// OverrideBlacklistFlag фиксирует "всё равно пропустить" по помеченному элементу (#481),
+	// снимая блокировку согласования по этому флагу. Только ответственный, идемпотентно.
+	OverrideBlacklistFlag(ctx context.Context, username string, applicationID int, req OverrideBlacklistFlagRequest) error
 
 	// CheckApprovalStatus проверяет текущий статус согласования заявки.
 	CheckApprovalStatus(ctx context.Context, applicationID int) (*ApprovalStatusResponse, error)
@@ -421,11 +424,14 @@ type CarWithPlaces struct {
 }
 
 // BlacklistFlagInfo - данные per-element предупреждения о возможном обходе ЧС (#481)
-// для детали заявки: что в ЧС похоже, причина записи и степень близости [0..1].
+// для детали заявки: id флага (для override), что в ЧС похоже, причина, близость [0..1]
+// и подтверждён ли уже пропуск (override) - чтобы фронт показал статус и разблокировку.
 type BlacklistFlagInfo struct {
+	FlagID        int     `json:"flag_id"`
 	MatchedValue  string  `json:"matched_value"`
 	MatchedReason string  `json:"matched_reason"`
 	Similarity    float64 `json:"similarity"`
+	Overridden    bool    `json:"overridden"`
 }
 
 // UnloadPlaceRef ссылка на место разгрузки.
@@ -1419,6 +1425,19 @@ func (s *applicationService) UpdateApplication(ctx context.Context, username str
 	if req.Confirmation != nil {
 		if !allowedConfirmations[*req.Confirmation] {
 			return nil, echo.NewHTTPError(http.StatusBadRequest, "Invalid confirmation value")
+		}
+		// Гейт обхода ЧС (#481): прямое выставление "Согласовано" этим путём (минуя
+		// поэлементное голосование) тоже блокируем, пока есть помеченные элементы без
+		// override - иначе блокировку согласования из ApproveApplicationByUser легко обойти.
+		if *req.Confirmation == models.ConfirmationApproved {
+			blocked, err := hasUnoverriddenBlacklistFlags(ctx, s.db, applicationID)
+			if err != nil {
+				return nil, err
+			}
+			if blocked {
+				return nil, echo.NewHTTPError(http.StatusConflict,
+					"Заявка содержит элементы, похожие на чёрный список. Подтвердите пропуск каждого ('Всё равно пропустить') перед согласованием")
+			}
 		}
 		setClauses = append(setClauses, "confirmation = ?")
 		args = append(args, *req.Confirmation)

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -44,7 +44,7 @@ var tables = []string{
 	"bug_reports",
 	"request_log", "request_logs", "notifications", "news", "announcements",
 	"feedback", "application_items", "items",
-	"application_blacklist_flags",
+	"application_blacklist_overrides", "application_blacklist_flags",
 	"employee_target_tables", "employee_files", "application_employees", "employees_history", "employees",
 	"car_unload_places", "cars_history", "cars",
 	"vehicle_blacklist_histories", "vehicle_blacklists",


### PR DESCRIPTION
Срез 4 эпика #481. Поверх среза 3 (per-element флаги при сабмите).

## Что делает
Помеченную как возможный обход ЧС заявку нельзя согласовать ('approved'), пока ответственный не подтвердит пропуск ('Всё равно пропустить') по КАЖДОМУ помеченному элементу. Отказ ('rejected') не блокируется. Решение пишется в аудит-таблицу.

## Реализация
- Новая модель `ApplicationBlacklistOverride` (flag_id uniqueIndex - один override на флаг, без FK = неизменяемый аудит-снимок: кто/когда/коммент + matched_value).
- `OverrideBlacklistFlag` (сервис) + endpoint `POST /applications/:id/blacklist-overrides`: только ответственный по заявке, флаг должен принадлежать заявке, комментарий обязателен, идемпотентно.
- Гейт `hasUnoverriddenBlacklistFlags` в `ApproveApplicationByUser` (только при 'approved', внутри tx) И в `UpdateApplication` (прямой PUT confirmation=Согласовано) - чтобы блокировку нельзя было обойти вторым путём.
- Деталь заявки: `fetchBlacklistFlags` отдаёт `flag_id` + `overridden` (для фронта срезов 5/6), фильтр по application_id.
- `migrate.go`: 2 аддитивные строки AllModels. CleanDB: новая таблица в очистку.

## Проверка
- Тесты: блокировка до override -> 409; обход через PUT -> 409; override без коммента -> 400; override не-ответственным -> 403; override пишет аудит + разблокирует -> approve 200; overridden=true в детали; rejected не блокируется.
- Полный `./internal/...` зелёный в изоляции, регрессий нет.
- code-reviewer: поймал обход через UpdateApplication (RED-1) - исправлено; RED-3 (фильтр application_id) - добавлен как защита-в-глубину.

Следующий: срез 5 (фронт - подсветка помеченных элементов в ApplicationDetail).