### PR TITLE
fix(cabinet): список заявок ЛК на всю высоту экрана без скролла страницы (#46)

### DIFF
--- a/frontend/src/components/AccountComponent.vue
+++ b/frontend/src/components/AccountComponent.vue
@@ -189,11 +189,10 @@ export default {
   padding: 15px;
   position: relative;
   /* Высоту на desktop задаёт applyDashboardHeight под доступный вьюпорт;
-     flex-колонка тянет блок заявок на остаток высоты, overflow держит остаток
-     внутри, а не на всей странице. */
+     flex-колонка тянет блок заявок на остаток высоты. На <=1200px высота
+     сбрасывается и блок снова в естественном потоке (страница скроллится). */
   display: flex;
   flex-direction: column;
-  overflow: hidden;
 }
 
 /* Стили для строк */

--- a/frontend/src/components/AccountComponent.vue
+++ b/frontend/src/components/AccountComponent.vue
@@ -1,5 +1,6 @@
 <template>
   <div
+    ref="root"
     class="account-dashboard"
     data-testid="cabinet-page"
   >
@@ -92,9 +93,50 @@ export default {
     };
   },
   mounted() {
+    this.headerObserver = null;
+    this.lastDashboardHeight = -1;
     this.fetchUserData();
+    this.$nextTick(this.applyDashboardHeight);
+    window.addEventListener('resize', this.applyDashboardHeight);
+    // Шапка in-flow и может менять высоту (анонс, перенос строки) - пересчитываем
+    // под неё. Наблюдаем саму шапку, а не body, чтобы Teleport-модалки не будили
+    // лишний reflow. Тот же приём, что в AdminPageShell.vue.
+    const header = document.querySelector('.theheader');
+    if (header && typeof ResizeObserver !== 'undefined') {
+      this.headerObserver = new ResizeObserver(this.applyDashboardHeight);
+      this.headerObserver.observe(header);
+    }
+  },
+  beforeUnmount() {
+    window.removeEventListener('resize', this.applyDashboardHeight);
+    if (this.headerObserver) {
+      this.headerObserver.disconnect();
+      this.headerObserver = null;
+    }
   },
   methods: {
+    /**
+     * Тянет дашборд кабинета на доступную высоту вьюпорта (под шапкой), чтобы
+     * список заявок занимал весь экран без скролла всей страницы. Высоту меряем
+     * фактически (innerHeight - top), а не 100vh минус хардкод шапки. На планшете
+     * и мобильном (<=1200px) возвращаем естественный поток - там работает
+     * адаптивная фикс-высота карточки и строки складываются в колонку.
+     */
+    applyDashboardHeight() {
+      const el = this.$refs.root;
+      if (!el) return;
+      if (window.innerWidth <= 1200) {
+        el.style.height = '';
+        this.lastDashboardHeight = -1;
+        return;
+      }
+      const top = el.getBoundingClientRect().top;
+      const height = Math.max(0, Math.round(window.innerHeight - top));
+      // Защита от ResizeObserver-петли: пишем стиль только при реальном изменении.
+      if (height === this.lastDashboardHeight) return;
+      this.lastDashboardHeight = height;
+      el.style.height = `${height}px`;
+    },
     async fetchUserData() {
       try {
         const authStore = useAuthStore();
@@ -146,6 +188,12 @@ export default {
   width: 100%;
   padding: 15px;
   position: relative;
+  /* Высоту на desktop задаёт applyDashboardHeight под доступный вьюпорт;
+     flex-колонка тянет блок заявок на остаток высоты, overflow держит остаток
+     внутри, а не на всей странице. */
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 /* Стили для строк */
@@ -153,6 +201,7 @@ export default {
   display: flex;
   gap: 15px;
   margin-bottom: 15px;
+  flex-shrink: 0;
 }
 
 .first-row :deep(.notifications) {
@@ -171,11 +220,19 @@ export default {
 }
 
 .dashboard-row {
- padding: 15px 0;
+  padding: 15px 0;
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 .applications-wrapper {
   position: relative;
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 /* Карточки личного кабинета (профиль/уведомления/заявки) */

--- a/frontend/src/components/UserApplications.vue
+++ b/frontend/src/components/UserApplications.vue
@@ -700,7 +700,11 @@ export default {
   border: 1px solid #e6e6e6;
   overflow: hidden;
   width: 100%;
-  height: 383px;
+  /* Тянемся на всю высоту flex-обёртки кабинета (desktop). На <=1200px высоту
+     задаёт адаптивная фикс-высота ниже - там родитель без жёсткой высоты, и
+     flex-basis отдаёт управление height. */
+  flex: 1 1 auto;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   position: relative;


### PR DESCRIPTION
Срез #14 эпика "46 правок" (косметика).

## Что было
`.applications-card` в личном кабинете жёстко зафиксирована на `height: 383px`. На больших экранах внизу оставался пустой хвост, а страница лишне скроллилась.

## Что сделано
- `AccountComponent.vue`: дашборд кабинета стал flex-колонкой; высота на desktop задаётся фактическим замером `window.innerHeight - root.getBoundingClientRect().top` (живой замер шапки через resize + ResizeObserver на `.theheader`, с защитой от ResizeObserver-петли). Перенос проверенного паттерна из `views/admin/AdminPageShell.vue`. На `<=1200px` инлайн-высота сбрасывается -> возврат к прежнему адаптивному потоку.
- `UserApplications.vue`: `.applications-card` `height:383px` -> `flex:1 1 auto; min-height:0`. Адаптивные медиа-оверрайды (`<=1200px`:450px, `<=992px`:500px) не тронуты.

## Ревью
Замечание ревью (overflow:hidden у дашборда мог обрезать контент на планшете) проверено эмпирично: на height:auto обрезки нет (бокс растёт под контент, страница скроллится), но overflow:hidden был не нужен и создавал риск обрезки всплывашек карточек - убран отдельным коммитом.

## Верификация (локально, vite :5199 + Playwright, DOM-замеры)
Desktop 1536x864:
- page scroll overflow: **0px** (скролла страницы нет)
- карточка тянется: высота **383px -> 529px**, низ в 30px от края (= два паддинга по 15px)
- внутренний скролл списка (`.applications-body overflow-y:auto`) сохранён
- console errors: 0

Планшет/мобайл (1100/768/390): инлайн-высота сброшена, фикс-высота 450px применяется, контент не обрезан (`clipped:false`), страница скроллится как раньше.