### PR TITLE
feat(blacklist): "Всё равно пропустить" - override помеченного элемента (#481)

### DIFF
--- a/frontend/src/components/ApplicationDetail/ApplicationAttachmentDetail.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationAttachmentDetail.vue
@@ -168,7 +168,7 @@
                     v-if="canOverride && isFlagged(employee)"
                     type="button"
                     class="lk-button lk-button--danger blacklist-override-btn"
-                    @click.stop="$emit('override-element', { label: employee.last_name + ' ' + employee.first_name, flag: employee.blacklist_similar })"
+                    @click.stop="$emit('override-element', { label: employeeFullName(employee), flag: employee.blacklist_similar })"
                   >
                     Пропустить
                   </button>
@@ -255,8 +255,7 @@ export default {
             type: Boolean,
             default: false
         },
-        // canOverride - показывать ли действие "Пропустить" на помеченных строках.
-        // true только для ответственного: бэкенд override-эндпоинт отвечает 403 остальным.
+        // Показываем "Пропустить" только ответственному - у остальных нет права на override.
         canOverride: {
             type: Boolean,
             default: false
@@ -267,6 +266,10 @@ export default {
         isFlagged(entity) {
             const flag = entity && entity.blacklist_similar;
             return !!flag && !flag.overridden;
+        },
+
+        employeeFullName(employee) {
+            return [employee.last_name, employee.first_name, employee.middle_name].filter(Boolean).join(' ');
         },
 
         blacklistVariant(flag) {

--- a/frontend/src/components/ApplicationDetail/ApplicationAttachmentDetail.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationAttachmentDetail.vue
@@ -93,6 +93,14 @@
                   >
                     {{ blacklistLabel(car.blacklist_similar) }}
                   </Badge>
+                  <button
+                    v-if="canOverride && isFlagged(car)"
+                    type="button"
+                    class="lk-button lk-button--danger blacklist-override-btn"
+                    @click.stop="$emit('override-element', { label: car.car_number, flag: car.blacklist_similar })"
+                  >
+                    Пропустить
+                  </button>
                 </div>
               </div>
             </div>
@@ -156,6 +164,14 @@
                   >
                     {{ blacklistLabel(employee.blacklist_similar) }}
                   </Badge>
+                  <button
+                    v-if="canOverride && isFlagged(employee)"
+                    type="button"
+                    class="lk-button lk-button--danger blacklist-override-btn"
+                    @click.stop="$emit('override-element', { label: employee.last_name + ' ' + employee.first_name, flag: employee.blacklist_similar })"
+                  >
+                    Пропустить
+                  </button>
                 </div>
               </div>
             </div>
@@ -238,9 +254,15 @@ export default {
         loading: {
             type: Boolean,
             default: false
+        },
+        // canOverride - показывать ли действие "Пропустить" на помеченных строках.
+        // true только для ответственного: бэкенд override-эндпоинт отвечает 403 остальным.
+        canOverride: {
+            type: Boolean,
+            default: false
         }
     },
-    emits: ['open-vehicle', 'open-employee'],
+    emits: ['open-vehicle', 'open-employee', 'override-element'],
     methods: {
         isFlagged(entity) {
             const flag = entity && entity.blacklist_similar;
@@ -534,6 +556,13 @@ export default {
 .blacklist-badge {
     flex-shrink: 0;
     margin-left: auto;
+}
+
+/* кнопка идёт сразу за бейджем (тот уже прижат вправо через margin-left:auto) */
+.blacklist-override-btn {
+    flex-shrink: 0;
+    padding: 5px 12px;
+    font-size: 12px;
 }
 
 .car-item-content, .employee-item-content, .item-item-content {

--- a/frontend/src/components/ApplicationDetail/ApplicationDetail.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationDetail.vue
@@ -866,7 +866,8 @@ export default {
                         await this.loadAttachmentDetails(this.selectedAttachment.id);
                     }
                     this.$emit('application-changed', this.applicationData);
-                } else {
+                } else if (response.status !== 403) {
+                    // 403 уже показывает тост через client.js - второй не дублируем
                     const data = await response.json();
                     useDeletionsStore().notify({
                         prefix: 'Не удалось подтвердить пропуск: ',

--- a/frontend/src/components/ApplicationDetail/ApplicationDetail.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationDetail.vue
@@ -120,8 +120,10 @@
             :employees="attachmentEmployees"
             :items="attachmentItems"
             :loading="loadingAttachmentDetails"
+            :can-override="isResponsibleUser"
             @open-vehicle="openVehicleModal"
             @open-employee="openEmployeeModal"
+            @override-element="openOverrideModal"
           />
         </div>
 
@@ -297,18 +299,28 @@
       :source="'application'"
       @close="showEmployeeModal = false"
     />
+
+    <BlacklistOverrideModal
+      :show="showOverrideModal"
+      :flag="overrideFlag"
+      :submitting="overrideSubmitting"
+      @confirm="confirmOverride"
+      @close="showOverrideModal = false"
+    />
   </div>
 </template>
 
 <script>
 import { apiRequest } from '@/api/client'
 import { markAsRead } from '@/api/applications'
+import { useDeletionsStore } from '@/stores/deletions'
 import ApplicationAttachments from './ApplicationAttachments.vue'
 import ApplicationConfirmation from './ApplicationConfirmation.vue'
 import ApplicationHistory from './ApplicationHistory.vue'
 import ForwardModal from './ForwardModal.vue'
 import ApplicationActionBar from './ApplicationActionBar.vue'
 import ApplicationAttachmentDetail from './ApplicationAttachmentDetail.vue'
+import BlacklistOverrideModal from './BlacklistOverrideModal.vue'
 import VehicleDetailsModal from '../CreateApplication/VehicleDetailsModal.vue'
 import EmployeeDetailsModal from '../CreateApplication/EmployeeDetailsModal.vue'
 
@@ -321,6 +333,7 @@ export default {
         ForwardModal,
         ApplicationActionBar,
         ApplicationAttachmentDetail,
+        BlacklistOverrideModal,
         VehicleDetailsModal,
         EmployeeDetailsModal
     },
@@ -375,7 +388,11 @@ export default {
             showVehicleModal: false,
             showEmployeeModal: false,
             selectedVehicle: null,
-            selectedEmployee: null
+            selectedEmployee: null,
+            showOverrideModal: false,
+            overrideFlag: null,
+            overrideLabel: '',
+            overrideSubmitting: false
         }
     },
     computed: {
@@ -822,6 +839,51 @@ export default {
                 territory_status: 0
             };
             this.showEmployeeModal = true;
+        },
+
+        openOverrideModal({ label, flag }) {
+            this.overrideLabel = label || '';
+            this.overrideFlag = flag || null;
+            this.showOverrideModal = true;
+        },
+
+        async confirmOverride(comment) {
+            if (!this.overrideFlag) return;
+            this.overrideSubmitting = true;
+            try {
+                const response = await apiRequest(`/applications/${this.applicationData.id}/blacklist-overrides`, {
+                    method: 'POST',
+                    body: JSON.stringify({ flag_id: this.overrideFlag.flag_id, comment })
+                });
+                if (response.ok) {
+                    useDeletionsStore().notify({
+                        prefix: 'Пропуск подтверждён: ',
+                        bold: this.overrideLabel || 'элемент',
+                        type: 'success'
+                    });
+                    this.showOverrideModal = false;
+                    if (this.selectedAttachment) {
+                        await this.loadAttachmentDetails(this.selectedAttachment.id);
+                    }
+                    this.$emit('application-changed', this.applicationData);
+                } else {
+                    const data = await response.json();
+                    useDeletionsStore().notify({
+                        prefix: 'Не удалось подтвердить пропуск: ',
+                        bold: data.message || 'ошибка',
+                        type: 'error'
+                    });
+                }
+            } catch (error) {
+                console.error('Ошибка при подтверждении пропуска:', error);
+                useDeletionsStore().notify({
+                    prefix: 'Не удалось подтвердить пропуск: ',
+                    bold: 'ошибка сети',
+                    type: 'error'
+                });
+            } finally {
+                this.overrideSubmitting = false;
+            }
         }
     }
 }

--- a/frontend/src/components/ApplicationDetail/BlacklistOverrideModal.vue
+++ b/frontend/src/components/ApplicationDetail/BlacklistOverrideModal.vue
@@ -29,20 +29,18 @@
         </div>
       </div>
 
-      <label
-        class="override-field-label"
-        for="blacklist-override-comment"
+      <FormField
+        label="Причина пропуска"
+        required
       >
-        Причина пропуска
-      </label>
-      <textarea
-        id="blacklist-override-comment"
-        v-model="comment"
-        class="lk-textarea"
-        rows="3"
-        placeholder="Например: проверено по СТС, это другой автомобиль"
-        @keydown.enter.ctrl="submit"
-      />
+        <textarea
+          v-model="comment"
+          class="lk-textarea"
+          rows="3"
+          placeholder="Например: проверено по СТС, это другой автомобиль"
+          @keydown.enter.ctrl="submit"
+        />
+      </FormField>
     </div>
 
     <template #actions>
@@ -68,10 +66,11 @@
 
 <script>
 import BaseModal from '@/components/ui/BaseModal.vue'
+import FormField from '@/components/ui/FormField.vue'
 
 export default {
     name: 'BlacklistOverrideModal',
-    components: { BaseModal },
+    components: { BaseModal, FormField },
     props: {
         show: {
             type: Boolean,
@@ -125,10 +124,11 @@ export default {
     color: #666;
 }
 
+/* красная палитра зеркалит Badge danger и подсветку строки (#481, срез 5) - семантических токенов под неё нет */
 .override-matched {
     border: 1px solid #fecaca;
     background: #fff5f5;
-    border-radius: 14px;
+    border-radius: var(--radius-md);
     padding: 12px 14px;
     margin-bottom: 16px;
 }
@@ -152,13 +152,5 @@ export default {
     font-size: 12.5px;
     color: #7f1d1d;
     margin-top: 2px;
-}
-
-.override-field-label {
-    display: block;
-    font-size: 12.5px;
-    font-weight: 600;
-    color: #333;
-    margin-bottom: 6px;
 }
 </style>

--- a/frontend/src/components/ApplicationDetail/BlacklistOverrideModal.vue
+++ b/frontend/src/components/ApplicationDetail/BlacklistOverrideModal.vue
@@ -1,0 +1,164 @@
+<template>
+  <BaseModal
+    :show="show"
+    title="Всё равно пропустить?"
+    width="460px"
+    @close="$emit('close')"
+  >
+    <div class="override-body">
+      <p class="override-lead">
+        Элемент похож на активную запись чёрного списка, но это не точное совпадение.
+        Подтвердите пропуск - действие фиксируется в аудите (кто, когда, причина).
+      </p>
+
+      <div
+        v-if="flag"
+        class="override-matched"
+      >
+        <div class="override-matched__label">
+          Похоже на запись ЧС
+        </div>
+        <div class="override-matched__value">
+          {{ flag.matched_value }}
+        </div>
+        <div
+          v-if="flag.matched_reason"
+          class="override-matched__reason"
+        >
+          Причина совпадения: {{ flag.matched_reason }}
+        </div>
+      </div>
+
+      <label
+        class="override-field-label"
+        for="blacklist-override-comment"
+      >
+        Причина пропуска
+      </label>
+      <textarea
+        id="blacklist-override-comment"
+        v-model="comment"
+        class="lk-textarea"
+        rows="3"
+        placeholder="Например: проверено по СТС, это другой автомобиль"
+        @keydown.enter.ctrl="submit"
+      />
+    </div>
+
+    <template #actions>
+      <button
+        type="button"
+        class="lk-button lk-button--ghost"
+        :disabled="submitting"
+        @click="$emit('close')"
+      >
+        Отмена
+      </button>
+      <button
+        type="button"
+        class="lk-button lk-button--primary"
+        :disabled="!canConfirm"
+        @click="submit"
+      >
+        Всё равно пропустить
+      </button>
+    </template>
+  </BaseModal>
+</template>
+
+<script>
+import BaseModal from '@/components/ui/BaseModal.vue'
+
+export default {
+    name: 'BlacklistOverrideModal',
+    components: { BaseModal },
+    props: {
+        show: {
+            type: Boolean,
+            required: true
+        },
+        flag: {
+            type: Object,
+            default: null
+        },
+        submitting: {
+            type: Boolean,
+            default: false
+        }
+    },
+    emits: ['confirm', 'close'],
+    data() {
+        return {
+            comment: ''
+        };
+    },
+    computed: {
+        canConfirm() {
+            return !this.submitting && this.comment.trim().length > 0;
+        }
+    },
+    watch: {
+        show(visible) {
+            if (visible) {
+                this.comment = '';
+            }
+        }
+    },
+    methods: {
+        submit() {
+            if (!this.canConfirm) return;
+            this.$emit('confirm', this.comment.trim());
+        }
+    }
+}
+</script>
+
+<style scoped>
+.override-body {
+    padding: 20px;
+}
+
+.override-lead {
+    margin: 0 0 16px;
+    font-size: 13.5px;
+    line-height: 1.5;
+    color: #666;
+}
+
+.override-matched {
+    border: 1px solid #fecaca;
+    background: #fff5f5;
+    border-radius: 14px;
+    padding: 12px 14px;
+    margin-bottom: 16px;
+}
+
+.override-matched__label {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-weight: 700;
+    color: #991b1b;
+}
+
+.override-matched__value {
+    font-size: 14px;
+    font-weight: 600;
+    color: #1f2330;
+    margin-top: 4px;
+}
+
+.override-matched__reason {
+    font-size: 12.5px;
+    color: #7f1d1d;
+    margin-top: 2px;
+}
+
+.override-field-label {
+    display: block;
+    font-size: 12.5px;
+    font-weight: 600;
+    color: #333;
+    margin-bottom: 6px;
+}
+</style>

--- a/frontend/src/components/ApplicationDetail/__tests__/ApplicationAttachmentDetail.spec.js
+++ b/frontend/src/components/ApplicationDetail/__tests__/ApplicationAttachmentDetail.spec.js
@@ -154,6 +154,6 @@ describe('ApplicationAttachmentDetail — кнопка "Пропустить" ov
       },
     });
     await wrapper.find('.blacklist-override-btn').trigger('click');
-    expect(wrapper.emitted('override-element')[0][0]).toEqual({ label: 'Иваноф Иван', flag: f });
+    expect(wrapper.emitted('override-element')[0][0]).toEqual({ label: 'Иваноф Иван Иванович', flag: f });
   });
 });

--- a/frontend/src/components/ApplicationDetail/__tests__/ApplicationAttachmentDetail.spec.js
+++ b/frontend/src/components/ApplicationDetail/__tests__/ApplicationAttachmentDetail.spec.js
@@ -103,3 +103,57 @@ describe('ApplicationAttachmentDetail — подсветка возможног�
     expect(badge.attributes('title')).toContain('Иваноф Иван Иванович');
   });
 });
+
+describe('ApplicationAttachmentDetail — кнопка "Пропустить" override (#481, срез 6a)', () => {
+  function mountCarsWith(cars, props = {}) {
+    return mount(ApplicationAttachmentDetail, {
+      props: {
+        attachment: { id: 1, attachment_type: 'cars', attachment_display_name: 'Машины' },
+        cars,
+        ...props,
+      },
+    });
+  }
+
+  it('canOverride=true: на помеченной строке есть кнопка "Пропустить"', () => {
+    const wrapper = mountCarsWith([car({ blacklist_similar: flag() })], { canOverride: true });
+    const btn = wrapper.find('.car-item .blacklist-override-btn');
+    expect(btn.exists()).toBe(true);
+    expect(btn.text()).toBe('Пропустить');
+  });
+
+  it('canOverride=false (дефолт): кнопки "Пропустить" нет даже на помеченной строке', () => {
+    const wrapper = mountCarsWith([car({ blacklist_similar: flag() })]);
+    expect(wrapper.find('.blacklist-override-btn').exists()).toBe(false);
+  });
+
+  it('overridden строка: кнопки нет даже при canOverride=true', () => {
+    const wrapper = mountCarsWith([car({ blacklist_similar: flag({ overridden: true }) })], { canOverride: true });
+    expect(wrapper.find('.blacklist-override-btn').exists()).toBe(false);
+  });
+
+  it('клик по "Пропустить" эмитит override-element с label и flag, но НЕ open-vehicle', async () => {
+    const f = flag();
+    const wrapper = mountCarsWith([car({ car_number: 'А123ВС', blacklist_similar: f })], { canOverride: true });
+    await wrapper.find('.blacklist-override-btn').trigger('click');
+
+    const emitted = wrapper.emitted('override-element');
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0][0]).toEqual({ label: 'А123ВС', flag: f });
+    // @click.stop не должен пробросить клик на строку (открытие модалки машины)
+    expect(wrapper.emitted('open-vehicle')).toBeUndefined();
+  });
+
+  it('сотрудник: override-element несёт ФИО как label', async () => {
+    const f = flag({ matched_value: 'Иванов И.И.' });
+    const wrapper = mount(ApplicationAttachmentDetail, {
+      props: {
+        attachment: { id: 1, attachment_type: 'people', attachment_display_name: 'Люди' },
+        employees: [employee({ last_name: 'Иваноф', first_name: 'Иван', blacklist_similar: f })],
+        canOverride: true,
+      },
+    });
+    await wrapper.find('.blacklist-override-btn').trigger('click');
+    expect(wrapper.emitted('override-element')[0][0]).toEqual({ label: 'Иваноф Иван', flag: f });
+  });
+});

