### PR TITLE
style(ui): RefreshButton в админ-вьюхах и журналах (#408 PR-3)

### DIFF
--- a/frontend/src/views/FeedbackPage.vue
+++ b/frontend/src/views/FeedbackPage.vue
@@ -5,17 +5,10 @@
         <h2 class="feedback-admin__title">
           Обратная связь
         </h2>
-        <button
-          class="lk-button lk-button--secondary"
-          :disabled="loading"
-          @click="fetchFeedbacks"
-        >
-          <span
-            v-if="loading"
-            class="spinner"
-          />
-          <span>Обновить</span>
-        </button>
+        <RefreshButton
+          :loading="loading"
+          @refresh="fetchFeedbacks"
+        />
       </div>
 
       <div class="summary-cards">
@@ -230,12 +223,14 @@
 import { apiRequest } from '@/api/client'
 import { useAuthStore } from '@/stores/auth'
 import SearchComponent from '@/components/SearchComponent.vue';
+import RefreshButton from '@/components/RefreshButton.vue';
 import { SkeletonTransition, SkeletonCard, Badge } from '@/components/ui';
 
 export default {
   name: 'FeedbackPage',
   components: {
     SearchComponent,
+    RefreshButton,
     SkeletonTransition,
     SkeletonCard,
     Badge,
@@ -639,19 +634,6 @@ export default {
   text-align: center;
   padding: 48px 24px;
   color: var(--color-text-muted);
-}
-
-.spinner {
-  width: 14px;
-  height: 14px;
-  border: 2px solid currentColor;
-  border-top-color: transparent;
-  border-radius: 50%;
-  animation: spin 0.7s linear infinite;
-}
-
-@keyframes spin {
-  to { transform: rotate(360deg); }
 }
 
 .modal-overlay {

--- a/frontend/src/views/RequestsView.vue
+++ b/frontend/src/views/RequestsView.vue
@@ -164,15 +164,10 @@
           @change="refreshLogs"
         >
       </div>
-      <button
-        class="refresh-button"
-        @click="refreshLogs"
-      >
-        <img
-          src="@/assets/icons/refresh.png"
-          class="refresh-icon"
-        >
-      </button>
+      <RefreshButton
+        :loading="isLoading"
+        @refresh="refreshLogs"
+      />
       <button
         class="clear-filters-btn"
         @click="clearFilters"
@@ -523,13 +518,15 @@ import { apiRequest, apiRequestRaw } from '@/api/client'
 import SearchComponent from '@/components/SearchComponent.vue'
 import RealTimeChart from '@/components/RealTimeChart.vue'
 import LoaderSpinner from '@/components/ui/LoaderSpinner.vue'
+import RefreshButton from '@/components/RefreshButton.vue'
 
 export default {
   name: 'RequestsView',
   components: {
     SearchComponent,
     RealTimeChart,
-    LoaderSpinner
+    LoaderSpinner,
+    RefreshButton
   },
   data() {
     return {
@@ -1075,25 +1072,6 @@ export default {
   box-shadow: 0 0 0 3px rgba(79, 91, 223, 0.12);
 }
 
-.refresh-button {
-  background: none;
-  border: 1px solid transparent;
-  cursor: pointer;
-  padding: 6px;
-  border-radius: 10px;
-  transition: background-color 0.15s ease, border-color 0.15s ease;
-}
-
-.refresh-button:hover {
-  background-color: #eef0ff;
-  border-color: #4F5BDF;
-}
-
-.refresh-icon {
-  width: 18px;
-  height: 18px;
-}
-
 .clear-filters-btn,
 .export-btn {
   padding: 8px 14px;
@@ -1477,20 +1455,6 @@ export default {
   align-items: center;
   justify-content: center;
   z-index: 1000;
-}
-
-.spinner {
-  width: 40px;
-  height: 40px;
-  border: 3px solid #f3f3f3;
-  border-top: 3px solid #4F5BDF;
-  border-radius: 50%;
-  animation: spin 1s linear infinite;
-}
-
-@keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
 }
 
 @media (max-width: 1200px) {

--- a/frontend/src/views/admin/AccessDenialsLog.vue
+++ b/frontend/src/views/admin/AccessDenialsLog.vue
@@ -4,13 +4,10 @@
       <h2 class="page-title">
         Журнал отказов в доступе
       </h2>
-      <button
-        class="lk-button lk-button--secondary"
-        :disabled="loading"
-        @click="fetch"
-      >
-        Обновить
-      </button>
+      <RefreshButton
+        :loading="loading"
+        @refresh="fetch"
+      />
     </header>
 
     <div class="toggle-row">
@@ -193,9 +190,11 @@ import {
   deleteAccessDenials,
   archiveAccessDenials,
 } from '@/api/permissions';
+import RefreshButton from '@/components/RefreshButton.vue';
 
 export default {
   name: 'AccessDenialsLog',
+  components: { RefreshButton },
   data() {
     return {
       mode: 'active',

--- a/frontend/src/views/admin/AdminPermissionGroups.vue
+++ b/frontend/src/views/admin/AdminPermissionGroups.vue
@@ -4,12 +4,18 @@
       <h2 class="page-title">
         Группы прав доступа
       </h2>
-      <button
-        class="lk-button lk-button--primary"
-        @click="openCreateModal"
-      >
-        + Создать группу
-      </button>
+      <div class="page-header__actions">
+        <button
+          class="lk-button lk-button--primary"
+          @click="openCreateModal"
+        >
+          + Создать группу
+        </button>
+        <RefreshButton
+          :loading="loading"
+          @refresh="fetch"
+        />
+      </div>
     </header>
 
     <div
@@ -143,11 +149,12 @@ import {
   deletePermissionGroup,
 } from '@/api/permissions';
 import PermissionTreeModal from '@/components/admin/PermissionTreeModal.vue';
+import RefreshButton from '@/components/RefreshButton.vue';
 import { ALL_PERMISSION_KEYS } from '@/constants/permissionKeys';
 
 export default {
   name: 'AdminPermissionGroups',
-  components: { PermissionTreeModal },
+  components: { PermissionTreeModal, RefreshButton },
   data() {
     return {
       groups: [],
@@ -254,6 +261,12 @@ export default {
   display: flex;
   justify-content: space-between;
   align-items: center;
+}
+
+.page-header__actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 .page-title {

--- a/frontend/src/views/admin/AdminRoles.vue
+++ b/frontend/src/views/admin/AdminRoles.vue
@@ -4,12 +4,18 @@
       <h2 class="page-title">
         Роли пользователей
       </h2>
-      <button
-        class="lk-button lk-button--primary"
-        @click="openCreate"
-      >
-        + Создать роль
-      </button>
+      <div class="page-header__actions">
+        <button
+          class="lk-button lk-button--primary"
+          @click="openCreate"
+        >
+          + Создать роль
+        </button>
+        <RefreshButton
+          :loading="loading"
+          @refresh="fetchAll"
+        />
+      </div>
     </header>
 
     <div
@@ -209,9 +215,11 @@ import {
   setRoleDefaultGroups,
   listPermissionGroups,
 } from '@/api/permissions';
+import RefreshButton from '@/components/RefreshButton.vue';
 
 export default {
   name: 'AdminRoles',
+  components: { RefreshButton },
   data() {
     return {
       roles: [],
@@ -320,6 +328,12 @@ export default {
   display: flex;
   justify-content: space-between;
   align-items: center;
+}
+
+.page-header__actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 .page-title {


### PR DESCRIPTION
Срез #408 (UI consistency sweep) PR-3/4. Часть эпика #406 (приведение компонентов управления к эталону TableConstructor).

Переиспользовал общий `RefreshButton.vue` (prop `loading`, emit `refresh`) вместо кастомных кнопок «Обновить» в пяти view, чтобы шапки были единообразны и не плодились свои варианты кнопки:

- **AdminRoles**, **AdminPermissionGroups** — кнопки «Обновить» не было, добавил RefreshButton рядом с «+ Создать» (обёртка `.page-header__actions`, flex gap 12px).
- **AccessDenialsLog**, **FeedbackPage** — заменил текстовую `lk-button` «Обновить» на RefreshButton.
- **RequestsView** — заменил иконочную `.refresh-button` в `filters-bar` на RefreshButton.

`:loading` привязан к реальному стейту (`loading`/`isLoading`), `@refresh` — к существующему методу загрузки (`fetchAll`/`fetch`/`fetchFeedbacks`/`refreshLogs`).

Зачистил осиротевший CSS: `.spinner`+`@keyframes spin` в FeedbackPage (жили только в заменённой кнопке), `.refresh-button`/`.refresh-icon` в RequestsView. Заодно убрал пре-существующий мёртвый `.spinner`+`@keyframes spin` (40px) в RequestsView — оверлей `v-if="isLoading"` использует `<LoaderSpinner>`, а `class="spinner"` в шаблоне нет (нашёл при ревью). Оверлейный спиннер не тронут по сути — только его неиспользуемый CSS.

AdminUsers намеренно пропущен (удаляется).

Ревью: code-reviewer GO. Verified: eslint 0 ошибок на всех 5 файлах. vitest/build/Playwright E2E — в CI.