### PR TITLE
fix(applications): фильтр Непрочитано по is_read, без ошибки времени, авто-выбор вложения (#529)

### DIFF
--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -494,11 +494,6 @@ export default {
                 if (!hasValidDates) {
                     reasons.push(`"${label}": заполните даты и время действия`);
                 }
-                const hasValidTime = !!(dateData.startTime && dateData.endTime && dateData.startTime < dateData.endTime);
-                if (hasValidDates && !hasValidTime) {
-                    reasons.push(`"${label}": время окончания должно быть позже времени начала`);
-                }
-
                 const uaId = attachment.template_id || attachment.id;
                 const fields = this.customFieldDefinitions[uaId] || [];
                 const values = this.customFieldsByAttachment[key] || {};
@@ -878,14 +873,10 @@ export default {
             const dateData = this.attachmentDatesByAttachment[attachmentId];
             if (!dateData || !dateData.errors) return;
             
-            if (dateData.startTime && dateData.endTime) {
-                if (dateData.startTime >= dateData.endTime) {
-                    dateData.errors.endTime = 'Время окончания должно быть позже времени начала';
-                } else {
-                    dateData.errors.endTime = '';
-                }
-            }
-            
+            // Время окончания раньше начала больше не ошибка: DateRangeSection авто-переносит
+            // окончание на следующий день (получается валидный кросс-дневной диапазон).
+            dateData.errors.endTime = '';
+
             this.saveToLocalStorage();
         },
         
@@ -1083,6 +1074,10 @@ export default {
 
             if (this.selectedAttachment && this.attachmentKey(this.selectedAttachment) === key) {
                 this.selectedAttachment = null;
+                // П.25: при удалении выбранного вложения открываем первое оставшееся (сверху).
+                if (this.attachments.length > 0) {
+                    this.handleAttachmentSelected(this.attachments[0]);
+                }
             }
 
             this.clearFormData();
@@ -1440,13 +1435,8 @@ export default {
             const dateData = this.attachmentDatesByAttachment[attachmentId];
             if (!dateData || !dateData.errors) return;
             
-            if (dateData.startTime && dateData.endTime) {
-                if (dateData.startTime >= dateData.endTime) {
-                    dateData.errors.endTime = 'Время окончания должно быть позже времени начала';
-                } else {
-                    dateData.errors.endTime = '';
-                }
-            }
+            // см. validateAttachmentTimeRange: время окончания раньше начала - не ошибка.
+            dateData.errors.endTime = '';
         },
 
         async submitApplication() {
@@ -1481,10 +1471,6 @@ export default {
                         }
                     }
 
-                    if (dateData.startTime && dateData.endTime && dateData.startTime >= dateData.endTime) {
-                        hasDateErrors = true;
-                        errorMessage = `В вложении "${attachment.display_name}" время окончания должно быть позже времени начала`;
-                    }
                 }
             });
 

--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -546,10 +546,13 @@ export default {
                 );
             }
 
-            // Фильтр по статусу заявки
+            // Фильтр по статусу заявки. "Непрочитано" срабатывает и на статусе заявки
+            // "Непрочитано", и на заявках, не прочитанных пользователем (!is_read).
             if (this.selectedApplicationStatuses.length > 0) {
-                filtered = filtered.filter(app => 
-                    this.selectedApplicationStatuses.includes(app.status)
+                const includeUnread = this.selectedApplicationStatuses.includes('Непрочитано');
+                filtered = filtered.filter(app =>
+                    this.selectedApplicationStatuses.includes(app.status) ||
+                    (includeUnread && !app.is_read)
                 );
             }
 


### PR DESCRIPTION
Лёгкая логика из ТЗ (46 правок), серийный батч.

- **П.7** Фильтр "Непрочитано" в Центре заявок срабатывает и на статусе заявки "Непрочитано", и на заявках, не прочитанных пользователем (`!is_read`) - раньше только по статусу. (ApplicationsCenter.vue, `filteredApplications`)
- **П.21** Убрана ошибка "Время окончания должно быть позже времени начала". DateRangeSection авто-переносит окончание на следующий день -> валидный кросс-дневной диапазон, а проверка сравнивала только время и ложно блокировала. Убрал в 4 местах: `validateAttachmentTimeRange`, `validateAttachmentTimeRangeForAttachment`, submit-причины, submit-гейт. Дата-проверка (start-date <= end-date) осталась.
- **П.25** При удалении выбранного вложения открывается первое оставшееся сверху (а не пустой экран) - через тот же `handleAttachmentSelected`, что и клик в BlankSelector. `this.vehicles/employees/items` - computed по selectedAttachment, поэтому save при переключении = self-assign (безопасно).

Логика - смотрю CI (lint + vitest) внимательно.