### PR TITLE
feat(blacklist): правка номера/марки и ФИО записи реестра, не только причины

### DIFF
--- a/frontend/src/api/blacklist.js
+++ b/frontend/src/api/blacklist.js
@@ -34,8 +34,8 @@ export function createVehicleBlacklist({ car_number, mark_id, reason }) {
   return mutate('/vehicle-blacklist', { body: { car_number, mark_id, reason } });
 }
 
-export function updateVehicleBlacklist(id, { reason }) {
-  return mutate(`/vehicle-blacklist/${id}`, { method: 'PUT', body: { reason } });
+export function updateVehicleBlacklist(id, { car_number, mark_id, reason }) {
+  return mutate(`/vehicle-blacklist/${id}`, { method: 'PUT', body: { car_number, mark_id, reason } });
 }
 
 export function archiveVehicleBlacklist(id) {
@@ -54,8 +54,8 @@ export function createPersonBlacklist({ last_name, first_name, middle_name, reas
   return mutate('/person-blacklist', { body: { last_name, first_name, middle_name, reason } });
 }
 
-export function updatePersonBlacklist(id, { reason }) {
-  return mutate(`/person-blacklist/${id}`, { method: 'PUT', body: { reason } });
+export function updatePersonBlacklist(id, { last_name, first_name, middle_name, reason }) {
+  return mutate(`/person-blacklist/${id}`, { method: 'PUT', body: { last_name, first_name, middle_name, reason } });
 }
 
 export function archivePersonBlacklist(id) {

--- a/frontend/src/components/admin/blacklist/AddToBlacklistModal.vue
+++ b/frontend/src/components/admin/blacklist/AddToBlacklistModal.vue
@@ -7,17 +7,80 @@
     @close="close"
   >
     <div class="atb">
-      <div class="atb-entity">
+      <!-- ADD: сущность уже известна (из карточки), показываем read-only -->
+      <div
+        v-if="!isEdit"
+        class="atb-entity"
+      >
         <span class="atb-entity-label">{{ entityCaption }}</span>
         <span class="atb-entity-value">{{ entityLabel }}</span>
       </div>
+
+      <!-- EDIT: правка идентичности записи реестра -->
+      <template v-else>
+        <template v-if="type === 'vehicle'">
+          <FormField
+            label="Номер Т/С"
+            :required="true"
+          >
+            <input
+              ref="firstInput"
+              v-model="carNumber"
+              class="lk-input"
+              placeholder="А777АА 77"
+            >
+          </FormField>
+          <FormField
+            label="Марка Т/С"
+            :required="true"
+          >
+            <BaseDropdown
+              v-model="markId"
+              :options="marks"
+              label-key="name"
+              value-key="id"
+              :searchable="true"
+              placeholder="Выберите марку"
+            />
+          </FormField>
+        </template>
+        <template v-else>
+          <FormField
+            label="Фамилия"
+            :required="true"
+          >
+            <input
+              ref="firstInput"
+              v-model="lastName"
+              class="lk-input"
+              placeholder="Иванов"
+            >
+          </FormField>
+          <FormField
+            label="Имя"
+            :required="true"
+          >
+            <input
+              v-model="firstName"
+              class="lk-input"
+              placeholder="Иван"
+            >
+          </FormField>
+          <FormField label="Отчество">
+            <input
+              v-model="middleName"
+              class="lk-input"
+              placeholder="Иванович (необязательно)"
+            >
+          </FormField>
+        </template>
+      </template>
 
       <FormField
         label="Причина"
         :required="true"
       >
         <textarea
-          ref="reasonInput"
           v-model="reason"
           class="lk-textarea"
           rows="3"
@@ -44,7 +107,7 @@
       <button
         class="lk-button"
         :class="isEdit ? 'lk-button--primary' : 'lk-button--danger'"
-        :disabled="!reason.trim() || saving"
+        :disabled="!canConfirm || saving"
         @click="confirm"
       >
         {{ confirmText }}
@@ -56,39 +119,50 @@
 <script>
 import BaseModal from '@/components/ui/BaseModal.vue';
 import FormField from '@/components/ui/FormField.vue';
+import BaseDropdown from '@/components/ui/BaseDropdown.vue';
+import { listMarks } from '@/api/marks';
 
 /**
- * Модалка-подтверждение добавления в чёрный список из карточки сущности (#443).
- * Сущность уже известна (показывается read-only), оператору остаётся ввести причину.
- * Само создание (резолв mark_id для машин, вызов API) - на стороне родителя: модалка
- * только собирает причину и эмитит confirm(reason). error/saving контролирует родитель.
+ * Модалка добавления/редактирования записи чёрного списка.
+ * - mode='add' (из карточки сущности, #443): сущность read-only, оператор вводит причину,
+ *   confirm(reason: string).
+ * - mode='edit' (из реестра ЧС): правка идентичности (номер+марка / ФИО) и причины,
+ *   confirm(payload: object). Идентичность приходит в initialEntity.
+ * Сам вызов API (create/update) - на стороне родителя; error/saving контролирует родитель.
  */
 export default {
   name: 'AddToBlacklistModal',
-  components: { BaseModal, FormField },
+  components: { BaseModal, FormField, BaseDropdown },
   props: {
     show: { type: Boolean, default: false },
     type: { type: String, required: true, validator: (v) => ['vehicle', 'person'].includes(v) },
-    // 'add' - добавление из карточки; 'edit' - редактирование причины из страницы ЧС.
     mode: { type: String, default: 'add', validator: (v) => ['add', 'edit'].includes(v) },
     entityLabel: { type: String, default: '' },
     initialReason: { type: String, default: '' },
+    // Префилл идентичности для edit: { car_number, mark_id, last_name, first_name, middle_name }.
+    initialEntity: { type: Object, default: () => ({}) },
     saving: { type: Boolean, default: false },
     error: { type: String, default: '' },
-    // Открывается из карточки Т/С/сотрудника (z-index 10001) - перекрываем её. Ниже
-    // DirtyConfirmModal (11000).
     zIndex: { type: Number, default: 10500 },
   },
   emits: ['close', 'confirm'],
   data() {
-    return { reason: '' };
+    return {
+      reason: '',
+      carNumber: '',
+      markId: null,
+      lastName: '',
+      firstName: '',
+      middleName: '',
+      marks: [],
+    };
   },
   computed: {
     isEdit() {
       return this.mode === 'edit';
     },
     title() {
-      if (this.isEdit) return 'Редактировать причину';
+      if (this.isEdit) return this.type === 'vehicle' ? 'Редактировать машину' : 'Редактировать человека';
       return this.type === 'vehicle' ? 'Добавить машину в чёрный список' : 'Добавить человека в чёрный список';
     },
     entityCaption() {
@@ -98,24 +172,60 @@ export default {
       if (this.isEdit) return this.saving ? 'Сохранение...' : 'Сохранить';
       return this.saving ? 'Добавление...' : 'Добавить в ЧС';
     },
+    canConfirm() {
+      if (!this.reason.trim() || this.saving) return false;
+      if (!this.isEdit) return true;
+      if (this.type === 'vehicle') return !!this.carNumber.trim() && !!this.markId;
+      return !!this.lastName.trim() && !!this.firstName.trim();
+    },
   },
   watch: {
     show(open) {
-      if (open) {
-        this.reason = this.initialReason || '';
-        this.$nextTick(() => this.$refs.reasonInput?.focus());
+      if (!open) return;
+      this.reason = this.initialReason || '';
+      if (this.isEdit) {
+        const e = this.initialEntity || {};
+        this.carNumber = e.car_number || '';
+        this.markId = e.mark_id ?? null;
+        this.lastName = e.last_name || '';
+        this.firstName = e.first_name || '';
+        this.middleName = e.middle_name || '';
+        if (this.type === 'vehicle') this.loadMarks();
       }
+      this.$nextTick(() => this.$refs.firstInput?.focus());
     },
   },
   methods: {
+    async loadMarks() {
+      try {
+        const marks = await listMarks();
+        const arr = Array.isArray(marks) ? marks : [];
+        this.marks = arr.filter((m) => m.is_active !== false).map((m) => ({ id: m.id, name: m.name }));
+      } catch {
+        this.marks = [];
+      }
+    },
     close() {
       if (this.saving) return;
       this.$emit('close');
     },
     confirm() {
+      if (!this.canConfirm) return;
       const reason = this.reason.trim();
-      if (!reason || this.saving) return;
-      this.$emit('confirm', reason);
+      if (!this.isEdit) {
+        this.$emit('confirm', reason);
+        return;
+      }
+      if (this.type === 'vehicle') {
+        this.$emit('confirm', { car_number: this.carNumber.trim(), mark_id: this.markId, reason });
+      } else {
+        this.$emit('confirm', {
+          last_name: this.lastName.trim(),
+          first_name: this.firstName.trim(),
+          middle_name: this.middleName.trim(),
+          reason,
+        });
+      }
     },
   },
 };

--- a/frontend/src/components/admin/blacklist/PersonBlacklistTab.vue
+++ b/frontend/src/components/admin/blacklist/PersonBlacklistTab.vue
@@ -27,6 +27,7 @@
       mode="edit"
       :entity-label="editItem ? primaryText(editItem) : ''"
       :initial-reason="editItem ? editItem.reason : ''"
+      :initial-entity="editItem || {}"
       :saving="savingEdit"
       :error="editError"
       :z-index="1000"
@@ -177,18 +178,18 @@ export default {
       this.editError = '';
       this.editItem = item;
     },
-    async saveEdit(reason) {
+    async saveEdit(payload) {
       const item = this.editItem;
       if (!item || this.savingEdit) return;
       this.savingEdit = true;
       this.editError = '';
       try {
-        await updatePersonBlacklist(item.id, { reason });
-        useDeletionsStore().notify({ prefix: 'Причина обновлена для ', bold: this.primaryText(item) });
+        const updated = await updatePersonBlacklist(item.id, payload);
+        useDeletionsStore().notify({ prefix: 'Запись обновлена: ', bold: this.primaryText(updated || item) });
         this.editItem = null;
         await this.$refs.base.fetchData();
       } catch (e) {
-        this.editError = e?.message || 'Не удалось сохранить причину';
+        this.editError = e?.message || 'Не удалось сохранить';
       } finally {
         this.savingEdit = false;
       }

--- a/frontend/src/components/admin/blacklist/VehicleBlacklistTab.vue
+++ b/frontend/src/components/admin/blacklist/VehicleBlacklistTab.vue
@@ -27,6 +27,7 @@
       mode="edit"
       :entity-label="editItem ? primaryText(editItem) : ''"
       :initial-reason="editItem ? editItem.reason : ''"
+      :initial-entity="editItem || {}"
       :saving="savingEdit"
       :error="editError"
       :z-index="1000"
@@ -172,18 +173,18 @@ export default {
       this.editError = '';
       this.editItem = item;
     },
-    async saveEdit(reason) {
+    async saveEdit(payload) {
       const item = this.editItem;
       if (!item || this.savingEdit) return;
       this.savingEdit = true;
       this.editError = '';
       try {
-        await updateVehicleBlacklist(item.id, { reason });
-        useDeletionsStore().notify({ prefix: 'Причина обновлена для ', bold: this.primaryText(item) });
+        const updated = await updateVehicleBlacklist(item.id, payload);
+        useDeletionsStore().notify({ prefix: 'Запись обновлена: ', bold: this.primaryText(updated || item) });
         this.editItem = null;
         await this.$refs.base.fetchData();
       } catch (e) {
-        this.editError = e?.message || 'Не удалось сохранить причину';
+        this.editError = e?.message || 'Не удалось сохранить';
       } finally {
         this.savingEdit = false;
       }

--- a/frontend/src/components/admin/blacklist/__tests__/AddToBlacklistModal.spec.js
+++ b/frontend/src/components/admin/blacklist/__tests__/AddToBlacklistModal.spec.js
@@ -1,6 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import AddToBlacklistModal from '../AddToBlacklistModal.vue';
+
+// marks подгружаются в vehicle edit-режиме - мокаем, чтобы не ходить в сеть.
+vi.mock('@/api/marks', () => ({ listMarks: () => Promise.resolve([{ id: 5, name: 'BMW' }]) }));
 
 // BaseModal рендерит через Teleport - стабим, чтобы контент был в обёртке для запросов.
 const stubs = {
@@ -67,23 +70,47 @@ describe('AddToBlacklistModal', () => {
   describe('режим редактирования (mode=edit)', () => {
     it('заголовок и кнопка - для редактирования', () => {
       const wrapper = mountModal({ mode: 'edit', type: 'person' });
-      expect(wrapper.vm.title).toBe('Редактировать причину');
+      expect(wrapper.vm.title).toBe('Редактировать человека');
       const btn = wrapper.findAll('button').find((b) => b.text().includes('Сохранить'));
       expect(btn).toBeTruthy();
     });
 
-    it('предзаполняет причину из initialReason при открытии', async () => {
-      const wrapper = mountModal({ show: false, mode: 'edit', initialReason: 'прежняя причина' });
+    it('предзаполняет причину и идентичность из initial* при открытии', async () => {
+      const wrapper = mountModal({
+        show: false, mode: 'edit', type: 'person', initialReason: 'прежняя причина',
+        initialEntity: { last_name: 'Иванов', first_name: 'Иван', middle_name: 'Иванович' },
+      });
       await wrapper.setProps({ show: true });
       expect(wrapper.vm.reason).toBe('прежняя причина');
+      expect(wrapper.vm.lastName).toBe('Иванов');
+      expect(wrapper.vm.firstName).toBe('Иван');
     });
 
-    it('confirm эмитит изменённую причину', async () => {
-      const wrapper = mountModal({ show: false, mode: 'edit', initialReason: 'старая' });
+    it('confirm (person) эмитит объект с ФИО и причиной', async () => {
+      const wrapper = mountModal({
+        show: false, mode: 'edit', type: 'person',
+        initialEntity: { last_name: 'Иванов', first_name: 'Иван', middle_name: '' },
+      });
       await wrapper.setProps({ show: true });
       await wrapper.find('textarea').setValue('новая причина');
       await wrapper.findAll('button').find((b) => b.text().includes('Сохранить')).trigger('click');
-      expect(wrapper.emitted('confirm')[0]).toEqual(['новая причина']);
+      expect(wrapper.emitted('confirm')[0]).toEqual([
+        { last_name: 'Иванов', first_name: 'Иван', middle_name: '', reason: 'новая причина' },
+      ]);
+    });
+
+    it('confirm (vehicle) эмитит объект с номером, маркой и причиной', async () => {
+      const wrapper = mountModal({
+        show: false, mode: 'edit', type: 'vehicle',
+        initialEntity: { car_number: 'А777АА77', mark_id: 5 },
+      });
+      await wrapper.setProps({ show: true });
+      await wrapper.find('textarea').setValue('угон');
+      expect(wrapper.vm.markId).toBe(5);
+      wrapper.vm.confirm();
+      expect(wrapper.emitted('confirm')[0]).toEqual([
+        { car_number: 'А777АА77', mark_id: 5, reason: 'угон' },
+      ]);
     });
   });
 });

--- a/internal/handlers/person_blacklist.go
+++ b/internal/handlers/person_blacklist.go
@@ -60,13 +60,13 @@ func (h *PersonBlacklistHandler) Create(c echo.Context) error {
 }
 
 // Update godoc
-// @Summary      Редактировать причину записи чёрного списка
+// @Summary      Редактировать запись чёрного списка (ФИО, причина)
 // @Tags         person-blacklist
 // @Accept       json
 // @Produce      json
 // @Security     BearerAuth
 // @Param        id path int true "ID записи"
-// @Param        request body models.UpdateBlacklistReasonRequest true "Новая причина"
+// @Param        request body models.UpdatePersonBlacklistRequest true "ФИО, причина"
 // @Success      200 {object} models.PersonBlacklist
 // @Router       /person-blacklist/{id} [put]
 func (h *PersonBlacklistHandler) Update(c echo.Context) error {
@@ -74,12 +74,12 @@ func (h *PersonBlacklistHandler) Update(c echo.Context) error {
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
 	}
-	var req models.UpdateBlacklistReasonRequest
+	var req models.UpdatePersonBlacklistRequest
 	if err := BindAndValidate(c, &req); err != nil {
 		return err
 	}
 	userID, _ := c.Get("user_id").(int)
-	entry, err := h.service.UpdateReason(c.Request().Context(), id, req.Reason, userID)
+	entry, err := h.service.Update(c.Request().Context(), id, req, userID)
 	if err != nil {
 		return err
 	}

--- a/internal/handlers/person_blacklist_test.go
+++ b/internal/handlers/person_blacklist_test.go
@@ -341,3 +341,70 @@ func TestPersonBlacklist_FindSimilar(t *testing.T) {
 		}
 	})
 }
+
+// TestPersonBlacklist_Update покрывает правку ФИО/причины: лог истории, пересчёт нормали,
+// дубль -> 409, запрет правки архивной.
+func TestPersonBlacklist_Update(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	userID, _, userCleanup := setupMWUser(t, db, true, false)
+	defer userCleanup()
+	svc := newPersonBlacklistService(db)
+	ctx := context.Background()
+
+	entry, err := svc.Create(ctx, models.CreatePersonBlacklistRequest{
+		LastName: "Иванов", FirstName: "Иван", MiddleName: "Иванович", Reason: "старая",
+	}, userID)
+	require.NoError(t, err)
+	oldFIO := entry.NormalizedFIO
+
+	t.Run("правка причины - сохраняется + история", func(t *testing.T) {
+		_, err := svc.Update(ctx, entry.ID, models.UpdatePersonBlacklistRequest{
+			LastName: "Иванов", FirstName: "Иван", MiddleName: "Иванович", Reason: "  новая  ",
+		}, userID)
+		require.NoError(t, err)
+		stored, err := svc.GetByID(ctx, entry.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "новая", stored.Reason)
+	})
+
+	t.Run("смена ФИО - пересчёт нормали", func(t *testing.T) {
+		_, err := svc.Update(ctx, entry.ID, models.UpdatePersonBlacklistRequest{
+			LastName: "Петров", FirstName: "Пётр", MiddleName: "Петрович", Reason: "новая",
+		}, userID)
+		require.NoError(t, err)
+		stored, err := svc.GetByID(ctx, entry.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "Петров", stored.LastName)
+		assert.NotEqual(t, oldFIO, stored.NormalizedFIO, "нормаль должна пересчитаться")
+		assert.NotEmpty(t, stored.NormalizedFIO)
+	})
+
+	t.Run("пустые фамилия/имя - 400", func(t *testing.T) {
+		_, err := svc.Update(ctx, entry.ID, models.UpdatePersonBlacklistRequest{
+			LastName: "  ", FirstName: "Пётр", Reason: "x",
+		}, userID)
+		assertHTTPStatus(t, err, 400)
+	})
+
+	t.Run("дубль активной записи - 409", func(t *testing.T) {
+		other, err := svc.Create(ctx, models.CreatePersonBlacklistRequest{
+			LastName: "Сидоров", FirstName: "Сидор", Reason: "вторая",
+		}, userID)
+		require.NoError(t, err)
+		_, err = svc.Update(ctx, other.ID, models.UpdatePersonBlacklistRequest{
+			LastName: "Петров", FirstName: "Пётр", MiddleName: "Петрович", Reason: "вторая",
+		}, userID)
+		assertHTTPStatus(t, err, 409)
+	})
+
+	t.Run("нельзя редактировать архивную - 400", func(t *testing.T) {
+		require.NoError(t, svc.Archive(ctx, entry.ID, userID))
+		_, err := svc.Update(ctx, entry.ID, models.UpdatePersonBlacklistRequest{
+			LastName: "Петров", FirstName: "Пётр", MiddleName: "Петрович", Reason: "после архива",
+		}, userID)
+		assertHTTPStatus(t, err, 400)
+	})
+}

--- a/internal/handlers/vehicle_blacklist.go
+++ b/internal/handlers/vehicle_blacklist.go
@@ -60,13 +60,13 @@ func (h *VehicleBlacklistHandler) Create(c echo.Context) error {
 }
 
 // Update godoc
-// @Summary      Редактировать причину записи чёрного списка
+// @Summary      Редактировать запись чёрного списка (номер, марка, причина)
 // @Tags         vehicle-blacklist
 // @Accept       json
 // @Produce      json
 // @Security     BearerAuth
 // @Param        id path int true "ID записи"
-// @Param        request body models.UpdateBlacklistReasonRequest true "Новая причина"
+// @Param        request body models.UpdateVehicleBlacklistRequest true "Номер, марка, причина"
 // @Success      200 {object} models.VehicleBlacklist
 // @Router       /vehicle-blacklist/{id} [put]
 func (h *VehicleBlacklistHandler) Update(c echo.Context) error {
@@ -74,12 +74,12 @@ func (h *VehicleBlacklistHandler) Update(c echo.Context) error {
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
 	}
-	var req models.UpdateBlacklistReasonRequest
+	var req models.UpdateVehicleBlacklistRequest
 	if err := BindAndValidate(c, &req); err != nil {
 		return err
 	}
 	userID, _ := c.Get("user_id").(int)
-	entry, err := h.service.UpdateReason(c.Request().Context(), id, req.Reason, userID)
+	entry, err := h.service.Update(c.Request().Context(), id, req, userID)
 	if err != nil {
 		return err
 	}

--- a/internal/handlers/vehicle_blacklist_test.go
+++ b/internal/handlers/vehicle_blacklist_test.go
@@ -262,7 +262,11 @@ func TestVehicleBlacklist_UpdateReason(t *testing.T) {
 	}, userID)
 	require.NoError(t, err)
 
-	updated, err := svc.UpdateReason(ctx, entry.ID, "  новая причина  ", userID)
+	reasonOnly := func(reason string) models.UpdateVehicleBlacklistRequest {
+		return models.UpdateVehicleBlacklistRequest{CarNumber: "U111UU799", MarkID: mark.ID, Reason: reason}
+	}
+
+	updated, err := svc.Update(ctx, entry.ID, reasonOnly("  новая причина  "), userID)
 	require.NoError(t, err)
 	assert.Equal(t, "новая причина", updated.Reason)
 
@@ -281,21 +285,45 @@ func TestVehicleBlacklist_UpdateReason(t *testing.T) {
 	assert.True(t, hasUpdated, "ожидали запись истории 'updated'")
 
 	t.Run("пустая причина - 400", func(t *testing.T) {
-		_, err := svc.UpdateReason(ctx, entry.ID, "   ", userID)
+		_, err := svc.Update(ctx, entry.ID, reasonOnly("   "), userID)
 		assertHTTPStatus(t, err, http.StatusBadRequest)
 	})
 
-	t.Run("та же причина - без новой записи истории", func(t *testing.T) {
+	t.Run("та же причина и номер - без новой записи истории", func(t *testing.T) {
 		before, _ := svc.GetHistory(ctx, entry.ID)
-		_, err := svc.UpdateReason(ctx, entry.ID, "новая причина", userID)
+		_, err := svc.Update(ctx, entry.ID, reasonOnly("новая причина"), userID)
 		require.NoError(t, err)
 		after, _ := svc.GetHistory(ctx, entry.ID)
-		assert.Equal(t, len(before), len(after), "идентичная причина не должна писать историю")
+		assert.Equal(t, len(before), len(after), "идентичная правка не должна писать историю")
+	})
+
+	t.Run("смена номера - история + пересчёт нормали", func(t *testing.T) {
+		_, err := svc.Update(ctx, entry.ID, models.UpdateVehicleBlacklistRequest{
+			CarNumber: "U222UU799", MarkID: mark.ID, Reason: "новая причина",
+		}, userID)
+		require.NoError(t, err)
+		stored, err := svc.GetByID(ctx, entry.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "U222UU799", stored.CarNumber)
+		assert.Equal(t, normalize.Plate("U222UU799"), stored.NormalizedNumber)
+	})
+
+	t.Run("дубль активной записи - 409", func(t *testing.T) {
+		other, err := svc.Create(ctx, models.CreateVehicleBlacklistRequest{
+			CarNumber: "U333UU799", MarkID: mark.ID, Reason: "вторая",
+		}, userID)
+		require.NoError(t, err)
+		_, err = svc.Update(ctx, other.ID, models.UpdateVehicleBlacklistRequest{
+			CarNumber: "U222UU799", MarkID: mark.ID, Reason: "вторая",
+		}, userID)
+		assertHTTPStatus(t, err, http.StatusConflict)
 	})
 
 	t.Run("нельзя редактировать архивную запись - 400", func(t *testing.T) {
 		require.NoError(t, svc.Archive(ctx, entry.ID, userID))
-		_, err := svc.UpdateReason(ctx, entry.ID, "после архива", userID)
+		_, err := svc.Update(ctx, entry.ID, models.UpdateVehicleBlacklistRequest{
+			CarNumber: "U222UU799", MarkID: mark.ID, Reason: "после архива",
+		}, userID)
 		assertHTTPStatus(t, err, http.StatusBadRequest)
 	})
 }

--- a/internal/models/blacklist.go
+++ b/internal/models/blacklist.go
@@ -62,9 +62,19 @@ type CreateVehicleBlacklistRequest struct {
 	Reason    string `json:"reason" validate:"required,min=1"`
 }
 
-// UpdateBlacklistReasonRequest - тело PUT /<entity>-blacklist/{id} (редактирование причины).
-type UpdateBlacklistReasonRequest struct {
-	Reason string `json:"reason" validate:"required,min=1"`
+// UpdateVehicleBlacklistRequest - тело PUT /vehicle-blacklist/{id}: правка номера, марки и причины.
+type UpdateVehicleBlacklistRequest struct {
+	CarNumber string `json:"car_number" validate:"required,min=1,max=50"`
+	MarkID    int    `json:"mark_id" validate:"required"`
+	Reason    string `json:"reason" validate:"required,min=1"`
+}
+
+// UpdatePersonBlacklistRequest - тело PUT /person-blacklist/{id}: правка ФИО и причины.
+type UpdatePersonBlacklistRequest struct {
+	LastName   string `json:"last_name" validate:"required,min=1,max=100"`
+	FirstName  string `json:"first_name" validate:"required,min=1,max=100"`
+	MiddleName string `json:"middle_name" validate:"omitempty,max=100"`
+	Reason     string `json:"reason" validate:"required,min=1"`
 }
 
 // VehicleBlacklistHistoryItem - элемент истории для API (с именем пользователя).

--- a/internal/services/person_blacklist_service.go
+++ b/internal/services/person_blacklist_service.go
@@ -32,8 +32,10 @@ type PersonBlacklistService interface {
 	// отсутствия отчества), порог 0.7. Слой предупреждения о возможном обходе (#481): точное
 	// совпадение ловит Check (409). Пустой срез - похожих нет.
 	FindSimilar(ctx context.Context, lastName, firstName, middleName string) ([]models.BlacklistSimilarMatch, error)
-	// UpdateReason - редактирование причины записи + лог в историю (updated).
-	UpdateReason(ctx context.Context, id int, reason string, userID int) (*models.PersonBlacklist, error)
+	// Update - правка активной записи (ФИО/причина) + лог в историю (updated). При смене
+	// ФИО перекаскадивает employees: реактивирует совпадавших со старым ФИО, деактивирует
+	// совпадающих с новым. Дубль активной записи -> 409.
+	Update(ctx context.Context, id int, req models.UpdatePersonBlacklistRequest, userID int) (*models.PersonBlacklist, error)
 	// Purge - удаление архивной записи навсегда: запись удаляется физически, но событие
 	// purged (с ФИО) остаётся в общем журнале ЧС. Активную удалять нельзя.
 	Purge(ctx context.Context, id int, userID int) error
@@ -247,38 +249,90 @@ func (s *personBlacklistService) FindSimilar(ctx context.Context, lastName, firs
 	return matches, nil
 }
 
-func (s *personBlacklistService) UpdateReason(ctx context.Context, id int, reason string, userID int) (*models.PersonBlacklist, error) {
+func (s *personBlacklistService) Update(ctx context.Context, id int, req models.UpdatePersonBlacklistRequest, userID int) (*models.PersonBlacklist, error) {
 	e, err := s.GetByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
 	if !e.IsActive {
-		return nil, echo.NewHTTPError(http.StatusBadRequest, "Нельзя редактировать причину архивной записи")
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "Нельзя редактировать архивную запись")
 	}
-	newReason := strings.TrimSpace(reason)
+	lastName := strings.TrimSpace(req.LastName)
+	firstName := strings.TrimSpace(req.FirstName)
+	middleName := strings.TrimSpace(req.MiddleName)
+	newReason := strings.TrimSpace(req.Reason)
+	if lastName == "" || firstName == "" {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "Фамилия и имя обязательны")
+	}
 	if newReason == "" {
 		return nil, echo.NewHTTPError(http.StatusBadRequest, "Причина обязательна")
 	}
-	if newReason == e.Reason {
+
+	oldMiddle := ""
+	if e.MiddleName != nil {
+		oldMiddle = *e.MiddleName
+	}
+	identityChanged := !strings.EqualFold(strings.TrimSpace(e.LastName), lastName) ||
+		!strings.EqualFold(strings.TrimSpace(e.FirstName), firstName) ||
+		!strings.EqualFold(strings.TrimSpace(oldMiddle), middleName)
+	if !identityChanged && newReason == e.Reason {
 		return e, nil // без изменений - не пишем историю
 	}
-	oldReason := e.Reason
+
+	old := *e
+	updated := *e
+	updated.LastName = lastName
+	updated.FirstName = firstName
+	updated.MiddleName = normalizeMiddleName(req.MiddleName)
+	updated.NormalizedFIO = normalize.Name(lastName, firstName, middleName)
+	updated.Reason = newReason
+
 	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		if err := tx.Model(&models.PersonBlacklist{}).Where("id = ?", e.ID).Update("reason", newReason).Error; err != nil {
+		reactivated, deactivated := 0, 0
+		// При смене ФИО employees, привязанные к старому ФИО, больше не покрыты этой записью -
+		// возвращаем их; новые совпадения гасим.
+		if identityChanged {
+			r, err := s.reactivateMatchingEmployees(ctx, tx, old, userID)
+			if err != nil {
+				return err
+			}
+			reactivated = r
+		}
+		if err := tx.Model(&models.PersonBlacklist{}).Where("id = ?", e.ID).Updates(map[string]interface{}{
+			"last_name":      updated.LastName,
+			"first_name":     updated.FirstName,
+			"middle_name":    updated.MiddleName,
+			"normalized_fio": updated.NormalizedFIO,
+			"reason":         updated.Reason,
+		}).Error; err != nil {
 			return err
 		}
+		if identityChanged {
+			d, err := s.deactivateMatchingEmployees(ctx, tx, updated, userID)
+			if err != nil {
+				return err
+			}
+			deactivated = d
+		}
 		details := map[string]interface{}{
-			"full_name":  personFullName(*e),
-			"reason_old": oldReason,
-			"reason_new": newReason,
+			"full_name_old": personFullName(old),
+			"full_name_new": personFullName(updated),
+			"reason_old":    old.Reason,
+			"reason_new":    updated.Reason,
+		}
+		if identityChanged {
+			details["employees_reactivated"] = reactivated
+			details["employees_deactivated"] = deactivated
 		}
 		return s.history.Log(ctx, tx, e.ID, &userID, models.BlacklistActionUpdated, details)
 	})
 	if err != nil {
-		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка обновления причины")
+		if isUniqueViolation(err) {
+			return nil, echo.NewHTTPError(http.StatusConflict, "Этот человек уже в чёрном списке")
+		}
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка обновления записи")
 	}
-	e.Reason = newReason
-	return e, nil
+	return &updated, nil
 }
 
 // Purge удаляет архивную запись навсегда. Логируем purged-событие (с ФИО в details),

--- a/internal/services/vehicle_blacklist_service.go
+++ b/internal/services/vehicle_blacklist_service.go
@@ -47,8 +47,10 @@ type VehicleBlacklistService interface {
 	// Слой предупреждения о возможном обходе (#481): точное совпадение ловит Check (409),
 	// сюда попадают опечатка/гомоглиф/подмена 0<->О. Пустой срез - похожих нет.
 	FindSimilar(ctx context.Context, carNumber string) ([]models.BlacklistSimilarMatch, error)
-	// UpdateReason - редактирование причины записи + лог в историю (updated).
-	UpdateReason(ctx context.Context, id int, reason string, userID int) (*models.VehicleBlacklist, error)
+	// Update - правка активной записи (номер/марка/причина) + лог в историю (updated). При
+	// смене идентичности перекаскадивает cars: реактивирует совпадавшие со старым номером,
+	// деактивирует совпадающие с новым. Дубль активной записи -> 409.
+	Update(ctx context.Context, id int, req models.UpdateVehicleBlacklistRequest, userID int) (*models.VehicleBlacklist, error)
 	// Purge - удаление архивной записи навсегда: запись удаляется физически, но событие
 	// purged (с лейблом машины) остаётся в общем журнале ЧС. Активную удалять нельзя.
 	Purge(ctx context.Context, id int, userID int) error
@@ -164,39 +166,95 @@ func (s *vehicleBlacklistService) Archive(ctx context.Context, id int, userID in
 	return nil
 }
 
-func (s *vehicleBlacklistService) UpdateReason(ctx context.Context, id int, reason string, userID int) (*models.VehicleBlacklist, error) {
+func (s *vehicleBlacklistService) Update(ctx context.Context, id int, req models.UpdateVehicleBlacklistRequest, userID int) (*models.VehicleBlacklist, error) {
 	e, err := s.GetByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
 	if !e.IsActive {
-		return nil, echo.NewHTTPError(http.StatusBadRequest, "Нельзя редактировать причину архивной записи")
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "Нельзя редактировать архивную запись")
 	}
-	newReason := strings.TrimSpace(reason)
+
+	var mark models.Mark
+	if err := s.db.WithContext(ctx).First(&mark, req.MarkID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, echo.NewHTTPError(http.StatusBadRequest, "Марка не найдена")
+		}
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения марки")
+	}
+
+	carNumber := strings.TrimSpace(req.CarNumber)
+	newReason := strings.TrimSpace(req.Reason)
+	if carNumber == "" {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "Номер обязателен")
+	}
 	if newReason == "" {
 		return nil, echo.NewHTTPError(http.StatusBadRequest, "Причина обязательна")
 	}
-	if newReason == e.Reason {
+
+	// Идентичность - номер (без учёта регистра/пробелов, как в uidx) либо марка.
+	identityChanged := !strings.EqualFold(strings.TrimSpace(e.CarNumber), carNumber) || e.MarkID != req.MarkID
+	if !identityChanged && newReason == e.Reason {
 		return e, nil // без изменений - не пишем историю
 	}
-	oldReason := e.Reason
+
+	old := *e
+	updated := *e
+	updated.CarNumber = carNumber
+	updated.MarkID = req.MarkID
+	updated.MarkName = mark.Name
+	updated.NormalizedNumber = normalize.Plate(carNumber)
+	updated.Reason = newReason
+
 	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		if err := tx.Model(&models.VehicleBlacklist{}).Where("id = ?", e.ID).Update("reason", newReason).Error; err != nil {
+		reactivated, deactivated := 0, 0
+		// При смене идентичности cars, привязанные к старому номеру, больше не покрыты этой
+		// записью - возвращаем их; новые совпадения гасим. Иначе авто осталось бы ошибочно
+		// заблокированным/разблокированным.
+		if identityChanged {
+			r, err := s.reactivateMatchingCars(ctx, tx, old, userID)
+			if err != nil {
+				return err
+			}
+			reactivated = r
+		}
+		if err := tx.Model(&models.VehicleBlacklist{}).Where("id = ?", e.ID).Updates(map[string]interface{}{
+			"car_number":        updated.CarNumber,
+			"mark_id":           updated.MarkID,
+			"mark_name":         updated.MarkName,
+			"normalized_number": updated.NormalizedNumber,
+			"reason":            updated.Reason,
+		}).Error; err != nil {
 			return err
 		}
+		if identityChanged {
+			d, err := s.deactivateMatchingCars(ctx, tx, updated, userID)
+			if err != nil {
+				return err
+			}
+			deactivated = d
+		}
 		details := map[string]interface{}{
-			"car_number": e.CarNumber,
-			"mark_name":  e.MarkName,
-			"reason_old": oldReason,
-			"reason_new": newReason,
+			"car_number_old": old.CarNumber,
+			"car_number_new": updated.CarNumber,
+			"mark_name_old":  old.MarkName,
+			"mark_name_new":  updated.MarkName,
+			"reason_old":     old.Reason,
+			"reason_new":     updated.Reason,
+		}
+		if identityChanged {
+			details["cars_reactivated"] = reactivated
+			details["cars_deactivated"] = deactivated
 		}
 		return s.history.Log(ctx, tx, e.ID, &userID, models.BlacklistActionUpdated, details)
 	})
 	if err != nil {
-		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка обновления причины")
+		if isUniqueViolation(err) {
+			return nil, echo.NewHTTPError(http.StatusConflict, "Эта машина уже в чёрном списке")
+		}
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка обновления записи")
 	}
-	e.Reason = newReason
-	return e, nil
+	return &updated, nil
 }
 
 // Purge удаляет архивную запись навсегда. Сначала логируем purged-событие (с лейблом


### PR DESCRIPTION
Правка номера/марки и ФИО записи реестра ЧС (#481 follow-up). Раньше редактировалась
только причина - номер машины и ФИО человека правились лишь пересозданием.

## BE
- `internal/services/{vehicle,person}_blacklist_service.go`: `UpdateReason` -> `Update`.
  Меняет идентичность (номер+марка / ФИО) + причину, пересчитывает нормаль
  (normalize.Plate / normalize.Name) для нечёткого поиска обхода.
- При смене идентичности перекаскадивает cars/employees в одной транзакции:
  реактивирует совпадавших со старым значением, деактивирует совпадающих с новым.
- Дубль активной записи -> 409 (partial unique index), откат транзакции полный.
- Handlers биндят `UpdateVehicleBlacklistRequest` / `UpdatePersonBlacklistRequest`.

## FE
- `AddToBlacklistModal` mode=edit: инпуты номера + дропдаун марки (машины) / ФИО (люди),
  префилл из `initialEntity`. mode=add (из карточки) без изменений.
- `api/blacklist.js`: update-методы шлют идентичность. Таб-консьюмеры прокидывают payload.

## Верификация
- Go: `go test ./internal/handlers -run Blacklist` - зелёные, включая новые кейсы
  смены номера/ФИО (пересчёт нормали), дубль 409, архив 400.
- FE: vitest `AddToBlacklistModal.spec` 10 passed (edit-payload контракт).
- Браузер: модалка правки открывается с редактируемыми предзаполненными полями
  идентичности, PUT шлёт верный payload (локальный backend старый - персист имени
  проверен Go-интеграционными тестами, не браузером).
- Независимое ревью субагентом: GO, блокеров нет.
