### PR TITLE
style(nav): admin-страницы справочников - карточка на всю высоту, радиус 35px (#510)

### DIFF
--- a/frontend/src/views/admin/AdminPageShell.vue
+++ b/frontend/src/views/admin/AdminPageShell.vue
@@ -1,0 +1,85 @@
+<template>
+  <section
+    ref="root"
+    class="admin-page"
+  >
+    <slot />
+  </section>
+</template>
+
+<script setup>
+import { ref, onMounted, onBeforeUnmount, nextTick } from 'vue';
+
+/**
+ * Полноширинная обёртка страниц /admin/*: растягивает вложенный компонент
+ * управления на всю доступную высоту вьюпорта (под шапкой) и не даёт ему
+ * вылезти за край - чтобы из-за height:100% не появлялся скролл всей страницы
+ * и пустой хвост снизу. Высоту меряем фактически (innerHeight - top карточки),
+ * а не 100dvh минус хардкод шапки: шапка in-flow и может менять высоту.
+ */
+const root = ref(null);
+let resizeObserver = null;
+let lastHeight = -1;
+
+function applyHeight() {
+  const el = root.value;
+  if (!el) return;
+  const top = el.getBoundingClientRect().top;
+  const height = Math.max(0, Math.round(window.innerHeight - top));
+  // Защита от ResizeObserver-петли: пишем стиль только при реальном изменении.
+  if (height === lastHeight) return;
+  lastHeight = height;
+  el.style.height = `${height}px`;
+}
+
+onMounted(async () => {
+  await nextTick();
+  applyHeight();
+  window.addEventListener('resize', applyHeight);
+  // Пересчёт при изменении высоты шапки (анонс, перенос строки). Наблюдаем
+  // саму шапку, а не body - иначе Teleport-модалки (их в проекте десятки)
+  // будили бы лишний reflow на каждое открытие.
+  const header = document.querySelector('.theheader');
+  if (header && typeof ResizeObserver !== 'undefined') {
+    resizeObserver = new ResizeObserver(applyHeight);
+    resizeObserver.observe(header);
+  }
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', applyHeight);
+  if (resizeObserver) {
+    resizeObserver.disconnect();
+    resizeObserver = null;
+  }
+});
+</script>
+
+<style scoped>
+.admin-page {
+  padding: 16px;
+  box-sizing: border-box;
+  /* Высоту задаёт скрипт под доступный вьюпорт; overflow здесь держит скролл
+     внутри обёртки, а не на всей странице, если контент выше доступного. */
+  overflow: auto;
+}
+
+/* Карточка компонента управления занимает всю высоту обёртки. Корень делаем
+   flex-колонкой, а мастер-детейл (.content-container) - flex:1, чтобы тело
+   тянулось на всю высоту вместо фикс. 450/500px и снизу не оставался пустой
+   хвост. Внутренний скролл списка (.table-body overflow:auto) не трогаем. */
+.admin-page :deep(.dashboard-card) {
+  height: 100%;
+  border-radius: 35px;
+  display: flex;
+  flex-direction: column;
+}
+
+/* height: auto намеренно переопределяет фикс-высоту .content-container
+   (450/500/540px), заданную внутри самих компонентов. */
+.admin-page :deep(.content-container) {
+  flex: 1 1 auto;
+  min-height: 0;
+  height: auto;
+}
+</style>

--- a/frontend/src/views/admin/ApproversView.vue
+++ b/frontend/src/views/admin/ApproversView.vue
@@ -1,21 +1,15 @@
 <template>
-  <section class="admin-page">
+  <AdminPageShell>
     <ApplicationApprovers />
-  </section>
+  </AdminPageShell>
 </template>
 
 <script>
+import AdminPageShell from './AdminPageShell.vue';
 import ApplicationApprovers from '@/components/ApplicationApprovers.vue';
 
 export default {
   name: 'ApproversView',
-  components: { ApplicationApprovers },
+  components: { AdminPageShell, ApplicationApprovers },
 };
 </script>
-
-<style scoped>
-.admin-page {
-  padding: 16px;
-  height: 100%;
-}
-</style>

--- a/frontend/src/views/admin/AttachmentTypesView.vue
+++ b/frontend/src/views/admin/AttachmentTypesView.vue
@@ -1,21 +1,15 @@
 <template>
-  <section class="admin-page">
+  <AdminPageShell>
     <AttachmentsManagement />
-  </section>
+  </AdminPageShell>
 </template>
 
 <script>
+import AdminPageShell from './AdminPageShell.vue';
 import AttachmentsManagement from '@/components/AttachmentsManagement.vue';
 
 export default {
   name: 'AttachmentTypesView',
-  components: { AttachmentsManagement },
+  components: { AdminPageShell, AttachmentsManagement },
 };
 </script>
-
-<style scoped>
-.admin-page {
-  padding: 16px;
-  height: 100%;
-}
-</style>

--- a/frontend/src/views/admin/CitizenshipView.vue
+++ b/frontend/src/views/admin/CitizenshipView.vue
@@ -1,21 +1,15 @@
 <template>
-  <section class="admin-page">
+  <AdminPageShell>
     <CitizenshipManagement />
-  </section>
+  </AdminPageShell>
 </template>
 
 <script>
+import AdminPageShell from './AdminPageShell.vue';
 import CitizenshipManagement from '@/components/CitizenshipManagement.vue';
 
 export default {
   name: 'CitizenshipView',
-  components: { CitizenshipManagement },
+  components: { AdminPageShell, CitizenshipManagement },
 };
 </script>
-
-<style scoped>
-.admin-page {
-  padding: 16px;
-  height: 100%;
-}
-</style>

--- a/frontend/src/views/admin/CompaniesView.vue
+++ b/frontend/src/views/admin/CompaniesView.vue
@@ -1,21 +1,15 @@
 <template>
-  <section class="admin-page">
+  <AdminPageShell>
     <CompaniesManagement />
-  </section>
+  </AdminPageShell>
 </template>
 
 <script>
+import AdminPageShell from './AdminPageShell.vue';
 import CompaniesManagement from '@/components/CompaniesManagement.vue';
 
 export default {
   name: 'CompaniesView',
-  components: { CompaniesManagement },
+  components: { AdminPageShell, CompaniesManagement },
 };
 </script>
-
-<style scoped>
-.admin-page {
-  padding: 16px;
-  height: 100%;
-}
-</style>

--- a/frontend/src/views/admin/MarksView.vue
+++ b/frontend/src/views/admin/MarksView.vue
@@ -1,21 +1,15 @@
 <template>
-  <section class="admin-page">
+  <AdminPageShell>
     <MarksManagement />
-  </section>
+  </AdminPageShell>
 </template>
 
 <script>
+import AdminPageShell from './AdminPageShell.vue';
 import MarksManagement from '@/components/MarksManagement.vue';
 
 export default {
   name: 'MarksView',
-  components: { MarksManagement },
+  components: { AdminPageShell, MarksManagement },
 };
 </script>
-
-<style scoped>
-.admin-page {
-  padding: 16px;
-  height: 100%;
-}
-</style>

--- a/frontend/src/views/admin/NumberFormatsView.vue
+++ b/frontend/src/views/admin/NumberFormatsView.vue
@@ -1,21 +1,15 @@
 <template>
-  <section class="admin-page">
+  <AdminPageShell>
     <NumberFormat />
-  </section>
+  </AdminPageShell>
 </template>
 
 <script>
+import AdminPageShell from './AdminPageShell.vue';
 import NumberFormat from '@/components/NumberFormat.vue';
 
 export default {
   name: 'NumberFormatsView',
-  components: { NumberFormat },
+  components: { AdminPageShell, NumberFormat },
 };
 </script>
-
-<style scoped>
-.admin-page {
-  padding: 16px;
-  height: 100%;
-}
-</style>

--- a/frontend/src/views/admin/OrganizationsView.vue
+++ b/frontend/src/views/admin/OrganizationsView.vue
@@ -1,21 +1,15 @@
 <template>
-  <section class="admin-page">
+  <AdminPageShell>
     <OrganizationsManagement />
-  </section>
+  </AdminPageShell>
 </template>
 
 <script>
+import AdminPageShell from './AdminPageShell.vue';
 import OrganizationsManagement from '@/components/OrganizationsManagement.vue';
 
 export default {
   name: 'OrganizationsView',
-  components: { OrganizationsManagement },
+  components: { AdminPageShell, OrganizationsManagement },
 };
 </script>
-
-<style scoped>
-.admin-page {
-  padding: 16px;
-  height: 100%;
-}
-</style>

--- a/frontend/src/views/admin/UnloadPlacesView.vue
+++ b/frontend/src/views/admin/UnloadPlacesView.vue
@@ -1,21 +1,15 @@
 <template>
-  <section class="admin-page">
+  <AdminPageShell>
     <UnloadPlacesContainer />
-  </section>
+  </AdminPageShell>
 </template>
 
 <script>
+import AdminPageShell from './AdminPageShell.vue';
 import UnloadPlacesContainer from '@/components/UnloadPlaces/UnloadPlacesContainer.vue';
 
 export default {
   name: 'UnloadPlacesView',
-  components: { UnloadPlacesContainer },
+  components: { AdminPageShell, UnloadPlacesContainer },
 };
 </script>
-
-<style scoped>
-.admin-page {
-  padding: 16px;
-  height: 100%;
-}
-</style>

--- a/frontend/src/views/admin/UserTypesView.vue
+++ b/frontend/src/views/admin/UserTypesView.vue
@@ -1,21 +1,15 @@
 <template>
-  <section class="admin-page">
+  <AdminPageShell>
     <UserTypes />
-  </section>
+  </AdminPageShell>
 </template>
 
 <script>
+import AdminPageShell from './AdminPageShell.vue';
 import UserTypes from '@/components/UserTypes.vue';
 
 export default {
   name: 'UserTypesView',
-  components: { UserTypes },
+  components: { AdminPageShell, UserTypes },
 };
 </script>
-
-<style scoped>
-.admin-page {
-  padding: 16px;
-  height: 100%;
-}
-</style>


### PR DESCRIPTION
## Что и зачем

Полиш к Срезу 1 эпика #510. Вынесенные в `/admin/*` справочники открывались фиксированной карточкой (~450-540px) с пустым хвостом снизу. По просьбе: карточка должна занимать всю доступную высоту страницы - без скролла самой страницы и без пустого отступа снизу; радиус карточки 35px.

## Изменения

- Новый общий `views/admin/AdminPageShell.vue`: меряет фактическую доступную высоту (`innerHeight - top` карточки), растягивает обёртку; через `:deep` задаёт карточке `height:100%`, `border-radius:35px`, делает корень flex-колонкой, а мастер-детейл `.content-container` - `flex:1`, чтобы тело тянулось на всю высоту.
- Все 9 обёрток `views/admin/*View.vue` переведены на `<AdminPageShell>`; удалён дублированный scoped `.admin-page` (DRY, закрывает nit прошлого ревью).

Внутренние скроллы компонентов не тронуты (правим height/flex, не overflow). Правка скоуплена на `/admin/*` через `:deep` - в кабинете компоненты хостит `AccountComponent`, туда стили шелла не доходят.

## Проверено

- Локально (vite + Playwright, логин buropropuskov) на 5 роутах: `pageScroll = 0`, карточка упирается в низ вьюпорта, мастер-детейл заполняет карточку (gap карточка↔низ контента ~1px), `border-radius = 35px`, 0 ошибок консоли. Скриншоты согласованы с заказчиком до мержа.
- ESLint чисто; `code-reviewer` - GO. Закрыты замечания: RO навешен на шапку (не на body, чтобы Teleport-модалки не будили reflow), добавлен комментарий про намеренное переопределение фикс-высот.