### PR TITLE
feat(attachments): фундамент настройки полей вложения - модель, реестр, сервис (#529)

### DIFF
--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -88,6 +88,7 @@ func AllModels() []interface{} {
 		&models.AttachmentTemplateMapping{},
 		&models.AttachmentCustomField{},
 		&models.AttachmentCustomValue{},
+		&models.AttachmentFieldConfig{},
 
 		// Cars (depends on Attachment)
 		&models.Car{},

--- a/internal/models/attachment_template.go
+++ b/internal/models/attachment_template.go
@@ -6,20 +6,20 @@ import "time"
 // Несколько шаблонов на UniqueAttachment, активный определяется IsActive=true.
 // file_path - путь к загруженному .xlsx в uploads/templates/.
 type AttachmentTemplate struct {
-	ID                  int                          `json:"id"`
-	UniqueAttachmentID  int                          `gorm:"index" json:"unique_attachment_id"`
-	IsActive            bool                         `gorm:"default:true;index" json:"is_active"`
-	UniqueAttachment    *UniqueAttachment            `gorm:"foreignKey:UniqueAttachmentID" json:"-"`
-	FilePath            string                       `gorm:"size:500" json:"file_path"`
-	OriginalFileName    string                       `gorm:"size:255" json:"original_file_name"`
-	ListStartRow        int                          `json:"list_start_row"`
-	ListEndRow          int                          `json:"list_end_row"`
-	MaxListRows         int                          `json:"max_list_rows"`
-	ConcatSeparator     *string                      `gorm:"size:20" json:"concat_separator,omitempty"`
-	UploadedByUserID    *int                         `json:"uploaded_by_user_id,omitempty"`
-	CreatedAt           time.Time                    `json:"created_at"`
-	UpdatedAt           time.Time                    `json:"updated_at"`
-	Mappings            []AttachmentTemplateMapping  `gorm:"foreignKey:TemplateID" json:"mappings,omitempty"`
+	ID                 int                         `json:"id"`
+	UniqueAttachmentID int                         `gorm:"index" json:"unique_attachment_id"`
+	IsActive           bool                        `gorm:"default:true;index" json:"is_active"`
+	UniqueAttachment   *UniqueAttachment           `gorm:"foreignKey:UniqueAttachmentID" json:"-"`
+	FilePath           string                      `gorm:"size:500" json:"file_path"`
+	OriginalFileName   string                      `gorm:"size:255" json:"original_file_name"`
+	ListStartRow       int                         `json:"list_start_row"`
+	ListEndRow         int                         `json:"list_end_row"`
+	MaxListRows        int                         `json:"max_list_rows"`
+	ConcatSeparator    *string                     `gorm:"size:20" json:"concat_separator,omitempty"`
+	UploadedByUserID   *int                        `json:"uploaded_by_user_id,omitempty"`
+	CreatedAt          time.Time                   `json:"created_at"`
+	UpdatedAt          time.Time                   `json:"updated_at"`
+	Mappings           []AttachmentTemplateMapping `gorm:"foreignKey:TemplateID" json:"mappings,omitempty"`
 }
 
 // AttachmentTemplateMapping - связь между ячейкой Excel и полем заявки.
@@ -27,12 +27,12 @@ type AttachmentTemplate struct {
 // из словаря (см. attachment_template_fields.go). Для list-полей
 // IsListField=true означает что эта пара заполняется по каждой строке списка.
 type AttachmentTemplateMapping struct {
-	ID          int        `json:"id"`
-	TemplateID  int        `gorm:"index" json:"template_id"`
-	CellRef     string     `gorm:"size:10" json:"cell_ref"`
-	FieldPath   string     `gorm:"size:100" json:"field_path"`
-	IsListField bool       `gorm:"default:false" json:"is_list_field"`
-	CreatedAt   time.Time  `json:"-"`
+	ID          int       `json:"id"`
+	TemplateID  int       `gorm:"index" json:"template_id"`
+	CellRef     string    `gorm:"size:10" json:"cell_ref"`
+	FieldPath   string    `gorm:"size:100" json:"field_path"`
+	IsListField bool      `gorm:"default:false" json:"is_list_field"`
+	CreatedAt   time.Time `json:"-"`
 }
 
 // AttachmentCustomField - дополнительное поле для UniqueAttachment.
@@ -43,7 +43,23 @@ type AttachmentCustomField struct {
 	Label              string    `gorm:"size:200" json:"label"`
 	Placeholder        *string   `gorm:"size:200" json:"placeholder,omitempty"`
 	SortOrder          int       `gorm:"default:0" json:"sort_order"`
+	IsRequired         bool      `gorm:"default:false" json:"is_required"`
 	IsActive           bool      `gorm:"default:true;index" json:"is_active"`
+	CreatedAt          time.Time `json:"created_at"`
+	UpdatedAt          time.Time `json:"updated_at"`
+}
+
+// AttachmentFieldConfig - оверрайд видимости/обязательности базового поля
+// для конкретного UniqueAttachment (feedback-0608-H / #529).
+// Хранит ТОЛЬКО отличия от дефолта реестра (attachment_fields_registry.go):
+// нет строки для (unique_attachment_id, field_key) -> поле берёт дефолт реестра.
+// FieldKey - стабильный ключ из реестра ("passport", "entry_date_from", ...).
+type AttachmentFieldConfig struct {
+	ID                 int       `json:"id"`
+	UniqueAttachmentID int       `gorm:"uniqueIndex:idx_field_config_ua_key,priority:1;not null" json:"unique_attachment_id"`
+	FieldKey           string    `gorm:"uniqueIndex:idx_field_config_ua_key,priority:2;size:64;not null" json:"field_key"`
+	Visible            bool      `json:"visible"`
+	Required           bool      `json:"required"`
 	CreatedAt          time.Time `json:"created_at"`
 	UpdatedAt          time.Time `json:"updated_at"`
 }
@@ -85,6 +101,31 @@ type CreateCustomFieldRequest struct {
 	Label       string  `json:"label" validate:"required,min=1,max=200"`
 	Placeholder *string `json:"placeholder" validate:"omitempty,max=200"`
 	SortOrder   int     `json:"sort_order"`
+	IsRequired  bool    `json:"is_required"`
+}
+
+// FieldConfigItem - элемент тела PUT /attachments/{id}/field-config:
+// оверрайд видимости/обязательности одного базового поля по ключу реестра.
+type FieldConfigItem struct {
+	Key      string `json:"key" validate:"required,max=64"`
+	Visible  bool   `json:"visible"`
+	Required bool   `json:"required"`
+}
+
+// SaveFieldConfigRequest - bulk-upsert оверрайдов базовых полей вложения.
+type SaveFieldConfigRequest struct {
+	Base []FieldConfigItem `json:"base" validate:"dive"`
+}
+
+// MergedField - базовое поле вложения, смерженное с оверрайдами для
+// конкретного UniqueAttachment. Единый источник для админ-модалки и формы
+// подачи: реестр типа вложения + оверрайды из attachment_field_config.
+type MergedField struct {
+	Key      string `json:"key"`
+	Label    string `json:"label"`
+	Group    string `json:"group"`
+	Visible  bool   `json:"visible"`
+	Required bool   `json:"required"`
 }
 
 // CustomValueInput - значение кастомного поля при создании attachment.

--- a/internal/services/attachment_field_config_service.go
+++ b/internal/services/attachment_field_config_service.go
@@ -1,0 +1,140 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"systemburo/internal/models"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// AttachmentFieldConfigService - оверрайды видимости/обязательности базовых
+// полей вложения per-UniqueAttachment (feedback-0608-H / #529).
+// Реестр полей - в коде (attachment_fields_registry.go), сервис мержит его с
+// оверрайдами из БД и принимает bulk-upsert оверрайдов.
+type AttachmentFieldConfigService interface {
+	// GetMerged возвращает базовые поля типа вложения, смерженные с оверрайдами.
+	GetMerged(ctx context.Context, uniqueAttachmentID int) ([]models.MergedField, error)
+	// Save делает bulk-upsert оверрайдов. Ключи не из реестра типа отклоняются.
+	Save(ctx context.Context, uniqueAttachmentID int, items []models.FieldConfigItem) error
+}
+
+type attachmentFieldConfigService struct {
+	db *gorm.DB
+}
+
+// NewAttachmentFieldConfigService создаёт сервис.
+func NewAttachmentFieldConfigService(db *gorm.DB) AttachmentFieldConfigService {
+	return &attachmentFieldConfigService{db: db}
+}
+
+// UnknownFieldKeys возвращает ключи, которых нет в реестре указанного типа
+// вложения. Пустой результат = все ключи валидны. Чистая функция (без БД).
+func UnknownFieldKeys(attachmentType string, keys []string) []string {
+	valid := fieldDefByKey(attachmentType)
+	var unknown []string
+	for _, k := range keys {
+		if _, ok := valid[k]; !ok {
+			unknown = append(unknown, k)
+		}
+	}
+	return unknown
+}
+
+// buildFieldConfigRows готовит строки для bulk-upsert: дедуп по ключу
+// (last-wins) и форс required=false для не-Requirable полей. Чистая функция.
+//
+// Дедуп нужен против PG "ON CONFLICT cannot affect row a second time": один и
+// тот же ключ дважды в одном INSERT иначе падает. PUT идемпотентен -
+// побеждает последнее значение ключа.
+func buildFieldConfigRows(attType string, uaID int, items []models.FieldConfigItem) []models.AttachmentFieldConfig {
+	defs := fieldDefByKey(attType)
+	byKey := make(map[string]models.FieldConfigItem, len(items))
+	order := make([]string, 0, len(items))
+	for _, it := range items {
+		if _, seen := byKey[it.Key]; !seen {
+			order = append(order, it.Key)
+		}
+		byKey[it.Key] = it
+	}
+
+	rows := make([]models.AttachmentFieldConfig, 0, len(order))
+	for _, key := range order {
+		it := byKey[key]
+		required := it.Required
+		if d := defs[key]; !d.Requirable {
+			required = false
+		}
+		rows = append(rows, models.AttachmentFieldConfig{
+			UniqueAttachmentID: uaID,
+			FieldKey:           key,
+			Visible:            it.Visible,
+			Required:           required,
+		})
+	}
+	return rows
+}
+
+func (s *attachmentFieldConfigService) attachmentType(ctx context.Context, uaID int) (string, error) {
+	var ua models.UniqueAttachment
+	err := s.db.WithContext(ctx).Select("attachment_type").First(&ua, uaID).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return "", echo.NewHTTPError(http.StatusNotFound, "Вложение не найдено")
+		}
+		return "", echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения вложения")
+	}
+	return ua.AttachmentType, nil
+}
+
+func (s *attachmentFieldConfigService) GetMerged(ctx context.Context, uaID int) ([]models.MergedField, error) {
+	attType, err := s.attachmentType(ctx, uaID)
+	if err != nil {
+		return nil, err
+	}
+
+	var overrides []models.AttachmentFieldConfig
+	if err := s.db.WithContext(ctx).
+		Where("unique_attachment_id = ?", uaID).
+		Find(&overrides).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения настройки полей")
+	}
+
+	return MergeFieldConfig(attType, overrides), nil
+}
+
+func (s *attachmentFieldConfigService) Save(ctx context.Context, uaID int, items []models.FieldConfigItem) error {
+	attType, err := s.attachmentType(ctx, uaID)
+	if err != nil {
+		return err
+	}
+
+	keys := make([]string, len(items))
+	for i, it := range items {
+		keys[i] = it.Key
+	}
+	if unknown := UnknownFieldKeys(attType, keys); len(unknown) > 0 {
+		return echo.NewHTTPError(http.StatusBadRequest,
+			fmt.Sprintf("Неизвестные поля для типа %q: %v", attType, unknown))
+	}
+
+	if len(items) == 0 {
+		return nil
+	}
+
+	rows := buildFieldConfigRows(attType, uaID, items)
+
+	err = s.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "unique_attachment_id"}, {Name: "field_key"}},
+		DoUpdates: clause.AssignmentColumns([]string{"visible", "required", "updated_at"}),
+	}).Create(&rows).Error
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка сохранения настройки полей")
+	}
+	return nil
+}

