### PR TITLE
feat(create-application): формы вложения недоступны до заполнения обязательных полей (#46)

### DIFF
--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -184,6 +184,7 @@
               :key="vehicleFormKey"
               ref="vehicleForm"
               :field-config="currentFieldConfig"
+              :disabled="!currentAttachmentReady"
               :user-organization="organization"
               :user-organization-id="organizationId"
               :user-company="company"
@@ -212,6 +213,7 @@
               :key="employeeFormKey"
               ref="employeeForm"
               :field-config="currentFieldConfig"
+              :disabled="!currentAttachmentReady"
               :user-organization="organization"
               :user-organization-id="organizationId"
               :user-company="company"
@@ -239,6 +241,7 @@
               :key="itemsFormKey"
               ref="itemsForm"
               :field-config="currentFieldConfig"
+              :disabled="!currentAttachmentReady"
               :existing-items="items"
               @item-added="handleItemAdded"
               @items-added="handleItemsAdded"
@@ -447,6 +450,15 @@ export default {
             const data = this.attachmentDatesByAttachment[this.attachmentKey(this.selectedAttachment)];
             return data?.errors || {};
         },
+
+        // Гейт п.36: формы добавления (авто/сотрудник/ТМЦ) доступны только когда
+        // обязательные поля текущего вложения (даты/время + обязательные доп. поля) заполнены.
+        currentAttachmentReady() {
+            if (!this.selectedAttachment) return false;
+            const key = this.attachmentKey(this.selectedAttachment);
+            if (!this.attachmentDatesComplete(this.attachmentDatesByAttachment[key])) return false;
+            return this.emptyRequiredCustomFields(this.selectedAttachment, key).length === 0;
+        },
         
         submitValidation() {
             const reasons = [];
@@ -488,16 +500,10 @@ export default {
                     reasons.push(`"${label}": укажите даты действия`);
                     return;
                 }
-                const hasValidDates = dateData.isOneDay
-                    ? !!(dateData.singleDate && dateData.startTime && dateData.endTime)
-                    : !!(dateData.startDate && dateData.endDate && dateData.startTime && dateData.endTime);
-                if (!hasValidDates) {
+                if (!this.attachmentDatesComplete(dateData)) {
                     reasons.push(`"${label}": заполните даты и время действия`);
                 }
-                const uaId = attachment.template_id || attachment.id;
-                const fields = this.customFieldDefinitions[uaId] || [];
-                const values = this.customFieldsByAttachment[key] || {};
-                const emptyFields = fields.filter(f => f.is_required && (!values[f.id] || !values[f.id].trim()));
+                const emptyFields = this.emptyRequiredCustomFields(attachment, key);
                 if (emptyFields.length > 0) {
                     reasons.push(`"${label}": заполните доп. поля: ${emptyFields.map(f => f.label).join(', ')}`);
                 }
@@ -563,10 +569,7 @@ export default {
                     errors.push('Не заполнены даты действия и время пребывания');
                 }
 
-                const uaId = attachment.template_id || attachment.id;
-                const cfFields = this.customFieldDefinitions[uaId] || [];
-                const cfValues = this.customFieldsByAttachment[key] || {};
-                const emptyCf = cfFields.filter(f => f.is_required && (!cfValues[f.id] || !cfValues[f.id].trim()));
+                const emptyCf = this.emptyRequiredCustomFields(attachment, key);
                 if (emptyCf.length > 0) {
                     emptyCf.forEach(f => errors.push(`Не заполнено доп. поле "${f.label}"`));
                 }
@@ -794,6 +797,22 @@ export default {
                 freeParking: false,
                 errors: {}
             };
+        },
+
+        // Дата+время вложения заполнены полностью (одиночная дата либо диапазон).
+        attachmentDatesComplete(dateData) {
+            if (!dateData) return false;
+            return dateData.isOneDay
+                ? !!(dateData.singleDate && dateData.startTime && dateData.endTime)
+                : !!(dateData.startDate && dateData.endDate && dateData.startTime && dateData.endTime);
+        },
+
+        // Незаполненные обязательные доп. поля вложения.
+        emptyRequiredCustomFields(attachment, key) {
+            const uaId = attachment.template_id || attachment.id;
+            const fields = this.customFieldDefinitions[uaId] || [];
+            const values = this.customFieldsByAttachment[key] || {};
+            return fields.filter(f => f.is_required && (!values[f.id] || !values[f.id].trim()));
         },
 
         updateAttachmentData(field, value) {

--- a/frontend/src/components/CreateApplication/EmployeeForm.vue
+++ b/frontend/src/components/CreateApplication/EmployeeForm.vue
@@ -1,5 +1,15 @@
 <template>
-  <div class="data__completion">
+  <div
+    class="data__completion"
+    :class="{ 'data__completion--locked': disabled }"
+    :inert="disabled ? '' : undefined"
+  >
+    <div
+      v-if="disabled"
+      class="completion__lock"
+    >
+      <span>Сначала заполните обязательные поля вложения</span>
+    </div>
     <div class="completion__header">
       <h3>Новый сотрудник</h3>
       <button
@@ -460,6 +470,11 @@ export default {
         fieldConfig: {
             type: Object,
             default: () => ({})
+        },
+        // Гейт п.36: форма недоступна, пока не заполнены обязательные поля вложения.
+        disabled: {
+            type: Boolean,
+            default: false
         }
     },
     emits: ['edit-cancelled', 'employee-added', 'employee-updated', 'employees-added'],
@@ -1165,6 +1180,30 @@ export default {
     padding: 15px;
     width: 450px;
     border-right: 1px solid #e6e6e6;
+}
+
+.data__completion--locked {
+    position: relative;
+}
+
+.completion__lock {
+    position: absolute;
+    inset: 0;
+    z-index: 3;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 24px;
+    background: rgba(244, 245, 248, 0.7);
+}
+
+.completion__lock span {
+    max-width: 240px;
+    font-size: 13px;
+    font-weight: 600;
+    line-height: 1.4;
+    color: #8a8f9a;
 }
 
 .completion__citizenship {

--- a/frontend/src/components/CreateApplication/ItemsForm.vue
+++ b/frontend/src/components/CreateApplication/ItemsForm.vue
@@ -1,5 +1,15 @@
 <template>
-  <div class="data__completion">
+  <div
+    class="data__completion"
+    :class="{ 'data__completion--locked': disabled }"
+    :inert="disabled ? '' : undefined"
+  >
+    <div
+      v-if="disabled"
+      class="completion__lock"
+    >
+      <span>Сначала заполните обязательные поля вложения</span>
+    </div>
     <div class="completion__header">
       <h3>Новые ТМЦ</h3>
       <div class="completion__actions">
@@ -141,6 +151,11 @@ export default {
         fieldConfig: {
             type: Object,
             default: () => ({})
+        },
+        // Гейт п.36: форма недоступна, пока не заполнены обязательные поля вложения.
+        disabled: {
+            type: Boolean,
+            default: false
         }
     },
     emits: ['edit-cancelled', 'item-added', 'item-updated', 'items-added'],
@@ -343,6 +358,30 @@ export default {
     padding: 15px;
     width: 450px;
     border-right: 1px solid #e6e6e6;
+}
+
+.data__completion--locked {
+    position: relative;
+}
+
+.completion__lock {
+    position: absolute;
+    inset: 0;
+    z-index: 3;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 24px;
+    background: rgba(244, 245, 248, 0.7);
+}
+
+.completion__lock span {
+    max-width: 240px;
+    font-size: 13px;
+    font-weight: 600;
+    line-height: 1.4;
+    color: #8a8f9a;
 }
 
 .completion__header {

--- a/frontend/src/components/CreateApplication/VehicleForm.vue
+++ b/frontend/src/components/CreateApplication/VehicleForm.vue
@@ -1,5 +1,15 @@
 <template>
-  <div class="data__completion">
+  <div
+    class="data__completion"
+    :class="{ 'data__completion--locked': disabled }"
+    :inert="disabled ? '' : undefined"
+  >
+    <div
+      v-if="disabled"
+      class="completion__lock"
+    >
+      <span>Сначала заполните обязательные поля вложения</span>
+    </div>
     <div class="completion__header">
       <h3>Добавление Т/С</h3>
       <button
@@ -394,6 +404,11 @@ export default {
         fieldConfig: {
             type: Object,
             default: () => ({})
+        },
+        // Гейт п.36: форма недоступна, пока не заполнены обязательные поля вложения.
+        disabled: {
+            type: Boolean,
+            default: false
         }
     },
     emits: ['edit-cancelled', 'vehicle-added', 'vehicle-updated', 'vehicles-added'],
@@ -1049,6 +1064,30 @@ export default {
     padding: 15px;
     width: 450px;
     border-right: 1px solid #e6e6e6;
+}
+
+.data__completion--locked {
+    position: relative;
+}
+
+.completion__lock {
+    position: absolute;
+    inset: 0;
+    z-index: 3;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 24px;
+    background: rgba(244, 245, 248, 0.7);
+}
+
+.completion__lock span {
+    max-width: 240px;
+    font-size: 13px;
+    font-weight: 600;
+    line-height: 1.4;
+    color: #8a8f9a;
 }
 
 .completion__format {

--- a/frontend/src/components/CreateApplication/__tests__/FormGateDisabled.spec.js
+++ b/frontend/src/components/CreateApplication/__tests__/FormGateDisabled.spec.js
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import VehicleForm from '../VehicleForm.vue';
+import EmployeeForm from '../EmployeeForm.vue';
+import ItemsForm from '../ItemsForm.vue';
+
+// п.36: формы добавления (авто/сотрудник/ТМЦ) недоступны, пока не заполнены
+// обязательные поля вложения. CreateApplication отдаёт это через prop `disabled`:
+// форма получает класс-замок, атрибут inert и оверлей-плашку с подсказкой.
+
+vi.mock('@/api/client', () => ({
+  apiRequest: vi.fn().mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue([]) }),
+}));
+vi.mock('@/api/blacklist', () => ({
+  checkVehicleBlacklist: vi.fn().mockResolvedValue(null),
+  checkPersonBlacklist: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('@/api/marks', () => ({
+  listMarks: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: vi.fn().mockReturnValue({ token: 'test-token' }),
+}));
+vi.mock('@/composables/useToast', () => ({
+  useToast: vi.fn().mockReturnValue({ success: vi.fn(), error: vi.fn() }),
+}));
+vi.mock('@/components/CreateApplication/ExistingCarsModal.vue', () => ({
+  default: { name: 'ExistingCarsModal', template: '<div />' },
+}));
+vi.mock('@/components/CreateApplication/ExistingEmployeesModal.vue', () => ({
+  default: { name: 'ExistingEmployeesModal', template: '<div />' },
+}));
+
+const FORMS = [
+  ['VehicleForm', VehicleForm],
+  ['EmployeeForm', EmployeeForm],
+  ['ItemsForm', ItemsForm],
+];
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+});
+
+describe('Гейт форм вложения (п.36)', () => {
+  it.each(FORMS)('%s: по умолчанию доступна - нет замка и inert', (_name, Form) => {
+    const w = mount(Form);
+    const root = w.find('.data__completion');
+    expect(root.classes()).not.toContain('data__completion--locked');
+    expect(root.attributes('inert')).toBeUndefined();
+    expect(w.find('.completion__lock').exists()).toBe(false);
+  });
+
+  it.each(FORMS)('%s: disabled=true - замок, inert и плашка с подсказкой', (_name, Form) => {
+    const w = mount(Form, { props: { disabled: true } });
+    const root = w.find('.data__completion');
+    expect(root.classes()).toContain('data__completion--locked');
+    expect(root.attributes('inert')).toBeDefined();
+    const lock = w.find('.completion__lock');
+    expect(lock.exists()).toBe(true);
+    expect(lock.text()).toContain('обязательные поля вложения');
+  });
+});


### PR DESCRIPTION
## Что и зачем (п.36 эпика 46-edits)

Пока не заполнены обязательные поля текущего вложения, формы добавления авто/сотрудника/ТМЦ теперь недоступны: серый оверлей с подсказкой "Сначала заполните обязательные поля вложения" + атрибут `inert` (нельзя ни кликнуть, ни сфокусировать). Так пользователь не добавит запись раньше, чем заполнит шапку вложения.

Что считается "обязательными полями вложения" (по согласованию с пользователем): **только поля самого вложения** — даты/время + обязательные доп. поля. Организация/ответственный/телефон (уровень всей заявки) форму НЕ блокируют. Гейт применён ко **всем трём** формам (Vehicle/Employee/Items).

## Реализация

- `CreateApplication.vue`: computed `currentAttachmentReady` (даты вложения заполнены + нет пустых обязательных доп. полей) → проброс `:disabled="!currentAttachmentReady"` в три формы. Логика заполненности вынесена в хелперы `attachmentDatesComplete` / `emptyRequiredCustomFields`, на них же переведены `submitValidation` и доп.-поля в `tooltipSections` (единый источник правды с гейтом, поведение submit-валидации идентично).
- `VehicleForm` / `EmployeeForm` / `ItemsForm`: prop `disabled` (Boolean, default false); корень `.data__completion` получает класс-замок, `:inert` и оверлей `.completion__lock`.

## Проверки

- Vitest: новый `FormGateDisabled.spec.js` (6 тестов) — по умолчанию форма доступна (нет замка/inert), при `disabled=true` — замок, `inert`, подсказка. Зелёный. Соседние `*FieldConfigSpec` (формы с новым проп) тоже зелёные.
- Локальная проверка через Playwright на свежем вложении: оверлей виден, класс `data__completion--locked`, атрибут `inert`, текст подсказки — подтверждено программно (DOM). Сессия восстанавливается из cookie, форма получает данные с бэка.
- Поймал баг по ходу: голый `:inert="disabled"` рендерит `inert="false"`, а это булев атрибут по присутствию — форма осталась бы inert и в активном состоянии. Исправлено на `:inert="disabled ? '' : undefined"`, покрыто тестом.

## Ревью

`code-reviewer`: блокеров нет. Два 🟡 (дубль ветвистой логики дат в `tooltipSections` — замена на булев-хелпер потеряла бы специфичные формулировки сообщений; CSS оверлея продублирован по трём формам — следует существующему паттерну, где базовый `.data__completion` и так дублируется per-form) оставлены осознанно.