### PR TITLE
feat(attachments): эндпоинты настройки полей вложения (#529)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -181,6 +181,7 @@ func main() {
 	personBlacklistService := services.NewPersonBlacklistService(db, personBlacklistHistoryService)
 	applicationService := services.NewApplicationService(db, permissionService, notificationService, vehicleBlacklistService, personBlacklistService)
 	attachmentTemplateService := services.NewAttachmentTemplateService(db, cfg.UploadPath)
+	attachmentFieldConfigService := services.NewAttachmentFieldConfigService(db)
 	attachmentBlankService := services.NewAttachmentBlankService(db)
 	trashService := services.NewTrashService(db)
 	trashDBRef := services.NewTrashDBRef(db)
@@ -220,7 +221,7 @@ func main() {
 	markHandler := handlers.NewMarkHandler(markService)
 	vehicleBlacklistHandler := handlers.NewVehicleBlacklistHandler(vehicleBlacklistService)
 	personBlacklistHandler := handlers.NewPersonBlacklistHandler(personBlacklistService)
-	attachmentTemplateHandler := handlers.NewAttachmentTemplateHandler(attachmentTemplateService)
+	attachmentTemplateHandler := handlers.NewAttachmentTemplateHandler(attachmentTemplateService, attachmentFieldConfigService)
 	attachmentBlankHandler := handlers.NewAttachmentBlankHandler(attachmentBlankService)
 	trashHandler := handlers.NewTrashHandler(trashService, trashDBRef)
 

--- a/internal/handlers/attachment_field_config_test.go
+++ b/internal/handlers/attachment_field_config_test.go
@@ -152,6 +152,9 @@ func TestFieldConfig_RequiresAuth(t *testing.T) {
 
 	rec := testutil.GET(t, e, "/attachments/1/field-config", nil)
 	assert.Equal(t, http.StatusUnauthorized, rec.Code, rec.Body.String())
+
+	rec = testutil.PUT(t, e, "/attachments/1/field-config", `{"base":[]}`, nil)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code, rec.Body.String())
 }
 
 // TestCustomField_PersistsIsRequired: is_required проходит через CRUD кастомных

--- a/internal/handlers/attachment_field_config_test.go
+++ b/internal/handlers/attachment_field_config_test.go
@@ -1,0 +1,189 @@
+package handlers_test
+
+import (
+	"net/http"
+	"testing"
+
+	"systemburo/internal/models"
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fieldByKey ищет базовое поле в смерженном ответе по ключу реестра.
+func fieldByKey(t *testing.T, fields []models.MergedField, key string) models.MergedField {
+	t.Helper()
+	for _, f := range fields {
+		if f.Key == key {
+			return f
+		}
+	}
+	t.Fatalf("base field %q not found in response", key)
+	return models.MergedField{}
+}
+
+// TestGetFieldConfig_DefaultsForFreshAttachment: у вложения без оверрайдов
+// GET отдаёт дефолты реестра типа (common + people) и пустой список кастомных.
+func TestGetFieldConfig_DefaultsForFreshAttachment(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	token := testutil.RegisterAdmin(t, e, 0, 0)
+	uaID := seedUniqueAttachment(t, db, "people", "people_tpl", "Люди")
+
+	rec := testutil.GET(t, e, "/attachments/"+itoa(uaID)+"/field-config", testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	resp := testutil.ParseResponse[models.FieldConfigResponse](t, rec)
+	require.NotEmpty(t, resp.Base)
+	assert.Empty(t, resp.Custom)
+
+	// people-тип не должен содержать поля cars/items.
+	for _, f := range resp.Base {
+		assert.NotEqual(t, "number", f.Key, "cars field leaked into people config")
+		assert.NotEqual(t, "item_name", f.Key, "items field leaked into people config")
+	}
+
+	last := fieldByKey(t, resp.Base, "last_name")
+	assert.True(t, last.Visible)
+	assert.True(t, last.Required)
+
+	middle := fieldByKey(t, resp.Base, "middle_name")
+	assert.True(t, middle.Visible)
+	assert.False(t, middle.Required, "middle_name по дефолту необязателен")
+
+	// Дата/время - залочены: всегда visible+required и помечены Locked.
+	dateFrom := fieldByKey(t, resp.Base, "entry_date_from")
+	assert.True(t, dateFrom.Locked)
+	assert.True(t, dateFrom.Visible)
+	assert.True(t, dateFrom.Required)
+}
+
+// TestSaveAndGetFieldConfig_AppliesOverrides: PUT сохраняет оверрайды, GET их
+// отражает; залоченные и не-requirable поля ведут себя по правилам реестра.
+func TestSaveAndGetFieldConfig_AppliesOverrides(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	token := testutil.RegisterAdmin(t, e, 0, 0)
+	uaID := seedUniqueAttachment(t, db, "people", "people_tpl", "Люди")
+
+	// Скрываем patent, делаем work_permission обязательным; пытаемся снять
+	// залоченный entry_date_from и пометить required чекбокс roof_access.
+	body := `{"base":[
+		{"key":"patent","visible":false,"required":false},
+		{"key":"work_permission","visible":true,"required":true},
+		{"key":"entry_date_from","visible":false,"required":false},
+		{"key":"roof_access","visible":false,"required":true}
+	]}`
+	rec := testutil.PUT(t, e, "/attachments/"+itoa(uaID)+"/field-config", body, testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	rec = testutil.GET(t, e, "/attachments/"+itoa(uaID)+"/field-config", testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	resp := testutil.ParseResponse[models.FieldConfigResponse](t, rec)
+
+	patent := fieldByKey(t, resp.Base, "patent")
+	assert.False(t, patent.Visible, "patent должен быть скрыт оверрайдом")
+
+	wp := fieldByKey(t, resp.Base, "work_permission")
+	assert.True(t, wp.Required, "work_permission стал обязательным")
+
+	// Залоченное поле игнорирует оверрайд - остаётся visible+required.
+	dateFrom := fieldByKey(t, resp.Base, "entry_date_from")
+	assert.True(t, dateFrom.Visible)
+	assert.True(t, dateFrom.Required)
+
+	// roof_access - булевый чекбокс: видимость меняется, required форсится в false.
+	roof := fieldByKey(t, resp.Base, "roof_access")
+	assert.False(t, roof.Visible)
+	assert.False(t, roof.Required, "required не имеет смысла для булевого чекбокса")
+
+	// Повторный PUT того же ключа - идемпотентен (upsert, не дубль-вставка).
+	body2 := `{"base":[{"key":"patent","visible":true,"required":true}]}`
+	rec = testutil.PUT(t, e, "/attachments/"+itoa(uaID)+"/field-config", body2, testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	rec = testutil.GET(t, e, "/attachments/"+itoa(uaID)+"/field-config", testutil.AuthHeader(token))
+	resp = testutil.ParseResponse[models.FieldConfigResponse](t, rec)
+	patent = fieldByKey(t, resp.Base, "patent")
+	assert.True(t, patent.Visible)
+	assert.True(t, patent.Required)
+}
+
+// TestSaveFieldConfig_RejectsUnknownKey: ключ не из реестра типа - 400.
+func TestSaveFieldConfig_RejectsUnknownKey(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	token := testutil.RegisterAdmin(t, e, 0, 0)
+	uaID := seedUniqueAttachment(t, db, "people", "people_tpl", "Люди")
+
+	// number - поле машин, для people-типа неизвестно.
+	body := `{"base":[{"key":"number","visible":true,"required":true}]}`
+	rec := testutil.PUT(t, e, "/attachments/"+itoa(uaID)+"/field-config", body, testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+
+	body = `{"base":[{"key":"totally_bogus","visible":true,"required":true}]}`
+	rec = testutil.PUT(t, e, "/attachments/"+itoa(uaID)+"/field-config", body, testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+}
+
+// TestFieldConfig_NotFound: несуществующий UA - 404 на GET и PUT.
+func TestFieldConfig_NotFound(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	token := testutil.RegisterAdmin(t, e, 0, 0)
+
+	rec := testutil.GET(t, e, "/attachments/999999/field-config", testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusNotFound, rec.Code, rec.Body.String())
+
+	body := `{"base":[{"key":"last_name","visible":true,"required":true}]}`
+	rec = testutil.PUT(t, e, "/attachments/999999/field-config", body, testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusNotFound, rec.Code, rec.Body.String())
+}
+
+// TestFieldConfig_RequiresAuth: без токена - 401.
+func TestFieldConfig_RequiresAuth(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	rec := testutil.GET(t, e, "/attachments/1/field-config", nil)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code, rec.Body.String())
+}
+
+// TestCustomField_PersistsIsRequired: is_required проходит через CRUD кастомных
+// полей и попадает в ответ field-config.
+func TestCustomField_PersistsIsRequired(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	token := testutil.RegisterAdmin(t, e, 0, 0)
+	uaID := seedUniqueAttachment(t, db, "people", "people_tpl", "Люди")
+
+	// Создаём обязательное кастомное поле.
+	create := `{"label":"Телефон","placeholder":"+7","sort_order":1,"is_required":true}`
+	rec := testutil.POST(t, e, "/attachments/"+itoa(uaID)+"/custom-fields", create, testutil.AuthHeader(token))
+	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+	created := testutil.ParseResponse[models.AttachmentCustomField](t, rec)
+	assert.True(t, created.IsRequired)
+
+	// field-config отдаёт его в custom с is_required=true.
+	rec = testutil.GET(t, e, "/attachments/"+itoa(uaID)+"/field-config", testutil.AuthHeader(token))
+	resp := testutil.ParseResponse[models.FieldConfigResponse](t, rec)
+	require.Len(t, resp.Custom, 1)
+	assert.Equal(t, "Телефон", resp.Custom[0].Label)
+	assert.True(t, resp.Custom[0].IsRequired)
+
+	// Снимаем обязательность через UpdateCustomField - отражается в ответе.
+	update := `{"label":"Телефон","placeholder":"+7","sort_order":1,"is_required":false}`
+	rec = testutil.PUT(t, e, "/attachments/custom-fields/"+itoa(created.ID), update, testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	rec = testutil.GET(t, e, "/attachments/"+itoa(uaID)+"/field-config", testutil.AuthHeader(token))
+	resp = testutil.ParseResponse[models.FieldConfigResponse](t, rec)
+	require.Len(t, resp.Custom, 1)
+	assert.False(t, resp.Custom[0].IsRequired)
+}

--- a/internal/handlers/attachment_templates.go
+++ b/internal/handlers/attachment_templates.go
@@ -11,14 +11,16 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// AttachmentTemplateHandler - HTTP API настроек Excel-бланков (#183).
+// AttachmentTemplateHandler - HTTP API настроек Excel-бланков (#183) и настройки
+// полей вложения (feedback-0608-H / #529).
 type AttachmentTemplateHandler struct {
-	service services.AttachmentTemplateService
+	service     services.AttachmentTemplateService
+	fieldConfig services.AttachmentFieldConfigService
 }
 
 // NewAttachmentTemplateHandler создаёт handler.
-func NewAttachmentTemplateHandler(s services.AttachmentTemplateService) *AttachmentTemplateHandler {
-	return &AttachmentTemplateHandler{service: s}
+func NewAttachmentTemplateHandler(s services.AttachmentTemplateService, fc services.AttachmentFieldConfigService) *AttachmentTemplateHandler {
+	return &AttachmentTemplateHandler{service: s, fieldConfig: fc}
 }
 
 // GetTemplate godoc
@@ -337,4 +339,55 @@ func (h *AttachmentTemplateHandler) DeleteCustomField(c echo.Context) error {
 		return err
 	}
 	return RespondMessage(c, "Поле удалено")
+}
+
+// GetFieldConfig godoc
+// @Summary      Настройка полей вложения (базовые + кастомные)
+// @Description  Базовые поля реестра типа, смерженные с оверрайдами видимости/обязательности, плюс кастомные поля. Единый источник для админ-модалки и формы подачи.
+// @Tags         attachment-templates
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID UniqueAttachment"
+// @Success      200 {object} models.FieldConfigResponse
+// @Router       /attachments/{id}/field-config [get]
+func (h *AttachmentTemplateHandler) GetFieldConfig(c echo.Context) error {
+	uaID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	base, err := h.fieldConfig.GetMerged(c.Request().Context(), uaID)
+	if err != nil {
+		return err
+	}
+	custom, err := h.service.ListCustomFields(c.Request().Context(), uaID)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, models.FieldConfigResponse{Base: base, Custom: custom})
+}
+
+// SaveFieldConfig godoc
+// @Summary      Сохранить настройку базовых полей вложения
+// @Description  Bulk-upsert оверрайдов видимости/обязательности базовых полей. Ключи не из реестра типа отклоняются. Залоченные поля (дата/время) игнорируются.
+// @Tags         attachment-templates
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID UniqueAttachment"
+// @Param        request body models.SaveFieldConfigRequest true "Оверрайды базовых полей"
+// @Success      200 {string} string "Настройка полей сохранена"
+// @Router       /attachments/{id}/field-config [put]
+func (h *AttachmentTemplateHandler) SaveFieldConfig(c echo.Context) error {
+	uaID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	var req models.SaveFieldConfigRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	if err := h.fieldConfig.Save(c.Request().Context(), uaID, req.Base); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Настройка полей сохранена")
 }

--- a/internal/models/attachment_template.go
+++ b/internal/models/attachment_template.go
@@ -117,6 +117,14 @@ type SaveFieldConfigRequest struct {
 	Base []FieldConfigItem `json:"base" validate:"dive"`
 }
 
+// FieldConfigResponse - ответ GET /attachments/{id}/field-config: базовые поля
+// (реестр типа, смерженный с оверрайдами) + кастомные поля вложения. Единый
+// источник для админ-модалки настройки и формы подачи.
+type FieldConfigResponse struct {
+	Base   []MergedField           `json:"base"`
+	Custom []AttachmentCustomField `json:"custom"`
+}
+
 // MergedField - базовое поле вложения, смерженное с оверрайдами для
 // конкретного UniqueAttachment. Единый источник для админ-модалки и формы
 // подачи: реестр типа вложения + оверрайды из attachment_field_config.

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -242,6 +242,10 @@ func Setup(e *echo.Echo, d Dependencies) {
 	attRoot.POST("/:id/custom-fields", attachmentTemplates.CreateCustomField)
 	attRoot.PUT("/custom-fields/:fid", attachmentTemplates.UpdateCustomField)
 	attRoot.DELETE("/custom-fields/:fid", attachmentTemplates.DeleteCustomField)
+	// Настройка полей вложения (feedback-0608-H / #529): видимость/обязательность
+	// базовых полей реестра + кастомные поля одним ответом.
+	attRoot.GET("/:id/field-config", attachmentTemplates.GetFieldConfig)
+	attRoot.PUT("/:id/field-config", attachmentTemplates.SaveFieldConfig)
 
 	// Организации
 	orgg := protected.Group("/organizations")

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -139,6 +139,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	personBlacklistService := services.NewPersonBlacklistService(db, personBlacklistHistoryService)
 	applicationService := services.NewApplicationService(db, permissionService, notificationService, vehicleBlacklistService, personBlacklistService)
 	attachmentTemplateService := services.NewAttachmentTemplateService(db, "./uploads")
+	attachmentFieldConfigService := services.NewAttachmentFieldConfigService(db)
 	attachmentBlankService := services.NewAttachmentBlankService(db)
 	trashService := services.NewTrashService(db)
 	trashDBRef := services.NewTrashDBRef(db)
@@ -180,7 +181,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	markHandler := handlers.NewMarkHandler(markService)
 	vehicleBlacklistHandler := handlers.NewVehicleBlacklistHandler(vehicleBlacklistService)
 	personBlacklistHandler := handlers.NewPersonBlacklistHandler(personBlacklistService)
-	attachmentTemplateHandler := handlers.NewAttachmentTemplateHandler(attachmentTemplateService)
+	attachmentTemplateHandler := handlers.NewAttachmentTemplateHandler(attachmentTemplateService, attachmentFieldConfigService)
 	attachmentBlankHandler := handlers.NewAttachmentBlankHandler(attachmentBlankService)
 	trashHandler := handlers.NewTrashHandler(trashService, trashDBRef)
 


### PR DESCRIPTION
Срез H-2 эпика feedback-0608-H (#529, часть #406). Фаза A, backend.

## Что добавил
- `GET /attachments/{id}/field-config` - отдаёт `{base, custom}`: базовые поля реестра типа, смерженные с оверрайдами видимости/обязательности (через `AttachmentFieldConfigService.GetMerged`, фундамент H-1 #530), плюс кастомные поля одним ответом. Единый источник для админ-модалки и формы подачи.
- `PUT /attachments/{id}/field-config` - bulk-upsert оверрайдов (`Save`). Неизвестные для типа ключи отклоняются 400; залоченные дата/время и не-requirable булевые чекбоксы обрабатываются реестром/сервисом H-1.
- Роуты в `attRoot` рядом с custom-fields (та же protected-группа, без спец-permission - как у соседних ручек).
- Инъекция `AttachmentFieldConfigService` в `AttachmentTemplateHandler` (оба call-site обновлены: main.go + testutil.go).
- `is_required` кастомных полей уже шёл через CRUD из H-1 - закрыл контур handler-тестами.

## Тесты
Новый `attachment_field_config_test.go` (6 тестов, все зелёные): дефолты реестра для свежего вложения, применение оверрайдов + идемпотентность upsert + семантика locked/non-requirable, отклонение неизвестных ключей, 404 на несуществующий UA, 401 без токена (GET+PUT), сквозной `is_required` для кастомных полей.

`go build` + `go test ./internal/handlers/... ./internal/services/...` зелёные в контейнере.

## Вне scope (следующие срезы)
H-3/H-4 - админ-модалка; H-5..H-8 - уважение конфига формами подачи; H-9 - BE-валидация submit + устойчивость blacklist. Off-limits (auth/permission/migrate) не трогались.