--- a/internal/services/attachment_field_config_test.go
+++ b/internal/services/attachment_field_config_test.go
@@ -1,0 +1,270 @@
+package services
+
+import (
+	"testing"
+
+	"systemburo/internal/models"
+)
+
+func defByKey(defs []FieldDef, key string) (FieldDef, bool) {
+	for _, d := range defs {
+		if d.Key == key {
+			return d, true
+		}
+	}
+	return FieldDef{}, false
+}
+
+func mergedByKey(fields []models.MergedField, key string) (models.MergedField, bool) {
+	for _, f := range fields {
+		if f.Key == key {
+			return f, true
+		}
+	}
+	return models.MergedField{}, false
+}
+
+func TestFieldRegistryFor_GroupsByType(t *testing.T) {
+	tests := []struct {
+		attType   string
+		wantKeys  []string // должны присутствовать
+		absentKey []string // не должны
+	}{
+		{
+			attType:   "people",
+			wantKeys:  []string{"entry_date_from", "last_name", "passport", "target_tables"},
+			absentKey: []string{"number", "mark", "item_name"},
+		},
+		{
+			attType:   "cars",
+			wantKeys:  []string{"entry_date_from", "number", "mark", "unloading_places"},
+			absentKey: []string{"last_name", "item_name"},
+		},
+		{
+			attType:   "items",
+			wantKeys:  []string{"entry_date_from", "item_name", "quantity"},
+			absentKey: []string{"number", "last_name"},
+		},
+		{
+			attType:   "unknown",
+			wantKeys:  []string{"entry_date_from", "roof_access"},
+			absentKey: []string{"number", "last_name", "item_name"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.attType, func(t *testing.T) {
+			defs := FieldRegistryFor(tc.attType)
+			for _, k := range tc.wantKeys {
+				if _, ok := defByKey(defs, k); !ok {
+					t.Errorf("FieldRegistryFor(%q): ожидался ключ %q", tc.attType, k)
+				}
+			}
+			for _, k := range tc.absentKey {
+				if _, ok := defByKey(defs, k); ok {
+					t.Errorf("FieldRegistryFor(%q): не должно быть ключа %q", tc.attType, k)
+				}
+			}
+		})
+	}
+}
+
+func TestFieldRegistryFor_CommonFirst(t *testing.T) {
+	defs := FieldRegistryFor("people")
+	if len(defs) == 0 {
+		t.Fatal("пустой реестр")
+	}
+	// common-поля идут до type-specific
+	sawTypeGroup := false
+	for _, d := range defs {
+		if d.Group != FieldGroupCommon {
+			sawTypeGroup = true
+		} else if sawTypeGroup {
+			t.Errorf("common-поле %q после type-specific - порядок нарушен", d.Key)
+		}
+	}
+}
+
+// Дефолты обязаны отражать ТЕКУЩЕЕ поведение форм (обязательство среза H-1).
+func TestRegistryDefaults_MatchForms(t *testing.T) {
+	cases := []struct {
+		attType      string
+		key          string
+		wantVisible  bool
+		wantRequired bool
+		wantRequirbl bool
+	}{
+		// common: даты И время обязательны (CreateApplication.vue hasValidDates).
+		{"people", "entry_date_from", true, true, true},
+		{"people", "entry_time_from", true, true, true},
+		{"people", "entry_time_to", true, true, true},
+		// булевые чекбоксы - не обязуемы
+		{"people", "roof_access", true, false, false},
+		{"people", "free_parking", true, false, false},
+		{"people", "notify_situation_center", true, false, false},
+		// people
+		{"people", "last_name", true, true, true},
+		{"people", "middle_name", true, false, true},
+		{"people", "patent", true, false, true},
+		{"people", "work_permission", true, false, true},
+		// cars
+		{"cars", "number", true, true, true},
+		{"cars", "unloading_places", true, true, true},
+		// items
+		{"items", "quantity", true, true, true},
+	}
+	for _, c := range cases {
+		t.Run(c.attType+"/"+c.key, func(t *testing.T) {
+			d, ok := defByKey(FieldRegistryFor(c.attType), c.key)
+			if !ok {
+				t.Fatalf("нет поля %q у типа %q", c.key, c.attType)
+			}
+			if d.DefaultVisible != c.wantVisible {
+				t.Errorf("%s: visible=%v, ожидалось %v", c.key, d.DefaultVisible, c.wantVisible)
+			}
+			if d.DefaultRequired != c.wantRequired {
+				t.Errorf("%s: required=%v, ожидалось %v", c.key, d.DefaultRequired, c.wantRequired)
+			}
+			if d.Requirable != c.wantRequirbl {
+				t.Errorf("%s: requirable=%v, ожидалось %v", c.key, d.Requirable, c.wantRequirbl)
+			}
+		})
+	}
+}
+
+func TestMergeFieldConfig_DefaultsWhenNoOverrides(t *testing.T) {
+	merged := MergeFieldConfig("cars", nil)
+	if len(merged) != len(FieldRegistryFor("cars")) {
+		t.Fatalf("merged=%d, реестр=%d", len(merged), len(FieldRegistryFor("cars")))
+	}
+	number, ok := mergedByKey(merged, "number")
+	if !ok {
+		t.Fatal("нет number")
+	}
+	if !number.Visible || !number.Required {
+		t.Errorf("number дефолт: visible=%v required=%v, ожидалось true/true", number.Visible, number.Required)
+	}
+}
+
+func TestMergeFieldConfig_OverrideApplied(t *testing.T) {
+	overrides := []models.AttachmentFieldConfig{
+		{FieldKey: "passport", Visible: false, Required: false},
+		{FieldKey: "middle_name", Visible: true, Required: true},
+	}
+	merged := MergeFieldConfig("people", overrides)
+
+	passport, _ := mergedByKey(merged, "passport")
+	if passport.Visible || passport.Required {
+		t.Errorf("passport оверрайд не применён: visible=%v required=%v", passport.Visible, passport.Required)
+	}
+	mid, _ := mergedByKey(merged, "middle_name")
+	if !mid.Required {
+		t.Errorf("middle_name required оверрайд не применён: required=%v", mid.Required)
+	}
+	// не затронутое поле остаётся дефолтным
+	if lastName, _ := mergedByKey(merged, "last_name"); !lastName.Required {
+		t.Error("last_name должен остаться required по дефолту")
+	}
+}
+
+func TestMergeFieldConfig_NonRequirableForcedFalse(t *testing.T) {
+	overrides := []models.AttachmentFieldConfig{
+		{FieldKey: "roof_access", Visible: true, Required: true}, // required=true должен игнорироваться
+	}
+	merged := MergeFieldConfig("cars", overrides)
+	roof, ok := mergedByKey(merged, "roof_access")
+	if !ok {
+		t.Fatal("нет roof_access")
+	}
+	if roof.Required {
+		t.Error("roof_access не обязуем - required должен форситься в false даже с оверрайдом")
+	}
+	if !roof.Visible {
+		t.Error("roof_access visible оверрайд должен примениться")
+	}
+}
+
+func TestMergeFieldConfig_IgnoresOverrideForOtherType(t *testing.T) {
+	// оверрайд по ключу не из реестра типа не должен ничего ломать
+	overrides := []models.AttachmentFieldConfig{
+		{FieldKey: "number", Visible: false, Required: false}, // number нет у people
+	}
+	merged := MergeFieldConfig("people", overrides)
+	if _, ok := mergedByKey(merged, "number"); ok {
+		t.Error("number не должен попасть в merged для people")
+	}
+	// чужой оверрайд не должен затронуть реальные поля people
+	if lastName, _ := mergedByKey(merged, "last_name"); !lastName.Visible || !lastName.Required {
+		t.Error("last_name должен остаться дефолтным при чужом оверрайде")
+	}
+	if pass, _ := mergedByKey(merged, "passport"); !pass.Visible || !pass.Required {
+		t.Error("passport должен остаться дефолтным при чужом оверрайде")
+	}
+}
+
+func TestBuildFieldConfigRows_DedupLastWins(t *testing.T) {
+	items := []models.FieldConfigItem{
+		{Key: "passport", Visible: true, Required: true},
+		{Key: "last_name", Visible: true, Required: true},
+		{Key: "passport", Visible: false, Required: false}, // дубль - побеждает он
+	}
+	rows := buildFieldConfigRows("people", 7, items)
+	if len(rows) != 2 {
+		t.Fatalf("ожидалось 2 строки после дедупа, got %d", len(rows))
+	}
+	var passport *models.AttachmentFieldConfig
+	for i := range rows {
+		if rows[i].FieldKey == "passport" {
+			passport = &rows[i]
+		}
+		if rows[i].UniqueAttachmentID != 7 {
+			t.Errorf("uaID не проставлен: %d", rows[i].UniqueAttachmentID)
+		}
+	}
+	if passport == nil {
+		t.Fatal("нет passport")
+	}
+	if passport.Visible || passport.Required {
+		t.Errorf("last-wins не сработал: passport visible=%v required=%v", passport.Visible, passport.Required)
+	}
+}
+
+func TestBuildFieldConfigRows_ForcesNonRequirableFalse(t *testing.T) {
+	items := []models.FieldConfigItem{
+		{Key: "roof_access", Visible: true, Required: true},
+	}
+	rows := buildFieldConfigRows("cars", 1, items)
+	if len(rows) != 1 {
+		t.Fatalf("ожидалась 1 строка, got %d", len(rows))
+	}
+	if rows[0].Required {
+		t.Error("roof_access не обязуем - required должен форситься в false при сохранении")
+	}
+}
+
+func TestUnknownFieldKeys(t *testing.T) {
+	tests := []struct {
+		name    string
+		attType string
+		keys    []string
+		want    []string
+	}{
+		{"все валидны people", "people", []string{"last_name", "passport", "entry_date_from"}, nil},
+		{"ключ чужой группы", "people", []string{"last_name", "number"}, []string{"number"}},
+		{"выдуманный ключ", "cars", []string{"number", "bogus"}, []string{"bogus"}},
+		{"пустой список", "items", nil, nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := UnknownFieldKeys(tc.attType, tc.keys)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("got %v, want %v", got, tc.want)
+				}
+			}
+		})
+	}
+}

