### PR TITLE
fix(applications): детали в истории пропуска ЧС + единый ввод номера авто (#481)

### DIFF
--- a/frontend/src/components/admin/blacklist/AddToBlacklistModal.vue
+++ b/frontend/src/components/admin/blacklist/AddToBlacklistModal.vue
@@ -19,17 +19,11 @@
       <!-- EDIT: правка идентичности записи реестра -->
       <template v-else>
         <template v-if="type === 'vehicle'">
-          <FormField
-            label="Номер Т/С"
-            :required="true"
-          >
-            <input
-              ref="firstInput"
-              v-model="carNumber"
-              class="lk-input"
-              placeholder="А777АА 77"
-            >
-          </FormField>
+          <!-- Поячеечный ввод номера по формату - тот же, что при создании записи ЧС (#481). -->
+          <VehicleNumberFormatInput
+            :key="openSeq"
+            v-model="carNumber"
+          />
           <FormField
             label="Марка Т/С"
             :required="true"
@@ -120,6 +114,7 @@
 import BaseModal from '@/components/ui/BaseModal.vue';
 import FormField from '@/components/ui/FormField.vue';
 import BaseDropdown from '@/components/ui/BaseDropdown.vue';
+import VehicleNumberFormatInput from './VehicleNumberFormatInput.vue';
 import { listMarks } from '@/api/marks';
 
 /**
@@ -132,7 +127,7 @@ import { listMarks } from '@/api/marks';
  */
 export default {
   name: 'AddToBlacklistModal',
-  components: { BaseModal, FormField, BaseDropdown },
+  components: { BaseModal, FormField, BaseDropdown, VehicleNumberFormatInput },
   props: {
     show: { type: Boolean, default: false },
     type: { type: String, required: true, validator: (v) => ['vehicle', 'person'].includes(v) },
@@ -155,6 +150,9 @@ export default {
       firstName: '',
       middleName: '',
       marks: [],
+      // Меняется при каждом открытии - форсит ремоунт VehicleNumberFormatInput, чтобы он
+      // заново разложил префилл номера по ячейкам.
+      openSeq: 0,
     };
   },
   computed: {
@@ -190,6 +188,7 @@ export default {
         this.lastName = e.last_name || '';
         this.firstName = e.first_name || '';
         this.middleName = e.middle_name || '';
+        this.openSeq += 1; // ремоунт ввода номера -> повторный префилл по ячейкам
         if (this.type === 'vehicle') this.loadMarks();
       }
       this.$nextTick(() => this.$refs.firstInput?.focus());

--- a/frontend/src/components/admin/blacklist/BlacklistCreateModal.vue
+++ b/frontend/src/components/admin/blacklist/BlacklistCreateModal.vue
@@ -7,77 +7,14 @@
   >
     <div class="bl-create">
       <template v-if="type === 'vehicle'">
-        <div class="completion__format">
-          <div class="format__header">
-            <label class="format__label">Формат номеров <span class="required">*</span></label>
-          </div>
-          <div class="format__dropdown">
-            <button
-              class="dropdown__button"
-              @click="toggleFormatDropdown"
-            >
-              <div class="button__content">
-                <span class="button__text">{{ selectedFormatText }}</span>
-                <img
-                  src="@/assets/icons/arrow.png"
-                  class="button__arrow"
-                  :class="{ 'button__arrow--open': isFormatDropdownOpen }"
-                >
-              </div>
-            </button>
-            <transition name="dropdown">
-              <div
-                v-if="isFormatDropdownOpen"
-                class="dropdown__menu"
-              >
-                <div
-                  v-for="format in formats"
-                  :key="format.format.id"
-                  class="dropdown__item"
-                  @click="selectFormat(format)"
-                >
-                  <span class="item__text">{{ format.format.name }}</span>
-                </div>
-                <div
-                  v-if="!formats.length"
-                  class="dropdown__item"
-                >
-                  <span class="item__text">Нет форматов</span>
-                </div>
-              </div>
-            </transition>
-          </div>
-        </div>
+        <!-- Поячеечный ввод номера по формату вынесен в общий компонент - он же используется
+             при правке записи ЧС, чтобы создание и редактирование не расходились (#481). -->
+        <VehicleNumberFormatInput
+          v-model="carNumber"
+          class="bl-create__number"
+        />
 
         <div class="completion__fields">
-          <div class="completion__number">
-            <div class="completion__number-header">
-              <label class="input__label">Номер Т/С <span class="required">*</span></label>
-            </div>
-            <div
-              v-if="selectedFormat"
-              class="number__field"
-            >
-              <input
-                v-for="(cell, index) in selectedFormat.cells"
-                :key="index"
-                v-model="numberParts[index]"
-                class="number__input"
-                :placeholder="getPlaceholder(cell)"
-                :maxlength="cell.max_length"
-                :style="{ width: getInputWidth(cell) }"
-                @input="validatePart(index, $event, cell)"
-                @blur="formatPart(index, cell)"
-              >
-            </div>
-            <div
-              v-else
-              class="no-format-message"
-            >
-              Выберите формат номера
-            </div>
-          </div>
-
           <div class="completion__mark">
             <div class="completion__mark-header">
               <label class="input__label">Марка Т/С <span class="required">*</span></label>
@@ -205,9 +142,8 @@
 <script>
 import BaseModal from '@/components/ui/BaseModal.vue';
 import FormField from '@/components/ui/FormField.vue';
-import { apiRequest } from '@/api/client';
+import VehicleNumberFormatInput from './VehicleNumberFormatInput.vue';
 import { listMarks } from '@/api/marks';
-import { validatePartValue, formatPartValue, initializeNumberParts } from '@/composables/useNumberFormat';
 
 /**
  * Модалка добавления записи в чёрный список (#443). Тип определяет форму: 'vehicle' -
@@ -217,7 +153,7 @@ import { validatePartValue, formatPartValue, initializeNumberParts } from '@/com
  */
 export default {
   name: 'BlacklistCreateModal',
-  components: { BaseModal, FormField },
+  components: { BaseModal, FormField, VehicleNumberFormatInput },
   props: {
     show: { type: Boolean, default: false },
     type: { type: String, required: true, validator: (v) => ['vehicle', 'person'].includes(v) },
@@ -226,15 +162,12 @@ export default {
   emits: ['close', 'created'],
   data() {
     return {
-      formats: [],
-      selectedFormatId: null,
-      isFormatDropdownOpen: false,
+      carNumber: '',
       marks: [],
       markId: null,
       selectedMark: '',
       isMarkDropdownOpen: false,
       markSearch: '',
-      numberParts: [],
       lastName: '',
       firstName: '',
       middleName: '',
@@ -247,12 +180,6 @@ export default {
     title() {
       return this.type === 'vehicle' ? 'Добавить машину в чёрный список' : 'Добавить человека в чёрный список';
     },
-    selectedFormat() {
-      return this.formats.find((f) => f.format.id === this.selectedFormatId) || null;
-    },
-    selectedFormatText() {
-      return this.selectedFormat ? this.selectedFormat.format.name : 'Выберите формат';
-    },
     filteredMarks() {
       const q = this.markSearch.trim().toLowerCase();
       if (!q) return this.marks;
@@ -261,8 +188,7 @@ export default {
     canSubmit() {
       if (!this.reason.trim()) return false;
       if (this.type === 'vehicle') {
-        return !!this.selectedFormat && this.numberParts.length > 0 &&
-          this.numberParts.every((p) => p && p.trim()) && !!this.markId;
+        return !!this.carNumber.trim() && !!this.markId;
       }
       return !!this.lastName.trim() && !!this.firstName.trim();
     },
@@ -285,14 +211,11 @@ export default {
   },
   methods: {
     resetForm() {
-      this.selectedFormatId = null;
-      this.formats = [];
-      this.isFormatDropdownOpen = false;
+      this.carNumber = '';
       this.markId = null;
       this.selectedMark = '';
       this.isMarkDropdownOpen = false;
       this.markSearch = '';
-      this.numberParts = [];
       this.lastName = '';
       this.firstName = '';
       this.middleName = '';
@@ -302,15 +225,6 @@ export default {
     },
     async loadVehicleData() {
       try {
-        const res = await apiRequest('/license-plate-formats');
-        const data = await res.json();
-        this.formats = Array.isArray(data) ? data : [];
-        const def = this.formats.find((f) => f.format.is_default) || this.formats[0];
-        if (def) this.selectFormat(def);
-      } catch {
-        this.formError = 'Не удалось загрузить форматы номеров';
-      }
-      try {
         const marks = await listMarks();
         const arr = Array.isArray(marks) ? marks : [];
         this.marks = arr.filter((m) => m.is_active !== false).map((m) => ({ id: m.id, name: m.name }));
@@ -319,43 +233,16 @@ export default {
       }
     },
     onDocumentClick(e) {
-      if (!e.target.closest('.format__dropdown')) this.isFormatDropdownOpen = false;
       if (!e.target.closest('.mark__dropdown')) this.isMarkDropdownOpen = false;
-    },
-    toggleFormatDropdown() {
-      this.isFormatDropdownOpen = !this.isFormatDropdownOpen;
-      this.isMarkDropdownOpen = false;
-    },
-    selectFormat(format) {
-      this.selectedFormatId = format.format.id;
-      this.numberParts = initializeNumberParts(this.selectedFormat);
-      this.isFormatDropdownOpen = false;
     },
     toggleMarkDropdown() {
       this.isMarkDropdownOpen = !this.isMarkDropdownOpen;
-      this.isFormatDropdownOpen = false;
     },
     selectMark(mark) {
       this.markId = mark.id;
       this.selectedMark = mark.name;
       this.isMarkDropdownOpen = false;
       this.markSearch = '';
-    },
-    validatePart(index, event, cell) {
-      const value = validatePartValue(event.target.value, cell);
-      this.numberParts[index] = value;
-      event.target.value = value;
-    },
-    formatPart(index, cell) {
-      this.numberParts[index] = formatPartValue(this.numberParts[index], cell);
-    },
-    getPlaceholder(cell) {
-      if (cell.cell_type === 'numbers') return '0'.repeat(cell.max_length);
-      return 'A'.repeat(cell.max_length);
-    },
-    getInputWidth(cell) {
-      const width = Math.max(50, (cell.max_length || 2) * 25);
-      return `${width}px`;
     },
     close() {
       if (this.saving) return;
@@ -369,7 +256,7 @@ export default {
         let payload;
         let displayName;
         if (this.type === 'vehicle') {
-          const carNumber = this.numberParts.join(' ').trim();
+          const carNumber = this.carNumber.trim();
           const markName = (this.marks.find((m) => m.id === this.markId) || {}).name || this.selectedMark || '';
           payload = { car_number: carNumber, mark_id: this.markId, reason: this.reason.trim() };
           displayName = [carNumber, markName].filter(Boolean).join(' ');
@@ -411,116 +298,6 @@ export default {
   color: #ff4444;
 }
 
-.completion__format {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  position: relative;
-  padding-bottom: 15px;
-}
-
-.format__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: end;
-}
-
-.format__label {
-  font-size: 13px;
-  color: #a2a2a2;
-}
-
-.format__dropdown {
-  position: relative;
-}
-
-.dropdown__button {
-  width: 100%;
-  height: 40px;
-  border: 1px solid #e6e6e6;
-  background-color: #fff;
-  border-radius: 15px;
-  outline: none;
-  cursor: pointer;
-  padding: 0 15px;
-  transition: border-color 0.2s;
-}
-
-.dropdown__button:hover {
-  border-color: #4f5bdf;
-}
-
-.button__content {
-  display: flex;
-  align-items: center;
-  width: 100%;
-  height: 100%;
-  justify-content: space-between;
-}
-
-.button__text {
-  font-size: 14px;
-  color: #000;
-  font-weight: 500;
-  display: block;
-}
-
-.button__arrow {
-  width: 10px;
-  height: 10px;
-  transition: transform 0.2s;
-  transform: rotate(90deg);
-  flex-shrink: 0;
-}
-
-.button__arrow--open {
-  transform: rotate(-90deg);
-}
-
-.dropdown__menu {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  width: 100%;
-  background: #fff;
-  border: 1px solid #e6e6e6;
-  border-radius: 20px;
-  margin-top: 5px;
-  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.1);
-  z-index: 1000;
-  max-height: 300px;
-  overflow-y: auto;
-}
-
-.dropdown__item {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 10px 15px;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-
-.dropdown__item:hover {
-  background-color: #f5f5f5;
-}
-
-.dropdown__item:first-child {
-  border-radius: 10px 10px 0 0;
-}
-
-.dropdown__item:last-child {
-  border-radius: 0 0 10px 10px;
-}
-
-.item__text {
-  font-size: 13px;
-  color: #333;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
 .completion__fields {
   display: flex;
   gap: 20px;
@@ -528,12 +305,10 @@ export default {
   margin-bottom: 15px;
 }
 
-.completion__number,
 .completion__mark {
   flex: 1;
 }
 
-.completion__number-header,
 .completion__mark-header {
   display: flex;
   align-items: center;
@@ -541,51 +316,8 @@ export default {
   padding-bottom: 5px;
 }
 
-.number__field {
-  max-width: 202px;
-  min-width: 202px;
-  height: 40px;
-  display: flex;
-  border: 1px solid #e6e6e6;
-  border-radius: 15px;
-  overflow: hidden;
-  background: #fff;
-}
-
-.number__input {
-  border: none;
-  height: 100%;
-  outline: none;
-  text-align: center;
-  font-size: 14px;
-  background: transparent;
-  flex: 1;
-  min-width: 0;
-  text-transform: uppercase;
-}
-
-.number__input:not(:last-child) {
-  border-right: 1px solid #e6e6e6;
-}
-
-.number__input::placeholder {
-  color: #a2a2a2;
-  font-size: 12px;
-  text-transform: none;
-}
-
-.number__input:focus {
-  background-color: #f8f8f8;
-}
-
-.no-format-message {
-  font-size: 12px;
-  color: #a2a2a2;
-  text-align: center;
-  padding: 10px;
-  background: #f8f8f8;
-  border-radius: 10px;
-  border: 1px solid #e6e6e6;
+.bl-create__number {
+  margin-bottom: 15px;
 }
 
 .mark__field {

--- a/frontend/src/components/admin/blacklist/VehicleNumberFormatInput.vue
+++ b/frontend/src/components/admin/blacklist/VehicleNumberFormatInput.vue
@@ -1,0 +1,360 @@
+<template>
+  <div class="vnf">
+    <div class="vnf__format">
+      <div class="vnf__header">
+        <label class="vnf__label">Формат номеров <span class="vnf__required">*</span></label>
+      </div>
+      <div class="vnf__dropdown">
+        <button
+          type="button"
+          class="vnf__dropdown-button"
+          @click="toggleFormatDropdown"
+        >
+          <div class="vnf__button-content">
+            <span class="vnf__button-text">{{ selectedFormatText }}</span>
+            <img
+              src="@/assets/icons/arrow.png"
+              class="vnf__button-arrow"
+              :class="{ 'vnf__button-arrow--open': isFormatDropdownOpen }"
+            >
+          </div>
+        </button>
+        <transition name="vnf-dropdown">
+          <div
+            v-if="isFormatDropdownOpen"
+            class="vnf__dropdown-menu"
+          >
+            <div
+              v-for="format in formats"
+              :key="format.format.id"
+              class="vnf__dropdown-item"
+              @click="selectFormat(format)"
+            >
+              <span class="vnf__item-text">{{ format.format.name }}</span>
+            </div>
+            <div
+              v-if="!formats.length"
+              class="vnf__dropdown-item"
+            >
+              <span class="vnf__item-text">Нет форматов</span>
+            </div>
+          </div>
+        </transition>
+      </div>
+    </div>
+
+    <div class="vnf__number">
+      <div class="vnf__header">
+        <label class="vnf__label">Номер Т/С <span class="vnf__required">*</span></label>
+      </div>
+      <div
+        v-if="selectedFormat"
+        class="vnf__number-field"
+      >
+        <input
+          v-for="(cell, index) in selectedFormat.cells"
+          :key="index"
+          v-model="numberParts[index]"
+          class="vnf__number-input"
+          :placeholder="getPlaceholder(cell)"
+          :maxlength="cell.max_length"
+          :style="{ width: getInputWidth(cell) }"
+          @input="validatePart(index, $event, cell)"
+          @blur="formatPart(index, cell)"
+        >
+      </div>
+      <div
+        v-else
+        class="vnf__no-format"
+      >
+        Выберите формат номера
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { apiRequest } from '@/api/client';
+import { validatePartValue, formatPartValue, initializeNumberParts } from '@/composables/useNumberFormat';
+
+/**
+ * Поячеечный ввод номера Т/С по выбранному формату (формат-дропдаун + ячейки). Единый
+ * источник UX номера для создания (BlacklistCreateModal) и правки (AddToBlacklistModal)
+ * записи ЧС - раньше правка использовала простой text-input и расходилась с созданием (#481).
+ * v-model отдаёт собранную строку номера ("часть часть"). Для правки initialNumber лучшим
+ * усилием раскладывается обратно по ячейкам, если число частей совпадает с форматом.
+ */
+export default {
+  name: 'VehicleNumberFormatInput',
+  props: {
+    modelValue: { type: String, default: '' },
+  },
+  emits: ['update:modelValue'],
+  data() {
+    return {
+      formats: [],
+      selectedFormatId: null,
+      isFormatDropdownOpen: false,
+      numberParts: [],
+    };
+  },
+  computed: {
+    selectedFormat() {
+      return this.formats.find((f) => f.format.id === this.selectedFormatId) || null;
+    },
+    selectedFormatText() {
+      return this.selectedFormat ? this.selectedFormat.format.name : 'Выберите формат';
+    },
+  },
+  watch: {
+    numberParts: {
+      deep: true,
+      handler() {
+        this.$emit('update:modelValue', this.numberParts.join(' ').trim());
+      },
+    },
+  },
+  mounted() {
+    this.loadFormats();
+    document.addEventListener('click', this.onDocumentClick);
+  },
+  beforeUnmount() {
+    document.removeEventListener('click', this.onDocumentClick);
+  },
+  methods: {
+    async loadFormats() {
+      try {
+        const res = await apiRequest('/license-plate-formats');
+        const data = await res.json();
+        this.formats = Array.isArray(data) ? data : [];
+      } catch {
+        this.formats = [];
+      }
+      this.applyInitial();
+    },
+    // Префилл правки: ищем формат, число ячеек которого совпадает с числом частей сохранённого
+    // номера (приоритет дефолтному), и раскладываем; иначе берём дефолт с пустыми ячейками.
+    applyInitial() {
+      const raw = (this.modelValue || '').trim();
+      const parts = raw ? raw.split(/\s+/).filter(Boolean) : [];
+      let fmt = null;
+      if (parts.length) {
+        fmt = this.formats.find((f) => f.format.is_default && f.cells.length === parts.length)
+          || this.formats.find((f) => f.cells.length === parts.length);
+      }
+      if (!fmt) fmt = this.formats.find((f) => f.format.is_default) || this.formats[0] || null;
+      if (!fmt) return;
+      this.selectedFormatId = fmt.format.id;
+      if (parts.length && fmt.cells.length === parts.length) {
+        this.numberParts = parts.slice();
+      } else {
+        this.numberParts = initializeNumberParts(fmt);
+      }
+    },
+    toggleFormatDropdown() {
+      this.isFormatDropdownOpen = !this.isFormatDropdownOpen;
+    },
+    selectFormat(format) {
+      this.selectedFormatId = format.format.id;
+      this.numberParts = initializeNumberParts(this.selectedFormat);
+      this.isFormatDropdownOpen = false;
+    },
+    validatePart(index, event, cell) {
+      const value = validatePartValue(event.target.value, cell);
+      this.numberParts[index] = value;
+      event.target.value = value;
+    },
+    formatPart(index, cell) {
+      this.numberParts[index] = formatPartValue(this.numberParts[index], cell);
+    },
+    getPlaceholder(cell) {
+      if (cell.cell_type === 'numbers') return '0'.repeat(cell.max_length);
+      return 'A'.repeat(cell.max_length);
+    },
+    getInputWidth(cell) {
+      const width = Math.max(50, (cell.max_length || 2) * 25);
+      return `${width}px`;
+    },
+    onDocumentClick(e) {
+      if (!e.target.closest('.vnf__dropdown')) this.isFormatDropdownOpen = false;
+    },
+  },
+};
+</script>
+
+<style scoped>
+.vnf {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.vnf__format {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  position: relative;
+  flex: 1;
+  min-width: 180px;
+}
+
+.vnf__number {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.vnf__header {
+  display: flex;
+  align-items: end;
+}
+
+.vnf__label {
+  font-size: 13px;
+  color: #a2a2a2;
+}
+
+.vnf__required {
+  color: #ff4444;
+}
+
+.vnf__dropdown {
+  position: relative;
+}
+
+.vnf__dropdown-button {
+  width: 100%;
+  height: 40px;
+  border: 1px solid #e6e6e6;
+  background-color: #fff;
+  border-radius: 15px;
+  outline: none;
+  cursor: pointer;
+  padding: 0 15px;
+  transition: border-color 0.2s;
+}
+
+.vnf__dropdown-button:hover {
+  border-color: #4f5bdf;
+}
+
+.vnf__button-content {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  justify-content: space-between;
+}
+
+.vnf__button-text {
+  font-size: 14px;
+  color: #000;
+  font-weight: 500;
+  display: block;
+}
+
+.vnf__button-arrow {
+  width: 10px;
+  height: 10px;
+  transition: transform 0.2s;
+  transform: rotate(90deg);
+  flex-shrink: 0;
+}
+
+.vnf__button-arrow--open {
+  transform: rotate(-90deg);
+}
+
+.vnf__dropdown-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  width: 100%;
+  background: #fff;
+  border: 1px solid #e6e6e6;
+  border-radius: 20px;
+  margin-top: 5px;
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.1);
+  z-index: 1000;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.vnf__dropdown-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 15px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.vnf__dropdown-item:hover {
+  background-color: #f5f5f5;
+}
+
+.vnf__item-text {
+  font-size: 13px;
+  color: #333;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.vnf__number-field {
+  height: 40px;
+  display: flex;
+  border: 1px solid #e6e6e6;
+  border-radius: 15px;
+  overflow: hidden;
+  background: #fff;
+}
+
+.vnf__number-input {
+  border: none;
+  height: 100%;
+  outline: none;
+  text-align: center;
+  font-size: 14px;
+  background: transparent;
+  flex: 1;
+  min-width: 0;
+  text-transform: uppercase;
+}
+
+.vnf__number-input:not(:last-child) {
+  border-right: 1px solid #e6e6e6;
+}
+
+.vnf__number-input::placeholder {
+  color: #a2a2a2;
+  font-size: 12px;
+  text-transform: none;
+}
+
+.vnf__number-input:focus {
+  background-color: #f8f8f8;
+}
+
+.vnf__no-format {
+  font-size: 12px;
+  color: #a2a2a2;
+  text-align: center;
+  padding: 10px;
+  background: #f8f8f8;
+  border-radius: 10px;
+  border: 1px solid #e6e6e6;
+}
+
+.vnf-dropdown-enter-active,
+.vnf-dropdown-leave-active {
+  transition: all 0.2s ease;
+}
+
+.vnf-dropdown-enter-from,
+.vnf-dropdown-leave-to {
+  opacity: 0;
+  transform: translateY(-10px);
+}
+</style>

--- a/frontend/src/components/admin/blacklist/__tests__/AddToBlacklistModal.spec.js
+++ b/frontend/src/components/admin/blacklist/__tests__/AddToBlacklistModal.spec.js
@@ -6,9 +6,11 @@ import AddToBlacklistModal from '../AddToBlacklistModal.vue';
 vi.mock('@/api/marks', () => ({ listMarks: () => Promise.resolve([{ id: 5, name: 'BMW' }]) }));
 
 // BaseModal рендерит через Teleport - стабим, чтобы контент был в обёртке для запросов.
+// VehicleNumberFormatInput сам грузит форматы по сети - стабим, carNumber выставляет watcher.
 const stubs = {
   BaseModal: { template: '<div class="base-modal"><slot /><slot name="actions" /></div>' },
   FormField: { template: '<div class="form-field"><slot /></div>' },
+  VehicleNumberFormatInput: true,
 };
 
 function mountModal(props = {}) {

--- a/frontend/src/components/admin/blacklist/__tests__/BlacklistCreateModal.spec.js
+++ b/frontend/src/components/admin/blacklist/__tests__/BlacklistCreateModal.spec.js
@@ -2,9 +2,11 @@ import { describe, it, expect, vi } from 'vitest';
 import { mount, flushPromises } from '@vue/test-utils';
 import BlacklistCreateModal from '../BlacklistCreateModal.vue';
 
-// BaseModal использует Teleport - стабим, чтобы не тянуть портал в тест.
+// BaseModal использует Teleport - стабим. VehicleNumberFormatInput грузит форматы по сети -
+// стабим, номер задаём через carNumber (его v-model).
 const stubs = {
   BaseModal: { template: '<div><slot /><slot name="actions" /></div>' },
+  VehicleNumberFormatInput: true,
 };
 
 function mountModal(props = {}) {
@@ -58,31 +60,25 @@ describe('BlacklistCreateModal (person)', () => {
 });
 
 describe('BlacklistCreateModal (vehicle)', () => {
-  const fmt = [{ format: { id: 1, name: 'РФ' }, cells: [{ cell_type: 'letters', max_length: 1 }, { cell_type: 'numbers', max_length: 3 }] }];
-
-  it('canSubmit false без формата, ячеек и марки', () => {
+  it('canSubmit false без номера и марки', () => {
     const w = mountModal({ type: 'vehicle' });
     expect(w.vm.canSubmit).toBe(false);
   });
 
-  it('canSubmit true когда формат, ячейки, марка и причина заполнены', async () => {
+  it('canSubmit true когда номер, марка и причина заполнены', async () => {
     const w = mountModal({ type: 'vehicle' });
-    w.vm.formats = fmt;
-    w.vm.selectedFormatId = 1;
-    w.vm.numberParts = ['А', '123'];
+    w.vm.carNumber = 'А 123';
     w.vm.markId = 5;
     w.vm.reason = 'причина';
     await flushPromises();
     expect(w.vm.canSubmit).toBe(true);
   });
 
-  it('submit собирает car_number из ячеек и эмитит created с номером и маркой', async () => {
+  it('submit берёт car_number из v-model компонента и эмитит created с номером и маркой', async () => {
     const createFn = vi.fn().mockResolvedValue({});
     const w = mountModal({ type: 'vehicle', createFn });
-    w.vm.formats = fmt;
-    w.vm.selectedFormatId = 1;
     w.vm.marks = [{ id: 5, name: 'BMW' }];
-    w.vm.numberParts = ['А', '123'];
+    w.vm.carNumber = 'А 123';
     w.vm.markId = 5;
     w.vm.reason = 'причина';
     await w.vm.submit();

--- a/frontend/src/components/admin/blacklist/__tests__/VehicleNumberFormatInput.spec.js
+++ b/frontend/src/components/admin/blacklist/__tests__/VehicleNumberFormatInput.spec.js
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import VehicleNumberFormatInput from '../VehicleNumberFormatInput.vue';
+
+const FORMATS = [
+  {
+    format: { id: 1, name: 'РФ', is_default: true },
+    cells: [{ cell_type: 'letters', max_length: 1 }, { cell_type: 'numbers', max_length: 3 }],
+  },
+  {
+    format: { id: 2, name: 'Один блок', is_default: false },
+    cells: [{ cell_type: 'letters', max_length: 6 }],
+  },
+];
+
+vi.mock('@/api/client', () => ({
+  apiRequest: vi.fn(() => Promise.resolve({ json: () => Promise.resolve(FORMATS) })),
+}));
+
+function lastModel(wrapper) {
+  const ev = wrapper.emitted('update:modelValue');
+  return ev ? ev[ev.length - 1][0] : undefined;
+}
+
+describe('VehicleNumberFormatInput', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('по умолчанию выбирает дефолтный формат с пустыми ячейками', async () => {
+    const w = mount(VehicleNumberFormatInput, { props: { modelValue: '' } });
+    await flushPromises();
+    expect(w.vm.selectedFormatId).toBe(1);
+    expect(w.vm.numberParts.length).toBe(2);
+    expect(w.findAll('.vnf__number-input').length).toBe(2);
+  });
+
+  it('префилл раскладывает номер по ячейкам формата с совпадающим числом частей', async () => {
+    const w = mount(VehicleNumberFormatInput, { props: { modelValue: 'А 123' } });
+    await flushPromises();
+    expect(w.vm.selectedFormatId).toBe(1);
+    expect(w.vm.numberParts).toEqual(['А', '123']);
+    expect(lastModel(w)).toBe('А 123');
+  });
+
+  it('префилл с одной частью выбирает одноблочный формат', async () => {
+    const w = mount(VehicleNumberFormatInput, { props: { modelValue: 'АВС123' } });
+    await flushPromises();
+    expect(w.vm.selectedFormatId).toBe(2);
+    expect(w.vm.numberParts).toEqual(['АВС123']);
+  });
+
+  it('смена формата сбрасывает ячейки', async () => {
+    const w = mount(VehicleNumberFormatInput, { props: { modelValue: 'А 123' } });
+    await flushPromises();
+    w.vm.selectFormat(FORMATS[1]);
+    await flushPromises();
+    expect(w.vm.selectedFormatId).toBe(2);
+    expect(w.vm.numberParts.length).toBe(1);
+  });
+});

--- a/internal/handlers/applications_blacklist_override_test.go
+++ b/internal/handlers/applications_blacklist_override_test.go
@@ -390,6 +390,14 @@ func TestBlacklistOverride_HistoryAndSuppression(t *testing.T) {
 		db.Table("cars_history").
 			Where("car_id = ? AND action_type = 'blacklist_override'", carID).Count(&carHist)
 		assert.Equal(t, int64(1), carHist, "запись в истории машины")
+
+		// В комментарии видно, КАКУЮ машину пропустили и причину - иначе в истории непонятно.
+		var carComment string
+		db.Table("cars_history").
+			Where("car_id = ? AND action_type = 'blacklist_override'", carID).
+			Select("comment").Scan(&carComment)
+		assert.Contains(t, carComment, "H777HH798", "в истории должен быть номер машины")
+		assert.Contains(t, carComment, "проверил лично", "в истории должна быть причина")
 	})
 
 	t.Run("после пропуска та же машина в новой заявке не помечается", func(t *testing.T) {

--- a/internal/services/application_blacklist_override_service.go
+++ b/internal/services/application_blacklist_override_service.go
@@ -97,12 +97,25 @@ func (s *applicationService) OverrideBlacklistFlag(ctx context.Context, username
 
 // logBlacklistOverrideAction фиксирует подтверждение/отмену пропуска И в истории заявки, И в
 // истории самого элемента (машины/человека) - чтобы решение было видно из обеих карточек (#481,
-// срез C-followup). actionType: 'blacklist_override' / 'blacklist_override_revoke'.
-func (s *applicationService) logBlacklistOverrideAction(tx *gorm.DB, flag models.ApplicationBlacklistFlag, userID int, actionType, comment string, at time.Time) error {
+// срез C-followup). actionType: 'blacklist_override' / 'blacklist_override_revoke'. В комментарий
+// кладём, КАКОЙ элемент и на что похоже (+ причину для подтверждения), иначе в истории не видно,
+// о какой машине/человеке речь.
+func (s *applicationService) logBlacklistOverrideAction(tx *gorm.DB, flag models.ApplicationBlacklistFlag, userID int, actionType, reason string, at time.Time) error {
+	label := s.blacklistElementLabel(tx, flag)
+	desc := label
+	if flag.MatchedValue != "" {
+		desc = strings.TrimSpace(label + " - похоже на " + flag.MatchedValue)
+	}
+	comment := desc
+	if reason = strings.TrimSpace(reason); reason != "" {
+		comment = desc + " (причина: " + reason + ")"
+	}
+
 	meta, _ := json.Marshal(map[string]any{
 		"flag_id":              flag.ID,
 		"matched_blacklist_id": flag.MatchedBlacklistID,
 		"matched_value":        flag.MatchedValue,
+		"element":              label,
 	})
 	if err := tx.Exec(`
 		INSERT INTO application_history (application_id, user_id, action_type, comment, metadata, created_at)
@@ -111,24 +124,54 @@ func (s *applicationService) logBlacklistOverrideAction(tx *gorm.DB, flag models
 		return err
 	}
 
-	// В истории элемента поясняем, на что похоже (комментарий-причину сюда же, если есть).
-	elemComment := comment
-	if elemComment == "" {
-		elemComment = flag.MatchedValue
-	}
 	switch flag.ElementType {
 	case models.BlacklistElementCar:
 		return tx.Exec(`
 			INSERT INTO cars_history (car_id, user_id, action_type, comment, created_at)
 			VALUES (?, ?, ?, ?, ?)
-		`, flag.ElementID, userID, actionType, elemComment, at).Error
+		`, flag.ElementID, userID, actionType, comment, at).Error
 	case models.BlacklistElementEmployee:
 		return tx.Exec(`
 			INSERT INTO employees_history (employee_id, user_id, action_type, comment, created_at)
 			VALUES (?, ?, ?, ?, ?)
-		`, flag.ElementID, userID, actionType, elemComment, at).Error
+		`, flag.ElementID, userID, actionType, comment, at).Error
 	}
 	return nil
+}
+
+// blacklistElementLabel - человекочитаемое имя помеченного элемента для истории: "номер марка"
+// для машины, ФИО для человека. Берём из текущей строки cars/employees (она жива на момент
+// override/отмены - это элемент заявки).
+func (s *applicationService) blacklistElementLabel(tx *gorm.DB, flag models.ApplicationBlacklistFlag) string {
+	switch flag.ElementType {
+	case models.BlacklistElementCar:
+		var r struct {
+			CarNumber string
+			CarBrand  string
+		}
+		tx.Raw("SELECT car_number, car_brand FROM cars WHERE id = ?", flag.ElementID).Scan(&r)
+		return joinNonEmpty(" ", r.CarNumber, r.CarBrand)
+	case models.BlacklistElementEmployee:
+		var r struct {
+			LastName   string
+			FirstName  string
+			MiddleName string
+		}
+		tx.Raw("SELECT last_name, first_name, middle_name FROM employees WHERE id = ?", flag.ElementID).Scan(&r)
+		return joinNonEmpty(" ", r.LastName, r.FirstName, r.MiddleName)
+	}
+	return ""
+}
+
+// joinNonEmpty склеивает непустые (после TrimSpace) части через sep.
+func joinNonEmpty(sep string, parts ...string) string {
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return strings.Join(out, sep)
 }
 
 // DeleteBlacklistOverride снимает ранее подтверждённый пропуск по флагу (#481, срез C):


### PR DESCRIPTION
Доработки по фидбеку после правок override-флоу.

## 1. В истории не видно, какой элемент пропустили/отменили
Записи `blacklist_override` / `blacklist_override_revoke` в истории заявки и машины/человека несли только заголовок действия. Теперь в комментарий пишем человекочитаемый элемент (номер+марка / ФИО) + на что похоже (matched_value) + причину для подтверждения. Имя элемента берём из текущей строки cars/employees через хелпер `blacklistElementLabel`.

## 2. Правка номера авто в реестре ЧС - как при создании
Раньше edit (`AddToBlacklistModal`) использовал простой text-input для номера, а создание (`BlacklistCreateModal`) - поячеечный ввод по формату. Расхождение и было багом. Вынес ввод номера в общий компонент `VehicleNumberFormatInput` (формат-дропдаун + ячейки, на базе `useNumberFormat`) и подключил его в ОБЕ модалки. При правке номер лучшим усилием раскладывается обратно по ячейкам (если число частей совпадает с форматом). `BlacklistCreateModal` похудел на ~290 строк (убран дублированный ввод + мёртвый CSS).

## Тесты
- BE: `TestBlacklistOverride_HistoryAndSuppression` усилен - проверяет, что в истории машины виден номер и причина.
- FE: новый `VehicleNumberFormatInput.spec` (префилл/смена формата/v-model) + обновлены спеки обеих модалок; blacklist-папка 56/56.
- eslint/gofmt/go vet чисто.