### PR TITLE
fix(applications): организация или компания - достаточно одного поля

### DIFF
--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -445,8 +445,7 @@ export default {
             }
 
             const missingFields = [];
-            if (!this.organization) missingFields.push('организация');
-            if (!this.company) missingFields.push('компания');
+            if (!this.organization?.trim() && !this.company?.trim()) missingFields.push('организация или компания');
             if (!this.responsiblePerson) missingFields.push('ответственный');
             if (!this.phoneNumber) missingFields.push('телефон');
             if (!this.consentGiven) missingFields.push('согласие на обработку данных');
@@ -515,8 +514,7 @@ export default {
 
             const globalErrors = [];
             if (this.attachments.length === 0) globalErrors.push('Не добавлено ни одного вложения');
-            if (!this.organization) globalErrors.push('Не заполнена организация');
-            if (!this.company) globalErrors.push('Не заполнена компания');
+            if (!this.organization?.trim() && !this.company?.trim()) globalErrors.push('Не заполнена организация или компания');
             if (!this.responsiblePerson) globalErrors.push('Не указано ответственное лицо');
             if (!this.phoneNumber) globalErrors.push('Не указан номер телефона');
             if (!this.consentGiven) globalErrors.push('Не дано согласие на обработку данных');
@@ -1365,11 +1363,14 @@ export default {
 
             switch (field) {
                 case 'organization':
-                    this.errors.organization = this.organization ? '' : 'Обязательное поле';
+                case 'company': {
+                    // Достаточно заполнить организацию ИЛИ компанию - не оба поля.
+                    const orgOrCompany = this.organization?.trim() || this.company?.trim()
+                        ? '' : 'Укажите организацию или компанию';
+                    this.errors.organization = orgOrCompany;
+                    this.errors.company = orgOrCompany;
                     break;
-                case 'company':
-                    this.errors.company = this.company ? '' : 'Обязательное поле';
-                    break;
+                }
                 case 'responsiblePerson':
                     this.errors.responsiblePerson = this.responsiblePerson ? '' : 'Обязательное поле';
                     break;

--- a/frontend/src/components/CreateApplication/UserInfoRow.vue
+++ b/frontend/src/components/CreateApplication/UserInfoRow.vue
@@ -1,15 +1,16 @@
 <template>
   <div class="user-info-row">
     <div class="user__input">
-      <label class="input__label">Организация / Отдел <span class="required">*</span></label>
-      <input 
-        class="input" 
-        placeholder="Введите организацию" 
+      <label class="input__label">Организация / Отдел</label>
+      <input
+        class="input"
+        placeholder="Введите организацию"
         :value="organization"
         :class="{ 'input--error': errors.organization }"
         @input="$emit('update:organization', $event.target.value)"
         @blur="$emit('validate-field', 'organization')"
       >
+      <span class="input__hint">Заполните организацию или компанию</span>
       <div
         v-if="errors.organization"
         class="error-message"
@@ -18,7 +19,7 @@
       </div>
     </div>
     <div class="user__input">
-      <label class="input__label">Компания <span class="required">*</span></label>
+      <label class="input__label">Компания</label>
       <input 
         class="input" 
         placeholder="Введите компанию" 
@@ -139,6 +140,11 @@ export default {
 
 .input__label {
     font-size: 13px;
+    color: #a2a2a2;
+}
+
+.input__hint {
+    font-size: 11px;
     color: #a2a2a2;
 }
 

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -162,6 +162,9 @@ func AutoMigrate(db *gorm.DB) error {
 	if err := fixAttachmentTemplateIndex(db); err != nil {
 		return err
 	}
+	if err := relaxApplicationOrgNotNull(db); err != nil {
+		return err
+	}
 	if err := installSQLFunctions(db); err != nil {
 		return err
 	}
@@ -187,6 +190,19 @@ func backfillSuperAdmin(db *gorm.DB) error {
 	}
 	if res.RowsAffected > 0 {
 		slog.Info("super-admin backfilled", "users_updated", res.RowsAffected)
+	}
+	return nil
+}
+
+// relaxApplicationOrgNotNull снимает NOT NULL с applications.organization_id:
+// при подаче заявки достаточно указать организацию ИЛИ компанию, поэтому
+// organization_id может быть NULL (company-only подача). Свежий AutoMigrate уже
+// создаёт колонку nullable, но на БД из старой "NOT NULL"-эры констрейнт остаётся -
+// AutoMigrate существующие колонки не ослабляет. ALTER ... DROP NOT NULL идемпотентен
+// (на уже nullable колонке - noop).
+func relaxApplicationOrgNotNull(db *gorm.DB) error {
+	if err := db.Exec(`ALTER TABLE applications ALTER COLUMN organization_id DROP NOT NULL`).Error; err != nil {
+		return fmt.Errorf("relax applications.organization_id NOT NULL: %w", err)
 	}
 	return nil
 }

--- a/internal/handlers/applications_test.go
+++ b/internal/handlers/applications_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"systemburo/internal/database"
 	"systemburo/internal/models"
 	"systemburo/internal/services"
 	"systemburo/internal/testutil"
@@ -287,6 +288,100 @@ func TestSubmitCompleteApplication_DataApprovalRequired(t *testing.T) {
 	}`
 	rec := testutil.POST(t, e, "/applications/submit-complete-application", body, testutil.AuthHeader(token))
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestSubmitCompleteApplication_CompanyOnly(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	uaID := seedUniqueAttachment(t, db, "cars", "co_cars", "Company Only Cars")
+	token := testutil.RegisterAndLogin(t, e, "componly", "pass123", 1, td.OrgID, td.CompanyID)
+
+	// Организация пустая, заполнена только компания - заявка должна создаться.
+	body := fmt.Sprintf(`{
+		"message": "company only",
+		"organization": "",
+		"company": "Test Company",
+		"responsible_person": "Test Person",
+		"contact_phone": "+79001234567",
+		"data_approval": true,
+		"attachments": [{
+			"attachment_type": "cars",
+			"attachment_name": "co_cars",
+			"attachment_display_name": "Company Only Cars",
+			"unique_attachment_id": %d,
+			"entry_date_from": "2026-04-01",
+			"entry_date_to": "2099-12-31",
+			"entry_time_from": "08:00",
+			"entry_time_to": "18:00",
+			"data": {"vehicles": [{"car_number": "A001AA777", "car_brand": "Toyota"}]}
+		}]
+	}`, uaID)
+
+	rec := testutil.POST(t, e, "/applications/submit-complete-application", body, testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code, "company-only submit: %s", rec.Body.String())
+
+	resp := testutil.ParseResponse[services.CompleteApplicationResponse](t, rec)
+	assert.NotZero(t, resp.ApplicationID)
+
+	// Чтение company-only заявки не должно падать: organization_id NULL в LEFT JOIN organizations.
+	listRec := testutil.GET(t, e, "/applications/user", testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, listRec.Code, "read company-only app: %s", listRec.Body.String())
+}
+
+func TestSubmitCompleteApplication_NoOrgNoCompany(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	uaID := seedUniqueAttachment(t, db, "cars", "noorg_cars", "No Org Cars")
+	token := testutil.RegisterAndLogin(t, e, "noorg", "pass123", 1, td.OrgID, td.CompanyID)
+
+	// Ни организация, ни компания не заполнены - заявку отклоняем (400).
+	body := fmt.Sprintf(`{
+		"message": "no org no company",
+		"organization": "",
+		"responsible_person": "Test Person",
+		"contact_phone": "+79001234567",
+		"data_approval": true,
+		"attachments": [{
+			"attachment_type": "cars",
+			"attachment_name": "noorg_cars",
+			"attachment_display_name": "No Org Cars",
+			"unique_attachment_id": %d,
+			"entry_date_from": "2026-04-01",
+			"entry_date_to": "2099-12-31",
+			"entry_time_from": "08:00",
+			"entry_time_to": "18:00",
+			"data": {"vehicles": [{"car_number": "A002AA777", "car_brand": "Toyota"}]}
+		}]
+	}`, uaID)
+
+	rec := testutil.POST(t, e, "/applications/submit-complete-application", body, testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "no org/company should be 400: %s", rec.Body.String())
+}
+
+// TestAutoMigrate_RelaxesOrganizationNotNull: на БД из старой "NOT NULL"-эры
+// (свежий AutoMigrate уже делает колонку nullable, поэтому эмулируем констрейнт)
+// повторный AutoMigrate должен снять NOT NULL с applications.organization_id -
+// иначе company-only подача упадёт 500 на существующих staging/prod.
+func TestAutoMigrate_RelaxesOrganizationNotNull(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+
+	require.NoError(t, db.Exec(`TRUNCATE applications CASCADE`).Error)
+	require.NoError(t, db.Exec(`ALTER TABLE applications ALTER COLUMN organization_id SET NOT NULL`).Error)
+
+	require.NoError(t, database.AutoMigrate(db))
+
+	var nullable string
+	require.NoError(t, db.Raw(
+		`SELECT is_nullable FROM information_schema.columns WHERE table_name='applications' AND column_name='organization_id'`,
+	).Row().Scan(&nullable))
+	require.Equal(t, "YES", nullable, "organization_id должна стать nullable после миграции")
 }
 
 // --- GET /applications/:id ---

--- a/internal/services/application_service.go
+++ b/internal/services/application_service.go
@@ -147,7 +147,7 @@ type ApplicationCreateRequest struct {
 // CompleteApplicationRequest тело запроса на создание полной заявки с вложениями.
 type CompleteApplicationRequest struct {
 	Message           *string              `json:"message"`
-	Organization      string               `json:"organization" validate:"required"`
+	Organization      string               `json:"organization"`
 	Company           *string              `json:"company"`
 	ResponsiblePerson string               `json:"responsible_person" validate:"required"`
 	ContactPhone      string               `json:"contact_phone" validate:"required"`
@@ -1095,6 +1095,11 @@ func (s *applicationService) SubmitCompleteApplication(ctx context.Context, user
 	}
 	if len(req.Attachments) == 0 {
 		return nil, echo.NewHTTPError(http.StatusBadRequest, "At least one attachment is required")
+	}
+	// Организация и компания взаимозаменяемы: для отправки достаточно одной из двух.
+	if strings.TrimSpace(req.Organization) == "" &&
+		(req.Company == nil || strings.TrimSpace(*req.Company) == "") {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "Укажите организацию или компанию")
 	}
 
 	// Серверный гард ЧС (#443): отклоняем заявку с заблокированной машиной/человеком


### PR DESCRIPTION
## Что и зачем
При подаче заявки организация и компания были обязательны обе. Теперь достаточно заполнить хотя бы одно из двух - это идентификация отправителя, одной из сущностей хватает.

## Изменения
- **BE**: снят `validate:"required"` с `Organization` в `CompleteApplicationRequest`; в `SubmitCompleteApplication` гард "хотя бы одно из двух" (иначе 400 "Укажите организацию или компанию").
- **Схема**: `applications.organization_id` был NOT NULL на базах из старой эры (AutoMigrate существующие колонки не ослабляет). Добавлена идемпотентная миграция `ALTER ... DROP NOT NULL` в `migrate.go` - без неё company-only подача упала бы 500 на staging/prod. OK на правку off-limits `migrate.go` получен от владельца.
- **FE**: валидация шапки (submitValidation / tooltipSections / validateField) переведена на "либо/либо" с `?.trim()`; убраны индивидуальные звёздочки с Организация/Компания, добавлена подсказка "Заполните организацию или компанию".

## Тесты
- `TestSubmitCompleteApplication_CompanyOnly` - только компания -> 200 + read-back (LEFT JOIN с NULL org).
- `TestSubmitCompleteApplication_NoOrgNoCompany` - оба пусты -> 400.
- `TestAutoMigrate_RelaxesOrganizationNotNull` - эмуляция старой NOT NULL-БД -> миграция снимает констрейнт.
- Локально: go test (handlers) зелёные, gofmt/vet чисто, eslint чисто.

## Ревью
code-reviewer: **GO**. RED-1 (NOT NULL на существующих БД) закрыт миграцией; read/excel-пути NULL-safe (LEFT JOIN + `COALESCE(o.name, c.name)`, бланк гардит `OrganizationID != 0`). Y-1 (whitespace) исправлен; Y-2/Y-3 - осознанный паритет со стилем файла.

## Осталось
Ship-check company-only на staging после деплоя (миграция применяется при старте бэкенда).