### PR TITLE
feat(applications): EmployeeForm уважает field-config шаблона (#529)

### DIFF
--- a/frontend/src/components/CreateApplication/EmployeeForm.vue
+++ b/frontend/src/components/CreateApplication/EmployeeForm.vue
@@ -472,26 +472,30 @@ export default {
             const vm = instance.proxy
 
             if (vm.selectedExistingEmployees.length > 0) {
-                return [
-                    { check: vm.selectedPassageTables.length > 0, message: 'выберите хотя бы одно место прохода' }
-                ]
+                const existingRules = []
+                if (fieldVisible('target_tables') && fieldRequired('target_tables')) {
+                    existingRules.push({ check: vm.selectedPassageTables.length > 0, message: 'выберите хотя бы одно место прохода' })
+                }
+                return existingRules
             }
 
+            // Поле требует заполнения только когда видимо И помечено обязательным.
+            // Видимое необязательное (required=false) не должно блокировать submit.
             const rules = []
-            if (fieldVisible('last_name')) {
+            if (fieldVisible('last_name') && fieldRequired('last_name')) {
                 rules.push({ check: !!vm.lastName.trim(), message: 'фамилию' })
             }
-            if (fieldVisible('first_name')) {
+            if (fieldVisible('first_name') && fieldRequired('first_name')) {
                 rules.push({ check: !!vm.firstName.trim(), message: 'имя' })
             }
             rules.push({ check: !vm.blacklistInfo, message: 'Человек в чёрном списке' })
-            if (fieldVisible('position')) {
+            if (fieldVisible('position') && fieldRequired('position')) {
                 rules.push({ check: !!vm.position.trim(), message: 'должность' })
             }
-            if (fieldVisible('citizenship')) {
+            if (fieldVisible('citizenship') && fieldRequired('citizenship')) {
                 rules.push({ check: !!vm.selectedCitizenship, message: 'гражданство' })
             }
-            if (fieldVisible('passport')) {
+            if (fieldVisible('passport') && fieldRequired('passport')) {
                 rules.push({ check: !!vm.passportSeriesNumber.trim(), message: 'паспортные данные' })
             }
             if (fieldVisible('patent')) {
@@ -500,7 +504,7 @@ export default {
                     message: 'номер патента или иное разрешение'
                 })
             }
-            if (fieldVisible('target_tables')) {
+            if (fieldVisible('target_tables') && fieldRequired('target_tables')) {
                 rules.push({ check: vm.selectedPassageTables.length > 0, message: 'выберите хотя бы одно место прохода' })
             }
 
@@ -578,8 +582,10 @@ export default {
         isPatentRequired() {
             return this.selectedCitizenship ? this.selectedCitizenship.patent_required : false;
         },
-        // При явном required=true в конфиге для patent - всегда обязателен независимо от гражданства.
-        // Дефолт (нет строки конфига) - текущая условная логика по гражданству (patent_required).
+        // patent трёхзначен: нет строки конфига -> условная логика по гражданству;
+        // required=true -> всегда обязателен; required=false -> снова условная.
+        // fieldRequired() тут не годится: при отсутствии строки он даёт true (дефолт),
+        // что форсировало бы обязательность вместо условной логики - читаем конфиг напрямую.
         effectivePatentRequired() {
             const cfg = this.fieldConfig && this.fieldConfig['patent']
             if (cfg) {

--- a/frontend/src/components/CreateApplication/EmployeeForm.vue
+++ b/frontend/src/components/CreateApplication/EmployeeForm.vue
@@ -35,9 +35,15 @@
     </div>
 
     <div v-else>
-      <div class="completion__citizenship">
+      <div
+        v-if="fieldVisible('citizenship')"
+        class="completion__citizenship"
+      >
         <div class="citizenship__header">
-          <label class="citizenship__label">Гражданство <span class="required">*</span></label>
+          <label class="citizenship__label">Гражданство <span
+            v-if="fieldRequired('citizenship')"
+            class="required"
+          >*</span></label>
           <div class="citizenship-actions">
             <button
               v-if="editingEmployee"
@@ -103,25 +109,40 @@
       </div>
             
       <div class="completion__fields">
-        <div class="completion__name-row">
-          <div class="completion__last-name">
+        <div
+          v-if="fieldVisible('last_name') || fieldVisible('first_name')"
+          class="completion__name-row"
+        >
+          <div
+            v-if="fieldVisible('last_name')"
+            class="completion__last-name"
+          >
             <div class="completion__last-name-header">
-              <label class="input__label">Фамилия <span class="required">*</span></label>
+              <label class="input__label">Фамилия <span
+                v-if="fieldRequired('last_name')"
+                class="required"
+              >*</span></label>
             </div>
-            <input 
-              v-model="lastName" 
+            <input
+              v-model="lastName"
               class="name__input"
               placeholder="Введите фамилию"
               :disabled="editingEmployee && editingEmployee.isExisting"
               @blur="formatNameField('lastName')"
             >
           </div>
-          <div class="completion__first-name">
+          <div
+            v-if="fieldVisible('first_name')"
+            class="completion__first-name"
+          >
             <div class="completion__first-name-header">
-              <label class="input__label">Имя <span class="required">*</span></label>
+              <label class="input__label">Имя <span
+                v-if="fieldRequired('first_name')"
+                class="required"
+              >*</span></label>
             </div>
-            <input 
-              v-model="firstName" 
+            <input
+              v-model="firstName"
               class="name__input"
               placeholder="Введите имя"
               :disabled="editingEmployee && editingEmployee.isExisting"
@@ -129,23 +150,38 @@
             >
           </div>
         </div>
-                
-        <div class="completion__name-row">
-          <div class="completion__middle-name">
+
+        <div
+          v-if="fieldVisible('middle_name') || fieldVisible('position')"
+          class="completion__name-row"
+        >
+          <div
+            v-if="fieldVisible('middle_name')"
+            class="completion__middle-name"
+          >
             <div class="completion__middle-name-header">
-              <label class="input__label">Отчество</label>
+              <label class="input__label">Отчество <span
+                v-if="fieldRequired('middle_name')"
+                class="required"
+              >*</span></label>
             </div>
-            <input 
-              v-model="middleName" 
+            <input
+              v-model="middleName"
               class="name__input"
               placeholder="Введите отчество"
               :disabled="editingEmployee && editingEmployee.isExisting"
               @blur="formatNameField('middleName')"
             >
           </div>
-          <div class="completion__position">
+          <div
+            v-if="fieldVisible('position')"
+            class="completion__position"
+          >
             <div class="completion__position-header">
-              <label class="input__label">Должность <span class="required">*</span></label>
+              <label class="input__label">Должность <span
+                v-if="fieldRequired('position')"
+                class="required"
+              >*</span></label>
             </div>
             <input
               v-model="position"
@@ -171,50 +207,64 @@
           </p>
         </div>
 
-        <div class="completion__name-row">
-          <div class="completion__passport">
+        <div
+          v-if="fieldVisible('passport') || fieldVisible('patent')"
+          class="completion__name-row"
+        >
+          <div
+            v-if="fieldVisible('passport')"
+            class="completion__passport"
+          >
             <div class="completion__passport-header">
-              <label class="input__label">Паспортные данные <span class="required">*</span></label>
+              <label class="input__label">Паспортные данные <span
+                v-if="fieldRequired('passport')"
+                class="required"
+              >*</span></label>
             </div>
-            <input 
-              v-model="passportSeriesNumber" 
+            <input
+              v-model="passportSeriesNumber"
               class="name__input"
               placeholder="Введите паспортные данные"
               :disabled="editingEmployee && editingEmployee.isExisting"
             >
           </div>
           <div
+            v-if="fieldVisible('patent')"
             class="completion__patent"
-            :class="{ 'disabled-field': !isPatentRequired }"
+            :class="{ 'disabled-field': !effectivePatentRequired }"
           >
             <div class="completion__patent-header">
-              <label class="input__label">Номер патента</label>
+              <label class="input__label">Номер патента <span
+                v-if="fieldRequired('patent') && effectivePatentRequired"
+                class="required"
+              >*</span></label>
             </div>
-            <input 
-              v-model="patentNumber" 
+            <input
+              v-model="patentNumber"
               class="name__input"
-              :placeholder="isPatentRequired ? 'Номер патента' : 'Не требуется'"
-              :disabled="!isPatentRequired || patentFieldDisabled || (editingEmployee && editingEmployee.isExisting)"
+              :placeholder="effectivePatentRequired ? 'Номер патента' : 'Не требуется'"
+              :disabled="!effectivePatentRequired || patentFieldDisabled || (editingEmployee && editingEmployee.isExisting)"
               @input="handlePatentInput"
             >
           </div>
         </div>
-                
+
         <div
+          v-if="fieldVisible('work_permission')"
           class="completion__permission"
-          :class="{ 'disabled-field': !isPatentRequired }"
+          :class="{ 'disabled-field': !effectivePatentRequired }"
         >
           <div class="completion__permission-header">
             <label class="input__label">Иное разрешение на работы</label>
           </div>
           <div class="permission__dropdown">
             <button
-              class="permission__dropdown-button" 
-              :disabled="!isPatentRequired || permissionFieldDisabled || (editingEmployee && editingEmployee.isExisting)" 
+              class="permission__dropdown-button"
+              :disabled="!effectivePatentRequired || permissionFieldDisabled || (editingEmployee && editingEmployee.isExisting)"
               @click="togglePermissionDropdown"
             >
               <div class="permission__button-content">
-                <span class="permission__button-text">{{ selectedPermission || (isPatentRequired ? 'Выберите разрешение' : 'Не требуется') }}</span>
+                <span class="permission__button-text">{{ selectedPermission || (effectivePatentRequired ? 'Выберите разрешение' : 'Не требуется') }}</span>
                 <img
                   src="@/assets/icons/arrow.png"
                   class="permission__button-arrow"
@@ -227,8 +277,8 @@
                 v-if="isPermissionDropdownOpen"
                 class="permission__dropdown-menu"
               >
-                <div 
-                  v-for="permission in availablePermissions" 
+                <div
+                  v-for="permission in availablePermissions"
                   :key="permission"
                   class="permission__dropdown-item"
                   @click="selectPermission(permission)"
@@ -239,9 +289,9 @@
             </transition>
           </div>
         </div>
-                
+
         <div
-          v-if="isPatentRequired"
+          v-if="fieldVisible('patent') && effectivePatentRequired"
           class="completion__files"
         >
           <div class="completion__files-header">
@@ -300,8 +350,14 @@
       </div>
     </div>
 
-    <div class="completion__passage">
-      <label class="input__label">Места прохода (целевые таблицы) <span class="required">*</span></label>
+    <div
+      v-if="fieldVisible('target_tables')"
+      class="completion__passage"
+    >
+      <label class="input__label">Места прохода (целевые таблицы) <span
+        v-if="fieldRequired('target_tables')"
+        class="required"
+      >*</span></label>
       <div
         v-if="!loadingPassageTables && filteredPassageTables.length > 0"
         class="passage__grid"
@@ -370,6 +426,7 @@ import { useAuthStore } from '@/stores/auth'
 import { useToast } from '@/composables/useToast'
 import ExistingEmployeesModal from '@/components/CreateApplication/ExistingEmployeesModal.vue'
 import { useFormValidation } from '@/composables/useFormValidation'
+import { useFieldConfig } from '@/composables/useFieldConfig'
 import { getCurrentInstance } from 'vue'
 
 export default {
@@ -406,9 +463,10 @@ export default {
         }
     },
     emits: ['edit-cancelled', 'employee-added', 'employee-updated', 'employees-added'],
-    setup() {
+    setup(props) {
         const instance = getCurrentInstance()
         const toast = useToast()
+        const { fieldVisible, fieldRequired } = useFieldConfig(() => props.fieldConfig)
 
         const { isValid, tooltipMessage, showTooltip } = useFormValidation(() => {
             const vm = instance.proxy
@@ -419,22 +477,37 @@ export default {
                 ]
             }
 
-            return [
-                { check: !!vm.lastName.trim(), message: 'фамилию' },
-                { check: !!vm.firstName.trim(), message: 'имя' },
-                { check: !vm.blacklistInfo, message: 'Человек в чёрном списке' },
-                { check: !!vm.position.trim(), message: 'должность' },
-                { check: !!vm.selectedCitizenship, message: 'гражданство' },
-                { check: !!vm.passportSeriesNumber.trim(), message: 'паспортные данные' },
-                {
-                    check: !vm.isPatentRequired || !!(vm.patentNumber.trim() || vm.selectedPermission),
+            const rules = []
+            if (fieldVisible('last_name')) {
+                rules.push({ check: !!vm.lastName.trim(), message: 'фамилию' })
+            }
+            if (fieldVisible('first_name')) {
+                rules.push({ check: !!vm.firstName.trim(), message: 'имя' })
+            }
+            rules.push({ check: !vm.blacklistInfo, message: 'Человек в чёрном списке' })
+            if (fieldVisible('position')) {
+                rules.push({ check: !!vm.position.trim(), message: 'должность' })
+            }
+            if (fieldVisible('citizenship')) {
+                rules.push({ check: !!vm.selectedCitizenship, message: 'гражданство' })
+            }
+            if (fieldVisible('passport')) {
+                rules.push({ check: !!vm.passportSeriesNumber.trim(), message: 'паспортные данные' })
+            }
+            if (fieldVisible('patent')) {
+                rules.push({
+                    check: !vm.effectivePatentRequired || !!(vm.patentNumber.trim() || vm.selectedPermission),
                     message: 'номер патента или иное разрешение'
-                },
-                { check: vm.selectedPassageTables.length > 0, message: 'выберите хотя бы одно место прохода' }
-            ]
+                })
+            }
+            if (fieldVisible('target_tables')) {
+                rules.push({ check: vm.selectedPassageTables.length > 0, message: 'выберите хотя бы одно место прохода' })
+            }
+
+            return rules
         })
 
-        return { canAddEmployee: isValid, getTooltipMessage: tooltipMessage, showTooltip, toast }
+        return { canAddEmployee: isValid, getTooltipMessage: tooltipMessage, showTooltip, toast, fieldVisible, fieldRequired }
     },
     data() {
         return {
@@ -504,6 +577,15 @@ export default {
         },
         isPatentRequired() {
             return this.selectedCitizenship ? this.selectedCitizenship.patent_required : false;
+        },
+        // При явном required=true в конфиге для patent - всегда обязателен независимо от гражданства.
+        // Дефолт (нет строки конфига) - текущая условная логика по гражданству (patent_required).
+        effectivePatentRequired() {
+            const cfg = this.fieldConfig && this.fieldConfig['patent']
+            if (cfg) {
+                return cfg.required ? true : this.isPatentRequired
+            }
+            return this.isPatentRequired
         },
         patentFieldDisabled() {
             return this.selectedPermission !== '';
@@ -848,8 +930,8 @@ export default {
                 citizenshipId: this.selectedCitizenship.id,
                 citizenshipName: this.selectedCitizenship.name,
                 passportSeriesNumber: this.passportSeriesNumber.trim(),
-                patentNumber: this.isPatentRequired ? this.patentNumber.trim() : null,
-                otherPermission: this.isPatentRequired ? this.selectedPermission : null,
+                patentNumber: this.effectivePatentRequired ? this.patentNumber.trim() : null,
+                otherPermission: this.effectivePatentRequired ? this.selectedPermission : null,
                 passageTables: this.formatPassageTables(),
                 targetTables: [...this.selectedPassageTables],
                 isExisting: false

--- a/frontend/src/components/CreateApplication/__tests__/EmployeeFormFieldConfig.spec.js
+++ b/frontend/src/components/CreateApplication/__tests__/EmployeeFormFieldConfig.spec.js
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import EmployeeForm from '../EmployeeForm.vue';
+
+// H-6 (#529): EmployeeForm уважает field-config выбранного шаблона.
+// Ключи реестра: last_name/first_name/middle_name/passport/position/citizenship/patent/work_permission/target_tables.
+// Дефолт хелперов = видимо+обязательно -> пустой конфиг не меняет поведение.
+// patent: при fieldRequired=true форсируется обязательным; при дефолте - по isPatentRequired (гражданство).
+
+vi.mock('@/api/client', () => ({
+  apiRequest: vi.fn().mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue([]) })
+}));
+vi.mock('@/api/blacklist', () => ({
+  checkPersonBlacklist: vi.fn().mockResolvedValue(null)
+}));
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: vi.fn().mockReturnValue({ token: 'test-token' })
+}));
+vi.mock('@/composables/useToast', () => ({
+  useToast: vi.fn().mockReturnValue({ success: vi.fn(), error: vi.fn() })
+}));
+vi.mock('@/components/CreateApplication/ExistingEmployeesModal.vue', () => ({
+  default: { name: 'ExistingEmployeesModal', template: '<div />' }
+}));
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+});
+
+const hasField = (w, text) => w.text().includes(text);
+
+describe('EmployeeForm - потребление field-config (#529 H-6)', () => {
+  it('без конфига: все поля видимы, звёздочки на обязательных', () => {
+    const w = mount(EmployeeForm);
+    expect(hasField(w, 'Фамилия')).toBe(true);
+    expect(hasField(w, 'Имя')).toBe(true);
+    expect(hasField(w, 'Отчество')).toBe(true);
+    expect(hasField(w, 'Должность')).toBe(true);
+    expect(hasField(w, 'Гражданство')).toBe(true);
+    expect(hasField(w, 'Паспортные данные')).toBe(true);
+    expect(hasField(w, 'Места прохода')).toBe(true);
+  });
+
+  it('fieldVisible: нет строки конфига -> true; visible:false -> false', () => {
+    const w = mount(EmployeeForm, {
+      props: { fieldConfig: { foo: { visible: false, required: true } } }
+    });
+    expect(w.vm.fieldVisible('missing')).toBe(true);
+    expect(w.vm.fieldVisible('foo')).toBe(false);
+  });
+
+  it('fieldRequired: нет строки конфига -> true; required:false -> false', () => {
+    const w = mount(EmployeeForm, {
+      props: { fieldConfig: { foo: { visible: true, required: false } } }
+    });
+    expect(w.vm.fieldRequired('missing')).toBe(true);
+    expect(w.vm.fieldRequired('foo')).toBe(false);
+  });
+
+  it('скрывает поле Фамилия при last_name.visible=false', () => {
+    const w = mount(EmployeeForm, {
+      props: { fieldConfig: { last_name: { visible: false, required: true } } }
+    });
+    expect(hasField(w, 'Фамилия')).toBe(false);
+    expect(hasField(w, 'Имя')).toBe(true);
+  });
+
+  it('скрывает поле Имя при first_name.visible=false', () => {
+    const w = mount(EmployeeForm, {
+      props: { fieldConfig: { first_name: { visible: false, required: true } } }
+    });
+    expect(hasField(w, 'Имя')).toBe(false);
+    expect(hasField(w, 'Фамилия')).toBe(true);
+  });
+
+  it('скрывает поле Отчество при middle_name.visible=false', () => {
+    const w = mount(EmployeeForm, {
+      props: { fieldConfig: { middle_name: { visible: false, required: true } } }
+    });
+    expect(hasField(w, 'Отчество')).toBe(false);
+  });
+
+  it('скрывает поле Должность при position.visible=false', () => {
+    const w = mount(EmployeeForm, {
+      props: { fieldConfig: { position: { visible: false, required: true } } }
+    });
+    expect(hasField(w, 'Должность')).toBe(false);
+  });
+
+  it('скрывает поле Гражданство при citizenship.visible=false', () => {
+    const w = mount(EmployeeForm, {
+      props: { fieldConfig: { citizenship: { visible: false, required: true } } }
+    });
+    expect(hasField(w, 'Гражданство')).toBe(false);
+  });
+
+  it('скрывает поле Паспортные данные при passport.visible=false', () => {
+    const w = mount(EmployeeForm, {
+      props: { fieldConfig: { passport: { visible: false, required: true } } }
+    });
+    expect(hasField(w, 'Паспортные данные')).toBe(false);
+  });
+
+  it('скрывает Места прохода при target_tables.visible=false', () => {
+    const w = mount(EmployeeForm, {
+      props: { fieldConfig: { target_tables: { visible: false, required: true } } }
+    });
+    expect(hasField(w, 'Места прохода')).toBe(false);
+  });
+
+  it('patent: при дефолтном конфиге effectivePatentRequired следует isPatentRequired (по гражданству)', () => {
+    const w = mount(EmployeeForm);
+    // Без выбранного гражданства isPatentRequired=false -> effectivePatentRequired=false
+    expect(w.vm.isPatentRequired).toBe(false);
+    expect(w.vm.effectivePatentRequired).toBe(false);
+  });
+
+  it('patent: при fieldRequired=true форсирует обязательность независимо от гражданства', () => {
+    const w = mount(EmployeeForm, {
+      props: { fieldConfig: { patent: { visible: true, required: true } } }
+    });
+    // isPatentRequired=false (нет гражданства с patent_required), но config.required=true
+    expect(w.vm.isPatentRequired).toBe(false);
+    expect(w.vm.effectivePatentRequired).toBe(true);
+  });
+
+  it('patent: при required=false и нет patent_required гражданства - effectivePatentRequired=false', () => {
+    const w = mount(EmployeeForm, {
+      props: { fieldConfig: { patent: { visible: true, required: false } } }
+    });
+    expect(w.vm.effectivePatentRequired).toBe(false);
+  });
+});

--- a/frontend/src/components/CreateApplication/__tests__/EmployeeFormFieldConfig.spec.js
+++ b/frontend/src/components/CreateApplication/__tests__/EmployeeFormFieldConfig.spec.js
@@ -131,4 +131,25 @@ describe('EmployeeForm - потребление field-config (#529 H-6)', () => 
     });
     expect(w.vm.effectivePatentRequired).toBe(false);
   });
+
+  it('скрывает блок "Иное разрешение на работы" при work_permission.visible=false', () => {
+    const w = mount(EmployeeForm, {
+      props: { fieldConfig: { work_permission: { visible: false, required: false } } }
+    });
+    expect(w.find('.completion__permission').exists()).toBe(false);
+  });
+
+  it('видимое необязательное поле не блокирует canAddEmployee (red H-6)', () => {
+    // Все поля видимы, но required=false -> единственное правило это проверка ЧС
+    // (blacklistInfo=null, мок). До фикса required-проверки гейтились лишь fieldVisible
+    // и блокировали submit при пустом optional-поле.
+    const optional = { visible: true, required: false };
+    const w = mount(EmployeeForm, {
+      props: { fieldConfig: {
+        last_name: optional, first_name: optional, position: optional,
+        citizenship: optional, passport: optional, patent: optional, target_tables: optional,
+      } }
+    });
+    expect(w.vm.canAddEmployee).toBe(true);
+  });
 });


### PR DESCRIPTION
H-6 эпика #406 / фичи #529. EmployeeForm потребляет field-config через useFieldConfig: скрытие и обязательность ФИО, паспорта, должности, гражданства, патента, иного разрешения, мест прохода. Патент трёхзначен: нет строки конфига - условная логика по гражданству; required=true - всегда обязателен. Ревью-фикс: required-проверки уважают fieldRequired (видимое необязательное не блокирует submit, включая места прохода). Тесты vitest на optional-поле и work_permission.