### PR TITLE
fix(nav): polish-round 4 - sticky дропдаун, "Новая заявка", стрелка, отступы (#510)

### DIFF
--- a/frontend/src/components/NavMenu.vue
+++ b/frontend/src/components/NavMenu.vue
@@ -152,6 +152,20 @@
                 {{ newApplicationsCount > 9 ? '9+' : newApplicationsCount }}
               </span>
             </div>
+            <div
+              v-show="matches('Новая заявка')"
+              class="nav-item"
+              :class="{ active: isActive('/new-application') }"
+              data-testid="nav-link-new-application"
+              @click="navigateToNewApplication"
+            >
+              <NavIcon
+                name="new-application"
+                :size="18"
+                class="nav-icon"
+              />
+              <span class="nav-text">Новая заявка</span>
+            </div>
           </div>
 
           <!-- УПРАВЛЕНИЕ ДАННЫМИ -->
@@ -316,11 +330,11 @@
                 />
                 <span class="nav-text">Администрирование</span>
               </div>
-              <!-- Не дропдаун, а открытие боковой колонки: глиф панели с подколонкой. -->
+              <!-- Не дропдаун, а открытие боковой колонки: прямая стрелка вправо. -->
               <svg
                 class="panel-indicator"
-                width="15"
-                height="15"
+                width="16"
+                height="16"
                 viewBox="0 0 24 24"
                 fill="none"
                 stroke="currentColor"
@@ -329,19 +343,13 @@
                 stroke-linejoin="round"
                 aria-hidden="true"
               >
-                <rect
-                  x="3"
-                  y="5"
-                  width="18"
-                  height="14"
-                  rx="2"
-                />
                 <line
-                  x1="14"
-                  y1="5"
-                  x2="14"
-                  y2="19"
+                  x1="4"
+                  y1="12"
+                  x2="18"
+                  y2="12"
                 />
+                <polyline points="13 7 18 12 13 17" />
               </svg>
             </div>
           </div>
@@ -685,7 +693,7 @@ export default {
     sectionVisible() {
       const on = this.searchActive;
       return {
-        requests: !on || this.matches('Центр заявок'),
+        requests: !on || this.matches('Центр заявок') || this.matches('Новая заявка'),
         data: !on || this.tablesItemVisible || this.matches('Сотрудники') || this.matches('Автомобили'),
         analytics: !on || this.matches('Статистика') || this.matches('Аналитика'),
         admin: !on || this.matches('Администрирование'),
@@ -710,6 +718,9 @@ export default {
     this.syncContentMargin();
     await this.fetchBanStatus();
     await this.fetchSystemTables();
+    // Заход напрямую на страницу таблицы - раскрываем список один раз, чтобы
+    // активная была видна. Дальше состояние дропдауна управляется только кликом.
+    if (this.isActive('/table')) this.dropdowns.tables = true;
     this.startApplicationsPolling();
     this.startTablesPolling();
 
@@ -839,13 +850,13 @@ export default {
         this.hoverTimeout = null;
       }
       this.isExpanded = true;
-      // На странице таблицы держим список раскрытым, чтобы активная была видна.
-      if (this.isActive('/table')) this.dropdowns.tables = true;
     },
     collapseMenu() {
+      // Сворачиваем только рельс (hover-разворот). Состояние дропдауна «Таблицы»
+      // намеренно НЕ трогаем: открыт по клику - остаётся открытым, скрывается лишь
+      // визуально вместе со схлопыванием рельса и возвращается при наведении.
       this.hoverTimeout = setTimeout(() => {
         this.isExpanded = false;
-        this.closeAllDropdowns();
         this.hoverTimeout = null;
       }, 150);
     },
@@ -890,7 +901,10 @@ export default {
 
     navigateToCenter() {
       this.$router.push('/center');
-      this.closeAllDropdowns();
+    },
+    navigateToNewApplication() {
+      this.$router.push('/new-application');
+      this.closeMobile();
     },
     navigateToAccount() {
       this.$router.push('/personal-cabinet');

--- a/frontend/src/components/TableConstructor.vue
+++ b/frontend/src/components/TableConstructor.vue
@@ -1,632 +1,634 @@
 <template>
-  <div class="table-constructor-container dashboard-card">
-    <div class="management-header">
-      <h3 class="management-title">
-        Таблицы системы
-      </h3>
-      <div class="header-controls">
-        <BaseDropdown
-          class="archive-dropdown"
-          :model-value="showArchive ? 'archive' : 'active'"
-          :options="archiveOptions"
-          label-key="label"
-          value-key="value"
-          @update:model-value="onArchiveModeChange"
-        />
-        <SearchComponent
-          v-model="searchQuery"
-          :title="'Поиск таблиц...'"
-        />
-        <button
-          class="add-header-button"
-          @click="showAddModal = true"
-        >
-          Создать таблицу
-        </button>
-        <RefreshButton
-          :loading="refreshing"
-          @refresh="refreshData"
-        />
-      </div>
-    </div>
-
-    <div class="content-container">
-      <!-- Левая часть - список таблиц -->
-      <div
-        class="table-section"
-        :class="{'with-details': selectedTable}"
-      >
-        <div class="table-container">
-          <div class="table-header">
-            <div
-              class="header-col id-col"
-              @click="sortBy('id')"
-            >
-              <p :class="{ 'active-sort': sortField === 'id' }">
-                ID
-              </p>
-              <img 
-                src="@/assets/icons/sort.png" 
-                class="sort-icon" 
-                :class="{ 
-                  'sorted': sortField === 'id',
-                  'desc': sortField === 'id' && sortDirection === 'desc'
-                }" 
-              >
-            </div>
-            <div
-              class="header-col name-col"
-              @click="sortBy('name')"
-            >
-              <p :class="{ 'active-sort': sortField === 'name' }">
-                Наименование
-              </p>
-              <img 
-                src="@/assets/icons/sort.png" 
-                class="sort-icon" 
-                :class="{ 
-                  'sorted': sortField === 'name',
-                  'desc': sortField === 'name' && sortDirection === 'desc'
-                }" 
-              >
-            </div>
-            <div
-              class="header-col type-col"
-              @click="sortBy('type')"
-            >
-              <p :class="{ 'active-sort': sortField === 'type' }">
-                Тип
-              </p>
-              <img 
-                src="@/assets/icons/sort.png" 
-                class="sort-icon" 
-                :class="{ 
-                  'sorted': sortField === 'type',
-                  'desc': sortField === 'type' && sortDirection === 'desc'
-                }" 
-              >
-            </div>
-            <div class="header-col status-col">
-              <p>Статус</p>
-            </div>
-          </div>
-
-          <div class="table-body">
-            <div
-              v-for="table in sortedTables"
-              :key="table.table.id"
-              class="table-row"
-              :class="{
-                'selected': selectedTable && selectedTable.table.id === table.table.id,
-                'inactive': !table.table.is_active,
-              }"
-              @click="selectTable(table)"
-            >
-              <div class="table-col id-col">
-                <span class="cell-content id-value">{{ table.table.id }}</span>
-              </div>
-              <div class="table-col name-col">
-                <span
-                  class="truncate-text"
-                  :title="table.table.display_name"
-                >
-                  {{ table.table.display_name }}
-                  <span
-                    v-if="!table.table.is_active"
-                    class="inactive-badge"
-                  >(архив)</span>
-                </span>
-              </div>
-              <div class="table-col type-col">
-                <span
-                  class="type-badge"
-                  :class="table.table.table_type"
-                >
-                  {{ getTableTypeLabel(table.table.table_type) }}
-                </span>
-              </div>
-              <div class="table-col status-col">
-                <span
-                  class="status-badge"
-                  :class="getTableStatusClass(table)"
-                >
-                  {{ getTableStatusText(table) }}
-                </span>
-              </div>
-            </div>
-          </div>
-
-          <div class="table-footer">
-            <span class="items-count">
-              {{ showArchive ? 'В архиве' : 'Всего таблиц' }}: {{ filteredTables.length }}
-            </span>
-          </div>
-        </div>
-      </div>
-
-      <!-- Правая часть - детали таблицы -->
-      <div
-        v-if="selectedTable"
-        class="details-section"
-      >
-        <div
-          v-if="selectedTable.table.is_active"
-          class="details-tabs"
-        >
-          <div class="details-tabs__row">
-            <button
-              class="tab-btn"
-              :class="{ 'active': activeTab === 'main' }"
-              @click="switchTab('main')"
-            >
-              Основное
-            </button>
-            <button
-              class="tab-btn"
-              :class="{ 'active': activeTab === 'schedule' }"
-              @click="switchTab('schedule')"
-            >
-              Расписание
-            </button>
-            <button
-              class="tab-btn"
-              :class="{ 'active': activeTab === 'location' }"
-              @click="switchTab('location')"
-            >
-              Местоположение
-            </button>
-            <button
-              class="tab-btn"
-              :class="{ 'active': activeTab === 'columns' }"
-              @click="switchTab('columns')"
-            >
-              Колонки
-            </button>
-            <button
-              class="tab-btn"
-              :class="{ 'active': activeTab === 'appearance' }"
-              @click="switchTab('appearance')"
-            >
-              Оформление
-            </button>
-          </div>
-          <div
-            v-if="selectedTable.table.show_fact_table"
-            class="details-tabs__row details-tabs__row--fact"
+  <AdminPageShell>
+    <div class="table-constructor-container dashboard-card">
+      <div class="management-header">
+        <h3 class="management-title">
+          Таблицы системы
+        </h3>
+        <div class="header-controls">
+          <BaseDropdown
+            class="archive-dropdown"
+            :model-value="showArchive ? 'archive' : 'active'"
+            :options="archiveOptions"
+            label-key="label"
+            value-key="value"
+            @update:model-value="onArchiveModeChange"
+          />
+          <SearchComponent
+            v-model="searchQuery"
+            :title="'Поиск таблиц...'"
+          />
+          <button
+            class="add-header-button"
+            @click="showAddModal = true"
           >
-            <span class="details-tabs__group-label">По факту:</span>
-            <button
-              class="tab-btn"
-              :class="{ 'active': activeTab === 'fact-columns' }"
-              @click="switchTab('fact-columns')"
-            >
-              Колонки
-            </button>
-            <button
-              class="tab-btn"
-              :class="{ 'active': activeTab === 'fact-appearance' }"
-              @click="switchTab('fact-appearance')"
-            >
-              Оформление
-            </button>
+            Создать таблицу
+          </button>
+          <RefreshButton
+            :loading="refreshing"
+            @refresh="refreshData"
+          />
+        </div>
+      </div>
+
+      <div class="content-container">
+        <!-- Левая часть - список таблиц -->
+        <div
+          class="table-section"
+          :class="{'with-details': selectedTable}"
+        >
+          <div class="table-container">
+            <div class="table-header">
+              <div
+                class="header-col id-col"
+                @click="sortBy('id')"
+              >
+                <p :class="{ 'active-sort': sortField === 'id' }">
+                  ID
+                </p>
+                <img 
+                  src="@/assets/icons/sort.png" 
+                  class="sort-icon" 
+                  :class="{ 
+                    'sorted': sortField === 'id',
+                    'desc': sortField === 'id' && sortDirection === 'desc'
+                  }" 
+                >
+              </div>
+              <div
+                class="header-col name-col"
+                @click="sortBy('name')"
+              >
+                <p :class="{ 'active-sort': sortField === 'name' }">
+                  Наименование
+                </p>
+                <img 
+                  src="@/assets/icons/sort.png" 
+                  class="sort-icon" 
+                  :class="{ 
+                    'sorted': sortField === 'name',
+                    'desc': sortField === 'name' && sortDirection === 'desc'
+                  }" 
+                >
+              </div>
+              <div
+                class="header-col type-col"
+                @click="sortBy('type')"
+              >
+                <p :class="{ 'active-sort': sortField === 'type' }">
+                  Тип
+                </p>
+                <img 
+                  src="@/assets/icons/sort.png" 
+                  class="sort-icon" 
+                  :class="{ 
+                    'sorted': sortField === 'type',
+                    'desc': sortField === 'type' && sortDirection === 'desc'
+                  }" 
+                >
+              </div>
+              <div class="header-col status-col">
+                <p>Статус</p>
+              </div>
+            </div>
+
+            <div class="table-body">
+              <div
+                v-for="table in sortedTables"
+                :key="table.table.id"
+                class="table-row"
+                :class="{
+                  'selected': selectedTable && selectedTable.table.id === table.table.id,
+                  'inactive': !table.table.is_active,
+                }"
+                @click="selectTable(table)"
+              >
+                <div class="table-col id-col">
+                  <span class="cell-content id-value">{{ table.table.id }}</span>
+                </div>
+                <div class="table-col name-col">
+                  <span
+                    class="truncate-text"
+                    :title="table.table.display_name"
+                  >
+                    {{ table.table.display_name }}
+                    <span
+                      v-if="!table.table.is_active"
+                      class="inactive-badge"
+                    >(архив)</span>
+                  </span>
+                </div>
+                <div class="table-col type-col">
+                  <span
+                    class="type-badge"
+                    :class="table.table.table_type"
+                  >
+                    {{ getTableTypeLabel(table.table.table_type) }}
+                  </span>
+                </div>
+                <div class="table-col status-col">
+                  <span
+                    class="status-badge"
+                    :class="getTableStatusClass(table)"
+                  >
+                    {{ getTableStatusText(table) }}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            <div class="table-footer">
+              <span class="items-count">
+                {{ showArchive ? 'В архиве' : 'Всего таблиц' }}: {{ filteredTables.length }}
+              </span>
+            </div>
           </div>
         </div>
 
