### PR TITLE
style(ui): тени карточек, выравнивание заголовков таблиц, радиусы фильтров (#529)

### DIFF
--- a/frontend/src/components/AccountComponent.vue
+++ b/frontend/src/components/AccountComponent.vue
@@ -183,7 +183,6 @@ export default {
   opacity: 0;
   transform: translateY(20px);
   animation: fadeInUp 0.5s cubic-bezier(0.16, 1, 0.3, 1) forwards;
-  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.1);
 }
 
 /* Анимации */

--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -1274,7 +1274,6 @@ export default {
   overflow: hidden;
   width: 100%;
   max-height: 575px;
-  box-shadow: 0 3px 10px rgba(0,0,0,0.05);
   display: flex;
   flex-direction: column;
 }

--- a/frontend/src/components/DateFilter.vue
+++ b/frontend/src/components/DateFilter.vue
@@ -1136,7 +1136,7 @@ export default {
 .action-btn {
     flex: 1;
     padding: 8px 12px;
-    border-radius: 6px;
+    border-radius: 50px;
     font-size: 12px;
     font-weight: 500;
     cursor: pointer;

--- a/frontend/src/components/FactTable.vue
+++ b/frontend/src/components/FactTable.vue
@@ -888,7 +888,6 @@ export default {
   width: 100%;
   min-height: 222px;
   max-height: 222px;
-  box-shadow: 0 3px 10px rgba(0,0,0,0.05);
 }
 
 .card-header {

--- a/frontend/src/components/OrganizationFilter.vue
+++ b/frontend/src/components/OrganizationFilter.vue
@@ -269,7 +269,7 @@ export default {
     width: 230px; /* Такая же ширина как у поля */
     background: white;
     border: 1px solid #e6e6e6;
-    border-radius: 10px;
+    border-radius: 20px;
     max-height: 360px;
     overflow: hidden;
     z-index: 1001;

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -1227,7 +1227,6 @@ export default {
   overflow: hidden;
   width: 100%;
   max-height: 575px;
-  box-shadow: 0 3px 10px rgba(0,0,0,0.05);
   display: flex;
   flex-direction: column;
 }

--- a/frontend/src/components/UserApplications.vue
+++ b/frontend/src/components/UserApplications.vue
@@ -700,7 +700,6 @@ export default {
   border: 1px solid #e6e6e6;
   overflow: hidden;
   width: 100%;
-  box-shadow: 0 3px 10px rgba(0,0,0,0.05);
   height: 383px;
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/UserNotificationsInline.vue
+++ b/frontend/src/components/UserNotificationsInline.vue
@@ -247,7 +247,6 @@ export default {
   background-color: #fff;
   border-radius: 30px;
   border: 1px solid #e6e6e6;
-  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.05);
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/frontend/src/components/UserProfileHeader.vue
+++ b/frontend/src/components/UserProfileHeader.vue
@@ -308,7 +308,6 @@ export default {
   gap: 20px;
   padding: 20px 45px;
   border-radius: 30px;
-  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.05);
   border: 1px solid #e6e6e6;
   height: 200px;
   position: relative;

--- a/frontend/src/views/CarsView.vue
+++ b/frontend/src/views/CarsView.vue
@@ -1492,7 +1492,7 @@ export default {
     font-weight: 500;
     color: #a2a2a2;
     text-align: left;
-    padding: 0 0px;
+    padding: 0 8px;
     font-size: 14px;
     display: flex;
     align-items: center;

--- a/frontend/src/views/EmployeeView.vue
+++ b/frontend/src/views/EmployeeView.vue
@@ -813,7 +813,7 @@ export default {
     font-weight: 500;
     color: #a2a2a2;
     text-align: left;
-    padding: 0 0px;
+    padding: 0 8px;
     font-size: 14px;
     display: flex;
     align-items: center;


### PR DESCRIPTION
Косметика из ТЗ (46 правок), безопасный CSS-батч.

- **П.13** убрал box-shadow: FactTable, CarsTable, PeopleTable + блоки ЛК (UserProfileHeader, UserNotificationsInline, UserApplications, обёртка .dashboard-card-animated). Функциональные тени (hover/tooltip/бейдж) не трогал.
- **П.16** заголовки таблиц Сотрудники/Автомобили выровнены по левому краю с данными: header-col `padding: 0 0` -> `0 8px` под data-col `0 8px`.
- **П.30(3)** радиус выпадающего меню фильтра "Организация" 10 -> 20px.
- **П.30(4)** кнопки "Очистить"/"Применить" в фильтре даты 6 -> 50px.

П.19 (размер подсказки в VehicleForm) проверен - уже сделан, в этот PR не входит.
Чистый CSS, без правок шаблона/скрипта.