### PR TITLE
feat(applications): ItemsForm и CustomFieldsSection уважают field-config (#529)

### DIFF
--- a/frontend/src/components/CreateApplication/CustomFieldsSection.vue
+++ b/frontend/src/components/CreateApplication/CustomFieldsSection.vue
@@ -5,10 +5,13 @@
       :key="field.id"
       class="custom-fields__item"
     >
-      <label class="input__label">{{ field.label }}</label>
+      <label class="input__label">{{ field.label }}<span
+        v-if="field.is_required"
+        class="required"
+      > *</span></label>
       <input
         type="text"
-        class="input"
+        :class="['input', { 'input--error': field.is_required && submitted && !modelValue[field.id]?.trim() }]"
         :placeholder="field.placeholder"
         :value="modelValue[field.id] || ''"
         @input="$emit('update:modelValue', { ...modelValue, [field.id]: $event.target.value })"
@@ -23,6 +26,9 @@ export default {
     props: {
         fields: { type: Array, default: () => [] },
         modelValue: { type: Object, default: () => ({}) },
+        // Триггер подсветки ошибок обязательных полей (is_required=true).
+        // Дефолт false - поведение без переданного пропса не меняется.
+        submitted: { type: Boolean, default: false },
     },
     emits: ['update:modelValue'],
 };
@@ -48,6 +54,10 @@ export default {
     color: #a2a2a2;
 }
 
+.required {
+    color: #ff4444;
+}
+
 .input {
     width: 100%;
     height: 40px;
@@ -63,5 +73,9 @@ export default {
 
 .input:focus {
     border-color: #4F5BDF;
+}
+
+.input--error {
+    border-color: #ff4444;
 }
 </style>

--- a/frontend/src/components/CreateApplication/ItemsForm.vue
+++ b/frontend/src/components/CreateApplication/ItemsForm.vue
@@ -249,12 +249,19 @@ export default {
                 return;
             }
             
-            // Фильтруем пустые строки
-            const validItems = this.tempItems.filter(item => 
-                item.itemName && item.itemName.trim() && 
-                item.quantity && item.quantity >= 1
-            );
-            
+            // Валидность строки - тот же конфиг-aware критерий, что и canAddItems:
+            // скрытое/необязательное поле не делает строку невалидной. Иначе при
+            // скрытом item_name validItems пустел и addItems молча ничего не эмитил.
+            const nameVisible = this.fieldVisible('item_name');
+            const quantityVisible = this.fieldVisible('quantity');
+            const nameRequired = this.fieldRequired('item_name');
+            const quantityRequired = this.fieldRequired('quantity');
+            const validItems = this.tempItems.filter(item => {
+                const nameOk = !nameVisible || !nameRequired || (item.itemName && item.itemName.trim());
+                const quantityOk = !quantityVisible || !quantityRequired || (item.quantity && item.quantity >= 1);
+                return nameOk && quantityOk;
+            });
+
             if (validItems.length === 0) {
                 return;
             }

--- a/frontend/src/components/CreateApplication/ItemsForm.vue
+++ b/frontend/src/components/CreateApplication/ItemsForm.vue
@@ -40,11 +40,23 @@
             <div class="header-cell number-header">
               <label class="input__label">№</label>
             </div>
-            <div class="header-cell name-header">
-              <label class="input__label">Наименование ТМЦ <span class="required">*</span></label>
+            <div
+              v-if="fieldVisible('item_name')"
+              class="header-cell name-header"
+            >
+              <label class="input__label">Наименование ТМЦ <span
+                v-if="fieldRequired('item_name')"
+                class="required"
+              >*</span></label>
             </div>
-            <div class="header-cell quantity-header">
-              <label class="input__label">Количество <span class="required">*</span></label>
+            <div
+              v-if="fieldVisible('quantity')"
+              class="header-cell quantity-header"
+            >
+              <label class="input__label">Количество <span
+                v-if="fieldRequired('quantity')"
+                class="required"
+              >*</span></label>
             </div>
             <div class="header-cell actions-header" />
           </div>
@@ -58,24 +70,30 @@
               <div class="table-cell number-cell">
                 <span class="item-number">{{ index + 1 }}</span>
               </div>
-              <div class="table-cell name-cell">
-                <input 
-                  v-model="item.itemName" 
+              <div
+                v-if="fieldVisible('item_name')"
+                class="table-cell name-cell"
+              >
+                <input
+                  v-model="item.itemName"
                   type="text"
                   placeholder="Введите наименование"
                   class="name__input"
-                  :class="{ 'input--error': !item.itemName && submitted }"
+                  :class="{ 'input--error': fieldRequired('item_name') && !item.itemName && submitted }"
                   @input="updateItem(index, $event.target.value, 'itemName')"
                 >
               </div>
-              <div class="table-cell quantity-cell">
-                <input 
-                  v-model.number="item.quantity" 
+              <div
+                v-if="fieldVisible('quantity')"
+                class="table-cell quantity-cell"
+              >
+                <input
+                  v-model.number="item.quantity"
                   type="number"
                   min="1"
                   placeholder="1"
                   class="name__input"
-                  :class="{ 'input--error': (!item.quantity || item.quantity < 1) && submitted }"
+                  :class="{ 'input--error': fieldRequired('quantity') && (!item.quantity || item.quantity < 1) && submitted }"
                   @input="updateItem(index, parseInt($event.target.value) || 1, 'quantity')"
                 >
               </div>
@@ -109,6 +127,8 @@
 </template>
 
 <script>
+import { useFieldConfig } from '@/composables/useFieldConfig';
+
 export default {
     name: 'ItemsForm',
     props: {
@@ -117,13 +137,16 @@ export default {
             default: () => []
         },
         // Настройка полей шаблона (#529): { [fieldKey]: { visible, required, locked, requirable } }.
-        // Раздаётся из CreateApplication; потребление (скрытие/обязательность полей предметов) - срез H-8.
+        // Раздаётся из CreateApplication; fieldVisible/fieldRequired через useFieldConfig.
         fieldConfig: {
             type: Object,
             default: () => ({})
         }
     },
     emits: ['edit-cancelled', 'item-added', 'item-updated', 'items-added'],
+    setup(props) {
+        return useFieldConfig(() => props.fieldConfig);
+    },
     data() {
         return {
             tempItems: [
@@ -142,26 +165,32 @@ export default {
     },
     computed: {
         canAddItems() {
-            // Проверяем, что все строки заполнены правильно
-            return this.tempItems.every(item => 
-                item.itemName && item.itemName.trim() && 
-                item.quantity && item.quantity >= 1
-            ) && this.tempItems.length > 0;
+            const nameVisible = this.fieldVisible('item_name');
+            const quantityVisible = this.fieldVisible('quantity');
+            const nameRequired = this.fieldRequired('item_name');
+            const quantityRequired = this.fieldRequired('quantity');
+            return this.tempItems.every(item => {
+                const nameOk = !nameVisible || !nameRequired || (item.itemName && item.itemName.trim());
+                const quantityOk = !quantityVisible || !quantityRequired || (item.quantity && item.quantity >= 1);
+                return nameOk && quantityOk;
+            }) && this.tempItems.length > 0;
         },
         getTooltipMessage() {
-            const invalidItems = this.tempItems.filter(item => 
-                !item.itemName || !item.itemName.trim() || 
-                !item.quantity || item.quantity < 1
-            );
-            
-            if (invalidItems.length > 0) {
-                return 'Заполните все обязательные поля (Наименование ТМЦ и количество)';
-            }
-            
             if (this.tempItems.length === 0) {
                 return 'Добавьте хотя бы одну ТМЦ';
             }
-            
+            const nameVisible = this.fieldVisible('item_name');
+            const quantityVisible = this.fieldVisible('quantity');
+            const nameRequired = this.fieldRequired('item_name');
+            const quantityRequired = this.fieldRequired('quantity');
+            const invalidItems = this.tempItems.filter(item => {
+                const nameInvalid = nameVisible && nameRequired && (!item.itemName || !item.itemName.trim());
+                const quantityInvalid = quantityVisible && quantityRequired && (!item.quantity || item.quantity < 1);
+                return nameInvalid || quantityInvalid;
+            });
+            if (invalidItems.length > 0) {
+                return 'Заполните все обязательные поля (Наименование ТМЦ и количество)';
+            }
             return '';
         }
     },

--- a/frontend/src/components/CreateApplication/__tests__/ItemsFormFieldConfig.spec.js
+++ b/frontend/src/components/CreateApplication/__tests__/ItemsFormFieldConfig.spec.js
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import ItemsForm from '../ItemsForm.vue';
+import CustomFieldsSection from '../CustomFieldsSection.vue';
+
+// H-8 (#529): ItemsForm уважает field-config; CustomFieldsSection показывает ошибку
+// при is_required=true + submitted=true + пустом значении.
+
+describe('ItemsForm - потребление field-config (#529)', () => {
+  it('без конфига: оба столбца видимы, звёздочки обязательности на месте', () => {
+    const w = mount(ItemsForm);
+    expect(w.find('.name-header').exists()).toBe(true);
+    expect(w.find('.quantity-header').exists()).toBe(true);
+    expect(w.findAll('.required')).toHaveLength(2);
+  });
+
+  it('fieldVisible: нет строки -> true; visible:false -> false', () => {
+    const w = mount(ItemsForm, {
+      props: { fieldConfig: { foo: { visible: false, required: true } } },
+    });
+    expect(w.vm.fieldVisible('missing')).toBe(true);
+    expect(w.vm.fieldVisible('foo')).toBe(false);
+  });
+
+  it('fieldRequired: нет строки -> true; required:false -> false', () => {
+    const w = mount(ItemsForm, {
+      props: { fieldConfig: { foo: { visible: true, required: false } } },
+    });
+    expect(w.vm.fieldRequired('missing')).toBe(true);
+    expect(w.vm.fieldRequired('foo')).toBe(false);
+  });
+
+  it('конфиг скрывает столбец item_name при visible=false', () => {
+    const w = mount(ItemsForm, {
+      props: { fieldConfig: { item_name: { visible: false, required: true } } },
+    });
+    expect(w.find('.name-header').exists()).toBe(false);
+    expect(w.find('.name-cell').exists()).toBe(false);
+    expect(w.find('.quantity-header').exists()).toBe(true);
+  });
+
+  it('конфиг скрывает столбец quantity при visible=false', () => {
+    const w = mount(ItemsForm, {
+      props: { fieldConfig: { quantity: { visible: false, required: true } } },
+    });
+    expect(w.find('.quantity-header').exists()).toBe(false);
+    expect(w.find('.quantity-cell').exists()).toBe(false);
+    expect(w.find('.name-header').exists()).toBe(true);
+  });
+
+  it('конфиг убирает звёздочку item_name при required=false', () => {
+    const w = mount(ItemsForm, {
+      props: { fieldConfig: { item_name: { visible: true, required: false } } },
+    });
+    // только одна звёздочка - у quantity
+    expect(w.findAll('.required')).toHaveLength(1);
+  });
+
+  it('конфиг убирает звёздочку quantity при required=false', () => {
+    const w = mount(ItemsForm, {
+      props: { fieldConfig: { quantity: { visible: true, required: false } } },
+    });
+    // только одна звёздочка - у item_name
+    expect(w.findAll('.required')).toHaveLength(1);
+  });
+
+  it('canAddItems: без конфига - false при пустом item_name', () => {
+    const w = mount(ItemsForm);
+    expect(w.vm.canAddItems).toBe(false);
+  });
+
+  it('canAddItems: скрытый item_name не блокирует добавление при filled quantity', async () => {
+    const w = mount(ItemsForm, {
+      props: { fieldConfig: { item_name: { visible: false, required: true } } },
+    });
+    // item_name скрыт - quantity=1 (дефолт), должно быть разрешено
+    expect(w.vm.canAddItems).toBe(true);
+  });
+
+  it('canAddItems: скрытый quantity не блокирует добавление при filled item_name', async () => {
+    const w = mount(ItemsForm, {
+      props: { fieldConfig: { quantity: { visible: false, required: true } } },
+    });
+    // устанавливаем через editItem чтобы триггернуть реактивность
+    w.vm.editItem({ id: null, itemName: 'Тестовое наименование', quantity: null });
+    await w.vm.$nextTick();
+    expect(w.vm.canAddItems).toBe(true);
+  });
+
+  it('canAddItems: required=false снимает блок даже при пустом item_name', async () => {
+    const w = mount(ItemsForm, {
+      props: { fieldConfig: { item_name: { visible: true, required: false } } },
+    });
+    // item_name пустой, но required=false - quantity=1 (дефолт)
+    expect(w.vm.canAddItems).toBe(true);
+  });
+});
+
+describe('CustomFieldsSection - is_required + submitted (#529)', () => {
+  const fields = [
+    { id: 1, label: 'Экспедитор', placeholder: '', is_required: true },
+    { id: 2, label: 'Примечание', placeholder: '', is_required: false },
+  ];
+
+  it('без submitted: нет ошибочной подсветки даже при пустых required полях', () => {
+    const w = mount(CustomFieldsSection, {
+      props: { fields, modelValue: {} },
+    });
+    expect(w.findAll('.input--error')).toHaveLength(0);
+  });
+
+  it('submitted=true + пустое required поле -> подсветка input--error', () => {
+    const w = mount(CustomFieldsSection, {
+      props: { fields, modelValue: {}, submitted: true },
+    });
+    // поле 1 (is_required=true) должно подсветиться, поле 2 (is_required=false) - нет
+    expect(w.findAll('.input--error')).toHaveLength(1);
+  });
+
+  it('submitted=true + заполненное required поле -> нет ошибки', () => {
+    const w = mount(CustomFieldsSection, {
+      props: { fields, modelValue: { 1: 'Иванов', 2: '' }, submitted: true },
+    });
+    expect(w.findAll('.input--error')).toHaveLength(0);
+  });
+
+  it('звёздочка отображается только для is_required=true полей', () => {
+    const w = mount(CustomFieldsSection, {
+      props: { fields, modelValue: {} },
+    });
+    expect(w.findAll('.required')).toHaveLength(1);
+  });
+});

--- a/frontend/src/components/CreateApplication/__tests__/ItemsFormFieldConfig.spec.js
+++ b/frontend/src/components/CreateApplication/__tests__/ItemsFormFieldConfig.spec.js
@@ -94,6 +94,17 @@ describe('ItemsForm - потребление field-config (#529)', () => {
     // item_name пустой, но required=false - quantity=1 (дефолт)
     expect(w.vm.canAddItems).toBe(true);
   });
+
+  it('addItems эмитит при скрытом item_name, а не молчит (red H-8)', async () => {
+    const w = mount(ItemsForm, {
+      props: { fieldConfig: { item_name: { visible: false, required: true } } },
+    });
+    // item_name скрыт, quantity=1 (дефолт) -> строка валидна, эмит должен произойти
+    w.vm.addItems();
+    await w.vm.$nextTick();
+    expect(w.emitted('item-added')).toBeTruthy();
+    expect(w.emitted('item-added')[0][0].quantity).toBe(1);
+  });
 });
 
 describe('CustomFieldsSection - is_required + submitted (#529)', () => {


### PR DESCRIPTION
H-8 эпика #406 / фичи #529. ItemsForm потребляет field-config: скрытие и обязательность наименования ТМЦ и количества. CustomFieldsSection подсвечивает обязательные кастомные поля при submitted. Ревью-фикс: addItems выровнен с конфиг-aware canAddItems - при скрытом item_name больше не молчит (эмит происходит). Тесты vitest, включая покрытие эмита при скрытом поле.