### PR TITLE
fix(attachments): тип вложения первым полем в форме создания (#529)

### DIFF
--- a/frontend/src/components/AttachmentsManagement.vue
+++ b/frontend/src/components/AttachmentsManagement.vue
@@ -328,6 +328,17 @@
 
             <div class="modal-body">
               <div class="form-group">
+                <label class="form-label">Тип вложения</label>
+                <BaseDropdown
+                  :model-value="addForm.attachment_type"
+                  :options="typeOptions"
+                  label-key="label"
+                  value-key="value"
+                  @update:model-value="addForm.attachment_type = $event"
+                />
+              </div>
+
+              <div class="form-group">
                 <label class="form-label">Наименование вложения</label>
                 <input
                   v-model="addForm.display_name"
@@ -372,17 +383,6 @@
                   @keyup.enter="submitAdd"
                 >
                 <span class="field-hint">Отображается в заголовке категории (в верхнем регистре)</span>
-              </div>
-
-              <div class="form-group">
-                <label class="form-label">Тип вложения</label>
-                <BaseDropdown
-                  :model-value="addForm.attachment_type"
-                  :options="typeOptions"
-                  label-key="label"
-                  value-key="value"
-                  @update:model-value="addForm.attachment_type = $event"
-                />
               </div>
 
               <div


### PR DESCRIPTION
## Что

В модалке создания нового вложения (`AttachmentsManagement.vue`, кнопка «Создать вложение») поле «Тип вложения» (Люди/Машины/ТМЦ) переместил в самый верх формы - теперь оно первым полем перед «Наименование вложения».

## Зачем

Тип вложения - определяющий выбор, логичнее выбирать его до остальных полей.

## Детали

- Перемещён только блок `<div class="form-group">` с `BaseDropdown` для `addForm.attachment_type` - разметка, биндинги, валидация и стили без изменений.
- Форма редактирования существующего вложения (панель деталей, `form.attachment_type`) не затронута - там порядок полей прежний.
- Дифф: 11 insert / 11 delete, чистое перемещение блока.

## Проверка

- vue-tsc по компоненту - без ошибок.
- Выделенного vitest-теста у компонента нет (только у `UniqueAttachmentHistoryModal`, он не затронут).