### PR TITLE
feat(applications): качественная адаптивность тегов и колонок (#529)

### DIFF
--- a/frontend/src/components/UserApplications.vue
+++ b/frontend/src/components/UserApplications.vue
@@ -165,9 +165,10 @@
                         {{ application.sender_name || application.sender_full_name || '—' }}
                       </div>
                       <div class="application-col confirmation-col">
-                        <span 
+                        <span
                           class="confirmation-badge"
                           :class="getConfirmationClass(application.confirmation)"
+                          :title="application.confirmation"
                         >
                           {{ application.confirmation }}
                         </span>
@@ -176,6 +177,7 @@
                         <span
                           class="status-badge"
                           :class="getStatusClass(application.status)"
+                          :title="application.status"
                         >
                           {{ application.status }}
                         </span>
@@ -184,6 +186,10 @@
                         <div
                           v-if="blacklistFlagCount(application) > 0 || application.has_roof_access || application.has_free_parking"
                           class="application-tags"
+                          :class="{
+                            'application-tags--both': application.has_roof_access && application.has_free_parking,
+                            'application-tags--chs': blacklistFlagCount(application) > 0
+                          }"
                         >
                           <Badge
                             v-if="blacklistFlagCount(application) > 0"
@@ -194,13 +200,12 @@
                             :title="blacklistFlagTitle()"
                           >
                             <span class="rt-tag__text">{{ blacklistFlagLabel(application) }}</span>
-                            <span class="rt-tag__short">{{ blacklistFlagCount(application) }}</span>
                           </Badge>
                           <Badge
                             v-if="application.has_roof_access"
                             variant="primary"
                             size="sm"
-                            class="rt-tag"
+                            class="rt-tag rt-tag--roof"
                             title="Доступ на крышу"
                           >
                             <svg
@@ -220,7 +225,7 @@
                             v-if="application.has_free_parking"
                             variant="warning"
                             size="sm"
-                            class="rt-tag"
+                            class="rt-tag rt-tag--parking"
                             title="Бесплатная парковка"
                           >
                             <svg
