### PR TITLE
fix(applications): необязательные доп. поля не блокируют отправку заявки (#529)

### DIFF
--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -504,7 +504,7 @@ export default {
                 const uaId = attachment.template_id || attachment.id;
                 const fields = this.customFieldDefinitions[uaId] || [];
                 const values = this.customFieldsByAttachment[key] || {};
-                const emptyFields = fields.filter(f => !values[f.id] || !values[f.id].trim());
+                const emptyFields = fields.filter(f => f.is_required && (!values[f.id] || !values[f.id].trim()));
                 if (emptyFields.length > 0) {
                     reasons.push(`"${label}": заполните доп. поля: ${emptyFields.map(f => f.label).join(', ')}`);
                 }
@@ -573,7 +573,7 @@ export default {
                 const uaId = attachment.template_id || attachment.id;
                 const cfFields = this.customFieldDefinitions[uaId] || [];
                 const cfValues = this.customFieldsByAttachment[key] || {};
-                const emptyCf = cfFields.filter(f => !cfValues[f.id] || !cfValues[f.id].trim());
+                const emptyCf = cfFields.filter(f => f.is_required && (!cfValues[f.id] || !cfValues[f.id].trim()));
                 if (emptyCf.length > 0) {
                     emptyCf.forEach(f => errors.push(`Не заполнено доп. поле "${f.label}"`));
                 }


### PR DESCRIPTION
Баг со staging: кастомное поле «Экспедитор» (is_required=false) блокировало отправку заявки, а hint кнопки врал что оно обязательное.

Причина: submit-валидация в CreateApplication.vue (computed submitValidation и tooltipSections) фильтровала ВСЕ кастомные поля как обязательные, без проверки is_required. Флаг is_required добавляли кастомным полям в #529 (H-4/H-8), но submit-валидацию не обновили - CustomFieldsSection флаг уважал, а кнопка нет.

Фикс: добавил f.is_required в оба фильтра (строки 507, 576). Грепнул фронт - других мест с тем же паттерном нет.