### PR TITLE
feat(registry): кнопка "Открыть заявку" в карточках вкладок Автомобили/Сотрудники (#46)

### DIFF
--- a/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
@@ -31,7 +31,7 @@
                   <span>Полная история</span>
                 </button>
                 <button
-                  v-if="showCarFeatures && source !== 'application' && source !== 'blacklist'"
+                  v-if="canOpenApplication"
                   class="application-btn"
                   @click="openApplication"
                 >
@@ -510,11 +510,18 @@ export default {
         overlayZIndex() {
             return this.source === 'application' ? 10003 : 10001;
         },
+        // "Открыть заявку" доступна, когда у машины есть активная заявка и карточка
+        // открыта не из самой заявки/ЧС (там переход не нужен). От showCarFeatures НЕ
+        // зависит: на вкладке Автомобили features выкл, но открыть заявку нужно.
+        canOpenApplication() {
+            return this.source !== 'application' && this.source !== 'blacklist'
+                && !!(this.vehicle?.applicationId || this.vehicle?.application_id);
+        },
         // Кнопки в шапке: "Полная история" видна при showCarFeatures,
-        // "Открыть заявку" - при showCarFeatures и source !== 'application'.
+        // "Открыть заявку" - при canOpenApplication.
         visibleActionsCount() {
             const history = this.showCarFeatures ? 1 : 0;
-            const application = (this.showCarFeatures && this.source !== 'application' && this.source !== 'blacklist') ? 1 : 0;
+            const application = this.canOpenApplication ? 1 : 0;
             return history + application;
         },
         modalTitle() {

--- a/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
@@ -510,9 +510,8 @@ export default {
         overlayZIndex() {
             return this.source === 'application' ? 10003 : 10001;
         },
-        // "Открыть заявку" доступна, когда у машины есть активная заявка и карточка
-        // открыта не из самой заявки/ЧС (там переход не нужен). От showCarFeatures НЕ
-        // зависит: на вкладке Автомобили features выкл, но открыть заявку нужно.
+        // Намеренно НЕ зависит от showCarFeatures: на вкладке Автомобили features выкл,
+        // но переход в заявку нужен. Гейт - наличие заявки (как у EmployeeDetailsModal).
         canOpenApplication() {
             return this.source !== 'application' && this.source !== 'blacklist'
                 && !!(this.vehicle?.applicationId || this.vehicle?.application_id);

--- a/frontend/src/views/CarsView.vue
+++ b/frontend/src/views/CarsView.vue
@@ -794,6 +794,8 @@ export default {
                 // active_car_id - id заявочной строки активной заявки; по нему тянем
                 // места разгрузки и статус территории (в реестре их нет).
                 activeCarId: car.active_car_id || null,
+                // id самой заявки - для кнопки "Открыть заявку" (open-application).
+                applicationId: car.active_application_id || null,
                 unloadPlaces: this.carUnloadPlacesMap[car.active_car_id] || [],
                 entry_date_to: car.active_entry_date_to,
                 entry_time_from: car.active_entry_time_from,

--- a/frontend/src/views/EmployeeView.vue
+++ b/frontend/src/views/EmployeeView.vue
@@ -599,6 +599,8 @@ export default {
                 // id заявочной строки активной заявки; по нему карточка тянет статус
                 // территории (current-status ключуется по employees.id, не по реестру).
                 activeEmployeeId: employee.active_employee_id || null,
+                // id самой заявки - для кнопки "Открыть заявку" (open-application).
+                applicationId: employee.active_application_id || null,
                 last_name: employee.last_name,
                 first_name: employee.first_name,
                 middle_name: employee.middle_name,

--- a/internal/handlers/unique_cars_test.go
+++ b/internal/handlers/unique_cars_test.go
@@ -104,6 +104,10 @@ func TestUniqueCars_ActiveCarIDForActiveApplication(t *testing.T) {
 	assert.Equal(t, true, found["status"], "у машины с активной заявкой status=true")
 	require.NotNil(t, found["active_car_id"], "active_car_id должен быть заполнен для активной машины")
 	assert.Equal(t, float64(carID), found["active_car_id"], "active_car_id = id активной заявочной машины")
+	// active_application_id - id самой заявки той же активной строки; по нему вкладка
+	// "Автомобили" открывает заявку (кнопка "Открыть заявку").
+	require.NotNil(t, found["active_application_id"], "active_application_id заполнен для активной машины")
+	assert.Equal(t, float64(appID), found["active_application_id"], "active_application_id = id активной заявки")
 
 	// Машина в реестре без активной заявки: active_car_id пустой (фронт полагается на это,
 	// чтобы не дёргать статус/места по чужому id).
@@ -121,6 +125,7 @@ func TestUniqueCars_ActiveCarIDForActiveApplication(t *testing.T) {
 	require.NotNil(t, idle, "машина без заявки должна быть в реестре")
 	assert.Equal(t, false, idle["status"], "без активной заявки status=false")
 	assert.Nil(t, idle["active_car_id"], "без активной заявки active_car_id пустой")
+	assert.Nil(t, idle["active_application_id"], "без активной заявки active_application_id пустой")
 }
 
 func TestUniqueCars_DuplicateCreate(t *testing.T) {

--- a/internal/handlers/unique_employees_test.go
+++ b/internal/handlers/unique_employees_test.go
@@ -20,6 +20,63 @@ func TestUniqueEmployees_Unauthorized(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 }
 
+// active_application_id связывает строку реестра сотрудников с id активной заявки.
+// Без него вкладка "Сотрудники" не может открыть заявку (кнопка "Открыть заявку").
+// Реестр и заявочный сотрудник связаны по passport_series_number_hmac, поэтому
+// реестровую запись активного сотрудника заводим с тем же паспортом, что и в seed-заявке.
+func TestUniqueEmployees_ActiveApplicationIDForActiveApplication(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	appID, _, empID := seedEmployeeViaCompleteApp(t, e, db, token, "Test Organization")
+	activateCarViaApp(t, e, db, appID, td)
+
+	// Паспорт совпадает с сотрудником из seed-заявки ("1234 567890") - так подзапрос
+	// активной заявки сматчится по passport_series_number_hmac.
+	active := fmt.Sprintf(`{"last_name":"RegActive","first_name":"A","passport_series_number":"1234 567890","organization_id":%d,"company_id":%d}`, td.OrgID, td.CompanyID)
+	testutil.POST(t, e, "/unique-employees", active, h)
+
+	rec := testutil.GET(t, e, "/unique-employees?filter_type=all_system", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	rows := testutil.ParseSlice(t, rec)
+
+	var found map[string]interface{}
+	for _, r := range rows {
+		if n, _ := r["last_name"].(string); n == "RegActive" {
+			found = r
+			break
+		}
+	}
+	require.NotNil(t, found, "реестровый сотрудник RegActive должен быть в списке")
+	assert.Equal(t, true, found["status"], "у сотрудника с активной заявкой status=true")
+	require.NotNil(t, found["active_employee_id"], "active_employee_id заполнен для активного сотрудника")
+	assert.Equal(t, float64(empID), found["active_employee_id"], "active_employee_id = id активной заявочной строки")
+	require.NotNil(t, found["active_application_id"], "active_application_id заполнен для активного сотрудника")
+	assert.Equal(t, float64(appID), found["active_application_id"], "active_application_id = id активной заявки")
+
+	// Сотрудник без активной заявки: active_* пустые (фронт прячет кнопку "Открыть заявку").
+	idle := fmt.Sprintf(`{"last_name":"RegIdle","first_name":"B","passport_series_number":"0000 000111","organization_id":%d,"company_id":%d}`, td.OrgID, td.CompanyID)
+	testutil.POST(t, e, "/unique-employees", idle, h)
+	rec = testutil.GET(t, e, "/unique-employees?filter_type=all_system", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	rows = testutil.ParseSlice(t, rec)
+	var idleRow map[string]interface{}
+	for _, r := range rows {
+		if n, _ := r["last_name"].(string); n == "RegIdle" {
+			idleRow = r
+			break
+		}
+	}
+	require.NotNil(t, idleRow, "сотрудник без заявки должен быть в реестре")
+	assert.Equal(t, false, idleRow["status"], "без активной заявки status=false")
+	assert.Nil(t, idleRow["active_employee_id"], "без активной заявки active_employee_id пустой")
+	assert.Nil(t, idleRow["active_application_id"], "без активной заявки active_application_id пустой")
+}
+
 func TestUniqueEmployees_CRUD(t *testing.T) {
 	e, db, cleanup := testutil.SetupTestApp(t)
 	defer cleanup()

--- a/internal/services/unique_car_service.go
+++ b/internal/services/unique_car_service.go
@@ -69,6 +69,9 @@ type UniqueCarWithRelations struct {
 	// Нужен фронту, чтобы подтянуть статус территории и места разгрузки активной машины
 	// (current-status и cars/unload-places ключуются по cars.id, а не по unique_cars.id).
 	ActiveCarID *int `json:"active_car_id"`
+	// ActiveApplicationID -- id заявки (applications.id) той же активной заявки, что и
+	// прочие active_*-поля. Нужен фронту для кнопки "Открыть заявку" на вкладке Автомобили.
+	ActiveApplicationID *int `json:"active_application_id"`
 }
 
 // NewUniqueCarRequest -- тело запроса на создание/обновление машины.
@@ -284,7 +287,15 @@ func (s *uniqueCarService) GetAll(ctx context.Context, username string, filterTy
 				AND cr.status = 1 AND app.status IN ('В работе', 'Завершено')
 				AND CURRENT_DATE <= a.entry_date_to::date
 				ORDER BY a.entry_date_to DESC LIMIT 1
-			) as active_car_id`).
+			) as active_car_id,
+			(SELECT app.id FROM cars cr
+				JOIN attachments a ON cr.attachment_id = a.id
+				JOIN applications app ON a.application_id = app.id
+				WHERE LOWER(TRIM(cr.car_number)) = LOWER(TRIM(uc.number))
+				AND cr.status = 1 AND app.status IN ('В работе', 'Завершено')
+				AND CURRENT_DATE <= a.entry_date_to::date
+				ORDER BY a.entry_date_to DESC LIMIT 1
+			) as active_application_id`).
 		Joins("LEFT JOIN organizations o ON uc.organization_id = o.id").
 		Joins("LEFT JOIN companies c ON uc.company_id = c.id").
 		Joins("LEFT JOIN license_plate_formats lpf ON uc.format_id = lpf.id").

--- a/internal/services/unique_employee_service.go
+++ b/internal/services/unique_employee_service.go
@@ -91,6 +91,9 @@ type UniqueEmployeeWithRelations struct {
 	// не реестр). Нужен фронту, чтобы подтянуть территориальный статус сотрудника
 	// (current-status ключуется по employees.id, а не по unique_employees.id).
 	ActiveEmployeeID *int `json:"active_employee_id"`
+	// ActiveApplicationID -- id заявки (applications.id) той же активной заявки, что и
+	// прочие active_*-поля. Нужен фронту для кнопки "Открыть заявку" на вкладке Сотрудники.
+	ActiveApplicationID *int `json:"active_application_id"`
 }
 
 // NewUniqueEmployeeRequest -- тело запроса на создание/обновление сотрудника.
@@ -298,7 +301,15 @@ func (s *uniqueEmployeeService) GetAll(ctx context.Context, username string, fil
 				AND e.status = 1 AND app.status IN ('В работе', 'Завершено')
 				AND CURRENT_DATE <= a.entry_date_to::date
 				ORDER BY a.entry_date_to DESC LIMIT 1
-			) as active_employee_id`).
+			) as active_employee_id,
+			(SELECT app.id FROM employees e
+				JOIN attachments a ON e.attachment_id = a.id
+				JOIN applications app ON a.application_id = app.id
+				WHERE e.passport_series_number_hmac = ue.passport_series_number_hmac
+				AND e.status = 1 AND app.status IN ('В работе', 'Завершено')
+				AND CURRENT_DATE <= a.entry_date_to::date
+				ORDER BY a.entry_date_to DESC LIMIT 1
+			) as active_application_id`).
 		Joins("LEFT JOIN organizations o ON ue.organization_id = o.id").
 		Joins("LEFT JOIN companies c ON ue.company_id = c.id").
 		Joins("LEFT JOIN citizenships cit ON ue.citizenship_id = cit.id")


### PR DESCRIPTION
## Что (п.6 ТЗ #46, направление 2)

На вкладках "Автомобили" (CarsView) и "Сотрудники" (EmployeeView) в карточке детали не показывалась кнопка "Открыть заявку" - перехода из карточки в деталь заявки (поверх карточки) не было. Направление 1 (из заявки в карточку) уже работало; #589 (п.10) добавил места/статус, но кнопки на вкладки намеренно не выносил - это п.6.

Корень: реестр `/unique-cars` и `/unique-employees` отдавал поля активной заявки (`active_app_org_name`, даты), но не её `id` - кнопке нечего было эмитить в `open-application`.

## Изменения

- **BE** (`unique_car_service.go`, `unique_employee_service.go`): добавлен коррелированный подзапрос `active_application_id` (id той же активной заявки, что и прочие `active_*`-поля; идентичный predicate и `ORDER BY entry_date_to DESC LIMIT 1` - рассинхрон "показываем A, открываем B" исключён) + поле в структуры ответа.
- **FE** (`CarsView.vue`, `EmployeeView.vue`): проброс `applicationId: active_application_id` в объект карточки.
- **FE** (`VehicleDetailsModal.vue`): кнопка "Открыть заявку" развязана от `showCarFeatures` (computed `canOpenApplication`, гейт по наличию заявки - как уже было у `EmployeeDetailsModal`); `visibleActionsCount`/`modalTitle` синхронизированы.

Кнопка не зажглась там, где не должна, и не погасла где работала: Центр (FactTable/CarsTable, applicationId есть), Trash, ApplicationDetail (`source=application`), ЧС (`source=blacklist`), create-flow (нет applicationId) - проверено.

## Тесты

- `TestUniqueCars_ActiveCarIDForActiveApplication` расширен проверкой `active_application_id` (= id активной заявки; nil без активной).
- Добавлен `TestUniqueEmployees_ActiveApplicationIDForActiveApplication` (зеркально, seed по `passport_series_number_hmac`).
- Скоуп `go test ./internal/handlers -run 'TestUniqueCars|TestUniqueEmployees'` зелёный.

## Ревью

`code-reviewer`: GO, блокеров нет. Один yellow поправлен (сжат комментарий до WHY). Дублирование подзапросов (8 шт. одной формы) и misnomer `activateCarViaApp` в тесте - pre-existing/приемлемо, рефактор через LATERAL/CTE - отдельной задачей.

## Swagger

Не регенерён: `swag init` падает на пред-существующей ошибке (`models.HTTPError`), CI свежесть не валидит (как в #589). Поле аддитивное.