### PR TITLE
fix(applications): бейдж ЧС не ломает шапку Списка заявок в кабинете (#481)

### DIFF
--- a/frontend/src/components/UserApplications.vue
+++ b/frontend/src/components/UserApplications.vue
@@ -803,19 +803,28 @@ export default {
   flex: 1.2; /* Немного шире для номера заявки */
   min-width: 180px;
   max-width: 180px;
+}
+
+/* column-stack (номер + бейдж ЧС) только в строках данных. У заголовка остаётся row из
+   .header-col, иначе иконка сортировки уезжает под текст "Номер заявки" и шапка кривится.
+   Двойной класс заодно перебивает overflow: hidden из .application-col, иначе бейдж под
+   номером обрезается. */
+.application-col.id-col {
+  overflow: visible;
   flex-direction: column;
   justify-content: center;
   align-items: flex-start;
   gap: 4px;
 }
 
-/* Двойной класс перебивает overflow: hidden из .application-col, иначе бейдж под номером обрезается. */
-.application-col.id-col {
-  overflow: visible;
-}
-
 .blacklist-flag-badge {
   max-width: 100%;
+}
+
+/* у .application-col нет overflow:hidden после оверрайда - даём бейджу перенестись в
+   пределах фикс-ширины колонки, а не вылезать (специфичность бьёт nowrap из Badge). */
+.id-col .blacklist-flag-badge {
+  white-space: normal;
 }
 
 .date-col {


### PR DESCRIPTION
## Что и зачем
В личном кабинете ("Список заявок", `UserApplications.vue`) - тот же баг, что чинили в Центре заявок (#543/#545). Правило `.id-col { flex-direction: column }` (общий класс) перебивало `.header-col` и применялось к **шапке** тоже: иконка сортировки уезжала под текст "Номер заявки", шапка кривилась и расходилась со строками.

## Фикс
- column-stack (номер + бейдж ЧС) перенёс с `.id-col` на `.application-col.id-col` - только строки данных; шапка остаётся row из `.header-col` (иконка сортировки рядом с текстом).
- Бейджу под номером разрешил перенос (`white-space: normal`) в пределах фикс-ширины колонки, как в Центре заявок.

CSS-only, один файл. Логику не трогает.