### PR TITLE
fix(applications): пропуск ЧС - модалка отмены поверх, лог в историю, гашение повтора (#481)

### DIFF
--- a/frontend/src/components/ApplicationDetail/ApplicationHistory.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationHistory.vue
@@ -622,6 +622,7 @@ export default {
                 'assigned_viewer': 'dot-view',
                 'confirmation_change': 'dot-system',
                 'status_change': 'dot-system',
+                'blacklist_override': 'dot-success',
                 'blacklist_override_revoke': 'dot-warning'
             };
             return classes[actionType] || 'dot-default';
@@ -655,6 +656,7 @@ export default {
                 'assigned_viewer': 'Получил(-а) доступ к просмотру заявки',
                 'confirmation_change': 'Статус согласования изменился',
                 'status_change': 'Статус заявки изменился',
+                'blacklist_override': 'Подтвердил(-а) пропуск (возможный обход ЧС)',
                 'blacklist_override_revoke': 'Отменил(-а) подтверждение пропуска'
             };
             

--- a/frontend/src/components/CarHistoryModal.vue
+++ b/frontend/src/components/CarHistoryModal.vue
@@ -450,7 +450,9 @@ export default {
         'activate': 'dot-activate',
         'deactivate': 'dot-deactivate',
         'blacklisted': 'dot-delete',
-        'unblacklisted': 'dot-activate'
+        'unblacklisted': 'dot-activate',
+        'blacklist_override': 'dot-activate',
+        'blacklist_override_revoke': 'dot-deactivate'
       };
       return classes[actionType] || 'dot-default';
     },
@@ -470,9 +472,11 @@ export default {
         'deactivate': 'Автомобиль выведен из работы',
         'restore': 'Автомобиль восстановлен',
         'blacklisted': 'Добавлен в чёрный список',
-        'unblacklisted': 'Снят с чёрного списка'
+        'unblacklisted': 'Снят с чёрного списка',
+        'blacklist_override': 'Пропущен несмотря на подозрение в обходе ЧС',
+        'blacklist_override_revoke': 'Отменено подтверждение пропуска (обход ЧС)'
       };
-      
+
       let text = texts[item.action_type] || item.action_type;
       
       if (item.action_type === 'update' && item.field_name) {

--- a/frontend/src/components/ConfirmDialog.vue
+++ b/frontend/src/components/ConfirmDialog.vue
@@ -83,7 +83,11 @@ export default {
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1100;
+  /* Глобальный блокирующий confirm должен лежать ПОВЕРХ любых стопок модалок, из которых
+     его зовут (деталь заявки 10002, карточка 10003, override 10005, история 12000). Ниже
+     тоста (29000), чтобы уведомления оставались видны. Раньше было 1100 - терялся за
+     карточкой авто/сотрудника, открытой из заявки (#481). */
+  z-index: 20000;
   padding: 20px;
   backdrop-filter: blur(0.1px);
   -webkit-backdrop-filter: blur(0.1px);

--- a/frontend/src/components/CreateApplication/EmployeeHistoryModal.vue
+++ b/frontend/src/components/CreateApplication/EmployeeHistoryModal.vue
@@ -484,7 +484,9 @@ export default {
         'deactivate': 'dot-deactivate',
         'restore': 'dot-restore',
         'blacklisted': 'dot-delete',
-        'unblacklisted': 'dot-activate'
+        'unblacklisted': 'dot-activate',
+        'blacklist_override': 'dot-activate',
+        'blacklist_override_revoke': 'dot-deactivate'
       };
       return classes[actionType] || 'dot-default';
     },
@@ -504,7 +506,9 @@ export default {
         'deactivate': 'Сотрудник выведен из работы',
         'restore': 'Сотрудник восстановлен',
         'blacklisted': 'Добавлен в чёрный список',
-        'unblacklisted': 'Снят с чёрного списка'
+        'unblacklisted': 'Снят с чёрного списка',
+        'blacklist_override': 'Пропущен несмотря на подозрение в обходе ЧС',
+        'blacklist_override_revoke': 'Отменено подтверждение пропуска (обход ЧС)'
       };
       
       let text = texts[item.action_type] || item.action_type;

--- a/frontend/src/components/SessionExpiredModal.vue
+++ b/frontend/src/components/SessionExpiredModal.vue
@@ -110,7 +110,9 @@ export default {
   display: flex;
   justify-content: center;
   align-items: center;
-  z-index: 10000;
+  /* Истечение сессии - блокирующий takeover, должен лежать поверх любых открытых стопок
+     модалок (деталь/карточка/override/история), иначе re-auth прячется за ними (#481). */
+  z-index: 25000;
   backdrop-filter: blur(0.1px);
   -webkit-backdrop-filter: blur(0.1px);
 }

--- a/internal/handlers/applications_blacklist_override_test.go
+++ b/internal/handlers/applications_blacklist_override_test.go
@@ -341,3 +341,74 @@ func TestBlacklistOverride_Delete(t *testing.T) {
 		assert.Equal(t, int64(0), overrideCount())
 	})
 }
