### PR TITLE
feat(applications): серверная валидация настроенных полей подачи + устойчивость ЧС (#529)

### DIFF
--- a/internal/handlers/applications_field_config_test.go
+++ b/internal/handlers/applications_field_config_test.go
@@ -1,0 +1,161 @@
+package handlers_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"systemburo/internal/models"
+	"systemburo/internal/testutil"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// seedFieldConfig добавляет override настройки поля вложения (#529 H-9).
+func seedFieldConfig(t *testing.T, db *gorm.DB, uaID int, key string, visible, required bool) {
+	t.Helper()
+	require.NoError(t, db.Create(&models.AttachmentFieldConfig{
+		UniqueAttachmentID: uaID, FieldKey: key, Visible: visible, Required: required,
+	}).Error)
+}
+
+// submitFC подаёт заявку с одним вложением заданного типа и data-объектом (сырой JSON).
+func submitFC(t *testing.T, e *echo.Echo, token, org, attType string, uaID int, dataJSON string) *httptest.ResponseRecorder {
+	t.Helper()
+	body := fmt.Sprintf(`{
+		"message": "h9",
+		"organization": "%s",
+		"responsible_person": "Test",
+		"contact_phone": "+79001234567",
+		"data_approval": true,
+		"attachments": [{
+			"attachment_type": "%s",
+			"attachment_name": "h9_tmpl",
+			"attachment_display_name": "H9 Template",
+			"unique_attachment_id": %d,
+			"entry_date_from": "2026-04-01",
+			"entry_date_to": "2099-12-31",
+			"entry_time_from": "08:00",
+			"entry_time_to": "18:00",
+			"data": %s
+		}]
+	}`, org, attType, uaID, dataJSON)
+	return testutil.POST(t, e, "/applications/submit-complete-application", body, testutil.AuthHeader(token))
+}
+
+// TestSubmitCompleteApplication_FieldConfigValidation проверяет config-only валидацию
+// обязательных полей (#529 H-9): бэкенд требует поле только если админ явно настроил его
+// required (override visible+required). Скрытые и ненастроенные поля не валидируются.
+func TestSubmitCompleteApplication_FieldConfigValidation(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	const orgName = "Test Organization"
+	token := testutil.RegisterAndLogin(t, e, "h9_user", "pass123", 1, td.OrgID, td.CompanyID)
+	citizenshipID := seedCitizenship(t, db)
+	tableID := seedSystemTable(t, db)
+
+	t.Run("people: настроенное required middle_name - без отчества 400", func(t *testing.T) {
+		uaID := seedUniqueAttachment(t, db, "people", "h9_mn_req", "tmpl")
+		seedFieldConfig(t, db, uaID, "middle_name", true, true)
+		data := fmt.Sprintf(`{"employees": [{"last_name": "Иванов", "first_name": "Иван", "citizenship_id": %d, "position": "Рабочий", "passport_series_number": "1234 567890", "target_tables": [%d]}]}`, citizenshipID, tableID)
+		rec := submitFC(t, e, token, orgName, "people", uaID, data)
+		require.Equal(t, http.StatusBadRequest, rec.Code, "body: %s", rec.Body.String())
+		assert.Contains(t, rec.Body.String(), "Отчество")
+	})
+
+	t.Run("people: настроенное required middle_name - с отчеством 200", func(t *testing.T) {
+		uaID := seedUniqueAttachment(t, db, "people", "h9_mn_ok", "tmpl")
+		seedFieldConfig(t, db, uaID, "middle_name", true, true)
+		data := fmt.Sprintf(`{"employees": [{"last_name": "Иванов", "first_name": "Иван", "middle_name": "Иванович", "citizenship_id": %d, "position": "Рабочий", "passport_series_number": "1234 567890", "target_tables": [%d]}]}`, citizenshipID, tableID)
+		rec := submitFC(t, e, token, orgName, "people", uaID, data)
+		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+	})
+
+	t.Run("people: скрытое поле (visible=false) не валидируется даже при required", func(t *testing.T) {
+		uaID := seedUniqueAttachment(t, db, "people", "h9_hidden", "tmpl")
+		seedFieldConfig(t, db, uaID, "passport", false, true) // скрыто -> не требуем
+		data := fmt.Sprintf(`{"employees": [{"last_name": "Петров", "first_name": "Пётр", "citizenship_id": %d, "position": "Рабочий", "target_tables": [%d]}]}`, citizenshipID, tableID)
+		rec := submitFC(t, e, token, orgName, "people", uaID, data)
+		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+	})
+
+	t.Run("cars: настроенное required unloading_places - без мест 400", func(t *testing.T) {
+		uaID := seedUniqueAttachment(t, db, "cars", "h9_unload_req", "tmpl")
+		seedFieldConfig(t, db, uaID, "unloading_places", true, true)
+		data := `{"vehicles": [{"car_number": "A123AA77", "car_brand": "Kamaz", "mark_id": null}]}`
+		rec := submitFC(t, e, token, orgName, "cars", uaID, data)
+		require.Equal(t, http.StatusBadRequest, rec.Code, "body: %s", rec.Body.String())
+		assert.Contains(t, rec.Body.String(), "Места разгрузки")
+	})
+
+	t.Run("cars: by-fact 'По факту' проходит required number и mark", func(t *testing.T) {
+		uaID := seedUniqueAttachment(t, db, "cars", "h9_byfact", "tmpl")
+		seedFieldConfig(t, db, uaID, "number", true, true)
+		seedFieldConfig(t, db, uaID, "mark", true, true)
+		data := `{"vehicles": [{"car_number": "По факту", "car_brand": "По факту", "mark_id": null}]}`
+		rec := submitFC(t, e, token, orgName, "cars", uaID, data)
+		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+	})
+
+	t.Run("items: настроенное required quantity - count 0 -> 400", func(t *testing.T) {
+		uaID := seedUniqueAttachment(t, db, "items", "h9_qty_req", "tmpl")
+		seedFieldConfig(t, db, uaID, "quantity", true, true)
+		data := `{"items": [{"name": "Ящик", "count": 0}]}`
+		rec := submitFC(t, e, token, orgName, "items", uaID, data)
+		require.Equal(t, http.StatusBadRequest, rec.Code, "body: %s", rec.Body.String())
+		assert.Contains(t, rec.Body.String(), "Количество")
+	})
+
+	t.Run("items: настроенное required quantity - count>=1 -> 200", func(t *testing.T) {
+		uaID := seedUniqueAttachment(t, db, "items", "h9_qty_ok", "tmpl")
+		seedFieldConfig(t, db, uaID, "quantity", true, true)
+		data := `{"items": [{"name": "Ящик", "count": 3}]}`
+		rec := submitFC(t, e, token, orgName, "items", uaID, data)
+		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+	})
+
+	t.Run("без override валидация не срабатывает (текущее поведение сохранено)", func(t *testing.T) {
+		uaID := seedUniqueAttachment(t, db, "cars", "h9_no_override", "tmpl")
+		// Нет ни одной строки конфига -> бэкенд не требует unload_places, как и раньше.
+		data := `{"vehicles": [{"car_number": "B456BB77", "car_brand": "Kamaz", "mark_id": null}]}`
+		rec := submitFC(t, e, token, orgName, "cars", uaID, data)
+		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+	})
+}
+
+// TestSubmitCompleteApplication_BlacklistHiddenFIO проверяет тихую деградацию ЧС (#529 H-9):
+// при скрытом ФИО (пустые last_name+first_name) проверка чёрного списка пропускается -
+// не падает и не матчит, даже если в ЧС есть запись с пустым ФИО.
+func TestSubmitCompleteApplication_BlacklistHiddenFIO(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	ctx := context.Background()
+
+	const orgName = "Test Organization"
+	token := testutil.RegisterAndLogin(t, e, "h9_bl_user", "pass123", 1, td.OrgID, td.CompanyID)
+	citizenshipID := seedCitizenship(t, db)
+	tableID := seedSystemTable(t, db)
+
+	// Патологическая запись ЧС с пустым ФИО: без skip пустая подача сматчилась бы 409.
+	require.NoError(t, db.WithContext(ctx).Create(&models.PersonBlacklist{
+		LastName: "", FirstName: "", Reason: "пустой эталон", IsActive: true,
+	}).Error)
+
+	uaID := seedUniqueAttachment(t, db, "people", "h9_hidden_fio", "tmpl")
+	// ФИО скрыто конфигом -> фронт шлёт пустые имена.
+	seedFieldConfig(t, db, uaID, "last_name", false, false)
+	seedFieldConfig(t, db, uaID, "first_name", false, false)
+	data := fmt.Sprintf(`{"employees": [{"last_name": "", "first_name": "", "citizenship_id": %d, "position": "Рабочий", "passport_series_number": "1234 567890", "target_tables": [%d]}]}`, citizenshipID, tableID)
+	rec := submitFC(t, e, token, orgName, "people", uaID, data)
+	require.Equal(t, http.StatusOK, rec.Code, "пустое ФИО должно пропускать ЧС, а не падать/блокировать; body: %s", rec.Body.String())
+}

--- a/internal/services/application_service.go
+++ b/internal/services/application_service.go
@@ -381,17 +381,17 @@ type ViewerWithUser struct {
 
 // AttachmentInfo информация о вложении заявки.
 type AttachmentInfo struct {
-	ID                          int        `json:"id"`
-	AttachmentType              string     `json:"attachment_type"`
-	AttachmentName              string     `json:"attachment_name"`
-	AttachmentDisplayName       string     `json:"attachment_display_name"`
-	EntryDateFrom               *string    `json:"entry_date_from"`
-	EntryDateTo                 *string    `json:"entry_date_to"`
-	EntryTimeFrom               *string    `json:"entry_time_from"`
-	EntryTimeTo                 *string    `json:"entry_time_to"`
-	CreatedAt                   *time.Time `json:"created_at"`
-	UniqueAttachmentID          *int       `json:"unique_attachment_id"`
-	UniqueAttachmentTitle       *string    `json:"unique_attachment_title"`
+	ID                          int                 `json:"id"`
+	AttachmentType              string              `json:"attachment_type"`
+	AttachmentName              string              `json:"attachment_name"`
+	AttachmentDisplayName       string              `json:"attachment_display_name"`
+	EntryDateFrom               *string             `json:"entry_date_from"`
+	EntryDateTo                 *string             `json:"entry_date_to"`
+	EntryTimeFrom               *string             `json:"entry_time_from"`
+	EntryTimeTo                 *string             `json:"entry_time_to"`
+	CreatedAt                   *time.Time          `json:"created_at"`
+	UniqueAttachmentID          *int                `json:"unique_attachment_id"`
+	UniqueAttachmentTitle       *string             `json:"unique_attachment_title"`
 	UniqueAttachmentDisplayName *string             `json:"unique_attachment_display_name"`
 	HasTemplate                 bool                `json:"has_template"`
 	CustomValues                []CustomValueDetail `gorm:"-" json:"custom_values,omitempty"`
@@ -399,9 +399,9 @@ type AttachmentInfo struct {
 
 // CustomValueDetail значение кастомного поля для отображения.
 type CustomValueDetail struct {
-	FieldID   int    `json:"field_id"`
-	Label     string `json:"label"`
-	Value     string `json:"value"`
+	FieldID int    `json:"field_id"`
+	Label   string `json:"label"`
+	Value   string `json:"value"`
 }
 
 // CarWithPlaces автомобиль с привязанными местами разгрузки.
@@ -1006,6 +1006,11 @@ func (s *applicationService) validateBlacklist(ctx context.Context, req Complete
 		}
 		if att.Data.Employees != nil {
 			for _, e := range *att.Data.Employees {
+				// Тихая деградация ЧС (#529): если ФИО скрыто конфигом - данных для
+				// совпадения нет, матчить нечем, пропускаем (не падаем, не 500).
+				if strings.TrimSpace(e.LastName) == "" && strings.TrimSpace(e.FirstName) == "" {
+					continue
+				}
 				middleName := ""
 				if e.MiddleName != nil {
 					middleName = *e.MiddleName
@@ -1018,6 +1023,131 @@ func (s *applicationService) validateBlacklist(ctx context.Context, req Complete
 					fio := strings.TrimSpace(fmt.Sprintf("%s %s %s", e.LastName, e.FirstName, middleName))
 					return echo.NewHTTPError(http.StatusConflict,
 						fmt.Sprintf("Человек %s в чёрном списке: %s", fio, res.Reason))
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// requiredFieldKeys - ключи полей, которые админ ЯВНО настроил обязательными для
+// вложения (override visible=true И required=true). Поля без override не валидируются:
+// строгая проверка только для настроенных полей, существующие шаблоны не ломаются
+// (решение владельца, #529 H-9).
+func requiredFieldKeys(overrides []models.AttachmentFieldConfig) map[string]bool {
+	req := make(map[string]bool, len(overrides))
+	for _, o := range overrides {
+		if o.Visible && o.Required {
+			req[o.FieldKey] = true
+		}
+	}
+	return req
+}
+
+// employeeFieldPresent сообщает, заполнено ли поле сотрудника с данным ключом реестра.
+// Незнакомый ключ -> true (не валидируем то, чего не знаем).
+func employeeFieldPresent(e EmployeeInput, key string) bool {
+	switch key {
+	case "last_name":
+		return strings.TrimSpace(e.LastName) != ""
+	case "first_name":
+		return strings.TrimSpace(e.FirstName) != ""
+	case "middle_name":
+		return e.MiddleName != nil && strings.TrimSpace(*e.MiddleName) != ""
+	case "passport":
+		return strings.TrimSpace(e.PassportSeriesNumber) != ""
+	case "position":
+		return strings.TrimSpace(e.Position) != ""
+	case "citizenship":
+		return e.CitizenshipID > 0
+	case "patent":
+		// Патент удовлетворяется номером патента ИЛИ иным разрешением (как на фронте).
+		return (e.PatentNumber != nil && strings.TrimSpace(*e.PatentNumber) != "") ||
+			(e.OtherPermission != nil && strings.TrimSpace(*e.OtherPermission) != "")
+	case "work_permission":
+		// Делит поле OtherPermission с patent: если оба настроены required,
+		// одно заполненное разрешение удовлетворяет обоим (как на фронте).
+		return e.OtherPermission != nil && strings.TrimSpace(*e.OtherPermission) != ""
+	case "target_tables":
+		return len(e.TargetTables) > 0
+	}
+	return true
+}
+
+// vehicleFieldPresent сообщает, заполнено ли поле машины. "По факту" приходит непустым
+// sentinel-ом ("По факту") в car_number/car_brand, поэтому by-fact проходит проверку.
+func vehicleFieldPresent(v VehicleInput, key string) bool {
+	switch key {
+	case "number":
+		return strings.TrimSpace(v.CarNumber) != ""
+	case "mark":
+		return v.MarkID != nil || strings.TrimSpace(v.CarBrand) != ""
+	case "unloading_places":
+		return len(v.UnloadPlaces) > 0
+	}
+	return true
+}
+
+// itemFieldPresent сообщает, заполнено ли поле ТМЦ.
+func itemFieldPresent(i ItemInput, key string) bool {
+	switch key {
+	case "item_name":
+		return strings.TrimSpace(i.Name) != ""
+	case "quantity":
+		return i.Count >= 1
+	}
+	return true
+}
+
+// validateConfiguredRequiredFields проверяет, что поля, явно настроенные админом
+// обязательными (override visible+required), присутствуют в подаче. Скрытые и
+// ненастроенные поля не валидируются. Запускается до транзакции (#529 H-9).
+func (s *applicationService) validateConfiguredRequiredFields(ctx context.Context, req CompleteApplicationRequest) error {
+	for _, att := range req.Attachments {
+		var overrides []models.AttachmentFieldConfig
+		if err := s.db.WithContext(ctx).
+			Where("unique_attachment_id = ?", att.UniqueAttachmentID).
+			Find(&overrides).Error; err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка проверки настройки полей")
+		}
+		required := requiredFieldKeys(overrides)
+		if len(required) == 0 {
+			continue
+		}
+		labels := fieldDefByKey(att.AttachmentType)
+		fail := func(key string) error {
+			label := key
+			if d, ok := labels[key]; ok {
+				label = d.Label
+			}
+			return echo.NewHTTPError(http.StatusBadRequest,
+				fmt.Sprintf("Поле «%s» обязательно для заполнения", label))
+		}
+
+		if att.Data.Employees != nil {
+			for _, e := range *att.Data.Employees {
+				for key := range required {
+					if !employeeFieldPresent(e, key) {
+						return fail(key)
+					}
+				}
+			}
+		}
+		if att.Data.Vehicles != nil {
+			for _, v := range *att.Data.Vehicles {
+				for key := range required {
+					if !vehicleFieldPresent(v, key) {
+						return fail(key)
+					}
+				}
+			}
+		}
+		if att.Data.Items != nil {
+			for _, item := range *att.Data.Items {
+				for key := range required {
+					if !itemFieldPresent(item, key) {
+						return fail(key)
+					}
 				}
 			}
 		}
@@ -1104,6 +1234,12 @@ func (s *applicationService) SubmitCompleteApplication(ctx context.Context, user
 	if strings.TrimSpace(req.Organization) == "" &&
 		(req.Company == nil || strings.TrimSpace(*req.Company) == "") {
 		return nil, echo.NewHTTPError(http.StatusBadRequest, "Укажите организацию или компанию")
+	}
+
+	// Серверная валидация настроенных обязательных полей (#529 H-9): поля, помеченные
+	// админом required, должны присутствовать; скрытые/ненастроенные пропускаются.
+	if err := s.validateConfiguredRequiredFields(ctx, req); err != nil {
+		return nil, err
 	}
 
 	// Серверный гард ЧС (#443): отклоняем заявку с заблокированной машиной/человеком


### PR DESCRIPTION
H-9 эпика #406 / #529. Бэкенд не валидировал присутствие полей при подаче - требовательность жила только на фронте (обходима через API).

**Config-only валидация** (по решению владельца): поле обязательно на сервере ТОЛЬКО если админ явно настроил его required (override visible+required в attachment_field_config). Поля без override и скрытые (visible=false) не валидируются - существующие шаблоны не ломаются, текущее поведение сохранено. By-fact машины ('По факту' приходит непустым sentinel-ом) и patent (номер ИЛИ иное разрешение) обрабатываются - нет ложных отказов.

**Устойчивость ЧС:** проверка чёрного списка пропускает пустое (скрытое конфигом) ФИО - не матчит и не падает в 500 (тихая деградация, ответственность за безопасный конфиг на админе).

Тесты: 8 config-валидаций (400/200 по группам people/cars/items, by-fact, hidden, no-override lenient) + skip пустого ФИО против патологической ЧС-записи. Прошёл code-reviewer (go, без red, off-limits не затронуты). Валидация до транзакции - нет частичных вставок на 400.