### PR TITLE
feat(applications): теги крыша/парковка отдельной колонкой + тумблеры (#529)

### DIFF
--- a/frontend/src/components/ApplicationDetail/ApplicationAttachmentDetail.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationAttachmentDetail.vue
@@ -1,7 +1,28 @@
 <template>
   <div class="attachment-details">
     <div class="attachment-header-section">
-      <h4>{{ attachment.attachment_display_name }}</h4>
+      <div class="attachment-title-row">
+        <h4>{{ attachment.attachment_display_name }}</h4>
+        <div
+          v-if="attachment.roof_access || attachment.free_parking"
+          class="attachment-tags"
+        >
+          <Badge
+            v-if="attachment.roof_access"
+            variant="info"
+            size="lg"
+          >
+            Крыша
+          </Badge>
+          <Badge
+            v-if="attachment.free_parking"
+            variant="success"
+            size="lg"
+          >
+            Парковка
+          </Badge>
+        </div>
+      </div>
 
       <!-- Даты действия -->
       <div
@@ -23,27 +44,6 @@
         <span class="time-value">
           {{ formatTimeRange(attachment.entry_time_from, attachment.entry_time_to) }}
         </span>
-      </div>
-
-      <!-- Теги вложения: доступ на крышу / бесплатная парковка (#529) -->
-      <div
-        v-if="attachment.roof_access || attachment.free_parking"
-        class="attachment-tags"
-      >
-        <Badge
-          v-if="attachment.roof_access"
-          variant="info"
-          size="sm"
-        >
-          Крыша
-        </Badge>
-        <Badge
-          v-if="attachment.free_parking"
-          variant="success"
-          size="sm"
-        >
-          Парковка
-        </Badge>
       </div>
     </div>
 
@@ -429,11 +429,19 @@ export default {
     font-size: 14px;
 }
 
-.attachment-tags {
+.attachment-title-row {
     grid-column: 1 / -1;
     display: flex;
-    gap: 6px;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.attachment-tags {
+    display: flex;
+    gap: 8px;
     flex-wrap: wrap;
+    flex-shrink: 0;
 }
 
 .date-range:last-child, .time-range:last-child {

--- a/frontend/src/components/CreateApplication/DateRangeSection.vue
+++ b/frontend/src/components/CreateApplication/DateRangeSection.vue
@@ -393,24 +393,28 @@
       <div class="additional-options">
         <label
           v-if="fieldVisible('roof_access')"
-          class="option-checkbox"
+          class="option-toggle"
         >
           <input
             type="checkbox"
+            class="option-toggle__input"
             :checked="roofAccess"
             @change="$emit('update:roof-access', $event.target.checked)"
           >
+          <span class="option-toggle__switch" />
           <span class="option-text">Доступ на крышу</span>
         </label>
         <label
           v-if="fieldVisible('free_parking')"
-          class="option-checkbox"
+          class="option-toggle"
         >
           <input
             type="checkbox"
+            class="option-toggle__input"
             :checked="freeParking"
             @change="$emit('update:free-parking', $event.target.checked)"
           >
+          <span class="option-toggle__switch" />
           <span class="option-text">Бесплатная парковка</span>
         </label>
       </div>
@@ -1117,32 +1121,63 @@ export default {
     cursor: pointer;
 }
 
-/* Чекбоксы справа */
+/* Тумблеры "Дополнительно": без фикс-высоты и justify-center - скрытое поле не оставляет дыру,
+   оставшееся встаёт наверх. */
 .additional-options {
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 12px;
     width: 100%;
-    height: 80px;
-    justify-content:center;
 }
 
-.option-checkbox {
+.option-toggle {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: 11px;
     cursor: pointer;
-    font-size: 12px;
-    line-height: 1.2;
-    height: 16px;
+    user-select: none;
 }
 
-.option-checkbox input[type="checkbox"] {
-    width: 12px;
-    height: 12px;
-    cursor: pointer;
-    margin: 0;
+.option-toggle__input {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.option-toggle__switch {
+    position: relative;
+    width: 42px;
+    height: 24px;
+    border-radius: var(--radius-pill, 999px);
+    background: #d4d7e3;
+    transition: background 0.22s ease;
     flex-shrink: 0;
+}
+
+.option-toggle__switch::after {
+    content: '';
+    position: absolute;
+    top: 3px;
+    left: 3px;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: #fff;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+    transition: transform 0.22s cubic-bezier(0.3, 1.3, 0.5, 1);
+}
+
+.option-toggle__input:checked + .option-toggle__switch {
+    background: var(--color-primary, #4F5BDF);
+}
+
+.option-toggle__input:checked + .option-toggle__switch::after {
+    transform: translateX(18px);
+}
+
+.option-toggle__input:focus-visible + .option-toggle__switch {
+    box-shadow: 0 0 0 3px rgba(79, 91, 223, 0.3);
 }
 
 .option-text {

--- a/frontend/src/components/UserApplications.vue
+++ b/frontend/src/components/UserApplications.vue
@@ -122,6 +122,9 @@
                   }"
                 >
               </div>
+              <div class="header-col tags-col">
+                <p>Теги</p>
+              </div>
               <div class="header-col actions-col" />
             </div>
           </div>
@@ -186,6 +189,27 @@
                         >
                           {{ application.status }}
                         </span>
+                      </div>
+                      <div class="application-col tags-col">
+                        <div
+                          v-if="application.has_roof_access || application.has_free_parking"
+                          class="application-tags"
+                        >
+                          <Badge
+                            v-if="application.has_roof_access"
+                            variant="info"
+                            size="sm"
+                          >
+                            Крыша
+                          </Badge>
+                          <Badge
+                            v-if="application.has_free_parking"
+                            variant="success"
+                            size="sm"
+                          >
+                            Парковка
+                          </Badge>
+                        </div>
                       </div>
                       <div class="application-col actions-col">
                         <button
@@ -801,8 +825,7 @@ export default {
 /* Колонки с пропорциональной шириной для 5 столбцов */
 .id-col {
   flex: 1.2; /* Немного шире для номера заявки */
-  min-width: 180px;
-  max-width: 180px;
+  min-width: 160px;
 }
 
 /* column-stack (номер + бейдж ЧС) только в строках данных. У заголовка остаётся row из
@@ -828,27 +851,42 @@ export default {
 }
 
 .date-col {
-  flex: 1.5; /* Шире для даты и времени */
-  min-width: 180px;
-  max-width: 180px;
+  flex: 1.3; /* Шире для даты и времени */
+  min-width: 150px;
 }
 
 .sender-col {
-  flex: 1.2; /* Отправитель */
-  min-width: 200px;
-  max-width: 200px;
+  flex: 1.4; /* Отправитель */
+  min-width: 160px;
 }
 
 .confirmation-col {
   flex: 1; /* Подтверждение */
-  min-width: 180px;
-  max-width: 180px;
+  min-width: 140px;
 }
 
 .status-col {
+  flex: 1.1;
+  min-width: 150px;
+}
+
+.tags-col {
   flex: 1;
-  min-width: 180px;
-  max-width: 180px;
+  min-width: 130px;
+}
+
+.header-col.tags-col {
+  cursor: default;
+}
+
+.header-col.tags-col:hover {
+  color: #a2a2a2;
+}
+
+.tags-col .application-tags {
+  display: flex;
+  gap: 4px;
+  flex-wrap: nowrap;
 }
 
 .actions-col {

--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -233,6 +233,9 @@
               }" 
             >
           </div>
+          <div class="header-col tags-col">
+            <p>Теги</p>
+          </div>
           <div class="header-col actions-col">
             <RefreshButton
               :loading="refreshing"
@@ -295,25 +298,6 @@
                   >
                     {{ blacklistFlagLabel(application) }}
                   </Badge>
-                  <div
-                    v-if="application.has_roof_access || application.has_free_parking"
-                    class="application-tags"
-                  >
-                    <Badge
-                      v-if="application.has_roof_access"
-                      variant="info"
-                      size="sm"
-                    >
-                      Крыша
-                    </Badge>
-                    <Badge
-                      v-if="application.has_free_parking"
-                      variant="success"
-                      size="sm"
-                    >
-                      Парковка
-                    </Badge>
-                  </div>
                 </div>
                 <div class="application-col date-col">
                   {{ formatDateTime(application.sending_datetime) }}
@@ -337,6 +321,27 @@
                   >
                     {{ application.status }}
                   </span>
+                </div>
+                <div class="application-col tags-col">
+                  <div
+                    v-if="application.has_roof_access || application.has_free_parking"
+                    class="application-tags"
+                  >
+                    <Badge
+                      v-if="application.has_roof_access"
+                      variant="info"
+                      size="sm"
+                    >
+                      Крыша
+                    </Badge>
+                    <Badge
+                      v-if="application.has_free_parking"
+                      variant="success"
+                      size="sm"
+                    >
+                      Парковка
+                    </Badge>
+                  </div>
                 </div>
                 <div class="application-col actions-col">
                   <button
@@ -1368,11 +1373,11 @@ export default {
 
 /* Перераспределение размеров колонок */
 .confirmation-col {
-    width: 15%;
+    width: 13%;
 }
 
 .number-col {
-    width: 18%;
+    width: 15%;
     /* min-width:0 снимает min-content "пол" flex-элемента: иначе nowrap-бейдж под номером
        не даёт строке сжаться до своей доли, и шапка (узкий контент) расходится со строкой. */
     min-width: 0;
@@ -1397,23 +1402,27 @@ export default {
     white-space: normal;
 }
 
-/* теги вложений (крыша/парковка) строкой под номером заявки (#529) */
+/* теги вложений (крыша/парковка) в отдельной колонке, в одну строку (#529) */
 .application-tags {
     display: flex;
     gap: 4px;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
+}
+
+.tags-col {
+    width: 11%;
 }
 
 .date-col {
-    width: 15%;
+    width: 13%;
 }
 
 .organization-col {
-    width: 17%;
+    width: 15%;
 }
 
 .sender-col {
-    width: 15%;
+    width: 13%;
 }
 
 .sender-tooltip-anchor {
@@ -1460,7 +1469,7 @@ export default {
 }
 
 .status-col {
-    width: 15%;
+    width: 13%;
 }
 
 .actions-col {


### PR DESCRIPTION
Доработка презентации тегов по утверждённому мокапу (ветка design/529-tags-layout, вариант A).

## Изменения
- **Центр заявок** (`ApplicationsCenter`): теги переехали из-под номера в отдельную колонку **«Теги»** после «Статус заявки», в одну строку (`flex`, `nowrap`). Ширины колонок пересчитаны: 13/15/13/15/13/13/**11**/7% = 100%.
- **Личный кабинет** (`UserApplications`): та же колонка «Теги» после «Статус». Плюс убрал `max-width` у колонок - таблица тянется на всю ширину компонента, пустоты справа больше нет (`flex`+`min-width`).
- **Форма подачи** (`DateRangeSection`): чекбоксы крыша/парковка заменены **тумблерами**; убрана фикс-высота и `justify-content:center` - скрытое настройкой поле не оставляет дыру, второе встаёт наверх.
- **Деталь вложения** (`ApplicationAttachmentDetail`): тег справа от заголовка `h4` (`space-between`), размер крупнее (lg).

Данные уже есть: `has_roof_access`/`has_free_parking` в list-ответе (Центр+ЛК), `roof_access`/`free_parking` в детали - бэк не трогался.

## Проверки
eslint чисто; vitest ApplicationAttachmentDetail 10/10, DateRangeSectionFieldConfig 6/6.