--- a/internal/services/attachment_fields_registry.go
+++ b/internal/services/attachment_fields_registry.go
@@ -1,0 +1,136 @@
+package services
+
+import "systemburo/internal/models"
+
+// Реестр базовых полей вложений (feedback-0608-H / #529).
+//
+// Source of truth - КОД, а не БД: базовые поля жёстко завязаны на компоненты-формы
+// подачи (DateRangeSection / EmployeeForm / VehicleForm / ItemsForm), каталог в БД
+// разъехался бы с кодом. БД (attachment_field_config) хранит только оверрайды.
+//
+// Дефолты visible/required отражают ТЕКУЩЕЕ поведение форм (сверено со срезом H-1):
+//   - common даты/время обязательны (CreateApplication.vue hasValidDates);
+//   - роof/parking/notify - булевые чекбоксы, required для них не имеет смысла
+//     (Requirable=false): значение есть всегда;
+//   - people/cars/items - required совпадает со звёздочками и useFormValidation форм.
+
+// Группы полей. common применяется ко всем типам вложения, остальные - к своему.
+const (
+	FieldGroupCommon = "common"
+	FieldGroupPeople = "people"
+	FieldGroupCars   = "cars"
+	FieldGroupItems  = "items"
+)
+
+// FieldDef - описание одного базового поля вложения в реестре.
+type FieldDef struct {
+	Key             string // стабильный ключ, напр. "passport", "entry_date_from"
+	Label           string // подпись для админ-модалки
+	Group           string // FieldGroupCommon | People | Cars | Items
+	DefaultVisible  bool
+	DefaultRequired bool
+	// Requirable=false для булевых чекбоксов (роof/parking/notify): значение всегда
+	// есть, тумблер "обязательно" бессмыслен. Оверрайд required для них игнорируется.
+	Requirable bool
+}
+
+// attachmentFieldRegistry - полный реестр. Порядок = порядок показа в UI.
+var attachmentFieldRegistry = []FieldDef{
+	// common - присутствует у всех типов вложения
+	{Key: "entry_date_from", Label: "Дата въезда с", Group: FieldGroupCommon, DefaultVisible: true, DefaultRequired: true, Requirable: true},
+	{Key: "entry_date_to", Label: "Дата въезда по", Group: FieldGroupCommon, DefaultVisible: true, DefaultRequired: true, Requirable: true},
+	{Key: "entry_time_from", Label: "Время с", Group: FieldGroupCommon, DefaultVisible: true, DefaultRequired: true, Requirable: true},
+	{Key: "entry_time_to", Label: "Время по", Group: FieldGroupCommon, DefaultVisible: true, DefaultRequired: true, Requirable: true},
+	{Key: "roof_access", Label: "Доступ на крышу", Group: FieldGroupCommon, DefaultVisible: true, DefaultRequired: false, Requirable: false},
+	{Key: "free_parking", Label: "Свободная парковка", Group: FieldGroupCommon, DefaultVisible: true, DefaultRequired: false, Requirable: false},
+	{Key: "notify_situation_center", Label: "Уведомить ситуационный центр", Group: FieldGroupCommon, DefaultVisible: true, DefaultRequired: false, Requirable: false},
+
+	// people
+	{Key: "last_name", Label: "Фамилия", Group: FieldGroupPeople, DefaultVisible: true, DefaultRequired: true, Requirable: true},
+	{Key: "first_name", Label: "Имя", Group: FieldGroupPeople, DefaultVisible: true, DefaultRequired: true, Requirable: true},
+	{Key: "middle_name", Label: "Отчество", Group: FieldGroupPeople, DefaultVisible: true, DefaultRequired: false, Requirable: true},
+	{Key: "passport", Label: "Паспортные данные", Group: FieldGroupPeople, DefaultVisible: true, DefaultRequired: true, Requirable: true},
+	{Key: "position", Label: "Должность", Group: FieldGroupPeople, DefaultVisible: true, DefaultRequired: true, Requirable: true},
+	{Key: "citizenship", Label: "Гражданство", Group: FieldGroupPeople, DefaultVisible: true, DefaultRequired: true, Requirable: true},
+	{Key: "patent", Label: "Номер патента", Group: FieldGroupPeople, DefaultVisible: true, DefaultRequired: false, Requirable: true},
+	{Key: "work_permission", Label: "Иное разрешение на работы", Group: FieldGroupPeople, DefaultVisible: true, DefaultRequired: false, Requirable: true},
+	{Key: "target_tables", Label: "Места прохода", Group: FieldGroupPeople, DefaultVisible: true, DefaultRequired: true, Requirable: true},
+
+	// cars
+	{Key: "number", Label: "Номер ТС", Group: FieldGroupCars, DefaultVisible: true, DefaultRequired: true, Requirable: true},
+	{Key: "mark", Label: "Марка ТС", Group: FieldGroupCars, DefaultVisible: true, DefaultRequired: true, Requirable: true},
+	{Key: "unloading_places", Label: "Места разгрузки", Group: FieldGroupCars, DefaultVisible: true, DefaultRequired: true, Requirable: true},
+
+	// items
+	{Key: "item_name", Label: "Наименование ТМЦ", Group: FieldGroupItems, DefaultVisible: true, DefaultRequired: true, Requirable: true},
+	{Key: "quantity", Label: "Количество", Group: FieldGroupItems, DefaultVisible: true, DefaultRequired: true, Requirable: true},
+}
+
+// groupForAttachmentType возвращает type-specific группу полей для типа вложения.
+func groupForAttachmentType(attachmentType string) string {
+	switch attachmentType {
+	case "people":
+		return FieldGroupPeople
+	case "cars":
+		return FieldGroupCars
+	case "items":
+		return FieldGroupItems
+	default:
+		return ""
+	}
+}
+
+// FieldRegistryFor возвращает базовые поля, применимые к типу вложения:
+// common + type-specific группа. Порядок сохраняется (common впереди).
+// Неизвестный тип -> только common.
+func FieldRegistryFor(attachmentType string) []FieldDef {
+	typeGroup := groupForAttachmentType(attachmentType)
+	out := make([]FieldDef, 0, len(attachmentFieldRegistry))
+	for _, f := range attachmentFieldRegistry {
+		if f.Group == FieldGroupCommon || f.Group == typeGroup {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// fieldDefByKey строит индекс ключ->FieldDef для применимых полей типа.
+func fieldDefByKey(attachmentType string) map[string]FieldDef {
+	defs := FieldRegistryFor(attachmentType)
+	idx := make(map[string]FieldDef, len(defs))
+	for _, d := range defs {
+		idx[d.Key] = d
+	}
+	return idx
+}
+
+// MergeFieldConfig мержит реестр типа вложения с оверрайдами из БД.
+// Где оверрайда нет - берётся дефолт реестра. Для не-Requirable полей
+// (булевые чекбоксы) required всегда false независимо от оверрайда.
+func MergeFieldConfig(attachmentType string, overrides []models.AttachmentFieldConfig) []models.MergedField {
+	byKey := make(map[string]models.AttachmentFieldConfig, len(overrides))
+	for _, o := range overrides {
+		byKey[o.FieldKey] = o
+	}
+
+	defs := FieldRegistryFor(attachmentType)
+	out := make([]models.MergedField, 0, len(defs))
+	for _, d := range defs {
+		visible, required := d.DefaultVisible, d.DefaultRequired
+		if o, ok := byKey[d.Key]; ok {
+			visible = o.Visible
+			required = o.Required
+		}
+		if !d.Requirable {
+			required = false
+		}
+		out = append(out, models.MergedField{
+			Key:      d.Key,
+			Label:    d.Label,
+			Group:    d.Group,
+			Visible:  visible,
+			Required: required,
+		})
+	}
+	return out
+}

--- a/internal/services/attachment_template_service.go
+++ b/internal/services/attachment_template_service.go
@@ -266,6 +266,7 @@ func (s *attachmentTemplateService) CreateCustomField(ctx context.Context, uaID 
 		Label:              req.Label,
 		Placeholder:        req.Placeholder,
 		SortOrder:          req.SortOrder,
+		IsRequired:         req.IsRequired,
 		IsActive:           true,
 	}
 	if err := s.db.WithContext(ctx).Create(&cf).Error; err != nil {
@@ -279,6 +280,7 @@ func (s *attachmentTemplateService) UpdateCustomField(ctx context.Context, id in
 		"label":       req.Label,
 		"placeholder": req.Placeholder,
 		"sort_order":  req.SortOrder,
+		"is_required": req.IsRequired,
 	}
 	res := s.db.WithContext(ctx).Model(&models.AttachmentCustomField{}).Where("id = ?", id).Updates(updates)
 	if res.Error != nil {


### PR DESCRIPTION
Срез H-1 (фаза A, BE) фичи **«Настройка полей вложения»** (feedback-0608-H, #529). Бэкенд-фундамент: эндпоинтов и UI здесь нет, они в H-2+.

## Что в срезе
- **Реестр базовых полей в коде** — `internal/services/attachment_fields_registry.go`. Source of truth: какие поля есть у каждого типа вложения (common + people/cars/items). `FieldDef` + `FieldRegistryFor` + `MergeFieldConfig` + `UnknownFieldKeys`.
- **Модель оверрайдов** `AttachmentFieldConfig` (per-UniqueAttachment, хранит только отличия от дефолта) с композитным uniqueIndex `(unique_attachment_id, field_key)`.
- **Сервис merge/upsert** `attachment_field_config_service.go`: `GetMerged` (реестр + оверрайды) и `Save` (bulk-upsert через `ON CONFLICT`, отклонение неизвестных ключей).
- **`is_required`** добавлен `AttachmentCustomField` + проброшен в Create/Update CRUD.
- **AutoMigrate** — модель зарегистрирована в `migrate.go` (off-limits, **OK владельца получен 10.06**).
- Unit-тесты на реестр, merge, валидацию ключей, дедуп, форс-required.

## Верификация
- `go build` / `go vet` / `gofmt` — чисто.
- `go test ./...` — весь модуль зелёный (включая attachment-интеграционные с реальным AutoMigrate).
- Миграция проверена на реальном Postgres: таблица `attachment_field_configs` с индексом `idx_field_config_ua_key UNIQUE (unique_attachment_id, field_key)` и колонка `is_required boolean default false` на `attachment_custom_fields` созданы.

## Отклонение от спеки (требует внимания владельца)
**`entry_time_from` / `entry_time_to`: `required = true`, хотя таблица спеки указывает `false`.** Решение владельца #6 — «дефолты = текущее поведение, существующие шаблоны не ломаются». Проверка `CreateApplication.vue` (`hasValidDates` требует `startTime && endTime`, строки ~481-485) показывает, что время **сейчас обязательно** при подаче. `false` сломал бы все существующие шаблоны, поэтому реестр сохраняет текущее поведение (`true`). Если время действительно должно стать необязательным по умолчанию — это тривиальная правка одной строки реестра в отдельном follow-up.

## Findings ревью
Исправлены: проброс `is_required` в Create/Update custom-полей; дедуп ключей в `Save` (last-wins) против PG `ON CONFLICT cannot affect row a second time`; усилены тесты.
Не делал осознанно: FK/CASCADE на `AttachmentFieldConfig` — консистентность с соседней `AttachmentCustomField` (тоже без FK), спека использует plain index, а композитный uniqueIndex покрывает запрос по leftmost-префиксу. Транзакция вокруг Save — без FK orphan-строка безвредна.

Часть эпика #406.