### PR TITLE
feat(approvers): модалка истории принимающих + кнопка История в шапке (#417)

### DIFF
--- a/frontend/src/api/__tests__/approvers.spec.js
+++ b/frontend/src/api/__tests__/approvers.spec.js
@@ -9,6 +9,7 @@ import {
   getAllUsers,
   addApprover,
   deleteApprover,
+  getApproverHistory,
 } from '../approvers'
 
 function okJson(payload) {
@@ -75,6 +76,21 @@ describe('api/approvers', () => {
     it('бросает при ошибке удаления', async () => {
       apiRequest.mockResolvedValue(errJson('Принимающий не найден', 404))
       await expect(deleteApprover(3)).rejects.toThrow('Принимающий не найден')
+    })
+  })
+
+  describe('getApproverHistory', () => {
+    it('GET /application-approvers/history (глобальный, без id) возвращает массив', async () => {
+      const log = [{ id: 1, approver_user_id: 5, action_type: 'created' }]
+      apiRequest.mockResolvedValue(okJson(log))
+      const data = await getApproverHistory()
+      expect(apiRequest).toHaveBeenCalledWith('/application-approvers/history')
+      expect(data).toEqual(log)
+    })
+
+    it('бросает при ошибке загрузки', async () => {
+      apiRequest.mockResolvedValue(errJson('Нет доступа', 403))
+      await expect(getApproverHistory()).rejects.toThrow('Нет доступа')
     })
   })
 })

--- a/frontend/src/api/approvers.js
+++ b/frontend/src/api/approvers.js
@@ -34,3 +34,12 @@ export async function deleteApprover(id) {
   const res = await apiRequest(`/application-approvers/${id}`, { method: 'DELETE' });
   return unwrap(res, 'Не удалось удалить принимающего');
 }
+
+/**
+ * Глобальный аудит-лог принимающих (без :id - принимающие hard-delete,
+ * история хранит снимок имени). Записи отсортированы новыми сверху.
+ */
+export async function getApproverHistory() {
+  const res = await apiRequest('/application-approvers/history');
+  return unwrap(res, 'Не удалось загрузить историю принимающих');
+}

