### PR TITLE
fix(nav): polish-round 5 - детали не плющат шапку, сворачивание сбрасывает дропдаун (#510)

### DIFF
--- a/frontend/src/components/NavMenu.vue
+++ b/frontend/src/components/NavMenu.vue
@@ -718,9 +718,6 @@ export default {
     this.syncContentMargin();
     await this.fetchBanStatus();
     await this.fetchSystemTables();
-    // Заход напрямую на страницу таблицы - раскрываем список один раз, чтобы
-    // активная была видна. Дальше состояние дропдауна управляется только кликом.
-    if (this.isActive('/table')) this.dropdowns.tables = true;
     this.startApplicationsPolling();
     this.startTablesPolling();
 
@@ -852,11 +849,12 @@ export default {
       this.isExpanded = true;
     },
     collapseMenu() {
-      // Сворачиваем только рельс (hover-разворот). Состояние дропдауна «Таблицы»
-      // намеренно НЕ трогаем: открыт по клику - остаётся открытым, скрывается лишь
-      // визуально вместе со схлопыванием рельса и возвращается при наведении.
       this.hoverTimeout = setTimeout(() => {
         this.isExpanded = false;
+        // Если рельс реально схлопывается (не закреплён пином) - сворачиваем и
+        // раскрытые дропдауны, чтобы при следующем наведении они были закрыты.
+        // У закреплённого рельса (пин) состояние держится: он не сворачивается.
+        if (!this.uiStore.sidebarExpanded) this.closeAllDropdowns();
         this.hoverTimeout = null;
       }, 150);
     },

--- a/frontend/src/views/admin/AdminPageShell.vue
+++ b/frontend/src/views/admin/AdminPageShell.vue
@@ -82,4 +82,11 @@ onBeforeUnmount(() => {
   min-height: 0;
   height: auto;
 }
+
+/* Шапка карточки не сжимается во flex-колонке: иначе высокий контент в теле
+   (открытые детали мастер-детейла) выдавливал бы и плющил заголовок вместо
+   внутреннего скролла тела (.table-body / .tab-content уже overflow:auto). */
+.admin-page :deep(.management-header) {
+  flex-shrink: 0;
+}
 </style>


### PR DESCRIPTION
Пятый раунд полиша навигации #510.

## Правки
- **Детали таблицы плющили шапку.** После обёртки `/table-constructor` в `AdminPageShell` (раунд 4) карточка стала flex-колонкой. При открытии деталей высокий контент мастер-детейла выдавливал заголовок «Таблицы системы» (у `.management-header` был `flex-shrink:1`). Добавил `:deep(.management-header){flex-shrink:0}` в `AdminPageShell` - шапка фиксируется, остаток высоты забирает `.content-container`, тело скроллится внутри (`.table-body`/`.tab-content` уже `overflow:auto`). Фикс в шелле, поэтому покрывает и `RequestsView`, и все `/admin/*`.
- **Сворачивание рельса сбрасывает раскрытые дропдауны.** Уточнение к раунду 4. Теперь: незакреплённый рельс при схлопывании в иконки сворачивает раскрытые дропдауны (при следующем наведении они закрыты); закреплённый пином рельс не сворачивается, поэтому состояние держится по клику (требование раунда 4 сохранено). `collapseMenu` закрывает дропдауны только когда `!sidebarExpanded`; убрал авто-открытие списка таблиц в `mounted` (по умолчанию свёрнут).

## Проверка (vite + Playwright, DOM + скриншоты)
- header: высота 50px и top=77 одинаковы до/после открытия деталей; `flex-shrink:0`; детали раскрыты.
- незакреплённый: открыт после клика -> закрыт после сворачивания+разворота.
- закреплённый: открыт после клика -> остаётся открыт после ухода курсора.
- регрессия: `/admin/citizenship` (header 50) и `/admin/requests` (header 95, статистика) рендерятся без сжатия.