### PR TITLE
refactor(applications): composable useFieldConfig + перевод DateRangeSection (#529)

### DIFF
--- a/frontend/src/components/CreateApplication/DateRangeSection.vue
+++ b/frontend/src/components/CreateApplication/DateRangeSection.vue
@@ -389,6 +389,8 @@
 </template>
 
 <script>
+import { useFieldConfig } from '@/composables/useFieldConfig';
+
 export default {
     name: 'DateRangeSection',
     props: {
@@ -402,8 +404,9 @@ export default {
         freeParking: Boolean,
         notifySituationCenter: Boolean,
         errors: { type: Object, default: () => ({}) },
-        // Настройка полей выбранного шаблона (#529): { [fieldKey]: { visible, required, locked, requirable } }.
-        // Дата/время реестром залочены (всегда visible+required) - хелперы ниже для них резолвятся в true.
+        // Настройка полей выбранного шаблона (#529): { [fieldKey]: { visible, required } }.
+        // Потребляется через composable useFieldConfig (setup); дата/время реестром
+        // залочены (всегда visible+required), поэтому при пустом конфиге поведение прежнее.
         fieldConfig: { type: Object, default: () => ({}) }
     },
     emits: [
@@ -420,6 +423,10 @@ export default {
         'validate-date-range',
         'validate-time-range'
     ],
+    setup(props) {
+        // Геттер, а не props.fieldConfig напрямую - сохраняет реактивность пропса в хелперах (#529).
+        return useFieldConfig(() => props.fieldConfig);
+    },
     data() {
         const today = new Date();
         return {
@@ -517,16 +524,6 @@ export default {
         this.validateTimeCrossing();
     },
     methods: {
-        // Видимость поля по конфигу шаблона. Нет строки конфига -> поле видимо (дефолт).
-        fieldVisible(key) {
-            const c = this.fieldConfig[key];
-            return c ? c.visible : true;
-        },
-        // Обязательность поля по конфигу. Нет строки -> обязательно (текущее поведение дат/времени).
-        fieldRequired(key) {
-            const c = this.fieldConfig[key];
-            return c ? c.required : true;
-        },
         setQuickDate(kind) {
             const today = new Date();
             today.setHours(0, 0, 0, 0);

--- a/frontend/src/composables/__tests__/useFieldConfig.spec.js
+++ b/frontend/src/composables/__tests__/useFieldConfig.spec.js
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { ref } from 'vue';
+import { useFieldConfig } from '../useFieldConfig.js';
+
+// H-5b (#529): единый composable потребления field-config для секций формы подачи.
+// Дефолт (нет строки конфига) = поле видимо и обязательно -> текущее поведение форм.
+
+describe('useFieldConfig', () => {
+  it('пустой конфиг: любое поле видимо и обязательно', () => {
+    const { fieldVisible, fieldRequired } = useFieldConfig({});
+    expect(fieldVisible('any')).toBe(true);
+    expect(fieldRequired('any')).toBe(true);
+  });
+
+  it('нет строки для ключа -> дефолт true/true', () => {
+    const { fieldVisible, fieldRequired } = useFieldConfig({ foo: { visible: false, required: false } });
+    expect(fieldVisible('missing')).toBe(true);
+    expect(fieldRequired('missing')).toBe(true);
+  });
+
+  it('читает visible/required из строки конфига', () => {
+    const { fieldVisible, fieldRequired } = useFieldConfig({
+      hidden: { visible: false, required: true },
+      optional: { visible: true, required: false },
+    });
+    expect(fieldVisible('hidden')).toBe(false);
+    expect(fieldRequired('hidden')).toBe(true);
+    expect(fieldVisible('optional')).toBe(true);
+    expect(fieldRequired('optional')).toBe(false);
+  });
+
+  // Уровень вызова: хелпер читает источник на каждый вызов. Реактивность Vue
+  // (перерисовка компонента при смене пропа) покрыта DateRangeSectionFieldConfig.spec.js.
+  it('принимает геттер и читает источник на каждый вызов', () => {
+    let cfg = { x: { visible: true, required: true } };
+    const { fieldVisible } = useFieldConfig(() => cfg);
+    expect(fieldVisible('x')).toBe(true);
+    cfg = { x: { visible: false, required: true } };
+    expect(fieldVisible('x')).toBe(false);
+  });
+
+  it('принимает ref и читает актуальное значение', () => {
+    const cfg = ref({ x: { visible: true, required: false } });
+    const { fieldRequired } = useFieldConfig(cfg);
+    expect(fieldRequired('x')).toBe(false);
+    cfg.value = { x: { visible: true, required: true } };
+    expect(fieldRequired('x')).toBe(true);
+  });
+
+  it('источник null/undefined не падает -> дефолт', () => {
+    const { fieldVisible } = useFieldConfig(() => null);
+    expect(fieldVisible('x')).toBe(true);
+  });
+});

--- a/frontend/src/composables/useFieldConfig.js
+++ b/frontend/src/composables/useFieldConfig.js
@@ -1,0 +1,38 @@
+import { unref } from 'vue'
+
+/**
+ * Хелперы потребления настройки полей выбранного шаблона вложения (#529).
+ *
+ * Источник конфига - ref / reactive / геттер / простой объект вида
+ * `{ [fieldKey]: { visible, required } }`. Передавать лучше геттером
+ * (`() => props.fieldConfig`), чтобы сохранить реактивность пропса.
+ *
+ * Семантика дефолта: нет строки конфига для ключа -> поле видимо и обязательно.
+ * Это повторяет текущее поведение форм подачи, поэтому шаблоны без явной
+ * настройки не меняются.
+ *
+ * Единая точка потребления field-config для всех секций формы подачи
+ * (DateRangeSection + люди/машины/предметы) - чтобы H-6/7/8 не разъехались
+ * в разные способы интеграции.
+ *
+ * @param {object | import('vue').Ref<object> | (() => object)} source - источник конфига
+ * @returns {{ fieldVisible: (key: string) => boolean, fieldRequired: (key: string) => boolean }}
+ */
+export function useFieldConfig(source) {
+  const resolve = (key) => {
+    const cfg = typeof source === 'function' ? source() : unref(source)
+    return cfg ? cfg[key] : undefined
+  }
+
+  const fieldVisible = (key) => {
+    const c = resolve(key)
+    return c ? c.visible : true
+  }
+
+  const fieldRequired = (key) => {
+    const c = resolve(key)
+    return c ? c.required : true
+  }
+
+  return { fieldVisible, fieldRequired }
+}


### PR DESCRIPTION
## Что и зачем

Срез **H-5b** эпика #406 (фича настройки полей вложения, #529). Prep-рефактор под параллельный веер H-6/7/8.

H-5 (#537) добавил в `DateRangeSection.vue` inline-хелперы `fieldVisible(key)`/`fieldRequired(key)`, читающие проп `fieldConfig`. H-6/7/8 (формы людей/машин/предметов) будут потреблять тот же конфиг — чтобы они не разъехались в три разных способа интеграции, выношу хелперы в общий composable.

## Изменения

- **`composables/useFieldConfig.js`** (новый) — `useFieldConfig(source)` возвращает `{ fieldVisible, fieldRequired }`. Источник — геттер / `ref` / объект (через `unref`). Дефолт без строки конфига: поле видимо и обязательно (= текущее поведение форм).
- **`DateRangeSection.vue`** — `import` + `setup(props){ return useFieldConfig(() => props.fieldConfig) }`, inline-методы удалены. Геттер сохраняет реактивность пропса.
- **`composables/__tests__/useFieldConfig.spec.js`** (новый, 6 кейсов) — дефолты, чтение visible/required, геттер/ref/null-источник.

Поведение не меняется: даты/время реестром залочены (always visible+required), при пустом конфиге всё как было. Существующая `DateRangeSectionFieldConfig.spec.js` (6 кейсов) остаётся зелёной — хелперы из `setup` доступны на vm.

## Проверка

- vitest скоупом: 12 зелёных (6 composable + 6 DateRangeSection).
- eslint чисто.
- Ревью `code-reviewer`: **GO**. Применены YELLOW-1 (ужал «what»-комментарий в setup до WHY), YELLOW-2 (пояснил, что тест геттера — уровень вызова, Vue-реактивность покрыта компонентной спекой). NIT про `unref` при геттере — осознанно (ветка нужна для ref-источника).

## Для H-7/H-8 (на будущее)

`setup()` у `VehicleForm.vue`/`EmployeeForm.vue` объявлен **без параметра `props`** — при подключении `useFieldConfig` сменить сигнатуру на `setup(props)`, иначе `props.fieldConfig` будет `undefined`.

Часть #529 / эпик #406. Чистый FE-рефактор без визуальных изменений.