### PR TITLE
feat(applications): сохранение флагов крыша/бесплатная парковка на вложении (#529)

### DIFF
--- a/frontend/src/components/ApplicationDetail/ApplicationDetail.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationDetail.vue
@@ -287,7 +287,11 @@
       :current-user-name="currentUserName"
       :show-car-features="true"
       :source="'application'"
+      :can-override="isResponsibleUser"
+      :can-cancel-override="canManageBlacklistOverride"
       @close="showVehicleModal = false"
+      @override="onCardOverride('vehicle')"
+      @cancel-override="onCardCancelOverride('vehicle')"
     />
 
     <EmployeeDetailsModal
@@ -298,7 +302,11 @@
       :current-user-id="currentUserId"
       :current-user-name="currentUserName"
       :source="'application'"
+      :can-override="isResponsibleUser"
+      :can-cancel-override="canManageBlacklistOverride"
       @close="showEmployeeModal = false"
+      @override="onCardOverride('employee')"
+      @cancel-override="onCardCancelOverride('employee')"
     />
 
     <BlacklistOverrideModal
@@ -315,6 +323,7 @@
 import { apiRequest } from '@/api/client'
 import { markAsRead } from '@/api/applications'
 import { useDeletionsStore } from '@/stores/deletions'
+import { useUiStore } from '@/stores/ui'
 import ApplicationAttachments from './ApplicationAttachments.vue'
 import ApplicationConfirmation from './ApplicationConfirmation.vue'
 import ApplicationHistory from './ApplicationHistory.vue'
@@ -405,6 +414,12 @@ export default {
         isApprover() {
             if (!this.currentUserId || !this.approvers.length) return false;
             return this.approvers.some(approver => approver.user_id === this.currentUserId);
+        },
+
+        // Отменить подтверждение пропуска может ответственный по заявке ИЛИ принимающий -
+        // зеркалит право DELETE /blacklist-overrides на бэке (шире, чем создание override).
+        canManageBlacklistOverride() {
+            return this.isResponsibleUser || this.isApprover;
         },
 
         hasUserVoted() {
@@ -813,7 +828,8 @@ export default {
                 applicationId: this.applicationData.id,
                 territory_status: 0,
                 entry_checked: false,
-                exit_checked: false
+                exit_checked: false,
+                blacklist_similar: car.blacklist_similar || null
             };
             this.showVehicleModal = true;
         },
@@ -837,7 +853,8 @@ export default {
                 pass_time: employee.pass_time || null,
                 target_tables: employee.target_tables ? employee.target_tables.map(t => t.id) : [],
                 applicationId: this.applicationData.id,
-                territory_status: 0
+                territory_status: 0,
+                blacklist_similar: employee.blacklist_similar || null
             };
             this.showEmployeeModal = true;
         },
@@ -867,6 +884,7 @@ export default {
                         this.selectedAttachment ? this.loadAttachmentDetails(this.selectedAttachment.id) : Promise.resolve(),
                         this.refreshApplicationGate()
                     ]);
+                    this.syncSelectedDetailFlags();
                     this.$emit('application-changed', this.applicationData);
                 } else if (response.status !== 403) {
                     // 403 уже показывает тост через client.js - второй не дублируем
@@ -909,6 +927,83 @@ export default {
                 bold: 'обновите страницу для согласования',
                 type: 'error'
             });
+        },
+
+        // Открытая карточка детали держит свою копию flag - после override/отмены
+        // переносим в неё свежий blacklist_similar из перечитанного вложения, чтобы блок
+        // "Подозрение на обход ЧС" сразу показал актуальный статус без закрытия карточки.
+        syncSelectedDetailFlags() {
+            if (this.showVehicleModal && this.selectedVehicle) {
+                const fresh = this.attachmentCars.find(c => c.id === this.selectedVehicle.id);
+                if (fresh) this.selectedVehicle.blacklist_similar = fresh.blacklist_similar || null;
+            }
+            if (this.showEmployeeModal && this.selectedEmployee) {
+                const fresh = this.attachmentEmployees.find(emp => emp.id === this.selectedEmployee.id);
+                if (fresh) this.selectedEmployee.blacklist_similar = fresh.blacklist_similar || null;
+            }
+        },
+
+        // "Всё равно пропустить" из карточки детали - переиспользуем POST-флоу с причиной.
+        onCardOverride(kind) {
+            const entity = kind === 'vehicle' ? this.selectedVehicle : this.selectedEmployee;
+            if (!entity || !entity.blacklist_similar) return;
+            const label = kind === 'vehicle'
+                ? (entity.plateNumber || 'Т/С')
+                : [entity.last_name, entity.first_name, entity.middle_name].filter(Boolean).join(' ').trim() || 'Сотрудник';
+            this.openOverrideModal({ label, flag: entity.blacklist_similar });
+        },
+
+        // "Отменить" подтверждение пропуска из карточки - подтверждение БЕЗ причины, затем DELETE.
+        async onCardCancelOverride(kind) {
+            const entity = kind === 'vehicle' ? this.selectedVehicle : this.selectedEmployee;
+            const flag = entity && entity.blacklist_similar;
+            if (!flag || !flag.flag_id) return;
+            const label = kind === 'vehicle'
+                ? (entity.plateNumber || 'Т/С')
+                : [entity.last_name, entity.first_name, entity.middle_name].filter(Boolean).join(' ').trim() || 'Сотрудник';
+
+            const ok = await useUiStore().confirm({
+                title: 'Снять подтверждение пропуска?',
+                message: 'Подтверждение пропуска будет снято, и согласование заявки снова заблокируется по этому элементу.',
+                confirmText: 'Снять',
+                cancelText: 'Отмена',
+                danger: true
+            });
+            if (!ok) return;
+
+            try {
+                const response = await apiRequest(
+                    `/applications/${this.applicationData.id}/blacklist-overrides?flag_id=${flag.flag_id}`,
+                    { method: 'DELETE' }
+                );
+                if (response.ok) {
+                    useDeletionsStore().notify({
+                        prefix: 'Подтверждение пропуска снято: ',
+                        bold: label,
+                        type: 'success'
+                    });
+                    await Promise.all([
+                        this.selectedAttachment ? this.loadAttachmentDetails(this.selectedAttachment.id) : Promise.resolve(),
+                        this.refreshApplicationGate()
+                    ]);
+                    this.syncSelectedDetailFlags();
+                    this.$emit('application-changed', this.applicationData);
+                } else if (response.status !== 403) {
+                    const data = await response.json();
+                    useDeletionsStore().notify({
+                        prefix: 'Не удалось снять подтверждение: ',
+                        bold: data.message || 'ошибка',
+                        type: 'error'
+                    });
+                }
+            } catch (error) {
+                console.error('Ошибка при отмене подтверждения пропуска:', error);
+                useDeletionsStore().notify({
+                    prefix: 'Не удалось снять подтверждение: ',
+                    bold: 'ошибка сети',
+                    type: 'error'
+                });
+            }
         }
     }
 }

