### PR TITLE
fix(create-application): отступ кнопки "Быстрый выбор" от инпута даты (#46) [polish-r3]

### DIFF
--- a/frontend/src/components/CreateApplication/DateRangeSection.vue
+++ b/frontend/src/components/CreateApplication/DateRangeSection.vue
@@ -1110,7 +1110,9 @@ export default {
 .date__input {
     display: flex;
     flex-direction: column;
-    gap: 5px;
+    /* 9px (а не 5): "Быстрый выбор" вынесен из потока и свисает в этот зазор -
+       больший gap отодвигает кнопку от инпута. Одинаков для даты и времени -> уровни совпадают. */
+    gap: 9px;
     position: relative;
 }
 


### PR DESCRIPTION
После выноса дропдауна из потока (polish-r2) он встал вплотную к инпуту даты (зазор 1px на staging). Увеличил gap колонки `.date__input` с 5px до 9px: кнопка "Быстрый выбор" свисает в этот зазор, больший gap даёт ей отступ от инпута. gap общий для колонок даты и времени, поэтому инпуты остаются на одном уровне (top совпадает). Однострочная CSS-правка.