### PR TITLE
feat(nav): вынес справочники в роуты /admin/* через тонкие обёртки (#510)

### DIFF
--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -9,7 +9,6 @@ import CreateApplication from './components/CreateApplication/CreateApplication.
 import CarsView from './views/CarsView.vue';
 import ApplicationsCenter from './views/ApplicationsCenter.vue';
 import TableConstructor from './components/TableConstructor.vue';
-import NumberFormat from './components/NumberFormat.vue';
 import EmployeeView from './views/EmployeeView.vue';
 import NewsAndReview from './views/NewsAndReview.vue';
 import FeedbackPage from './views/FeedbackPage.vue';
@@ -74,9 +73,7 @@ const routes = [
   },
   {
     path: '/number-format',
-    name: 'NumberFormat',
-    component: NumberFormat,
-    meta: { requiresAuth: true, requiresBuro: true }
+    redirect: '/admin/number-formats'
   },
   {
     path: '/employeesview',
@@ -137,6 +134,61 @@ const routes = [
     name: 'AccessDenialsLog',
     component: () => import('./views/admin/AccessDenialsLog.vue'),
     meta: { requiresAuth: true, requiresBuro: true, permission: 'permission.audit.read' }
+  },
+  // requiresBuro сохраняет текущий доступ супер-админа без правок бэкенда прав.
+  {
+    path: '/admin/organizations',
+    name: 'AdminOrganizations',
+    component: () => import('./views/admin/OrganizationsView.vue'),
+    meta: { requiresAuth: true, requiresBuro: true }
+  },
+  {
+    path: '/admin/companies',
+    name: 'AdminCompanies',
+    component: () => import('./views/admin/CompaniesView.vue'),
+    meta: { requiresAuth: true, requiresBuro: true }
+  },
+  {
+    path: '/admin/unload-places',
+    name: 'AdminUnloadPlaces',
+    component: () => import('./views/admin/UnloadPlacesView.vue'),
+    meta: { requiresAuth: true, requiresBuro: true }
+  },
+  {
+    path: '/admin/number-formats',
+    name: 'AdminNumberFormats',
+    component: () => import('./views/admin/NumberFormatsView.vue'),
+    meta: { requiresAuth: true, requiresBuro: true }
+  },
+  {
+    path: '/admin/citizenship',
+    name: 'AdminCitizenship',
+    component: () => import('./views/admin/CitizenshipView.vue'),
+    meta: { requiresAuth: true, requiresBuro: true }
+  },
+  {
+    path: '/admin/marks',
+    name: 'AdminMarks',
+    component: () => import('./views/admin/MarksView.vue'),
+    meta: { requiresAuth: true, requiresBuro: true }
+  },
+  {
+    path: '/admin/attachment-types',
+    name: 'AdminAttachmentTypes',
+    component: () => import('./views/admin/AttachmentTypesView.vue'),
+    meta: { requiresAuth: true, requiresBuro: true }
+  },
+  {
+    path: '/admin/user-types',
+    name: 'AdminUserTypes',
+    component: () => import('./views/admin/UserTypesView.vue'),
+    meta: { requiresAuth: true, requiresBuro: true }
+  },
+  {
+    path: '/admin/approvers',
+    name: 'AdminApprovers',
+    component: () => import('./views/admin/ApproversView.vue'),
+    meta: { requiresAuth: true, requiresBuro: true }
   },
   {
     path: '/500',

--- a/frontend/src/views/admin/ApproversView.vue
+++ b/frontend/src/views/admin/ApproversView.vue
@@ -1,0 +1,21 @@
+<template>
+  <section class="admin-page">
+    <ApplicationApprovers />
+  </section>
+</template>
+
+<script>
+import ApplicationApprovers from '@/components/ApplicationApprovers.vue';
+
+export default {
+  name: 'ApproversView',
+  components: { ApplicationApprovers },
+};
+</script>
+
+<style scoped>
+.admin-page {
+  padding: 16px;
+  height: 100%;
+}
+</style>

--- a/frontend/src/views/admin/AttachmentTypesView.vue
+++ b/frontend/src/views/admin/AttachmentTypesView.vue
@@ -1,0 +1,21 @@
+<template>
+  <section class="admin-page">
+    <AttachmentsManagement />
+  </section>
+</template>
+
+<script>
+import AttachmentsManagement from '@/components/AttachmentsManagement.vue';
+
+export default {
+  name: 'AttachmentTypesView',
+  components: { AttachmentsManagement },
+};
+</script>
+
+<style scoped>
+.admin-page {
+  padding: 16px;
+  height: 100%;
+}
+</style>

--- a/frontend/src/views/admin/CitizenshipView.vue
+++ b/frontend/src/views/admin/CitizenshipView.vue
@@ -1,0 +1,21 @@
+<template>
+  <section class="admin-page">
+    <CitizenshipManagement />
+  </section>
+</template>
+
+<script>
+import CitizenshipManagement from '@/components/CitizenshipManagement.vue';
+
+export default {
+  name: 'CitizenshipView',
+  components: { CitizenshipManagement },
+};
+</script>
+
+<style scoped>
+.admin-page {
+  padding: 16px;
+  height: 100%;
+}
+</style>

--- a/frontend/src/views/admin/CompaniesView.vue
+++ b/frontend/src/views/admin/CompaniesView.vue
@@ -1,0 +1,21 @@
+<template>
+  <section class="admin-page">
+    <CompaniesManagement />
+  </section>
+</template>
+
+<script>
+import CompaniesManagement from '@/components/CompaniesManagement.vue';
+
+export default {
+  name: 'CompaniesView',
+  components: { CompaniesManagement },
+};
+</script>
+
+<style scoped>
+.admin-page {
+  padding: 16px;
+  height: 100%;
+}
+</style>

--- a/frontend/src/views/admin/MarksView.vue
+++ b/frontend/src/views/admin/MarksView.vue
@@ -1,0 +1,21 @@
+<template>
+  <section class="admin-page">
+    <MarksManagement />
+  </section>
+</template>
+
+<script>
+import MarksManagement from '@/components/MarksManagement.vue';
+
+export default {
+  name: 'MarksView',
+  components: { MarksManagement },
+};
+</script>
+
+<style scoped>
+.admin-page {
+  padding: 16px;
+  height: 100%;
+}
+</style>

--- a/frontend/src/views/admin/NumberFormatsView.vue
+++ b/frontend/src/views/admin/NumberFormatsView.vue
@@ -1,0 +1,21 @@
+<template>
+  <section class="admin-page">
+    <NumberFormat />
+  </section>
+</template>
+
+<script>
+import NumberFormat from '@/components/NumberFormat.vue';
+
+export default {
+  name: 'NumberFormatsView',
+  components: { NumberFormat },
+};
+</script>
+
+<style scoped>
+.admin-page {
+  padding: 16px;
+  height: 100%;
+}
+</style>

--- a/frontend/src/views/admin/OrganizationsView.vue
+++ b/frontend/src/views/admin/OrganizationsView.vue
@@ -1,0 +1,21 @@
+<template>
+  <section class="admin-page">
+    <OrganizationsManagement />
+  </section>
+</template>
+
+<script>
+import OrganizationsManagement from '@/components/OrganizationsManagement.vue';
+
+export default {
+  name: 'OrganizationsView',
+  components: { OrganizationsManagement },
+};
+</script>
+
+<style scoped>
+.admin-page {
+  padding: 16px;
+  height: 100%;
+}
+</style>

--- a/frontend/src/views/admin/UnloadPlacesView.vue
+++ b/frontend/src/views/admin/UnloadPlacesView.vue
@@ -1,0 +1,21 @@
+<template>
+  <section class="admin-page">
+    <UnloadPlacesContainer />
+  </section>
+</template>
+
+<script>
+import UnloadPlacesContainer from '@/components/UnloadPlaces/UnloadPlacesContainer.vue';
+
+export default {
+  name: 'UnloadPlacesView',
+  components: { UnloadPlacesContainer },
+};
+</script>
+
+<style scoped>
+.admin-page {
+  padding: 16px;
+  height: 100%;
+}
+</style>

--- a/frontend/src/views/admin/UserTypesView.vue
+++ b/frontend/src/views/admin/UserTypesView.vue
@@ -1,0 +1,21 @@
+<template>
+  <section class="admin-page">
+    <UserTypes />
+  </section>
+</template>
+
+<script>
+import UserTypes from '@/components/UserTypes.vue';
+
+export default {
+  name: 'UserTypesView',
+  components: { UserTypes },
+};
+</script>
+
+<style scoped>
+.admin-page {
+  padding: 16px;
+  height: 100%;
+}
+</style>


### PR DESCRIPTION
## Что и зачем

Срез 1 эпика #510 (редизайн навигации). Управленческие справочники жили якорями внутри `/personal-cabinet` (зажаты в `max-width:38%`), их нельзя забукмаркать и в навигации их нет. Этот срез аддитивно выносит их в полноширинные роуты `/admin/*` — без правки навигации и без касания самих компонентов управления.

## Изменения

- 9 тонких обёрток `frontend/src/views/admin/*View.vue` по образцу `views/admin/BlacklistView.vue` (page-shell `padding:16px`, без `max-width`, без тени): Organizations, Companies, UnloadPlaces, NumberFormats, Citizenship, Marks, AttachmentTypes, UserTypes, Approvers. Компоненты самодостаточны (грузят данные в `mounted`, без пропсов) — обёртки только хостят их full-width.
- `router.js`: 9 lazy-роутов `/admin/*` с `meta: { requiresAuth, requiresBuro }` — `requiresBuro` сохраняет текущий доступ супер-админа без правок бэкенда прав.
- `/number-format` нормализован редиректом на `/admin/number-formats` (на старый path/имя роута ничего не ссылалось), удалён ставший лишним eager-импорт `NumberFormat`.

`/admin/users` и `/table-constructor` не трогаю — первый переедет в Срезе 2 (UserControl), второй уже есть и переиспользуется.

## Проверено

- ESLint по всем изменённым файлам — чисто.
- Все 9 целевых компонентов существуют (lazy-импорт не даст 404-чанк), имена роутов уникальны.
- Ревью `code-reviewer` — GO, блокеров нет; учтён стилевой nit по комментарию.
- Полная сборка/vitest — на CI. Визуальный smoke (full-width открытие каждого справочника, deep-link гейтится) — на staging после мержа.