### PR TITLE
fix(admin): эмодзи расписания, подсветка нав на /table-constructor, вместимость конструктора (#510)

### DIFF
--- a/frontend/src/components/NavMenu.vue
+++ b/frontend/src/components/NavMenu.vue
@@ -764,7 +764,8 @@ export default {
   methods: {
     isActive(path) {
       const current = this.$route.path;
-      if (path === '/table') return current.startsWith('/table');
+      // Только список таблиц /table и /table/:name, но НЕ /table-constructor.
+      if (path === '/table') return current === '/table' || current.startsWith('/table/');
       if (path === '/admin') return current.startsWith('/admin');
       return current === path;
     },

--- a/frontend/src/components/TableConstructor.vue
+++ b/frontend/src/components/TableConstructor.vue
@@ -1294,6 +1294,16 @@ export default {
   transition: .2s;
   cursor: pointer;
   user-select: none;
+  /* В узкой секции метка обрезается, а не наезжает на соседнюю колонку. */
+  overflow: hidden;
+}
+
+.header-col p {
+  margin: 0;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .header-col:hover {
@@ -1308,6 +1318,7 @@ export default {
   width: 12px;
   height: 12px;
   transition: .2s;
+  flex-shrink: 0;
 }
 
 .sort-icon.sorted {
@@ -1324,23 +1335,27 @@ export default {
 }
 
 .id-col {
-  width: 15%;
-  min-width: 60px;
+  width: 12%;
+  min-width: 50px;
 }
 
+/* Наименование сжимается первым (текст обрезается через .truncate-text),
+   отдавая место колонкам Тип/Статус с бейджами фиксированной ширины. */
 .name-col {
-  width: 40%;
-  min-width: 200px;
+  width: 32%;
+  min-width: 84px;
 }
 
 .type-col {
-  width: 25%;
-  min-width: 100px;
+  width: 26%;
+  min-width: 76px;
 }
 
+/* Под самый широкий бейдж статуса ("На обслуживании", nowrap ~108px), иначе
+   он вылезает за колонку и прижимается к правому краю секции. */
 .status-col {
-  width: 20%;
-  min-width: 80px;
+  width: 30%;
+  min-width: 108px;
 }
 
 .table-body {

--- a/frontend/src/components/WorkScheduleTab.vue
+++ b/frontend/src/components/WorkScheduleTab.vue
@@ -197,7 +197,7 @@
                 v-if="timeConflictError"
                 class="error-hint"
               >
-                ⚠️ {{ timeConflictError }}
+                {{ timeConflictError }}
               </div>
 
               <!-- Подсказка о следующем дне -->
@@ -674,8 +674,10 @@ export default {
 
 .schedule-grid {
   display: grid;
-  /* max 4 столбика: min(25%, ...) ограничивает до четверти ширины. */
-  grid-template-columns: repeat(auto-fill, minmax(max(150px, calc(25% - 9px)), 1fr));
+  /* Колонка не уже 190px (иначе день недели + тумблер 24/7 не помещаются);
+     при нехватке места колонок становится меньше и они растягиваются (1fr).
+     calc(25% - 9px) сверху ограничивает до 4 столбцов на широком экране. */
+  grid-template-columns: repeat(auto-fill, minmax(max(190px, calc(25% - 9px)), 1fr));
   gap: 12px;
 }
 
@@ -696,6 +698,9 @@ export default {
   align-items: center;
   justify-content: space-between;
   gap: 8px;
+  /* Если день недели + тумблер не влезают в строку - тумблер переносится вниз,
+     а не вылезает за карточку. */
+  flex-wrap: wrap;
 }
 
 .schedule-day-card__body {


### PR DESCRIPTION
Пакет правок по фидбеку (закреплённое меню сужает контент - вылезали проблемы вместимости).

## Правки
- **Эмодзи в расписании.** Убрал `⚠️` из сообщения о пересечении окон в `WorkScheduleTab` (`.error-hint` и так красная пилюля).
- **Подсветка навигации.** На `/table-constructor` подсвечивался пункт «Таблицы» в рельсе: `isActive('/table')` ловил его через `startsWith('/table')`. Теперь матчит только `/table` и `/table/:name`.
- **Колонки конструктора таблиц** (узкая `.table-section` при закреплённом рельсе + открытых деталях): колонки переполняли секцию, «Статус» прижимался к краю и обрезался. «Наименование» сузил (34%->32%, обрезается через `.truncate-text`), «Тип»/«Статус» получили min под бейджи (статус под «На обслуживании» ~108px, иначе вылезал), заголовки колонок усекаются с ellipsis вместо наезда друг на друга (`sort-icon` не сжимается).
- **Сетка расписания.** День недели + тумблер 24/7 не вмещались на узких колонках (минимум был 150px). Поднял минимум до 190px - колонок становится меньше и они растягиваются (1fr); шапка дня получила `flex-wrap` как страховка.

## Проверка (vite + Playwright, DOM + скриншоты)
- isActive: «Таблицы» НЕ active на /table-constructor (1366 и 1180).
- колонки: «Статус» (заголовок и бейдж) внутри секции на 1366/1180/1100; заголовки усекаются без наезда, «ID» виден целиком.
- расписание: нет overflow шапки дня; 3 колонки@1366, 2@1180, растянуты.
- ESLint 3 файла - чисто.