### PR TITLE
style(ui): инпуты управляющих компонентов к токену .lk-input (#406)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -181,10 +181,6 @@ body.nav-drawer-open {
   overflow: hidden;
 }
 
-.form-input-sm {
-  border-radius: 15px !important;
-}
-
 /* Включает анимацию transition между length и intrinsic-значениями (auto / max-content)
    для width/height/max-width/min-width. Без этого схлопывание столбца таблицы
    через max-width: 0 -> auto обратно не анимируется и даёт визуальный скачок

--- a/frontend/src/components/TableConstructor.vue
+++ b/frontend/src/components/TableConstructor.vue
@@ -292,7 +292,7 @@
                     <label class="detail-label">Наименование таблицы:</label>
                     <input 
                       v-model="selectedTable.table.display_name" 
-                      class="form-input-sm"
+                      class="lk-input"
                       placeholder="Название таблицы"
                       autocomplete="off"
                       @change="updateTableField('display_name')"
@@ -1738,21 +1738,6 @@ export default {
   font-size: 12px;
   color: #a2a2a2;
   line-height: 1.5;
-}
-
-.form-input-sm {
-  padding: 8px 12px;
-  border: 1px solid #e6e6e6;
-  border-radius: 15px;
-  font-size: 13px;
-  width: 100%;
-  transition: border-color 0.2s;
-  background: #fff;
-}
-
-.form-input-sm:focus {
-  border-color: #4F5BDF;
-  outline: none;
 }
 
 .form-textarea {

--- a/frontend/src/components/UserControl.vue
+++ b/frontend/src/components/UserControl.vue
@@ -239,7 +239,7 @@
                   <label class="detail-label">Фамилия:</label>
                   <input 
                     v-model="selectedUser.last_name" 
-                    class="form-input-sm"
+                    class="lk-input"
                     placeholder="Введите фамилию"
                     autocomplete="new-password"
                     autocorrect="off"
@@ -253,7 +253,7 @@
                   <label class="detail-label">Отчество:</label>
                   <input 
                     v-model="selectedUser.middle_name" 
-                    class="form-input-sm"
+                    class="lk-input"
                     placeholder="Введите отчество"
                     autocomplete="new-password"
                     autocorrect="off"
@@ -280,7 +280,7 @@
                   <label class="detail-label">Должность:</label>
                   <input 
                     v-model="selectedUser.position" 
-                    class="form-input-sm"
+                    class="lk-input"
                     placeholder="Введите должность"
                     autocomplete="new-password"
                     autocorrect="off"
@@ -297,7 +297,7 @@
                   <label class="detail-label">Имя:</label>
                   <input 
                     v-model="selectedUser.first_name" 
-                    class="form-input-sm"
+                    class="lk-input"
                     placeholder="Введите имя"
                     autocomplete="new-password"
                     autocorrect="off"
@@ -311,7 +311,7 @@
                   <label class="detail-label">Телефон:</label>
                   <input
                     :value="selectedUser.phone"
-                    class="form-input-sm"
+                    class="lk-input"
                     placeholder="+7 (___) ___ __-__"
                     type="tel"
                     autocomplete="new-password"
@@ -340,7 +340,7 @@
                   <label class="detail-label">Email:</label>
                   <input 
                     v-model="selectedUser.email" 
-                    class="form-input-sm"
+                    class="lk-input"
                     placeholder="Введите email"
                     type="email"
                     autocomplete="new-password"
@@ -1591,22 +1591,6 @@ export default {
    вровень с соседними инпутами (а не полужирным весом BaseDropdown по умолчанию). */
 .detail-group :deep(.base-dropdown__text) {
   font-weight: 400;
-}
-
-/* Уменьшенные инпуты */
-.form-input-sm {
-  padding: 6px 10px;
-  border: 1px solid #ddd;
-  border-radius: 15px;
-  font-size: 14px;
-  width: 100%;
-  height: 32px;
-  transition: border-color 0.2s;
-}
-
-.form-input-sm:focus {
-  border-color: #4F5BDF;
-  outline: none;
 }
 
 .full-width {

--- a/frontend/src/components/UserTypes.vue
+++ b/frontend/src/components/UserTypes.vue
@@ -168,7 +168,7 @@
                   <label class="detail-label">Наименование типа:</label>
                   <input
                     v-model="selectedType.name"
-                    class="form-input-sm"
+                    class="lk-input"
                     placeholder="Название типа"
                     autocomplete="off"
                     :disabled="selectedType.is_system"
@@ -180,7 +180,7 @@
                   <label class="detail-label">Системное имя:</label>
                   <input 
                     v-model="selectedType.code" 
-                    class="form-input-sm"
+                    class="lk-input"
                     disabled
                     placeholder="Системное имя"
                   >
@@ -957,27 +957,6 @@ export default {
   font-weight:400;
 }
 
-.form-input-sm {
-  padding:5px 12px;
-  border: 1px solid #e6e6e6;
-  border-radius: var(--radius-md);
-  font-size: 0.8em;
-  height: 35px;
-  transition: border-color 0.2s ease;
-  background: #fff;
-  width: 300px;
-}
-
-.form-input-sm:focus {
-  border-color: #4F5BDF;
-  outline: none;
-}
-
-.form-input-sm:disabled {
-  background: #f5f5f5;
-  color: #999;
-}
-
 .form-hint {
   font-size: 0.7em;
   color: #999;
@@ -1203,11 +1182,6 @@ export default {
     flex-direction: column;
     align-items: flex-start;
     gap: 8px;
-  }
-  
-  .form-input-sm,
-  .form-input {
-    width: 100% !important;
   }
 }
 </style>


### PR DESCRIPTION
## Что и зачем
Полиш-срез эпика #406 (приведение управляющих компонентов к UI-эталону). По фидбэку владельца 08.06: инпуты одного смысла на разных экранах имели разную высоту. Корень — легаси-класс `.form-input-sm` с расходящимися значениями между компонентами:

| Компонент | было (height/padding) |
|-----------|----------------------|
| TableConstructor | auto, 8px 12px, font 13px |
| UserControl | 32px, 6px 10px |
| UserTypes | 35px, 5px 12px, width 300px |

Свёл все детальные инпуты к дизайн-токену `.lk-input` (`forms.css`, padding 10px 14px / radius 15px / font 14px / width 100%, с `:focus` и `:disabled`). Теперь все ~42px, как уже 21 существующее использование `.lk-input`.

## Изменения
- `TableConstructor.vue` (1×), `UserControl.vue` (6×), `UserTypes.vue` (2×): `class="form-input-sm"` → `class="lk-input"` (все элементы — `<input>`).
- Удалены мёртвые локальные CSS-блоки `.form-input-sm`/`:focus`/`:disabled` в трёх компонентах.
- `App.vue`: удалён мёртвый глобальный `.form-input-sm { border-radius: 15px !important }`.
- `UserTypes.vue`: из media-селектора убран осиротевший `.form-input-sm, .form-input` (после миграции не используется).
- `.map-link-group .form-input` в TableConstructor НЕ тронут (специализированный композит input+кнопка, height 40px).

## Проверка
- Ветка пересобрана на свежем `dev` после landing #510 (TableConstructor переработан) — конфликтов нет, целевые строки идентичны.
- Локально: eslint по 4 файлам чисто (0 errors).
- Ревью `code-reviewer`: GO; единственный YELLOW (осиротевший `.form-input` в media-блоке) закрыт.
- vitest + build + Playwright E2E — в CI.

Не closes — частичный полиш в рамках эпика #406.