### PR TITLE
feat(blacklist): блокировка кнопки "Согласовать" в UI до пропуска флагов ЧС (#481)

### DIFF
--- a/frontend/src/components/ApplicationDetail/ApplicationActionBar.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationActionBar.vue
@@ -14,7 +14,8 @@
             <button
               class="accept-btn"
               data-testid="app-detail-button-approve"
-              :disabled="processing"
+              :disabled="processing || approvalBlockedByBlacklist"
+              :title="approvalBlockedByBlacklist ? blacklistGateHint : null"
               @click="handleCombinedAction('accept')"
             >
               <span
@@ -219,7 +220,8 @@
             <button
               class="confirm-btn"
               data-testid="app-detail-button-approve"
-              :disabled="updatingConfirmation || processing"
+              :disabled="updatingConfirmation || processing || approvalBlockedByBlacklist"
+              :title="approvalBlockedByBlacklist ? blacklistGateHint : null"
               @click="updateConfirmation('Согласовано')"
             >
               <span
@@ -330,6 +332,15 @@
           На согласовании
         </div>
       </template>
+
+      <!-- Гейт ЧС (#481): подсказка, почему согласование заблокировано -->
+      <div
+        v-if="approvalBlockedByBlacklist"
+        class="blacklist-gate-hint"
+        data-testid="app-detail-blacklist-gate-hint"
+      >
+        Подтвердите пропуск по помеченным
+      </div>
     </div>
 
     <!-- Режим просмотра заявок пользователя -->
@@ -379,6 +390,10 @@ export default {
         actionComment: {
             type: String,
             default: ''
+        },
+        hasUnoverriddenBlacklistFlags: {
+            type: Boolean,
+            default: false
         }
     },
     emits: ['action-completed', 'processing-change', 'updating-confirmation-change', 'comment-clear'],
@@ -431,6 +446,23 @@ export default {
                 return 'Ожидает согласования';
             }
             return 'Готова к принятию';
+        },
+
+        // Кнопка "Согласовать"/"Согласовать и принять" видна только ответственному,
+        // который ещё не голосовал, по не отклонённой и не завершённой заявке.
+        showsApproveButton() {
+            if (!this.isResponsibleUser || this.hasUserVoted) return false;
+            return this.application.confirmation !== 'Не согласовано' && this.application.status !== 'Завершено';
+        },
+
+        // Гейт ЧС (#481): согласование заблокировано в UI, пока есть непереопределённые
+        // флаги. Зеркало бэкенд-гейта (409) - кнопка disabled + подсказка.
+        approvalBlockedByBlacklist() {
+            return this.hasUnoverriddenBlacklistFlags && this.showsApproveButton;
+        },
+
+        blacklistGateHint() {
+            return 'Подтвердите пропуск по всем помеченным элементам, чтобы согласовать заявку';
         }
     },
     methods: {
@@ -750,6 +782,19 @@ export default {
     background: #f0f0f0;
     color: #666;
     border: 1px solid #e6e6e6;
+}
+
+.blacklist-gate-hint {
+    padding: 6px 14px;
+    border-radius: 50px;
+    font-size: 13px;
+    font-weight: 500;
+    text-align: center;
+    max-width: 240px;
+    background: rgba(245, 158, 11, 0.1);
+    color: #b45309;
+    border: 1px solid rgba(245, 158, 11, 0.35);
+    cursor: help;
 }
 
 .status-badge {

--- a/frontend/src/components/ApplicationDetail/ApplicationDetail.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationDetail.vue
@@ -63,6 +63,7 @@
             :processing="processingApplication"
             :updating-confirmation="updatingConfirmation"
             :action-comment="actionComment"
+            :has-unoverridden-blacklist-flags="!!applicationData.has_unoverridden_blacklist_flags"
             @action-completed="handleActionCompleted"
             @processing-change="processingApplication = $event"
             @updating-confirmation-change="updatingConfirmation = $event"
@@ -862,9 +863,10 @@ export default {
                         type: 'success'
                     });
                     this.showOverrideModal = false;
-                    if (this.selectedAttachment) {
-                        await this.loadAttachmentDetails(this.selectedAttachment.id);
-                    }
+                    await Promise.all([
+                        this.selectedAttachment ? this.loadAttachmentDetails(this.selectedAttachment.id) : Promise.resolve(),
+                        this.refreshApplicationGate()
+                    ]);
                     this.$emit('application-changed', this.applicationData);
                 } else if (response.status !== 403) {
                     // 403 уже показывает тост через client.js - второй не дублируем
@@ -885,6 +887,28 @@ export default {
             } finally {
                 this.overrideSubmitting = false;
             }
+        },
+
+        // После override обновляем только заявочные поля (в т.ч. гейт
+        // has_unoverridden_blacklist_flags), не сбрасывая выбранное вложение.
+        async refreshApplicationGate() {
+            try {
+                const response = await apiRequest(`/applications/${this.applicationData.id}/details`, { method: 'GET' });
+                if (response.ok) {
+                    const appData = await response.json();
+                    this.applicationData = { ...this.applicationData, ...appData };
+                    return;
+                }
+            } catch (error) {
+                console.error('Ошибка при обновлении состояния заявки:', error);
+            }
+            // Override прошёл, но детали не перечитались - кнопка согласования может
+            // остаться заблокированной. Сообщаем, чтобы пользователь обновил вручную.
+            useDeletionsStore().notify({
+                prefix: 'Пропуск подтверждён, ',
+                bold: 'обновите страницу для согласования',
+                type: 'error'
+            });
         }
     }
 }