--- a/frontend/src/components/ApplicationApproverHistoryModal.vue
+++ b/frontend/src/components/ApplicationApproverHistoryModal.vue
@@ -1,0 +1,936 @@
+<template>
+  <Teleport to="body">
+    <transition
+      name="modal-fade"
+      @after-leave="onAfterLeave"
+    >
+      <div
+        v-if="visible"
+        class="modal-overlay"
+        data-testid="approver-history-modal"
+        @mousedown="onOverlayMousedown"
+        @mouseup="onOverlayMouseup"
+      >
+        <div
+          class="approver-history-modal"
+          @mousedown.stop
+        >
+          <div class="modal-header">
+            <h3>История принимающих заявки</h3>
+            <div class="header-actions">
+              <button
+                class="export-btn"
+                :disabled="filteredHistory.length === 0 || isExporting"
+                @click="exportToExcel"
+              >
+                <img
+                  v-if="!isExporting"
+                  src="@/assets/icons/export.png"
+                  class="export-icon"
+                >
+                <span v-if="!isExporting">Экспорт</span>
+                <div
+                  v-else
+                  class="export-loader"
+                />
+              </button>
+              <button
+                class="close-btn"
+                aria-label="Закрыть"
+                @click="requestClose"
+              >
+                ×
+              </button>
+            </div>
+          </div>
+
+          <div class="history-filters">
+            <div class="filter-row">
+              <div class="search-filter">
+                <span class="filter-label">Поиск:</span>
+                <input
+                  v-model="searchQuery"
+                  type="text"
+                  class="search-input"
+                  placeholder="Поиск по пользователю, принимающему..."
+                >
+              </div>
+
+              <div class="user-filter">
+                <span class="filter-label">Пользователь:</span>
+                <!-- Кастомный select, не BaseDropdown: повторяет фильтр-строку эталона
+                     SystemTableHistoryModal (32px-контролы поиск/период/сортировка в ряд). -->
+                <div
+                  ref="userSelect"
+                  class="custom-select"
+                  @click="toggleUserDropdown"
+                >
+                  <div class="select-trigger">
+                    <span class="selected-value">{{ selectedUserName }}</span>
+                    <img
+                      src="@/assets/icons/arrow.png"
+                      class="select-arrow"
+                      :class="{ 'arrow-open': userDropdownOpen }"
+                    >
+                  </div>
+                  <transition name="fade">
+                    <div
+                      v-if="userDropdownOpen"
+                      class="select-dropdown"
+                    >
+                      <div
+                        class="select-option"
+                        :class="{ 'selected': selectedUserId === null }"
+                        @click.stop="selectUser(null)"
+                      >
+                        Все пользователи
+                      </div>
+                      <div
+                        v-for="user in uniqueUsers"
+                        :key="user.id"
+                        class="select-option"
+                        :class="{ 'selected': selectedUserId === user.id }"
+                        @click.stop="selectUser(user.id)"
+                      >
+                        {{ user.name }}
+                      </div>
+                    </div>
+                  </transition>
+                </div>
+              </div>
+
+              <div class="date-filter">
+                <span class="filter-label">Период:</span>
+                <input
+                  v-model="dateFrom"
+                  type="date"
+                  class="date-input"
+                >
+                <span class="date-separator">-</span>
+                <input
+                  v-model="dateTo"
+                  type="date"
+                  class="date-input"
+                >
+              </div>
+
+              <div class="sort-filter">
+                <span class="filter-label">Сортировка:</span>
+                <button
+                  class="sort-btn"
+                  @click="toggleSortOrder"
+                >
+                  <img
+                    src="@/assets/icons/sort.png"
+                    class="sort-icon"
+                    :class="{ 'sort-asc': sortOrder === 'asc' }"
+                  >
+                  <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <div class="modal-content">
+            <div
+              v-if="loading"
+              class="history-loading"
+            >
+              <LoaderSpinner label="Загрузка истории..." />
+            </div>
+
+            <div
+              v-else-if="filteredHistory.length === 0"
+              class="history-empty"
+            >
+              История пуста
+            </div>
+
+            <div
+              v-else
+              class="history-timeline"
+            >
+              <div
+                v-for="(item, index) in filteredHistory"
+                :key="item.id"
+                class="history-item"
+              >
+                <div
+                  class="timeline-dot"
+                  :class="getActionClass(item.action_type)"
+                />
+                <div
+                  v-if="index < filteredHistory.length - 1"
+                  class="timeline-line"
+                />
+
+                <div class="history-content">
+                  <div class="history-header">
+                    <span class="user-name">{{ item.actor_name || 'Система' }}</span>
+                    <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                  </div>
+
+                  <div class="action-text">
+                    {{ getActionText(item) }}
+                  </div>
+
+                  <div
+                    v-if="item.approver_name"
+                    class="action-comment"
+                  >
+                    Принимающий: {{ item.approver_name }}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </transition>
+  </Teleport>
+</template>
+
+<script>
+import { ref } from 'vue';
+import { getApproverHistory } from '@/api/approvers';
+import { useDeletionsStore } from '@/stores/deletions';
+import { useOverlayClose } from '@/composables/useOverlayClose';
+import LoaderSpinner from './ui/LoaderSpinner.vue';
+import ExcelJS from 'exceljs';
+
+const ACTION_TEXTS = {
+  created: 'Добавлен принимающий',
+  deleted: 'Удалён принимающий',
+};
+
+const ACTION_DOT_CLASS = {
+  created: 'dot-create',
+  deleted: 'dot-deactivate',
+};
+
+export default {
+  name: 'ApplicationApproverHistoryModal',
+  components: { LoaderSpinner },
+  props: {
+    currentUserName: { type: String, default: '' },
+  },
+  emits: ['close'],
+  setup(_, { emit }) {
+    // Анимация закрытия: показ управляем внутренним visible (enter по mounted,
+    // leave по requestClose); emit('close') шлём только ПОСЛЕ leave-перехода
+    // (@after-leave), иначе родитель размонтирует мгновенно и анимация не проиграется.
+    const visible = ref(false);
+    const requestClose = () => { visible.value = false; };
+    const onAfterLeave = () => emit('close');
+    const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(requestClose);
+    return { visible, requestClose, onAfterLeave, onOverlayMousedown, onOverlayMouseup };
+  },
+  data() {
+    return {
+      loading: false,
+      history: [],
+      sortOrder: 'desc',
+      searchQuery: '',
+      selectedUserId: null,
+      dateFrom: '',
+      dateTo: '',
+      userDropdownOpen: false,
+      isExporting: false,
+    };
+  },
+  computed: {
+    uniqueUsers() {
+      // Акторы (кто назначил/снял), не принимающие - фильтр по тому, кто отображён в шапке записи.
+      const users = new Map();
+      this.history.forEach((item) => {
+        if (item.actor_user_id && !users.has(item.actor_user_id)) {
+          users.set(item.actor_user_id, {
+            id: item.actor_user_id,
+            name: item.actor_name || 'Система',
+          });
+        }
+      });
+      return Array.from(users.values()).sort((a, b) => a.name.localeCompare(b.name));
+    },
+
+    selectedUserName() {
+      if (this.selectedUserId === null) return 'Все пользователи';
+      const user = this.uniqueUsers.find((u) => u.id === this.selectedUserId);
+      return user ? user.name : 'Все пользователи';
+    },
+
+    filteredHistory() {
+      let filtered = [...this.history];
+
+      if (this.searchQuery && this.searchQuery.trim() !== '') {
+        const query = this.searchQuery.toLowerCase().trim();
+        filtered = filtered.filter((item) => {
+          const actorName = (item.actor_name || '').toLowerCase();
+          const approverName = (item.approver_name || '').toLowerCase();
+          const actionText = this.getActionText(item).toLowerCase();
+          return actorName.includes(query)
+            || approverName.includes(query)
+            || actionText.includes(query);
+        });
+      }
+
+      if (this.selectedUserId) {
+        filtered = filtered.filter((item) => item.actor_user_id === this.selectedUserId);
+      }
+
+      if (this.dateFrom) {
+        const fromDate = new Date(this.dateFrom);
+        fromDate.setHours(0, 0, 0, 0);
+        filtered = filtered.filter((item) => new Date(item.created_at) >= fromDate);
+      }
+
+      if (this.dateTo) {
+        const toDate = new Date(this.dateTo);
+        toDate.setHours(23, 59, 59, 999);
+        filtered = filtered.filter((item) => new Date(item.created_at) <= toDate);
+      }
+
+      return filtered.sort((a, b) => {
+        const timeA = new Date(a.created_at).getTime();
+        const timeB = new Date(b.created_at).getTime();
+        return this.sortOrder === 'desc' ? timeB - timeA : timeA - timeB;
+      });
+    },
+
+    formattedCurrentDateTime() {
+      const now = new Date();
+      return now.toLocaleString('ru-RU', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+      }).replace(',', '');
+    },
+
+    currentUserDisplayName() {
+      if (!this.currentUserName) return 'Пользователь';
+      const parts = this.currentUserName.split(' ').filter((p) => p && p !== 'null' && p !== 'undefined');
+      return parts.length > 0 ? parts.join(' ') : 'Пользователь';
+    },
+
+    exportData() {
+      return this.filteredHistory.map((item) => ({
+        'Дата и время': this.formatDateTime(item.created_at),
+        'Пользователь': item.actor_name || 'Система',
+        'Действие': this.getActionText(item),
+        'Принимающий': item.approver_name || '',
+        'Тип действия': item.action_type,
+        'ID записи': item.id,
+      }));
+    },
+  },
+  mounted() {
+    this.visible = true;
+    this.loadHistory();
+    document.addEventListener('click', this.handleClickOutside);
+    document.addEventListener('keydown', this.onKeydown);
+  },
+  beforeUnmount() {
+    document.removeEventListener('click', this.handleClickOutside);
+    document.removeEventListener('keydown', this.onKeydown);
+  },
+  methods: {
+    onKeydown(e) {
+      if (e.key === 'Escape') this.requestClose();
+    },
+    handleClickOutside(event) {
+      // ref, не this.$el.querySelector: при <Teleport> $el - это якорный комментарий
+      // без querySelector, и дропдаун фильтра не закрывался бы по клику снаружи.
+      const select = this.$refs.userSelect;
+      if (select && !select.contains(event.target)) {
+        this.userDropdownOpen = false;
+      }
+    },
+
+    async loadHistory() {
+      this.loading = true;
+      try {
+        const data = await getApproverHistory();
+        this.history = Array.isArray(data) ? data : [];
+      } catch (error) {
+        console.error('Error loading approver history:', error);
+        useDeletionsStore().notify({ prefix: 'Не удалось загрузить ', bold: 'историю принимающих', type: 'error' });
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    getActionClass(actionType) {
+      return ACTION_DOT_CLASS[actionType] || 'dot-default';
+    },
+
+    getActionText(item) {
+      return ACTION_TEXTS[item.action_type] || item.action_type;
+    },
+
+    formatDateTime(s) {
+      if (!s) return '';
+      const d = new Date(s);
+      return d.toLocaleString('ru-RU', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+      }).replace(',', '');
+    },
+
+    toggleSortOrder() {
+      this.sortOrder = this.sortOrder === 'desc' ? 'asc' : 'desc';
+    },
+
+    toggleUserDropdown() {
+      this.userDropdownOpen = !this.userDropdownOpen;
+    },
+
+    selectUser(userId) {
+      this.selectedUserId = userId;
+      this.userDropdownOpen = false;
+    },
+
+    async exportToExcel() {
+      if (this.filteredHistory.length === 0) return;
+      this.isExporting = true;
+      try {
+        const workbook = new ExcelJS.Workbook();
+        const worksheet = workbook.addWorksheet('Istoriya_prinimayushchih');
+
+        const headers = ['Дата и время', 'Пользователь', 'Действие', 'Принимающий', 'Тип действия', 'ID записи'];
+        const headerRow = worksheet.addRow(headers);
+        headerRow.height = 25;
+        headerRow.eachCell((cell) => {
+          cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FF4F5BDF' } };
+          cell.font = { name: 'Verdana', size: 11, bold: true, color: { argb: 'FFFFFFFF' } };
+          cell.alignment = { vertical: 'middle', horizontal: 'center' };
+          cell.border = {
+            top: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+            bottom: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+            left: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+            right: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+          };
+        });
+
+        this.exportData.forEach((item, index) => {
+          const row = worksheet.addRow([
+            item['Дата и время'],
+            item['Пользователь'],
+            item['Действие'],
+            item['Принимающий'],
+            item['Тип действия'],
+            item['ID записи'],
+          ]);
+          row.height = 20;
+          const fillColor = index % 2 === 0 ? 'FFF0F5FF' : 'FFE0E9FF';
+          row.eachCell((cell) => {
+            cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: fillColor } };
+            cell.font = { name: 'Verdana', size: 9, color: { argb: 'FF333333' } };
+            cell.alignment = { vertical: 'middle', wrapText: true };
+            cell.border = {
+              top: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+              bottom: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+              left: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+              right: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+            };
+          });
+        });
+
+        const lastDataRow = this.exportData.length;
+        const cols = headers.length;
+        for (let row = 1; row <= lastDataRow + 1; row++) {
+          const rightCell = worksheet.getCell(row, cols);
+          rightCell.border = { ...rightCell.border, right: { style: 'medium', color: { argb: 'FF000000' } } };
+          const leftCell = worksheet.getCell(row, 1);
+          leftCell.border = { ...leftCell.border, left: { style: 'medium', color: { argb: 'FF000000' } } };
+        }
+        for (let col = 1; col <= cols; col++) {
+          const topCell = worksheet.getCell(1, col);
+          topCell.border = { ...topCell.border, top: { style: 'medium', color: { argb: 'FF000000' } } };
+          const bottomCell = worksheet.getCell(lastDataRow + 1, col);
+          bottomCell.border = { ...bottomCell.border, bottom: { style: 'medium', color: { argb: 'FF000000' } } };
+        }
+
+        worksheet.addRow([]);
+        const infoRow1 = worksheet.addRow(['Отчёт сформировал:', this.currentUserDisplayName]);
+        const infoRow2 = worksheet.addRow(['Дата формирования:', this.formattedCurrentDateTime]);
+        [infoRow1, infoRow2].forEach((row) => {
+          row.eachCell((cell) => {
+            cell.font = { name: 'Verdana', size: 10, color: { argb: 'FF333333' } };
+            cell.alignment = { vertical: 'middle' };
+            cell.border = {
+              top: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+              bottom: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+              left: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+              right: { style: 'thin', color: { argb: 'FFE6E6E6' } },
+            };
+          });
+        });
+
+        worksheet.columns = [
+          { width: 22 },
+          { width: 30 },
+          { width: 26 },
+          { width: 30 },
+          { width: 16 },
+          { width: 12 },
+        ];
+
+        const buffer = await workbook.xlsx.writeBuffer();
+        const blob = new Blob([buffer], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.download = `Istoriya_prinimayushchih_${this.formattedCurrentDateTime.replace(/[.:,]/g, '-')}.xlsx`;
+        a.href = url;
+        a.click();
+        window.URL.revokeObjectURL(url);
+      } catch (error) {
+        console.error('Error exporting approver history to Excel:', error);
+        useDeletionsStore().notify({ prefix: 'Не удалось ', bold: 'выгрузить историю', type: 'error' });
+      } finally {
+        this.isExporting = false;
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 12000;
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
+}
+
+/* Анимация открытия/закрытия (паттерн BaseModal): overlay fade + контент scale */
+.modal-fade-enter-active {
+  transition: opacity 0.25s ease;
+}
+
+.modal-fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+  opacity: 0;
+}
+
+.modal-fade-enter-active .approver-history-modal {
+  animation: modal-scale-in 0.25s ease;
+}
+
+.modal-fade-leave-active .approver-history-modal {
+  animation: modal-scale-out 0.2s ease;
+}
+
+@keyframes modal-scale-in {
+  from { transform: scale(0.95); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
+}
+
+@keyframes modal-scale-out {
+  from { transform: scale(1); opacity: 1; }
+  to { transform: scale(0.95); opacity: 0; }
+}
+
+.approver-history-modal {
+  background: white;
+  border-radius: 30px;
+  width: 900px;
+  max-width: 95%;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 15px 25px;
+  border-bottom: 1px solid #e6e6e6;
+}
+
+.modal-header h3 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: #333;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.export-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 6px 16px;
+  background: white;
+  border: 1px solid #e6e6e6;
+  border-radius: 20px;
+  font-size: 13px;
+  color: #000;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  height: 32px;
+}
+
+.export-btn:hover:not(:disabled) {
+  background: #f5f5f5;
+  border-color: #4F5BDF;
+}
+
+.export-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.export-icon {
+  width: 14px;
+  height: 14px;
+}
+
+.export-loader {
+  width: 16px;
+  height: 16px;
+  border: 2px solid #e6e6e6;
+  border-top: 2px solid #4F5BDF;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  font-size: 24px;
+  color: #a2a2a2;
+  cursor: pointer;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  transition: all 0.2s ease;
+}
+
+.close-btn:hover {
+  background: #f5f5f5;
+  color: #333;
+}
+
+.history-filters {
+  padding: 15px 25px;
+  border-bottom: 1px solid #e6e6e6;
+  background-color: #fafafa;
+}
+
+.filter-row {
+  display: flex;
+  gap: 15px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.search-filter,
+.user-filter,
+.date-filter,
+.sort-filter {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.filter-label {
+  font-size: 12px;
+  color: #a2a2a2;
+  white-space: nowrap;
+}
+
+.search-input {
+  padding: 6px 12px;
+  border: 1px solid #e6e6e6;
+  border-radius: 15px;
+  font-size: 12px;
+  width: 200px;
+  height: 32px;
+  transition: all 0.2s ease;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: #4F5BDF;
+  box-shadow: 0 0 0 3px rgba(79, 91, 223, 0.1);
+}
+
+.custom-select {
+  position: relative;
+  width: 200px;
+  cursor: pointer;
+}
+
+.select-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 12px;
+  background: white;
+  border: 1px solid #e6e6e6;
+  border-radius: 15px;
+  transition: all 0.2s ease;
+  height: 32px;
+}
+
+.select-trigger:hover {
+  border-color: #4F5BDF;
+  background: #f5f5f5;
+}
+
+.selected-value {
+  font-size: 12px;
+  color: #000;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+}
+
+.select-arrow {
+  width: 8px;
+  height: 8px;
+  transition: transform 0.2s ease;
+}
+
+.select-arrow.arrow-open {
+  transform: rotate(90deg);
+}
+
+.fade-enter-active, .fade-leave-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.fade-enter-from, .fade-leave-to {
+  opacity: 0;
+  transform: translateY(-10px);
+}
+
+.select-dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  max-height: 300px;
+  overflow-y: auto;
+  background: white;
+  border: 1px solid #e6e6e6;
+  border-radius: 15px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  z-index: 1000;
+}
+
+.select-option {
+  padding: 10px 14px;
+  font-size: 12px;
+  color: #000;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.select-option:hover {
+  background-color: #f0f3ff;
+}
+
+.select-option.selected {
+  background-color: #f0f3ff;
+  font-weight: 500;
+}
+
+.date-input {
+  padding: 6px 8px;
+  border: 1px solid #e6e6e6;
+  border-radius: 15px;
+  font-size: 12px;
+  width: 120px;
+  height: 32px;
+}
+
+.date-separator {
+  color: #a2a2a2;
+  font-size: 12px;
+}
+
+.sort-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  background: white;
+  border: 1px solid #e6e6e6;
+  border-radius: 20px;
+  font-size: 12px;
+  color: #000;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  height: 32px;
+  width: 170px;
+}
+
+.sort-btn:hover {
+  background: #f5f5f5;
+  border-color: #4F5BDF;
+}
+
+.sort-icon {
+  width: 14px;
+  height: 14px;
+  transition: transform 0.2s ease;
+}
+
+.sort-icon.sort-asc {
+  transform: rotate(180deg);
+}
+
+.modal-content {
+  padding: 20px 25px;
+  overflow-y: auto;
+  max-height: calc(80vh - 180px);
+  position: relative;
+}
+
+.history-loading,
+.history-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px;
+  color: #a2a2a2;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.history-timeline {
+  position: relative;
+  padding-left: 20px;
+  min-height: 100px;
+}
+
+.history-item {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 20px;
+  position: relative;
+}
+
+.history-item:last-child {
+  margin-bottom: 0;
+}
+
+.timeline-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  margin-top: 4px;
+  z-index: 1;
+  position: relative;
+}
+
+.timeline-line {
+  position: absolute;
+  left: 4px;
+  top: 18px;
+  width: 2px;
+  height: calc(100% + 2px);
+  background: #e6e6e6;
+}
+
+.dot-create { background: #4F5BDF; }
+.dot-deactivate { background: #6b7280; }
+.dot-default { background: #9ca3af; }
+
+.history-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.history-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 4px;
+}
+
+.user-name {
+  font-weight: 500;
+  color: #333;
+  font-size: 13px;
+}
+
+.action-time {
+  color: #a2a2a2;
+  font-size: 11px;
+}
+
+.action-text {
+  color: #666;
+  font-size: 12px;
+  margin-bottom: 2px;
+}
+
+.action-comment {
+  font-size: 11px;
+  color: #666;
+  font-style: italic;
+  margin-top: 4px;
+  padding-left: 6px;
+  border-left: 2px solid #e6e6e6;
+  word-break: break-word;
+}
+
+@media (max-width: 768px) {
+  .filter-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .search-filter,
+  .user-filter,
+  .date-filter,
+  .sort-filter {
+    width: 100%;
+  }
+  .custom-select,
+  .search-input,
+  .date-input,
+  .sort-btn {
+    width: 100%;
+  }
+  .date-input {
+    width: calc(50% - 20px);
+  }
+}
+</style>

--- a/frontend/src/components/ApplicationApprovers.vue
+++ b/frontend/src/components/ApplicationApprovers.vue
@@ -10,6 +10,13 @@
           :title="'Поиск принимающих...'"
         />
         <button
+          class="lk-button lk-button--secondary"
+          data-testid="approver-history"
+          @click="openHistory"
+        >
+          История
+        </button>
+        <button
           class="add-header-button"
           :disabled="isAdding"
           @click="openAddModal"
@@ -302,19 +309,27 @@
         </div>
       </transition>
     </Teleport>
+
+    <ApplicationApproverHistoryModal
+      v-if="showHistory"
+      :current-user-name="currentUserName"
+      @close="showHistory = false"
+    />
   </div>
 </template>
 
 <script>
 import SearchComponent from './SearchComponent.vue';
 import RefreshButton from './RefreshButton.vue';
+import ApplicationApproverHistoryModal from './ApplicationApproverHistoryModal.vue';
 import { useDeletionsStore } from '@/stores/deletions';
 import { useOverlayClose } from '@/composables/useOverlayClose';
+import { apiRequest } from '@/api/client';
 import { getApprovers, getAllUsers, addApprover, deleteApprover } from '@/api/approvers';
 
 export default {
   name: 'ApplicationApproversManagement',
-  components: { SearchComponent, RefreshButton },
+  components: { SearchComponent, RefreshButton, ApplicationApproverHistoryModal },
   setup() {
     const overlay = { close: () => {} };
     const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(() => overlay.close());
@@ -335,6 +350,8 @@ export default {
       showUserDropdown: false,
       selectedUsers: [],
       isAdding: false,
+      showHistory: false,
+      currentUserName: '',
     };
   },
   computed: {
@@ -393,6 +410,7 @@ export default {
   },
   mounted() {
     this.refresh();
+    this.fetchCurrentUser();
     document.addEventListener('keydown', this.onKeydown);
   },
   beforeUnmount() {
@@ -426,6 +444,21 @@ export default {
     },
     selectApprover(approver) {
       this.selectedApprover = approver;
+    },
+    openHistory() {
+      this.showHistory = true;
+    },
+    async fetchCurrentUser() {
+      // Имя нужно для футера Excel-экспорта истории ("Отчёт сформировал").
+      try {
+        const res = await apiRequest('/users/me');
+        if (!res.ok) return;
+        const u = await res.json();
+        const parts = [u.last_name, u.first_name, u.middle_name].filter(Boolean);
+        this.currentUserName = parts.join(' ') || u.username || '';
+      } catch {
+        // Имя - необязательная деталь экспорта, молчим (footer покажет дефолт).
+      }
     },
     async refresh() {
       this.isLoading = true;

--- a/frontend/src/components/__tests__/ApplicationApproverHistoryModal.spec.js
+++ b/frontend/src/components/__tests__/ApplicationApproverHistoryModal.spec.js
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+
+const getApproverHistory = vi.fn();
+vi.mock('@/api/approvers', () => ({
+  getApproverHistory: (...args) => getApproverHistory(...args),
+}));
+// exceljs тяжёлый и нужен только для экспорта - экспорт здесь не тестируем.
+vi.mock('exceljs', () => ({ default: { Workbook: class {} } }));
+// notify нужен для проверки error-ветки loadHistory.
+const notify = vi.hoisted(() => vi.fn());
+vi.mock('@/stores/deletions', () => ({ useDeletionsStore: () => ({ notify }) }));
+
+import ApplicationApproverHistoryModal from '../ApplicationApproverHistoryModal.vue';
+
+async function mountWith(history) {
+  getApproverHistory.mockResolvedValue(history);
+  const wrapper = mount(ApplicationApproverHistoryModal, {
+    props: { currentUserName: 'Иванов Иван' },
+    global: { stubs: { teleport: true } },
+    attachTo: document.body,
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+function entry(over = {}) {
+  return {
+    id: 1,
+    approver_user_id: 5,
+    approver_name: 'Соколов Пётр Сергеевич',
+    action_type: 'created',
+    actor_user_id: 3,
+    actor_name: 'Петров П.П.',
+    created_at: '2026-05-01T10:00:00Z',
+    ...over,
+  };
+}
+
+describe('ApplicationApproverHistoryModal', () => {
+  beforeEach(() => {
+    getApproverHistory.mockReset();
+    notify.mockClear();
+    document.body.innerHTML = '';
+  });
+
+  it('загружает глобальную историю без аргументов', async () => {
+    await mountWith([entry()]);
+    expect(getApproverHistory).toHaveBeenCalledWith();
+  });
+
+  it('открывается видимым (visible=true по mounted, overlay отрендерен)', async () => {
+    const wrapper = await mountWith([entry()]);
+    expect(wrapper.vm.visible).toBe(true);
+    expect(wrapper.find('.modal-overlay').exists()).toBe(true);
+  });
+
+  it('created: "Добавлен принимающий" + имя принимающего в комментарии, dot-create', async () => {
+    const wrapper = await mountWith([entry()]);
+    const item = wrapper.find('.history-item');
+    expect(item.find('.action-text').text()).toBe('Добавлен принимающий');
+    expect(item.find('.action-comment').text()).toContain('Соколов Пётр Сергеевич');
+    expect(item.find('.user-name').text()).toBe('Петров П.П.');
+    expect(item.find('.timeline-dot').classes()).toContain('dot-create');
+  });
+
+  it('deleted: "Удалён принимающий", dot-deactivate', async () => {
+    const wrapper = await mountWith([
+      entry({ id: 2, action_type: 'deleted', approver_name: 'Зайцев З.З.' }),
+    ]);
+    const item = wrapper.find('.history-item');
+    expect(item.find('.action-text').text()).toBe('Удалён принимающий');
+    expect(item.find('.action-comment').text()).toContain('Зайцев З.З.');
+    expect(item.find('.timeline-dot').classes()).toContain('dot-deactivate');
+  });
+
+  it('поиск фильтрует по актору и по имени принимающего', async () => {
+    const wrapper = await mountWith([
+      entry({ id: 1, actor_name: 'Сидоров С.С.', approver_name: 'Орлов О.О.' }),
+      entry({ id: 2, actor_name: 'Петров П.П.', approver_name: 'Грачёв Г.Г.' }),
+    ]);
+
+    expect(wrapper.findAll('.history-item')).toHaveLength(2);
+
+    await wrapper.find('.search-input').setValue('сидоров');
+    expect(wrapper.findAll('.history-item')).toHaveLength(1);
+
+    await wrapper.find('.search-input').setValue('грач');
+    expect(wrapper.findAll('.history-item')).toHaveLength(1);
+    expect(wrapper.find('.action-comment').text()).toContain('Грачёв Г.Г.');
+  });
+
+  it('фильтр пользователей собирает уникальных акторов (не принимающих)', async () => {
+    const wrapper = await mountWith([
+      entry({ id: 1, actor_user_id: 3, actor_name: 'Петров П.П.', approver_name: 'A' }),
+      entry({ id: 2, actor_user_id: 5, actor_name: 'Сидоров С.С.', approver_name: 'B' }),
+      entry({ id: 3, actor_user_id: 3, actor_name: 'Петров П.П.', approver_name: 'C' }),
+    ]);
+
+    await wrapper.find('.custom-select').trigger('click');
+    // 2 уникальных актора + опция "Все пользователи".
+    expect(wrapper.findAll('.select-option')).toHaveLength(3);
+  });
+
+  it('выбор актора в фильтре оставляет только его записи', async () => {
+    const wrapper = await mountWith([
+      entry({ id: 1, actor_user_id: 3, actor_name: 'Петров П.П.' }),
+      entry({ id: 2, actor_user_id: 5, actor_name: 'Сидоров С.С.' }),
+    ]);
+    wrapper.vm.selectUser(5);
+    await wrapper.vm.$nextTick();
+    expect(wrapper.findAll('.history-item')).toHaveLength(1);
+    expect(wrapper.find('.user-name').text()).toBe('Сидоров С.С.');
+  });
+
+  it('дропдаун пользователей закрывается по клику снаружи (ref, не $el при Teleport)', async () => {
+    const wrapper = await mountWith([entry()]);
+
+    await wrapper.find('.custom-select').trigger('click');
+    expect(wrapper.find('.select-dropdown').exists()).toBe(true);
+
+    document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('.select-dropdown').exists()).toBe(false);
+  });
+
+  it('пустой actor_name отображается как "Система" в записи и в фильтре', async () => {
+    const wrapper = await mountWith([entry({ actor_user_id: 9, actor_name: '' })]);
+    expect(wrapper.find('.user-name').text()).toBe('Система');
+    await wrapper.find('.custom-select').trigger('click');
+    const options = wrapper.findAll('.select-option').map((o) => o.text());
+    expect(options).toContain('Система');
+  });
+
+  it('пустая история показывает "История пуста"', async () => {
+    const wrapper = await mountWith([]);
+    expect(wrapper.find('.history-empty').text()).toBe('История пуста');
+  });
+
+  it('сортировка: desc - новые сверху, клик по .sort-btn переключает на asc', async () => {
+    const wrapper = await mountWith([
+      entry({ id: 1, action_type: 'created', approver_name: 'Новый', created_at: '2026-05-01T10:00:00Z' }),
+      entry({ id: 2, action_type: 'deleted', approver_name: 'Старый', created_at: '2026-05-01T09:00:00Z' }),
+    ]);
+    // desc по умолчанию: новее (10:00, created) сверху
+    let texts = wrapper.findAll('.history-item .action-text').map((t) => t.text());
+    expect(texts[0]).toBe('Добавлен принимающий');
+    expect(texts[1]).toBe('Удалён принимающий');
+
+    await wrapper.find('.sort-btn').trigger('click');
+    texts = wrapper.findAll('.history-item .action-text').map((t) => t.text());
+    // asc: старее (09:00, deleted) сверху
+    expect(texts[0]).toBe('Удалён принимающий');
+    expect(texts[1]).toBe('Добавлен принимающий');
+  });
+
+  it('фильтр по периоду отсекает записи вне диапазона', async () => {
+    // Дни с запасом, чтобы UTC<->локальный сдвиг не задел границу.
+    const wrapper = await mountWith([
+      entry({ id: 1, approver_name: 'Майский', created_at: '2026-05-01T10:00:00Z' }),
+      entry({ id: 2, approver_name: 'Десятый', created_at: '2026-05-10T10:00:00Z' }),
+    ]);
+    expect(wrapper.findAll('.history-item')).toHaveLength(2);
+
+    wrapper.vm.dateFrom = '2026-05-05';
+    await wrapper.vm.$nextTick();
+    expect(wrapper.findAll('.history-item')).toHaveLength(1);
+    expect(wrapper.find('.action-comment').text()).toContain('Десятый');
+
+    wrapper.vm.dateFrom = '';
+    wrapper.vm.dateTo = '2026-05-05';
+    await wrapper.vm.$nextTick();
+    expect(wrapper.findAll('.history-item')).toHaveLength(1);
+    expect(wrapper.find('.action-comment').text()).toContain('Майский');
+  });
+
+  it('ошибка загрузки: notify(type:error) + history пуст + "История пуста", loading снят', async () => {
+    getApproverHistory.mockRejectedValue(new Error('boom'));
+    const wrapper = mount(ApplicationApproverHistoryModal, {
+      props: { currentUserName: '' },
+      global: { stubs: { teleport: true } },
+      attachTo: document.body,
+    });
+    await flushPromises();
+
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(notify.mock.calls[0][0]).toMatchObject({ type: 'error' });
+    expect(wrapper.vm.loading).toBe(false);
+    expect(wrapper.vm.history).toEqual([]);
+    expect(wrapper.find('.history-empty').exists()).toBe(true);
+  });
+
+  describe('анимация закрытия', () => {
+    it('requestClose прячет overlay (visible=false), но НЕ эмитит close сразу', async () => {
+      const wrapper = await mountWith([entry()]);
+      wrapper.vm.requestClose();
+      await wrapper.vm.$nextTick();
+      expect(wrapper.vm.visible).toBe(false);
+      expect(wrapper.emitted('close')).toBeFalsy();
+    });
+
+    it('close эмитится по завершении leave-перехода (onAfterLeave)', async () => {
+      const wrapper = await mountWith([entry()]);
+      wrapper.vm.requestClose();
+      wrapper.vm.onAfterLeave();
+      expect(wrapper.emitted('close')).toBeTruthy();
+      expect(wrapper.emitted('close')).toHaveLength(1);
+    });
+
+    it('Escape запускает закрытие через requestClose (visible=false)', async () => {
+      const wrapper = await mountWith([entry()]);
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      await wrapper.vm.$nextTick();
+      expect(wrapper.vm.visible).toBe(false);
+    });
+
+    it('клик по overlay (mousedown+mouseup) закрывает через useOverlayClose', async () => {
+      const wrapper = await mountWith([entry()]);
+      const overlay = wrapper.find('.modal-overlay');
+      await overlay.trigger('mousedown');
+      await overlay.trigger('mouseup');
+      await wrapper.vm.$nextTick();
+      expect(wrapper.vm.visible).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Срез 417-3 эпика приведения компонентов управления к эталону (#406, под-issue #417). Закрывает фронт-часть истории принимающих заявки: backend (#502) и FE-эталон самого компонента (#499) уже в dev.

## Что сделано
- `ApplicationApproverHistoryModal.vue` - клон эталона `MarkHistoryModal` под глобальный лог: Teleport, анимация открытия/закрытия (visible/requestClose/onAfterLeave), useOverlayClose + Escape, 30px, фильтры (поиск/пользователь/период/сортировка), ExcelJS-экспорт, ref-based handleClickOutside (не `$el.querySelector` - баг под Teleport).
- Кнопка «История» в шапке `ApplicationApprovers.vue` (`lk-button--secondary`, reuse-стиль). История глобальная, без `:id` - принимающие hard-delete, поэтому кнопка в шапке, а не в детали строки.
- `getApproverHistory()` в `api/approvers.js` (GET /application-approvers/history, unwrap+throw на !ok).

## Контракт (от #502)
`[{id, approver_user_id, approver_name, action_type('created'|'deleted'), actor_user_id, actor_name, created_at}]`, новые сверху. Актор (кто назначил/снял) показан в шапке записи и в фильтре «Пользователь»; имя принимающего - в комментарии записи. Поиск ищет по актору, принимающему и тексту действия.

## Ревью code-reviewer: GO
Применены: Y-1 (кнопка переведена на `lk-button--secondary` вместо кастомного класса - reuse before create); Y-2 (добавлен тест фильтра по периоду). Осознанно НЕ менял (паритет с эталоном): `console.error` в catch (долг #407, чинится отдельным sweep'ом), `uniqueUsers` не включает системные записи без актора (как в `MarkHistoryModal`), fallback `getActionText` на сырой `action_type`.

## Тесты
- `api/__tests__/approvers.spec.js`: +`getApproverHistory` (успех + 403).
- `components/__tests__/ApplicationApproverHistoryModal.spec.js`: загрузка без id, created/deleted (текст+dot+комментарий), поиск по актору и принимающему, фильтр уникальных акторов, выбор актора, clickoutside (ref при Teleport), пустой actor_name -> «Система», пустая история, сортировка desc/asc, фильтр по периоду, error-путь (notify+пусто), анимация закрытия (requestClose не эмитит сразу / onAfterLeave / Escape / overlay).

vitest/eslint/build - в CI (FE-верификацию локально не гоняю по RAM-правилу). Связан с #417, #406.