### PR TITLE
fix(create-application): заливка гейта #f5f5f59e, заглавная hint, выравнивание быстрого выбора (#46) [polish-r2]

### DIFF
--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -303,7 +303,7 @@
                   fill="#fff"
                 />
               </svg>
-              <span class="form__data-lock-hint">сначала заполните основные поля заявки выше</span>
+              <span class="form__data-lock-hint">Сначала заполните основные поля заявки выше</span>
             </div>
           </div>
         </div>
@@ -2442,9 +2442,8 @@ export default {
         display: flex;
         align-items: center;
         justify-content: center;
-        /* Светлый серый тон сам по себе сливался с фоном формы - frosted-blur
-           делает заблокированное состояние читаемым, оставаясь светлым. */
-        background: rgba(216, 220, 233, 0.62);
+        /* Светлая полупрозрачная заливка + лёгкое размытие - блок читается как заблокированный. */
+        background: #f5f5f59e;
         backdrop-filter: blur(2px);
         -webkit-backdrop-filter: blur(2px);
     }

--- a/frontend/src/components/CreateApplication/DateRangeSection.vue
+++ b/frontend/src/components/CreateApplication/DateRangeSection.vue
@@ -1124,21 +1124,25 @@ export default {
 
 /* Лейбл + компактный "Быстрый выбор" в одной строке - кнопки не сдвигают инпут вниз */
 .date__label-row {
+    position: relative;
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    gap: 8px;
 }
 
+/* Дропдаун вне потока: строка лейбла остаётся высотой лейбла -
+   инпуты даты совпадают по уровню с инпутами времени. */
 .qd-dropdown {
-    position: relative;
+    position: absolute;
+    top: 50%;
+    right: 0;
+    transform: translateY(-50%);
 }
 
 .qd-trigger {
     display: inline-flex;
     align-items: center;
     gap: 5px;
-    height: 26px;
+    height: 24px;
     padding: 0 10px;
     border-radius: 50px;
     border: 1px solid #cfd4ff;


### PR DESCRIPTION
## polish-r2 (фидбек пользователя)

1. **Заливка замка-гейта** → `#f5f5f59e` (CreateApplication.vue `.form__data-lock`).
2. **Подсказка замка** с заглавной буквы: «Сначала заполните основные поля заявки выше».
3. **«Быстрый выбор» не сдвигает «Дата действия»** (DateRangeSection.vue): дропдаун вынесен из потока (`position:absolute`, центрирован на строке лейбла), строка лейбла осталась высотой лейбла → инпуты даты теперь на одном уровне с инпутами времени. Высота триггера 26→24px (без наезда на инпут).

Выравнивание проверено локальным рендером (date+time инпуты по одной горизонтали). Остальное визуально проверится на staging.