+
+// TestBlacklistOverride_HistoryAndSuppression: "всё равно пропустить" фиксируется в истории
+// заявки И машины (#481, срез C-followup), и гасит повторное предупреждение для той же машины
+// в будущих заявках, пока override жив; после отмены override предупреждение снова появляется.
+func TestBlacklistOverride_HistoryAndSuppression(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	ctx := context.Background()
+
+	const orgName = "Test Organization"
+	senderToken := testutil.RegisterAndLogin(t, e, "bh_sender", "pass123", 1, td.OrgID, td.CompanyID)
+	senderID := getUserID(t, db, "bh_sender")
+	mark := seedMark(t, db, "BH_Mark")
+
+	_, err := newVehicleBlacklistService(db).Create(ctx, models.CreateVehicleBlacklistRequest{
+		CarNumber: "H777HH799", MarkID: mark.ID, Reason: "розыск",
+	}, senderID)
+	require.NoError(t, err)
+
+	rec := submitCarApp(t, e, db, senderToken, orgName, "h1", "H777HH798", mark.ID)
+	require.Equal(t, http.StatusOK, rec.Code, "submit1: %s", rec.Body.String())
+	carID := latestElementID(t, db, "cars", "car_number = ?", "H777HH798")
+	flag, ok := blacklistFlagFor(t, db, models.BlacklistElementCar, carID)
+	require.True(t, ok, "ожидался флаг похожести")
+	appID := flag.ApplicationID
+
+	testutil.RegisterUser(t, e, "bh_appr", "pass123", 1, td.OrgID, td.CompanyID)
+	apprID := getUserID(t, db, "bh_appr")
+	fwd := fmt.Sprintf(`{"users":[{"user_id":%d,"required_approval":true,"can_view":false}]}`, apprID)
+	rec = testutil.POST(t, e, fmt.Sprintf("/applications/%d/forward", appID), fwd, testutil.AuthHeader(senderToken))
+	require.Equal(t, http.StatusOK, rec.Code, "forward: %s", rec.Body.String())
+	apprToken, _ := testutil.LoginUser(t, e, "bh_appr", "pass123")
+
+	rec = testutil.POST(t, e, fmt.Sprintf("/applications/%d/blacklist-overrides", appID),
+		fmt.Sprintf(`{"flag_id":%d,"comment":"проверил лично"}`, flag.ID), testutil.AuthHeader(apprToken))
+	require.Equal(t, http.StatusOK, rec.Code, "override: %s", rec.Body.String())
+
+	t.Run("override пишет историю заявки и машины", func(t *testing.T) {
+		var appHist int64
+		db.Table("application_history").
+			Where("application_id = ? AND action_type = 'blacklist_override'", appID).Count(&appHist)
+		assert.Equal(t, int64(1), appHist, "запись в истории заявки")
+
+		var carHist int64
+		db.Table("cars_history").
+			Where("car_id = ? AND action_type = 'blacklist_override'", carID).Count(&carHist)
+		assert.Equal(t, int64(1), carHist, "запись в истории машины")
+	})
+
+	t.Run("после пропуска та же машина в новой заявке не помечается", func(t *testing.T) {
+		rec := submitCarApp(t, e, db, senderToken, orgName, "h2", "H777HH798", mark.ID)
+		require.Equal(t, http.StatusOK, rec.Code, "submit2: %s", rec.Body.String())
+		car2 := latestElementID(t, db, "cars", "car_number = ?", "H777HH798")
+		require.NotEqual(t, carID, car2, "ожидалась новая строка машины")
+		_, ok := blacklistFlagFor(t, db, models.BlacklistElementCar, car2)
+		assert.False(t, ok, "повторное предупреждение должно быть подавлено после override")
+	})
+
+	t.Run("после отмены пропуска предупреждение снова появляется", func(t *testing.T) {
+		del := testutil.DELETE(t, e, fmt.Sprintf("/applications/%d/blacklist-overrides?flag_id=%d", appID, flag.ID), testutil.AuthHeader(apprToken))
+		require.Equal(t, http.StatusOK, del.Code, "delete: %s", del.Body.String())
+
+		rec := submitCarApp(t, e, db, senderToken, orgName, "h3", "H777HH798", mark.ID)
+		require.Equal(t, http.StatusOK, rec.Code, "submit3: %s", rec.Body.String())
+		car3 := latestElementID(t, db, "cars", "car_number = ?", "H777HH798")
+		_, ok := blacklistFlagFor(t, db, models.BlacklistElementCar, car3)
+		assert.True(t, ok, "после отмены override предупреждение снова появляется")
+	})
+}

