### PR TITLE
style(filters): svg-иконки фильтров Таблиц вместо png (#529)

### DIFF
--- a/frontend/src/components/DateFilter.vue
+++ b/frontend/src/components/DateFilter.vue
@@ -8,10 +8,33 @@
         <div class="field-input">
           {{ displayText }}
         </div>
-        <img
-          src="@/assets/icons/calendar.png"
+        <svg
           class="field-icon"
+          viewBox="0 0 24 24"
+          fill="none"
+          aria-hidden="true"
         >
+          <rect
+            x="3"
+            y="5"
+            width="18"
+            height="16"
+            rx="3"
+            stroke="#555"
+            stroke-width="2"
+          />
+          <path
+            d="M3 9.5H21"
+            stroke="#555"
+            stroke-width="2"
+          />
+          <path
+            d="M8 3V7M16 3V7"
+            stroke="#555"
+            stroke-width="2"
+            stroke-linecap="round"
+          />
+        </svg>
       </div>
             
       <transition name="calendar-slide">
@@ -794,9 +817,9 @@ export default {
 }
 
 .field-icon {
-    width: 15px;
-    height: 15px;
-    opacity: 0.6;
+    width: 14px;
+    height: 14px;
+    opacity: 0.7;
     flex-shrink: 0;
 }
 

--- a/frontend/src/components/OrganizationFilter.vue
+++ b/frontend/src/components/OrganizationFilter.vue
@@ -4,11 +4,21 @@
     @click="toggleDropdown"
   >
     <span class="select-text">{{ displayText }}</span>
-    <img 
-      src="@/assets/icons/arrow.png" 
-      class="select-icon" 
-      :class="{ 'select-icon--rotated': isOpen }" 
+    <svg
+      class="select-icon"
+      :class="{ 'select-icon--rotated': isOpen }"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
     >
+      <path
+        d="M6 9L12 15L18 9"
+        stroke="#555"
+        stroke-width="2.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
         
     <transition name="dropdown">
       <div 
@@ -232,15 +242,14 @@ export default {
 }
 
 .select-icon {
-    width: 10px;
-    height: 10px;
+    width: 9px;
+    height: 9px;
     transition: transform 0.3s ease;
-    transform: rotate(90deg);
     flex-shrink: 0;
 }
 
 .select-icon--rotated {
-    transform: rotate(-90deg);
+    transform: rotate(180deg);
 }
 
 /* Анимации для выпадающего меню */

--- a/frontend/src/components/UnloadingPlaceFilter.vue
+++ b/frontend/src/components/UnloadingPlaceFilter.vue
@@ -4,11 +4,21 @@
     @click="toggleDropdown"
   >
     <span class="select-text">{{ displayText }}</span>
-    <img 
-      src="@/assets/icons/arrow.png" 
-      class="select-icon" 
-      :class="{ 'select-icon--rotated': isOpen }" 
+    <svg
+      class="select-icon"
+      :class="{ 'select-icon--rotated': isOpen }"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
     >
+      <path
+        d="M6 9L12 15L18 9"
+        stroke="#555"
+        stroke-width="2.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
         
     <transition name="dropdown">
       <div 
@@ -248,15 +258,14 @@ export default {
 }
 
 .select-icon {
-    width: 10px;
-    height: 10px;
+    width: 9px;
+    height: 9px;
     transition: transform 0.3s ease;
-    transform: rotate(90deg);
     flex-shrink: 0;
 }
 
 .select-icon--rotated {
-    transform: rotate(-90deg);
+    transform: rotate(180deg);
 }
 
 /* Анимации для выпадающего меню */
@@ -285,7 +294,7 @@ export default {
     width: 200px;
     background: white;
     border: 1px solid #e6e6e6;
-    border-radius: 10px;
+    border-radius: 20px;
     max-height: 355px;
     overflow: hidden;
     z-index: 1001;


### PR DESCRIPTION
Финиш косметики фильтров из ТЗ (п.30 эпика 46-edits). Фильтры во вкладках "Таблицы" (Организация / Место разгрузки / Выберите дату).

## Что сделано
- Стрелки дропдаунов **Организация** и **Место разгрузки**: растровый `arrow.png` -> inline svg chevron (9px, чётче и мельче). Логика поворота сохранена: закрыто - стрелка вниз, открыто - вверх (rotate 180deg вместо прежних 90/-90 от горизонтального png).
- Иконка **календаря** в фильтре даты: `calendar.png` -> inline svg (14px, opacity 0.7), класс `field-icon` сохранён.
- Дропдаун **Место разгрузки**: `border-radius` 10 -> 20px - паритет с фильтром Организаций (там 20px смержён в #571, у Места разгрузки осталось).

Ширина field == ширине dropdown у обоих фильтров уже совпадала (230/230 и 200/200) - 30(2) удовлетворён без правок.

## Скоуп
Ровно 3 файла. `arrow.png` в остальных ~35 компонентах (истории, формы) НЕ тронут - это не фильтры Таблиц.

## Ревью
code-reviewer: GO, блокеров нет. Хардкод `stroke="#555"` оставлен намеренно - это локальная конвенция файла (существующие nav-стрелки в DateFilter тоже хардкодят stroke); перевод только новых иконок на currentColor дал бы рассинхрон с nav-стрелками вне скоупа. `console.error` в UnloadingPlaceFilter - pre-existing, вне диффа.

Inline svg переиспользует паттерн, уже применённый в DateFilter (nav-стрелки) - новый компонент-обёртку не плодил.