### PR TITLE
feat(applications): ЧС-тег в колонке, адаптивные иконки, выравнивание ЛК (#529)

### DIFF
--- a/frontend/src/components/ApplicationDetail/ApplicationAttachmentDetail.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationAttachmentDetail.vue
@@ -9,14 +9,14 @@
         >
           <Badge
             v-if="attachment.roof_access"
-            variant="info"
+            variant="primary"
             size="lg"
           >
             Крыша
           </Badge>
           <Badge
             v-if="attachment.free_parking"
-            variant="success"
+            variant="warning"
             size="lg"
           >
             Парковка

--- a/frontend/src/components/UserApplications.vue
+++ b/frontend/src/components/UserApplications.vue
@@ -157,16 +157,6 @@
                     <div class="application-row">
                       <div class="application-col id-col">
                         <span class="application-id">{{ application.application_number }}</span>
-                        <Badge
-                          v-if="blacklistFlagCount(application) > 0"
-                          variant="danger"
-                          size="sm"
-                          dot
-                          class="blacklist-flag-badge"
-                          :title="blacklistFlagTitle()"
-                        >
-                          {{ blacklistFlagLabel(application) }}
-                        </Badge>
                       </div>
                       <div class="application-col date-col">
                         {{ formatDateTime(application.sending_datetime) }}
@@ -192,22 +182,59 @@
                       </div>
                       <div class="application-col tags-col">
                         <div
-                          v-if="application.has_roof_access || application.has_free_parking"
+                          v-if="blacklistFlagCount(application) > 0 || application.has_roof_access || application.has_free_parking"
                           class="application-tags"
                         >
                           <Badge
-                            v-if="application.has_roof_access"
-                            variant="info"
+                            v-if="blacklistFlagCount(application) > 0"
+                            variant="danger"
                             size="sm"
+                            dot
+                            class="rt-tag rt-tag--chs blacklist-flag-badge"
+                            :title="blacklistFlagTitle()"
                           >
-                            Крыша
+                            <span class="rt-tag__text">{{ blacklistFlagLabel(application) }}</span>
+                            <span class="rt-tag__short">{{ blacklistFlagCount(application) }}</span>
+                          </Badge>
+                          <Badge
+                            v-if="application.has_roof_access"
+                            variant="primary"
+                            size="sm"
+                            class="rt-tag"
+                            title="Доступ на крышу"
+                          >
+                            <svg
+                              class="rt-tag__icon"
+                              width="13"
+                              height="13"
+                              viewBox="0 0 24 24"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-width="2"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                            ><path d="M3 11l9-7 9 7" /><path d="M5 10v9h14v-9" /></svg>
+                            <span class="rt-tag__text">Крыша</span>
                           </Badge>
                           <Badge
                             v-if="application.has_free_parking"
-                            variant="success"
+                            variant="warning"
                             size="sm"
+                            class="rt-tag"
+                            title="Бесплатная парковка"
                           >
-                            Парковка
+                            <svg
+                              class="rt-tag__icon"
+                              width="13"
+                              height="13"
+                              viewBox="0 0 24 24"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-width="2.2"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                            ><path d="M8 4h8a4 4 0 0 1 4 4v8a4 4 0 0 1-4 4H8a4 4 0 0 1-4-4V8a4 4 0 0 1 4-4z" /><path d="M9 16V8h3.2a2.4 2.4 0 0 1 0 4.8H9" /></svg>
+                            <span class="rt-tag__text">Парковка</span>
                           </Badge>
                         </div>
                       </div>
@@ -768,7 +795,7 @@ export default {
 /* Заголовок таблицы */
 .applications-header {
   border-bottom: 1px solid #e6e6e6;
-  padding: 12px 16px;
+  padding: 12px 0;
   flex-shrink: 0;
   height: 44px;
   box-sizing: border-box;
@@ -791,6 +818,7 @@ export default {
   cursor: pointer;
   user-select: none;
   flex: 1;
+  padding: 0 16px;
   overflow: hidden;
 }
 
@@ -871,8 +899,14 @@ export default {
 }
 
 .tags-col {
-  flex: 1;
-  min-width: 130px;
+  flex: 1.5;
+  min-width: 150px;
+  container-type: inline-size;
+}
+
+.application-col.tags-col {
+  overflow: visible;
+  white-space: normal;
 }
 
 .header-col.tags-col {
@@ -886,7 +920,39 @@ export default {
 .tags-col .application-tags {
   display: flex;
   gap: 4px;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.tags-col .rt-tag__icon {
+  display: none;
+}
+
+.tags-col .rt-tag__short {
+  display: none;
+}
+
+/* тесно (закреплено нав-меню / узкий экран) - теги сворачиваются в иконки */
+@container (max-width: 175px) {
+  .tags-col .application-tags {
+    flex-wrap: nowrap;
+  }
+
+  .tags-col .rt-tag .rt-tag__text {
+    display: none;
+  }
+
+  .tags-col .rt-tag .rt-tag__icon {
+    display: block;
+  }
+
+  .tags-col .rt-tag--chs .rt-tag__short {
+    display: inline;
+  }
+
+  .tags-col .rt-tag.badge--sm {
+    padding: 4px;
+  }
 }
 
 .actions-col {

--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -288,16 +288,6 @@
                     @click.stop="copyApplicationNumber(application.application_number)"
                     @keydown.enter.prevent="copyApplicationNumber(application.application_number)"
                   >{{ application.application_number }}</span>
-                  <Badge
-                    v-if="blacklistFlagCount(application) > 0"
-                    variant="danger"
-                    size="sm"
-                    dot
-                    class="blacklist-flag-badge"
-                    :title="blacklistFlagTitle()"
-                  >
-                    {{ blacklistFlagLabel(application) }}
-                  </Badge>
                 </div>
                 <div class="application-col date-col">
                   {{ formatDateTime(application.sending_datetime) }}
@@ -324,22 +314,59 @@
                 </div>
                 <div class="application-col tags-col">
                   <div
-                    v-if="application.has_roof_access || application.has_free_parking"
+                    v-if="blacklistFlagCount(application) > 0 || application.has_roof_access || application.has_free_parking"
                     class="application-tags"
                   >
                     <Badge
-                      v-if="application.has_roof_access"
-                      variant="info"
+                      v-if="blacklistFlagCount(application) > 0"
+                      variant="danger"
                       size="sm"
+                      dot
+                      class="rt-tag rt-tag--chs blacklist-flag-badge"
+                      :title="blacklistFlagTitle()"
                     >
-                      Крыша
+                      <span class="rt-tag__text">{{ blacklistFlagLabel(application) }}</span>
+                      <span class="rt-tag__short">{{ blacklistFlagCount(application) }}</span>
+                    </Badge>
+                    <Badge
+                      v-if="application.has_roof_access"
+                      variant="primary"
+                      size="sm"
+                      class="rt-tag"
+                      title="Доступ на крышу"
+                    >
+                      <svg
+                        class="rt-tag__icon"
+                        width="13"
+                        height="13"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      ><path d="M3 11l9-7 9 7" /><path d="M5 10v9h14v-9" /></svg>
+                      <span class="rt-tag__text">Крыша</span>
                     </Badge>
                     <Badge
                       v-if="application.has_free_parking"
-                      variant="success"
+                      variant="warning"
                       size="sm"
+                      class="rt-tag"
+                      title="Бесплатная парковка"
                     >
-                      Парковка
+                      <svg
+                        class="rt-tag__icon"
+                        width="13"
+                        height="13"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2.2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      ><path d="M8 4h8a4 4 0 0 1 4 4v8a4 4 0 0 1-4 4H8a4 4 0 0 1-4-4V8a4 4 0 0 1 4-4z" /><path d="M9 16V8h3.2a2.4 2.4 0 0 1 0 4.8H9" /></svg>
+                      <span class="rt-tag__text">Парковка</span>
                     </Badge>
                   </div>
                 </div>
@@ -1373,11 +1400,11 @@ export default {
 
 /* Перераспределение размеров колонок */
 .confirmation-col {
-    width: 13%;
+    width: 11%;
 }
 
 .number-col {
-    width: 15%;
+    width: 12%;
     /* min-width:0 снимает min-content "пол" flex-элемента: иначе nowrap-бейдж под номером
        не даёт строке сжаться до своей доли, и шапка (узкий контент) расходится со строкой. */
     min-width: 0;
@@ -1402,27 +1429,61 @@ export default {
     white-space: normal;
 }
 
-/* теги вложений (крыша/парковка) в отдельной колонке, в одну строку (#529) */
+/* теги вложения (ЧС/крыша/парковка) в отдельной колонке (#529).
+   Широко - текст с переносом; тесно (закреплено нав-меню / узкий экран) -
+   container query сворачивает теги в иконки в одну строку. */
 .application-tags {
     display: flex;
     gap: 4px;
-    flex-wrap: nowrap;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.rt-tag__icon {
+    display: none;
+}
+
+.rt-tag__short {
+    display: none;
+}
+
+@container (max-width: 175px) {
+    .application-tags {
+        flex-wrap: nowrap;
+    }
+
+    .rt-tag .rt-tag__text {
+        display: none;
+    }
+
+    .rt-tag .rt-tag__icon {
+        display: block;
+    }
+
+    .rt-tag--chs .rt-tag__short {
+        display: inline;
+    }
+
+    .rt-tag.badge--sm {
+        padding: 4px;
+    }
 }
 
 .tags-col {
-    width: 11%;
+    width: 15%;
+    container-type: inline-size;
 }
 
 .date-col {
-    width: 13%;
+    width: 12%;
 }
 
 .organization-col {
-    width: 15%;
+    width: 17%;
 }
 
 .sender-col {
-    width: 13%;
+    width: 15%;
 }
 
 .sender-tooltip-anchor {


### PR DESCRIPTION
Полировка тегов по фидбеку.

## Изменения
- **«Похоже на ЧС» - тоже тег**: бейдж ЧС переехал из-под номера в колонку «Теги» (Центр и ЛК), первым перед Крыша/Парковка.
- **Адаптивные иконки**: при нехватке ширины (закреплено нав-меню / узкий экран) теги сворачиваются в иконки (домик, P, точка+счётчик ЧС) через CSS `@container` query на колонке - реагирует на реальную ширину колонки, не на конкретное состояние меню. Широко - текст.
- **ЛК - выравнивание**: шапка и данные были смещены (боковой padding только у шапки -> колонки расходились вправо). Убрал горизонтальный padding шапки, дал `padding:0 16px` всем `.header-col` - теперь всё по левой линии. Колонка «Теги» тянется, overflow для переноса/иконок.
- **Центр - ширины**: Статус 11%, Номер 12% (уже), Организация 17% / Отправитель 15% (шире), Теги 15% (под 3 тега). Сумма 100%.
- **Цвета тегов** на ранее неиспользованные варианты Badge: Крыша `primary`, Парковка `warning` (ЧС остаётся `danger`).

## Проверки
eslint 0/0; vitest ApplicationAttachmentDetail 10/10; сворачивание в иконки подтверждено отдельным container-query рендером (текст широко -> иконки узко).