### PR TITLE
fix(application): убрал дублирующую границу у привязанного места разгрузки (#46)

### DIFF
--- a/frontend/src/components/CreateApplication/VehicleForm.vue
+++ b/frontend/src/components/CreateApplication/VehicleForm.vue
@@ -297,9 +297,8 @@
           v-for="place in allUnloadingPlaces" 
           :key="place.id"
           class="unloading__item"
-          :class="{ 
+          :class="{
             'unloading__item--active': selectedUnloadingPlaces.includes(place.id) && place.status === 'active',
-            'unloading__item--attached': attachedPlacesIds.includes(place.id),
             'unloading__item--inactive': place.status !== 'active'
           }"
           @click="toggleUnloadingPlace(place)"
@@ -481,9 +480,6 @@ export default {
     computed: {
         selectedFormatText() {
             return this.selectedFormat ? this.selectedFormat.format.name : 'Выберите формат';
-        },
-        attachedPlacesIds() {
-            return this.attachedUnloadingPlaces.map(place => place.id);
         },
         canAddExistingCars() {
             // Проверяем, что среди выбранных мест нет неактивных
@@ -1663,10 +1659,6 @@ export default {
     border-color: #ffcccc;
     cursor: not-allowed;
     opacity: 0.7;
-}
-
-.unloading__item--attached {
-    border-left: 3px solid #4F5BDF;
 }
 
 .error-message {


### PR DESCRIPTION
## Что

Эпик 46-edits, срез **п.2**. В форме создания вложения (VehicleForm, секция «Места разгрузки») привязанное к организации/компании место отображалось двойной индикацией: целиком синяя плашка (оно предвыбрано в `selectedUnloadingPlaces` → класс `--active`) и поверх ещё `border-left: 3px solid` (класс `--attached`). Выглядело как лишняя полоса слева на и без того выделенном месте.

## Изменения

- убран класс-биндинг `unloading__item--attached` из шаблона;
- удалён ставший мёртвым computed `attachedPlacesIds` (использовался только для этого класса);
- удалено CSS-правило `.unloading__item--attached { border-left: 3px solid #4F5BDF }`.

Предвыбор привязанных активных мест (`loadUnloadingPlaces` по org/company) не трогал — он уже работал; правка чисто визуальная.

## Эффект

Привязанное активное место — целиком синее (как и любое выбранное), без дублирующей границы. Привязанное неактивное место — просто `--inactive` (недоступно), что корректно: различать «привязано к моей организации, но недоступно» от «просто недоступно» смысла нет, оба заблокированы для выбора. Tooltip с причиной недоступности сохранён.

Дифф: 1 файл, +1/−9.