### PR TITLE
feat(blacklist): подсветка помеченных элементов заявки в детали (#481)

### DIFF
--- a/frontend/src/components/ApplicationDetail/ApplicationAttachmentDetail.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationAttachmentDetail.vue
@@ -63,6 +63,7 @@
                 v-for="(car, index) in cars"
                 :key="car.id"
                 class="car-item"
+                :class="{ 'car-item--flagged': isFlagged(car) }"
                 @click="$emit('open-vehicle', car)"
               >
                 <div class="car-item-content">
@@ -82,6 +83,16 @@
                       {{ getTruncatedPlacesList(car.unload_places) }}
                     </span>
                   </div>
+                  <Badge
+                    v-if="blacklistFlag(car)"
+                    class="blacklist-badge"
+                    :variant="blacklistFlag(car).overridden ? 'neutral' : 'danger'"
+                    size="sm"
+                    dot
+                    :title="blacklistTooltip(blacklistFlag(car))"
+                  >
+                    {{ blacklistFlag(car).overridden ? 'пропуск подтверждён' : 'похоже на ЧС' }}
+                  </Badge>
                 </div>
               </div>
             </div>
@@ -115,6 +126,7 @@
                 v-for="(employee, index) in employees"
                 :key="employee.id"
                 class="employee-item"
+                :class="{ 'employee-item--flagged': isFlagged(employee) }"
                 @click="$emit('open-employee', employee)"
               >
                 <div class="employee-item-content">
@@ -134,6 +146,16 @@
                       {{ getTruncatedTablesList(employee.target_tables) }}
                     </span>
                   </div>
+                  <Badge
+                    v-if="blacklistFlag(employee)"
+                    class="blacklist-badge"
+                    :variant="blacklistFlag(employee).overridden ? 'neutral' : 'danger'"
+                    size="sm"
+                    dot
+                    :title="blacklistTooltip(blacklistFlag(employee))"
+                  >
+                    {{ blacklistFlag(employee).overridden ? 'пропуск подтверждён' : 'похоже на ЧС' }}
+                  </Badge>
                 </div>
               </div>
             </div>
@@ -191,8 +213,11 @@
 </template>
 
 <script>
+import Badge from '@/components/ui/Badge.vue'
+
 export default {
     name: 'ApplicationAttachmentDetail',
+    components: { Badge },
     props: {
         attachment: {
             type: Object,
@@ -217,6 +242,24 @@ export default {
     },
     emits: ['open-vehicle', 'open-employee'],
     methods: {
+        blacklistFlag(entity) {
+            return entity && entity.blacklist_similar ? entity.blacklist_similar : null;
+        },
+
+        isFlagged(entity) {
+            const flag = this.blacklistFlag(entity);
+            return !!flag && !flag.overridden;
+        },
+
+        blacklistTooltip(flag) {
+            if (!flag) return '';
+            const value = flag.matched_value || '';
+            const base = value
+                ? `Возможный обход чёрного списка. Похоже на: ${value}`
+                : 'Возможный обход чёрного списка.';
+            return flag.matched_reason ? `${base} (${flag.matched_reason})` : base;
+        },
+
         formatDate(date) {
             if (!date) return '';
             if (typeof date === 'string') {
@@ -473,6 +516,21 @@ export default {
 .car-item:hover, .employee-item:hover, .item-item:hover {
     border-color: #4F5BDF;
     background: #f8f9ff;
+}
+
+.car-item--flagged, .employee-item--flagged {
+    background: #fff5f5;
+    border-color: #fecaca;
+}
+
+.car-item--flagged:hover, .employee-item--flagged:hover {
+    border-color: #f87171;
+    background: #fee2e2;
+}
+
+.blacklist-badge {
+    flex-shrink: 0;
+    margin-left: auto;
 }
 
 .car-item-content, .employee-item-content, .item-item-content {

--- a/frontend/src/components/ApplicationDetail/ApplicationAttachmentDetail.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationAttachmentDetail.vue
@@ -86,12 +86,12 @@
                   <Badge
                     v-if="car.blacklist_similar"
                     class="blacklist-badge"
-                    :variant="car.blacklist_similar.overridden ? 'neutral' : 'danger'"
+                    :variant="blacklistVariant(car.blacklist_similar)"
                     size="sm"
                     dot
                     :title="blacklistTooltip(car.blacklist_similar)"
                   >
-                    {{ car.blacklist_similar.overridden ? 'пропуск подтверждён' : 'похоже на ЧС' }}
+                    {{ blacklistLabel(car.blacklist_similar) }}
                   </Badge>
                 </div>
               </div>
@@ -149,12 +149,12 @@
                   <Badge
                     v-if="employee.blacklist_similar"
                     class="blacklist-badge"
-                    :variant="employee.blacklist_similar.overridden ? 'neutral' : 'danger'"
+                    :variant="blacklistVariant(employee.blacklist_similar)"
                     size="sm"
                     dot
                     :title="blacklistTooltip(employee.blacklist_similar)"
                   >
-                    {{ employee.blacklist_similar.overridden ? 'пропуск подтверждён' : 'похоже на ЧС' }}
+                    {{ blacklistLabel(employee.blacklist_similar) }}
                   </Badge>
                 </div>
               </div>
@@ -245,6 +245,14 @@ export default {
         isFlagged(entity) {
             const flag = entity && entity.blacklist_similar;
             return !!flag && !flag.overridden;
+        },
+
+        blacklistVariant(flag) {
+            return flag.overridden ? 'neutral' : 'danger';
+        },
+
+        blacklistLabel(flag) {
+            return flag.overridden ? 'пропуск подтверждён' : 'похоже на ЧС';
         },
 
         blacklistTooltip(flag) {

--- a/frontend/src/components/ApplicationDetail/ApplicationAttachmentDetail.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationAttachmentDetail.vue
@@ -84,14 +84,14 @@
                     </span>
                   </div>
                   <Badge
-                    v-if="blacklistFlag(car)"
+                    v-if="car.blacklist_similar"
                     class="blacklist-badge"
-                    :variant="blacklistFlag(car).overridden ? 'neutral' : 'danger'"
+                    :variant="car.blacklist_similar.overridden ? 'neutral' : 'danger'"
                     size="sm"
                     dot
-                    :title="blacklistTooltip(blacklistFlag(car))"
+                    :title="blacklistTooltip(car.blacklist_similar)"
                   >
-                    {{ blacklistFlag(car).overridden ? 'пропуск подтверждён' : 'похоже на ЧС' }}
+                    {{ car.blacklist_similar.overridden ? 'пропуск подтверждён' : 'похоже на ЧС' }}
                   </Badge>
                 </div>
               </div>
@@ -147,14 +147,14 @@
                     </span>
                   </div>
                   <Badge
-                    v-if="blacklistFlag(employee)"
+                    v-if="employee.blacklist_similar"
                     class="blacklist-badge"
-                    :variant="blacklistFlag(employee).overridden ? 'neutral' : 'danger'"
+                    :variant="employee.blacklist_similar.overridden ? 'neutral' : 'danger'"
                     size="sm"
                     dot
-                    :title="blacklistTooltip(blacklistFlag(employee))"
+                    :title="blacklistTooltip(employee.blacklist_similar)"
                   >
-                    {{ blacklistFlag(employee).overridden ? 'пропуск подтверждён' : 'похоже на ЧС' }}
+                    {{ employee.blacklist_similar.overridden ? 'пропуск подтверждён' : 'похоже на ЧС' }}
                   </Badge>
                 </div>
               </div>
@@ -242,17 +242,12 @@ export default {
     },
     emits: ['open-vehicle', 'open-employee'],
     methods: {
-        blacklistFlag(entity) {
-            return entity && entity.blacklist_similar ? entity.blacklist_similar : null;
-        },
-
         isFlagged(entity) {
-            const flag = this.blacklistFlag(entity);
+            const flag = entity && entity.blacklist_similar;
             return !!flag && !flag.overridden;
         },
 
         blacklistTooltip(flag) {
-            if (!flag) return '';
             const value = flag.matched_value || '';
             const base = value
                 ? `Возможный обход чёрного списка. Похоже на: ${value}`

--- a/frontend/src/components/ApplicationDetail/__tests__/ApplicationAttachmentDetail.spec.js
+++ b/frontend/src/components/ApplicationDetail/__tests__/ApplicationAttachmentDetail.spec.js
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import ApplicationAttachmentDetail from '../ApplicationAttachmentDetail.vue';
+
+function car(over = {}) {
+  return {
+    id: 1,
+    car_number: 'А123ВС',
+    car_brand: 'Toyota',
+    unload_places: [],
+    ...over,
+  };
+}
+
+function employee(over = {}) {
+  return {
+    id: 1,
+    last_name: 'Иванов',
+    first_name: 'Иван',
+    middle_name: 'Иванович',
+    position: 'Водитель',
+    target_tables: [],
+    ...over,
+  };
+}
+
+function flag(over = {}) {
+  return {
+    flag_id: 10,
+    matched_value: 'А124ВС Toyota',
+    matched_reason: 'похожий номер',
+    similarity: 0.85,
+    overridden: false,
+    ...over,
+  };
+}
+
+function mountCars(cars) {
+  return mount(ApplicationAttachmentDetail, {
+    props: {
+      attachment: { id: 1, attachment_type: 'cars', attachment_display_name: 'Машины' },
+      cars,
+    },
+  });
+}
+
+function mountEmployees(employees) {
+  return mount(ApplicationAttachmentDetail, {
+    props: {
+      attachment: { id: 1, attachment_type: 'people', attachment_display_name: 'Люди' },
+      employees,
+    },
+  });
+}
+
+describe('ApplicationAttachmentDetail — подсветка возможного обхода ЧС (#481)', () => {
+  it('помеченная машина: красноватый модификатор + бейдж "похоже на ЧС"', () => {
+    const wrapper = mountCars([car({ blacklist_similar: flag() })]);
+    const item = wrapper.find('.car-item');
+    expect(item.classes()).toContain('car-item--flagged');
+
+    const badge = item.find('.blacklist-badge');
+    expect(badge.exists()).toBe(true);
+    expect(badge.text()).toBe('похоже на ЧС');
+    expect(badge.classes()).toContain('badge--danger');
+  });
+
+  it('чистая машина: нет модификатора и нет бейджа', () => {
+    const wrapper = mountCars([car()]);
+    const item = wrapper.find('.car-item');
+    expect(item.classes()).not.toContain('car-item--flagged');
+    expect(item.find('.blacklist-badge').exists()).toBe(false);
+  });
+
+  it('подтверждённый пропуск (overridden): без красной подсветки, нейтральный бейдж', () => {
+    const wrapper = mountCars([car({ blacklist_similar: flag({ overridden: true }) })]);
+    const item = wrapper.find('.car-item');
+    expect(item.classes()).not.toContain('car-item--flagged');
+
+    const badge = item.find('.blacklist-badge');
+    expect(badge.exists()).toBe(true);
+    expect(badge.text()).toBe('пропуск подтверждён');
+    expect(badge.classes()).toContain('badge--neutral');
+  });
+
+  it('tooltip содержит совпавшее значение и причину', () => {
+    const wrapper = mountCars([car({ blacklist_similar: flag() })]);
+    const badge = wrapper.find('.car-item .blacklist-badge');
+    expect(badge.attributes('title')).toBe('Возможный обход чёрного списка. Похоже на: А124ВС Toyota (похожий номер)');
+  });
+
+  it('помеченный сотрудник: красноватый модификатор + бейдж', () => {
+    const wrapper = mountEmployees([
+      employee({ blacklist_similar: flag({ matched_value: 'Иваноф Иван Иванович', matched_reason: 'опечатка в фамилии' }) }),
+    ]);
+    const item = wrapper.find('.employee-item');
+    expect(item.classes()).toContain('employee-item--flagged');
+
+    const badge = item.find('.blacklist-badge');
+    expect(badge.exists()).toBe(true);
+    expect(badge.text()).toBe('похоже на ЧС');
+    expect(badge.attributes('title')).toContain('Иваноф Иван Иванович');
+  });
+});


### PR DESCRIPTION
Срез 5 эпика #481 (мягкое предупреждение о возможном обходе ЧС).

## Что делает
В деталях вложения заявки (`ApplicationAttachmentDetail.vue`) элементы, которые бэкенд (срезы 1-4) пометил как похожие на активную запись чёрного списка (`blacklist_similar`), теперь видны оператору и согласующему:
- строка машины/сотрудника получает красноватый фон (`--flagged`);
- рядом бейдж "похоже на ЧС" (`Badge variant=danger`, reuse `components/ui/Badge.vue`) с tooltip про совпавшее ФИО/номер и причину;
- если пропуск уже подтверждён (`overridden`), фон не красный, бейдж нейтральный "пропуск подтверждён".

ТМЦ не флагаются - бэкенд ведёт нечёткий поиск только по машинам и людям, у `items` поля `blacklist_similar` не бывает.

## Проверка
- vitest: 5 сценариев (помечен/чист/overridden/tooltip/сотрудник) зелёные.
- Реальная форма ответа сверена с бэком: `BlacklistFlagInfo{flag_id, matched_value, matched_reason, similarity, overridden}` приходит на каждом car/employee, фронт читает напрямую (envelope разворачивается в client.js, double-wrap тут нет - `RespondSuccess` отдаёт массив).
- Визуальный рендер компонента - владельцу до мержа.

## По ревью (code-reviewer GO + /code-review high)
- Убраны повторные вызовы метода на рендере и дубль тернарников variant/label - вынесены в хелперы.
- Всплытие @click с бейджа на строку (открывает деталь сущности) оставлено осознанно: бейдж информационный, интерактивное действие "Всё равно пропустить" со stopPropagation - срез 6.
- Хардкод hex вместо токенов - сознательно: файл исторически без дизайн-токенов, новый код матчит окружение.
- Сырой `.json()` в `ApplicationDetail.vue:609` - вне скоупа (pre-existing, файл не трогался).