### PR TITLE
fix(admin): пустые состояния таблиц без эмодзи + отступ закреплённого рельса 124px (#510)

### DIFF
--- a/frontend/src/components/NavMenu.vue
+++ b/frontend/src/components/NavMenu.vue
@@ -826,7 +826,7 @@ export default {
     syncContentMargin() {
       const width = this.uiStore.sidebarHidden
         ? '0px'
-        : (this.uiStore.sidebarExpanded ? '120px' : '25px');
+        : (this.uiStore.sidebarExpanded ? '124px' : '25px');
       document.body.style.setProperty('--nav-ml', width);
     },
     toggleMobile() {

--- a/frontend/src/components/TableConstructor.vue
+++ b/frontend/src/components/TableConstructor.vue
@@ -135,6 +135,12 @@
                   </span>
                 </div>
               </div>
+              <div
+                v-if="!sortedTables.length"
+                class="no-results"
+              >
+                {{ emptyText }}
+              </div>
             </div>
 
             <div class="table-footer">
@@ -592,15 +598,6 @@
         </div>
       </div>
 
-      <div
-        v-if="filteredTables.length === 0"
-        class="no-results"
-      >
-        <div class="no-results-icon">
-          📊
-        </div>
-        <p>Таблицы не найдены</p>
-      </div>
 
       <!-- Модальное окно создания таблицы -->
       <TableConstructorCreateModal
@@ -687,6 +684,10 @@ export default {
     };
   },
   computed: {
+    emptyText() {
+      if (this.searchQuery.trim()) return 'Ничего не найдено по запросу';
+      return this.showArchive ? 'В архиве пусто' : 'Таблиц пока нет';
+    },
     filteredTables() {
       if (!this.searchQuery) return this.tables;
       const query = this.searchQuery.toLowerCase();
@@ -2046,17 +2047,6 @@ export default {
   padding: 40px 20px;
   color: #a2a2a2;
   width: 100%;
-}
-
-.no-results-icon {
-  font-size: 3em;
-  margin-bottom: 16px;
-  opacity: 0.5;
-}
-
-.no-results p {
-  margin: 0;
-  font-size: 1.1em;
 }
 
 /* Модальное окно */

--- a/frontend/src/components/UnloadPlaces/UnloadPlacesContainer.vue
+++ b/frontend/src/components/UnloadPlaces/UnloadPlacesContainer.vue
@@ -110,6 +110,12 @@
                 </span>
               </div>
             </div>
+            <div
+              v-if="!sortedUnloadPlaces.length"
+              class="no-results"
+            >
+              {{ emptyText }}
+            </div>
           </div>
 
           <div class="table-footer">
@@ -432,15 +438,6 @@
       </div>
     </div>
 
-    <div
-      v-if="filteredUnloadPlaces.length === 0"
-      class="no-results"
-    >
-      <div class="no-results-icon">
-        📍
-      </div>
-      <p>{{ emptyText }}</p>
-    </div>
 
     <!-- Модальное окно добавления места -->
     <Teleport to="body">
@@ -1919,17 +1916,6 @@ async uploadPhotoFiles(files) {
   padding: 40px 20px;
   color: #a2a2a2;
   width: 100%;
-}
-
-.no-results-icon {
-  font-size: 3em;
-  margin-bottom: 16px;
-  opacity: 0.5;
-}
-
-.no-results p {
-  margin: 0;
-  font-size: 1.1em;
 }
 
 /* Стили для модальных окон */

--- a/frontend/src/components/UserTypes.vue
+++ b/frontend/src/components/UserTypes.vue
@@ -107,6 +107,12 @@
                 <span class="users-count">{{ type.users_count }}</span>
               </div>
             </div>
+            <div
+              v-if="!sortedTypes.length"
+              class="no-results"
+            >
+              {{ emptyText }}
+            </div>
           </div>
 
           <div class="table-footer">
@@ -193,15 +199,6 @@
       </div>
     </div>
 
-    <div
-      v-if="filteredTypes.length === 0"
-      class="no-results"
-    >
-      <div class="no-results-icon">
-        👥
-      </div>
-      <p>Типы пользователей не найдены</p>
-    </div>
 
     <!-- Модальное окно создания типа -->
     <Teleport to="body">
@@ -361,6 +358,9 @@ export default {
     };
   },
   computed: {
+    emptyText() {
+      return this.searchQuery.trim() ? 'Ничего не найдено по запросу' : 'Типов пока нет';
+    },
     filteredTypes() {
       if (!this.searchQuery) return this.types;
       const query = this.searchQuery.toLowerCase();
@@ -1005,17 +1005,6 @@ export default {
   padding: 40px 20px;
   color: #a2a2a2;
   width: 100%;
-}
-
-.no-results-icon {
-  font-size: 3em;
-  margin-bottom: 16px;
-  opacity: 0.5;
-}
-
-.no-results p {
-  margin: 0;
-  font-size: 1.1em;
 }
 
 /* Стили для улучшенного модального окна */


### PR DESCRIPTION
Чистка эмодзи-заглушек пустых таблиц в компонентах настройки системы + мелкий отступ.

## Пустые состояния
В трёх компонентах пустое состояние рисовалось плавающим блоком с эмодзи-иконкой и хардкод-текстом НИЖЕ таблицы (детач от списка):
- `TableConstructor` - символ + «Таблицы не найдены»
- `UserTypes` - символ + «Типы пользователей не найдены»
- `UnloadPlacesContainer` - символ + текст

Свёл к эталону остальных справочников (Citizenship/Marks/NumberFormat/...): контекстное сообщение (`emptyText`: поиск -> «Ничего не найдено по запросу», архив -> «В архиве пусто», иначе -> «… пока нет») центрируется ВНУТРИ тела таблицы. Эмодзи-иконку и стили `.no-results-icon`/`.no-results p` убрал.

## Отступ рельса
`--nav-ml` для закреплённого пином рельса: 120px -> 124px.

## Проверка (vite + Playwright, DOM + скриншоты)
- по всем трём: сообщение рендерится внутри `.table-body`, текст контекстный, строк 0, эмодзи в карточке нет.
- ESLint по 4 файлам - чисто.