### PR TITLE
fix(create-application): серый замок-гейт поверх формы и списка вложения (#46)

### DIFF
--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -248,7 +248,7 @@
               @item-updated="handleItemUpdated"
               @edit-cancelled="handleItemEditCancelled"
             />
-            <ItemsList 
+            <ItemsList
               :items="sortedItems"
               :sort-field="sortField"
               :sort-direction="sortDirection"
@@ -257,6 +257,55 @@
               @delete-item="deleteItem"
             />
           </template>
+
+          <!-- Серый замок-гейт поверх формы И списка, пока не заполнены основные поля вложения -->
+          <div
+            v-if="!currentAttachmentReady"
+            class="form__data-lock"
+          >
+            <div
+              class="form__data-lock-target"
+              tabindex="0"
+            >
+              <svg
+                width="38"
+                height="38"
+                viewBox="0 0 24 24"
+                fill="none"
+                aria-hidden="true"
+              >
+                <rect
+                  x="5"
+                  y="10.5"
+                  width="14"
+                  height="10"
+                  rx="2.5"
+                  fill="#1a1a1a"
+                />
+                <path
+                  d="M8 10.5V7.5a4 4 0 0 1 8 0v3"
+                  stroke="#1a1a1a"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                />
+                <circle
+                  cx="12"
+                  cy="14.5"
+                  r="1.5"
+                  fill="#fff"
+                />
+                <rect
+                  x="11.25"
+                  y="15"
+                  width="1.5"
+                  height="3"
+                  rx="0.75"
+                  fill="#fff"
+                />
+              </svg>
+              <span class="form__data-lock-hint">сначала заполните основные поля заявки выше</span>
+            </div>
+          </div>
         </div>
       </div>
             
@@ -2382,6 +2431,53 @@ export default {
 
     .form__data {
         display: flex;
+        position: relative;
+    }
+
+    /* Серый замок-гейт: накрывает форму и список вложения, пока не заполнены основные поля */
+    .form__data-lock {
+        position: absolute;
+        inset: 0;
+        z-index: 5;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: rgba(244, 245, 248, 0.5);
+    }
+
+    .form__data-lock-target {
+        position: relative;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        cursor: help;
+        outline: none;
+    }
+
+    /* Подсказка под замком - только по наведению/фокусу */
+    .form__data-lock-hint {
+        position: absolute;
+        top: calc(100% + 10px);
+        left: 50%;
+        transform: translateX(-50%) translateY(4px);
+        white-space: nowrap;
+        background: #fff;
+        color: #333;
+        font-size: 12px;
+        font-weight: 500;
+        padding: 7px 12px;
+        border-radius: 10px;
+        border: 1px solid #e6e6e6;
+        box-shadow: 0 4px 14px rgba(0, 0, 0, 0.1);
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.18s ease, transform 0.18s ease;
+    }
+
+    .form__data-lock-target:hover .form__data-lock-hint,
+    .form__data-lock-target:focus-visible .form__data-lock-hint {
+        opacity: 1;
+        transform: translateX(-50%) translateY(0);
     }
 
     .blue {

--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -258,9 +258,9 @@
             />
           </template>
 
-          <!-- Серый замок-гейт поверх формы И списка, пока не заполнены основные поля вложения -->
+          <!-- Гейт на уровне form__data: накрывает и форму, и список (в самих формах его нет) -->
           <div
-            v-if="!currentAttachmentReady"
+            v-if="selectedAttachment && !currentAttachmentReady"
             class="form__data-lock"
           >
             <div
@@ -2434,7 +2434,7 @@ export default {
         position: relative;
     }
 
-    /* Серый замок-гейт: накрывает форму и список вложения, пока не заполнены основные поля */
+    /* Гейт на уровне form__data - один оверлей и на форму, и на список */
     .form__data-lock {
         position: absolute;
         inset: 0;

--- a/frontend/src/components/CreateApplication/EmployeeForm.vue
+++ b/frontend/src/components/CreateApplication/EmployeeForm.vue
@@ -4,12 +4,6 @@
     :class="{ 'data__completion--locked': disabled }"
     :inert="disabled ? '' : undefined"
   >
-    <div
-      v-if="disabled"
-      class="completion__lock"
-    >
-      <span>Сначала заполните обязательные поля вложения</span>
-    </div>
     <div class="completion__header">
       <h3>Новый сотрудник</h3>
       <button
@@ -1184,26 +1178,6 @@ export default {
 
 .data__completion--locked {
     position: relative;
-}
-
-.completion__lock {
-    position: absolute;
-    inset: 0;
-    z-index: 3;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    text-align: center;
-    padding: 24px;
-    background: rgba(244, 245, 248, 0.7);
-}
-
-.completion__lock span {
-    max-width: 240px;
-    font-size: 13px;
-    font-weight: 600;
-    line-height: 1.4;
-    color: #8a8f9a;
 }
 
 .completion__citizenship {

--- a/frontend/src/components/CreateApplication/ItemsForm.vue
+++ b/frontend/src/components/CreateApplication/ItemsForm.vue
@@ -4,12 +4,6 @@
     :class="{ 'data__completion--locked': disabled }"
     :inert="disabled ? '' : undefined"
   >
-    <div
-      v-if="disabled"
-      class="completion__lock"
-    >
-      <span>Сначала заполните обязательные поля вложения</span>
-    </div>
     <div class="completion__header">
       <h3>Новые ТМЦ</h3>
       <div class="completion__actions">
@@ -362,26 +356,6 @@ export default {
 
 .data__completion--locked {
     position: relative;
-}
-
-.completion__lock {
-    position: absolute;
-    inset: 0;
-    z-index: 3;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    text-align: center;
-    padding: 24px;
-    background: rgba(244, 245, 248, 0.7);
-}
-
-.completion__lock span {
-    max-width: 240px;
-    font-size: 13px;
-    font-weight: 600;
-    line-height: 1.4;
-    color: #8a8f9a;
 }
 
 .completion__header {

--- a/frontend/src/components/CreateApplication/VehicleForm.vue
+++ b/frontend/src/components/CreateApplication/VehicleForm.vue
@@ -4,12 +4,6 @@
     :class="{ 'data__completion--locked': disabled }"
     :inert="disabled ? '' : undefined"
   >
-    <div
-      v-if="disabled"
-      class="completion__lock"
-    >
-      <span>Сначала заполните обязательные поля вложения</span>
-    </div>
     <div class="completion__header">
       <h3>Добавление Т/С</h3>
       <button
@@ -1068,26 +1062,6 @@ export default {
 
 .data__completion--locked {
     position: relative;
-}
-
-.completion__lock {
-    position: absolute;
-    inset: 0;
-    z-index: 3;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    text-align: center;
-    padding: 24px;
-    background: rgba(244, 245, 248, 0.7);
-}
-
-.completion__lock span {
-    max-width: 240px;
-    font-size: 13px;
-    font-weight: 600;
-    line-height: 1.4;
-    color: #8a8f9a;
 }
 
 .completion__format {

--- a/frontend/src/components/CreateApplication/__tests__/FormGateDisabled.spec.js
+++ b/frontend/src/components/CreateApplication/__tests__/FormGateDisabled.spec.js
@@ -7,7 +7,8 @@ import ItemsForm from '../ItemsForm.vue';
 
 // п.36: формы добавления (авто/сотрудник/ТМЦ) недоступны, пока не заполнены
 // обязательные поля вложения. CreateApplication отдаёт это через prop `disabled`:
-// форма получает класс-замок, атрибут inert и оверлей-плашку с подсказкой.
+// форма получает класс-замок и атрибут inert (барьер взаимодействия). Сам серый
+// оверлей с замком и подсказкой живёт уровнем выше - на form__data в CreateApplication.
 
 vi.mock('@/api/client', () => ({
   apiRequest: vi.fn().mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue([]) }),
@@ -43,21 +44,20 @@ beforeEach(() => {
 });
 
 describe('Гейт форм вложения (п.36)', () => {
-  it.each(FORMS)('%s: по умолчанию доступна - нет замка и inert', (_name, Form) => {
+  it.each(FORMS)('%s: по умолчанию доступна - нет класса-замка и inert', (_name, Form) => {
     const w = mount(Form);
     const root = w.find('.data__completion');
     expect(root.classes()).not.toContain('data__completion--locked');
     expect(root.attributes('inert')).toBeUndefined();
-    expect(w.find('.completion__lock').exists()).toBe(false);
   });
 
-  it.each(FORMS)('%s: disabled=true - замок, inert и плашка с подсказкой', (_name, Form) => {
+  it.each(FORMS)('%s: disabled=true - класс-замок и inert (барьер взаимодействия)', (_name, Form) => {
     const w = mount(Form, { props: { disabled: true } });
     const root = w.find('.data__completion');
     expect(root.classes()).toContain('data__completion--locked');
     expect(root.attributes('inert')).toBeDefined();
-    const lock = w.find('.completion__lock');
-    expect(lock.exists()).toBe(true);
-    expect(lock.text()).toContain('обязательные поля вложения');
+    // Визуальный замок и подсказка перенесены на form__data (CreateApplication) -
+    // внутри самой формы их больше нет.
+    expect(w.find('.completion__lock').exists()).toBe(false);
   });
 });


### PR DESCRIPTION
## Что (полировка гейта вложения, по п.36)

Текстовая плашка «Сначала заполните обязательные поля» висела только на форме и выглядела громоздко.

## Изменения
- Убран текст-замок из VehicleForm/EmployeeForm/ItemsForm (разметка + CSS `.completion__lock`). `:inert` на форме сохранён.
- Серый оверлей поднят на весь блок `form__data` (форма + список) в CreateApplication.vue: по центру чёрный замок (SVG), под ним по наведению/фокусу — подсказка «сначала заполните основные поля заявки выше» (цвет #333).
- Заливка светлее: `rgba(244,245,248,0.5)` вместо `0.7`.

Условие показа — `!currentAttachmentReady` (тот же гейт, что у форм).

## Проверка
CSS/layout-правка. Визуально проверяется на staging после деплоя (создание заявки → выбор вложения → незаполненные обязательные поля → серый замок поверх формы+списка, hover по замку → подсказка).