--- a/internal/models/application_blacklist.go
+++ b/internal/models/application_blacklist.go
@@ -20,11 +20,16 @@ const (
 // флаг это снимок момента подачи (matched_value/reason фиксируются), он должен пережить
 // изменение/удаление записи ЧС и не каскадиться при удалении элемента.
 type ApplicationBlacklistFlag struct {
-	ID                 int       `json:"id"`
-	ApplicationID      int       `gorm:"index" json:"application_id"`
-	ElementType        string    `gorm:"size:20;index:idx_app_blacklist_flag_element,priority:1" json:"element_type"`
-	ElementID          int       `gorm:"index:idx_app_blacklist_flag_element,priority:2" json:"element_id"`
-	MatchedBlacklistID int       `json:"matched_blacklist_id"`
+	ID            int    `json:"id"`
+	ApplicationID int    `gorm:"index" json:"application_id"`
+	ElementType   string `gorm:"size:20;index:idx_app_blacklist_flag_element,priority:1" json:"element_type"`
+	ElementID     int    `gorm:"index:idx_app_blacklist_flag_element,priority:2" json:"element_id"`
+	// ElementNormalized - нормализованная форма самого элемента (normalize.Plate / normalize.Name),
+	// не записи ЧС. Стабильный ключ "этой машины/человека" между сабмитами (ElementID меняется,
+	// т.к. cars/employees создаются заново). По нему + MatchedBlacklistID гасим повторные
+	// предупреждения после "всё равно пропустить" (#481, срез C-followup).
+	ElementNormalized  string    `gorm:"size:300;index" json:"element_normalized"`
+	MatchedBlacklistID int       `gorm:"index" json:"matched_blacklist_id"`
 	MatchedValue       string    `gorm:"size:300" json:"matched_value"`
 	MatchedReason      string    `gorm:"size:500" json:"matched_reason"`
 	Similarity         float64   `json:"similarity"`
@@ -37,11 +42,16 @@ type ApplicationBlacklistFlag struct {
 // комментарий и снимок совпавшего значения - запись неизменяема и переживает удаление флага.
 // FlagID уникален (один override на флаг) и без FK - это исторический след, а не живая связь.
 type ApplicationBlacklistOverride struct {
-	ID                 int       `json:"id"`
-	FlagID             int       `gorm:"uniqueIndex" json:"flag_id"`
-	ApplicationID      int       `gorm:"index" json:"application_id"`
-	ElementType        string    `gorm:"size:20" json:"element_type"`
-	ElementID          int       `json:"element_id"`
+	ID            int    `json:"id"`
+	FlagID        int    `gorm:"uniqueIndex" json:"flag_id"`
+	ApplicationID int    `gorm:"index" json:"application_id"`
+	ElementType   string `gorm:"size:20" json:"element_type"`
+	ElementID     int    `json:"element_id"`
+	// ElementNormalized + MatchedBlacklistID копируются с флага: служат ключом подавления
+	// будущих предупреждений по той же паре "элемент <-> запись ЧС" (#481, срез C-followup).
+	// Пока override жив - не предупреждаем; отмена override (DELETE) снова включает предупреждение.
+	ElementNormalized  string    `gorm:"size:300;index" json:"element_normalized"`
+	MatchedBlacklistID int       `gorm:"index" json:"matched_blacklist_id"`
 	MatchedValue       string    `gorm:"size:300" json:"matched_value"`
 	OverriddenByUserID int       `json:"overridden_by_user_id"`
 	Comment            string    `gorm:"size:1000" json:"comment"`

--- a/internal/services/application_blacklist_override_service.go
+++ b/internal/services/application_blacklist_override_service.go
@@ -66,21 +66,67 @@ func (s *applicationService) OverrideBlacklistFlag(ctx context.Context, username
 		return nil // уже подтверждён - идемпотентно
 	}
 
+	now := time.Now().UTC()
 	override := models.ApplicationBlacklistOverride{
 		FlagID:             flag.ID,
 		ApplicationID:      flag.ApplicationID,
 		ElementType:        flag.ElementType,
 		ElementID:          flag.ElementID,
+		ElementNormalized:  flag.ElementNormalized,
+		MatchedBlacklistID: flag.MatchedBlacklistID,
 		MatchedValue:       flag.MatchedValue,
 		OverriddenByUserID: user.ID,
 		Comment:            comment,
-		CreatedAt:          time.Now().UTC(),
+		CreatedAt:          now,
 	}
-	if err := s.db.WithContext(ctx).Create(&override).Error; err != nil {
+	// Создание override + запись решения в обе истории (заявки и элемента) атомарно.
+	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(&override).Error; err != nil {
+			return err
+		}
+		return s.logBlacklistOverrideAction(tx, flag, user.ID, "blacklist_override", comment, now)
+	})
+	if err != nil {
 		if isUniqueViolation(err) {
 			return nil // гонка двух параллельных override одного флага - не ошибка
 		}
 		return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка сохранения подтверждения пропуска")
+	}
+	return nil
+}
+
+// logBlacklistOverrideAction фиксирует подтверждение/отмену пропуска И в истории заявки, И в
+// истории самого элемента (машины/человека) - чтобы решение было видно из обеих карточек (#481,
+// срез C-followup). actionType: 'blacklist_override' / 'blacklist_override_revoke'.
+func (s *applicationService) logBlacklistOverrideAction(tx *gorm.DB, flag models.ApplicationBlacklistFlag, userID int, actionType, comment string, at time.Time) error {
+	meta, _ := json.Marshal(map[string]any{
+		"flag_id":              flag.ID,
+		"matched_blacklist_id": flag.MatchedBlacklistID,
+		"matched_value":        flag.MatchedValue,
+	})
+	if err := tx.Exec(`
+		INSERT INTO application_history (application_id, user_id, action_type, comment, metadata, created_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`, flag.ApplicationID, userID, actionType, comment, string(meta), at).Error; err != nil {
+		return err
+	}
+
+	// В истории элемента поясняем, на что похоже (комментарий-причину сюда же, если есть).
+	elemComment := comment
+	if elemComment == "" {
+		elemComment = flag.MatchedValue
+	}
+	switch flag.ElementType {
+	case models.BlacklistElementCar:
+		return tx.Exec(`
+			INSERT INTO cars_history (car_id, user_id, action_type, comment, created_at)
+			VALUES (?, ?, ?, ?, ?)
+		`, flag.ElementID, userID, actionType, elemComment, at).Error
+	case models.BlacklistElementEmployee:
+		return tx.Exec(`
+			INSERT INTO employees_history (employee_id, user_id, action_type, comment, created_at)
+			VALUES (?, ?, ?, ?, ?)
+		`, flag.ElementID, userID, actionType, elemComment, at).Error
 	}
 	return nil
 }
@@ -129,11 +175,8 @@ func (s *applicationService) DeleteBlacklistOverride(ctx context.Context, userna
 		if err := tx.Delete(&models.ApplicationBlacklistOverride{}, override.ID).Error; err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка отмены подтверждения пропуска")
 		}
-		meta, _ := json.Marshal(map[string]any{"flag_id": flag.ID, "matched_value": override.MatchedValue})
-		if err := tx.Exec(`
-			INSERT INTO application_history (application_id, user_id, action_type, comment, metadata, created_at)
-			VALUES (?, ?, 'blacklist_override_revoke', ?, ?, ?)
-		`, applicationID, user.ID, override.MatchedValue, string(meta), time.Now().UTC()).Error; err != nil {
+		// Отмена без причины - комментарий пустой, история элемента подставит matched_value.
+		if err := s.logBlacklistOverrideAction(tx, flag, user.ID, "blacklist_override_revoke", "", time.Now().UTC()); err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка записи истории")
 		}
 		return nil

--- a/internal/services/application_service.go
+++ b/internal/services/application_service.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"systemburo/internal/models"
+	"systemburo/internal/normalize"
 
 	"github.com/labstack/echo/v4"
 	"gorm.io/gorm"
@@ -1190,7 +1191,7 @@ func (s *applicationService) detectBlacklistSimilarity(ctx context.Context, appI
 			slog.Warn("blacklist similarity check failed (vehicle)", "err", err, "app_id", appID, "car_id", v.carID)
 			continue
 		}
-		s.saveBlacklistFlag(ctx, appID, models.BlacklistElementCar, v.carID, matches)
+		s.saveBlacklistFlag(ctx, appID, models.BlacklistElementCar, v.carID, normalize.Plate(v.carNumber), matches)
 	}
 	for _, e := range employees {
 		matches, err := s.personBlacklist.FindSimilar(ctx, e.lastName, e.firstName, e.middleName)
@@ -1198,22 +1199,28 @@ func (s *applicationService) detectBlacklistSimilarity(ctx context.Context, appI
 			slog.Warn("blacklist similarity check failed (person)", "err", err, "app_id", appID, "employee_id", e.empID)
 			continue
 		}
-		s.saveBlacklistFlag(ctx, appID, models.BlacklistElementEmployee, e.empID, matches)
+		s.saveBlacklistFlag(ctx, appID, models.BlacklistElementEmployee, e.empID, normalize.Name(e.lastName, e.firstName, e.middleName), matches)
 	}
 }
 
 // saveBlacklistFlag сохраняет ЛУЧШЕЕ совпадение как флаг элемента: matches приходят
 // отсортированными по убыванию близости (контракт FindSimilar). Пустой срез - элемент
 // чист, флаг не пишем. Ошибку записи логируем и проглатываем (best-effort warning-слой).
