### PR TITLE
feat(history): клик по 'Подана заявка' в истории открывает заявку (#46)

### DIFF
--- a/frontend/src/components/CarHistoryModal.vue
+++ b/frontend/src/components/CarHistoryModal.vue
@@ -165,7 +165,11 @@
                   class="timeline-line"
                 />
             
-                <div class="history-content">
+                <div
+                  class="history-content"
+                  :class="{ 'history-content--link': isApplicationLink(item) }"
+                  @click="handleHistoryClick(item)"
+                >
                   <div class="history-header">
                     <span class="user-name">{{ item.user_name || 'Система' }}</span>
                     <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
@@ -269,7 +273,7 @@ export default {
       default: ''
     }
   },
-  emits: ['close'],
+  emits: ['close', 'open-application'],
   setup(_, { emit }) {
     // Анимация закрытия: внутренний visible (enter по mounted, leave по requestClose),
     // emit('close') только ПОСЛЕ leave-перехода (@after-leave) - иначе родитель
@@ -455,6 +459,17 @@ export default {
         'blacklist_override_revoke': 'dot-deactivate'
       };
       return classes[actionType] || 'dot-default';
+    },
+
+    isApplicationLink(item) {
+      return item.action_type === 'create' && item.application_id != null;
+    },
+
+    handleHistoryClick(item) {
+      if (this.isApplicationLink(item)) {
+        this.$emit('open-application', item.application_id);
+        this.requestClose();
+      }
     },
 
     getActionText(item) {
@@ -1182,6 +1197,19 @@ export default {
   color: #666;
   font-size: 12px;
   margin-bottom: 2px;
+}
+
+.history-content--link {
+  cursor: pointer;
+}
+
+.history-content--link .action-text {
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+.history-content--link:hover .action-text {
+  text-decoration: underline;
 }
 
 .action-comment {

--- a/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
@@ -429,6 +429,7 @@
     :current-user-id="currentUserId"
     :current-user-name="currentUserName"
     @close="showFullHistoryModal = false"
+    @open-application="$emit('open-application', $event)"
   />
 
   <AddToBlacklistModal

--- a/frontend/src/components/CreateApplication/EmployeeHistoryModal.vue
+++ b/frontend/src/components/CreateApplication/EmployeeHistoryModal.vue
@@ -206,7 +206,11 @@
                   class="timeline-line"
                 />
             
-                <div class="history-content">
+                <div
+                  class="history-content"
+                  :class="{ 'history-content--link': isApplicationLink(item) }"
+                  @click="handleHistoryClick(item)"
+                >
                   <div class="history-header">
                     <span class="user-name">{{ item.user_name || 'Система' }}</span>
                     <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
@@ -291,7 +295,7 @@ export default {
       default: ''
     }
   },
-  emits: ['close'],
+  emits: ['close', 'open-application'],
   setup(_, { emit }) {
     // Анимация закрытия: внутренний visible (enter по mounted, leave по requestClose),
     // emit('close') только ПОСЛЕ leave-перехода (@after-leave) - иначе родитель
@@ -489,6 +493,17 @@ export default {
         'blacklist_override_revoke': 'dot-deactivate'
       };
       return classes[actionType] || 'dot-default';
+    },
+
+    isApplicationLink(item) {
+      return item.action_type === 'create' && item.application_id != null;
+    },
+
+    handleHistoryClick(item) {
+      if (this.isApplicationLink(item)) {
+        this.$emit('open-application', item.application_id);
+        this.requestClose();
+      }
     },
 
     getActionText(item) {
@@ -1184,6 +1199,19 @@ export default {
   color: #666;
   font-size: 12px;
   margin-bottom: 2px;
+}
+
+.history-content--link {
+  cursor: pointer;
+}
+
+.history-content--link .action-text {
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+.history-content--link:hover .action-text {
+  text-decoration: underline;
 }
 
 .action-comment {

--- a/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
@@ -396,6 +396,7 @@
     :current-user-id="currentUserId"
     :current-user-name="currentUserName"
     @close="showCarHistoryModal = false"
+    @open-application="$emit('open-application', $event)"
   />
 
   <AddToBlacklistModal

--- a/frontend/src/views/CarsView.vue
+++ b/frontend/src/views/CarsView.vue
@@ -550,6 +550,17 @@
       :show-car-features="false"
       source="carsview"
       @close="closeCarDetails"
+      @open-application="handleOpenApplication"
+    />
+
+    <ApplicationDetail
+      v-if="showApplicationDetail"
+      :application="selectedApplication"
+      :current-user-id="ownershipInfo?.user_id || null"
+      :current-user-name="''"
+      :mode="'center'"
+      @close="closeApplicationDetail"
+      @application-changed="fetchCars"
     />
   </section>
 </template>
@@ -563,6 +574,7 @@ import SkeletonTable from '@/components/ui/SkeletonTable.vue';
 import StatusBadge from '@/components/ui/StatusBadge.vue';
 import ConfirmationModal from '@/components/ConfirmationModal.vue';
 import VehicleDetailsModal from '@/components/CreateApplication/VehicleDetailsModal.vue';
+import ApplicationDetail from '@/components/ApplicationDetail/ApplicationDetail.vue';
 import { listVehicleBlacklist } from '@/api/blacklist';
 
 export default {
@@ -573,7 +585,8 @@ export default {
         SkeletonTable,
         StatusBadge,
         ConfirmationModal,
-        VehicleDetailsModal
+        VehicleDetailsModal,
+        ApplicationDetail
     },
     data() {
         return {
@@ -592,6 +605,8 @@ export default {
             availableFormats: [],
             showDetailsViewModal: false,
             detailsCar: null,
+            showApplicationDetail: false,
+            selectedApplication: null,
 
             
             // Формат номера
@@ -783,6 +798,16 @@ export default {
         closeCarDetails() {
             this.showDetailsViewModal = false;
             this.detailsCar = null;
+        },
+        handleOpenApplication(applicationId) {
+            if (!applicationId) return;
+            // ApplicationDetail сам догружает детали/вложения/читателей по id через watch.
+            this.selectedApplication = { id: applicationId };
+            this.showApplicationDetail = true;
+        },
+        closeApplicationDetail() {
+            this.showApplicationDetail = false;
+            this.selectedApplication = null;
         },
         /**
          * Можно ли текущему пользователю редактировать/удалять машину.

--- a/frontend/src/views/EmployeeView.vue
+++ b/frontend/src/views/EmployeeView.vue
@@ -317,6 +317,17 @@
       :current-user-name="''"
       source="employeesview"
       @close="closeDetailsModal"
+      @open-application="handleOpenApplication"
+    />
+
+    <ApplicationDetail
+      v-if="showApplicationDetail"
+      :application="selectedApplication"
+      :current-user-id="ownershipInfo?.user_id || null"
+      :current-user-name="''"
+      :mode="'center'"
+      @close="closeApplicationDetail"
+      @application-changed="fetchEmployees"
     />
   </section>
 </template>
@@ -330,6 +341,7 @@ import SkeletonTable from '@/components/ui/SkeletonTable.vue';
 import StatusBadge from '@/components/ui/StatusBadge.vue';
 import EmployeeEditModal from '@/components/EmployeeEditModal.vue';
 import EmployeeDetailsModal from '@/components/CreateApplication/EmployeeDetailsModal.vue';
+import ApplicationDetail from '@/components/ApplicationDetail/ApplicationDetail.vue';
 import { listPersonBlacklist } from '@/api/blacklist';
 
 export default {
@@ -340,7 +352,8 @@ export default {
         SkeletonTable,
         StatusBadge,
         EmployeeEditModal,
-        EmployeeDetailsModal
+        EmployeeDetailsModal,
+        ApplicationDetail
     },
     data() {
         return {
@@ -357,7 +370,9 @@ export default {
             availableCitizenships: [],
             editingEmployee: null,
             showDetailsModal: false,
-            detailsEmployee: null
+            detailsEmployee: null,
+            showApplicationDetail: false,
+            selectedApplication: null
         };
     },
     computed: {
@@ -601,6 +616,16 @@ export default {
         closeDetailsModal() {
             this.showDetailsModal = false;
             this.detailsEmployee = null;
+        },
+        handleOpenApplication(applicationId) {
+            if (!applicationId) return;
+            // ApplicationDetail сам догружает детали/вложения/читателей по id через watch.
+            this.selectedApplication = { id: applicationId };
+            this.showApplicationDetail = true;
+        },
+        closeApplicationDetail() {
+            this.showApplicationDetail = false;
+            this.selectedApplication = null;
         },
 
         showAddEmployeeModal() {


### PR DESCRIPTION
## Что

Срез 45b эпика «46 правок» (П.45). Бэк (`application_id` в ответах истории машины/сотрудника) уже смержен в #580. Здесь — фронт-провязка.

Запись истории «Подана заявка на автомобиль/сотрудника» (`action_type === 'create'`) теперь кликабельна и открывает `ApplicationDetail` именно той заявки, к которой относится запись.

## Цепочка

- `CarHistoryModal` / `EmployeeHistoryModal`: запись `create` с непустым `application_id` подсвечена как ссылка, по клику эмитит `open-application(application_id)` и закрывает себя через `requestClose()` (анимированно). У сотрудника без заявки `application_id` приходит null — запись не кликабельна.
- `VehicleDetailsModal` / `EmployeeDetailsModal` форвардят `open-application` наверх.
- `CarsView` / `EmployeeView` рендерят `ApplicationDetail` по событию. В Центре (`TablesComponent` → `CarsTable`/`PeopleTable`) терминал уже был.

## z-index

История (12000) выше `ApplicationDetail` (10002), поэтому при открытии заявки история закрывается. Карточка детали (10001) остаётся фоном под заявкой — закрыл заявку, вернулся к карточке.

## По ревью

- Убрал лишний предзапрос `/details` в обработчике: `ApplicationDetail` сам догружает детали/вложения/читателей по `id` через watch — передаю `{ id }`. Это чище, чем терминал в `TablesComponent` (там двойной fetch).
- Добавил `@application-changed` → refresh списка вкладки (как в `TablesComponent`), чтобы смена статуса заявки обновляла Автомобили/Сотрудники.
- Молчаливый отказ при 403/404 на загрузке заявки — поведение самого `ApplicationDetail` (общее для всех вызывающих, вне скоупа); в этом флоу 403 маловероятен — машина/сотрудник видны пользователю по правам, значит к заявке-источнику доступ есть.

Примечание: в `CarsView` карточка идёт с `show-car-features="false"`, поэтому история машины там пока не открывается (станет доступна в срезе про контекстную видимость #10) — провязка добавлена впрок и не мешает. Реально достижимые пути сейчас: Центр (машины и сотрудники) и вкладка Сотрудники.