### PR TITLE
fix(tables): тексты архивации таблицы в эталоне TableConstructor (#406)

### DIFF
--- a/frontend/src/components/TableConstructor.vue
+++ b/frontend/src/components/TableConstructor.vue
@@ -615,12 +615,12 @@
       @close="historyTable = null"
     />
 
-    <!-- Подтверждение удаления таблицы -->
+    <!-- Подтверждение архивации таблицы -->
     <ConfirmationModal
       :show="!!deleteConfirmTable"
-      title="Удаление таблицы"
-      :message="deleteConfirmTable ? `Удалить таблицу &quot;${deleteConfirmTable.table.display_name}&quot;? Её можно будет восстановить из архива.` : ''"
-      confirm-text="Удалить"
+      title="Архивация таблицы"
+      :message="deleteConfirmTable ? `Архивировать таблицу «${deleteConfirmTable.table.display_name}»? Её можно будет восстановить из архива.` : ''"
+      confirm-text="В архив"
       cancel-text="Отмена"
       :confirm-button-style="{ background: '#c62828', borderColor: '#c62828' }"
       @confirm="performDeleteTable"
@@ -984,11 +984,11 @@ export default {
           method: "DELETE",
         });
         if (response.ok) {
-          const deletedName = table.table.display_name;
+          const archivedName = table.table.display_name;
           this.selectedTable = null;
           this.activeTab = 'main';
           await this.refreshData();
-          useDeletionsStore().notify({ bold: deletedName, suffix: ' удалена' });
+          useDeletionsStore().notify({ prefix: 'Таблица ', bold: archivedName, suffix: ' архивирована' });
         } else {
           const errorText = await response.text();
           console.error('Error response text:', errorText);
@@ -999,7 +999,7 @@ export default {
           } catch {
             // оставляем сырой текст
           }
-          useDeletionsStore().notify({ prefix: 'Не удалось удалить: ', bold: message, type: 'error' });
+          useDeletionsStore().notify({ prefix: 'Не удалось архивировать: ', bold: message, type: 'error' });
         }
       } catch (error) {
         console.error('Error deleting system table:', error);


### PR DESCRIPTION
Полиш-фикс из фидбэка владельца 08.06 (срез **A** батча feedback-0608-polish).

Эталонный `TableConstructor.vue` при удалении таблицы делает soft-delete (есть restore-флоу, переключатель Активные/Архив, «восстановить из архива»), но UI говорил «Удаление таблицы» / «Удалить» / тост «<имя> удалена» — вводит в заблуждение.

Привёл тексты к архив-вокабуляру по образцу дочерних компонентов (Marks/Citizenship/Companies/Attachments/NumberFormat/Organizations/UnloadPlaces):
- ConfirmationModal: `title="Архивация таблицы"`, message «Архивировать таблицу «X»? Её можно будет восстановить из архива.», `confirm-text="В архив"` (кавычки `«»` и красная кнопка `#c62828` — как у соседей);
- тост успеха: «Таблица **X** архивирована» (был «X удалена»);
- тост ошибки: «Не удалось архивировать: …» (был «Не удалось удалить: …»);
- локальная `deletedName` → `archivedName`.

Намеренно НЕ трогал: внутренние имена методов/полей (`performDeleteTable`/`deleteConfirmTable` — не user-facing, чтобы не раздувать дифф на эталоне), иконку-триггер `delete.png` (владелец флагнул только текст модалки; тултипа с «Удалить» на ней нет).

Ревью: сверено с 7 дочерними компонентами (вокабуляр, род «архивирована», кавычки, цвет кнопки) — 1:1. eslint 0 ошибок. Чистый текстовый дифф, поведение не менялось; vitest/E2E — в CI.