### PR TITLE
feat(applications): CreateApplication грузит field-config шаблона (#529)

### DIFF
--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -162,6 +162,7 @@
             :free-parking="currentAttachmentData.freeParking"
             :notify-situation-center="currentAttachmentData.notifySituationCenter"
             :errors="currentAttachmentErrors"
+            :field-config="currentFieldConfig"
             @update:is-one-day="updateAttachmentData('isOneDay', $event)"
             @update:start-date="updateAttachmentData('startDate', $event)"
             @update:end-date="updateAttachmentData('endDate', $event)"
@@ -181,9 +182,10 @@
         <div class="form__data">
           <!-- Для автомобилей -->
           <template v-if="selectedAttachment && selectedAttachment.attachment_type === 'cars'">
-            <VehicleForm 
+            <VehicleForm
               :key="vehicleFormKey"
               ref="vehicleForm"
+              :field-config="currentFieldConfig"
               :user-organization="organization"
               :user-organization-id="organizationId"
               :user-company="company"
@@ -208,9 +210,10 @@
 
           <!-- Для людей/сотрудников -->
           <template v-else-if="selectedAttachment && selectedAttachment.attachment_type === 'people'">
-            <EmployeeForm 
+            <EmployeeForm
               :key="employeeFormKey"
               ref="employeeForm"
+              :field-config="currentFieldConfig"
               :user-organization="organization"
               :user-organization-id="organizationId"
               :user-company="company"
@@ -234,9 +237,10 @@
 
           <!-- Для ТМЦ -->
           <template v-else-if="selectedAttachment && selectedAttachment.attachment_type === 'items'">
-            <ItemsForm 
+            <ItemsForm
               :key="itemsFormKey"
               ref="itemsForm"
+              :field-config="currentFieldConfig"
               :existing-items="items"
               @item-added="handleItemAdded"
               @items-added="handleItemsAdded"
@@ -386,6 +390,9 @@ export default {
 
             customFieldsByAttachment: {},
             customFieldDefinitions: {},
+            // Настройка полей по UniqueAttachment (#529): { [uaId]: { [fieldKey]: { visible, required, locked, requirable } } }.
+            // Источник - GET /attachments/{id}/field-config (base). Раздаётся секциям формы пропсом field-config.
+            fieldConfigByAttachment: {},
         }
     },
     computed: {
@@ -421,6 +428,12 @@ export default {
             if (!this.selectedAttachment) return {};
             const key = this.attachmentKey(this.selectedAttachment);
             return this.customFieldsByAttachment[key] || {};
+        },
+
+        currentFieldConfig() {
+            if (!this.selectedAttachment) return {};
+            const uaId = this.selectedAttachment.template_id || this.selectedAttachment.id;
+            return this.fieldConfigByAttachment[uaId] || {};
         },
 
         currentAttachmentData() {
@@ -951,13 +964,28 @@ export default {
             this.customFieldsByAttachment[key] = values;
         },
 
-        async loadCustomFields(uniqueAttachmentId) {
-            if (this.customFieldDefinitions[uniqueAttachmentId]) return;
+        async loadFieldConfig(uniqueAttachmentId) {
+            if (this.fieldConfigByAttachment[uniqueAttachmentId]) return;
             try {
-                const { listCustomFields } = await import('@/api/attachment-templates');
-                const data = await listCustomFields(uniqueAttachmentId);
-                this.customFieldDefinitions[uniqueAttachmentId] = Array.isArray(data) ? data : [];
+                const { getFieldConfig } = await import('@/api/attachment-templates');
+                const data = await getFieldConfig(uniqueAttachmentId);
+                const base = Array.isArray(data?.base) ? data.base : [];
+                const map = {};
+                base.forEach((f) => {
+                    map[f.key] = {
+                        visible: f.visible,
+                        required: f.required,
+                        locked: f.locked,
+                        requirable: f.requirable,
+                    };
+                });
+                this.fieldConfigByAttachment[uniqueAttachmentId] = map;
+                this.customFieldDefinitions[uniqueAttachmentId] = Array.isArray(data?.custom) ? data.custom : [];
             } catch {
+                // Конфиг недоступен (сеть/транзиентная ошибка) - деградируем к дефолту:
+                // дефолт = все поля видимы, обязательность как сейчас (спека #529). Пустой
+                // объект falsy -> следующий выбор вложения повторит запрос.
+                this.fieldConfigByAttachment[uniqueAttachmentId] = {};
                 this.customFieldDefinitions[uniqueAttachmentId] = [];
             }
         },
@@ -973,7 +1001,7 @@ export default {
             this.restoreAttachmentData(attachment);
 
             const uaId = attachment.template_id || attachment.id;
-            this.loadCustomFields(uaId);
+            this.loadFieldConfig(uaId);
         },
 
         attachmentKey(attachment) {
@@ -1033,7 +1061,7 @@ export default {
             this.selectAttachment(attachment);
 
             const uaId = attachment.template_id || attachment.id;
-            this.loadCustomFields(uaId);
+            this.loadFieldConfig(uaId);
 
             this.saveToLocalStorage();
         },
@@ -1949,6 +1977,7 @@ export default {
             this.attachmentDatesByAttachment = {};
             this.customFieldsByAttachment = {};
             this.customFieldDefinitions = {};
+            this.fieldConfigByAttachment = {};
 
             this.vehicleIdCounter = 1;
             this.employeeIdCounter = 1;

--- a/frontend/src/components/CreateApplication/DateRangeSection.vue
+++ b/frontend/src/components/CreateApplication/DateRangeSection.vue
@@ -1,7 +1,13 @@
 <template>
   <div class="date-range-section">
-    <div class="date__input">
-      <label class="input__label">Дата действия <span class="required">*</span></label>
+    <div
+      v-if="fieldVisible('entry_date_from')"
+      class="date__input"
+    >
+      <label class="input__label">Дата действия <span
+        v-if="fieldRequired('entry_date_from')"
+        class="required"
+      >*</span></label>
       <div class="quick-dates">
         <button
           type="button"
@@ -325,8 +331,14 @@
         <p>однодневная заявка</p>
       </div>
     </div>
-    <div class="date__input time-section">
-      <label class="input__label">Время пребывания (проезда) <span class="required">*</span></label>
+    <div
+      v-if="fieldVisible('entry_time_from')"
+      class="date__input time-section"
+    >
+      <label class="input__label">Время пребывания (проезда) <span
+        v-if="fieldRequired('entry_time_from')"
+        class="required"
+      >*</span></label>
       <div class="time-wrapper">
         <div class="time-input-group">
           <p class="date__text">
@@ -389,7 +401,10 @@ export default {
         roofAccess: Boolean,
         freeParking: Boolean,
         notifySituationCenter: Boolean,
-        errors: { type: Object, default: () => ({}) }
+        errors: { type: Object, default: () => ({}) },
+        // Настройка полей выбранного шаблона (#529): { [fieldKey]: { visible, required, locked, requirable } }.
+        // Дата/время реестром залочены (всегда visible+required) - хелперы ниже для них резолвятся в true.
+        fieldConfig: { type: Object, default: () => ({}) }
     },
     emits: [
         'update:is-one-day',
@@ -502,6 +517,16 @@ export default {
         this.validateTimeCrossing();
     },
     methods: {
+        // Видимость поля по конфигу шаблона. Нет строки конфига -> поле видимо (дефолт).
+        fieldVisible(key) {
+            const c = this.fieldConfig[key];
+            return c ? c.visible : true;
+        },
+        // Обязательность поля по конфигу. Нет строки -> обязательно (текущее поведение дат/времени).
+        fieldRequired(key) {
+            const c = this.fieldConfig[key];
+            return c ? c.required : true;
+        },
         setQuickDate(kind) {
             const today = new Date();
             today.setHours(0, 0, 0, 0);

--- a/frontend/src/components/CreateApplication/EmployeeForm.vue
+++ b/frontend/src/components/CreateApplication/EmployeeForm.vue
@@ -397,6 +397,12 @@ export default {
         existingEmployees: {
             type: Array,
             default: () => []
+        },
+        // Настройка полей шаблона (#529): { [fieldKey]: { visible, required, locked, requirable } }.
+        // Раздаётся из CreateApplication; потребление (скрытие/обязательность полей людей) - срез H-6.
+        fieldConfig: {
+            type: Object,
+            default: () => ({})
         }
     },
     emits: ['edit-cancelled', 'employee-added', 'employee-updated', 'employees-added'],

--- a/frontend/src/components/CreateApplication/ItemsForm.vue
+++ b/frontend/src/components/CreateApplication/ItemsForm.vue
@@ -115,6 +115,12 @@ export default {
         existingItems: {
             type: Array,
             default: () => []
+        },
+        // Настройка полей шаблона (#529): { [fieldKey]: { visible, required, locked, requirable } }.
+        // Раздаётся из CreateApplication; потребление (скрытие/обязательность полей предметов) - срез H-8.
+        fieldConfig: {
+            type: Object,
+            default: () => ({})
         }
     },
     emits: ['edit-cancelled', 'item-added', 'item-updated', 'items-added'],

--- a/frontend/src/components/CreateApplication/VehicleForm.vue
+++ b/frontend/src/components/CreateApplication/VehicleForm.vue
@@ -370,6 +370,12 @@ export default {
         existingVehicles: {
             type: Array,
             default: () => []
+        },
+        // Настройка полей шаблона (#529): { [fieldKey]: { visible, required, locked, requirable } }.
+        // Раздаётся из CreateApplication; потребление (скрытие/обязательность полей машин) - срез H-7.
+        fieldConfig: {
+            type: Object,
+            default: () => ({})
         }
     },
     emits: ['edit-cancelled', 'vehicle-added', 'vehicle-updated', 'vehicles-added'],

--- a/frontend/src/components/CreateApplication/__tests__/DateRangeSectionFieldConfig.spec.js
+++ b/frontend/src/components/CreateApplication/__tests__/DateRangeSectionFieldConfig.spec.js
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import DateRangeSection from '../DateRangeSection.vue';
+
+// H-5 (#529): DateRangeSection уважает field-config выбранного шаблона.
+// Даты/время реестром залочены (всегда visible+required), поэтому при пустом
+// конфиге поведение прежнее. Проверяем сам механизм потребления конфига:
+// хелперы fieldVisible/fieldRequired + биндинги v-if в шаблоне. Видимость блоков
+// проверяем по уникальному тексту лейбла (устойчиво к переверстке разметки).
+
+const hasDateBlock = (w) => w.text().includes('Дата действия');
+const hasTimeBlock = (w) => w.text().includes('Время пребывания');
+
+describe('DateRangeSection - потребление field-config (#529)', () => {
+  it('без конфига: блоки даты и времени видимы, звёздочки обязательности на месте', () => {
+    const w = mount(DateRangeSection);
+    expect(hasDateBlock(w)).toBe(true);
+    expect(hasTimeBlock(w)).toBe(true);
+    expect(w.findAll('.input__label .required')).toHaveLength(2);
+  });
+
+  it('fieldVisible: нет строки -> true; visible:false -> false', () => {
+    const w = mount(DateRangeSection, {
+      props: { fieldConfig: { foo: { visible: false, required: true } } },
+    });
+    expect(w.vm.fieldVisible('missing')).toBe(true);
+    expect(w.vm.fieldVisible('foo')).toBe(false);
+  });
+
+  it('fieldRequired: нет строки -> true; required:false -> false', () => {
+    const w = mount(DateRangeSection, {
+      props: { fieldConfig: { foo: { visible: true, required: false } } },
+    });
+    expect(w.vm.fieldRequired('missing')).toBe(true);
+    expect(w.vm.fieldRequired('foo')).toBe(false);
+  });
+
+  it('конфиг скрывает блок даты при entry_date_from.visible=false', () => {
+    const w = mount(DateRangeSection, {
+      props: { fieldConfig: { entry_date_from: { visible: false, required: true } } },
+    });
+    expect(hasDateBlock(w)).toBe(false);
+    expect(hasTimeBlock(w)).toBe(true);
+  });
+
+  it('конфиг скрывает блок времени при entry_time_from.visible=false', () => {
+    const w = mount(DateRangeSection, {
+      props: { fieldConfig: { entry_time_from: { visible: false, required: true } } },
+    });
+    expect(hasTimeBlock(w)).toBe(false);
+    expect(hasDateBlock(w)).toBe(true);
+  });
+
+  it('конфиг убирает звёздочку даты при required=false', () => {
+    const w = mount(DateRangeSection, {
+      props: { fieldConfig: { entry_date_from: { visible: true, required: false } } },
+    });
+    // остаётся только звёздочка времени
+    expect(w.findAll('.input__label .required')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Часть #529 (фаза C — интеграция настройки полей в подачу заявки), эпик #406. Срез H-5.

## Что делает
При выборе вложения форма подачи теперь грузит настройку полей выбранного шаблона (`GET /attachments/{id}/field-config`, H-2) и раздаёт её пропсом `field-config` во **все** секции формы: `DateRangeSection`, `EmployeeForm`, `VehicleForm`, `ItemsForm`. Раздача сразу во все секции (а не только в DateRangeSection) делает H-6/7/8 изолированными правками своего файла без возни с CreateApplication.vue.

Загрузка кастомных полей и базового конфига объединена в один `loadFieldConfig` (раньше `loadCustomFields` дёргал `listCustomFields`). `getFieldConfig` возвращает `{base, custom}` — оба берём одним запросом, без двойного фетча. `field-config` — это «единый источник для админ-модалки и формы подачи» по спеке.

`DateRangeSection` потребляет конфиг через хелперы `fieldVisible`/`fieldRequired`. Даты и время в Go-реестре залочены (`Locked` = always visible+required, PR #531), поэтому блоки и звёздочки резолвятся в always-on — **поведение не меняется**, но механизм потребления установлен как образец для H-6/7/8.

В `EmployeeForm`/`VehicleForm`/`ItemsForm` проп `fieldConfig` пока только объявлен (потребление — H-6/7/8 по плану).

## Ревью (code-reviewer)
- **RED исправлен:** `resetForm()` чистил `customFieldDefinitions`, но не `fieldConfigByAttachment` — после сброса формы кэш-гард не пускал перезагрузку, и кастомные поля переставали рендериться при повторном выборе того же вложения. Обе карты грузятся вместе → теперь и чистятся вместе.
- YELLOW: к `catch` добавлен комментарий об осознанной деградации к дефолту (спека: нет конфига = все поля видимы); тестовые DOM-ассерты переведены с хрупкого `:not()`-CSS на проверку по тексту лейбла.
- GREEN: паритет доступа `GET /field-config` и `GET /custom-fields` (оба под `protected.Group`), реактивность Vue 3 на новые ключи, симметрия ключа `template_id || id`.

## Проверено
- vitest: новая спека `DateRangeSectionFieldConfig.spec.js` (6 кейсов) + вся CreateApplication-директория зелёные.
- eslint на изменённых файлах чисто.
- Полный vitest/build/E2E — в CI. Ship-check на staging — после деплоя (фокус: кастомные поля при подаче всё ещё рендерятся, `GET /field-config` 200).

Без визуальных изменений у пользователя (даты залочены, формы пока не потребляют конфиг). Off-limits не затронуты.