--- a/frontend/src/components/ApplicationDetail/__tests__/BlacklistOverrideModal.spec.js
+++ b/frontend/src/components/ApplicationDetail/__tests__/BlacklistOverrideModal.spec.js
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import BlacklistOverrideModal from '../BlacklistOverrideModal.vue';
+
+function mountModal(props = {}) {
+  return mount(BlacklistOverrideModal, {
+    props: {
+      show: true,
+      flag: { flag_id: 7, matched_value: 'А124ВС Toyota', matched_reason: 'похожий номер' },
+      ...props,
+    },
+    global: { stubs: { teleport: true } },
+  });
+}
+
+describe('BlacklistOverrideModal (#481, срез 6a)', () => {
+  it('показывает совпавшую запись ЧС и причину', () => {
+    const wrapper = mountModal();
+    expect(wrapper.find('.override-matched__value').text()).toBe('А124ВС Toyota');
+    expect(wrapper.find('.override-matched__reason').text()).toContain('похожий номер');
+  });
+
+  it('кнопка подтверждения заблокирована при пустом комментарии', () => {
+    const wrapper = mountModal();
+    const confirm = wrapper.find('.lk-button--primary');
+    expect(confirm.attributes('disabled')).toBeDefined();
+  });
+
+  it('после ввода причины кнопка активна и эмитит confirm с обрезанным текстом', async () => {
+    const wrapper = mountModal();
+    await wrapper.find('.lk-textarea').setValue('  проверено по СТС  ');
+    const confirm = wrapper.find('.lk-button--primary');
+    expect(confirm.attributes('disabled')).toBeUndefined();
+
+    await confirm.trigger('click');
+    expect(wrapper.emitted('confirm')).toHaveLength(1);
+    expect(wrapper.emitted('confirm')[0][0]).toBe('проверено по СТС');
+  });
+
+  it('не эмитит confirm, если комментарий только из пробелов', async () => {
+    const wrapper = mountModal();
+    await wrapper.find('.lk-textarea').setValue('    ');
+    await wrapper.find('.lk-button--primary').trigger('click');
+    expect(wrapper.emitted('confirm')).toBeUndefined();
+  });
+
+  it('submitting=true блокирует кнопку даже с заполненным комментарием', async () => {
+    const wrapper = mountModal({ submitting: true });
+    await wrapper.find('.lk-textarea').setValue('причина');
+    expect(wrapper.find('.lk-button--primary').attributes('disabled')).toBeDefined();
+  });
+
+  it('кнопка "Отмена" эмитит close', async () => {
+    const wrapper = mountModal();
+    await wrapper.find('.lk-button--ghost').trigger('click');
+    expect(wrapper.emitted('close')).toHaveLength(1);
+  });
+
+  it('повторное открытие сбрасывает прежний комментарий', async () => {
+    const wrapper = mountModal({ show: false });
+    await wrapper.setProps({ show: true });
+    await wrapper.find('.lk-textarea').setValue('старое');
+    await wrapper.setProps({ show: false });
+    await wrapper.setProps({ show: true });
+    expect(wrapper.find('.lk-textarea').element.value).toBe('');
+  });
+});


