### PR TITLE
feat(attachments): модалка настройки полей вложения (#529)

### DIFF
--- a/frontend/src/api/attachment-templates.js
+++ b/frontend/src/api/attachment-templates.js
@@ -81,6 +81,32 @@ export async function getTemplateFields(uniqueAttachmentID) {
   return res.json();
 }
 
+// --- Field Config (базовые поля: видимость/обязательность) ---
+
+/**
+ * Настройка полей вложения: базовые поля реестра типа (смерженные с оверрайдами)
+ * и кастомные поля. Единый источник для админ-модалки и формы подачи (#529).
+ * @returns {Promise<{ base: Array, custom: Array }>}
+ */
+export async function getFieldConfig(uniqueAttachmentID) {
+  const res = await apiRequest(`/attachments/${uniqueAttachmentID}/field-config`);
+  return res.json();
+}
+
+/**
+ * Сохранить оверрайды видимости/обязательности базовых полей (bulk-upsert).
+ * Залоченные поля (дата/время) бэк игнорирует.
+ * @param {number} uniqueAttachmentID
+ * @param {Array<{ key: string, visible: boolean, required: boolean }>} base
+ */
+export async function saveFieldConfig(uniqueAttachmentID, base) {
+  const res = await apiRequest(`/attachments/${uniqueAttachmentID}/field-config`, {
+    method: 'PUT',
+    body: JSON.stringify({ base }),
+  });
+  return res.json();
+}
+
 // --- Custom Fields ---
 
 export async function listCustomFields(uniqueAttachmentID) {

--- a/frontend/src/components/AttachmentsManagement.vue
+++ b/frontend/src/components/AttachmentsManagement.vue
@@ -159,6 +159,14 @@
               </button>
               <button
                 v-if="selectedAttachment.is_active"
+                class="action-btn template-btn"
+                data-testid="attachment-fields-btn"
+                @click="openFieldsConfig(selectedAttachment)"
+              >
+                Настройка полей
+              </button>
+              <button
+                v-if="selectedAttachment.is_active"
                 class="action-btn archive-action-btn"
                 data-testid="attachment-archive"
                 @click="onArchiveClick(selectedAttachment)"
@@ -446,6 +454,13 @@
       :current-user-name="currentUserName"
       @close="historyForAttachment = null"
     />
+
+    <AttachmentFieldsModal
+      v-if="fieldsForAttachment"
+      :unique-attachment-id="fieldsForAttachment.id"
+      :attachment-name="fieldsForAttachment.name"
+      @close="fieldsForAttachment = null"
+    />
   </div>
 </template>
 
@@ -457,6 +472,7 @@ import TextConstructor from './TextConstructor.vue';
 import BaseDropdown from './ui/BaseDropdown.vue';
 import LoaderSpinner from './ui/LoaderSpinner.vue';
 import AttachmentCustomFields from './admin/AttachmentCustomFields.vue';
+import AttachmentFieldsModal from './admin/AttachmentFieldsModal.vue';
 import AttachmentTemplateEditor from './admin/AttachmentTemplateEditor.vue';
 import UniqueAttachmentHistoryModal from './UniqueAttachmentHistoryModal.vue';
 import { useDeletionsStore } from '@/stores/deletions';
@@ -487,6 +503,7 @@ export default {
     BaseDropdown,
     LoaderSpinner,
     AttachmentCustomFields,
+    AttachmentFieldsModal,
     AttachmentTemplateEditor,
     UniqueAttachmentHistoryModal,
   },
@@ -517,6 +534,7 @@ export default {
       isAdding: false,
       archiveConfirm: null,
       historyForAttachment: null,
+      fieldsForAttachment: null,
       currentUserName: '',
       archiveOptions: [
         { label: 'Активные', value: 'active' },
@@ -827,6 +845,9 @@ export default {
     openHistory(a) {
       // Подпись в заголовке - актуальное наименование (из формы, если правилось).
       this.historyForAttachment = { id: a.id, name: this.original.display_name || a.display_name };
+    },
+    openFieldsConfig(a) {
+      this.fieldsForAttachment = { id: a.id, name: this.original.display_name || a.display_name };
     },
     async fetchCurrentUser() {
       // Имя нужно для футера Excel-экспорта истории ("Отчёт сформировал").

--- a/frontend/src/components/admin/AttachmentFieldsModal.vue
+++ b/frontend/src/components/admin/AttachmentFieldsModal.vue
@@ -1,0 +1,406 @@
+<template>
+  <Teleport to="body">
+    <transition
+      name="modal-fade"
+      @after-leave="onAfterLeave"
+    >
+      <div
+        v-if="visible"
+        class="modal-overlay"
+        data-testid="attachment-fields-modal"
+        @mousedown="onOverlayMousedown"
+        @mouseup="onOverlayMouseup"
+      >
+        <div
+          class="fields-modal"
+          @mousedown.stop
+        >
+          <div class="modal-header">
+            <h3>Настройка полей{{ attachmentName ? ` «${attachmentName}»` : '' }}</h3>
+            <button
+              class="close-btn"
+              aria-label="Закрыть"
+              @click="requestClose"
+            >
+              ×
+            </button>
+          </div>
+
+          <div class="modal-content">
+            <div
+              v-if="loading"
+              class="modal-state"
+            >
+              <LoaderSpinner label="Загрузка настройки полей..." />
+            </div>
+
+            <template v-else>
+              <p class="fields-hint">
+                Скрытые поля не показываются при подаче заявки. Период действия
+                (даты и время) обязателен всегда и не настраивается.
+              </p>
+
+              <div
+                v-for="group in groups"
+                :key="group.key"
+                class="fields-group"
+              >
+                <div class="group-title">
+                  {{ group.label }}
+                </div>
+
+                <div
+                  v-for="field in group.fields"
+                  :key="field.key"
+                  class="field-row"
+                  :class="{ 'field-row--locked': field.locked }"
+                  :data-testid="`field-row-${field.key}`"
+                >
+                  <span class="field-label">{{ field.label }}</span>
+
+                  <div
+                    v-if="field.locked"
+                    class="field-locked"
+                  >
+                    Всегда включено
+                  </div>
+                  <div
+                    v-else
+                    class="field-toggles"
+                  >
+                    <ToggleSwitch
+                      v-model="field.visible"
+                      :data-testid="`field-visible-${field.key}`"
+                    >
+                      Показывать
+                    </ToggleSwitch>
+                    <ToggleSwitch
+                      v-if="field.requirable"
+                      v-model="field.required"
+                      :disabled="!field.visible"
+                      :data-testid="`field-required-${field.key}`"
+                    >
+                      Обязательно
+                    </ToggleSwitch>
+                  </div>
+                </div>
+              </div>
+            </template>
+          </div>
+
+          <div class="modal-footer">
+            <button
+              class="lk-button lk-button--ghost"
+              :disabled="isSaving"
+              @click="requestClose"
+            >
+              Отмена
+            </button>
+            <button
+              class="lk-button lk-button--primary"
+              :disabled="loading || isSaving || !isDirty"
+              data-testid="fields-save"
+              @click="save"
+            >
+              {{ isSaving ? 'Сохранение...' : 'Сохранить' }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </transition>
+  </Teleport>
+</template>
+
+<script>
+import { ref } from 'vue';
+import { getFieldConfig, saveFieldConfig } from '@/api/attachment-templates';
+import { useDeletionsStore } from '@/stores/deletions';
+import { useOverlayClose } from '@/composables/useOverlayClose';
+import ToggleSwitch from '@/components/ui/ToggleSwitch.vue';
+import LoaderSpinner from '@/components/ui/LoaderSpinner.vue';
+
+// Подписи групп полей реестра. Порядок групп в ответе сохраняется (common впереди),
+// поэтому собираем группы в порядке появления полей.
+const GROUP_LABELS = {
+  common: 'Общие поля',
+  people: 'Поля сотрудников',
+  cars: 'Поля транспорта',
+  items: 'Поля ТМЦ',
+};
+
+export default {
+  name: 'AttachmentFieldsModal',
+  components: { ToggleSwitch, LoaderSpinner },
+  props: {
+    uniqueAttachmentId: { type: Number, required: true },
+    attachmentName: { type: String, default: '' },
+  },
+  emits: ['close', 'saved'],
+  setup(_, { emit }) {
+    // Анимация открытия/закрытия по образцу UniqueAttachmentHistoryModal: внутренний
+    // visible управляет enter/leave, emit('close') шлём только @after-leave - иначе
+    // родительский v-if размонтирует нас мгновенно и leave-анимация не проиграется.
+    const visible = ref(false);
+    const requestClose = () => { visible.value = false; };
+    const onAfterLeave = () => emit('close');
+    const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(requestClose);
+    return { visible, requestClose, onAfterLeave, onOverlayMousedown, onOverlayMouseup };
+  },
+  data() {
+    return {
+      loading: false,
+      isSaving: false,
+      fields: [],
+      // Снимок настраиваемых полей на момент загрузки - для проверки "грязности".
+      original: '',
+    };
+  },
+  computed: {
+    groups() {
+      const out = [];
+      const byKey = new Map();
+      this.fields.forEach((f) => {
+        let group = byKey.get(f.group);
+        if (!group) {
+          group = { key: f.group, label: GROUP_LABELS[f.group] || f.group, fields: [] };
+          byKey.set(f.group, group);
+          out.push(group);
+        }
+        group.fields.push(f);
+      });
+      return out;
+    },
+    // Тело PUT: только настраиваемые поля (залоченные бэк игнорирует).
+    payload() {
+      return this.fields
+        .filter((f) => !f.locked)
+        .map((f) => ({ key: f.key, visible: f.visible, required: f.required }));
+    },
+    isDirty() {
+      return JSON.stringify(this.payload) !== this.original;
+    },
+  },
+  mounted() {
+    this.visible = true;
+    this.load();
+    document.addEventListener('keydown', this.onKeydown);
+  },
+  beforeUnmount() {
+    document.removeEventListener('keydown', this.onKeydown);
+  },
+  methods: {
+    onKeydown(e) {
+      if (e.key === 'Escape') this.requestClose();
+    },
+    async load() {
+      this.loading = true;
+      try {
+        const data = await getFieldConfig(this.uniqueAttachmentId);
+        const base = Array.isArray(data?.base) ? data.base : [];
+        this.fields = base.map((f) => ({
+          key: f.key,
+          label: f.label,
+          group: f.group,
+          visible: f.visible,
+          required: f.required,
+          requirable: f.requirable,
+          locked: f.locked,
+        }));
+        this.original = JSON.stringify(this.payload);
+      } catch (error) {
+        console.error('Error loading field config:', error);
+        useDeletionsStore().notify({ prefix: 'Не удалось загрузить ', bold: 'настройку полей', type: 'error' });
+        this.requestClose();
+      } finally {
+        this.loading = false;
+      }
+    },
+    async save() {
+      if (!this.isDirty || this.isSaving) return;
+      this.isSaving = true;
+      try {
+        await saveFieldConfig(this.uniqueAttachmentId, this.payload);
+        useDeletionsStore().notify({ prefix: 'Настройка полей ', bold: 'сохранена', type: 'success' });
+        this.$emit('saved');
+        this.requestClose();
+      } catch (error) {
+        console.error('Error saving field config:', error);
+        useDeletionsStore().notify({ prefix: 'Не удалось ', bold: 'сохранить настройку полей', type: 'error' });
+      } finally {
+        this.isSaving = false;
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 12000;
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
+}
+
+.fields-modal {
+  background: white;
+  border-radius: 30px;
+  width: 560px;
+  max-width: 95%;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+}
+
+/* Анимация открытия/закрытия (паттерн BaseModal): overlay fade + контент scale */
+.modal-fade-enter-active {
+  transition: opacity 0.25s ease;
+}
+
+.modal-fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+  opacity: 0;
+}
+
+.modal-fade-enter-active .fields-modal {
+  animation: modal-scale-in 0.25s ease;
+}
+
+.modal-fade-leave-active .fields-modal {
+  animation: modal-scale-out 0.2s ease;
+}
+
+@keyframes modal-scale-in {
+  from { transform: scale(0.95); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
+}
+
+@keyframes modal-scale-out {
+  from { transform: scale(1); opacity: 1; }
+  to { transform: scale(0.95); opacity: 0; }
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 15px 25px;
+  border-bottom: 1px solid #e6e6e6;
+}
+
+.modal-header h3 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: #333;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  font-size: 24px;
+  color: #a2a2a2;
+  cursor: pointer;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  transition: all 0.2s ease;
+}
+
+.close-btn:hover {
+  background: #f5f5f5;
+  color: #333;
+}
+
+.modal-content {
+  padding: 20px 25px;
+  overflow-y: auto;
+}
+
+.modal-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px;
+  color: #a2a2a2;
+}
+
+.fields-hint {
+  margin: 0 0 16px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #a2a2a2;
+}
+
+.fields-group + .fields-group {
+  margin-top: 18px;
+}
+
+.group-title {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #a2a2a2;
+  margin-bottom: 8px;
+}
+
+.field-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 10px 0;
+  border-bottom: 1px solid #f0f2f5;
+}
+
+.field-row:last-child {
+  border-bottom: none;
+}
+
+.field-label {
+  font-size: 14px;
+  color: #333;
+}
+
+.field-row--locked .field-label {
+  color: #777;
+}
+
+.field-toggles {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex-shrink: 0;
+}
+
+.field-locked {
+  font-size: 12px;
+  color: #a2a2a2;
+  flex-shrink: 0;
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 15px 25px;
+  border-top: 1px solid #e6e6e6;
+}
+</style>

--- a/internal/models/attachment_template.go
+++ b/internal/models/attachment_template.go
@@ -134,6 +134,9 @@ type MergedField struct {
 	Group    string `json:"group"`
 	Visible  bool   `json:"visible"`
 	Required bool   `json:"required"`
+	// Requirable=false для булевых чекбоксов (крыша/парковка/уведомление): тумблер
+	// "обязательно" для них бессмыслен. Админ-модалка по нему прячет этот тумблер.
+	Requirable bool `json:"requirable"`
 	// Locked=true: поле не настраивается (дата/время). Админ-модалка не показывает
 	// для него тумблеры, форма подачи рендерит как обязательное всегда.
 	Locked bool `json:"locked"`

--- a/internal/services/attachment_fields_registry.go
+++ b/internal/services/attachment_fields_registry.go
@@ -138,12 +138,13 @@ func MergeFieldConfig(attachmentType string, overrides []models.AttachmentFieldC
 			}
 		}
 		out = append(out, models.MergedField{
-			Key:      d.Key,
-			Label:    d.Label,
-			Group:    d.Group,
-			Visible:  visible,
-			Required: required,
-			Locked:   d.Locked,
+			Key:        d.Key,
+			Label:      d.Label,
+			Group:      d.Group,
+			Visible:    visible,
+			Required:   required,
+			Requirable: d.Requirable,
+			Locked:     d.Locked,
 		})
 	}
 	return out

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -49,6 +49,7 @@ var tables = []string{
 	"car_unload_places", "cars_history", "cars",
 	"vehicle_blacklist_histories", "vehicle_blacklists",
 	"person_blacklist_histories", "person_blacklists",
+	"attachment_custom_values", "attachment_custom_fields", "attachment_field_configs",
 	"attachments",
 	"unique_employees_history", "unique_cars_history",
 	"unique_employees", "unique_cars", "unique_attachment_histories", "unique_attachments",


### PR DESCRIPTION
Срез H-3 эпика etalon-refactor (issue #529, фаза B). Админ-UI настройки видимости/обязательности базовых полей вложения.

## Что
- Новая модалка `AttachmentFieldsModal.vue` (admin/): тумблеры «Показывать»/«Обязательно» по реестру типа через GET/PUT `/attachments/{id}/field-config`. Поля сгруппированы (Общие + поля типа).
- Залоченные поля (дата/время) показаны без тумблеров, надпись «Всегда включено».
- Булевые чекбоксы (крыша/парковка/уведомление) — только «Показывать», без «Обязательно».
- Кнопка «Настройка полей» в шапке детали `AttachmentsManagement.vue` (рядом с «Excel-бланк», только для активных).
- API-клиент `getFieldConfig`/`saveFieldConfig` в `api/attachment-templates.js`.

## Эталон-модалка
Teleport, border-radius 30px, `useOverlayClose`, Escape, анимация закрытия (visible + transition + @after-leave) по образцу `UniqueAttachmentHistoryModal.vue`. Переиспользованы `ToggleSwitch`, `LoaderSpinner`, `.lk-button`. Уведомления через `useDeletionsStore`.

## BE (поддержка FE-контракта)
- Добавлено поле `Requirable` в `models.MergedField` — чтобы FE прятал тумблер «Обязательно» у булевых чекбоксов, не дублируя реестр на фронте.
- Нормализация в `buildFieldConfigRows`: скрытое поле (`visible=false`) не может быть обязательным — `required` форсится в false. Защищает контракт для формы подачи (H-5+).

## Заодно: фикс изоляции тестов
`internal/testutil/testutil.go` cleanup не удалял `attachment_custom_values/_fields/field_configs` (добавлены в H-1/H-2) — остаточные custom-поля флачили field-config тесты на повторных прогонах. Воспроизводилось на чистом `origin/dev`. Добавил таблицы в cleanup в child-before-parent порядке.

## Ревью
code-reviewer: вердикт GO. Закрыты замечания: тихая потеря ошибки GET/PUT (теперь throw на !res.ok), сброс required при скрытии (FE + BE), убран неиспользуемый emit `saved`.

## Проверено
- Go test suite (все пакеты) зелёный, ESLint по изменённым FE чист, добавлен unit-тест на нормализацию скрытое->необязательное.
- Локально через Playwright (worktree-сборка): модалка рендерится по эталону, тумблеры/локи/группы корректны, сохранение оверрайда персистится в БД, console без ошибок.