### PR TITLE
fix(create-application): видимая заливка гейт-замка + разделитель быстрого выбора (#46) [polish-r1]

### DIFF
--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -2442,7 +2442,11 @@ export default {
         display: flex;
         align-items: center;
         justify-content: center;
-        background: rgba(244, 245, 248, 0.5);
+        /* Светлый серый тон сам по себе сливался с фоном формы - frosted-blur
+           делает заблокированное состояние читаемым, оставаясь светлым. */
+        background: rgba(216, 220, 233, 0.62);
+        backdrop-filter: blur(2px);
+        -webkit-backdrop-filter: blur(2px);
     }
 
     .form__data-lock-target {

--- a/frontend/src/components/CreateApplication/DateRangeSection.vue
+++ b/frontend/src/components/CreateApplication/DateRangeSection.vue
@@ -1214,8 +1214,8 @@ export default {
 
 .qd-sep {
     height: 1px;
-    background: #f0f0f4;
-    margin: 3px 6px;
+    background: #e2e4ec;
+    margin: 4px 6px;
 }
 
 .qd-fade-enter-active,


### PR DESCRIPTION
## polish-r1 (фиксы по ship-check предыдущего раунда #591/#592)

Два тривиальных CSS-огреха, найденных при визуальной проверке на staging:

1. **Серый замок-гейт (#591):** заливка `rgba(244,245,248,0.5)` сливалась с фоном формы (#f9fafb) - оверлей был фактически невидим. Сделал тон заметнее (`rgba(216,220,233,0.62)`) и добавил `backdrop-filter: blur(2px)` - заблокированное состояние читается как frosted, оставаясь светлым.
2. **Разделитель в меню «Быстрый выбор» (#592):** `#f0f0f4` почти не виден на белом - заменил на `#e2e4ec`, отступ чуть больше.

Оба пункта остального ship-check прошли (замок по центру, подсказка #333 по hover, полные даты в меню, верные диапазоны, инпут не сдвинут). Это один раунд тривиальных правок -> батч допустим (polish-r1).