### PR TITLE
feat(ui): кнопка Обновить - перезарядка 3с с тремя точками (#529)

### DIFF
--- a/frontend/src/components/RefreshButton.vue
+++ b/frontend/src/components/RefreshButton.vue
@@ -1,38 +1,82 @@
 <template>
   <button
     class="refresh-btn"
-    :class="{ 'refresh-btn--loading': loading }"
-    :disabled="loading || cooldown"
+    :class="{ 'refresh-btn--charging': cooldown }"
+    :disabled="cooldown"
     type="button"
     @click="handleRefresh"
   >
-    <img
-      src="@/assets/icons/refresh.png"
-      class="refresh-btn__icon"
-      alt=""
+    <!-- Перезарядка: три точки по центру, каждую секунду зажигается одна (П.32) -->
+    <span
+      v-if="cooldown"
+      class="refresh-btn__dots"
+      aria-hidden="true"
     >
-    <p class="refresh-btn__text">
-      Обновить
-    </p>
+      <span
+        class="refresh-btn__dot"
+        :class="{ 'is-lit': chargeStep >= 1 }"
+      />
+      <span
+        class="refresh-btn__dot"
+        :class="{ 'is-lit': chargeStep >= 2 }"
+      />
+      <span
+        class="refresh-btn__dot"
+        :class="{ 'is-lit': chargeStep >= 3 }"
+      />
+    </span>
+    <!-- Готова: иконка + текст, появляются с анимацией -->
+    <span
+      v-else
+      class="refresh-btn__content"
+    >
+      <img
+        src="@/assets/icons/refresh.png"
+        class="refresh-btn__icon"
+        alt=""
+      >
+      <span class="refresh-btn__text">Обновить</span>
+    </span>
   </button>
 </template>
 <script>
+const CHARGE_MS = 3000;
+
 export default {
   props: {
     loading: { type: Boolean, default: false },
   },
   emits: ['refresh'],
   data() {
-    return { cooldown: false };
+    return { cooldown: false, chargeStep: 0, timers: [] };
+  },
+  beforeUnmount() {
+    this.clearTimers();
   },
   methods: {
     handleRefresh() {
       if (this.loading || this.cooldown) return;
-      this.cooldown = true;
       this.$emit('refresh');
-      setTimeout(() => { this.cooldown = false; }, 2000);
-    }
-  }
+      this.startCharge();
+    },
+    startCharge() {
+      this.clearTimers();
+      this.cooldown = true;
+      this.chargeStep = 0;
+      // каждую секунду зажигаем одну точку чёрным
+      this.timers.push(setTimeout(() => { this.chargeStep = 1; }, 1000));
+      this.timers.push(setTimeout(() => { this.chargeStep = 2; }, 2000));
+      this.timers.push(setTimeout(() => {
+        this.chargeStep = 3;
+        this.cooldown = false;
+        this.chargeStep = 0;
+      }, CHARGE_MS));
+    },
+    clearTimers() {
+      this.timers.forEach(clearTimeout);
+      this.timers = [];
+    },
+  },
 }
 </script>
 <style scoped>
@@ -55,13 +99,25 @@ export default {
         background-color: #f2f2f2;
     }
 
-    .refresh-btn--loading {
-        cursor: progress;
-        opacity: 0.85;
+    /* Во время перезарядки: без курсора-лоадера, фон не меняется */
+    .refresh-btn--charging {
+        cursor: default;
     }
 
-    .refresh-btn--loading:hover {
+    .refresh-btn--charging:hover {
         background-color: #FFF;
+    }
+
+    .refresh-btn__content {
+        display: flex;
+        align-items: center;
+        gap: 5px;
+        animation: refresh-btn-in 0.3s ease;
+    }
+
+    @keyframes refresh-btn-in {
+        from { opacity: 0; transform: scale(0.85); }
+        to { opacity: 1; transform: scale(1); }
     }
 
     .refresh-btn__icon {
@@ -73,5 +129,23 @@ export default {
         color: #4F5BDF;
         font-size: 12px;
         font-weight: 500;
+    }
+
+    .refresh-btn__dots {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+    }
+
+    .refresh-btn__dot {
+        width: 5px;
+        height: 5px;
+        border-radius: 50%;
+        background-color: #ccc;
+        transition: background-color 0.3s ease;
+    }
+
+    .refresh-btn__dot.is-lit {
+        background-color: #333;
     }
 </style>


### PR DESCRIPTION
**П.32, часть «кнопка»** (общий `RefreshButton` -> все ~20 таблиц сразу).

После клика кнопка уходит в перезарядку на 3 секунды: по центру три серые точки, каждую секунду зажигается одна чёрным, затем иконка+текст «Обновить» возвращаются с анимацией (fade+scale). Убрал `cursor:progress` (по ТЗ у курсора ничего появляться не должно). Гейт 3с - обновлять можно раз в 3 секунды. Состояния проверены рендером.

Spec BlacklistTabBase стабит RefreshButton, не ломается. Внешних ссылок на старый класс `refresh-btn--loading` нет.

**Follow-up (часть «кольцо-loader на месте данных» как в FactTable для остальных таблиц)** - отдельным PR, per-component.