### PR TITLE
fix(number-format): поле "Разрешённые буквы" на свою строку в модалках (#414)

### DIFF
--- a/frontend/src/components/NumberFormat.vue
+++ b/frontend/src/components/NumberFormat.vue
@@ -1818,6 +1818,12 @@ export default {
   min-width: 130px;
 }
 
+/* .field-full перебивается более специфичным .cell-edit-fields .field { flex:1 } -
+   возвращаем полю отдельную полную строку. */
+.cell-edit-fields .field-full {
+  flex: 0 0 100%;
+}
+
 .length-field {
   flex: 0 0 auto;
 }


### PR DESCRIPTION
## Что и зачем
Полиш-срез E эпика #406 (#414). По фидбэку владельца 08.06: в модалке «Добавить формат» поле «Разрешённые буквы» переносилось/зажималось.

## Корень
Поле `<div class="field field-full">` лежит в flex-wrap контейнере `.cell-edit-fields`. Класс `.field-full { flex-basis: 100% }` (специфичность 0,1,0) **перебивался** более специфичным `.cell-edit-fields .field { flex: 1 }` (0,2,0): shorthand `flex:1` сбрасывает `flex-basis` в 0. В итоге «Разрешённые буквы» не уходили на свою строку, а втискивались в общий ряд с Тип/Длина/Алфавит (130+150+130+130+gaps ≈ 576px ≤ доступных ~608px) — длинный лейбл переносился.

## Фикс
Добавлено `.cell-edit-fields .field-full { flex: 0 0 100% }` — та же специфичность (0,2,0), но определено позже в каскаде → выигрывает, поле занимает отдельную полную строку. Расширять модалку не потребовалось: после фикса поле и так на всю ширину ряда.

Фикс накрывает **обе** модалки (добавление формата `.nf-modal` 680px и правка клетки `.nf-modal--narrow` 460px) — обе используют `.cell-edit-fields`.

## Проверка
- eslint по файлу чисто.
- Ревью `code-reviewer`: GO. Подтверждено: правило выигрывает каскад по порядку, overflow в узкой модалке 460px не возникает (контент 420px + `overflow:hidden` страхует), другие `.field` (Тип/Длина/Алфавит) не затронуты.
- Визуально владельцу проверить после деплоя (мелкий CSS-фикс).

Не closes — частичный полиш в рамках #406/#414.