-        <!-- Вкладка Основное -->
+        <!-- Правая часть - детали таблицы -->
         <div
-          v-if="activeTab === 'main'"
-          class="tab-content"
+          v-if="selectedTable"
+          class="details-section"
         >
-          <div class="details-header">
-            <div class="details-title-wrapper">
-              <div class="table-info-title">
-                <h3 class="details-title">
-                  {{ selectedTable.table.display_name }}
-                </h3>
-                <span
-                  class="table-type-badge"
-                  :class="selectedTable.table.table_type"
-                >
-                  {{ getTableTypeLabel(selectedTable.table.table_type) }}
-                </span>
-              </div>
-              <div class="table-info-row">
-                <span
-                  class="current-status-badge"
-                  :class="getTableCurrentStatusClass(selectedTable)"
-                >
-                  {{ getTableCurrentStatusText(selectedTable) }}
-                </span>
-                <span class="system-name">{{ selectedTable.table.name }}</span>
-              </div>
+          <div
+            v-if="selectedTable.table.is_active"
+            class="details-tabs"
+          >
+            <div class="details-tabs__row">
+              <button
+                class="tab-btn"
+                :class="{ 'active': activeTab === 'main' }"
+                @click="switchTab('main')"
+              >
+                Основное
+              </button>
+              <button
+                class="tab-btn"
+                :class="{ 'active': activeTab === 'schedule' }"
+                @click="switchTab('schedule')"
+              >
+                Расписание
+              </button>
+              <button
+                class="tab-btn"
+                :class="{ 'active': activeTab === 'location' }"
+                @click="switchTab('location')"
+              >
+                Местоположение
+              </button>
+              <button
+                class="tab-btn"
+                :class="{ 'active': activeTab === 'columns' }"
+                @click="switchTab('columns')"
+              >
+                Колонки
+              </button>
+              <button
+                class="tab-btn"
+                :class="{ 'active': activeTab === 'appearance' }"
+                @click="switchTab('appearance')"
+              >
+                Оформление
+              </button>
             </div>
-            <div class="details-header-actions">
-              <span
-                v-if="!selectedTable.table.is_active"
-                class="archive-badge"
-              >В архиве</span>
+            <div
+              v-if="selectedTable.table.show_fact_table"
+              class="details-tabs__row details-tabs__row--fact"
+            >
+              <span class="details-tabs__group-label">По факту:</span>
               <button
-                class="action-btn history-btn"
-                @click="historyTable = selectedTable.table"
+                class="tab-btn"
+                :class="{ 'active': activeTab === 'fact-columns' }"
+                @click="switchTab('fact-columns')"
               >
-                История
+                Колонки
               </button>
               <button
-                v-if="selectedTable.table.is_active"
-                class="action-btn view-btn"
-                @click="openTable"
+                class="tab-btn"
+                :class="{ 'active': activeTab === 'fact-appearance' }"
+                @click="switchTab('fact-appearance')"
               >
-                Открыть
-              </button>
-              <button
-                v-if="!selectedTable.table.is_active"
-                class="action-btn restore-btn"
-                @click="restoreTable(selectedTable)"
-              >
-                Восстановить
-              </button>
-              <button
-                v-if="selectedTable.table.is_active"
-                class="delete-icon-btn"
-                @click="confirmDeleteTable(selectedTable)"
-              >
-                <img
-                  src="@/assets/icons/delete.png"
-                  class="delete-icon"
-                >
+                Оформление
               </button>
             </div>
           </div>
-          
-          <div class="details-body">
-            <div class="compact-form">
-              <div class="form-row">
-                <div class="form-group compact">
-                  <label class="detail-label">Наименование таблицы:</label>
-                  <input 
-                    v-model="selectedTable.table.display_name" 
-                    class="form-input-sm"
-                    placeholder="Название таблицы"
-                    autocomplete="off"
-                    @change="updateTableField('display_name')"
+
+          <!-- Вкладка Основное -->
+          <div
+            v-if="activeTab === 'main'"
+            class="tab-content"
+          >
+            <div class="details-header">
+              <div class="details-title-wrapper">
+                <div class="table-info-title">
+                  <h3 class="details-title">
+                    {{ selectedTable.table.display_name }}
+                  </h3>
+                  <span
+                    class="table-type-badge"
+                    :class="selectedTable.table.table_type"
                   >
