### PR TITLE
fix(applications-center): оверлей-лоадер таблицы при обновлении

### DIFF
--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -398,6 +398,14 @@
           </p>
         </SkeletonTransition>
       </div>
+
+      <!-- При первой загрузке работает скелетон (loading), поэтому оверлей только на refreshing. -->
+      <div
+        v-if="refreshing && !loading"
+        class="refresh-overlay"
+      >
+        <LoaderSpinner label="Обновление…" />
+      </div>
     </div>
 
     <!-- Исправлено: используем selectedApplication вместо showDetail -->
@@ -432,6 +440,7 @@ import DateFilter from '../components/DateFilter.vue';
 import FilterTabs from '@/components/ui/FilterTabs.vue';
 import SkeletonTransition from '@/components/ui/SkeletonTransition.vue';
 import SkeletonTable from '@/components/ui/SkeletonTable.vue';
+import LoaderSpinner from '@/components/ui/LoaderSpinner.vue';
 import DownloadBlanksModal from '@/components/applications/DownloadBlanksModal.vue';
 import Badge from '@/components/ui/Badge.vue';
 import { blacklistFlagCount, blacklistFlagLabel, BLACKLIST_FLAG_TITLE } from '@/utils/blacklistBadge';
@@ -447,6 +456,7 @@ export default {
         FilterTabs,
         SkeletonTransition,
         SkeletonTable,
+        LoaderSpinner,
         DownloadBlanksModal,
         Badge,
     },
@@ -1349,10 +1359,29 @@ export default {
     display: flex;
     flex-direction: column;
     transition: all 0.3s ease;
+    position: relative;
 }
 
 .applications-table.with-details {
     height: 500px;
+}
+
+/* Overlay-лоадер при refresh - накрывает только область данных (ниже шапки
+   45px), вне скролл-контейнера .table-body, поэтому держится на месте при
+   прокрутке. Высота таблицы не схлопывается. */
+.refresh-overlay {
+    position: absolute;
+    top: 45px;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(255, 255, 255, 0.75);
+    backdrop-filter: blur(1px);
+    z-index: 2;
+    pointer-events: none;
 }
 
 .table-header {


### PR DESCRIPTION
## Что было
В Центре заявок при обновлении по кнопке "Обновить" крутился только спиннер самой кнопки - таблица никак не реагировала. Скелетон завязан на `loading` (только первая загрузка), а `fetchApplications` поднимает `refreshing` без отклика в области данных.

## Что сделал
Добавил полупрозрачный overlay-лоадер (`LoaderSpinner` "Обновление…") поверх области данных на время `refreshing`, переиспользовав паттерн `.refresh-overlay` из `CarsTable.vue`. Высота таблицы не схлопывается (оверлей абсолютный, вне скролл-контейнера `.table-body`).

- `.applications-table` -> `position: relative`.
- Оверлей `top: 45px` (= высота `.table-header`), чтобы накрыть только данные, не димить шапку с кнопкой "Обновить". `inset: 0` тут не подходит - родитель оверлея это вся карточка, включая шапку (в отличие от CarsTable, где оверлей лежит в data-only контейнере).
- Условие `v-if="refreshing && !loading"` - не двоится со скелетоном первой загрузки.

## Ревью
Прогнал `code-reviewer`: must-fix нет. Замечание про `inset: 0` отклонил - оно основано на неверном чтении DOM (накрыло бы шапку). Замечание про дублирующийся комментарий учёл.

## Проверка
ESLint по файлу зелёный. Дифф аддитивный (~30 строк, без логики). Визуальную проверку оверлея на staging добавлю в комментарий после деплоя.