### PR TITLE
feat(history): application_id в ответах истории машины и сотрудника

### DIFF
--- a/internal/services/car_history_service.go
+++ b/internal/services/car_history_service.go
@@ -14,24 +14,25 @@ import (
 )
 
 type carHistoryRow struct {
-	ID           int
-	CarID        int
-	UserID       *int
-	UserName     string
-	LastName     *string
-	FirstName    *string
-	MiddleName   *string
-	ActionType   string
-	FieldName    *string
-	OldValue     *string
-	NewValue     *string
-	Comment      *string
-	CreatedAt    time.Time
-	Metadata     *string
-	CarNumber    *string
-	CarBrand     *string
-	Organization *string
-	Company      *string
+	ID            int
+	CarID         int
+	ApplicationID *int
+	UserID        *int
+	UserName      string
+	LastName      *string
+	FirstName     *string
+	MiddleName    *string
+	ActionType    string
+	FieldName     *string
+	OldValue      *string
+	NewValue      *string
+	Comment       *string
+	CreatedAt     time.Time
+	Metadata      *string
+	CarNumber     *string
+	CarBrand      *string
+	Organization  *string
+	Company       *string
 }
 
 // GetCarHistory возвращает историю конкретного автомобиля.
@@ -56,9 +57,13 @@ func (s *carService) GetCarHistory(ctx context.Context, carID int) ([]CarHistory
 			h.new_value,
 			h.comment,
 			h.created_at,
-			h.metadata::text AS metadata
+			h.metadata::text AS metadata,
+			app.id AS application_id
 		FROM cars_history h
 		LEFT JOIN users u ON h.user_id = u.id
+		LEFT JOIN cars c ON h.car_id = c.id
+		LEFT JOIN attachments a ON c.attachment_id = a.id
+		LEFT JOIN applications app ON a.application_id = app.id
 		WHERE h.car_id = ?
 		ORDER BY h.created_at DESC
 	`, carID).Scan(&rows).Error
@@ -228,7 +233,8 @@ func (s *carService) GetUnifiedCarHistory(ctx context.Context, req UnifiedCarHis
 			c.car_number,
 			c.car_brand,
 			COALESCE(o.name, '') AS organization,
-			COALESCE(c2.name, '') AS company
+			COALESCE(c2.name, '') AS company,
+			app.id AS application_id
 		FROM cars_history h
 		LEFT JOIN users u ON h.user_id = u.id
 		JOIN cars c ON h.car_id = c.id
@@ -262,20 +268,21 @@ func (s *carService) mapHistoryRows(rows []carHistoryRow, includeCarInfo bool) [
 		}
 
 		item := CarHistoryItemResponse{
-			ID:         r.ID,
-			CarID:      r.CarID,
-			UserID:     r.UserID,
-			UserName:   userName,
-			LastName:   r.LastName,
-			FirstName:  r.FirstName,
-			MiddleName: r.MiddleName,
-			ActionType: r.ActionType,
-			FieldName:  r.FieldName,
-			OldValue:   r.OldValue,
-			NewValue:   r.NewValue,
-			Comment:    r.Comment,
-			CreatedAt:  FormatUTC(r.CreatedAt),
-			Metadata:   metadata,
+			ID:            r.ID,
+			CarID:         r.CarID,
+			ApplicationID: r.ApplicationID,
+			UserID:        r.UserID,
+			UserName:      userName,
+			LastName:      r.LastName,
+			FirstName:     r.FirstName,
+			MiddleName:    r.MiddleName,
+			ActionType:    r.ActionType,
+			FieldName:     r.FieldName,
+			OldValue:      r.OldValue,
+			NewValue:      r.NewValue,
+			Comment:       r.Comment,
+			CreatedAt:     FormatUTC(r.CreatedAt),
+			Metadata:      metadata,
 		}
 		if includeCarInfo {
 			item.CarNumber = r.CarNumber

--- a/internal/services/car_history_service.go
+++ b/internal/services/car_history_service.go
@@ -61,6 +61,8 @@ func (s *carService) GetCarHistory(ctx context.Context, carID int) ([]CarHistory
 			app.id AS application_id
 		FROM cars_history h
 		LEFT JOIN users u ON h.user_id = u.id
+		-- car.attachment_id иммутабелен (машина не перепривязывается к другой заявке),
+		-- поэтому app.id = заявка-источник машины. LEFT JOIN, чтобы не терять записи истории.
 		LEFT JOIN cars c ON h.car_id = c.id
 		LEFT JOIN attachments a ON c.attachment_id = a.id
 		LEFT JOIN applications app ON a.application_id = app.id

--- a/internal/services/car_service.go
+++ b/internal/services/car_service.go
@@ -137,23 +137,23 @@ type UnifiedCarHistoryQuery struct {
 
 // TableCarResponse -- автомобиль для отображения в таблице.
 type TableCarResponse struct {
-	ID                 int       `json:"id"`
-	CarNumber          string    `json:"car_number"`
-	CarBrand           string    `json:"car_brand"`
-	Organization       *string   `json:"organization"`
-	OrganizationID     *int      `json:"organization_id"`
-	Company            *string   `json:"company"`
-	CompanyID          *int      `json:"company_id"`
-	UnloadPlace        *string   `json:"unload_place"`
-	UnloadPlaces       []string  `json:"unload_places"`
-	EntryDateTo        *string   `json:"entry_date_to"`
-	EntryTimeFrom      *string   `json:"entry_time_from"`
-	EntryTimeTo        *string   `json:"entry_time_to"`
-	Status             int       `json:"status"`
-	ApplicationID      *int      `json:"application_id"`
-	ApplicationNumber  *string   `json:"application_number"`
-	TerritoryStatus    *int      `json:"territory_status"`
-	TerritoryEntryTime *string   `json:"territory_entry_time"`
+	ID                 int      `json:"id"`
+	CarNumber          string   `json:"car_number"`
+	CarBrand           string   `json:"car_brand"`
+	Organization       *string  `json:"organization"`
+	OrganizationID     *int     `json:"organization_id"`
+	Company            *string  `json:"company"`
+	CompanyID          *int     `json:"company_id"`
+	UnloadPlace        *string  `json:"unload_place"`
+	UnloadPlaces       []string `json:"unload_places"`
+	EntryDateTo        *string  `json:"entry_date_to"`
+	EntryTimeFrom      *string  `json:"entry_time_from"`
+	EntryTimeTo        *string  `json:"entry_time_to"`
+	Status             int      `json:"status"`
+	ApplicationID      *int     `json:"application_id"`
+	ApplicationNumber  *string  `json:"application_number"`
+	TerritoryStatus    *int     `json:"territory_status"`
+	TerritoryEntryTime *string  `json:"territory_entry_time"`
 }
 
 // CarUnloadPlaceInfo -- связь автомобиля с местом разгрузки.
@@ -165,24 +165,25 @@ type CarUnloadPlaceInfo struct {
 
 // CarHistoryItemResponse -- элемент истории автомобиля.
 type CarHistoryItemResponse struct {
-	ID           int              `json:"id"`
-	CarID        int              `json:"car_id"`
-	UserID       *int             `json:"user_id"`
-	UserName     string           `json:"user_name"`
-	LastName     *string          `json:"last_name"`
-	FirstName    *string          `json:"first_name"`
-	MiddleName   *string          `json:"middle_name"`
-	ActionType   string           `json:"action_type"`
-	FieldName    *string          `json:"field_name"`
-	OldValue     *string          `json:"old_value"`
-	NewValue     *string          `json:"new_value"`
-	Comment      *string          `json:"comment"`
-	CreatedAt    string           `json:"created_at"`
-	Metadata     *json.RawMessage `json:"metadata" swaggertype:"object"`
-	CarNumber    *string          `json:"car_number"`
-	CarBrand     *string          `json:"car_brand"`
-	Organization *string          `json:"organization"`
-	Company      *string          `json:"company"`
+	ID            int              `json:"id"`
+	CarID         int              `json:"car_id"`
+	ApplicationID *int             `json:"application_id"`
+	UserID        *int             `json:"user_id"`
+	UserName      string           `json:"user_name"`
+	LastName      *string          `json:"last_name"`
+	FirstName     *string          `json:"first_name"`
+	MiddleName    *string          `json:"middle_name"`
+	ActionType    string           `json:"action_type"`
+	FieldName     *string          `json:"field_name"`
+	OldValue      *string          `json:"old_value"`
+	NewValue      *string          `json:"new_value"`
+	Comment       *string          `json:"comment"`
+	CreatedAt     string           `json:"created_at"`
+	Metadata      *json.RawMessage `json:"metadata" swaggertype:"object"`
+	CarNumber     *string          `json:"car_number"`
+	CarBrand      *string          `json:"car_brand"`
+	Organization  *string          `json:"organization"`
+	Company       *string          `json:"company"`
 }
 
 // AllCarsHistoryItem -- элемент общей истории (только entry/exit).

--- a/internal/services/employees_history_service.go
+++ b/internal/services/employees_history_service.go
@@ -28,6 +28,7 @@ type EmployeesHistoryService interface {
 type EmployeeHistoryItem struct {
 	ID                 int     `json:"id"`
 	EmployeeID         int     `json:"employee_id"`
+	ApplicationID      *int    `json:"application_id"`
 	UserID             *int    `json:"user_id"`
 	TableID            *int    `json:"table_id"`
 	TableName          *string `json:"table_name"`
@@ -69,6 +70,7 @@ func NewEmployeesHistoryService(db *gorm.DB) EmployeesHistoryService {
 type employeeHistoryRow struct {
 	ID                 int
 	EmployeeID         int
+	ApplicationID      *int
 	UserID             *int
 	TableID            *int
 	TableName          *string
@@ -92,6 +94,7 @@ const baseSelectSQL = `
 	SELECT
 		eh.id,
 		eh.employee_id,
+		app.id AS application_id,
 		eh.user_id,
 		eh.table_id,
 		st.display_name AS table_name,
@@ -241,6 +244,7 @@ func mapEmployeeHistoryRows(rows []employeeHistoryRow) []EmployeeHistoryItem {
 		items = append(items, EmployeeHistoryItem{
 			ID:                 r.ID,
 			EmployeeID:         r.EmployeeID,
+			ApplicationID:      r.ApplicationID,
 			UserID:             r.UserID,
 			TableID:            r.TableID,
 			TableName:          r.TableName,


### PR DESCRIPTION
Эпик **46-edits**, срез **45a** (бэкенд из П.45: клик по записи "Подана заявка" в истории должен открывать карточку заявки).

## Что
Прокинул `app.id AS application_id` в ответы истории:
- `car_history_service.go`: `GetCarHistory` (по конкретной машине - добавил JOIN cars->attachments->applications) и `GetUnifiedCarHistory` (JOIN уже был, только SELECT).
- `employees_history_service.go`: общий `baseSelectSQL` (JOIN applications уже был) - покрывает все эндпоинты истории сотрудника разом.
- Поле `ApplicationID *int` в DTO `CarHistoryItemResponse` / `EmployeeHistoryItem`.

## Зачем
Запись истории `action_type='create'` не несла id породившей заявки, поэтому фронт не мог открыть её карточку. Поле аддитивное, существующие потребители не ломаются (`*int`, nullable).

## Проверка
- `go build` + `go vet` пакета services - чисто.
- `go test ./internal/services/` - зелёно.
- Новый SQL `GetCarHistory` провалидирован через `EXPLAIN` на dev-БД (идёт по индексам, все колонки резолвятся).

## Заметки
- Swagger не регенерировал: не enforced в CI, в `docs/` уже копится несвязанный drift origin/dev vs `swag` (регенерация затащила бы ~25k строк шума). Поле документирую отдельным sweep'ом при необходимости.
- Потребитель (цепочка клик->открыть заявку в history-модалках и вьюхах) - следующий срез **45b**, чисто фронтовый.