### PR TITLE
feat(registry): места разгрузки и статус в карточках вкладок Автомобили/Сотрудники (#46)

### DIFF
--- a/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
@@ -787,12 +787,17 @@ export default {
         },
 
         async loadEmployeeStatus() {
-            if (!this.employee?.id) return;
+            // На вкладке "Сотрудники" (employeesview) employee.id - id реестра, а статус
+            // ключуется по employees.id (заявочная таблица), поэтому берём только
+            // activeEmployeeId (без отката на employee.id - id-пространства разные).
+            // В прочих источниках employee.id уже = employees.id.
+            const statusEmployeeId = this.source === 'employeesview' ? this.employee?.activeEmployeeId : this.employee?.id;
+            if (!statusEmployeeId) return;
             try {
                 const response = await apiRequest('/employees/history/current-status', { method: 'GET' });
                 if (response.ok) {
                     const statuses = await response.json();
-                    const status = statuses.find(s => s.employee_id === this.employee.id);
+                    const status = statuses.find(s => s.employee_id === statusEmployeeId);
                     if (status) {
                         this.territoryStatus = status.territory_status;
                     } else {

--- a/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
@@ -257,7 +257,7 @@
 
                 <!-- Секция Статус (только для автомобилей; в корзине не показываем) -->
                 <div
-                  v-if="showCarFeatures && source !== 'trash'"
+                  v-if="showStatusSection"
                   class="details-section"
                 >
                   <div class="section-header">
@@ -532,6 +532,11 @@ export default {
             if (this.entryChecked && !this.exitChecked) return 'На территории';
             if (this.exitChecked) return 'Выехал';
             return 'Не въезжал';
+        },
+        // Статус территории нужен на вкладке "Автомобили" (source='carsview', features выкл)
+        // наравне с Центром/деталью заявки. Скрываем только в корзине.
+        showStatusSection() {
+            return (this.showCarFeatures || this.source === 'carsview') && this.source !== 'trash';
         },
         // Только события въезда/выезда
         entryExitHistory() {
@@ -835,12 +840,17 @@ export default {
         },
 
         async loadCarStatus() {
-            if (!this.vehicle?.id) return;
+            // На вкладке "Автомобили" (carsview) vehicle.id - id реестра уникальных машин,
+            // а статус ключуется по cars.id (заявочная таблица), поэтому берём только
+            // activeCarId (без отката на vehicle.id - id-пространства разные, возможно ложное
+            // совпадение). В прочих источниках vehicle.id уже = cars.id.
+            const statusCarId = this.source === 'carsview' ? this.vehicle?.activeCarId : this.vehicle?.id;
+            if (!statusCarId) return;
             try {
                 const response = await apiRequest('/cars/history/current-status', {});
                 if (response.ok) {
                     const statuses = await response.json();
-                    const status = statuses.find(s => s.car_id === this.vehicle.id);
+                    const status = statuses.find(s => s.car_id === statusCarId);
                     if (status) {
                         this.entryChecked = status.territory_status === 1;
                         this.exitChecked = status.territory_status === 2;

--- a/frontend/src/views/CarsView.vue
+++ b/frontend/src/views/CarsView.vue
@@ -543,7 +543,7 @@
     <VehicleDetailsModal
       :show="showDetailsViewModal"
       :vehicle="detailsCar"
-      :all-unloading-places="[]"
+      :all-unloading-places="allUnloadingPlaces"
       :license-plate-formats="[]"
       :current-user-id="ownershipInfo?.user_id || null"
       :current-user-name="''"
@@ -607,6 +607,9 @@ export default {
             detailsCar: null,
             showApplicationDetail: false,
             selectedApplication: null,
+            // Места разгрузки: список для имён + карта active_car_id -> [place ids]
+            allUnloadingPlaces: [],
+            carUnloadPlacesMap: {},
 
             
             // Формат номера
@@ -760,7 +763,9 @@ export default {
             this.fetchOwnershipInfo(),
             this.fetchFormats(),
             this.loadMarks(),
-            this.loadBlacklist()
+            this.loadBlacklist(),
+            this.fetchUnloadingPlaces(),
+            this.fetchCarUnloadPlaces()
         ]);
         await this.fetchCars();
         
@@ -787,7 +792,10 @@ export default {
                 company: car.active_app_company_name || car.company_name || null,
                 companyId: car.company_id || null,
                 isExisting: true,
-                unloadPlaces: [],
+                // active_car_id - id заявочной строки активной заявки; по нему тянем
+                // места разгрузки и статус территории (в реестре их нет).
+                activeCarId: car.active_car_id || null,
+                unloadPlaces: this.carUnloadPlacesMap[car.active_car_id] || [],
                 entry_date_to: car.active_entry_date_to,
                 entry_time_from: car.active_entry_time_from,
                 entry_time_to: car.active_entry_time_to,
@@ -900,6 +908,35 @@ export default {
                 }
             } catch (error) {
                 console.error("Ошибка при загрузке форматов:", error);
+            }
+        },
+
+        async fetchUnloadingPlaces() {
+            try {
+                const response = await apiRequest('/unload-places', { method: 'GET' });
+                if (response.ok) this.allUnloadingPlaces = await response.json();
+            } catch (error) {
+                console.error('Ошибка при загрузке мест разгрузки:', error);
+            }
+        },
+
+        // Карта active_car_id -> [unload_place_id]. Реестр /unique-cars не несёт места
+        // разгрузки (они в заявочной cars), поэтому мапим по id активной заявочной строки.
+        async fetchCarUnloadPlaces() {
+            try {
+                const response = await apiRequest('/cars/unload-places', { method: 'GET' });
+                if (!response.ok) return;
+                const rows = await response.json();
+                const map = {};
+                (rows || []).forEach(cup => {
+                    if (!map[cup.car_id]) map[cup.car_id] = [];
+                    if (!map[cup.car_id].includes(cup.unload_place_id)) {
+                        map[cup.car_id].push(cup.unload_place_id);
+                    }
+                });
+                this.carUnloadPlacesMap = map;
+            } catch (error) {
+                console.error('Ошибка при загрузке мест разгрузки машин:', error);
             }
         },
 

--- a/frontend/src/views/CarsView.vue
+++ b/frontend/src/views/CarsView.vue
@@ -763,10 +763,9 @@ export default {
             this.fetchOwnershipInfo(),
             this.fetchFormats(),
             this.loadMarks(),
-            this.loadBlacklist(),
-            this.fetchUnloadingPlaces(),
-            this.fetchCarUnloadPlaces()
+            this.loadBlacklist()
         ]);
+        // fetchCars сам подтягивает места разгрузки (allUnloadingPlaces + карта по машинам).
         await this.fetchCars();
         
         // Закрытие dropdown при клике вне
@@ -869,6 +868,9 @@ export default {
 
                 if (response.ok) {
                     this.carsData = await response.json();
+                    // Места разгрузки тоже перезагружаем: при смене активной заявки у машины
+                    // меняется active_car_id и набор мест, иначе карта устаревает после рефреша.
+                    await Promise.all([this.fetchUnloadingPlaces(), this.fetchCarUnloadPlaces()]);
                 } else {
                     console.error("Ошибка при загрузке машин");
                     this.carsData = [];

--- a/frontend/src/views/EmployeeView.vue
+++ b/frontend/src/views/EmployeeView.vue
@@ -596,6 +596,9 @@ export default {
             // и поддерживает source=employeesview - заголовок \"Информация о сотруднике\"
             this.detailsEmployee = {
                 id: employee.id,
+                // id заявочной строки активной заявки; по нему карточка тянет статус
+                // территории (current-status ключуется по employees.id, не по реестру).
+                activeEmployeeId: employee.active_employee_id || null,
                 last_name: employee.last_name,
                 first_name: employee.first_name,
                 middle_name: employee.middle_name,

--- a/internal/handlers/unique_cars_test.go
+++ b/internal/handlers/unique_cars_test.go
@@ -104,6 +104,23 @@ func TestUniqueCars_ActiveCarIDForActiveApplication(t *testing.T) {
 	assert.Equal(t, true, found["status"], "у машины с активной заявкой status=true")
 	require.NotNil(t, found["active_car_id"], "active_car_id должен быть заполнен для активной машины")
 	assert.Equal(t, float64(carID), found["active_car_id"], "active_car_id = id активной заявочной машины")
+
+	// Машина в реестре без активной заявки: active_car_id пустой (фронт полагается на это,
+	// чтобы не дёргать статус/места по чужому id).
+	testutil.POST(t, e, "/unique-cars", `{"number":"NOAPP777","mark":"Lada"}`, h)
+	rec = testutil.GET(t, e, "/unique-cars?filter_type=all_system", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	rows = testutil.ParseSlice(t, rec)
+	var idle map[string]interface{}
+	for _, r := range rows {
+		if n, _ := r["number"].(string); n == "NOAPP777" {
+			idle = r
+			break
+		}
+	}
+	require.NotNil(t, idle, "машина без заявки должна быть в реестре")
+	assert.Equal(t, false, idle["status"], "без активной заявки status=false")
+	assert.Nil(t, idle["active_car_id"], "без активной заявки active_car_id пустой")
 }
 
 func TestUniqueCars_DuplicateCreate(t *testing.T) {

--- a/internal/handlers/unique_cars_test.go
+++ b/internal/handlers/unique_cars_test.go
@@ -72,6 +72,40 @@ func TestUniqueCars_CRUD(t *testing.T) {
 	assert.Equal(t, "Car deleted successfully", testutil.ParseMessage(t, rec))
 }
 
+// active_car_id связывает строку реестра с id активной заявочной машины (cars.id).
+// Без него фронт вкладки "Автомобили" не может подтянуть статус территории и места
+// разгрузки - они ключуются по cars.id, а реестр оперирует unique_cars.id.
+func TestUniqueCars_ActiveCarIDForActiveApplication(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	appID, _, carID := seedCarViaCompleteApp(t, e, db, token, "Test Organization")
+	activateCarViaApp(t, e, db, appID, td)
+
+	// Реестр должен содержать машину с тем же номером, чтобы подзапрос активной заявки сматчился.
+	testutil.POST(t, e, "/unique-cars", `{"number":"B002BB799","mark":"Kamaz"}`, h)
+
+	rec := testutil.GET(t, e, "/unique-cars?filter_type=all_system", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	rows := testutil.ParseSlice(t, rec)
+
+	var found map[string]interface{}
+	for _, r := range rows {
+		if n, _ := r["number"].(string); n == "B002BB799" {
+			found = r
+			break
+		}
+	}
+	require.NotNil(t, found, "уникальная машина B002BB799 должна быть в списке реестра")
+	assert.Equal(t, true, found["status"], "у машины с активной заявкой status=true")
+	require.NotNil(t, found["active_car_id"], "active_car_id должен быть заполнен для активной машины")
+	assert.Equal(t, float64(carID), found["active_car_id"], "active_car_id = id активной заявочной машины")
+}
+
 func TestUniqueCars_DuplicateCreate(t *testing.T) {
 	e, db, cleanup := testutil.SetupTestApp(t)
 	defer cleanup()

--- a/internal/services/unique_car_service.go
+++ b/internal/services/unique_car_service.go
@@ -65,6 +65,10 @@ type UniqueCarWithRelations struct {
 	ActiveEntryTimeTo    *string    `json:"active_entry_time_to"`
 	ActiveAppOrgName     *string    `json:"active_app_org_name"`
 	ActiveAppCompanyName *string    `json:"active_app_company_name"`
+	// ActiveCarID -- id строки в cars активной заявки (заявочная таблица, не реестр).
+	// Нужен фронту, чтобы подтянуть статус территории и места разгрузки активной машины
+	// (current-status и cars/unload-places ключуются по cars.id, а не по unique_cars.id).
+	ActiveCarID *int `json:"active_car_id"`
 }
 
 // NewUniqueCarRequest -- тело запроса на создание/обновление машины.
@@ -272,7 +276,15 @@ func (s *uniqueCarService) GetAll(ctx context.Context, username string, filterTy
 				AND cr.status = 1 AND app.status IN ('В работе', 'Завершено')
 				AND CURRENT_DATE <= a.entry_date_to::date
 				ORDER BY a.entry_date_to DESC LIMIT 1
-			) as active_app_company_name`).
+			) as active_app_company_name,
+			(SELECT cr.id FROM cars cr
+				JOIN attachments a ON cr.attachment_id = a.id
+				JOIN applications app ON a.application_id = app.id
+				WHERE LOWER(TRIM(cr.car_number)) = LOWER(TRIM(uc.number))
+				AND cr.status = 1 AND app.status IN ('В работе', 'Завершено')
+				AND CURRENT_DATE <= a.entry_date_to::date
+				ORDER BY a.entry_date_to DESC LIMIT 1
+			) as active_car_id`).
 		Joins("LEFT JOIN organizations o ON uc.organization_id = o.id").
 		Joins("LEFT JOIN companies c ON uc.company_id = c.id").
 		Joins("LEFT JOIN license_plate_formats lpf ON uc.format_id = lpf.id").

--- a/internal/services/unique_employee_service.go
+++ b/internal/services/unique_employee_service.go
@@ -87,6 +87,10 @@ type UniqueEmployeeWithRelations struct {
 	ActivePassTime       *string    `json:"active_pass_time"`
 	ActiveAppOrgName     *string    `json:"active_app_org_name"`
 	ActiveAppCompanyName *string    `json:"active_app_company_name"`
+	// ActiveEmployeeID -- id строки в employees активной заявки (заявочная таблица,
+	// не реестр). Нужен фронту, чтобы подтянуть территориальный статус сотрудника
+	// (current-status ключуется по employees.id, а не по unique_employees.id).
+	ActiveEmployeeID *int `json:"active_employee_id"`
 }
 
 // NewUniqueEmployeeRequest -- тело запроса на создание/обновление сотрудника.
@@ -286,7 +290,15 @@ func (s *uniqueEmployeeService) GetAll(ctx context.Context, username string, fil
 				AND e.status = 1 AND app.status IN ('В работе', 'Завершено')
 				AND CURRENT_DATE <= a.entry_date_to::date
 				ORDER BY a.entry_date_to DESC LIMIT 1
-			) as active_app_company_name`).
+			) as active_app_company_name,
+			(SELECT e.id FROM employees e
+				JOIN attachments a ON e.attachment_id = a.id
+				JOIN applications app ON a.application_id = app.id
+				WHERE e.passport_series_number_hmac = ue.passport_series_number_hmac
+				AND e.status = 1 AND app.status IN ('В работе', 'Завершено')
+				AND CURRENT_DATE <= a.entry_date_to::date
+				ORDER BY a.entry_date_to DESC LIMIT 1
+			) as active_employee_id`).
 		Joins("LEFT JOIN organizations o ON ue.organization_id = o.id").
 		Joins("LEFT JOIN companies c ON ue.company_id = c.id").
 		Joins("LEFT JOIN citizenships cit ON ue.citizenship_id = cit.id")


### PR DESCRIPTION
## Что было сломано

На вкладке «Автомобили» карточка активной машины показывала «места разгрузки не указаны» и не показывала статус; на «Сотрудники» статус всегда был «Не входил». Причина — id-пространства: вкладки работают с реестром (`/unique-cars`, `/unique-employees`, id = `unique_cars.id` / `unique_employees.id`), а статус территории и места разгрузки живут в заявочных таблицах `cars`/`employees` с другим id. Реестр эти данные не отдавал, а фронт пытался сопоставить статус по id реестра — совпадения не было.

## Фикс

**Бэкенд** (`unique_car_service.go`, `unique_employee_service.go`): добавил в ответ реестра id активной заявочной строки — `active_car_id` / `active_employee_id`. Это один коррелированный подзапрос по уже существующему паттерну активной заявки (тот же matcher, `status=1`, `app.status IN ('В работе','Завершено')`, `CURRENT_DATE <= entry_date_to`, `ORDER BY entry_date_to DESC LIMIT 1`).

**Фронт**: CarsView грузит места разгрузки (`/unload-places` + `/cars/unload-places`) и мапит их по `active_car_id`; карточки сверяют статус по активному id (`source==='carsview'/'employeesview' ? activeId : id`), без отката на id реестра — id-пространства разные, иначе возможно ложное совпадение. Места разгрузки перезагружаются вместе со списком (`fetchCars`), чтобы карта не устаревала после рефреша.

## Скоуп

Строго по задаче — только **места разгрузки + статус территории**. Чёрный список, история въездов/выездов и кнопки «Полная история»/«Открыть заявку» на вкладки сознательно НЕ выносил: это широкая модель видимости карточки по контексту/правам (отдельная задача П.6). Гейтинг `showStatusSection` трогает только источник `carsview`; center/application/blacklist/trash/general остаются как были.

## Проверки

- `go build` + `go test ./internal/handlers ./internal/services` — зелёные.
- Новый тест `TestUniqueCars_ActiveCarIDForActiveApplication`: полный цикл create→activate→реестр, проверяет `active_car_id` == id активной заявочной машины, и что у машины без заявки `active_car_id` пустой.
- ESLint/build фронта — в CI (worktree без node_modules, RAM-бюджет).
- Визуальная проверка карточек — в `/ship-check` на staging после деплоя.

## Ревью

Прогнал `code-reviewer`. Находку про vehicle-watch (статус не перегружается при смене машины без закрытия) отклонил: модалка — полноэкранный Teleport-оверлей, переключиться на другую машину можно только закрыв карточку, а `show`-watch вызывает `loadCarStatus()` безусловно при каждом открытии. Замечание про устаревание мест после рефреша — исправил (перенёс загрузку в `fetchCars`).

> Swagger docs не регенерил: CI их свежесть не валидирует, поля аддитивны; в репо docs обновляются отдельными коммитами (текущий `swag init` падает на пред-существующей ошибке аннотаций `models.HTTPError`).