### PR TITLE
fix(blacklist): полировка UI ЧС (заголовок колонки, модалка пропуска, кнопки)

### DIFF
--- a/frontend/src/components/ApplicationDetail/BlacklistOverrideModal.vue
+++ b/frontend/src/components/ApplicationDetail/BlacklistOverrideModal.vue
@@ -4,12 +4,13 @@
     title="Всё равно пропустить?"
     width="460px"
     :z-index="10005"
+    content-class="bl-override-modal"
     @close="$emit('close')"
   >
     <div class="override-body">
       <p class="override-lead">
         Элемент похож на активную запись чёрного списка, но это не точное совпадение.
-        Подтвердите пропуск - действие фиксируется в аудите (кто, когда, причина).
+        Подтвердите действие.
       </p>
 
       <div
@@ -26,7 +27,7 @@
           v-if="flag.matched_reason"
           class="override-matched__reason"
         >
-          Причина совпадения: {{ flag.matched_reason }}
+          Причина: {{ flag.matched_reason }}
         </div>
       </div>
 
@@ -38,7 +39,7 @@
           v-model="comment"
           class="lk-textarea"
           rows="3"
-          placeholder="Например: проверено по СТС, это другой автомобиль"
+          placeholder="Введите причину..."
           @keydown.enter.ctrl="submit"
         />
       </FormField>
@@ -153,5 +154,13 @@ export default {
     font-size: 12.5px;
     color: #7f1d1d;
     margin-top: 2px;
+}
+</style>
+
+<!-- не scoped: контент BaseModal телепортится в body и несёт data-v самого BaseModal,
+     поэтому радиус задаём глобально двойным классом (бьёт scoped .base-modal BaseModal). -->
+<style>
+.base-modal.bl-override-modal {
+    border-radius: 30px;
 }
 </style>

--- a/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
@@ -37,7 +37,7 @@
                   class="blacklist-add-btn"
                   @click="openAddBlacklist"
                 >
-                  <span>Добавить в ЧС</span>
+                  <span>В ЧС</span>
                 </button>
               </div>
               <button

--- a/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
@@ -42,7 +42,7 @@
                   class="blacklist-add-btn"
                   @click="openAddBlacklist"
                 >
-                  <span>Добавить в ЧС</span>
+                  <span>В ЧС</span>
                 </button>
               </div>
               <button

--- a/frontend/src/components/admin/blacklist/BlacklistTabBase.vue
+++ b/frontend/src/components/admin/blacklist/BlacklistTabBase.vue
@@ -353,6 +353,12 @@ export default {
   flex-shrink: 0;
 }
 
+/* фиксированная ширина: триггер не меняет размер между "Активные" и "Архив" */
+.bl-archive-dropdown {
+  width: 150px;
+  flex-shrink: 0;
+}
+
 .bl-content {
   display: flex;
   height: 460px;
@@ -546,7 +552,6 @@ export default {
   padding: 12px 16px;
   background: #fdf3f3;
   border-radius: var(--radius-md);
-  border-left: 3px solid var(--color-danger);
 }
 
 .bl-reason-label {

--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -1357,6 +1357,11 @@ export default {
     /* min-width:0 снимает min-content "пол" flex-элемента: иначе nowrap-бейдж под номером
        не даёт строке сжаться до своей доли, и шапка (узкий контент) расходится со строкой. */
     min-width: 0;
+}
+
+/* column-stack (номер + бейдж) только в строках данных. У заголовка остаётся row из
+   .header-col, иначе иконка сортировки уезжает под текст. */
+.application-col.number-col {
     flex-direction: column;
     justify-content: center;
     align-items: flex-start;


### PR DESCRIPTION
Полировка UI ЧС (#481) по замечаниям ручной проверки. Только FE, без BE.

- **Центр заявок:** `.number-col` имел `flex-direction:column` на общем классе - заголовок
  тоже стопкой, иконка сортировки уезжала под текст. Column оставил только строкам данных
  (`.application-col.number-col`), шапка снова row.
- **Модалка "Всё равно пропустить":** радиус 30px (через `content-class`, без правки общего
  BaseModal); текст урезан до "Подтвердите действие" (убрал про аудит); "Причина совпадения"
  -> "Причина" (matched_reason - это reason из записи ЧС); плейсхолдер "Введите причину...".
- **Карточки авто/сотрудника:** кнопка "Добавить в ЧС" -> "В ЧС".
- **/admin/blacklist:** дропдаун Активные/Архив фиксированной ширины (150px) - не прыгает
  при переключении; убран `border-left` у блока причины.

## Верификация (Playwright, локально)
- Шапка: иконка справа от текста (row), данные: бейдж под номером (column).
- Дропдаун: 150px и для "Активные", и для "Архив".
- Модалка: border-radius 30px, текст без "фиксируется" + "Подтвердите действие",
  "Причина: ...", плейсхолдер "Введите причину...".

ESLint чистый, BlacklistTabBase.spec - 21 passed.

Дальше отдельными PR: правка номера/ФИО при редактировании в ЧС; блок подозрения в
карточке + отмена "Пропуск подтверждён".