+                    {{ getTableTypeLabel(selectedTable.table.table_type) }}
+                  </span>
                 </div>
-                <div class="form-group compact">
-                  <label class="detail-label">Тип таблицы:</label>
-                  <div class="custom-select">
-                    <div
-                      class="select-header"
-                      @click="toggleTableTypeDropdown"
+                <div class="table-info-row">
+                  <span
+                    class="current-status-badge"
+                    :class="getTableCurrentStatusClass(selectedTable)"
+                  >
+                    {{ getTableCurrentStatusText(selectedTable) }}
+                  </span>
+                  <span class="system-name">{{ selectedTable.table.name }}</span>
+                </div>
+              </div>
+              <div class="details-header-actions">
+                <span
+                  v-if="!selectedTable.table.is_active"
+                  class="archive-badge"
+                >В архиве</span>
+                <button
+                  class="action-btn history-btn"
+                  @click="historyTable = selectedTable.table"
+                >
+                  История
+                </button>
+                <button
+                  v-if="selectedTable.table.is_active"
+                  class="action-btn view-btn"
+                  @click="openTable"
+                >
+                  Открыть
+                </button>
+                <button
+                  v-if="!selectedTable.table.is_active"
+                  class="action-btn restore-btn"
+                  @click="restoreTable(selectedTable)"
+                >
+                  Восстановить
+                </button>
+                <button
+                  v-if="selectedTable.table.is_active"
+                  class="delete-icon-btn"
+                  @click="confirmDeleteTable(selectedTable)"
+                >
+                  <img
+                    src="@/assets/icons/delete.png"
+                    class="delete-icon"
+                  >
+                </button>
+              </div>
+            </div>
+          
+            <div class="details-body">
+              <div class="compact-form">
+                <div class="form-row">
+                  <div class="form-group compact">
+                    <label class="detail-label">Наименование таблицы:</label>
+                    <input 
+                      v-model="selectedTable.table.display_name" 
+                      class="form-input-sm"
+                      placeholder="Название таблицы"
+                      autocomplete="off"
+                      @change="updateTableField('display_name')"
                     >
-                      <span class="select-value">{{ getTableTypeLabel(selectedTable.table.table_type) }}</span>
-                      <img
-                        src="@/assets/icons/arrow.png"
-                        class="select-arrow"
-                        :class="{ rotated: tableTypeDropdownOpen }"
-                      >
-                    </div>
-                    <transition name="dropdown-fade">
+                  </div>
+                  <div class="form-group compact">
+                    <label class="detail-label">Тип таблицы:</label>
+                    <div class="custom-select">
                       <div
-                        v-if="tableTypeDropdownOpen"
-                        class="select-dropdown"
+                        class="select-header"
+                        @click="toggleTableTypeDropdown"
                       >
-                        <div 
-                          class="select-option"
-                          :class="{ active: selectedTable.table.table_type === 'cars' }"
-                          @click="selectTableType('cars')"
+                        <span class="select-value">{{ getTableTypeLabel(selectedTable.table.table_type) }}</span>
+                        <img
+                          src="@/assets/icons/arrow.png"
+                          class="select-arrow"
+                          :class="{ rotated: tableTypeDropdownOpen }"
                         >
-                          Машины
-                        </div>
-                        <div 
-                          class="select-option"
-                          :class="{ active: selectedTable.table.table_type === 'people' }"
-                          @click="selectTableType('people')"
-                        >
-                          Люди
-                        </div>
                       </div>
-                    </transition>
+                      <transition name="dropdown-fade">
+                        <div
+                          v-if="tableTypeDropdownOpen"
+                          class="select-dropdown"
+                        >
+                          <div 
+                            class="select-option"
+                            :class="{ active: selectedTable.table.table_type === 'cars' }"
+                            @click="selectTableType('cars')"
+                          >
+                            Машины
+                          </div>
+                          <div 
+                            class="select-option"
+                            :class="{ active: selectedTable.table.table_type === 'people' }"
+                            @click="selectTableType('people')"
+                          >
+                            Люди
+                          </div>
+                        </div>
+                      </transition>
+                    </div>
                   </div>
                 </div>
-              </div>
 
-              <!-- Статус в виде кнопок -->
-              <div class="form-group">
-                <label class="detail-label">Статус:</label>
-                <p class="field-hint">
-                  "Не активно" / "На обслуживании" - таблицу нельзя выбрать в
-                  новой заявке. Пользователь видит причину.
-                </p>
-                <div class="status-toggle">
-                  <button 
-                    class="status-btn" 
-                    :class="{ 'active': selectedTable.table.status === 'active' }"
-                    @click="setTableStatus('active')"
-                  >
-                    Активно
-                  </button>
-                  <button 
-                    class="status-btn" 
-                    :class="{ 'active': selectedTable.table.status === 'inactive' }"
-                    @click="setTableStatus('inactive')"
-                  >
-                    Не активно
-                  </button>
-                  <button 
-                    class="status-btn" 
-                    :class="{ 'active': selectedTable.table.status === 'maintenance' }"
-                    @click="setTableStatus('maintenance')"
-                  >
-                    На обслуживании
-                  </button>
-                </div>
-              </div>
-
-              <!-- Комментарий к статусу (только для неактивных) -->
-              <div
-                v-if="selectedTable.table.status !== 'active'"
-                class="form-group"
-              >
-                <label class="detail-label">Причина:</label>
-                <textarea 
-                  v-model="selectedTable.table.status_comment" 
-                  class="form-textarea"
-                  placeholder="Укажите причину"
-                  rows="2"
-                  @change="updateTableField('status_comment')"
-                />
-              </div>
-
-              <div class="settings-section">
-                <label class="section-label">Настройки отображения:</label>
-
-                <div class="checkbox-group">
-                  <label class="checkbox-label">
-                    <input
-                      v-model="selectedTable.table.show_fact_table"
-                      type="checkbox"
-                      class="checkbox-input"
-                      @change="updateTableField('show_fact_table')"
-                    >
-                    <span class="checkbox-text">Отображать таблицу "по факту"</span>
-                  </label>
+                <!-- Статус в виде кнопок -->
+                <div class="form-group">
+                  <label class="detail-label">Статус:</label>
                   <p class="field-hint">
-                    На странице с основной таблицей отображается таблица
-                    "по факту". В ней отображаются люди/машины, данные которых
-                    заранее не известны.
+                    "Не активно" / "На обслуживании" - таблицу нельзя выбрать в
+                    новой заявке. Пользователь видит причину.
                   </p>
+                  <div class="status-toggle">
+                    <button 
+                      class="status-btn" 
+                      :class="{ 'active': selectedTable.table.status === 'active' }"
+                      @click="setTableStatus('active')"
+                    >
+                      Активно
+                    </button>
+                    <button 
+                      class="status-btn" 
+                      :class="{ 'active': selectedTable.table.status === 'inactive' }"
+                      @click="setTableStatus('inactive')"
+                    >
+                      Не активно
+                    </button>
+                    <button 
+                      class="status-btn" 
+                      :class="{ 'active': selectedTable.table.status === 'maintenance' }"
+                      @click="setTableStatus('maintenance')"
+                    >
+                      На обслуживании
+                    </button>
+                  </div>
                 </div>
 
+                <!-- Комментарий к статусу (только для неактивных) -->
                 <div
-                  v-if="selectedTable.table.show_fact_table"
-                  class="hint-section"
+                  v-if="selectedTable.table.status !== 'active'"
+                  class="form-group"
                 >
+                  <label class="detail-label">Причина:</label>
+                  <textarea 
+                    v-model="selectedTable.table.status_comment" 
+                    class="form-textarea"
+                    placeholder="Укажите причину"
+                    rows="2"
+                    @change="updateTableField('status_comment')"
+                  />
+                </div>
+
+                <div class="settings-section">
+                  <label class="section-label">Настройки отображения:</label>
+
+                  <div class="checkbox-group">
+                    <label class="checkbox-label">
+                      <input
+                        v-model="selectedTable.table.show_fact_table"
+                        type="checkbox"
+                        class="checkbox-input"
+                        @change="updateTableField('show_fact_table')"
+                      >
+                      <span class="checkbox-text">Отображать таблицу "по факту"</span>
+                    </label>
+                    <p class="field-hint">
+                      На странице с основной таблицей отображается таблица
+                      "по факту". В ней отображаются люди/машины, данные которых
+                      заранее не известны.
+                    </p>
+                  </div>
+
+                  <div
+                    v-if="selectedTable.table.show_fact_table"
+                    class="hint-section"
+                  >
+                    <div class="section-header-with-actions">
+                      <label class="detail-label">Подсказка для таблицы "по факту":</label>
+                      <div
+                        v-if="hintHasChanges"
+                        class="editor-actions"
+                      >
+                        <button
+                          class="compact-btn cancel-btn"
+                          @click="cancelHintEdit"
+                        >
+                          Отмена
+                        </button>
+                        <button
+                          class="compact-btn save-btn"
+                          @click="saveHint"
+                        >
+                          Сохранить
+                        </button>
+                      </div>
+                    </div>
+                    <TextConstructor
+                      ref="hintConstructor"
+                      v-model="selectedTable.table.fact_table_hint"
+                      :placeholder="getDefaultHint(selectedTable.table.table_type)"
+                      rows="4"
+                    />
+                  </div>
+                </div>
+
+                <div class="instruction-section">
+                  <p class="field-hint">
+                    Видна в шапке таблицы по клику на "Инструкция". Здесь пишут
+                    правила прохода/проезда для охранника на этой точке.
+                  </p>
                   <div class="section-header-with-actions">