--- a/frontend/src/components/ApplicationDetail/__tests__/ApplicationActionBar.spec.js
+++ b/frontend/src/components/ApplicationDetail/__tests__/ApplicationActionBar.spec.js
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+vi.mock('@/api/client', () => ({
+  apiRequest: vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) })),
+}));
+
+import ApplicationActionBar from '../ApplicationActionBar.vue';
+
+const APPROVE = '[data-testid="app-detail-button-approve"]';
+const REJECT = '[data-testid="app-detail-button-reject"]';
+const HINT = '[data-testid="app-detail-blacklist-gate-hint"]';
+
+function mountBar(props = {}) {
+  return mount(ApplicationActionBar, {
+    props: {
+      application: { id: 1, confirmation: 'Согласование', status: 'Непрочитано' },
+      currentUserId: 1,
+      responsibleUsers: [{ id: 1, approval_status: 'pending' }],
+      approvers: [],
+      ...props,
+    },
+  });
+}
+
+describe('ApplicationActionBar - гейт ЧС (#481, срез 6b)', () => {
+  it('при непереопределённом флаге кнопка "Согласовать" заблокирована и видна подсказка', () => {
+    const wrapper = mountBar({ hasUnoverriddenBlacklistFlags: true });
+    expect(wrapper.find(APPROVE).attributes('disabled')).toBeDefined();
+    expect(wrapper.find(HINT).exists()).toBe(true);
+  });
+
+  it('без флагов кнопка "Согласовать" активна и подсказки нет', () => {
+    const wrapper = mountBar({ hasUnoverriddenBlacklistFlags: false });
+    expect(wrapper.find(APPROVE).attributes('disabled')).toBeUndefined();
+    expect(wrapper.find(HINT).exists()).toBe(false);
+  });
+
+  it('гейт не блокирует "Отказать" - отклонить помеченную заявку можно сразу', () => {
+    const wrapper = mountBar({ hasUnoverriddenBlacklistFlags: true });
+    expect(wrapper.find(REJECT).attributes('disabled')).toBeUndefined();
+  });
+
+  it('для совмещённой роли блокируется "Согласовать и принять"', () => {
+    const wrapper = mountBar({
+      hasUnoverriddenBlacklistFlags: true,
+      approvers: [{ user_id: 1 }],
+    });
+    const approve = wrapper.find(APPROVE);
+    expect(approve.text()).toContain('Согласовать и принять');
+    expect(approve.attributes('disabled')).toBeDefined();
+    expect(wrapper.find(HINT).exists()).toBe(true);
+  });
+
+  it('после голоса approve-кнопки нет - гейт и подсказка не показываются', () => {
+    const wrapper = mountBar({
+      hasUnoverriddenBlacklistFlags: true,
+      responsibleUsers: [{ id: 1, approval_status: 'approved' }],
+    });
+    expect(wrapper.find(APPROVE).exists()).toBe(false);
+    expect(wrapper.find(HINT).exists()).toBe(false);
+  });
+});

