### PR TITLE
fix(blacklist): табы Машины/Люди не съезжают на узкой ширине + радиус модалок 30px (#481)

### DIFF
--- a/frontend/src/components/admin/blacklist/AddToBlacklistModal.vue
+++ b/frontend/src/components/admin/blacklist/AddToBlacklistModal.vue
@@ -4,6 +4,7 @@
     :title="title"
     width="480px"
     :z-index="zIndex"
+    content-class="bl-edit-modal"
     @close="close"
   >
     <div class="atb">
@@ -262,5 +263,13 @@ export default {
 .atb-error {
   color: var(--color-danger, #dc3545);
   font-size: 13px;
+}
+</style>
+
+<!-- не scoped: контент BaseModal телепортится в body с его data-v, радиус задаём глобально
+     двойным классом (бьёт scoped .base-modal). Эталон модалок - 30px. -->
+<style>
+.base-modal.bl-edit-modal {
+  border-radius: 30px;
 }
 </style>

--- a/frontend/src/components/admin/blacklist/BlacklistCreateModal.vue
+++ b/frontend/src/components/admin/blacklist/BlacklistCreateModal.vue
@@ -3,6 +3,7 @@
     :show="show"
     :title="title"
     width="520px"
+    content-class="bl-create-modal"
     @close="close"
   >
     <div class="bl-create">
@@ -724,5 +725,13 @@ export default {
 .dropdown-leave-to {
   opacity: 0;
   transform: translateY(-10px);
+}
+</style>
+
+<!-- не scoped: контент BaseModal телепортится в body с его data-v, поэтому радиус задаём
+     глобально двойным классом (бьёт scoped .base-modal). Эталон модалок - 30px. -->
+<style>
+.base-modal.bl-create-modal {
+  border-radius: 30px;
 }
 </style>

--- a/frontend/src/components/admin/blacklist/BlacklistTabBase.vue
+++ b/frontend/src/components/admin/blacklist/BlacklistTabBase.vue
@@ -333,10 +333,14 @@ export default {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0 20px;
-  height: 50px;
+  padding: 8px 20px;
+  /* min-height вместо фиксированной height: на узкой ширине (например при закреплённой
+     нав-панели) контролы/табы переносятся на вторую строку, а не вылезают из шапки. */
+  min-height: 50px;
   border-bottom: 1px solid #e6e6e6;
   gap: 12px;
+  flex-wrap: wrap;
+  row-gap: 8px;
 }
 
 .bl-header-left {
@@ -351,6 +355,8 @@ export default {
   gap: 10px;
   align-items: center;
   flex-shrink: 0;
+  flex-wrap: wrap;
+  row-gap: 8px;
 }
 
 /* фиксированная ширина: триггер не меняет размер между "Активные" и "Архив" */

--- a/frontend/src/views/admin/BlacklistView.vue
+++ b/frontend/src/views/admin/BlacklistView.vue
@@ -98,6 +98,14 @@ export default {
   align-items: center;
   gap: 16px;
   min-width: 0;
+  flex-wrap: wrap;
+  row-gap: 8px;
+}
+
+/* Табы "Машины"/"Люди" держим в одну строку (таргетно, без правки общего FilterTabs):
+   на узкой ширине переносится вся группа табов целиком, а не разрывается по строкам. */
+.bl-head-left :deep(.filter-tabs) {
+  flex-wrap: nowrap;
 }
 
 .bl-page-title {


### PR DESCRIPTION
Две UI-правки по реестру ЧС (по фидбеку).

## 1. Табы Машины/Люди съезжали на узкой ширине
Шапка реестра (`BlacklistTabBase`) имела фиксированную `height: 50px`, и при нехватке ширины (например когда закреплена нав-панель и контент ужимается) табы и контролы вылезали из неё. Сделал шапку переносимой: `min-height` вместо `height` + `flex-wrap` + вертикальный паддинг - на узкой ширине группы переносятся на вторую строку, шапка растёт, ничего не обрезается. Табы держим единым блоком: `flex-wrap: nowrap` таргетно через `:deep` в `BlacklistView` (общий `FilterTabs` НЕ трогал - он используется и в Центре заявок).

## 2. Радиус модалок
Модалкам создания (`BlacklistCreateModal`) и редактирования (`AddToBlacklistModal`) поднял `border-radius` до эталонных 30px (через content-class + non-scoped override, как у `BlacklistOverrideModal`).

CSS-only. Тесты blacklist 56/56, eslint чисто.