-func (s *applicationService) saveBlacklistFlag(ctx context.Context, appID int, elementType string, elementID int, matches []models.BlacklistSimilarMatch) {
+func (s *applicationService) saveBlacklistFlag(ctx context.Context, appID int, elementType string, elementID int, elementNormalized string, matches []models.BlacklistSimilarMatch) {
 	if len(matches) == 0 {
 		return
 	}
 	best := matches[0]
+	// Если оператор уже подтвердил пропуск этого элемента против этой записи ЧС - не
+	// предупреждаем повторно (#481, срез C-followup). Отмена override снова включит флаг.
+	if s.isBlacklistSuppressed(ctx, elementType, elementNormalized, best.ID) {
+		return
+	}
 	flag := models.ApplicationBlacklistFlag{
 		ApplicationID:      appID,
 		ElementType:        elementType,
 		ElementID:          elementID,
+		ElementNormalized:  elementNormalized,
 		MatchedBlacklistID: best.ID,
 		MatchedValue:       best.MatchedValue,
 		MatchedReason:      best.Reason,
@@ -1223,6 +1230,27 @@ func (s *applicationService) saveBlacklistFlag(ctx context.Context, appID int, e
 	if err := s.db.WithContext(ctx).Create(&flag).Error; err != nil {
 		slog.Warn("blacklist flag save failed", "err", err, "app_id", appID, "element_type", elementType, "element_id", elementID)
 	}
+}
+
+// isBlacklistSuppressed - оператор ранее нажал "всё равно пропустить" по этому элементу
+// против этой записи ЧС, и подтверждение ещё действует (override-строка жива) -> повторно
+// не предупреждаем (#481, срез C-followup). Ключ - нормализованная форма элемента + id записи
+// ЧС, поэтому переживает пересоздание cars/employees между заявками. Best-effort: при пустом
+// ключе или ошибке считаем "не подавлено" (лучше лишний раз предупредить, чем тихо пропустить).
+func (s *applicationService) isBlacklistSuppressed(ctx context.Context, elementType, elementNormalized string, matchedBlacklistID int) bool {
+	if elementNormalized == "" {
+		return false
+	}
+	var cnt int64
+	err := s.db.WithContext(ctx).Model(&models.ApplicationBlacklistOverride{}).
+		Where("element_type = ? AND element_normalized = ? AND matched_blacklist_id = ?",
+			elementType, elementNormalized, matchedBlacklistID).
+		Count(&cnt).Error
+	if err != nil {
+		slog.Warn("blacklist suppression check failed", "err", err, "element_type", elementType)
+		return false
+	}
+	return cnt > 0
 }
 
 // SubmitCompleteApplication создаёт полную заявку с вложениями, машинами и сотрудниками.


### PR DESCRIPTION
Три правки по флоу "всё равно пропустить" (по фидбеку после среза C).

## 1. Модалка отмены не видна
`ConfirmDialog` ("Снять подтверждение пропуска?") имел z-index 1100 и открывался ЗА деталью заявки/карточкой (стопка 10002-10005). Поднял глобальные блокирующие диалоги над стопкой: `ConfirmDialog` -> 20000, `SessionExpiredModal` -> 25000 (тот же латентный баг - re-auth прятался за открытой карточкой).

## 2. "Всё равно пропустить" не писалось в историю
POST override создавал только аудит-строку. Теперь подтверждение И отмена пишутся в историю заявки (`blacklist_override` / `blacklist_override_revoke`) И в историю машины/человека (`cars_history`/`employees_history`) - в одной транзакции с созданием/удалением override. Подписи добавлены в `ApplicationHistory`, `CarHistoryModal`, `EmployeeHistoryModal`.

## 3. Повторное предупреждение после пропуска
Если элемент один раз "всё равно пропустили", по той же паре (нормализованный номер/ФИО элемента + id записи ЧС) предупреждение больше не возникает в новых заявках. Ключ `element_normalized` + `matched_blacklist_id` добавлены в флаг и override (авто-миграция, модели уже в AllModels - migrate.go не трогал). Подавление живёт, пока есть override; отмена снова включает предупреждение.

## Тесты
- BE: `TestBlacklistOverride_HistoryAndSuppression` - история заявки+машины, подавление повторной подачи, повторное появление после отмены. Все `TestBlacklistOverride*` зелёные.
- FE: затронутые vitest-папки 120/120; eslint/gofmt/go vet чисто.