-                    <label class="detail-label">Подсказка для таблицы "по факту":</label>
+                    <label class="detail-label">Инструкция к таблице:</label>
                     <div
-                      v-if="hintHasChanges"
+                      v-if="instructionHasChanges"
                       class="editor-actions"
                     >
                       <button
                         class="compact-btn cancel-btn"
-                        @click="cancelHintEdit"
+                        @click="cancelInstructionEdit"
                       >
                         Отмена
                       </button>
                       <button
                         class="compact-btn save-btn"
-                        @click="saveHint"
+                        @click="saveInstruction"
                       >
                         Сохранить
                       </button>
                     </div>
                   </div>
                   <TextConstructor
-                    ref="hintConstructor"
-                    v-model="selectedTable.table.fact_table_hint"
-                    :placeholder="getDefaultHint(selectedTable.table.table_type)"
+                    ref="instructionConstructor"
+                    v-model="selectedTable.table.instruction"
+                    placeholder="Введите инструкцию для таблицы..."
                     rows="4"
                   />
                 </div>
               </div>
-
-              <div class="instruction-section">
-                <p class="field-hint">
-                  Видна в шапке таблицы по клику на "Инструкция". Здесь пишут
-                  правила прохода/проезда для охранника на этой точке.
-                </p>
-                <div class="section-header-with-actions">
-                  <label class="detail-label">Инструкция к таблице:</label>
-                  <div
-                    v-if="instructionHasChanges"
-                    class="editor-actions"
-                  >
-                    <button
-                      class="compact-btn cancel-btn"
-                      @click="cancelInstructionEdit"
-                    >
-                      Отмена
-                    </button>
-                    <button
-                      class="compact-btn save-btn"
-                      @click="saveInstruction"
-                    >
-                      Сохранить
-                    </button>
-                  </div>
-                </div>
-                <TextConstructor
-                  ref="instructionConstructor"
-                  v-model="selectedTable.table.instruction"
-                  placeholder="Введите инструкцию для таблицы..."
-                  rows="4"
-                />
-              </div>
             </div>
           </div>
-        </div>
 
-        <!-- Вкладка Расписание -->
-        <div
-          v-if="activeTab === 'schedule'"
-          class="tab-content"
-        >
-          <WorkScheduleTab
-            :resource-url="'/system-tables/' + selectedTable.table.id"
-            :time-slots="selectedTable.time_slots"
-            @update="refreshSelectedTable"
-          />
-        </div>
-
-        <!-- Вкладка Местоположение -->
-        <div
-          v-if="activeTab === 'location'"
-          class="tab-content"
-        >
-          <div class="location-section">
-            <h4 class="section-title">
-              Описание местоположения
-            </h4>
-            <textarea 
-              v-model="selectedTable.table.location_description" 
-              class="form-textarea"
-              placeholder="Введите описание местоположения..."
-              rows="3"
-              @change="updateTableField('location_description')"
+          <!-- Вкладка Расписание -->
+          <div
+            v-if="activeTab === 'schedule'"
+            class="tab-content"
+          >
+            <WorkScheduleTab
+              :resource-url="'/system-tables/' + selectedTable.table.id"
+              :time-slots="selectedTable.time_slots"
+              @update="refreshSelectedTable"
             />
           </div>
 
-          <div class="location-section">
-            <h4 class="section-title">
-              Ссылка на карту
-            </h4>
-            <div class="map-link-group">
-              <input 
-                v-model="selectedTable.table.map_link" 
-                class="form-input"
-                placeholder="https://maps.google.com/..."
-                autocomplete="off"
-                @change="updateTableField('map_link')"
-              >
-              <a 
-                v-if="selectedTable.table.map_link" 
-                :href="selectedTable.table.map_link" 
-                target="_blank" 
-                class="map-link-btn"
-              >
-                Открыть карту
-              </a>
+          <!-- Вкладка Местоположение -->
+          <div
+            v-if="activeTab === 'location'"
+            class="tab-content"
+          >
+            <div class="location-section">
+              <h4 class="section-title">
+                Описание местоположения
+              </h4>
+              <textarea 
+                v-model="selectedTable.table.location_description" 
+                class="form-textarea"
+                placeholder="Введите описание местоположения..."
+                rows="3"
+                @change="updateTableField('location_description')"
+              />
             </div>
+
+            <div class="location-section">
+              <h4 class="section-title">
+                Ссылка на карту
+              </h4>
+              <div class="map-link-group">
+                <input 
+                  v-model="selectedTable.table.map_link" 
+                  class="form-input"
+                  placeholder="https://maps.google.com/..."
+                  autocomplete="off"
+                  @change="updateTableField('map_link')"
+                >
+                <a 
+                  v-if="selectedTable.table.map_link" 
+                  :href="selectedTable.table.map_link" 
+                  target="_blank" 
+                  class="map-link-btn"
+                >
+                  Открыть карту
+                </a>
+              </div>
+            </div>
+
+            <TableConstructorPhotoSection
+              :table-id="selectedTable.table.id"
+              :photos="selectedTable.photos || []"
+              @photos-changed="refreshSelectedTable"
+            />
           </div>
 
