### PR TITLE
feat(applications): чекбоксы и теги крыша/бесплатная парковка (#529)

### DIFF
--- a/frontend/src/components/ApplicationDetail/ApplicationAttachmentDetail.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationAttachmentDetail.vue
@@ -24,6 +24,27 @@
           {{ formatTimeRange(attachment.entry_time_from, attachment.entry_time_to) }}
         </span>
       </div>
+
+      <!-- Теги вложения: доступ на крышу / бесплатная парковка (#529) -->
+      <div
+        v-if="attachment.roof_access || attachment.free_parking"
+        class="attachment-tags"
+      >
+        <Badge
+          v-if="attachment.roof_access"
+          variant="info"
+          size="sm"
+        >
+          Крыша
+        </Badge>
+        <Badge
+          v-if="attachment.free_parking"
+          variant="success"
+          size="sm"
+        >
+          Парковка
+        </Badge>
+      </div>
     </div>
 
     <div
@@ -406,6 +427,13 @@ export default {
     flex-direction: column;
     gap: 0px;
     font-size: 14px;
+}
+
+.attachment-tags {
+    grid-column: 1 / -1;
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
 }
 
 .date-range:last-child, .time-range:last-child {

--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -160,7 +160,6 @@
             :end-time="currentAttachmentData.endTime"
             :roof-access="currentAttachmentData.roofAccess"
             :free-parking="currentAttachmentData.freeParking"
-            :notify-situation-center="currentAttachmentData.notifySituationCenter"
             :errors="currentAttachmentErrors"
             :field-config="currentFieldConfig"
             @update:is-one-day="updateAttachmentData('isOneDay', $event)"
@@ -171,7 +170,6 @@
             @update:end-time="updateAttachmentData('endTime', $event)"
             @update:roof-access="updateAttachmentData('roofAccess', $event)"
             @update:free-parking="updateAttachmentData('freeParking', $event)"
-            @update:notify-situation-center="updateAttachmentData('notifySituationCenter', $event)"
             @validate-field="validateAttachmentField"
             @validate-date-range="validateAttachmentDateRange"
             @validate-time-range="validateAttachmentTimeRange"
@@ -799,11 +797,10 @@ export default {
                 endTime: '',
                 roofAccess: false,
                 freeParking: false,
-                notifySituationCenter: false,
                 errors: {}
             };
         },
-        
+
         updateAttachmentData(field, value) {
             if (!this.selectedAttachment) return;
             
@@ -1745,6 +1742,8 @@ export default {
                     entry_date_to: this.formatDateForAPI(dateData.isOneDay ? dateData.singleDate : dateData.endDate),
                     entry_time_from: dateData.startTime + ":00",
                     entry_time_to: dateData.endTime + ":00",
+                    roof_access: dateData.roofAccess,
+                    free_parking: dateData.freeParking,
                     data: {}
                 };
 
@@ -2104,7 +2103,6 @@ export default {
                                 endTime: data.entry_time_to ? data.entry_time_to.substring(0, 5) : '',
                                 roofAccess: false,
                                 freeParking: false,
-                                notifySituationCenter: false,
                                 errors: {}
                             };
                         });

--- a/frontend/src/components/CreateApplication/DateRangeSection.vue
+++ b/frontend/src/components/CreateApplication/DateRangeSection.vue
@@ -385,6 +385,36 @@
         {{ errors.startTime || errors.endTime }}
       </div>
     </div>
+    <div
+      v-if="fieldVisible('roof_access') || fieldVisible('free_parking')"
+      class="date__input"
+    >
+      <label class="input__label">Дополнительно</label>
+      <div class="additional-options">
+        <label
+          v-if="fieldVisible('roof_access')"
+          class="option-checkbox"
+        >
+          <input
+            type="checkbox"
+            :checked="roofAccess"
+            @change="$emit('update:roof-access', $event.target.checked)"
+          >
+          <span class="option-text">Доступ на крышу</span>
+        </label>
+        <label
+          v-if="fieldVisible('free_parking')"
+          class="option-checkbox"
+        >
+          <input
+            type="checkbox"
+            :checked="freeParking"
+            @change="$emit('update:free-parking', $event.target.checked)"
+          >
+          <span class="option-text">Бесплатная парковка</span>
+        </label>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -402,7 +432,6 @@ export default {
         endTime: { type: String, default: null },
         roofAccess: Boolean,
         freeParking: Boolean,
-        notifySituationCenter: Boolean,
         errors: { type: Object, default: () => ({}) },
         // Настройка полей выбранного шаблона (#529): { [fieldKey]: { visible, required } }.
         // Потребляется через composable useFieldConfig (setup); дата/время реестром
@@ -418,7 +447,6 @@ export default {
         'update:end-time',
         'update:roof-access',
         'update:free-parking',
-        'update:notify-situation-center',
         'validate-field',
         'validate-date-range',
         'validate-time-range'

--- a/frontend/src/utils/__tests__/blacklistBadge.spec.js
+++ b/frontend/src/utils/__tests__/blacklistBadge.spec.js
@@ -17,9 +17,9 @@ describe('blacklistBadge', () => {
   });
 
   it('label склоняет форму-1 на 1/21/31', () => {
-    expect(blacklistFlagLabel({ blacklist_flags_count: 1 })).toBe('1 похожа на ЧС');
-    expect(blacklistFlagLabel({ blacklist_flags_count: 21 })).toBe('21 похожа на ЧС');
-    expect(blacklistFlagLabel({ blacklist_flags_count: 31 })).toBe('31 похожа на ЧС');
+    expect(blacklistFlagLabel({ blacklist_flags_count: 1 })).toBe('1 похоже на ЧС');
+    expect(blacklistFlagLabel({ blacklist_flags_count: 21 })).toBe('21 похоже на ЧС');
+    expect(blacklistFlagLabel({ blacklist_flags_count: 31 })).toBe('31 похоже на ЧС');
   });
 
   it('label склоняет множественную форму на 2-20/11', () => {

--- a/frontend/src/utils/blacklistBadge.js
+++ b/frontend/src/utils/blacklistBadge.js
@@ -10,13 +10,13 @@ export function blacklistFlagCount(application) {
 }
 
 /**
- * Метка бейджа со склонением: 1/21/31 - "похожа", 11/12/2/5 - "похожи"
+ * Метка бейджа со склонением: 1/21/31 - "похоже", 11/12/2/5 - "похожи"
  * (форма-1 при n % 10 === 1 и n % 100 !== 11, иначе множественная).
  */
 export function blacklistFlagLabel(application) {
   const n = blacklistFlagCount(application);
   const singular = n % 10 === 1 && n % 100 !== 11;
-  return `${n} ${singular ? 'похожа' : 'похожи'} на ЧС`;
+  return `${n} ${singular ? 'похоже' : 'похожи'} на ЧС`;
 }
 
 /** Подсказка (title) бейджа - что делать с похожими элементами. */

--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -1397,6 +1397,13 @@ export default {
     white-space: normal;
 }
 
+/* теги вложений (крыша/парковка) строкой под номером заявки (#529) */
+.application-tags {
+    display: flex;
+    gap: 4px;
+    flex-wrap: wrap;
+}
+
 .date-col {
     width: 15%;
 }

--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -295,6 +295,25 @@
                   >
                     {{ blacklistFlagLabel(application) }}
                   </Badge>
+                  <div
+                    v-if="application.has_roof_access || application.has_free_parking"
+                    class="application-tags"
+                  >
+                    <Badge
+                      v-if="application.has_roof_access"
+                      variant="info"
+                      size="sm"
+                    >
+                      Крыша
+                    </Badge>
+                    <Badge
+                      v-if="application.has_free_parking"
+                      variant="success"
+                      size="sm"
+                    >
+                      Парковка
+                    </Badge>
+                  </div>
                 </div>
                 <div class="application-col date-col">
                   {{ formatDateTime(application.sending_datetime) }}

--- a/internal/handlers/testdata/applications_list.golden
+++ b/internal/handlers/testdata/applications_list.golden
@@ -7,6 +7,8 @@ data[].confirmation
 data[].confirmation_datetime
 data[].data_approval
 data[].has_blank_template
+data[].has_free_parking
+data[].has_roof_access
 data[].id
 data[].is_read
 data[].message

--- a/internal/services/application_service.go
+++ b/internal/services/application_service.go
@@ -301,6 +301,8 @@ type ApplicationWithDetails struct {
 	HasBlankTemplate     bool       `json:"has_blank_template"`
 	IsRead               bool       `json:"is_read"`
 	BlacklistFlagsCount  int        `json:"blacklist_flags_count"`
+	HasRoofAccess        bool       `json:"has_roof_access"`
+	HasFreeParking       bool       `json:"has_free_parking"`
 }
 
 // ApplicationCreateResponse ответ при создании заявки.
@@ -534,6 +536,8 @@ func (s *applicationService) GetApplications(ctx context.Context, username strin
 			format_short_name(ru.last_name, ru.first_name, ru.middle_name) as responsible_name,
 			EXISTS (SELECT 1 FROM attachments att JOIN attachment_templates at2 ON at2.unique_attachment_id = att.unique_attachment_id AND at2.is_active = true WHERE att.application_id = a.id) as has_blank_template,
 			EXISTS (SELECT 1 FROM application_reads ar WHERE ar.application_id = a.id AND ar.user_id = ?) as is_read,
+			EXISTS (SELECT 1 FROM attachments att WHERE att.application_id = a.id AND att.roof_access = true) as has_roof_access,
+			EXISTS (SELECT 1 FROM attachments att WHERE att.application_id = a.id AND att.free_parking = true) as has_free_parking,
 			(SELECT COUNT(*) FROM application_blacklist_flags f WHERE f.application_id = a.id AND NOT EXISTS (SELECT 1 FROM application_blacklist_overrides o WHERE o.flag_id = f.id)) as blacklist_flags_count
 		`, user.ID).
 		Joins("LEFT JOIN organizations o ON a.organization_id = o.id").
@@ -599,6 +603,8 @@ func (s *applicationService) GetApplicationsPaginated(ctx context.Context, usern
 			format_short_name(ru.last_name, ru.first_name, ru.middle_name) as responsible_name,
 			EXISTS (SELECT 1 FROM attachments att JOIN attachment_templates at2 ON at2.unique_attachment_id = att.unique_attachment_id AND at2.is_active = true WHERE att.application_id = a.id) as has_blank_template,
 			EXISTS (SELECT 1 FROM application_reads ar WHERE ar.application_id = a.id AND ar.user_id = ?) as is_read,
+			EXISTS (SELECT 1 FROM attachments att WHERE att.application_id = a.id AND att.roof_access = true) as has_roof_access,
+			EXISTS (SELECT 1 FROM attachments att WHERE att.application_id = a.id AND att.free_parking = true) as has_free_parking,
 			(SELECT COUNT(*) FROM application_blacklist_flags f WHERE f.application_id = a.id AND NOT EXISTS (SELECT 1 FROM application_blacklist_overrides o WHERE o.flag_id = f.id)) as blacklist_flags_count
 		`, user.ID).
 		Order("a.sending_datetime DESC").
@@ -632,6 +638,8 @@ func (s *applicationService) GetUserApplications(ctx context.Context, username s
 			format_short_name(ru.last_name, ru.first_name, ru.middle_name) as responsible_name,
 			EXISTS (SELECT 1 FROM attachments att JOIN attachment_templates at2 ON at2.unique_attachment_id = att.unique_attachment_id AND at2.is_active = true WHERE att.application_id = a.id) as has_blank_template,
 			EXISTS (SELECT 1 FROM application_reads ar WHERE ar.application_id = a.id AND ar.user_id = ?) as is_read,
+			EXISTS (SELECT 1 FROM attachments att WHERE att.application_id = a.id AND att.roof_access = true) as has_roof_access,
+			EXISTS (SELECT 1 FROM attachments att WHERE att.application_id = a.id AND att.free_parking = true) as has_free_parking,
 			(SELECT COUNT(*) FROM application_blacklist_flags f WHERE f.application_id = a.id AND NOT EXISTS (SELECT 1 FROM application_blacklist_overrides o WHERE o.flag_id = f.id)) as blacklist_flags_count
 		`, user.ID).
 		Joins("LEFT JOIN organizations o ON a.organization_id = o.id").


### PR DESCRIPTION
## Что и зачем

Срез #2-B по #529: фронт флагов крыша/парковка поверх бэка #550. Оказалось, чекбоксы крыша/парковка в форме никогда не рендерились - keeq0 в ноябре завёл пропсы/эмиты/CSS, но саму разметку не дописал, и флаги `roofAccess/freeParking` всегда оставались false (выставить было негде). Этот PR доводит фичу до рабочего вида end-to-end.

## Изменения

- **Форма подачи** (`DateRangeSection`): добавил чекбоксы "Доступ на крышу" и "Бесплатная парковка", гейт через `fieldVisible()` (паттерн field-config #529, переиспользует осиротевший CSS `.additional-options`). Убрал мёртвый `notifySituationCenter` (пропс/эмит/состояние) - бэк #550 его уже выпилил из реестра.
- **Payload** (`CreateApplication`): `roof_access`/`free_parking` теперь уходят в `attachmentData` при подаче (значения были в `currentAttachmentData`, но не доезжали).
- **Теги** через `Badge.vue`: "Крыша"/"Парковка" в детали вложения (`ApplicationAttachmentDetail`, из `AttachmentInfo`) и строкой под номером заявки в Центре (`ApplicationsCenter`).
- **Бэкенд-агрегат**: `has_roof_access`/`has_free_parking` в list-SQL (`ApplicationWithDetails`, 3 запроса) - строка списка отдаёт "есть вложение с флагом". Обновил golden-контракт `applications_list.golden`.
- **Заодно**: склонение бейджа ЧС - единственная форма "похоже" вместо "похожа" (`blacklistBadge.js`).

## Проверки

- vitest scoped (blacklistBadge, ApplicationAttachmentDetail): 15/15 зелёные
- go build + go test ./internal/handlers ./internal/services: зелёные (контракт обновлён)
- eslint, gofmt: чисто

Скриншот размещения тегов - отдельно перед мержем.