### PR TITLE
style(account): контактные бейджи профиля прижаты к низу блока (#529)

### DIFF
--- a/frontend/src/components/UserProfileHeader.vue
+++ b/frontend/src/components/UserProfileHeader.vue
@@ -354,6 +354,9 @@ export default {
 .user-info {
   flex-grow: 1;
   min-width: 0;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
 
 .main-info {
@@ -427,6 +430,8 @@ export default {
   align-items: center;
   gap: 8px;
   padding-top: 12px;
+  /* П.43: контактные бейджи прижаты к нижней части блока */
+  margin-top: auto;
 }
 
 .user-detail {


### PR DESCRIPTION
**П.43** из ТЗ. `.user-info` -> flex-column на всю высоту карточки, контактным бейджам `margin-top:auto`. Основная инфо сверху, бейджи у нижней части. Проверено рендером.

П.14 (высота списка заявок ЛК) не вошёл - требует живого замера высоты шапки/перестройки шелла, делаю отдельно.