### PR TITLE
fix(applications): Центр заявок обновляется сразу при любом изменении в детали (#529)

### DIFF
--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -1031,17 +1031,16 @@ export default {
                 }
             }
             
+            // П.40: подтягиваем актуальное состояние списка из Центра сразу после изменения
+            this.fetchApplications();
             this.$emit('refresh-data');
         },
 
-        handleApplicationUpdate(updatedApp) {
-            console.log('Application updated in center:', updatedApp);
-            this.fetchApplications(); // Обновляем список заявок
+        handleApplicationUpdate() {
+            this.fetchApplications();
         },
 
         handleApplicationChanged(updatedApp) {
-            console.log('Application changed in center (via application-changed):', updatedApp);
-            
             // Обновляем данные в списке
             const appIndex = this.applications.findIndex(app => app.id === updatedApp.id);
             if (appIndex !== -1) {
@@ -1061,6 +1060,8 @@ export default {
                 
                 // Принудительно обновляем список для пересчета computed свойств
                 this.applications = [...this.applications];
+                // П.40: дотягиваем актуальное состояние с сервера (локальный мердж может быть неполным)
+                this.fetchApplications();
             } else {
                 // Если заявка не найдена в списке (например, из-за фильтров), просто перезагружаем весь список
                 this.fetchApplications();


### PR DESCRIPTION
**П.40** из ТЗ.

`handleConfirmationUpdate` и `handleApplicationChanged` (когда заявка в списке) делали только локальный мердж payload из детали - но сервер при действии пересчитывает статус/подтверждение/ЧС-флаги, которых в payload могло не быть, и список Центра оставался неактуальным.

Теперь все хендлеры изменений (`confirmation-updated`, `application-updated`, `application-changed`) дотягивают актуальный список с сервера через `fetchApplications()`. Локальный мердж оставил для мгновенного отклика, затем fetch синхронизирует. Убрал прод-console.log из этих хендлеров.