--- a/internal/handlers/applications_blacklist_override_test.go
+++ b/internal/handlers/applications_blacklist_override_test.go
@@ -130,3 +130,56 @@ func TestBlacklistOverride_RejectionNotBlocked(t *testing.T) {
 		fmt.Sprintf(`{"user_id":%d,"status":"rejected","comment":"подозрительно"}`, apprID), testutil.AuthHeader(apprToken))
 	require.Equal(t, http.StatusOK, rec.Code, "reject не должен блокироваться: %s", rec.Body.String())
 }
+
+// TestGetApplicationDetails_BlacklistGateField: GET /applications/:id/details отдаёт
+// has_unoverridden_blacklist_flags - true пока есть помеченный элемент без override,
+// false после override (зеркало бэкенд-гейта для блокировки кнопки на фронте, #481).
+func TestGetApplicationDetails_BlacklistGateField(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	ctx := context.Background()
+
+	const orgName = "Test Organization"
+	senderToken := testutil.RegisterAndLogin(t, e, "bg_sender", "pass123", 1, td.OrgID, td.CompanyID)
+	senderID := getUserID(t, db, "bg_sender")
+	mark := seedMark(t, db, "BG_Mark")
+
+	_, err := newVehicleBlacklistService(db).Create(ctx, models.CreateVehicleBlacklistRequest{
+		CarNumber: "C777CC799", MarkID: mark.ID, Reason: "угон",
+	}, senderID)
+	require.NoError(t, err)
+
+	rec := submitCarApp(t, e, db, senderToken, orgName, "gate", "C777CC798", mark.ID)
+	require.Equal(t, http.StatusOK, rec.Code, "submit: %s", rec.Body.String())
+	carID := latestElementID(t, db, "cars", "car_number = ?", "C777CC798")
+	flag, ok := blacklistFlagFor(t, db, models.BlacklistElementCar, carID)
+	require.True(t, ok, "ожидался флаг похожести")
+	appID := flag.ApplicationID
+
+	detailsPath := fmt.Sprintf("/applications/%d/details", appID)
+
+	t.Run("true пока флаг не переопределён", func(t *testing.T) {
+		det := testutil.GET(t, e, detailsPath, testutil.AuthHeader(senderToken))
+		require.Equal(t, http.StatusOK, det.Code, "body: %s", det.Body.String())
+		assert.Contains(t, det.Body.String(), `"has_unoverridden_blacklist_flags":true`)
+	})
+
+	t.Run("false после override", func(t *testing.T) {
+		testutil.RegisterUser(t, e, "bg_appr", "pass123", 1, td.OrgID, td.CompanyID)
+		apprID := getUserID(t, db, "bg_appr")
+		fwd := fmt.Sprintf(`{"users":[{"user_id":%d,"required_approval":true,"can_view":false}]}`, apprID)
+		rec = testutil.POST(t, e, fmt.Sprintf("/applications/%d/forward", appID), fwd, testutil.AuthHeader(senderToken))
+		require.Equal(t, http.StatusOK, rec.Code, "forward: %s", rec.Body.String())
+
+		apprToken, _ := testutil.LoginUser(t, e, "bg_appr", "pass123")
+		rec = testutil.POST(t, e, fmt.Sprintf("/applications/%d/blacklist-overrides", appID),
+			fmt.Sprintf(`{"flag_id":%d,"comment":"проверено лично"}`, flag.ID), testutil.AuthHeader(apprToken))
+		require.Equal(t, http.StatusOK, rec.Code, "override: %s", rec.Body.String())
+
+		det := testutil.GET(t, e, detailsPath, testutil.AuthHeader(senderToken))
+		require.Equal(t, http.StatusOK, det.Code, "body: %s", det.Body.String())
+		assert.Contains(t, det.Body.String(), `"has_unoverridden_blacklist_flags":false`)
+	})
+}

