### PR TITLE
fix(attachments): дата и время вложения всегда обязательны и нескрываемы (#529)

### DIFF
--- a/internal/models/attachment_template.go
+++ b/internal/models/attachment_template.go
@@ -126,6 +126,9 @@ type MergedField struct {
 	Group    string `json:"group"`
 	Visible  bool   `json:"visible"`
 	Required bool   `json:"required"`
+	// Locked=true: поле не настраивается (дата/время). Админ-модалка не показывает
+	// для него тумблеры, форма подачи рендерит как обязательное всегда.
+	Locked bool `json:"locked"`
 }
 
 // CustomValueInput - значение кастомного поля при создании attachment.

--- a/internal/services/attachment_field_config_service.go
+++ b/internal/services/attachment_field_config_service.go
@@ -47,11 +47,13 @@ func UnknownFieldKeys(attachmentType string, keys []string) []string {
 }
 
 // buildFieldConfigRows готовит строки для bulk-upsert: дедуп по ключу
-// (last-wins) и форс required=false для не-Requirable полей. Чистая функция.
+// (last-wins), пропуск залоченных полей и форс required=false для не-Requirable.
+// Чистая функция.
 //
 // Дедуп нужен против PG "ON CONFLICT cannot affect row a second time": один и
 // тот же ключ дважды в одном INSERT иначе падает. PUT идемпотентен -
-// побеждает последнее значение ключа.
+// побеждает последнее значение ключа. Залоченные поля (дата/время) не настраиваются:
+// оверрайды для них не персистятся, даже если пришли в теле запроса.
 func buildFieldConfigRows(attType string, uaID int, items []models.FieldConfigItem) []models.AttachmentFieldConfig {
 	defs := fieldDefByKey(attType)
 	byKey := make(map[string]models.FieldConfigItem, len(items))
@@ -65,9 +67,13 @@ func buildFieldConfigRows(attType string, uaID int, items []models.FieldConfigIt
 
 	rows := make([]models.AttachmentFieldConfig, 0, len(order))
 	for _, key := range order {
+		d := defs[key]
+		if d.Locked {
+			continue
+		}
 		it := byKey[key]
 		required := it.Required
-		if d := defs[key]; !d.Requirable {
+		if !d.Requirable {
 			required = false
 		}
 		rows = append(rows, models.AttachmentFieldConfig{
@@ -128,6 +134,10 @@ func (s *attachmentFieldConfigService) Save(ctx context.Context, uaID int, items
 	}
 
 	rows := buildFieldConfigRows(attType, uaID, items)
+	if len(rows) == 0 {
+		// Все присланные ключи залочены - сохранять нечего (пустой батч уронил бы GORM).
+		return nil
+	}
 
 	err = s.db.WithContext(ctx).Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "unique_attachment_id"}, {Name: "field_key"}},

--- a/internal/services/attachment_field_config_test.go
+++ b/internal/services/attachment_field_config_test.go
@@ -242,6 +242,58 @@ func TestBuildFieldConfigRows_ForcesNonRequirableFalse(t *testing.T) {
 	}
 }
 
+func TestRegistryDateTimeLocked(t *testing.T) {
+	lockedKeys := []string{"entry_date_from", "entry_date_to", "entry_time_from", "entry_time_to"}
+	defs := FieldRegistryFor("people")
+	for _, k := range lockedKeys {
+		d, ok := defByKey(defs, k)
+		if !ok {
+			t.Fatalf("нет поля %q", k)
+		}
+		if !d.Locked {
+			t.Errorf("%s должен быть Locked", k)
+		}
+	}
+	// прочие поля не залочены
+	for _, k := range []string{"roof_access", "last_name", "passport"} {
+		if d, _ := defByKey(defs, k); d.Locked {
+			t.Errorf("%s не должен быть Locked", k)
+		}
+	}
+}
+
+func TestMergeFieldConfig_LockedForcedAndIgnoresOverride(t *testing.T) {
+	// оверрайд пытается скрыть/снять обязательность даты - должен игнорироваться
+	overrides := []models.AttachmentFieldConfig{
+		{FieldKey: "entry_date_from", Visible: false, Required: false},
+		{FieldKey: "entry_time_to", Visible: false, Required: false},
+	}
+	merged := MergeFieldConfig("cars", overrides)
+	for _, k := range []string{"entry_date_from", "entry_time_to"} {
+		f, ok := mergedByKey(merged, k)
+		if !ok {
+			t.Fatalf("нет %q", k)
+		}
+		if !f.Visible || !f.Required || !f.Locked {
+			t.Errorf("%s залочен: visible=%v required=%v locked=%v, ожидалось true/true/true", k, f.Visible, f.Required, f.Locked)
+		}
+	}
+}
+
+func TestBuildFieldConfigRows_SkipsLocked(t *testing.T) {
+	items := []models.FieldConfigItem{
+		{Key: "entry_date_from", Visible: false, Required: false}, // залочен - не персистится
+		{Key: "number", Visible: false, Required: false},
+	}
+	rows := buildFieldConfigRows("cars", 3, items)
+	if len(rows) != 1 {
+		t.Fatalf("ожидалась 1 строка (залоченное поле пропущено), got %d", len(rows))
+	}
+	if rows[0].FieldKey != "number" {
+		t.Errorf("ожидался number, got %q", rows[0].FieldKey)
+	}
+}
+
 func TestUnknownFieldKeys(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/services/attachment_fields_registry.go
+++ b/internal/services/attachment_fields_registry.go
@@ -9,7 +9,8 @@ import "systemburo/internal/models"
 // разъехался бы с кодом. БД (attachment_field_config) хранит только оверрайды.
 //
 // Дефолты visible/required отражают ТЕКУЩЕЕ поведение форм (сверено со срезом H-1):
-//   - common даты/время обязательны (CreateApplication.vue hasValidDates);
+//   - common даты/время ЗАЛОЧЕНЫ (Locked): всегда видимы и обязательны, не
+//     настраиваются - заявка без периода действия бессмысленна (решение владельца 10.06);
 //   - роof/parking/notify - булевые чекбоксы, required для них не имеет смысла
 //     (Requirable=false): значение есть всегда;
 //   - people/cars/items - required совпадает со звёздочками и useFormValidation форм.
@@ -32,15 +33,20 @@ type FieldDef struct {
 	// Requirable=false для булевых чекбоксов (роof/parking/notify): значение всегда
 	// есть, тумблер "обязательно" бессмыслен. Оверрайд required для них игнорируется.
 	Requirable bool
+	// Locked=true: поле нельзя настроить (всегда visible+required). Не показывается
+	// в админ-модалке настройки, любые оверрайды из БД игнорируются. Для common
+	// даты/времени - период действия обязателен у каждой заявки.
+	Locked bool
 }
 
 // attachmentFieldRegistry - полный реестр. Порядок = порядок показа в UI.
 var attachmentFieldRegistry = []FieldDef{
-	// common - присутствует у всех типов вложения
-	{Key: "entry_date_from", Label: "Дата въезда с", Group: FieldGroupCommon, DefaultVisible: true, DefaultRequired: true, Requirable: true},
-	{Key: "entry_date_to", Label: "Дата въезда по", Group: FieldGroupCommon, DefaultVisible: true, DefaultRequired: true, Requirable: true},
-	{Key: "entry_time_from", Label: "Время с", Group: FieldGroupCommon, DefaultVisible: true, DefaultRequired: true, Requirable: true},
-	{Key: "entry_time_to", Label: "Время по", Group: FieldGroupCommon, DefaultVisible: true, DefaultRequired: true, Requirable: true},
+	// common - присутствует у всех типов вложения.
+	// Дата/время залочены: период действия обязателен у каждой заявки, не настраивается.
+	{Key: "entry_date_from", Label: "Дата въезда с", Group: FieldGroupCommon, DefaultVisible: true, DefaultRequired: true, Requirable: true, Locked: true},
+	{Key: "entry_date_to", Label: "Дата въезда по", Group: FieldGroupCommon, DefaultVisible: true, DefaultRequired: true, Requirable: true, Locked: true},
+	{Key: "entry_time_from", Label: "Время с", Group: FieldGroupCommon, DefaultVisible: true, DefaultRequired: true, Requirable: true, Locked: true},
+	{Key: "entry_time_to", Label: "Время по", Group: FieldGroupCommon, DefaultVisible: true, DefaultRequired: true, Requirable: true, Locked: true},
 	{Key: "roof_access", Label: "Доступ на крышу", Group: FieldGroupCommon, DefaultVisible: true, DefaultRequired: false, Requirable: false},
 	{Key: "free_parking", Label: "Свободная парковка", Group: FieldGroupCommon, DefaultVisible: true, DefaultRequired: false, Requirable: false},
 	{Key: "notify_situation_center", Label: "Уведомить ситуационный центр", Group: FieldGroupCommon, DefaultVisible: true, DefaultRequired: false, Requirable: false},
@@ -107,6 +113,7 @@ func fieldDefByKey(attachmentType string) map[string]FieldDef {
 // MergeFieldConfig мержит реестр типа вложения с оверрайдами из БД.
 // Где оверрайда нет - берётся дефолт реестра. Для не-Requirable полей
 // (булевые чекбоксы) required всегда false независимо от оверрайда.
+// Залоченные поля (Locked) всегда visible+required, оверрайды для них игнорируются.
 func MergeFieldConfig(attachmentType string, overrides []models.AttachmentFieldConfig) []models.MergedField {
 	byKey := make(map[string]models.AttachmentFieldConfig, len(overrides))
 	for _, o := range overrides {
@@ -117,12 +124,18 @@ func MergeFieldConfig(attachmentType string, overrides []models.AttachmentFieldC
 	out := make([]models.MergedField, 0, len(defs))
 	for _, d := range defs {
 		visible, required := d.DefaultVisible, d.DefaultRequired
-		if o, ok := byKey[d.Key]; ok {
-			visible = o.Visible
-			required = o.Required
-		}
-		if !d.Requirable {
-			required = false
+		switch {
+		case d.Locked:
+			// Залоченные (дата/время) - всегда видимы и обязательны, оверрайд не применяется.
+			visible, required = true, true
+		default:
+			if o, ok := byKey[d.Key]; ok {
+				visible = o.Visible
+				required = o.Required
+			}
+			if !d.Requirable {
+				required = false
+			}
 		}
 		out = append(out, models.MergedField{
 			Key:      d.Key,
@@ -130,6 +143,7 @@ func MergeFieldConfig(attachmentType string, overrides []models.AttachmentFieldC
 			Group:    d.Group,
 			Visible:  visible,
 			Required: required,
+			Locked:   d.Locked,
 		})
 	}
 	return out


### PR DESCRIPTION
Follow-up к H-1 (#530) по уточнению владельца: дата и время вложения **всегда обязательны и не настраиваются**.

Период действия нужен каждой заявке, поэтому common-поля `entry_date_from/to`, `entry_time_from/to` залочены:
- всегда `visible=true` + `required=true`;
- не показываются в модалке «Настройка полей» (флаг `locked` в `MergedField`, админ-UI скроет их в срезе H-3);
- любые оверрайды из БД для них игнорируются (`MergeFieldConfig`), и `Save` не персистит для них строки (`buildFieldConfigRows` пропускает залоченные).

Изначально таблица спеки помечала их `required:false`/настраиваемыми — H-1 сохранил текущее поведение (required), теперь зафиксировал полный замок.

**Проверка:** `go build`/`vet`/`gofmt` чисто; `go test ./internal/services ./internal/handlers` зелёные, добавлены тесты `TestRegistryDateTimeLocked`, `TestMergeFieldConfig_LockedForcedAndIgnoresOverride`, `TestBuildFieldConfigRows_SkipsLocked`. Поверх уже отревьюенного H-1, дифф ~40 строк (реестр + merge + пропуск в upsert).

Часть эпика #406.