### PR TITLE
fix(applications): теги не прилипают к Скачать, многоточие, hover-подсказка тегов (#529)

### DIFF
--- a/frontend/src/components/UserApplications.vue
+++ b/frontend/src/components/UserApplications.vue
@@ -162,7 +162,7 @@
                         {{ formatDateTime(application.sending_datetime) }}
                       </div>
                       <div class="application-col sender-col">
-                        {{ application.sender_name || application.sender_full_name || '—' }}
+                        <span class="ellip">{{ application.sender_name || application.sender_full_name || '—' }}</span>
                       </div>
                       <div class="application-col confirmation-col">
                         <span
@@ -196,8 +196,8 @@
                             variant="danger"
                             size="sm"
                             dot
-                            class="rt-tag rt-tag--chs blacklist-flag-badge"
-                            :title="blacklistFlagTitle()"
+                            class="rt-tag rt-tag--chs blacklist-flag-badge tag-hint"
+                            :data-hint="blacklistFlagTitle()"
                           >
                             <span class="rt-tag__text">{{ blacklistFlagLabel(application) }}</span>
                           </Badge>
@@ -205,8 +205,8 @@
                             v-if="application.has_roof_access"
                             variant="primary"
                             size="sm"
-                            class="rt-tag rt-tag--roof"
-                            title="Доступ на крышу"
+                            class="rt-tag rt-tag--roof tag-hint"
+                            data-hint="Доступ на крышу"
                           >
                             <svg
                               class="rt-tag__icon"
@@ -225,8 +225,8 @@
                             v-if="application.has_free_parking"
                             variant="warning"
                             size="sm"
-                            class="rt-tag rt-tag--parking"
-                            title="Бесплатная парковка"
+                            class="rt-tag rt-tag--parking tag-hint"
+                            data-hint="Бесплатная парковка"
                           >
                             <svg
                               class="rt-tag__icon"
@@ -926,8 +926,65 @@ export default {
 .tags-col .application-tags {
   display: flex;
   gap: 4px;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   align-items: center;
+}
+
+/* текст с многоточием в flex-ячейке */
+.ellip {
+  display: block;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* hover-подсказка #333 под тегом */
+.tag-hint {
+  position: relative;
+}
+
+.tag-hint::after {
+  content: attr(data-hint);
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  width: max-content;
+  max-width: 240px;
+  background: #333;
+  color: #fff;
+  padding: 6px 10px;
+  border-radius: 6px;
+  font-size: 12px;
+  line-height: 1.3;
+  text-align: center;
+  white-space: normal;
+  z-index: 1000;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+}
+
+.tag-hint::before {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 5px solid transparent;
+  border-bottom-color: #333;
+  z-index: 1001;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.tag-hint:hover::after,
+.tag-hint:hover::before {
+  opacity: 1;
 }
 
 .tags-col .rt-tag__icon {

--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -294,7 +294,7 @@
                   {{ formatDateTime(application.sending_datetime) }}
                 </div>
                 <div class="application-col organization-col">
-                  {{ getOrganizationName(application) }}
+                  <span class="ellip">{{ getOrganizationName(application) }}</span>
                 </div>
                 <div
                   class="application-col sender-col"
@@ -303,7 +303,7 @@
                     v-if="application.sender_name"
                     class="sender-tooltip-anchor"
                     :data-tooltip="application.sender_full_name || application.sender_name"
-                  >{{ application.sender_name }}</span>
+                  ><span class="ellip">{{ application.sender_name }}</span></span>
                 </div>
                 <div class="application-col status-col">
                   <span
@@ -328,8 +328,8 @@
                       variant="danger"
                       size="sm"
                       dot
-                      class="rt-tag rt-tag--chs blacklist-flag-badge"
-                      :title="blacklistFlagTitle()"
+                      class="rt-tag rt-tag--chs blacklist-flag-badge tag-hint"
+                      :data-hint="blacklistFlagTitle()"
                     >
                       <span class="rt-tag__text">{{ blacklistFlagLabel(application) }}</span>
                     </Badge>
@@ -337,8 +337,8 @@
                       v-if="application.has_roof_access"
                       variant="primary"
                       size="sm"
-                      class="rt-tag rt-tag--roof"
-                      title="Доступ на крышу"
+                      class="rt-tag rt-tag--roof tag-hint"
+                      data-hint="Доступ на крышу"
                     >
                       <svg
                         class="rt-tag__icon"
@@ -357,8 +357,8 @@
                       v-if="application.has_free_parking"
                       variant="warning"
                       size="sm"
-                      class="rt-tag rt-tag--parking"
-                      title="Бесплатная парковка"
+                      class="rt-tag rt-tag--parking tag-hint"
+                      data-hint="Бесплатная парковка"
                     >
                       <svg
                         class="rt-tag__icon"
@@ -1434,19 +1434,75 @@ export default {
     white-space: normal;
 }
 
-/* теги вложения (ЧС/крыша/парковка) в отдельной колонке (#529), всегда в одну строку.
-   ЧС не сворачивается. Крыша/Парковка -> иконки только когда ОБА присутствуют и тесно
-   (закреплено нав-меню / узко); один из двух - всегда текст. Пороги - content-ширина
-   колонки (за вычетом padding). */
+/* теги вложения (ЧС/крыша/парковка) в отдельной колонке (#529).
+   ЧС не сворачивается; крыша/парковка -> иконки когда оба и тесно. wrap: широкий
+   ЧС+тег, не влезающий в узкую колонку, переносится ВНУТРИ колонки, а не в actions. */
 .application-tags {
     display: flex;
     gap: 4px;
-    flex-wrap: nowrap;
+    flex-wrap: wrap;
     align-items: center;
 }
 
 .rt-tag__icon {
     display: none;
+}
+
+/* текст с многоточием в flex-ячейке (на самой ячейке text-overflow:ellipsis не работает) */
+.ellip {
+    display: block;
+    min-width: 0;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* hover-подсказка #333 под тегом (как у Отправителя) */
+.tag-hint {
+    position: relative;
+}
+
+.tag-hint::after {
+    content: attr(data-hint);
+    position: absolute;
+    top: calc(100% + 6px);
+    left: 50%;
+    transform: translateX(-50%);
+    width: max-content;
+    max-width: 240px;
+    background: #333;
+    color: #fff;
+    padding: 6px 10px;
+    border-radius: 6px;
+    font-size: 12px;
+    line-height: 1.3;
+    text-align: center;
+    white-space: normal;
+    z-index: 1000;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+}
+
+.tag-hint::before {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 5px solid transparent;
+    border-bottom-color: #333;
+    z-index: 1001;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s;
+}
+
+.tag-hint:hover::after,
+.tag-hint:hover::before {
+    opacity: 1;
 }
 
 /* оба тега присутствуют (--both): сворачиваем крышу/парковку когда текст всех не влезает.
@@ -1510,9 +1566,16 @@ export default {
     min-width: 90px;
 }
 
+.application-col.sender-col {
+    overflow: visible;
+}
+
 .sender-tooltip-anchor {
     position: relative;
     cursor: default;
+    display: block;
+    min-width: 0;
+    max-width: 100%;
 }
 
 .sender-tooltip-anchor::after {


### PR DESCRIPTION
Три правки по фидбеку. Перенос тегов и многоточие выверены рендером на 1276; hover-подсказка - Playwright-наведением.

## Тег 'похоже на ЧС' прилипал к Скачать
ЧС-тег широкий (~110px) и не сворачивается; в узкой колонке (закреплённое меню) его контент вылезал через overflow:visible в столбец actions. Включил **flex-wrap** на .application-tags: ЧС+тег переносится ВНУТРИ колонки (2 строки), а не налезает на Скачать. Сворачивание крыши/парковки в иконки сохранено.

## Многоточие у обрезаемого текста
Организация/Отправитель просто обрезались без '…'. Причина - **text-overflow:ellipsis не работает на flex-ячейке**. Обернул текст во внутренний .ellip-span (block + overflow:hidden + ellipsis). Sender-col сделал overflow:visible (для тултипа), обрезка - на внутреннем span.

## Hover-подсказка тегов (#333, как у Отправителя)
Каждому тегу - кастомная подсказка #333 под ним через data-hint + ::after/::before (копия стиля sender-tooltip). Особенно полезно для свёрнутых в иконки крыши/парковки (видно смысл) и для длинного пояснения ЧС. Заменил нативный title.

То же применено в ЛК.

## Проверки
eslint 0/0; перенос+многоточие - рендер таблицы на 1276; тултип - Playwright hover (#333 под тегом, со стрелкой, длинный текст переносится в 240px).