### PR TITLE
fix(applications): бейдж ЧС не ломает колонку, модалки детали выходят поверх

### DIFF
--- a/frontend/src/components/ApplicationDetail/BlacklistOverrideModal.vue
+++ b/frontend/src/components/ApplicationDetail/BlacklistOverrideModal.vue
@@ -3,6 +3,7 @@
     :show="show"
     title="Всё равно пропустить?"
     width="460px"
+    :z-index="10005"
     @close="$emit('close')"
   >
     <div class="override-body">

--- a/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
@@ -4,6 +4,7 @@
       <div
         v-if="show"
         class="modal-overlay"
+        :style="{ zIndex: overlayZIndex }"
         @click.self="close"
       >
         <div class="modal-wrapper">
@@ -456,6 +457,12 @@ export default {
         };
     },
     computed: {
+        // Карточка, открытая ИЗ ApplicationDetail (source='application'), лежит ПОВЕРХ его
+        // оверлея (z-index 10002). В остальных местах - базовый слой 10001, чтобы открытый
+        // из карточки ApplicationDetail ("Открыть заявку") был выше карточки.
+        overlayZIndex() {
+            return this.source === 'application' ? 10003 : 10001;
+        },
         // Кнопки в шапке: "Полная история" (showHistoryButton) и
         // "Открыть заявку" (source !== 'application' и есть applicationId).
         visibleActionsCount() {

--- a/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
@@ -4,6 +4,7 @@
       <div
         v-if="show"
         class="modal-overlay"
+        :style="{ zIndex: overlayZIndex }"
         @mousedown="onOverlayMousedown"
         @mouseup="onOverlayMouseup"
       >
@@ -440,6 +441,12 @@ export default {
         }
     },
     computed: {
+        // Карточка, открытая ИЗ ApplicationDetail (source='application'), лежит ПОВЕРХ его
+        // оверлея (z-index 10002). В остальных местах - базовый слой 10001, чтобы открытый
+        // из карточки ApplicationDetail ("Открыть заявку") был выше карточки.
+        overlayZIndex() {
+            return this.source === 'application' ? 10003 : 10001;
+        },
         // Кнопки в шапке: "Полная история" видна при showCarFeatures,
         // "Открыть заявку" - при showCarFeatures и source !== 'application'.
         visibleActionsCount() {

--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -1353,7 +1353,10 @@ export default {
 }
 
 .number-col {
-    width: 15%;
+    width: 18%;
+    /* min-width:0 снимает min-content "пол" flex-элемента: иначе nowrap-бейдж под номером
+       не даёт строке сжаться до своей доли, и шапка (узкий контент) расходится со строкой. */
+    min-width: 0;
     flex-direction: column;
     justify-content: center;
     align-items: flex-start;
@@ -1364,12 +1367,18 @@ export default {
     max-width: 100%;
 }
 
+/* у .application-col нет overflow:hidden - на узкой раскладке даём бейджу перенестись,
+   а не вылезать в соседнюю колонку (специфичность бьёт white-space:nowrap из Badge). */
+.number-col .blacklist-flag-badge {
+    white-space: normal;
+}
+
 .date-col {
     width: 15%;
 }
 
 .organization-col {
-    width: 20%;
+    width: 17%;
 }
 
 .sender-col {


### PR DESCRIPTION
Follow-up багфиксы по ЧС (#481), найденные при ручной проверке.

## Что чинит

**1. Съезд колонки "Номер заявки" (Центр заявок).** Сводный бейдж "N похожи на ЧС"
под номером (`white-space:nowrap`) задавал min-content "пол" flex-ячейки. Без
`min-width:0` строка не сжималась до своей доли (15%), а шапка сжималась - колонки
расходились. Фикс: `min-width:0` на `.number-col` (корень выравнивания) + ширина
15% -> 18% и компенсация organization 20% -> 17%, плюс перенос бейджа как страховка
от вылезания на узких раскладках.

**2. Карточка элемента открывалась ЗА деталью заявки.** `VehicleDetailsModal`/
`EmployeeDetailsModal` (Teleport, overlay z-index 10001) против оверлея
`ApplicationDetail` (10002). Открытая из заявки карточка уходила под панель. Фикс:
overlay z-index условный по `source` - `application` -> 10003 (поверх панели), иначе
10001 (обратный поток "Открыть заявку" оставляет деталь поверх карточки, как нужно).

**3. Кнопка "Пропустить" выглядела нерабочей.** Модалка "Всё равно пропустить?"
(BaseModal, дефолт z-index 1000) рендерилась далеко за деталью (10002) - клик будто
не срабатывал. Фикс: `:z-index="10005"` на BaseModal.

## Верификация (локально, Playwright + инъекция флага в API)

- Выравнивание шапка/строка по number-col: дельта 0px на 1000/1180/1440px; бейдж
  внутри колонки; остаточные 2px на дальней колонке - субпиксельное округление flex
  (идентично строке без бейджа), не зависит от бейджа.
- Карточка из заявки: `.modal-overlay` z-index 10003 > панель 10002, hit-test центра
  внутри карточки (карточка ПЕРЕД деталью).
- Кнопка "Пропустить": открывает override-модалку z-index 10005 поверх панели,
  карточка НЕ открывается (`@click.stop` работает).

ESLint чистый. BE/swagger не трогались.