--- a/internal/services/application_service.go
+++ b/internal/services/application_service.go
@@ -798,6 +798,14 @@ func (s *applicationService) GetApplicationDetails(ctx context.Context, applicat
 
 	responsibles, _ := s.fetchResponsibleUsers(s.db.WithContext(ctx), applicationID)
 
+	// Зеркало гейта согласования (#481): пока есть помеченные элементы без override,
+	// фронт держит кнопку "Согласовать" заблокированной. Источник правды - тот же
+	// hasUnoverriddenBlacklistFlags, что блокирует согласование на бэке (409).
+	blacklistBlocked, err := hasUnoverriddenBlacklistFlags(ctx, s.db, applicationID)
+	if err != nil {
+		return nil, err
+	}
+
 	orgName := ""
 	if row.OrganizationName != nil {
 		orgName = *row.OrganizationName
@@ -837,6 +845,8 @@ func (s *applicationService) GetApplicationDetails(ctx context.Context, applicat
 		"responsible_comment":   row.ResponsibleComment,
 		"data_approval":         row.DataApproval,
 		"responsible_users":     responsibles,
+
+		"has_unoverridden_blacklist_flags": blacklistBlocked,
 	}
 
 	return response, nil


### PR DESCRIPTION
## Что и зачем (#481, эпик ЧС fuzzy-match, срез 6b)

Бэкенд-гейт среза 4 уже возвращает 409 при попытке согласовать заявку, у которой есть помеченные элементы ЧС без override. Но в интерфейсе кнопка "Согласовать" оставалась активной - пользователь жал и ловил ошибку. Этот срез зеркалит гейт в UI.

**BE:** `GetApplicationDetails` (GET `/applications/:id/details`) отдаёт новое поле `has_unoverridden_blacklist_flags` (bool), переиспользуя тот же `hasUnoverriddenBlacklistFlags`, что блокирует согласование на бэке. Единый источник правды, не зависит от открытого вложения. Ошибка count-запроса пробрасывается (не маскируется).

**FE:**
- `ApplicationActionBar` получает prop `hasUnoverriddenBlacklistFlags`, гасит обе approve-кнопки ("Согласовать" и "Согласовать и принять") и показывает подсказку "Подтвердите пропуск по помеченным". "Отказать"/"Принять"/take-to-work не блокируются.
- `ApplicationDetail` пробрасывает поле из `applicationData` (попадает туда автоматически через spread в `loadApplicationDetails`); после успешного override зовёт `refreshApplicationGate` (лёгкий рефреш `/details` без сброса выбранного вложения) - кнопка разблокируется.

## Проверено
- Go: новый `TestGetApplicationDetails_BlacklistGateField` (true при флаге -> false после override); полные пакеты `internal/handlers` + `internal/services` зелёные (без регрессий).
- vitest: новый `ApplicationActionBar.spec.js` 5/5 (флаг блокирует approve / без флага активна / "Отказать" не блокируется / combined-роль / после голоса гейта нет); вся папка `ApplicationDetail/__tests__` 22/22.
- eslint, go build, go vet чисто.

## Ревью (code-reviewer: GO с оговорками)
- **MAJOR закрыт:** `refreshApplicationGate` больше не глотает non-ok сбой - при неудачном рефреше уведомляет "обновите страницу для согласования".
- **NIT закрыт:** убран дублирующий `title` с подсказки (видимый текст достаточен; `title` оставлен на самих кнопках, где визуального объяснения нет).
- **Осознанно оставлено:** хардкод amber-цветов в `.blacklist-gate-hint` (консистентно с остальным файлом, где все цвета хардкод; `var(--color-warning)`=#ffc107 не подходит по контрасту); `showsApproveButton` дублирует условия шаблона (корректно, документировано комментарием); `assert.Contains` на raw JSON в Go-тесте (стиль существующих тестов файла, ключи map сериализуются детерминированно).

## Примечание по верификации
FE-гейт - чисто UX-зеркало: корректность по-прежнему защищена бэкенд-409, поэтому даже при ошибке FE данные не пострадают. На staging нет флагнутых данных (как и в срезах 5/6a), поэтому гейт там визуально не воспроизвести - верификация на unit-уровне.