--- a/frontend/src/components/ApplicationDetail/ApplicationHistory.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationHistory.vue
@@ -621,7 +621,8 @@ export default {
                 'assigned_responsible': 'dot-assign',
                 'assigned_viewer': 'dot-view',
                 'confirmation_change': 'dot-system',
-                'status_change': 'dot-system'
+                'status_change': 'dot-system',
+                'blacklist_override_revoke': 'dot-warning'
             };
             return classes[actionType] || 'dot-default';
         },
@@ -653,7 +654,8 @@ export default {
                 'assigned_responsible': 'Назначен(-а) ответственным получателем',
                 'assigned_viewer': 'Получил(-а) доступ к просмотру заявки',
                 'confirmation_change': 'Статус согласования изменился',
-                'status_change': 'Статус заявки изменился'
+                'status_change': 'Статус заявки изменился',
+                'blacklist_override_revoke': 'Отменил(-а) подтверждение пропуска'
             };
             
             let text = texts[item.action_type] || item.action_type;

--- a/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
@@ -78,6 +78,56 @@
                 </div>
               </div>
 
+              <!-- Подозрение на обход ЧС (#481, срез C): см. VehicleDetailsModal. -->
+              <div
+                v-if="blacklistSimilar"
+                class="bl-suspicion-section"
+                :class="{ 'is-resolved': blacklistSimilar.overridden }"
+              >
+                <div class="bl-suspicion-head">
+                  <span class="bl-suspicion-dot" />
+                  Подозрение на обход чёрного списка
+                </div>
+                <div class="bl-suspicion-row">
+                  <span class="bl-suspicion-label">Похоже на:</span> {{ blacklistSimilar.matched_value }}
+                </div>
+                <div
+                  v-if="blacklistSimilar.matched_reason"
+                  class="bl-suspicion-row"
+                >
+                  <span class="bl-suspicion-label">Причина:</span> {{ blacklistSimilar.matched_reason }}
+                </div>
+
+                <div
+                  v-if="blacklistSimilar.overridden"
+                  class="bl-suspicion-foot"
+                >
+                  <span class="bl-suspicion-confirmed">Пропуск подтверждён</span>
+                  <button
+                    v-if="canCancelOverride"
+                    type="button"
+                    class="bl-suspicion-btn bl-suspicion-btn--cancel"
+                    @click="$emit('cancel-override')"
+                  >
+                    Отменить
+                  </button>
+                </div>
+                <div
+                  v-else
+                  class="bl-suspicion-foot"
+                >
+                  <span class="bl-suspicion-blocked">Согласование заблокировано до подтверждения пропуска</span>
+                  <button
+                    v-if="canOverride"
+                    type="button"
+                    class="bl-suspicion-btn bl-suspicion-btn--allow"
+                    @click="$emit('override')"
+                  >
+                    Всё равно пропустить
+                  </button>
+                </div>
+              </div>
+
               <div
                 v-if="employee"
                 class="employee-details"
@@ -433,9 +483,19 @@ export default {
         source: {
             type: String,
             default: 'general'
+        },
+        // Право подтвердить пропуск (POST override) - только ответственный по заявке.
+        canOverride: {
+            type: Boolean,
+            default: false
+        },
+        // Право снять подтверждение (DELETE override) - ответственный или принимающий.
+        canCancelOverride: {
+            type: Boolean,
+            default: false
         }
     },
-    emits: ['close', 'open-application'],
+    emits: ['close', 'open-application', 'override', 'cancel-override'],
     data() {
         return {
             selectedTable: null,
@@ -462,6 +522,10 @@ export default {
         // из карточки ApplicationDetail ("Открыть заявку") был выше карточки.
         overlayZIndex() {
             return this.source === 'application' ? 10003 : 10001;
+        },
+        // Предупреждение о возможном обходе ЧС - только в контексте заявки (#481, срез C).
+        blacklistSimilar() {
+            return this.source === 'application' ? (this.employee?.blacklist_similar || null) : null;
         },
         // Кнопки в шапке: "Полная история" (showHistoryButton) и
         // "Открыть заявку" (source !== 'application' и есть applicationId).
@@ -1037,6 +1101,112 @@ export default {
 
 .bl-section-label {
     font-weight: 600;
+}
+
+/* Блок "Подозрение на обход ЧС" (#481, срез C) - зеркалит VehicleDetailsModal. */
+.bl-suspicion-section {
+    margin-bottom: 16px;
+    padding: 12px 16px;
+    background: #fdeaea;
+    border: 1px solid #f5b5b5;
+    border-radius: 20px;
+}
+
+.bl-suspicion-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 14px;
+    font-weight: 600;
+    color: #b91c1c;
+}
+
+.bl-suspicion-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #dc2626;
+    flex-shrink: 0;
+}
+
+.bl-suspicion-row {
+    margin-top: 6px;
+    font-size: 13px;
+    line-height: 1.5;
+    color: #7f1d1d;
+    word-break: break-word;
+}
+
+.bl-suspicion-label {
+    font-weight: 600;
+}
+
+.bl-suspicion-foot {
+    margin-top: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.bl-suspicion-blocked {
+    font-size: 12px;
+    color: #7f1d1d;
+}
+
+.bl-suspicion-confirmed {
+    font-size: 13px;
+    font-weight: 600;
+    color: #047857;
+}
+
+.bl-suspicion-btn {
+    padding: 6px 14px;
+    border-radius: 20px;
+    font-size: 12px;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.bl-suspicion-btn--allow {
+    background: #fff;
+    border: 1px solid #fecaca;
+    color: #dc2626;
+}
+
+.bl-suspicion-btn--allow:hover {
+    background: #fee2e2;
+    border-color: #dc2626;
+}
+
+.bl-suspicion-btn--cancel {
+    background: #fff;
+    border: 1px solid #cbd5e1;
+    color: #475569;
+}
+
+.bl-suspicion-btn--cancel:hover {
+    background: #f1f5f9;
+    border-color: #94a3b8;
+}
+
+.bl-suspicion-section.is-resolved {
+    background: #ecfdf5;
+    border-color: #a7f3d0;
+}
+
+.bl-suspicion-section.is-resolved .bl-suspicion-head {
+    color: #047857;
+}
+
+.bl-suspicion-section.is-resolved .bl-suspicion-dot {
+    background: #10b981;
+}
+
+.bl-suspicion-section.is-resolved .bl-suspicion-row {
+    color: #065f46;
 }
 
 .modal-title {

--- a/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
@@ -83,6 +83,58 @@
                 </div>
               </div>
 
+              <!-- Подозрение на обход ЧС (#481, срез C): мягкое предупреждение о похожем на
+                   запись ЧС элементе + управление пропуском (подтвердить/отменить), от которого
+                   зависит гейт согласования заявки. Видно только в контексте заявки. -->
+              <div
+                v-if="blacklistSimilar"
+                class="bl-suspicion-section"
+                :class="{ 'is-resolved': blacklistSimilar.overridden }"
+              >
+                <div class="bl-suspicion-head">
+                  <span class="bl-suspicion-dot" />
+                  Подозрение на обход чёрного списка
+                </div>
+                <div class="bl-suspicion-row">
+                  <span class="bl-suspicion-label">Похоже на:</span> {{ blacklistSimilar.matched_value }}
+                </div>
+                <div
+                  v-if="blacklistSimilar.matched_reason"
+                  class="bl-suspicion-row"
+                >
+                  <span class="bl-suspicion-label">Причина:</span> {{ blacklistSimilar.matched_reason }}
+                </div>
+
+                <div
+                  v-if="blacklistSimilar.overridden"
+                  class="bl-suspicion-foot"
+                >
+                  <span class="bl-suspicion-confirmed">Пропуск подтверждён</span>
+                  <button
+                    v-if="canCancelOverride"
+                    type="button"
+                    class="bl-suspicion-btn bl-suspicion-btn--cancel"
+                    @click="$emit('cancel-override')"
+                  >
+                    Отменить
+                  </button>
+                </div>
+                <div
+                  v-else
+                  class="bl-suspicion-foot"
+                >
+                  <span class="bl-suspicion-blocked">Согласование заблокировано до подтверждения пропуска</span>
+                  <button
+                    v-if="canOverride"
+                    type="button"
+                    class="bl-suspicion-btn bl-suspicion-btn--allow"
+                    @click="$emit('override')"
+                  >
+                    Всё равно пропустить
+                  </button>
+                </div>
+              </div>
+
               <!-- Блок предупреждения об активной заявке -->
               <div
                 v-if="activeInfo"
@@ -414,9 +466,19 @@ export default {
         activeInfo: {
             type: Object,
             default: null
+        },
+        // Право подтвердить пропуск (POST override) - только ответственный по заявке.
+        canOverride: {
+            type: Boolean,
+            default: false
+        },
+        // Право снять подтверждение (DELETE override) - ответственный или принимающий.
+        canCancelOverride: {
+            type: Boolean,
+            default: false
         }
     },
-    emits: ['close', 'open-application'],
+    emits: ['close', 'open-application', 'override', 'cancel-override'],
     setup(_, { emit }) {
         const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(() => emit('close'));
         return { onOverlayMousedown, onOverlayMouseup };
@@ -490,6 +552,11 @@ export default {
         hasVehicleIdentity() {
             const n = this.vehicleNumber.toLowerCase();
             return !!this.vehicleNumber && !!this.vehicleMark && n !== 'по факту';
+        },
+        // Предупреждение о возможном обходе ЧС показываем только в контексте заявки -
+        // флаг приходит из деталей вложения (#481, срез C).
+        blacklistSimilar() {
+            return this.source === 'application' ? (this.vehicle?.blacklist_similar || null) : null;
         }
     },
     watch: {
@@ -1121,6 +1188,113 @@ export default {
 
 .bl-section-label {
   font-weight: 600;
+}
+
+/* Блок "Подозрение на обход ЧС" (#481, срез C). По умолчанию красный (требует решения),
+   после подтверждения пропуска - зелёный "решено" (.is-resolved). */
+.bl-suspicion-section {
+  margin-bottom: 16px;
+  padding: 12px 16px;
+  background: #fdeaea;
+  border: 1px solid #f5b5b5;
+  border-radius: 20px;
+}
+
+.bl-suspicion-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #b91c1c;
+}
+
+.bl-suspicion-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #dc2626;
+  flex-shrink: 0;
+}
+
+.bl-suspicion-row {
+  margin-top: 6px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: #7f1d1d;
+  word-break: break-word;
+}
+
+.bl-suspicion-label {
+  font-weight: 600;
+}
+
+.bl-suspicion-foot {
+  margin-top: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.bl-suspicion-blocked {
+  font-size: 12px;
+  color: #7f1d1d;
+}
+
+.bl-suspicion-confirmed {
+  font-size: 13px;
+  font-weight: 600;
+  color: #047857;
+}
+
+.bl-suspicion-btn {
+  padding: 6px 14px;
+  border-radius: 20px;
+  font-size: 12px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.bl-suspicion-btn--allow {
+  background: #fff;
+  border: 1px solid #fecaca;
+  color: #dc2626;
+}
+
+.bl-suspicion-btn--allow:hover {
+  background: #fee2e2;
+  border-color: #dc2626;
+}
+
+.bl-suspicion-btn--cancel {
+  background: #fff;
+  border: 1px solid #cbd5e1;
+  color: #475569;
+}
+
+.bl-suspicion-btn--cancel:hover {
+  background: #f1f5f9;
+  border-color: #94a3b8;
+}
+
+.bl-suspicion-section.is-resolved {
+  background: #ecfdf5;
+  border-color: #a7f3d0;
+}
+
+.bl-suspicion-section.is-resolved .bl-suspicion-head {
+  color: #047857;
+}
+
+.bl-suspicion-section.is-resolved .bl-suspicion-dot {
+  background: #10b981;
+}
+
+.bl-suspicion-section.is-resolved .bl-suspicion-row {
+  color: #065f46;
 }
 
 .modal-title {

--- a/frontend/src/components/CreateApplication/__tests__/DetailModalsBlacklistSuspicion.spec.js
+++ b/frontend/src/components/CreateApplication/__tests__/DetailModalsBlacklistSuspicion.spec.js
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { setActivePinia, createPinia } from 'pinia';
+
+import VehicleDetailsModal from '../VehicleDetailsModal.vue';
+import EmployeeDetailsModal from '../EmployeeDetailsModal.vue';
+
+// Карточки на show=true дёргают вспомогательные API (статус/история/проверка ЧС) - глушим
+// их, нас интересует только блок "Подозрение на обход ЧС" (#481, срез C).
+vi.mock('@/api/client', () => ({ apiRequest: vi.fn().mockResolvedValue({ ok: false }) }));
+vi.mock('@/api/blacklist', () => ({
+  listVehicleBlacklist: vi.fn().mockResolvedValue([]),
+  createVehicleBlacklist: vi.fn().mockResolvedValue({}),
+  listPersonBlacklist: vi.fn().mockResolvedValue([]),
+  checkPersonBlacklist: vi.fn().mockResolvedValue({ is_blacklisted: false }),
+  createPersonBlacklist: vi.fn().mockResolvedValue({}),
+}));
+vi.mock('@/api/marks', () => ({ listMarks: vi.fn().mockResolvedValue([]) }));
+vi.mock('exceljs', () => ({ default: {} }));
+
+const stubs = {
+  teleport: true,
+  UnloadPlaceModal: true,
+  CarHistoryModal: true,
+  EmployeeHistoryModal: true,
+  TableInfoModal: true,
+  AddToBlacklistModal: true,
+  LoaderSpinner: true,
+};
+
+function vehicleFlag(over = {}) {
+  return { flag_id: 5, matched_value: 'А124ВС Toyota', matched_reason: 'похожий номер', similarity: 0.9, overridden: false, ...over };
+}
+
+function mountVehicle(vehicleOver = {}, props = {}) {
+  return mount(VehicleDetailsModal, {
+    props: {
+      show: true,
+      vehicle: { id: 1, plateNumber: 'А123ВС', mark: 'Toyota', unloadPlaces: [], ...vehicleOver },
+      source: 'application',
+      ...props,
+    },
+    global: { stubs },
+  });
+}
+
+function mountEmployee(employeeOver = {}, props = {}) {
+  return mount(EmployeeDetailsModal, {
+    props: {
+      show: true,
+      employee: { id: 1, last_name: 'Иваноф', first_name: 'Иван', middle_name: 'Иванович', target_tables: [], ...employeeOver },
+      source: 'application',
+      ...props,
+    },
+    global: { stubs },
+  });
+}
+
+describe('VehicleDetailsModal - блок подозрения на обход ЧС (#481, срез C)', () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  it('показывает "похоже на X" и причину при флаге в контексте заявки', () => {
+    const w = mountVehicle({ blacklist_similar: vehicleFlag() }, { canOverride: true });
+    const sec = w.find('.bl-suspicion-section');
+    expect(sec.exists()).toBe(true);
+    expect(sec.text()).toContain('Подозрение на обход чёрного списка');
+    expect(sec.text()).toContain('А124ВС Toyota');
+    expect(sec.text()).toContain('похожий номер');
+    expect(sec.classes()).not.toContain('is-resolved');
+  });
+
+  it('не overridden + право: кнопка "Всё равно пропустить" эмитит override', async () => {
+    const w = mountVehicle({ blacklist_similar: vehicleFlag() }, { canOverride: true });
+    const btn = w.find('.bl-suspicion-btn--allow');
+    expect(btn.exists()).toBe(true);
+    await btn.trigger('click');
+    expect(w.emitted('override')).toBeTruthy();
+  });
+
+  it('без права override кнопка "Всё равно пропустить" скрыта', () => {
+    const w = mountVehicle({ blacklist_similar: vehicleFlag() }, { canOverride: false });
+    expect(w.find('.bl-suspicion-btn--allow').exists()).toBe(false);
+  });
+
+  it('overridden + право: статус "Пропуск подтверждён", is-resolved, "Отменить" эмитит cancel-override', async () => {
+    const w = mountVehicle({ blacklist_similar: vehicleFlag({ overridden: true }) }, { canCancelOverride: true });
+    const sec = w.find('.bl-suspicion-section');
+    expect(sec.classes()).toContain('is-resolved');
+    expect(sec.text()).toContain('Пропуск подтверждён');
+    const btn = w.find('.bl-suspicion-btn--cancel');
+    expect(btn.exists()).toBe(true);
+    await btn.trigger('click');
+    expect(w.emitted('cancel-override')).toBeTruthy();
+  });
+
+  it('overridden без права отмены: "Отменить" скрыта', () => {
+    const w = mountVehicle({ blacklist_similar: vehicleFlag({ overridden: true }) }, { canCancelOverride: false });
+    expect(w.find('.bl-suspicion-btn--cancel').exists()).toBe(false);
+  });
+
+  it('вне контекста заявки (source != application) блок скрыт', () => {
+    const w = mountVehicle({ blacklist_similar: vehicleFlag() }, { source: 'general', canOverride: true });
+    expect(w.find('.bl-suspicion-section').exists()).toBe(false);
+  });
+
+  it('без флага похожести блок не рендерится', () => {
+    const w = mountVehicle({}, { canOverride: true });
+    expect(w.find('.bl-suspicion-section').exists()).toBe(false);
+  });
+});
+
+describe('EmployeeDetailsModal - блок подозрения на обход ЧС (#481, срез C)', () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  it('показывает похожее ФИО и эмитит cancel-override при overridden', async () => {
+    const flag = { flag_id: 7, matched_value: 'Иванов Иван Иванович', matched_reason: 'опечатка в фамилии', similarity: 0.92, overridden: true };
+    const w = mountEmployee({ blacklist_similar: flag }, { canCancelOverride: true });
+    const sec = w.find('.bl-suspicion-section');
+    expect(sec.exists()).toBe(true);
+    expect(sec.text()).toContain('Иванов Иван Иванович');
+    expect(sec.text()).toContain('опечатка в фамилии');
+    const btn = w.find('.bl-suspicion-btn--cancel');
+    expect(btn.exists()).toBe(true);
+    await btn.trigger('click');
+    expect(w.emitted('cancel-override')).toBeTruthy();
+  });
+
+  it('не overridden + право: "Всё равно пропустить" эмитит override', async () => {
+    const flag = { flag_id: 8, matched_value: 'Петров Пётр', matched_reason: '', similarity: 0.8, overridden: false };
+    const w = mountEmployee({ blacklist_similar: flag }, { canOverride: true });
+    const btn = w.find('.bl-suspicion-btn--allow');
+    expect(btn.exists()).toBe(true);
+    await btn.trigger('click');
+    expect(w.emitted('override')).toBeTruthy();
+  });
+});

--- a/internal/handlers/applications_blacklist_override_test.go
+++ b/internal/handlers/applications_blacklist_override_test.go
@@ -251,3 +251,93 @@ func TestGetApplications_BlacklistFlagsCount(t *testing.T) {
 		assert.Equal(t, float64(0), countFor(t, testutil.GET(t, e, "/applications/user", testutil.AuthHeader(senderToken))), "GetUserApplications после override")
 	})
 }
+
+// TestBlacklistOverride_Delete: отмена подтверждения пропуска (#481, срез C). Снять override
+// может ответственный по заявке ИЛИ принимающий, но не посторонний; после отмены согласование
+// снова блокируется, а факт фиксируется в истории заявки. Повторная отмена -> 404.
+func TestBlacklistOverride_Delete(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	ctx := context.Background()
+
+	const orgName = "Test Organization"
+	senderToken := testutil.RegisterAndLogin(t, e, "bd_sender", "pass123", 1, td.OrgID, td.CompanyID)
+	senderID := getUserID(t, db, "bd_sender")
+	mark := seedMark(t, db, "BD_Mark")
+
+	_, err := newVehicleBlacklistService(db).Create(ctx, models.CreateVehicleBlacklistRequest{
+		CarNumber: "D777DD799", MarkID: mark.ID, Reason: "розыск",
+	}, senderID)
+	require.NoError(t, err)
+
+	rec := submitCarApp(t, e, db, senderToken, orgName, "del", "D777DD798", mark.ID)
+	require.Equal(t, http.StatusOK, rec.Code, "submit: %s", rec.Body.String())
+	carID := latestElementID(t, db, "cars", "car_number = ?", "D777DD798")
+	flag, ok := blacklistFlagFor(t, db, models.BlacklistElementCar, carID)
+	require.True(t, ok, "ожидался флаг похожести")
+	appID := flag.ApplicationID
+
+	testutil.RegisterUser(t, e, "bd_appr", "pass123", 1, td.OrgID, td.CompanyID)
+	apprID := getUserID(t, db, "bd_appr")
+	fwd := fmt.Sprintf(`{"users":[{"user_id":%d,"required_approval":true,"can_view":false}]}`, apprID)
+	rec = testutil.POST(t, e, fmt.Sprintf("/applications/%d/forward", appID), fwd, testutil.AuthHeader(senderToken))
+	require.Equal(t, http.StatusOK, rec.Code, "forward: %s", rec.Body.String())
+	apprToken, _ := testutil.LoginUser(t, e, "bd_appr", "pass123")
+
+	overridePath := fmt.Sprintf("/applications/%d/blacklist-overrides", appID)
+	deletePath := fmt.Sprintf("%s?flag_id=%d", overridePath, flag.ID)
+	approveBody := fmt.Sprintf(`{"user_id":%d,"status":"approved","comment":"ok"}`, apprID)
+
+	overrideCount := func() int64 {
+		var cnt int64
+		db.Model(&models.ApplicationBlacklistOverride{}).Where("flag_id = ?", flag.ID).Count(&cnt)
+		return cnt
+	}
+
+	// Ответственный подтверждает пропуск (предусловие для отмены).
+	rec = testutil.POST(t, e, overridePath, fmt.Sprintf(`{"flag_id":%d,"comment":"проверил лично"}`, flag.ID), testutil.AuthHeader(apprToken))
+	require.Equal(t, http.StatusOK, rec.Code, "override: %s", rec.Body.String())
+	require.Equal(t, int64(1), overrideCount())
+
+	t.Run("отмена от постороннего запрещена", func(t *testing.T) {
+		outsiderToken := testutil.RegisterAndLogin(t, e, "bd_outsider", "pass123", 1, td.OrgID, td.CompanyID)
+		rec := testutil.DELETE(t, e, deletePath, testutil.AuthHeader(outsiderToken))
+		require.Equal(t, http.StatusForbidden, rec.Code, "body: %s", rec.Body.String())
+		assert.Equal(t, int64(1), overrideCount(), "посторонний не должен снять override")
+	})
+
+	t.Run("ответственный снимает - гейт снова блокирует, факт в истории", func(t *testing.T) {
+		rec := testutil.DELETE(t, e, deletePath, testutil.AuthHeader(apprToken))
+		require.Equal(t, http.StatusOK, rec.Code, "delete: %s", rec.Body.String())
+		assert.Equal(t, int64(0), overrideCount(), "override-строка удалена")
+
+		var histCnt int64
+		db.Table("application_history").
+			Where("application_id = ? AND action_type = 'blacklist_override_revoke'", appID).Count(&histCnt)
+		assert.Equal(t, int64(1), histCnt, "факт отмены залогирован в историю заявки")
+
+		rec = testutil.POST(t, e, fmt.Sprintf("/applications/%d/approve", appID), approveBody, testutil.AuthHeader(apprToken))
+		require.Equal(t, http.StatusConflict, rec.Code, "согласование снова заблокировано: %s", rec.Body.String())
+	})
+
+	t.Run("повторная отмена несуществующего - 404", func(t *testing.T) {
+		rec := testutil.DELETE(t, e, deletePath, testutil.AuthHeader(apprToken))
+		require.Equal(t, http.StatusNotFound, rec.Code, "body: %s", rec.Body.String())
+	})
+
+	t.Run("принимающий (не ответственный по заявке) может снять", func(t *testing.T) {
+		rec := testutil.POST(t, e, overridePath, fmt.Sprintf(`{"flag_id":%d,"comment":"снова"}`, flag.ID), testutil.AuthHeader(apprToken))
+		require.Equal(t, http.StatusOK, rec.Code, "re-override: %s", rec.Body.String())
+		require.Equal(t, int64(1), overrideCount())
+
+		accToken := testutil.RegisterAndLogin(t, e, "bd_acceptor", "pass123", 1, td.OrgID, td.CompanyID)
+		accID := getUserID(t, db, "bd_acceptor")
+		db.Exec("INSERT INTO application_approvers (user_id, created_at) VALUES (?, NOW()) ON CONFLICT DO NOTHING", accID)
+
+		rec = testutil.DELETE(t, e, deletePath, testutil.AuthHeader(accToken))
+		require.Equal(t, http.StatusOK, rec.Code, "delete принимающим: %s", rec.Body.String())
+		assert.Equal(t, int64(0), overrideCount())
+	})
+}

--- a/internal/handlers/applications_field_config_test.go
+++ b/internal/handlers/applications_field_config_test.go
@@ -159,3 +159,51 @@ func TestSubmitCompleteApplication_BlacklistHiddenFIO(t *testing.T) {
 	rec := submitFC(t, e, token, orgName, "people", uaID, data)
 	require.Equal(t, http.StatusOK, rec.Code, "пустое ФИО должно пропускать ЧС, а не падать/блокировать; body: %s", rec.Body.String())
 }
+
+// TestSubmitCompleteApplication_RoofParkingPersisted проверяет, что флаги
+// roof_access/free_parking сохраняются на вложении при подаче (#529 - основа для тегов).
+func TestSubmitCompleteApplication_RoofParkingPersisted(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	const orgName = "Test Organization"
+	token := testutil.RegisterAndLogin(t, e, "rp_user", "pass123", 1, td.OrgID, td.CompanyID)
+	citizenshipID := seedCitizenship(t, db)
+	tableID := seedSystemTable(t, db)
+	uaID := seedUniqueAttachment(t, db, "people", "rp_tmpl", "tmpl")
+
+	body := fmt.Sprintf(`{
+		"message": "rp",
+		"organization": "%s",
+		"responsible_person": "Test",
+		"contact_phone": "+79001234567",
+		"data_approval": true,
+		"attachments": [{
+			"attachment_type": "people",
+			"attachment_name": "rp_tmpl",
+			"attachment_display_name": "RP",
+			"unique_attachment_id": %d,
+			"entry_date_from": "2026-04-01",
+			"entry_date_to": "2099-12-31",
+			"entry_time_from": "08:00",
+			"entry_time_to": "18:00",
+			"roof_access": true,
+			"free_parking": true,
+			"data": {"employees": [{"last_name": "Иванов", "first_name": "Иван", "citizenship_id": %d, "position": "Рабочий", "passport_series_number": "1234 567890", "target_tables": [%d]}]}
+		}]
+	}`, orgName, uaID, citizenshipID, tableID)
+	rec := testutil.POST(t, e, "/applications/submit-complete-application", body, testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	var saved struct {
+		RoofAccess  bool `gorm:"column:roof_access"`
+		FreeParking bool `gorm:"column:free_parking"`
+	}
+	require.NoError(t, db.Raw(
+		"SELECT roof_access, free_parking FROM attachments WHERE unique_attachment_id = ? ORDER BY id DESC LIMIT 1", uaID,
+	).Scan(&saved).Error)
+	assert.True(t, saved.RoofAccess, "roof_access должен сохраниться true")
+	assert.True(t, saved.FreeParking, "free_parking должен сохраниться true")
+}

--- a/internal/handlers/applications_workflow.go
+++ b/internal/handlers/applications_workflow.go
@@ -109,6 +109,38 @@ func (h *ApplicationHandler) OverrideBlacklistFlag(c echo.Context) error {
 	return RespondMessage(c, "Пропуск подтверждён")
 }
 
+// DeleteBlacklistOverride godoc
+// @Summary      Отменить подтверждение пропуска
+// @Description  Снимает ранее подтверждённый пропуск по флагу (#481), снова блокируя согласование. Право: ответственный по заявке или принимающий.
+// @Tags         applications
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id      path int true "ID заявки"
+// @Param        flag_id query int true "ID предупреждения"
+// @Success      200 {object} map[string]interface{} "success + message"
+// @Failure      400 {object} models.HTTPError
+// @Failure      403 {object} models.HTTPError
+// @Failure      404 {object} models.HTTPError
+// @Failure      500 {object} models.HTTPError
+// @Router       /applications/{id}/blacklist-overrides [delete]
+func (h *ApplicationHandler) DeleteBlacklistOverride(c echo.Context) error {
+	username := c.Get("username").(string)
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid application ID")
+	}
+
+	flagID, err := strconv.Atoi(c.QueryParam("flag_id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid flag_id")
+	}
+
+	if err := h.service.DeleteBlacklistOverride(c.Request().Context(), username, id, flagID); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Подтверждение пропуска отменено")
+}
+
 // CheckApprovalStatus godoc
 // @Summary      Проверка статуса согласования
 // @Description  Возвращает текущие confirmation и status заявки.

--- a/internal/models/attachment.go
+++ b/internal/models/attachment.go
@@ -18,6 +18,9 @@ type Attachment struct {
 	UniqueAttachmentID    *int              `gorm:"index" json:"unique_attachment_id"`
 	UniqueAttachment      *UniqueAttachment `json:"-"`
 	Status                *int              `json:"status"`
+	// Общие булевы параметры заявки (#529): сохраняются на вложении, в просмотре - теги.
+	RoofAccess  bool `gorm:"default:false" json:"roof_access"`
+	FreeParking bool `gorm:"default:false" json:"free_parking"`
 }
 
 type UniqueAttachment struct {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -421,7 +421,8 @@ func Setup(e *echo.Echo, d Dependencies) {
 	apg.POST("/:id/update-items-status", app.UpdateApplicationItemsStatus)
 	apg.POST("/:id/forward", app.ForwardApplication)
 	apg.POST("/:id/approve", app.ApproveApplicationByUser)
-	apg.POST("/:id/blacklist-overrides", app.OverrideBlacklistFlag) // #481 - "всё равно пропустить"
+	apg.POST("/:id/blacklist-overrides", app.OverrideBlacklistFlag)     // #481 - "всё равно пропустить"
+	apg.DELETE("/:id/blacklist-overrides", app.DeleteBlacklistOverride) // #481 - отмена подтверждения (срез C)
 	apg.GET("/:id/check-approval-status", app.CheckApprovalStatus)
 	apg.POST("/:id/take-to-work", app.TakeApplicationToWork)
 	apg.POST("/:id/revoke-from-work", app.RevokeApplicationFromWork)

--- a/internal/services/application_attachment_service.go
+++ b/internal/services/application_attachment_service.go
@@ -51,6 +51,8 @@ func (s *applicationService) GetApplicationAttachments(ctx context.Context, appl
 			a.entry_date_to,
 			a.entry_time_from,
 			a.entry_time_to,
+			a.roof_access,
+			a.free_parking,
 			a.created_at,
 			a.unique_attachment_id,
 			ua.title as unique_attachment_title,

--- a/internal/services/application_blacklist_override_service.go
+++ b/internal/services/application_blacklist_override_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"strings"
@@ -82,6 +83,78 @@ func (s *applicationService) OverrideBlacklistFlag(ctx context.Context, username
 		return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка сохранения подтверждения пропуска")
 	}
 	return nil
+}
+
+// DeleteBlacklistOverride снимает ранее подтверждённый пропуск по флагу (#481, срез C):
+// удаляет аудит-запись override, чем снова блокирует согласование заявки по этому элементу
+// (hasUnoverriddenBlacklistFlags опять вернёт true). Право отмены шире, чем создание: не
+// только ответственный по заявке, но и принимающий (глобальный согласующий) - ошибочное
+// подтверждение должен мочь снять и тот, кто его не ставил. Override-строку удаляем (иначе
+// гейт не разблокируется обратно), поэтому факт отмены пишем отдельно в историю заявки.
+func (s *applicationService) DeleteBlacklistOverride(ctx context.Context, username string, applicationID, flagID int) error {
+	if flagID <= 0 {
+		return echo.NewHTTPError(http.StatusBadRequest, "Некорректный идентификатор предупреждения")
+	}
+	user, err := s.getUserByUsername(ctx, username)
+	if err != nil {
+		return err
+	}
+
+	allowed, err := s.canManageBlacklistOverride(ctx, applicationID, user.ID)
+	if err != nil {
+		return err
+	}
+	if !allowed {
+		return echo.NewHTTPError(http.StatusForbidden, "Недостаточно прав для отмены подтверждения пропуска")
+	}
+
+	// Флаг должен существовать и принадлежать этой заявке - защита от подмены чужого flag_id.
+	var flag models.ApplicationBlacklistFlag
+	if err := s.db.WithContext(ctx).Where("id = ? AND application_id = ?", flagID, applicationID).First(&flag).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "Предупреждение не найдено для этой заявки")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения предупреждения")
+	}
+
+	var override models.ApplicationBlacklistOverride
+	if err := s.db.WithContext(ctx).Where("flag_id = ? AND application_id = ?", flag.ID, applicationID).First(&override).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "Подтверждение пропуска не найдено")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения подтверждения пропуска")
+	}
+
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Delete(&models.ApplicationBlacklistOverride{}, override.ID).Error; err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка отмены подтверждения пропуска")
+		}
+		meta, _ := json.Marshal(map[string]any{"flag_id": flag.ID, "matched_value": override.MatchedValue})
+		if err := tx.Exec(`
+			INSERT INTO application_history (application_id, user_id, action_type, comment, metadata, created_at)
+			VALUES (?, ?, 'blacklist_override_revoke', ?, ?, ?)
+		`, applicationID, user.ID, override.MatchedValue, string(meta), time.Now().UTC()).Error; err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка записи истории")
+		}
+		return nil
+	})
+}
+
+// canManageBlacklistOverride - право отменять подтверждение пропуска (#481, срез C):
+// ответственный по этой заявке ИЛИ принимающий (глобальный согласующий). Шире, чем право
+// создавать override (только ответственный).
+func (s *applicationService) canManageBlacklistOverride(ctx context.Context, applicationID, userID int) (bool, error) {
+	var responsibleID int
+	if err := s.db.WithContext(ctx).Raw(
+		"SELECT id FROM application_responsible_users WHERE application_id = ? AND user_id = ?",
+		applicationID, userID,
+	).Scan(&responsibleID).Error; err != nil {
+		return false, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка проверки прав на заявку")
+	}
+	if responsibleID != 0 {
+		return true, nil
+	}
+	return s.isApprover(ctx, userID)
 }
 
 // hasUnoverriddenBlacklistFlags - есть ли у заявки помеченные элементы без override (#481).

--- a/internal/services/application_service.go
+++ b/internal/services/application_service.go
@@ -170,6 +170,8 @@ type AttachmentData struct {
 	EntryDateTo           *string                    `json:"entry_date_to"`
 	EntryTimeFrom         *string                    `json:"entry_time_from"`
 	EntryTimeTo           *string                    `json:"entry_time_to"`
+	RoofAccess            bool                       `json:"roof_access"`
+	FreeParking           bool                       `json:"free_parking"`
 	Data                  AttachmentContentData      `json:"data"`
 	CustomValues          *[]models.CustomValueInput `json:"custom_values,omitempty"`
 }
@@ -393,6 +395,8 @@ type AttachmentInfo struct {
 	EntryDateTo                 *string             `json:"entry_date_to"`
 	EntryTimeFrom               *string             `json:"entry_time_from"`
 	EntryTimeTo                 *string             `json:"entry_time_to"`
+	RoofAccess                  bool                `json:"roof_access"`
+	FreeParking                 bool                `json:"free_parking"`
 	CreatedAt                   *time.Time          `json:"created_at"`
 	UniqueAttachmentID          *int                `json:"unique_attachment_id"`
 	UniqueAttachmentTitle       *string             `json:"unique_attachment_title"`
@@ -1401,11 +1405,11 @@ func (s *applicationService) SubmitCompleteApplication(ctx context.Context, user
 	for _, att := range req.Attachments {
 		var attID int
 		err := tx.Raw(`
-			INSERT INTO attachments (application_id, attachment_type, attachment_name, attachment_display_name, unique_attachment_id, entry_date_from, entry_date_to, entry_time_from, entry_time_to, status)
-			VALUES (?, ?, ?, ?, ?, ?::date, ?::date, ?::time, ?::time, 1)
+			INSERT INTO attachments (application_id, attachment_type, attachment_name, attachment_display_name, unique_attachment_id, entry_date_from, entry_date_to, entry_time_from, entry_time_to, roof_access, free_parking, status)
+			VALUES (?, ?, ?, ?, ?, ?::date, ?::date, ?::time, ?::time, ?, ?, 1)
 			RETURNING id
 		`, appID, att.AttachmentType, att.AttachmentName, att.AttachmentDisplayName, att.UniqueAttachmentID,
-			att.EntryDateFrom, att.EntryDateTo, att.EntryTimeFrom, att.EntryTimeTo).Scan(&attID).Error
+			att.EntryDateFrom, att.EntryDateTo, att.EntryTimeFrom, att.EntryTimeTo, att.RoofAccess, att.FreeParking).Scan(&attID).Error
 		if err != nil {
 			tx.Rollback()
 			slog.Error("Ошибка создания вложения", "error", err)

--- a/internal/services/application_service.go
+++ b/internal/services/application_service.go
@@ -60,6 +60,10 @@ type ApplicationService interface {
 	// снимая блокировку согласования по этому флагу. Только ответственный, идемпотентно.
 	OverrideBlacklistFlag(ctx context.Context, username string, applicationID int, req OverrideBlacklistFlagRequest) error
 
+	// DeleteBlacklistOverride снимает ранее подтверждённый пропуск по флагу (#481), снова
+	// блокируя согласование по нему. Право шире, чем создание: ответственный ИЛИ принимающий.
+	DeleteBlacklistOverride(ctx context.Context, username string, applicationID, flagID int) error
+
 	// CheckApprovalStatus проверяет текущий статус согласования заявки.
 	CheckApprovalStatus(ctx context.Context, applicationID int) (*ApprovalStatusResponse, error)
 

--- a/internal/services/attachment_field_config_test.go
+++ b/internal/services/attachment_field_config_test.go
@@ -101,7 +101,6 @@ func TestRegistryDefaults_MatchForms(t *testing.T) {
 		// булевые чекбоксы - не обязуемы
 		{"people", "roof_access", true, false, false},
 		{"people", "free_parking", true, false, false},
-		{"people", "notify_situation_center", true, false, false},
 		// people
 		{"people", "last_name", true, true, true},
 		{"people", "middle_name", true, false, true},

--- a/internal/services/attachment_fields_registry.go
+++ b/internal/services/attachment_fields_registry.go
@@ -48,8 +48,7 @@ var attachmentFieldRegistry = []FieldDef{
 	{Key: "entry_time_from", Label: "Время с", Group: FieldGroupCommon, DefaultVisible: true, DefaultRequired: true, Requirable: true, Locked: true},
 	{Key: "entry_time_to", Label: "Время по", Group: FieldGroupCommon, DefaultVisible: true, DefaultRequired: true, Requirable: true, Locked: true},
 	{Key: "roof_access", Label: "Доступ на крышу", Group: FieldGroupCommon, DefaultVisible: true, DefaultRequired: false, Requirable: false},
-	{Key: "free_parking", Label: "Свободная парковка", Group: FieldGroupCommon, DefaultVisible: true, DefaultRequired: false, Requirable: false},
-	{Key: "notify_situation_center", Label: "Уведомить ситуационный центр", Group: FieldGroupCommon, DefaultVisible: true, DefaultRequired: false, Requirable: false},
+	{Key: "free_parking", Label: "Бесплатная парковка", Group: FieldGroupCommon, DefaultVisible: true, DefaultRequired: false, Requirable: false},
 
 	// people
 	{Key: "last_name", Label: "Фамилия", Group: FieldGroupPeople, DefaultVisible: true, DefaultRequired: true, Requirable: true},


### PR DESCRIPTION
Основа под теги заявок (#2 из фидбека). Чекбоксы «Доступ на крышу»/«Бесплатная парковка» раньше собирались формой подачи, но НЕ сохранялись (не было колонок, приёма в запросе и сохранения).

- Модель Attachment: поля roof_access/free_parking (AutoMigrate добавит колонки - migrate.go не трогал, модель уже в списке).
- Приём в AttachmentData, сохранение в INSERT при подаче, отдача в AttachmentInfo + SELECT детали.
- Реестр полей: удалил notify_situation_center (по просьбе владельца), переименовал «Свободная парковка» -> «Бесплатная парковка».
- Тесты: фокусный TestSubmitCompleteApplication_RoofParkingPersisted (true проходит submit -> сохраняется); существующие registry/config/submit зелёные; кейс на notify убран.

Фронт (слать значения из формы + теги в ApplicationsCenter/ApplicationDetail + убрать чекбокс notify) - отдельным PR поверх этого.