### PR TITLE
style(ui): радиус инпутов к токену 15px - sweep 1/4 (#408)

### DIFF
--- a/frontend/src/components/DatePicker.vue
+++ b/frontend/src/components/DatePicker.vue
@@ -513,7 +513,7 @@ export default {
     width: 200px;
     height: 35px;
     background-color: #FFF;
-    border-radius: 10px;
+    border-radius: var(--radius-md);
     border: 1px solid #e6e6e6;
     padding: 0 10px;
     display: flex;
@@ -664,7 +664,7 @@ export default {
 .date-input {
     padding: 8px 10px;
     border: 1px solid #e6e6e6;
-    border-radius: 8px;
+    border-radius: var(--radius-md);
     font-size: 13px;
     outline: none;
     height: 32px;

--- a/frontend/src/components/OrganizationFilter.vue
+++ b/frontend/src/components/OrganizationFilter.vue
@@ -291,7 +291,7 @@ export default {
     width: 100%;
     padding: 8px 12px;
     border: 1px solid #e6e6e6;
-    border-radius: 8px;
+    border-radius: var(--radius-md);
     font-size: 14px;
     outline: none;
     transition: border-color 0.2s;

--- a/frontend/src/components/ResponsibleUsersSection.vue
+++ b/frontend/src/components/ResponsibleUsersSection.vue
@@ -563,7 +563,7 @@ export default {
   width: 100%;
   padding: 6px 8px;
   border: 1px solid #e2e8f0;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   font-size: 0.7rem;
   transition: all 0.2s ease;
   background: #fff;

--- a/frontend/src/components/TableComponent.vue
+++ b/frontend/src/components/TableComponent.vue
@@ -401,7 +401,7 @@ export default {
   padding: 5px;
   font-size: 14px;
   margin-right: 25px;
-  border-radius: 5px;
+  border-radius: var(--radius-md);
   border: 2px solid #ddd;
 }
 

--- a/frontend/src/components/ui/BaseDropdown.vue
+++ b/frontend/src/components/ui/BaseDropdown.vue
@@ -254,7 +254,7 @@ export default {
   width: 100%;
   padding: 6px 12px;
   border: 1px solid #e6e6e6;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   font-size: 13px;
   outline: none;
   transition: border-color 0.2s;

--- a/frontend/src/components/ui/PasswordInput.vue
+++ b/frontend/src/components/ui/PasswordInput.vue
@@ -98,7 +98,7 @@ function onInput(event) {
   width: 100%;
   padding: 10px 38px 10px 12px;
   border: 1px solid #e0e0e0;
-  border-radius: 12px;
+  border-radius: var(--radius-md);
   font-size: 14px;
   font-family: inherit;
   background: #fff;

--- a/frontend/src/views/AdminSettings.vue
+++ b/frontend/src/views/AdminSettings.vue
@@ -626,7 +626,7 @@ export default {
   width: 140px;
   padding: 6px 10px;
   border: 1px solid #e6e6e6;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   font-size: 13px;
   font-family: 'Montserrat', sans-serif;
   color: #333;

--- a/frontend/src/views/NewsAndReview.vue
+++ b/frontend/src/views/NewsAndReview.vue
@@ -1587,7 +1587,7 @@ export default {
     width: 100%;
     padding: 10px 14px;
     border: 1px solid #e6e6e6;
-    border-radius: 20px;
+    border-radius: var(--radius-md);
     font-family: 'Montserrat', sans-serif;
     font-size: 13px;
     transition: all 0.2s ease;

--- a/frontend/src/views/RequestsView.vue
+++ b/frontend/src/views/RequestsView.vue
@@ -1049,7 +1049,7 @@ export default {
 .date-input {
   padding: 8px 12px;
   border: 1px solid #e0e0e0;
-  border-radius: 12px;
+  border-radius: var(--radius-md);
   font-size: 13px;
   font-family: inherit;
   background: #fff;
@@ -1334,7 +1334,7 @@ export default {
 .page-size-select {
   padding: 4px 8px;
   border: 1px solid #e6e6e6;
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   font-size: 12px;
 }
 

--- a/frontend/src/views/admin/SystemControl.vue
+++ b/frontend/src/views/admin/SystemControl.vue
@@ -318,7 +318,7 @@ export default {
   width: 100%;
   padding: 12px 16px;
   border: 1px solid #e6e6e6;
-  border-radius: 16px;
+  border-radius: var(--radius-md);
   font-family: 'Montserrat', sans-serif;
   font-size: 14px;
   color: #1a1a1a;


### PR DESCRIPTION
Часть эпика #406 (UI consistency sweep, #408). Первый из 4 PR cross-cutting-среза: унификация `border-radius` видимых полей ввода к эталонному токену `var(--radius-md)` (=15px) по правилу `.claude/ui-etalon/ui-inputs.md`.

## Что меняется
Чистый CSS-token swap, без JS/логики. 10 файлов, 12 правок:

- `ui/BaseDropdown.vue` `.base-dropdown__search-input` 8px
- `ui/PasswordInput.vue` `.password-input__field` 12px
- `OrganizationFilter.vue` `.dropdown-search__input` 8px
- `ResponsibleUsersSection.vue` `.user-search-input` 6px
- `views/AdminSettings.vue` `.form-input` 8px
- `views/RequestsView.vue` `.filter-select`+`.date-input` 12px, `.page-size-select` 4px
- `views/NewsAndReview.vue` `.form-input`+`.form-textarea` 20px
- `views/admin/SystemControl.vue` `.sc__input`+`.sc__textarea` 16px
- `components/TableComponent.vue` `.search-input` 5px
- `components/DatePicker.vue` `.date-field` 10px, `.date-input` 8px

Все правки -> `var(--radius-md)`. Токен определён на `:root` в tokens.css (импорт в main.js), резолвится в scoped-стилях.

## Скоуп и осознанные исключения
- Список построен грепом текущего кода (не по протухшему audit-списку): часть инпутов уже починена в компонентных PR (#418/#424/#432/#456/#465).
- **Не тронуты намеренно:** `.search-input`/`.select-trigger` history-модалок (20px - это эталонное значение `SystemTableHistoryModal.vue`, консистентно во всём семействе); не-management экраны вне эпика #406 (LoginComponent pill-инпуты, CreateApplication-флоу, TextConstructor #183); удаляемый AdminUsers. Эти form-инпуты не относятся к sweep'у управляющих компонентов.
- Радиус карточек/бейджей/кнопок/ячеек календаря НЕ трогался - только видимые form-элементы.

## Верификация
- Греп: подтверждено, что все 12 целевых блоков теперь `var(--radius-md)`, чужие radius не задеты.
- Ревью `code-reviewer`: GO, 0 RED (2 YELLOW информационные - окружающий долг вне скоупа).
- Локальную FE-сборку не гонял (по характеру среза: косметический CSS без JS-влияния) - eslint/vitest/build в CI.

Следующие срезы #408: PR-2 Teleport (ApplicationSuccessModal + DownloadBlanksModal), PR-3 RefreshButton, PR-4 BaseDropdown Активные/Архив.