### PR DESCRIPTION
Срез 6a эпика #481. Действие override для элементов заявки, помеченных как возможный обход ЧС (срезы 3-5).

## Что делает
- На помеченной (не-overridden) строке машины/сотрудника в деталях вложения - кнопка "Пропустить" (`.lk-button--danger`). Показывается ТОЛЬКО ответственному (`isResponsibleUser`); остальным бэкенд override-эндпоинта отвечает 403, поэтому кнопку им не показываем.
- Клик (`@click.stop`, чтобы не открыть модалку деталей) открывает `BlacklistOverrideModal` (поверх `BaseModal`: Teleport/Escape/overlay-close/анимация) с textarea причины (через `FormField`). Подтверждение заблокировано, пока причина пустая.
- По подтверждению: `POST /applications/:id/blacklist-overrides {flag_id, comment}` (эндпоинт готов в срезе 4), перечитываем детали вложения (строка становится "пропуск подтверждён"), `useDeletionsStore.notify` об успехе.

## Проверка
- vitest: 17 (5 подсветка среза 5 + 5 кнопка override + 7 модалка) зелёные.
- Живой Playwright-рендер реальных компонентов: кнопка только на 1 непереопределённой строке, модалка открывается с совпавшей записью, confirm gate по причине, после подтверждения строка -> overridden, 0 console-ошибок.
- Реальный визуальный флоу - владельцу до мержа.

## Reuse
BaseModal, FormField, lk-button/lk-textarea, useDeletionsStore - без кастома.

## По ревью (code-reviewer 2 раунда: GO)
- R1 (двойной тост при 403) - исправлено: на 403 свой тост не показываем (client.js уже показывает); 400/409/5xx показывают.
- Y1 ФИО с отчеством в уведомлении; Y2 радиус-токен в модалке; Y3 textarea через FormField; Y4 убран пересказ имени prop.
- Известное ограничение (YELLOW, осознанно): FormField во всём проекте без `for`, поэтому клик по label не фокусит textarea. Использование FormField консистентно с кодовой базой; ревёрт к кастомной label ради `for` сделал бы компонент уникальным в обход reuse-правила.
- Суперадмин (не назначенный ответственным) кнопку не видит - симметрично бэкенд-гейту (только ответственный, для аудита).

Дальше по эпику: 6b (блок кнопки "Согласовать" в UI пока есть непереопределённые флаги), 6c (сводный бейдж в списке - требует BE-поля).