-          <TableConstructorPhotoSection
-            :table-id="selectedTable.table.id"
-            :photos="selectedTable.photos || []"
-            @photos-changed="refreshSelectedTable"
-          />
+          <!-- Вкладка Колонки (#345) -->
+          <div
+            v-if="activeTab === 'columns'"
+            class="tab-content"
+          >
+            <SystemTableColumnsTab
+              :table-id="selectedTable.table.id"
+              :table-type="selectedTable.table.table_type"
+              :fields="selectedTable.fields || []"
+              @update="refreshSelectedTable"
+            />
+          </div>
+
+          <!-- Вкладка Оформление (#345 фазы 1D+1E) -->
+          <div
+            v-if="activeTab === 'appearance'"
+            class="tab-content"
+          >
+            <SystemTableAppearanceTab
+              :table-id="selectedTable.table.id"
+              :table="selectedTable.table"
+              :table-type="selectedTable.table.table_type"
+              :fields="selectedTable.fields || []"
+              @update="refreshSelectedTable"
+            />
+          </div>
+
+          <!-- Колонки FactTable (#345) -->
+          <div
+            v-if="activeTab === 'fact-columns' && selectedTable.table.show_fact_table"
+            class="tab-content"
+          >
+            <SystemTableColumnsTab
+              :table-id="selectedTable.table.id"
+              :table-type="selectedTable.table.table_type"
+              :fields="selectedTable.fact_fields || []"
+              variant="fact"
+              @update="refreshSelectedTable"
+            />
+          </div>
+
+          <!-- Оформление FactTable (#345) -->
+          <div
+            v-if="activeTab === 'fact-appearance' && selectedTable.table.show_fact_table"
+            class="tab-content"
+          >
+            <SystemTableAppearanceTab
+              :table-id="selectedTable.table.id"
+              :table="selectedTable.table"
+              :table-type="selectedTable.table.table_type"
+              :fields="selectedTable.fact_fields || []"
+              variant="fact"
+              @update="refreshSelectedTable"
+            />
+          </div>
         </div>
 
-        <!-- Вкладка Колонки (#345) -->
         <div
-          v-if="activeTab === 'columns'"
-          class="tab-content"
+          v-else
+          class="no-selection-message"
         >
-          <SystemTableColumnsTab
-            :table-id="selectedTable.table.id"
-            :table-type="selectedTable.table.table_type"
-            :fields="selectedTable.fields || []"
-            @update="refreshSelectedTable"
-          />
-        </div>
-
-        <!-- Вкладка Оформление (#345 фазы 1D+1E) -->
-        <div
-          v-if="activeTab === 'appearance'"
-          class="tab-content"
-        >
-          <SystemTableAppearanceTab
-            :table-id="selectedTable.table.id"
-            :table="selectedTable.table"
-            :table-type="selectedTable.table.table_type"
-            :fields="selectedTable.fields || []"
-            @update="refreshSelectedTable"
-          />
-        </div>
-
-        <!-- Колонки FactTable (#345) -->
-        <div
-          v-if="activeTab === 'fact-columns' && selectedTable.table.show_fact_table"
-          class="tab-content"
-        >
-          <SystemTableColumnsTab
-            :table-id="selectedTable.table.id"
-            :table-type="selectedTable.table.table_type"
-            :fields="selectedTable.fact_fields || []"
-            variant="fact"
-            @update="refreshSelectedTable"
-          />
-        </div>
-
-        <!-- Оформление FactTable (#345) -->
-        <div
-          v-if="activeTab === 'fact-appearance' && selectedTable.table.show_fact_table"
-          class="tab-content"
-        >
-          <SystemTableAppearanceTab
-            :table-id="selectedTable.table.id"
-            :table="selectedTable.table"
-            :table-type="selectedTable.table.table_type"
-            :fields="selectedTable.fact_fields || []"
-            variant="fact"
-            @update="refreshSelectedTable"
-          />
+          <p>Выберите таблицу для просмотра и редактирования</p>
         </div>
       </div>
 
       <div
-        v-else
-        class="no-selection-message"
+        v-if="filteredTables.length === 0"
+        class="no-results"
       >
-        <p>Выберите таблицу для просмотра и редактирования</p>
+        <div class="no-results-icon">
+          📊
+        </div>
+        <p>Таблицы не найдены</p>
       </div>
+
+      <!-- Модальное окно создания таблицы -->
+      <TableConstructorCreateModal
+        :show="showAddModal"
+        @created="onTableCreated"
+        @close="showAddModal = false"
+      />
+
+      <!-- Модалка истории таблицы -->
+      <SystemTableHistoryModal
+        v-if="historyTable"
+        :table="historyTable"
+        @close="historyTable = null"
+      />
+
+      <!-- Подтверждение архивации таблицы -->
+      <ConfirmationModal
+        :show="!!deleteConfirmTable"
+        title="Архивация таблицы"
+        :message="deleteConfirmTable ? `Архивировать таблицу «${deleteConfirmTable.table.display_name}»? Её можно будет восстановить из архива.` : ''"
+        confirm-text="В архив"
+        cancel-text="Отмена"
+        :confirm-button-style="{ background: '#c62828', borderColor: '#c62828' }"
+        @confirm="performDeleteTable"
+        @cancel="deleteConfirmTable = null"
+      />
     </div>
-
-    <div
-      v-if="filteredTables.length === 0"
-      class="no-results"
-    >
-      <div class="no-results-icon">
-        📊
-      </div>
-      <p>Таблицы не найдены</p>
-    </div>
-
-    <!-- Модальное окно создания таблицы -->
-    <TableConstructorCreateModal
-      :show="showAddModal"
-      @created="onTableCreated"
-      @close="showAddModal = false"
-    />
-
-    <!-- Модалка истории таблицы -->
-    <SystemTableHistoryModal
-      v-if="historyTable"
-      :table="historyTable"
-      @close="historyTable = null"
-    />
-
-    <!-- Подтверждение архивации таблицы -->
-    <ConfirmationModal
-      :show="!!deleteConfirmTable"
-      title="Архивация таблицы"
-      :message="deleteConfirmTable ? `Архивировать таблицу «${deleteConfirmTable.table.display_name}»? Её можно будет восстановить из архива.` : ''"
-      confirm-text="В архив"
-      cancel-text="Отмена"
-      :confirm-button-style="{ background: '#c62828', borderColor: '#c62828' }"
-      @confirm="performDeleteTable"
-      @cancel="deleteConfirmTable = null"
-    />
-  </div>
+  </AdminPageShell>
 </template>
 
 <script>
@@ -644,6 +646,7 @@ import TableConstructorPhotoSection from './TableConstructorPhotoSection.vue';
 import SystemTableHistoryModal from './SystemTableHistoryModal.vue';
 import ConfirmationModal from './ConfirmationModal.vue';
 import BaseDropdown from './ui/BaseDropdown.vue';
+import AdminPageShell from '@/views/admin/AdminPageShell.vue';
 
 export default {
   name: 'TableConstructor',
@@ -659,6 +662,7 @@ export default {
     SystemTableHistoryModal,
     ConfirmationModal,
     BaseDropdown,
+    AdminPageShell,
   },
   data() {
     return {
@@ -735,16 +739,6 @@ export default {
       return this.selectedTable && this.selectedTable.table.instruction !== this.originalInstruction;
     }
   },
-  mounted() {
-    this.refreshData();
-
-    // Закрываем dropdown при клике вне них
-    document.addEventListener('click', (e) => {
-      if (!this.$el.contains(e.target)) {
-        this.tableTypeDropdownOpen = false;
-      }
-    });
-  },
   watch: {
     // Если активна вкладка фактовой таблицы, а пользователь снял галочку
     // show_fact_table - возвращаем на главную, чтобы не висел пустой контент.
@@ -762,6 +756,16 @@ export default {
         }
       }
     },
+  },
+  mounted() {
+    this.refreshData();
+
+    // Закрываем dropdown при клике вне них
+    document.addEventListener('click', (e) => {
+      if (!this.$el.contains(e.target)) {
+        this.tableTypeDropdownOpen = false;
+      }
+    });
   },
   methods: {
     /**

--- a/frontend/src/components/icons/navIcons.js
+++ b/frontend/src/components/icons/navIcons.js
@@ -14,6 +14,9 @@ export const navIcons = {
   // Центр заявок - конверт/письмо.
   center:
     '<rect x="3" y="5.5" width="18" height="13" rx="2"/><path d="m3.5 7 8.5 6 8.5-6"/>',
+  // Новая заявка - простой плюс.
+  'new-application':
+    '<line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>',
   statistics:
     '<path d="M4 20h16"/><line x1="7" y1="20" x2="7" y2="13"/><line x1="12" y1="20" x2="12" y2="8"/><line x1="17" y1="20" x2="17" y2="11"/>',
   analytics:

--- a/frontend/src/views/RequestsView.vue
+++ b/frontend/src/views/RequestsView.vue
@@ -1,516 +1,518 @@
 <template>
-  <div class="requests-view dashboard-card">
-    <div class="management-header">
-      <h3 class="management-title">
-        Мониторинг запросов
-      </h3>
-      <div class="header-controls">
-        <div class="stats-summary">
-          <span class="stat-item">
-            <span class="stat-label">Всего:</span>
-            <span class="stat-value">{{ stats.total || 0 }}</span>
-          </span>
-          <span class="stat-item">
-            <span class="stat-label">Сегодня:</span>
-            <span class="stat-value">{{ stats.today || 0 }}</span>
-          </span>
-          <span class="stat-item">
-            <span class="stat-label">Среднее время:</span>
-            <span class="stat-value">{{ Math.round(stats.avg_duration || 0) }}мс</span>
-          </span>
-          <span class="stat-item">
-            <span class="stat-label">Ошибки:</span>
-            <span
-              class="stat-value"
-              :class="{ 'stat-error': stats.error_rate > 5 }"
-            >
-              {{ (stats.error_rate || 0).toFixed(1) }}%
+  <AdminPageShell>
+    <div class="requests-view dashboard-card">
+      <div class="management-header">
+        <h3 class="management-title">
+          Мониторинг запросов
+        </h3>
+        <div class="header-controls">
+          <div class="stats-summary">
+            <span class="stat-item">
+              <span class="stat-label">Всего:</span>
+              <span class="stat-value">{{ stats.total || 0 }}</span>
             </span>
-          </span>
-          <span class="stat-item">
-            <span class="stat-label">RPM:</span>
-            <span class="stat-value">{{ (stats.requests_per_minute || 0).toFixed(1) }}</span>
-          </span>
-          <span
-            v-if="realtime.last_minute_count != null"
-            class="stat-item realtime-stat"
-          >
-            <span class="stat-label">Сейчас:</span>
-            <span class="stat-value live-value">
-              {{ realtime.last_second_count || 0 }}/с
-              <span class="stat-minute">{{ realtime.last_minute_count || 0 }}/мин</span>
+            <span class="stat-item">
+              <span class="stat-label">Сегодня:</span>
+              <span class="stat-value">{{ stats.today || 0 }}</span>
             </span>
-          </span>
-        </div>
-      </div>
-    </div>
-
-    <div class="chart-section">
-      <div class="chart-header">
-        <h4 class="chart-title">
-          Запросы {{ selectedPeriod.title }}
-        </h4>
-        <div class="chart-header-actions">
-          <span class="chart-interval">интервал: {{ selectedPeriod.intervalHuman }}</span>
-          <div class="chart-period-dropdown">
-            <select
-              v-model="chartPeriod"
-              class="chart-period-select"
-              @change="onChartPeriodChange"
-            >
-              <option
-                v-for="p in chartPeriods"
-                :key="p.key"
-                :value="p.key"
+            <span class="stat-item">
+              <span class="stat-label">Среднее время:</span>
+              <span class="stat-value">{{ Math.round(stats.avg_duration || 0) }}мс</span>
+            </span>
+            <span class="stat-item">
+              <span class="stat-label">Ошибки:</span>
+              <span
+                class="stat-value"
+                :class="{ 'stat-error': stats.error_rate > 5 }"
               >
-                {{ p.label }}
-              </option>
-            </select>
-          </div>
-        </div>
-      </div>
-      <RealTimeChart
-        :data="timelineData"
-        :height="180"
-        color="#4F5BDF"
-        :interval-label="selectedPeriod.xAxisLabel"
-      />
-    </div>
-
-    <div class="filters-bar">
-      <SearchComponent
-        v-model="searchQuery"
-        :title="'Поиск по логам...'"
-        @keyup.enter="refreshLogs"
-      />
-      <div class="filter-controls">
-        <select
-          v-model="filterMethod"
-          class="filter-select"
-          @change="refreshLogs"
-        >
-          <option value="">
-            Все методы
-          </option>
-          <option value="GET">
-            GET
-          </option>
-          <option value="POST">
-            POST
-          </option>
-          <option value="PUT">
-            PUT
-          </option>
-          <option value="DELETE">
-            DELETE
-          </option>
-          <option value="PATCH">
-            PATCH
-          </option>
-        </select>
-        <select
-          v-model="filterStatus"
-          class="filter-select"
-          @change="refreshLogs"
-        >
-          <option value="">
-            Все статусы
-          </option>
-          <option value="200">
-            200 OK
-          </option>
-          <option value="400">
-            400 Bad Request
-          </option>
-          <option value="401">
-            401 Unauthorized
-          </option>
-          <option value="403">
-            403 Forbidden
-          </option>
-          <option value="404">
-            404 Not Found
-          </option>
-          <option value="500">
-            500 Server Error
-          </option>
-        </select>
-        <select
-          v-model="filterUser"
-          class="filter-select"
-          @change="refreshLogs"
-        >
-          <option value="">
-            Все пользователи
-          </option>
-          <option
-            v-for="u in users"
-            :key="u.id"
-            :value="u.id"
-          >
-            {{ u.username }}
-          </option>
-        </select>
-        <input
-          v-model="filterStartDate"
-          type="date"
-          class="date-input"
-          @change="refreshLogs"
-        >
-        <input
-          v-model="filterEndDate"
-          type="date"
-          class="date-input"
-          @change="refreshLogs"
-        >
-      </div>
-      <RefreshButton
-        :loading="isLoading"
-        @refresh="refreshLogs"
-      />
-      <button
-        class="clear-filters-btn"
-        @click="clearFilters"
-      >
-        Сбросить
-      </button>
-      <button
-        class="export-btn"
-        :disabled="isExporting"
-        @click="exportLogs"
-      >
-        {{ isExporting ? 'Экспорт...' : 'Экспорт' }}
-      </button>
-    </div>
-
-    <div class="content-container">
-      <div class="logs-table-section">
-        <div class="table-container">
-          <div class="table-header">
-            <div
-              class="header-col time-col"
-              @click="sortBy('created_at')"
-            >
-              <p :class="{ 'active-sort': sortField === 'created_at' }">
-                Время
-              </p>
-              <img
-                src="@/assets/icons/sort.png"
-                class="sort-icon"
-                :class="{
-                  'sorted': sortField === 'created_at',
-                  'desc': sortField === 'created_at' && sortDirection === 'desc'
-                }"
-              >
-            </div>
-            <div
-              class="header-col method-col"
-              @click="sortBy('method')"
-            >
-              <p :class="{ 'active-sort': sortField === 'method' }">
-                Метод
-              </p>
-              <img
-                src="@/assets/icons/sort.png"
-                class="sort-icon"
-                :class="{
-                  'sorted': sortField === 'method',
-                  'desc': sortField === 'method' && sortDirection === 'desc'
-                }"
-              >
-            </div>
-            <div
-              class="header-col path-col"
-              @click="sortBy('url')"
-            >
-              <p :class="{ 'active-sort': sortField === 'url' }">
-                URL
-              </p>
-              <img
-                src="@/assets/icons/sort.png"
-                class="sort-icon"
-                :class="{
-                  'sorted': sortField === 'url',
-                  'desc': sortField === 'url' && sortDirection === 'desc'
-                }"
-              >
-            </div>
-            <div
-              class="header-col status-col"
-              @click="sortBy('response_status')"
-            >
-              <p :class="{ 'active-sort': sortField === 'response_status' }">
-                Статус
-              </p>
-              <img
-                src="@/assets/icons/sort.png"
-                class="sort-icon"
-                :class="{
-                  'sorted': sortField === 'response_status',
-                  'desc': sortField === 'response_status' && sortDirection === 'desc'
-                }"
-              >
-            </div>
-            <div
-              class="header-col user-col"
-              @click="sortBy('username')"
-            >
-              <p :class="{ 'active-sort': sortField === 'username' }">
-                Пользователь
-              </p>
-              <img
-                src="@/assets/icons/sort.png"
-                class="sort-icon"
-                :class="{
-                  'sorted': sortField === 'username',
-                  'desc': sortField === 'username' && sortDirection === 'desc'
-                }"
-              >
-            </div>
-            <div
-              class="header-col duration-col"
-              @click="sortBy('duration_ms')"
-            >
-              <p :class="{ 'active-sort': sortField === 'duration_ms' }">
-                Время
-              </p>
-              <img
-                src="@/assets/icons/sort.png"
-                class="sort-icon"
-                :class="{
-                  'sorted': sortField === 'duration_ms',
-                  'desc': sortField === 'duration_ms' && sortDirection === 'desc'
-                }"
-              >
-            </div>
-          </div>
-
-          <div
-            ref="logsBody"
-            class="table-body"
-          >
-            <div
-              v-for="log in logs"
-              :key="log.id"
-              class="table-row"
-              :class="{
-                'selected': selectedLog && selectedLog.id === log.id,
-                'error-row': log.response_status && log.response_status >= 400,
-                'success-row': log.response_status && log.response_status < 400
-              }"
-              @click="selectLog(log)"
-            >
-              <div class="table-col time-col">
-                <span
-                  class="cell-content"
-                  :title="formatFullDate(log.created_at)"
-                >
-                  {{ formatTime(log.created_at) }}
-                </span>
-              </div>
-              <div class="table-col method-col">
-                <span
-                  class="method-badge"
-                  :class="getMethodClass(log.method)"
-                >
-                  {{ log.method }}
-                </span>
-              </div>
-              <div class="table-col path-col">
-                <span
-                  class="truncate-text"
-                  :title="log.url"
-                >
-                  {{ truncatePath(log.url) }}
-                </span>
-              </div>
-              <div class="table-col status-col">
-                <span
-                  class="status-badge"
-                  :class="getStatusClass(log.response_status)"
-                >
-                  {{ log.response_status || 'N/A' }}
-                </span>
-              </div>
-              <div class="table-col user-col">
-                <span class="cell-content">
-                  {{ log.username || 'Аноним' }}
-                  <span
-                    v-if="log.user_id"
-                    class="user-id"
-                  >(ID: {{ log.user_id }})</span>
-                </span>
-              </div>
-              <div class="table-col duration-col">
-                <span class="cell-content">
-                  {{ log.duration_ms || 0 }}мс
-                </span>
-              </div>
-            </div>
-          </div>
-
-          <div class="table-footer">
-            <div class="pagination-controls">
-              <button
-                :disabled="pagination.page <= 1"
-                class="pagination-btn"
-                @click="prevPage"
-              >
-                &larr;
-              </button>
-              <span class="page-info">
-                Страница {{ pagination.page }} из {{ totalPages }}
+                {{ (stats.error_rate || 0).toFixed(1) }}%
               </span>
-              <button
-                :disabled="pagination.page >= totalPages"
-                class="pagination-btn"
-                @click="nextPage"
-              >
-                &rarr;
-              </button>
+            </span>
+            <span class="stat-item">
+              <span class="stat-label">RPM:</span>
+              <span class="stat-value">{{ (stats.requests_per_minute || 0).toFixed(1) }}</span>
+            </span>
+            <span
+              v-if="realtime.last_minute_count != null"
+              class="stat-item realtime-stat"
+            >
+              <span class="stat-label">Сейчас:</span>
+              <span class="stat-value live-value">
+                {{ realtime.last_second_count || 0 }}/с
+                <span class="stat-minute">{{ realtime.last_minute_count || 0 }}/мин</span>
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div class="chart-section">
+        <div class="chart-header">
+          <h4 class="chart-title">
+            Запросы {{ selectedPeriod.title }}
+          </h4>
+          <div class="chart-header-actions">
+            <span class="chart-interval">интервал: {{ selectedPeriod.intervalHuman }}</span>
+            <div class="chart-period-dropdown">
               <select
-                v-model="perPage"
-                class="page-size-select"
-                @change="changePageSize"
+                v-model="chartPeriod"
+                class="chart-period-select"
+                @change="onChartPeriodChange"
               >
-                <option value="20">
-                  20
-                </option>
-                <option value="50">
-                  50
-                </option>
-                <option value="100">
-                  100
+                <option
+                  v-for="p in chartPeriods"
+                  :key="p.key"
+                  :value="p.key"
+                >
+                  {{ p.label }}
                 </option>
               </select>
             </div>
-            <span class="items-count">
-              Показано {{ logs.length }} из {{ pagination.total || 0 }} записей
-            </span>
+          </div>
+        </div>
+        <RealTimeChart
+          :data="timelineData"
+          :height="180"
+          color="#4F5BDF"
+          :interval-label="selectedPeriod.xAxisLabel"
+        />
+      </div>
+
+      <div class="filters-bar">
+        <SearchComponent
+          v-model="searchQuery"
+          :title="'Поиск по логам...'"
+          @keyup.enter="refreshLogs"
+        />
+        <div class="filter-controls">
+          <select
+            v-model="filterMethod"
+            class="filter-select"
+            @change="refreshLogs"
+          >
+            <option value="">
+              Все методы
+            </option>
+            <option value="GET">
+              GET
+            </option>
+            <option value="POST">
+              POST
+            </option>
+            <option value="PUT">
+              PUT
+            </option>
+            <option value="DELETE">
+              DELETE
+            </option>
+            <option value="PATCH">
+              PATCH
+            </option>
+          </select>
+          <select
+            v-model="filterStatus"
+            class="filter-select"
+            @change="refreshLogs"
+          >
+            <option value="">
+              Все статусы
+            </option>
+            <option value="200">
+              200 OK
+            </option>
+            <option value="400">
+              400 Bad Request
+            </option>
+            <option value="401">
+              401 Unauthorized
+            </option>
+            <option value="403">
+              403 Forbidden
+            </option>
+            <option value="404">
+              404 Not Found
+            </option>
+            <option value="500">
+              500 Server Error
+            </option>
+          </select>
+          <select
+            v-model="filterUser"
+            class="filter-select"
+            @change="refreshLogs"
+          >
+            <option value="">
+              Все пользователи
+            </option>
+            <option
+              v-for="u in users"
+              :key="u.id"
+              :value="u.id"
+            >
+              {{ u.username }}
+            </option>
+          </select>
+          <input
+            v-model="filterStartDate"
+            type="date"
+            class="date-input"
+            @change="refreshLogs"
+          >
+          <input
+            v-model="filterEndDate"
+            type="date"
+            class="date-input"
+            @change="refreshLogs"
+          >
+        </div>
+        <RefreshButton
+          :loading="isLoading"
+          @refresh="refreshLogs"
+        />
+        <button
+          class="clear-filters-btn"
+          @click="clearFilters"
+        >
+          Сбросить
+        </button>
+        <button
+          class="export-btn"
+          :disabled="isExporting"
+          @click="exportLogs"
+        >
+          {{ isExporting ? 'Экспорт...' : 'Экспорт' }}
+        </button>
+      </div>
+
+      <div class="content-container">
+        <div class="logs-table-section">
+          <div class="table-container">
+            <div class="table-header">
+              <div
+                class="header-col time-col"
+                @click="sortBy('created_at')"
+              >
+                <p :class="{ 'active-sort': sortField === 'created_at' }">
+                  Время
+                </p>
+                <img
+                  src="@/assets/icons/sort.png"
+                  class="sort-icon"
+                  :class="{
+                    'sorted': sortField === 'created_at',
+                    'desc': sortField === 'created_at' && sortDirection === 'desc'
+                  }"
+                >
+              </div>
+              <div
+                class="header-col method-col"
+                @click="sortBy('method')"
+              >
+                <p :class="{ 'active-sort': sortField === 'method' }">
+                  Метод
+                </p>
+                <img
+                  src="@/assets/icons/sort.png"
+                  class="sort-icon"
+                  :class="{
+                    'sorted': sortField === 'method',
+                    'desc': sortField === 'method' && sortDirection === 'desc'
+                  }"
+                >
+              </div>
+              <div
+                class="header-col path-col"
+                @click="sortBy('url')"
+              >
+                <p :class="{ 'active-sort': sortField === 'url' }">
+                  URL
+                </p>
+                <img
+                  src="@/assets/icons/sort.png"
+                  class="sort-icon"
+                  :class="{
+                    'sorted': sortField === 'url',
+                    'desc': sortField === 'url' && sortDirection === 'desc'
+                  }"
+                >
+              </div>
+              <div
+                class="header-col status-col"
+                @click="sortBy('response_status')"
+              >
+                <p :class="{ 'active-sort': sortField === 'response_status' }">
+                  Статус
+                </p>
+                <img
+                  src="@/assets/icons/sort.png"
+                  class="sort-icon"
+                  :class="{
+                    'sorted': sortField === 'response_status',
+                    'desc': sortField === 'response_status' && sortDirection === 'desc'
+                  }"
+                >
+              </div>
+              <div
+                class="header-col user-col"
+                @click="sortBy('username')"
+              >
+                <p :class="{ 'active-sort': sortField === 'username' }">
+                  Пользователь
+                </p>
+                <img
+                  src="@/assets/icons/sort.png"
+                  class="sort-icon"
+                  :class="{
+                    'sorted': sortField === 'username',
+                    'desc': sortField === 'username' && sortDirection === 'desc'
+                  }"
+                >
+              </div>
+              <div
+                class="header-col duration-col"
+                @click="sortBy('duration_ms')"
+              >
+                <p :class="{ 'active-sort': sortField === 'duration_ms' }">
+                  Время
+                </p>
+                <img
+                  src="@/assets/icons/sort.png"
+                  class="sort-icon"
+                  :class="{
+                    'sorted': sortField === 'duration_ms',
+                    'desc': sortField === 'duration_ms' && sortDirection === 'desc'
+                  }"
+                >
+              </div>
+            </div>
+
+            <div
+              ref="logsBody"
+              class="table-body"
+            >
+              <div
+                v-for="log in logs"
+                :key="log.id"
+                class="table-row"
+                :class="{
+                  'selected': selectedLog && selectedLog.id === log.id,
+                  'error-row': log.response_status && log.response_status >= 400,
+                  'success-row': log.response_status && log.response_status < 400
+                }"
+                @click="selectLog(log)"
+              >
+                <div class="table-col time-col">
+                  <span
+                    class="cell-content"
+                    :title="formatFullDate(log.created_at)"
+                  >
+                    {{ formatTime(log.created_at) }}
+                  </span>
+                </div>
+                <div class="table-col method-col">
+                  <span
+                    class="method-badge"
+                    :class="getMethodClass(log.method)"
+                  >
+                    {{ log.method }}
+                  </span>
+                </div>
+                <div class="table-col path-col">
+                  <span
+                    class="truncate-text"
+                    :title="log.url"
+                  >
+                    {{ truncatePath(log.url) }}
+                  </span>
+                </div>
+                <div class="table-col status-col">
+                  <span
+                    class="status-badge"
+                    :class="getStatusClass(log.response_status)"
+                  >
+                    {{ log.response_status || 'N/A' }}
+                  </span>
+                </div>
+                <div class="table-col user-col">
+                  <span class="cell-content">
+                    {{ log.username || 'Аноним' }}
+                    <span
+                      v-if="log.user_id"
+                      class="user-id"
+                    >(ID: {{ log.user_id }})</span>
+                  </span>
+                </div>
+                <div class="table-col duration-col">
+                  <span class="cell-content">
+                    {{ log.duration_ms || 0 }}мс
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            <div class="table-footer">
+              <div class="pagination-controls">
+                <button
+                  :disabled="pagination.page <= 1"
+                  class="pagination-btn"
+                  @click="prevPage"
+                >
+                  &larr;
+                </button>
+                <span class="page-info">
+                  Страница {{ pagination.page }} из {{ totalPages }}
+                </span>
+                <button
+                  :disabled="pagination.page >= totalPages"
+                  class="pagination-btn"
+                  @click="nextPage"
+                >
+                  &rarr;
+                </button>
+                <select
+                  v-model="perPage"
+                  class="page-size-select"
+                  @change="changePageSize"
+                >
+                  <option value="20">
+                    20
+                  </option>
+                  <option value="50">
+                    50
+                  </option>
+                  <option value="100">
+                    100
+                  </option>
+                </select>
+              </div>
+              <span class="items-count">
+                Показано {{ logs.length }} из {{ pagination.total || 0 }} записей
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div
+          class="log-details-section"
+          :class="{'with-details': selectedLog}"
+        >
+          <div
+            v-if="selectedLog"
+            class="log-details-content"
+          >
+            <div class="details-header">
+              <h3 class="details-title">
+                Детали запроса
+              </h3>
+              <button
+                class="close-details-btn"
+                @click="selectedLog = null"
+              >
+                &times;
+              </button>
+            </div>
+
+            <div class="details-body">
+              <div class="details-grid">
+                <div class="detail-group">
+                  <label class="detail-label">ID запроса:</label>
+                  <span class="detail-value">{{ selectedLog.id }}</span>
+                </div>
+
+                <div class="detail-group">
+                  <label class="detail-label">Время:</label>
+                  <span class="detail-value">{{ formatFullDate(selectedLog.created_at) }}</span>
+                </div>
+
+                <div class="detail-group">
+                  <label class="detail-label">Метод:</label>
+                  <span
+                    class="detail-value method-value"
+                    :class="getMethodClass(selectedLog.method)"
+                  >
+                    {{ selectedLog.method }}
+                  </span>
+                </div>
+
+                <div class="detail-group">
+                  <label class="detail-label">URL:</label>
+                  <span class="detail-value path-value">
+                    {{ selectedLog.url }}
+                  </span>
+                </div>
+
+                <div class="detail-group">
+                  <label class="detail-label">Статус ответа:</label>
+                  <span
+                    class="detail-value status-value"
+                    :class="getStatusClass(selectedLog.response_status)"
+                  >
+                    {{ selectedLog.response_status || 'N/A' }}
+                  </span>
+                </div>
+
+                <div class="detail-group">
+                  <label class="detail-label">Время выполнения:</label>
+                  <span class="detail-value">{{ selectedLog.duration_ms || 0 }}мс</span>
+                </div>
+
+                <div class="detail-group">
+                  <label class="detail-label">Пользователь:</label>
+                  <span class="detail-value">
+                    {{ selectedLog.username || 'Аноним' }}
+                    <span
+                      v-if="selectedLog.user_id"
+                      class="user-id"
+                    >(ID: {{ selectedLog.user_id }})</span>
+                  </span>
+                </div>
+
+                <div
+                  v-if="selectedLog.headers"
+                  class="detail-group"
+                >
+                  <label class="detail-label">Заголовки:</label>
+                  <pre class="detail-value code-block">{{ formatJson(selectedLog.headers) }}</pre>
+                </div>
+
+                <div
+                  v-if="selectedLog.request_body"
+                  class="detail-group"
+                >
+                  <label class="detail-label">Тело запроса:</label>
+                  <pre class="detail-value code-block request-body">{{ formatJson(selectedLog.request_body) }}</pre>
+                </div>
+
+                <div
+                  v-if="selectedLog.response_body"
+                  class="detail-group"
+                >
+                  <label class="detail-label">Тело ответа:</label>
+                  <pre class="detail-value code-block response-body">{{ formatJson(selectedLog.response_body) }}</pre>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            v-else
+            class="no-selection-message"
+          >
+            <p>Выберите запрос для просмотра деталей</p>
           </div>
         </div>
       </div>
 
       <div
-        class="log-details-section"
-        :class="{'with-details': selectedLog}"
+        v-if="isLoading"
+        class="loading-overlay"
       >
-        <div
-          v-if="selectedLog"
-          class="log-details-content"
-        >
-          <div class="details-header">
-            <h3 class="details-title">
-              Детали запроса
-            </h3>
-            <button
-              class="close-details-btn"
-              @click="selectedLog = null"
-            >
-              &times;
-            </button>
-          </div>
-
-          <div class="details-body">
-            <div class="details-grid">
-              <div class="detail-group">
-                <label class="detail-label">ID запроса:</label>
-                <span class="detail-value">{{ selectedLog.id }}</span>
-              </div>
-
-              <div class="detail-group">
-                <label class="detail-label">Время:</label>
-                <span class="detail-value">{{ formatFullDate(selectedLog.created_at) }}</span>
-              </div>
-
-              <div class="detail-group">
-                <label class="detail-label">Метод:</label>
-                <span
-                  class="detail-value method-value"
-                  :class="getMethodClass(selectedLog.method)"
-                >
-                  {{ selectedLog.method }}
-                </span>
-              </div>
-
-              <div class="detail-group">
-                <label class="detail-label">URL:</label>
-                <span class="detail-value path-value">
-                  {{ selectedLog.url }}
-                </span>
-              </div>
-
-              <div class="detail-group">
-                <label class="detail-label">Статус ответа:</label>
-                <span
-                  class="detail-value status-value"
-                  :class="getStatusClass(selectedLog.response_status)"
-                >
-                  {{ selectedLog.response_status || 'N/A' }}
-                </span>
-              </div>
-
-              <div class="detail-group">
-                <label class="detail-label">Время выполнения:</label>
-                <span class="detail-value">{{ selectedLog.duration_ms || 0 }}мс</span>
-              </div>
-
-              <div class="detail-group">
-                <label class="detail-label">Пользователь:</label>
-                <span class="detail-value">
-                  {{ selectedLog.username || 'Аноним' }}
-                  <span
-                    v-if="selectedLog.user_id"
-                    class="user-id"
-                  >(ID: {{ selectedLog.user_id }})</span>
-                </span>
-              </div>
-
-              <div
-                v-if="selectedLog.headers"
-                class="detail-group"
-              >
-                <label class="detail-label">Заголовки:</label>
-                <pre class="detail-value code-block">{{ formatJson(selectedLog.headers) }}</pre>
-              </div>
-
-              <div
-                v-if="selectedLog.request_body"
-                class="detail-group"
-              >
-                <label class="detail-label">Тело запроса:</label>
-                <pre class="detail-value code-block request-body">{{ formatJson(selectedLog.request_body) }}</pre>
-              </div>
-
-              <div
-                v-if="selectedLog.response_body"
-                class="detail-group"
-              >
-                <label class="detail-label">Тело ответа:</label>
-                <pre class="detail-value code-block response-body">{{ formatJson(selectedLog.response_body) }}</pre>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          v-else
-          class="no-selection-message"
-        >
-          <p>Выберите запрос для просмотра деталей</p>
-        </div>
+        <LoaderSpinner
+          size="large"
+          :label="''"
+        />
       </div>
     </div>
-
-    <div
-      v-if="isLoading"
-      class="loading-overlay"
-    >
-      <LoaderSpinner
-        size="large"
-        :label="''"
-      />
-    </div>
-  </div>
+  </AdminPageShell>
 </template>
 
 <script>
@@ -519,6 +521,7 @@ import SearchComponent from '@/components/SearchComponent.vue'
 import RealTimeChart from '@/components/RealTimeChart.vue'
 import LoaderSpinner from '@/components/ui/LoaderSpinner.vue'
 import RefreshButton from '@/components/RefreshButton.vue'
+import AdminPageShell from '@/views/admin/AdminPageShell.vue'
 
 export default {
   name: 'RequestsView',
@@ -526,7 +529,8 @@ export default {
     SearchComponent,
     RealTimeChart,
     LoaderSpinner,
-    RefreshButton
+    RefreshButton,
+    AdminPageShell
   },
   data() {
     return {
@@ -902,7 +906,6 @@ export default {
   border-radius: 16px;
   border: 1px solid #e6e6e6;
   overflow: hidden;
-  min-height: 80vh;
 }
 
 .management-header {


### PR DESCRIPTION
Четвёртый раунд полиша навигации #510 по фидбеку.

## Правки
- **Sticky дропдаун «Таблицы».** Раньше при закреплённом рельсе раскрытый список таблиц схлопывался, как только курсор уходил с панели (а иногда вообще не закрывался). Теперь состояние управляется только кликом по «Таблицы»: открыл - держится при любом сворачивании/наведении, закрыл - закрыт. Убрал закрытие дропдауна из `collapseMenu`, авто-открытие из `expandMenu` и из `navigateToCenter`; одноразовое открытие при прямом заходе на `/table` оставил в `mounted`.
- **«Новая заявка».** Новый пункт в разделе «Заявки» под «Центром заявок», ведёт на `/new-application`, иконка - простой плюс.
- **Глиф «Администрирования».** Открывает боковую колонку, а не дропдаун - заменил прямоугольник-панель на прямую стрелку вправо (стрела с древком, не шеврон).
- **Отступы страниц.** `/table-constructor` и `/admin/requests` рендерились без обёртки и прилипали к краям. Обернул оба в `AdminPageShell` (как остальные `/admin/*`) - вернулись `padding:16px`, скруглённая карточка и заполнение высоты. У `RequestsView` убрал конфликтующий `min-height:80vh`.

## Проверка (локально, vite + Playwright, DOM + скриншоты)
- `newApplicationAfterCenter: after`, иконка-плюс рисуется.
- глиф админки: `polyline` есть, `rect` нет (стрелка).
- дропдаун: открыт после клика, остаётся открыт после mouseleave, закрыт после повторного клика.
- `padding:16px` на обёртке и `/table-constructor`, и `/admin/requests`.
- ESLint по 4 файлам - чисто.