### PR TITLE
feat(approvers): бэкенд-история принимающих (#417)

### DIFF
--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -69,6 +69,7 @@ func AllModels() []interface{} {
 		&models.ApplicationStatusHistory{},
 		&models.ApplicationResponsibleUser{},
 		&models.ApplicationApprover{},
+		&models.ApplicationApproverHistory{},
 		&models.ApplicationViewer{},
 
 		// Unique records

--- a/internal/handlers/application_approvers.go
+++ b/internal/handlers/application_approvers.go
@@ -96,10 +96,28 @@ func (h *ApproverHandler) Delete(c echo.Context) error {
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
 	}
-	if err := h.service.Delete(c.Request().Context(), typeID, id); err != nil {
+	actorUsername, _ := c.Get("username").(string)
+	if err := h.service.Delete(c.Request().Context(), typeID, id, actorUsername); err != nil {
 		return err
 	}
 	return RespondSuccess(c, map[string]string{
 		"message": "Approver deleted successfully",
 	})
+}
+
+// GetHistory godoc
+// @Summary      Журнал принимающих заявки
+// @Description  Глобальный аудит-лог: кто и когда был добавлен или удалён из принимающих
+// @Tags         application-approvers
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200 {array} models.ApplicationApproverHistoryItem
+// @Failure      403 {object} models.HTTPError
+// @Router       /application-approvers/history [get]
+func (h *ApproverHandler) GetHistory(c echo.Context) error {
+	history, err := h.service.GetHistory(c.Request().Context())
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, history)
 }

--- a/internal/handlers/application_approvers_test.go
+++ b/internal/handlers/application_approvers_test.go
@@ -194,3 +194,146 @@ func TestApprovers_Create_RegularUserForbidden(t *testing.T) {
 	rec := testutil.POST(t, e, "/application-approvers", `{"user_id":1}`, testutil.AuthHeader(userToken))
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 }
+
+func TestApprovers_History_CreateWritesEntry(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	testutil.RegisterUser(t, e, "histuser", "password123", 1, td.OrgID, td.CompanyID)
+	adminToken := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	adminH := testutil.AuthHeader(adminToken)
+
+	rec := testutil.GET(t, e, "/application-approvers/available-users", adminH)
+	require.Equal(t, http.StatusOK, rec.Code)
+	available := testutil.ParseSlice(t, rec)
+
+	var targetUserID int
+	for _, u := range available {
+		if u["username"] == "histuser" {
+			targetUserID = int(u["id"].(float64))
+			break
+		}
+	}
+	require.Greater(t, targetUserID, 0)
+
+	body := fmt.Sprintf(`{"user_id":%d}`, targetUserID)
+	rec = testutil.POST(t, e, "/application-approvers", body, adminH)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	// История должна содержать запись created.
+	rec = testutil.GET(t, e, "/application-approvers/history", adminH)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	history := testutil.ParseSlice(t, rec)
+	require.Len(t, history, 1)
+	entry := history[0]
+	assert.Equal(t, "created", entry["action_type"])
+	assert.Equal(t, float64(targetUserID), entry["approver_user_id"])
+	assert.NotEmpty(t, entry["approver_name"])
+	// actor_user_id должен быть заполнен (admin создавал).
+	assert.NotNil(t, entry["actor_user_id"])
+}
+
+func TestApprovers_History_DeleteWritesEntry(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	testutil.RegisterUser(t, e, "delhistuser", "password123", 1, td.OrgID, td.CompanyID)
+	adminToken := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	adminH := testutil.AuthHeader(adminToken)
+
+	rec := testutil.GET(t, e, "/application-approvers/available-users", adminH)
+	require.Equal(t, http.StatusOK, rec.Code)
+	available := testutil.ParseSlice(t, rec)
+
+	var targetUserID int
+	for _, u := range available {
+		if u["username"] == "delhistuser" {
+			targetUserID = int(u["id"].(float64))
+			break
+		}
+	}
+	require.Greater(t, targetUserID, 0)
+
+	body := fmt.Sprintf(`{"user_id":%d}`, targetUserID)
+	rec = testutil.POST(t, e, "/application-approvers", body, adminH)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	rec = testutil.GET(t, e, "/application-approvers", adminH)
+	require.Equal(t, http.StatusOK, rec.Code)
+	approvers := testutil.ParseSlice(t, rec)
+	require.Len(t, approvers, 1)
+	approverID := int(approvers[0]["id"].(float64))
+
+	rec = testutil.DELETE(t, e, fmt.Sprintf("/application-approvers/%d", approverID), adminH)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// История: две записи (created + deleted), deleted — новее, стоит первой.
+	rec = testutil.GET(t, e, "/application-approvers/history", adminH)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	history := testutil.ParseSlice(t, rec)
+	require.GreaterOrEqual(t, len(history), 2)
+
+	// Первая запись — deleted (новее).
+	assert.Equal(t, "deleted", history[0]["action_type"])
+	assert.Equal(t, float64(targetUserID), history[0]["approver_user_id"])
+	// Снимок имени не пустой.
+	assert.NotEmpty(t, history[0]["approver_name"])
+	// actor заполнен.
+	assert.NotNil(t, history[0]["actor_user_id"])
+}
+
+func TestApprovers_History_OrderNewestFirst(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	testutil.RegisterUser(t, e, "orduser1", "password123", 1, td.OrgID, td.CompanyID)
+	testutil.RegisterUser(t, e, "orduser2", "password123", 1, td.OrgID, td.CompanyID)
+	adminToken := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	adminH := testutil.AuthHeader(adminToken)
+
+	rec := testutil.GET(t, e, "/application-approvers/available-users", adminH)
+	require.Equal(t, http.StatusOK, rec.Code)
+	available := testutil.ParseSlice(t, rec)
+
+	var uid1, uid2 int
+	for _, u := range available {
+		switch u["username"] {
+		case "orduser1":
+			uid1 = int(u["id"].(float64))
+		case "orduser2":
+			uid2 = int(u["id"].(float64))
+		}
+	}
+	require.Greater(t, uid1, 0)
+	require.Greater(t, uid2, 0)
+
+	rec = testutil.POST(t, e, "/application-approvers", fmt.Sprintf(`{"user_id":%d}`, uid1), adminH)
+	require.Equal(t, http.StatusCreated, rec.Code)
+	rec = testutil.POST(t, e, "/application-approvers", fmt.Sprintf(`{"user_id":%d}`, uid2), adminH)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	rec = testutil.GET(t, e, "/application-approvers/history", adminH)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	history := testutil.ParseSlice(t, rec)
+	require.Len(t, history, 2)
+
+	// Новые сверху: uid2 добавлен последним -> стоит первым в журнале.
+	assert.Equal(t, float64(uid2), history[0]["approver_user_id"])
+	assert.Equal(t, float64(uid1), history[1]["approver_user_id"])
+
+	// Оба — created, актор заполнен, actor_name не пустой.
+	for _, h := range history {
+		assert.Equal(t, "created", h["action_type"])
+		assert.NotNil(t, h["actor_user_id"])
+		assert.NotEmpty(t, h["actor_name"])
+	}
+}

--- a/internal/models/application_approver_history.go
+++ b/internal/models/application_approver_history.go
@@ -1,0 +1,32 @@
+package models
+
+import "time"
+
+// ApplicationApproverHistory — аудит-лог добавления и удаления принимающих заявки (#417).
+// История глобальная (не per-approver): принимающие hard-delete, поэтому нужен снимок имени.
+// FK (ApproverUserID) намеренно без constraint: аудит переживает удаление пользователя.
+type ApplicationApproverHistory struct {
+	ID             int       `json:"id"`
+	ApproverUserID int       `gorm:"index;not null" json:"approver_user_id"`
+	ApproverName   string    `gorm:"size:255" json:"approver_name"`
+	ActorUserID    *int      `gorm:"index" json:"actor_user_id,omitempty"`
+	ActionType     string    `gorm:"size:32;index" json:"action_type"`
+	CreatedAt      time.Time `json:"created_at"`
+}
+
+// Константы ActionType для ApplicationApproverHistory.
+const (
+	ApproverActionCreated = "created"
+	ApproverActionDeleted = "deleted"
+)
+
+// ApplicationApproverHistoryItem — запись аудита с именем актора для API (LEFT JOIN users).
+type ApplicationApproverHistoryItem struct {
+	ID             int       `json:"id"`
+	ApproverUserID int       `json:"approver_user_id"`
+	ApproverName   string    `json:"approver_name"`
+	ActionType     string    `json:"action_type"`
+	ActorUserID    *int      `json:"actor_user_id,omitempty"`
+	ActorName      string    `json:"actor_name"`
+	CreatedAt      time.Time `json:"created_at"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -438,6 +438,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	aag := protected.Group("/application-approvers")
 	aag.GET("", approvers.GetAll)
 	aag.GET("/available-users", approvers.GetAvailableUsers)
+	aag.GET("/history", approvers.GetHistory)
 	aag.POST("", approvers.Create)
 	aag.DELETE("/:id", approvers.Delete)
 

--- a/internal/services/approver_history_service.go
+++ b/internal/services/approver_history_service.go
@@ -1,0 +1,79 @@
+package services
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"systemburo/internal/models"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+// ApproverHistoryService — аудит действий над принимающими заявки (#417).
+type ApproverHistoryService interface {
+	// Log пишет запись аудита. Ошибка не возвращается: аудит не ломает основное действие.
+	Log(ctx context.Context, approverUserID int, approverName string, actorUserID *int, actionType string)
+	// GetAll возвращает глобальный журнал принимающих (новые сверху).
+	GetAll(ctx context.Context) ([]models.ApplicationApproverHistoryItem, error)
+}
+
+type approverHistoryService struct {
+	db *gorm.DB
+}
+
+// NewApproverHistoryService создаёт реализацию ApproverHistoryService.
+func NewApproverHistoryService(db *gorm.DB) ApproverHistoryService {
+	return &approverHistoryService{db: db}
+}
+
+func (s *approverHistoryService) Log(ctx context.Context, approverUserID int, approverName string, actorUserID *int, actionType string) {
+	entry := models.ApplicationApproverHistory{
+		ApproverUserID: approverUserID,
+		ApproverName:   approverName,
+		ActorUserID:    actorUserID,
+		ActionType:     actionType,
+	}
+	if err := s.db.WithContext(ctx).Create(&entry).Error; err != nil {
+		slog.Error("approver_history: insert", "approver_user_id", approverUserID, "action", actionType, "error", err)
+	}
+}
+
+func (s *approverHistoryService) GetAll(ctx context.Context) ([]models.ApplicationApproverHistoryItem, error) {
+	type row struct {
+		ID             int       `gorm:"column:id"`
+		ApproverUserID int       `gorm:"column:approver_user_id"`
+		ApproverName   string    `gorm:"column:approver_name"`
+		ActionType     string    `gorm:"column:action_type"`
+		ActorUserID    *int      `gorm:"column:actor_user_id"`
+		ActorName      string    `gorm:"column:actor_name"`
+		CreatedAt      time.Time `gorm:"column:created_at"`
+	}
+	var rows []row
+	if err := s.db.WithContext(ctx).
+		Table("application_approver_histories AS h").
+		Select(`h.id, h.approver_user_id, h.approver_name, h.action_type, h.actor_user_id,
+			COALESCE(NULLIF(TRIM(BOTH ' ' FROM CONCAT_WS(' ', u.last_name, u.first_name)), ''), u.username, '') AS actor_name,
+			h.created_at`).
+		Joins("LEFT JOIN users u ON u.id = h.actor_user_id").
+		Order("h.created_at DESC, h.id DESC").
+		Scan(&rows).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching approver history")
+	}
+
+	items := make([]models.ApplicationApproverHistoryItem, 0, len(rows))
+	for _, r := range rows {
+		items = append(items, models.ApplicationApproverHistoryItem{
+			ID:             r.ID,
+			ApproverUserID: r.ApproverUserID,
+			ApproverName:   r.ApproverName,
+			ActionType:     r.ActionType,
+			ActorUserID:    r.ActorUserID,
+			ActorName:      r.ActorName,
+			CreatedAt:      r.CreatedAt,
+		})
+	}
+	return items, nil
+}

--- a/internal/services/approver_service.go
+++ b/internal/services/approver_service.go
@@ -15,16 +15,18 @@ type ApproverService interface {
 	GetAll(ctx context.Context, typeID int) ([]models.ApplicationApproverWithUser, error)
 	GetAvailableUsers(ctx context.Context, typeID int) ([]models.AvailableApproverUser, error)
 	Create(ctx context.Context, typeID int, userID int, createdByUsername string) error
-	Delete(ctx context.Context, typeID int, id int) error
+	Delete(ctx context.Context, typeID int, id int, actorUsername string) error
+	GetHistory(ctx context.Context) ([]models.ApplicationApproverHistoryItem, error)
 }
 
 type approverService struct {
-	db *gorm.DB
+	db      *gorm.DB
+	history ApproverHistoryService
 }
 
 // NewApproverService создаёт сервис для управления утверждающими заявок.
 func NewApproverService(db *gorm.DB) ApproverService {
-	return &approverService{db: db}
+	return &approverService{db: db, history: NewApproverHistoryService(db)}
 }
 
 func (s *approverService) checkAdmin(ctx context.Context, typeID int) error {
@@ -118,14 +120,34 @@ func (s *approverService) Create(ctx context.Context, typeID int, userID int, cr
 	if err := s.db.WithContext(ctx).Create(&approver).Error; err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "Error creating approver")
 	}
+
+	// Снимок имени добавляемого принимающего для аудита.
+	approverName := s.resolveUserName(ctx, userID)
+	s.history.Log(ctx, userID, approverName, &createdByID, models.ApproverActionCreated)
 	return nil
 }
 
 // Delete удаляет утверждающего по ID.
-func (s *approverService) Delete(ctx context.Context, typeID int, id int) error {
+func (s *approverService) Delete(ctx context.Context, typeID int, id int, actorUsername string) error {
 	if err := s.checkAdmin(ctx, typeID); err != nil {
 		return err
 	}
+
+	// Снимок до удаления: берём user_id и имя принимающего.
+	type approverRow struct {
+		UserID int
+		Name   string
+	}
+	var snap approverRow
+	snapErr := s.db.WithContext(ctx).
+		Table("application_approvers aa").
+		Select(`aa.user_id,
+			COALESCE(NULLIF(TRIM(BOTH ' ' FROM CONCAT_WS(' ', u.last_name, u.first_name, u.middle_name)), ''), u.username, '') AS name`).
+		Joins("JOIN users u ON u.id = aa.user_id").
+		Where("aa.id = ?", id).
+		Row().
+		Scan(&snap.UserID, &snap.Name)
+	// snapErr не роняет удаление — аудит best-effort.
 
 	result := s.db.WithContext(ctx).Delete(&models.ApplicationApprover{}, id)
 	if result.Error != nil {
@@ -134,5 +156,32 @@ func (s *approverService) Delete(ctx context.Context, typeID int, id int) error 
 	if result.RowsAffected == 0 {
 		return echo.NewHTTPError(http.StatusNotFound, "Approver not found")
 	}
+
+	if snapErr == nil && snap.UserID > 0 {
+		var actorID *int
+		var aid int
+		if err := s.db.WithContext(ctx).Table("users").Select("id").Where("username = ?", actorUsername).Row().Scan(&aid); err == nil {
+			actorID = &aid
+		}
+		s.history.Log(ctx, snap.UserID, snap.Name, actorID, models.ApproverActionDeleted)
+	}
 	return nil
+}
+
+// GetHistory возвращает глобальный журнал принимающих (новые сверху).
+func (s *approverService) GetHistory(ctx context.Context) ([]models.ApplicationApproverHistoryItem, error) {
+	return s.history.GetAll(ctx)
+}
+
+// resolveUserName возвращает форматированное имя пользователя по ID
+// (фамилия имя отчество или username как фолбэк).
+func (s *approverService) resolveUserName(ctx context.Context, userID int) string {
+	var name string
+	_ = s.db.WithContext(ctx).
+		Table("users").
+		Select(`COALESCE(NULLIF(TRIM(BOTH ' ' FROM CONCAT_WS(' ', last_name, first_name, middle_name)), ''), username, '')`).
+		Where("id = ?", userID).
+		Row().
+		Scan(&name)
+	return name
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -52,7 +52,7 @@ var tables = []string{
 	"attachments",
 	"unique_employees_history", "unique_cars_history",
 	"unique_employees", "unique_cars", "unique_attachment_histories", "unique_attachments",
-	"application_reads", "application_viewers", "application_approvers", "application_responsible_users",
+	"application_reads", "application_viewers", "application_approver_histories", "application_approvers", "application_responsible_users",
 	"application_status_history", "application_history", "applications",
 	"companies_unload_places", "organization_unload_places",
 	"unload_place_histories",


### PR DESCRIPTION
Срез 417-2 эпика #406: глобальный аудит-лог «Принимающих заявки».

## Что сделано
- Модель `ApplicationApproverHistory` (глобальный лог, без FK-constraint - аудит переживает удаление) + `ApplicationApproverHistoryItem` для API.
- Сервис `ApproverHistoryService` (Log best-effort + GetAll: LEFT JOIN users для actor_name, ORDER created_at DESC, id DESC).
- `approverService` владеет под-сервисом истории (как citizenship): `Create` логирует created (актор=createdBy, снимок имени), `Delete` снимает user_id+имя ДО удаления и логирует deleted после успешного delete (актор из username, best-effort - аудит не роняет действие).
- Эндпоинт `GET /application-approvers/history` (глобальный, без :id - принимающие плоский список).
- AutoMigrate(ApplicationApproverHistory) - одна аддитивная строка в migrate.go (OK владельца получен).

## Решения
- История ГЛОБАЛЬНАЯ (не per-id): hard-delete, запись пропадает -> снимок имени в логе, запрос как blacklist GetAllHistory.
- actor_name = last+first (2 поля) - паритет со всеми *HistoryItem (citizenship и пр.); approver_name снимок = last+first+middle.

## Ревью (code-reviewer GO)
RED нет. Применён Y2 (усилил тест порядка: assert history[0]==uid2 + тай-брейк id DESC от флака при равном created_at). Y1 (middle_name в actor_name) - осознанно НЕ меняю: actor_name единообразен во всех модалках истории по эталону. Я сам поймал и убрал fmt.Errorf-обёртку echo.HTTPError (ломала бы рендер статуса Echo).

## Проверено
- Скоуплено в контейнере (бережём RAM хоста): `go test ./internal/handlers/... -run Approver` зелёные (CRUD + 3 history-теста created/deleted/order), gofmt + go vet чисто. Полный сьют - в CI.
- Pure-BE промежуточный срез: ship-check не требуется (по правилам эпика - CI достаточно).

## Дальше
417-3 - FE история-модалка ApplicationApproverHistoryModal + кнопка История (depends on этого PR).