### PR TITLE
fix(applications): вернул вёрстку Создать запись ЧС, правку номера сделал её копией (#481)

### DIFF
--- a/frontend/src/components/admin/blacklist/BlacklistCreateModal.vue
+++ b/frontend/src/components/admin/blacklist/BlacklistCreateModal.vue
@@ -7,14 +7,77 @@
   >
     <div class="bl-create">
       <template v-if="type === 'vehicle'">
-        <!-- Поячеечный ввод номера по формату вынесен в общий компонент - он же используется
-             при правке записи ЧС, чтобы создание и редактирование не расходились (#481). -->
-        <VehicleNumberFormatInput
-          v-model="carNumber"
-          class="bl-create__number"
-        />
+        <div class="completion__format">
+          <div class="format__header">
+            <label class="format__label">Формат номеров <span class="required">*</span></label>
+          </div>
+          <div class="format__dropdown">
+            <button
+              class="dropdown__button"
+              @click="toggleFormatDropdown"
+            >
+              <div class="button__content">
+                <span class="button__text">{{ selectedFormatText }}</span>
+                <img
+                  src="@/assets/icons/arrow.png"
+                  class="button__arrow"
+                  :class="{ 'button__arrow--open': isFormatDropdownOpen }"
+                >
+              </div>
+            </button>
+            <transition name="dropdown">
+              <div
+                v-if="isFormatDropdownOpen"
+                class="dropdown__menu"
+              >
+                <div
+                  v-for="format in formats"
+                  :key="format.format.id"
+                  class="dropdown__item"
+                  @click="selectFormat(format)"
+                >
+                  <span class="item__text">{{ format.format.name }}</span>
+                </div>
+                <div
+                  v-if="!formats.length"
+                  class="dropdown__item"
+                >
+                  <span class="item__text">Нет форматов</span>
+                </div>
+              </div>
+            </transition>
+          </div>
+        </div>
 
         <div class="completion__fields">
+          <div class="completion__number">
+            <div class="completion__number-header">
+              <label class="input__label">Номер Т/С <span class="required">*</span></label>
+            </div>
+            <div
+              v-if="selectedFormat"
+              class="number__field"
+            >
+              <input
+                v-for="(cell, index) in selectedFormat.cells"
+                :key="index"
+                v-model="numberParts[index]"
+                class="number__input"
+                :placeholder="getPlaceholder(cell)"
+                :maxlength="cell.max_length"
+                :style="{ width: getInputWidth(cell) }"
+                @input="validatePart(index, $event, cell)"
+                @blur="formatPart(index, cell)"
+              >
+            </div>
+            <div
+              v-else
+              class="no-format-message"
+            >
+              Выберите формат номера
+            </div>
+          </div>
+
           <div class="completion__mark">
             <div class="completion__mark-header">
               <label class="input__label">Марка Т/С <span class="required">*</span></label>
@@ -142,8 +205,9 @@
 <script>
 import BaseModal from '@/components/ui/BaseModal.vue';
 import FormField from '@/components/ui/FormField.vue';
-import VehicleNumberFormatInput from './VehicleNumberFormatInput.vue';
+import { apiRequest } from '@/api/client';
 import { listMarks } from '@/api/marks';
+import { validatePartValue, formatPartValue, initializeNumberParts } from '@/composables/useNumberFormat';
 
 /**
  * Модалка добавления записи в чёрный список (#443). Тип определяет форму: 'vehicle' -
@@ -153,7 +217,7 @@ import { listMarks } from '@/api/marks';
  */
 export default {
   name: 'BlacklistCreateModal',
-  components: { BaseModal, FormField, VehicleNumberFormatInput },
+  components: { BaseModal, FormField },
   props: {
     show: { type: Boolean, default: false },
     type: { type: String, required: true, validator: (v) => ['vehicle', 'person'].includes(v) },
@@ -162,12 +226,15 @@ export default {
   emits: ['close', 'created'],
   data() {
     return {
-      carNumber: '',
+      formats: [],
+      selectedFormatId: null,
+      isFormatDropdownOpen: false,
       marks: [],
       markId: null,
       selectedMark: '',
       isMarkDropdownOpen: false,
       markSearch: '',
+      numberParts: [],
       lastName: '',
       firstName: '',
       middleName: '',
@@ -180,6 +247,12 @@ export default {
     title() {
       return this.type === 'vehicle' ? 'Добавить машину в чёрный список' : 'Добавить человека в чёрный список';
     },
+    selectedFormat() {
+      return this.formats.find((f) => f.format.id === this.selectedFormatId) || null;
+    },
+    selectedFormatText() {
+      return this.selectedFormat ? this.selectedFormat.format.name : 'Выберите формат';
+    },
     filteredMarks() {
       const q = this.markSearch.trim().toLowerCase();
       if (!q) return this.marks;
@@ -188,7 +261,8 @@ export default {
     canSubmit() {
       if (!this.reason.trim()) return false;
       if (this.type === 'vehicle') {
-        return !!this.carNumber.trim() && !!this.markId;
+        return !!this.selectedFormat && this.numberParts.length > 0 &&
+          this.numberParts.every((p) => p && p.trim()) && !!this.markId;
       }
       return !!this.lastName.trim() && !!this.firstName.trim();
     },
@@ -211,11 +285,14 @@ export default {
   },
   methods: {
     resetForm() {
-      this.carNumber = '';
+      this.selectedFormatId = null;
+      this.formats = [];
+      this.isFormatDropdownOpen = false;
       this.markId = null;
       this.selectedMark = '';
       this.isMarkDropdownOpen = false;
       this.markSearch = '';
+      this.numberParts = [];
       this.lastName = '';
       this.firstName = '';
       this.middleName = '';
@@ -225,6 +302,15 @@ export default {
     },
     async loadVehicleData() {
       try {
+        const res = await apiRequest('/license-plate-formats');
+        const data = await res.json();
+        this.formats = Array.isArray(data) ? data : [];
+        const def = this.formats.find((f) => f.format.is_default) || this.formats[0];
+        if (def) this.selectFormat(def);
+      } catch {
+        this.formError = 'Не удалось загрузить форматы номеров';
+      }
+      try {
         const marks = await listMarks();
         const arr = Array.isArray(marks) ? marks : [];
         this.marks = arr.filter((m) => m.is_active !== false).map((m) => ({ id: m.id, name: m.name }));
@@ -233,16 +319,43 @@ export default {
       }
     },
     onDocumentClick(e) {
+      if (!e.target.closest('.format__dropdown')) this.isFormatDropdownOpen = false;
       if (!e.target.closest('.mark__dropdown')) this.isMarkDropdownOpen = false;
+    },
+    toggleFormatDropdown() {
+      this.isFormatDropdownOpen = !this.isFormatDropdownOpen;
+      this.isMarkDropdownOpen = false;
+    },
+    selectFormat(format) {
+      this.selectedFormatId = format.format.id;
+      this.numberParts = initializeNumberParts(this.selectedFormat);
+      this.isFormatDropdownOpen = false;
     },
     toggleMarkDropdown() {
       this.isMarkDropdownOpen = !this.isMarkDropdownOpen;
+      this.isFormatDropdownOpen = false;
     },
     selectMark(mark) {
       this.markId = mark.id;
       this.selectedMark = mark.name;
       this.isMarkDropdownOpen = false;
       this.markSearch = '';
+    },
+    validatePart(index, event, cell) {
+      const value = validatePartValue(event.target.value, cell);
+      this.numberParts[index] = value;
+      event.target.value = value;
+    },
+    formatPart(index, cell) {
+      this.numberParts[index] = formatPartValue(this.numberParts[index], cell);
+    },
+    getPlaceholder(cell) {
+      if (cell.cell_type === 'numbers') return '0'.repeat(cell.max_length);
+      return 'A'.repeat(cell.max_length);
+    },
+    getInputWidth(cell) {
+      const width = Math.max(50, (cell.max_length || 2) * 25);
+      return `${width}px`;
     },
     close() {
       if (this.saving) return;
@@ -256,7 +369,7 @@ export default {
         let payload;
         let displayName;
         if (this.type === 'vehicle') {
-          const carNumber = this.carNumber.trim();
+          const carNumber = this.numberParts.join(' ').trim();
           const markName = (this.marks.find((m) => m.id === this.markId) || {}).name || this.selectedMark || '';
           payload = { car_number: carNumber, mark_id: this.markId, reason: this.reason.trim() };
           displayName = [carNumber, markName].filter(Boolean).join(' ');
@@ -298,6 +411,116 @@ export default {
   color: #ff4444;
 }
 
+.completion__format {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  position: relative;
+  padding-bottom: 15px;
+}
+
+.format__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: end;
+}
+
+.format__label {
+  font-size: 13px;
+  color: #a2a2a2;
+}
+
+.format__dropdown {
+  position: relative;
+}
+
+.dropdown__button {
+  width: 100%;
+  height: 40px;
+  border: 1px solid #e6e6e6;
+  background-color: #fff;
+  border-radius: 15px;
+  outline: none;
+  cursor: pointer;
+  padding: 0 15px;
+  transition: border-color 0.2s;
+}
+
+.dropdown__button:hover {
+  border-color: #4f5bdf;
+}
+
+.button__content {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  justify-content: space-between;
+}
+
+.button__text {
+  font-size: 14px;
+  color: #000;
+  font-weight: 500;
+  display: block;
+}
+
+.button__arrow {
+  width: 10px;
+  height: 10px;
+  transition: transform 0.2s;
+  transform: rotate(90deg);
+  flex-shrink: 0;
+}
+
+.button__arrow--open {
+  transform: rotate(-90deg);
+}
+
+.dropdown__menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  width: 100%;
+  background: #fff;
+  border: 1px solid #e6e6e6;
+  border-radius: 20px;
+  margin-top: 5px;
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.1);
+  z-index: 1000;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.dropdown__item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 15px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.dropdown__item:hover {
+  background-color: #f5f5f5;
+}
+
+.dropdown__item:first-child {
+  border-radius: 10px 10px 0 0;
+}
+
+.dropdown__item:last-child {
+  border-radius: 0 0 10px 10px;
+}
+
+.item__text {
+  font-size: 13px;
+  color: #333;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .completion__fields {
   display: flex;
   gap: 20px;
@@ -305,10 +528,12 @@ export default {
   margin-bottom: 15px;
 }
 
+.completion__number,
 .completion__mark {
   flex: 1;
 }
 
+.completion__number-header,
 .completion__mark-header {
   display: flex;
   align-items: center;
@@ -316,8 +541,51 @@ export default {
   padding-bottom: 5px;
 }
 
-.bl-create__number {
-  margin-bottom: 15px;
+.number__field {
+  max-width: 202px;
+  min-width: 202px;
+  height: 40px;
+  display: flex;
+  border: 1px solid #e6e6e6;
+  border-radius: 15px;
+  overflow: hidden;
+  background: #fff;
+}
+
+.number__input {
+  border: none;
+  height: 100%;
+  outline: none;
+  text-align: center;
+  font-size: 14px;
+  background: transparent;
+  flex: 1;
+  min-width: 0;
+  text-transform: uppercase;
+}
+
+.number__input:not(:last-child) {
+  border-right: 1px solid #e6e6e6;
+}
+
+.number__input::placeholder {
+  color: #a2a2a2;
+  font-size: 12px;
+  text-transform: none;
+}
+
+.number__input:focus {
+  background-color: #f8f8f8;
+}
+
+.no-format-message {
+  font-size: 12px;
+  color: #a2a2a2;
+  text-align: center;
+  padding: 10px;
+  background: #f8f8f8;
+  border-radius: 10px;
+  border: 1px solid #e6e6e6;
 }
 
 .mark__field {

--- a/frontend/src/components/admin/blacklist/VehicleNumberFormatInput.vue
+++ b/frontend/src/components/admin/blacklist/VehicleNumberFormatInput.vue
@@ -1,61 +1,61 @@
 <template>
   <div class="vnf">
-    <div class="vnf__format">
-      <div class="vnf__header">
-        <label class="vnf__label">Формат номеров <span class="vnf__required">*</span></label>
+    <div class="completion__format">
+      <div class="format__header">
+        <label class="format__label">Формат номеров <span class="required">*</span></label>
       </div>
-      <div class="vnf__dropdown">
+      <div class="format__dropdown">
         <button
           type="button"
-          class="vnf__dropdown-button"
+          class="dropdown__button"
           @click="toggleFormatDropdown"
         >
-          <div class="vnf__button-content">
-            <span class="vnf__button-text">{{ selectedFormatText }}</span>
+          <div class="button__content">
+            <span class="button__text">{{ selectedFormatText }}</span>
             <img
               src="@/assets/icons/arrow.png"
-              class="vnf__button-arrow"
-              :class="{ 'vnf__button-arrow--open': isFormatDropdownOpen }"
+              class="button__arrow"
+              :class="{ 'button__arrow--open': isFormatDropdownOpen }"
             >
           </div>
         </button>
-        <transition name="vnf-dropdown">
+        <transition name="dropdown">
           <div
             v-if="isFormatDropdownOpen"
-            class="vnf__dropdown-menu"
+            class="dropdown__menu"
           >
             <div
               v-for="format in formats"
               :key="format.format.id"
-              class="vnf__dropdown-item"
+              class="dropdown__item"
               @click="selectFormat(format)"
             >
-              <span class="vnf__item-text">{{ format.format.name }}</span>
+              <span class="item__text">{{ format.format.name }}</span>
             </div>
             <div
               v-if="!formats.length"
-              class="vnf__dropdown-item"
+              class="dropdown__item"
             >
-              <span class="vnf__item-text">Нет форматов</span>
+              <span class="item__text">Нет форматов</span>
             </div>
           </div>
         </transition>
       </div>
     </div>
 
-    <div class="vnf__number">
-      <div class="vnf__header">
-        <label class="vnf__label">Номер Т/С <span class="vnf__required">*</span></label>
+    <div class="completion__number">
+      <div class="completion__number-header">
+        <label class="input__label">Номер Т/С <span class="required">*</span></label>
       </div>
       <div
         v-if="selectedFormat"
-        class="vnf__number-field"
+        class="number__field"
       >
         <input
           v-for="(cell, index) in selectedFormat.cells"
           :key="index"
           v-model="numberParts[index]"
-          class="vnf__number-input"
+          class="number__input"
           :placeholder="getPlaceholder(cell)"
           :maxlength="cell.max_length"
           :style="{ width: getInputWidth(cell) }"
@@ -65,7 +65,7 @@
       </div>
       <div
         v-else
-        class="vnf__no-format"
+        class="no-format-message"
       >
         Выберите формат номера
       </div>
@@ -78,11 +78,10 @@ import { apiRequest } from '@/api/client';
 import { validatePartValue, formatPartValue, initializeNumberParts } from '@/composables/useNumberFormat';
 
 /**
- * Поячеечный ввод номера Т/С по выбранному формату (формат-дропдаун + ячейки). Единый
- * источник UX номера для создания (BlacklistCreateModal) и правки (AddToBlacklistModal)
- * записи ЧС - раньше правка использовала простой text-input и расходилась с созданием (#481).
- * v-model отдаёт собранную строку номера ("часть часть"). Для правки initialNumber лучшим
- * усилием раскладывается обратно по ячейкам, если число частей совпадает с форматом.
+ * Поячеечный ввод номера Т/С по выбранному формату (формат-дропдаун + ячейки). Markup и стили
+ * 1:1 повторяют ввод номера в BlacklistCreateModal, чтобы правка записи ЧС выглядела так же, как
+ * создание (#481). v-model отдаёт собранную строку "часть часть". Для правки initialNumber
+ * лучшим усилием раскладывается обратно по ячейкам, если число частей совпадает с форматом.
  */
 export default {
   name: 'VehicleNumberFormatInput',
@@ -176,54 +175,52 @@ export default {
       return `${width}px`;
     },
     onDocumentClick(e) {
-      if (!e.target.closest('.vnf__dropdown')) this.isFormatDropdownOpen = false;
+      if (!e.target.closest('.format__dropdown')) this.isFormatDropdownOpen = false;
     },
   },
 };
 </script>
 
+<!-- Стили 1:1 из BlacklistCreateModal (ввод номера), чтобы правка выглядела как создание. -->
 <style scoped>
 .vnf {
   display: flex;
-  gap: 16px;
-  align-items: flex-start;
-  flex-wrap: wrap;
-}
-
-.vnf__format {
-  display: flex;
   flex-direction: column;
-  gap: 6px;
-  position: relative;
-  flex: 1;
-  min-width: 180px;
 }
 
-.vnf__number {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.vnf__header {
-  display: flex;
-  align-items: end;
-}
-
-.vnf__label {
+.input__label {
   font-size: 13px;
   color: #a2a2a2;
 }
 
-.vnf__required {
+.required {
   color: #ff4444;
 }
 
-.vnf__dropdown {
+.completion__format {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  position: relative;
+  padding-bottom: 15px;
+}
+
+.format__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: end;
+}
+
+.format__label {
+  font-size: 13px;
+  color: #a2a2a2;
+}
+
+.format__dropdown {
   position: relative;
 }
 
-.vnf__dropdown-button {
+.dropdown__button {
   width: 100%;
   height: 40px;
   border: 1px solid #e6e6e6;
@@ -235,11 +232,11 @@ export default {
   transition: border-color 0.2s;
 }
 
-.vnf__dropdown-button:hover {
+.dropdown__button:hover {
   border-color: #4f5bdf;
 }
 
-.vnf__button-content {
+.button__content {
   display: flex;
   align-items: center;
   width: 100%;
@@ -247,14 +244,14 @@ export default {
   justify-content: space-between;
 }
 
-.vnf__button-text {
+.button__text {
   font-size: 14px;
   color: #000;
   font-weight: 500;
   display: block;
 }
 
-.vnf__button-arrow {
+.button__arrow {
   width: 10px;
   height: 10px;
   transition: transform 0.2s;
@@ -262,11 +259,11 @@ export default {
   flex-shrink: 0;
 }
 
-.vnf__button-arrow--open {
+.button__arrow--open {
   transform: rotate(-90deg);
 }
 
-.vnf__dropdown-menu {
+.dropdown__menu {
   position: absolute;
   top: 100%;
   left: 0;
@@ -281,7 +278,7 @@ export default {
   overflow-y: auto;
 }
 
-.vnf__dropdown-item {
+.dropdown__item {
   display: flex;
   align-items: center;
   gap: 10px;
@@ -290,11 +287,19 @@ export default {
   transition: background-color 0.2s;
 }
 
-.vnf__dropdown-item:hover {
+.dropdown__item:hover {
   background-color: #f5f5f5;
 }
 
-.vnf__item-text {
+.dropdown__item:first-child {
+  border-radius: 10px 10px 0 0;
+}
+
+.dropdown__item:last-child {
+  border-radius: 0 0 10px 10px;
+}
+
+.item__text {
   font-size: 13px;
   color: #333;
   white-space: nowrap;
@@ -302,7 +307,20 @@ export default {
   text-overflow: ellipsis;
 }
 
-.vnf__number-field {
+.completion__number {
+  flex: 1;
+}
+
+.completion__number-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 5px;
+}
+
+.number__field {
+  max-width: 202px;
+  min-width: 202px;
   height: 40px;
   display: flex;
   border: 1px solid #e6e6e6;
@@ -311,7 +329,7 @@ export default {
   background: #fff;
 }
 
-.vnf__number-input {
+.number__input {
   border: none;
   height: 100%;
   outline: none;
@@ -323,21 +341,21 @@ export default {
   text-transform: uppercase;
 }
 
-.vnf__number-input:not(:last-child) {
+.number__input:not(:last-child) {
   border-right: 1px solid #e6e6e6;
 }
 
-.vnf__number-input::placeholder {
+.number__input::placeholder {
   color: #a2a2a2;
   font-size: 12px;
   text-transform: none;
 }
 
-.vnf__number-input:focus {
+.number__input:focus {
   background-color: #f8f8f8;
 }
 
-.vnf__no-format {
+.no-format-message {
   font-size: 12px;
   color: #a2a2a2;
   text-align: center;
@@ -347,13 +365,13 @@ export default {
   border: 1px solid #e6e6e6;
 }
 
-.vnf-dropdown-enter-active,
-.vnf-dropdown-leave-active {
+.dropdown-enter-active,
+.dropdown-leave-active {
   transition: all 0.2s ease;
 }
 
-.vnf-dropdown-enter-from,
-.vnf-dropdown-leave-to {
+.dropdown-enter-from,
+.dropdown-leave-to {
   opacity: 0;
   transform: translateY(-10px);
 }

--- a/frontend/src/components/admin/blacklist/__tests__/BlacklistCreateModal.spec.js
+++ b/frontend/src/components/admin/blacklist/__tests__/BlacklistCreateModal.spec.js
@@ -2,11 +2,9 @@ import { describe, it, expect, vi } from 'vitest';
 import { mount, flushPromises } from '@vue/test-utils';
 import BlacklistCreateModal from '../BlacklistCreateModal.vue';
 
-// BaseModal использует Teleport - стабим. VehicleNumberFormatInput грузит форматы по сети -
-// стабим, номер задаём через carNumber (его v-model).
+// BaseModal использует Teleport - стабим, чтобы не тянуть портал в тест.
 const stubs = {
   BaseModal: { template: '<div><slot /><slot name="actions" /></div>' },
-  VehicleNumberFormatInput: true,
 };
 
 function mountModal(props = {}) {
@@ -60,25 +58,31 @@ describe('BlacklistCreateModal (person)', () => {
 });
 
 describe('BlacklistCreateModal (vehicle)', () => {
-  it('canSubmit false без номера и марки', () => {
+  const fmt = [{ format: { id: 1, name: 'РФ' }, cells: [{ cell_type: 'letters', max_length: 1 }, { cell_type: 'numbers', max_length: 3 }] }];
+
+  it('canSubmit false без формата, ячеек и марки', () => {
     const w = mountModal({ type: 'vehicle' });
     expect(w.vm.canSubmit).toBe(false);
   });
 
-  it('canSubmit true когда номер, марка и причина заполнены', async () => {
+  it('canSubmit true когда формат, ячейки, марка и причина заполнены', async () => {
     const w = mountModal({ type: 'vehicle' });
-    w.vm.carNumber = 'А 123';
+    w.vm.formats = fmt;
+    w.vm.selectedFormatId = 1;
+    w.vm.numberParts = ['А', '123'];
     w.vm.markId = 5;
     w.vm.reason = 'причина';
     await flushPromises();
     expect(w.vm.canSubmit).toBe(true);
   });
 
-  it('submit берёт car_number из v-model компонента и эмитит created с номером и маркой', async () => {
+  it('submit собирает car_number из ячеек и эмитит created с номером и маркой', async () => {
     const createFn = vi.fn().mockResolvedValue({});
     const w = mountModal({ type: 'vehicle', createFn });
+    w.vm.formats = fmt;
+    w.vm.selectedFormatId = 1;
     w.vm.marks = [{ id: 5, name: 'BMW' }];
-    w.vm.carNumber = 'А 123';
+    w.vm.numberParts = ['А', '123'];
     w.vm.markId = 5;
     w.vm.reason = 'причина';
     await w.vm.submit();

--- a/frontend/src/components/admin/blacklist/__tests__/VehicleNumberFormatInput.spec.js
+++ b/frontend/src/components/admin/blacklist/__tests__/VehicleNumberFormatInput.spec.js
@@ -30,7 +30,7 @@ describe('VehicleNumberFormatInput', () => {
     await flushPromises();
     expect(w.vm.selectedFormatId).toBe(1);
     expect(w.vm.numberParts.length).toBe(2);
-    expect(w.findAll('.vnf__number-input').length).toBe(2);
+    expect(w.findAll('.number__input').length).toBe(2);
   });
 
   it('префилл раскладывает номер по ячейкам формата с совпадающим числом частей', async () => {


### PR DESCRIPTION
Откат регрессии: мой предыдущий вынос ввода номера в общий компонент (#556) сломал раскладку модалки **создания** записи ЧС.

## Что сделано
- **BlacklistCreateModal вернул к исходному виду 1:1** (восстановил файл и спек из коммита до #556). Создание снова автономно, не зависит от компонента.
- **VehicleNumberFormatInput переписал как точную копию** вёрстки и стилей ввода номера из создания (те же классы/размеры), оставил его **только в правке** (AddToBlacklistModal). Теперь правка номера выглядит как создание, но создание изолировано и не может сломаться от правок компонента.

Сначала вернул создание, потом починил правку - как просили.

## Тесты
- blacklist-папка 56/56, eslint чисто. Создание восстановлено побайтово к рабочей версии.