### PR TITLE
fix(applications): полная ширина таблицы Центра + пропорциональные колонки, теги 90/120 (#529)

### DIFF
--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -1148,7 +1148,6 @@ export default {
     border-radius: var(--radius-lg);
     box-shadow: var(--shadow-sm);
     margin-bottom: 16px;
-    max-width: 1480px;
 }
 
 .center__tabs {
@@ -1331,10 +1330,6 @@ export default {
 
 .applications-table {
     min-width: 300px;
-    /* Потолок ширины: на больших мониторах таблица не растягивается на весь экран -
-       иначе Организации пришлось бы раздуваться либо образовалась бы пустая дыра.
-       Лишняя ширина уходит в поле справа от таблицы (как у панели фильтров). */
-    max-width: 1480px;
     background-color: #fff;
     border-radius: 30px;
     border: 1px solid var(--color-border);
@@ -1410,14 +1405,15 @@ export default {
     font-weight: 500 !important;
 }
 
-/* Перераспределение размеров колонок */
+/* Перераспределение размеров колонок (пропорциональный рост, см. .organization-col) */
 .confirmation-col {
-    flex: 0 0 124px;
+    flex: 126 1 0;
+    min-width: 124px;
 }
 
 .number-col {
-    flex: 0 0 118px;
-    min-width: 0;
+    flex: 120 1 0;
+    min-width: 116px;
 }
 
 /* column-stack (номер + бейдж) только в строках данных. У заголовка остаётся row из
@@ -1528,9 +1524,24 @@ export default {
     padding: 4px;
 }
 
-/* тесно (нав-меню закреплено, ширина таблицы < 1320): крыша+парковка БЕЗ ЧС -> иконки.
-   Порог - ширина таблицы (.applications-table - container). */
-@container (max-width: 1320px) {
+/* Колонка тегов фиксированная: 120px когда таблица просторная, 90px когда тесно (нав-меню
+   закреплено). Базовое правило ДО @container, чтобы контейнерное переопределение (90px)
+   победило по порядку источника при равной специфичности. */
+.tags-col {
+    flex: 0 0 120px;
+}
+
+.application-col.tags-col {
+    overflow: visible;
+}
+
+/* тесно (нав-меню закреплено, ширина таблицы < 1300): теги -> 90px, крыша+парковка БЕЗ ЧС
+   -> иконки. Порог - ширина таблицы (.applications-table - container). */
+@container (max-width: 1300px) {
+    .tags-col {
+        flex: 0 0 90px;
+    }
+
     .application-tags--both .rt-tag--roof .rt-tag__text,
     .application-tags--both .rt-tag--parking .rt-tag__text {
         display: none;
@@ -1547,30 +1558,22 @@ export default {
     }
 }
 
-.tags-col {
-    flex: 0 0 162px;
-}
-
-.application-col.tags-col {
-    overflow: visible;
-}
-
 .date-col {
-    flex: 0 0 118px;
+    flex: 120 1 0;
+    min-width: 115px;
 }
 
-/* Организация - основная колонка (название компании): тянется, заполняя свободную ширину
-   таблицы. Ширину таблицы ограничивает max-width на .applications-table, поэтому на больших
-   мониторах колонка не раздувается, лишнее уходит в поле справа от таблицы, а не в дыру. */
+/* Все текстовые колонки растут ПРОПОРЦИОНАЛЬНО (flex-basis: 0 + вес во flex-grow), поэтому
+   на широком экране ширина распределяется между ними, а не достаётся одной Организации.
+   Организация - самая широкая (вес 270), но не единственный наполнитель. */
 .organization-col {
-    flex: 100 1 0;
-    min-width: 140px;
+    flex: 270 1 0;
+    min-width: 160px;
 }
 
-/* Отправитель - предпочтительная ширина 126px, ужимается до 90 на тесных раскладках, не растёт. */
 .sender-col {
-    flex: 0 1 126px;
-    min-width: 90px;
+    flex: 195 1 0;
+    min-width: 120px;
 }
 
 .application-col.sender-col {
@@ -1624,7 +1627,8 @@ export default {
 }
 
 .status-col {
-    flex: 0 0 124px;
+    flex: 126 1 0;
+    min-width: 124px;
 }
 
 .actions-col {


### PR DESCRIPTION
## Что чинит (по фидбеку)

1. Страница перестала тянуться на всю ширину - был жёсткий потолок `max-width: 1480px`. **Убрал.**
2. Организация одна забирала весь простор (400px на 1440, 500px на 1706), остальные стояли на месте. **Сделал колонки пропорциональными.**
3. Теги: 90px при закреплённом меню, 120px без. **Через container-query (порог 1300px).**

## Решение

- Убрал `max-width: 1480px` с `.applications-table` и `.center__filters` - полная ширина.
- Все текстовые колонки - пропорциональный рост (`flex-basis: 0` + вес во `flex-grow`): простор делится между ними. Веса: Организация 270, Отправитель 195, Подтверждение/Статус 126, Номер/Дата 120. Теги/Скачать - фиксированные.
- Теги: база `120px`, `@container (max-width: 1300px)` -> `90px` + крыша/парковка в иконки.

## Проверка рендером (ширина колонок)

| Сценарий (ширина таблицы) | Организация | Отправитель | Теги |
|---|---|---|---|
| 1440 закреплено (~1236) | 255 | 184 | 90 |
| 1440 откреплено (~1340) | 280 | 202 | 120 |
| 1706 откреплено (~1560) | 342 | 247 | 120 |

Организация больше не гигант (255-342), всё сбалансировано, полная ширина.

## Известный edge-case (вынесено пользователю)

Теги 90px физически не вмещают ЧС-бейдж: «11 похожи на ЧС» = 103px, а строка ЧС+крыша+парковка = 157px - вылезает на «Скачать». На строках без ЧС (один тег) 90px идеально. Если в закреплённом виде ЧС-строки мешают - поднять порог тегов до ~110px или укоротить текст ЧС.

Порог 1300px подобран под 1440 (закр ~1236 / откр ~1340); если на конкретной машине нав-рельс другой ширины - порог подстраивается одним числом.

Только Центр заявок.