@@ -920,7 +925,7 @@ export default {
 .tags-col .application-tags {
   display: flex;
   gap: 4px;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   align-items: center;
 }
 
@@ -928,30 +933,40 @@ export default {
   display: none;
 }
 
-.tags-col .rt-tag__short {
-  display: none;
-}
-
-/* тесно (закреплено нав-меню / узкий экран) - теги сворачиваются в иконки */
-@container (max-width: 175px) {
-  .tags-col .application-tags {
-    flex-wrap: nowrap;
-  }
-
-  .tags-col .rt-tag .rt-tag__text {
+/* ЧС не сворачивается. Крыша/Парковка -> иконки только когда ОБА (--both) и тесно.
+   Условия --both/--chs считаются во Vue (надёжнее :has() в scoped-стилях). */
+@container (max-width: 232px) {
+  .tags-col .application-tags--both .rt-tag--roof .rt-tag__text,
+  .tags-col .application-tags--both .rt-tag--parking .rt-tag__text {
     display: none;
   }
 
-  .tags-col .rt-tag .rt-tag__icon {
+  .tags-col .application-tags--both .rt-tag--roof .rt-tag__icon,
+  .tags-col .application-tags--both .rt-tag--parking .rt-tag__icon {
     display: block;
   }
 
-  .tags-col .rt-tag--chs .rt-tag__short {
+  .tags-col .application-tags--both .rt-tag--roof.badge--sm,
+  .tags-col .application-tags--both .rt-tag--parking.badge--sm {
+    padding: 4px;
+  }
+}
+
+/* без ЧС крыша+парковка держим текстом, пока колонка не станет узкой */
+@container (min-width: 133px) {
+  .tags-col .application-tags--both:not(.application-tags--chs) .rt-tag--roof .rt-tag__text,
+  .tags-col .application-tags--both:not(.application-tags--chs) .rt-tag--parking .rt-tag__text {
     display: inline;
   }
 
-  .tags-col .rt-tag.badge--sm {
-    padding: 4px;
+  .tags-col .application-tags--both:not(.application-tags--chs) .rt-tag--roof .rt-tag__icon,
+  .tags-col .application-tags--both:not(.application-tags--chs) .rt-tag--parking .rt-tag__icon {
+    display: none;
+  }
+
+  .tags-col .application-tags--both:not(.application-tags--chs) .rt-tag--roof.badge--sm,
+  .tags-col .application-tags--both:not(.application-tags--chs) .rt-tag--parking.badge--sm {
+    padding: 3px 8px;
   }
 }
 
@@ -1055,12 +1070,17 @@ export default {
 
 /* Бейджи подтверждения */
 .confirmation-badge {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
   padding: 4px 8px;
   border-radius: 12px;
   font-size: 11px;
   font-weight: 500;
-  display: inline-block;
+  text-align: center;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .confirmation-approved {
@@ -1089,14 +1109,17 @@ export default {
 
 /* Бейджи статуса */
 .status-badge {
-  display: inline-block;
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
   padding: 4px 8px;
   border-radius: 12px;
   font-size: 12px;
   font-weight: 500;
-  min-width: 70px;
   text-align: center;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* Статусы */

--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -272,9 +272,10 @@
             >
               <div class="application-row">
                 <div class="application-col confirmation-col">
-                  <span 
+                  <span
                     class="confirmation-badge"
                     :class="getConfirmationClass(application.confirmation)"
+                    :title="application.confirmation"
                   >
                     {{ application.confirmation }}
                   </span>
@@ -305,9 +306,10 @@
                   >{{ application.sender_name }}</span>
                 </div>
                 <div class="application-col status-col">
-                  <span 
+                  <span
                     class="status-badge"
                     :class="getStatusClass(application.status)"
+                    :title="application.status"
                   >
                     {{ application.status }}
                   </span>
@@ -316,6 +318,10 @@
                   <div
                     v-if="blacklistFlagCount(application) > 0 || application.has_roof_access || application.has_free_parking"
                     class="application-tags"
+                    :class="{
+                      'application-tags--both': application.has_roof_access && application.has_free_parking,
+                      'application-tags--chs': blacklistFlagCount(application) > 0
+                    }"
                   >
                     <Badge
                       v-if="blacklistFlagCount(application) > 0"
@@ -326,13 +332,12 @@
                       :title="blacklistFlagTitle()"
                     >
                       <span class="rt-tag__text">{{ blacklistFlagLabel(application) }}</span>
-                      <span class="rt-tag__short">{{ blacklistFlagCount(application) }}</span>
                     </Badge>
                     <Badge
                       v-if="application.has_roof_access"
                       variant="primary"
                       size="sm"
-                      class="rt-tag"
+                      class="rt-tag rt-tag--roof"
                       title="Доступ на крышу"
                     >
                       <svg
@@ -352,7 +357,7 @@
                       v-if="application.has_free_parking"
                       variant="warning"
                       size="sm"
-                      class="rt-tag"
+                      class="rt-tag rt-tag--parking"
                       title="Бесплатная парковка"
                     >
                       <svg
@@ -1400,11 +1405,11 @@ export default {
 
 /* Перераспределение размеров колонок */
 .confirmation-col {
-    width: 11%;
+    width: 14%;
 }
 
 .number-col {
-    width: 12%;
+    width: 11%;
     /* min-width:0 снимает min-content "пол" flex-элемента: иначе nowrap-бейдж под номером
        не даёт строке сжаться до своей доли, и шапка (узкий контент) расходится со строкой. */
     min-width: 0;
@@ -1429,13 +1434,14 @@ export default {
     white-space: normal;
 }
 
-/* теги вложения (ЧС/крыша/парковка) в отдельной колонке (#529).
-   Широко - текст с переносом; тесно (закреплено нав-меню / узкий экран) -
-   container query сворачивает теги в иконки в одну строку. */
+/* теги вложения (ЧС/крыша/парковка) в отдельной колонке (#529), всегда в одну строку.
+   ЧС не сворачивается. Крыша/Парковка -> иконки только когда ОБА присутствуют и тесно
+   (закреплено нав-меню / узко); один из двух - всегда текст. Пороги - content-ширина
+   колонки (за вычетом padding). */
 .application-tags {
     display: flex;
     gap: 4px;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     align-items: center;
 }
 
@@ -1443,35 +1449,50 @@ export default {
     display: none;
 }
 
-.rt-tag__short {
-    display: none;
-}
-
-@container (max-width: 175px) {
-    .application-tags {
-        flex-wrap: nowrap;
-    }
-
-    .rt-tag .rt-tag__text {
+/* оба тега присутствуют (--both): сворачиваем крышу/парковку когда текст всех не влезает.
+   Условия --both/--chs считаются во Vue (надёжнее :has() в scoped-стилях). */
+@container (max-width: 232px) {
+    .application-tags--both .rt-tag--roof .rt-tag__text,
+    .application-tags--both .rt-tag--parking .rt-tag__text {
         display: none;
     }
 
-    .rt-tag .rt-tag__icon {
+    .application-tags--both .rt-tag--roof .rt-tag__icon,
+    .application-tags--both .rt-tag--parking .rt-tag__icon {
         display: block;
     }
 
-    .rt-tag--chs .rt-tag__short {
-        display: inline;
-    }
-
-    .rt-tag.badge--sm {
+    .application-tags--both .rt-tag--roof.badge--sm,
+    .application-tags--both .rt-tag--parking.badge--sm {
         padding: 4px;
     }
 }
 
+/* без ЧС крыша+парковка влезают текстом дольше - держим текст, пока колонка не станет узкой */
+@container (min-width: 133px) {
+    .application-tags--both:not(.application-tags--chs) .rt-tag--roof .rt-tag__text,
+    .application-tags--both:not(.application-tags--chs) .rt-tag--parking .rt-tag__text {
+        display: inline;
+    }
+
+    .application-tags--both:not(.application-tags--chs) .rt-tag--roof .rt-tag__icon,
+    .application-tags--both:not(.application-tags--chs) .rt-tag--parking .rt-tag__icon {
+        display: none;
+    }
+
+    .application-tags--both:not(.application-tags--chs) .rt-tag--roof.badge--sm,
+    .application-tags--both:not(.application-tags--chs) .rt-tag--parking.badge--sm {
+        padding: 3px 8px;
+    }
+}
+
 .tags-col {
-    width: 15%;
+    width: 17%;
     container-type: inline-size;
+}
+
+.application-col.tags-col {
+    overflow: visible;
 }
 
 .date-col {
@@ -1479,7 +1500,7 @@ export default {
 }
 
 .organization-col {
-    width: 17%;
+    width: 18%;
 }
 
 .sender-col {
@@ -1534,7 +1555,8 @@ export default {
 }
 
 .actions-col {
-    width: 7%;
+    width: 104px;
+    flex-shrink: 0;
     justify-content: flex-end;
     cursor: default;
 }
@@ -1607,6 +1629,10 @@ export default {
     display: flex;
     align-items: center;
     height: 100%;
+    min-width: 0;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 }
 
 /* Стили для кнопки "Скачать" */
@@ -1634,11 +1660,17 @@ export default {
 }
 
 .confirmation-badge {
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
     padding: 4px 8px;
     border-radius: 12px;
     font-size: 11px;
     font-weight: 500;
-    display: inline-block;
+    text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .confirmation-approved {
@@ -1711,11 +1743,17 @@ export default {
 }
 
 .status-badge {
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
     padding: 4px 8px;
     border-radius: 8px;
     font-size: 11px;
     font-weight: 500;
-    display: inline-block;
+    text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
     border: 1px solid;
 }
 


### PR DESCRIPTION
Глубокая адаптивность списков по фидбеку. Проверено рендером на ширинах 1360/1040/820 для всех 7 комбинаций тегов.

## Теги (Центр и ЛК)
- **ЧС больше не сворачивается** - всегда текст 'N похоже на ЧС'.
- **Крыша/Парковка -> иконки только когда ОБА присутствуют И колонка узкая** (нав-меню закреплено). Один из двух - всегда текст. На полной ширине крыша+парковка - текст.
- Условия (--both / --chs) считаются во Vue (:class), а не через :has() в scoped-стилях - надёжнее.
- Всегда одна строка (nowrap).

## Колонки (Центр)
- Все колонки nowrap + ellipsis + min-width:0 -> не налезают друг на друга, тянутся на всю ширину, текст в одну строку (длинное усекается с …, полный текст в title).
- **Кнопка 'Обновить' не сжимается**: actions-col фиксированной ширины (104px, flex-shrink:0).
- Подтверждение шире (14%), Номер уже (11%), Организация 18% / Отправитель 15%, Статус 13%, Теги 17%.

## Бейджи Подтверждение/Статус (Центр и ЛК)
- Единая ширина (на всю колонку, box-sizing border-box, text-align center), усечение с title.

## Проверки
eslint 0/0; vitest blacklistBadge 5/5; адаптивность тегов и колонок проверена отдельным рендером таблицы Центра (class-based, идентично :has-варианту) на 3 ширинах x 7 комбинаций тегов.