### PR TITLE
fix(applications): пересчитал колонки Центра заявок, убрал раздувание и перекрытие (#529)

### DIFF
--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -1408,11 +1408,11 @@ export default {
 
 /* Перераспределение размеров колонок */
 .confirmation-col {
-    flex: 0 0 140px;
+    flex: 0 0 130px;
 }
 
 .number-col {
-    flex: 0 0 130px;
+    flex: 0 0 118px;
     min-width: 0;
 }
 
@@ -1506,41 +1506,37 @@ export default {
     opacity: 1;
 }
 
-/* ЧС + оба тега (3 тега): крыша/парковка всегда иконки - 3 текста в одну строку не влезают */
-.application-tags--chs.application-tags--both .rt-tag--roof .rt-tag__text,
-.application-tags--chs.application-tags--both .rt-tag--parking .rt-tag__text {
+/* ЧС в строке -> крыша/парковка ВСЕГДА иконки (любая ширина). ЧС держим полным текстом
+   (111px), а два-три текстовых тега рядом в одну строку не влезают. Одиночные крыша/
+   парковка без ЧС остаются текстом. */
+.application-tags--chs .rt-tag--roof .rt-tag__text,
+.application-tags--chs .rt-tag--parking .rt-tag__text {
     display: none;
 }
 
-.application-tags--chs.application-tags--both .rt-tag--roof .rt-tag__icon,
-.application-tags--chs.application-tags--both .rt-tag--parking .rt-tag__icon {
+.application-tags--chs .rt-tag--roof .rt-tag__icon,
+.application-tags--chs .rt-tag--parking .rt-tag__icon {
     display: block;
 }
 
-.application-tags--chs.application-tags--both .rt-tag--roof.badge--sm,
-.application-tags--chs.application-tags--both .rt-tag--parking.badge--sm {
+.application-tags--chs .rt-tag--roof.badge--sm,
+.application-tags--chs .rt-tag--parking.badge--sm {
     padding: 4px;
 }
 
-/* тесно (нав-меню закреплено): крыша/парковка -> иконки в строках с ЧС или с обоими тегами.
-   Порог - ширина таблицы (.applications-table - container). Одиночные крыша/парковка без ЧС - текст. */
+/* тесно (нав-меню закреплено, ширина таблицы < 1320): крыша+парковка БЕЗ ЧС -> иконки.
+   Порог - ширина таблицы (.applications-table - container). */
 @container (max-width: 1320px) {
-    .application-tags--chs .rt-tag--roof .rt-tag__text,
-    .application-tags--chs .rt-tag--parking .rt-tag__text,
     .application-tags--both .rt-tag--roof .rt-tag__text,
     .application-tags--both .rt-tag--parking .rt-tag__text {
         display: none;
     }
 
-    .application-tags--chs .rt-tag--roof .rt-tag__icon,
-    .application-tags--chs .rt-tag--parking .rt-tag__icon,
     .application-tags--both .rt-tag--roof .rt-tag__icon,
     .application-tags--both .rt-tag--parking .rt-tag__icon {
         display: block;
     }
 
-    .application-tags--chs .rt-tag--roof.badge--sm,
-    .application-tags--chs .rt-tag--parking.badge--sm,
     .application-tags--both .rt-tag--roof.badge--sm,
     .application-tags--both .rt-tag--parking.badge--sm {
         padding: 4px;
@@ -1548,7 +1544,7 @@ export default {
 }
 
 .tags-col {
-    flex: 0 0 185px;
+    flex: 0 0 175px;
 }
 
 .application-col.tags-col {
@@ -1556,17 +1552,21 @@ export default {
 }
 
 .date-col {
-    flex: 0 0 130px;
+    flex: 0 0 124px;
 }
 
+/* Организация - основная гибкая колонка-наполнитель: тянется, заполняя свободную ширину,
+   но не больше 560px (на больших мониторах не раздувается). */
 .organization-col {
-    flex: 2.2 1 0;
-    min-width: 90px;
+    flex: 100 1 0;
+    min-width: 120px;
+    max-width: 560px;
 }
 
+/* Отправитель - предпочтительная ширина 160px, ужимается до 90 на тесных раскладках, не растёт. */
 .sender-col {
-    flex: 1.2 1 0;
-    min-width: 80px;
+    flex: 0 1 160px;
+    min-width: 90px;
 }
 
 .application-col.sender-col {
@@ -1620,11 +1620,14 @@ export default {
 }
 
 .status-col {
-    flex: 0 0 130px;
+    flex: 0 0 124px;
 }
 
+/* actions тянется, забирая остаток ширины после потолка Организации - кнопка "Скачать"
+   прижата вправо (justify-content: flex-end), между тегами и ней появляется воздух на
+   широких мониторах вместо пустоты у правого края таблицы. */
 .actions-col {
-    flex: 0 0 96px;
+    flex: 1 0 96px;
     justify-content: flex-end;
     cursor: default;
 }


### PR DESCRIPTION
## Что чинит

Жалобы по таблице Центра заявок на разных мониторах:
- колонка тегов занимала много места и не ужималась, остальные жертвовали шириной -> Отправитель налезал на Статус;
- на больших мониторах Организация и Отправитель раздувались до критических размеров;
- ЧС-бейдж липнул к Скачать.

## Решение

Новая flex-модель колонок:
- **Организация** - основная гибкая колонка-наполнитель (`flex: 100 1 0`), тянется по свободной ширине, потолок `max-width: 560px` -> на больших мониторах не раздувается.
- **Отправитель** - `flex: 0 1 160px` (предпочтительно 160, ужимается до 90, не растёт) -> больше не огромный и не налезает на Статус.
- **Скачать** (actions) - `flex: 1 0 96px` + `justify-content: flex-end`: забирает остаток ширины после потолка Организации, кнопка прижата вправо, между тегами и ней появляется воздух вместо пустоты у правого края.
- Подтверждение 130 / Номер 118 / Дата 124 / Статус 124 - фиксированные.
- **Теги** - 175px (минимум под полный текст «N похожи на ЧС» = 111px + место). ЧС держим полным текстом, крыша/парковка рядом с ЧС всегда сворачиваются в иконки, поэтому ЧС не липнет к Скачать.

Полный текст ЧС оставлен по решению пользователя - поэтому колонку тегов нельзя сделать 120/100px (бейдж 111px не влезает), 175px - физический минимум.

## Проверка

Замеры рендером (container = ширина таблицы), переполнения нет ни на одной ширине:

| Состояние | Организация | Отправитель | Теги | Скачать |
|---|---|---|---|---|
| Закреплено 1440 (1276px) | 215 | 160 | 175 | 98 |
| Откреплено 1440 (1340px) | 278 | 160 | 175 | 99 |
| Большой 1920 (1750px) | 560 (потолок) | 160 | 175 | 227 |
| Узкий ноут (1100px) | 120 (min) | 90 (min) | 175 | 96 |

Только Центр заявок. ЛК (UserApplications.vue) - другой набор колонок (без Организации/Номера), не трогал.