### PR TITLE
fix(applications): бейджи под длинный текст + теги сворачиваются при закреплённом меню (#529)

### DIFF
--- a/frontend/src/components/UserApplications.vue
+++ b/frontend/src/components/UserApplications.vue
@@ -953,7 +953,7 @@ export default {
 }
 
 /* без ЧС крыша+парковка держим текстом, пока колонка не станет узкой */
-@container (min-width: 133px) {
+@container (min-width: 125px) {
   .tags-col .application-tags--both:not(.application-tags--chs) .rt-tag--roof .rt-tag__text,
   .tags-col .application-tags--both:not(.application-tags--chs) .rt-tag--parking .rt-tag__text {
     display: inline;
@@ -1071,7 +1071,7 @@ export default {
 /* Бейджи подтверждения */
 .confirmation-badge {
   display: block;
-  width: 100%;
+  width: 64px;
   box-sizing: border-box;
   padding: 4px 8px;
   border-radius: 12px;
@@ -1110,7 +1110,7 @@ export default {
 /* Бейджи статуса */
 .status-badge {
   display: block;
-  width: 100%;
+  width: 118px;
   box-sizing: border-box;
   padding: 4px 8px;
   border-radius: 12px;

--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -1405,11 +1405,11 @@ export default {
 
 /* Перераспределение размеров колонок */
 .confirmation-col {
-    width: 14%;
+    width: 15%;
 }
 
 .number-col {
-    width: 11%;
+    width: 12%;
     /* min-width:0 снимает min-content "пол" flex-элемента: иначе nowrap-бейдж под номером
        не даёт строке сжаться до своей доли, и шапка (узкий контент) расходится со строкой. */
     min-width: 0;
@@ -1469,7 +1469,7 @@ export default {
 }
 
 /* без ЧС крыша+парковка влезают текстом дольше - держим текст, пока колонка не станет узкой */
-@container (min-width: 133px) {
+@container (min-width: 125px) {
     .application-tags--both:not(.application-tags--chs) .rt-tag--roof .rt-tag__text,
     .application-tags--both:not(.application-tags--chs) .rt-tag--parking .rt-tag__text {
         display: inline;
@@ -1487,7 +1487,7 @@ export default {
 }
 
 .tags-col {
-    width: 17%;
+    width: 12%;
     container-type: inline-size;
 }
 
@@ -1496,15 +1496,15 @@ export default {
 }
 
 .date-col {
-    width: 12%;
+    width: 13%;
 }
 
 .organization-col {
-    width: 18%;
+    width: 20%;
 }
 
 .sender-col {
-    width: 15%;
+    width: 17%;
 }
 
 .sender-tooltip-anchor {
@@ -1551,7 +1551,7 @@ export default {
 }
 
 .status-col {
-    width: 13%;
+    width: 11%;
 }
 
 .actions-col {
@@ -1661,7 +1661,7 @@ export default {
 
 .confirmation-badge {
     display: block;
-    width: 100%;
+    width: 64px;
     box-sizing: border-box;
     padding: 4px 8px;
     border-radius: 12px;
@@ -1744,7 +1744,7 @@ export default {
 
 .status-badge {
     display: block;
-    width: 100%;
+    width: 118px;
     box-sizing: border-box;
     padding: 4px 8px;
     border-radius: 8px;


### PR DESCRIPTION
Фикс двух замечаний на разрешении 1440 с закреплённым нав-меню (контент = vw - 124px = 1316px). Проверено рендером таблицы на ширинах 1415/1300.

## Бейджи Подтверждение/Статус
- Больше НЕ во всю ширину колонки. Фикс-ширина под самый длинный текст: статус 118px (вмещает 'Непрочитано'/'В обработке'), подтверждение 64px. В колонке остаётся воздух, полный текст в title при усечении.

## Колонки Центра (1440 + закреплённое меню больше не слипаются)
- Сузил Статус 13->11%, Теги 17->12%, отдал ширину левым: Организация 18->20%, Отправитель 15->17%, Подтверждение 14->15%, Номер 11->12%, Дата 12->13%.
- Понизил порог сворачивания тегов (min-width 133->125px): крыша+парковка теперь сворачиваются в иконки при закреплённом меню (раньше оставались текстом и распирали колонку). ЧС и одиночные теги по-прежнему текст.

То же применено в ЛК (бейджи под длинный, порог 125).

## Проверки
eslint 0/0; адаптивность и ширины выверены рендером таблицы Центра на реальных ширинах (1415 без меню / 1300 с закреплённым).