### PR TITLE
fix(create-application): меню "Быстрый выбор" поверх гейта и кнопок (#46) [polish-r4]

### DIFF
--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -2417,6 +2417,10 @@ export default {
         display: flex;
         gap: 50px;
         border-bottom: 1px solid #e6e6e6;
+        /* Поднимаем ряд дат над form__data: иначе выпадающее меню "Быстрый выбор"
+           (открывается вниз) уходит под серый гейт-оверлей и кнопки формы ниже. */
+        position: relative;
+        z-index: 1;
     }
 
     h4 {


### PR DESCRIPTION
Меню «Быстрый выбор» открывается вниз и попадало в область `.form__data` (форма+список с серым гейт-оверлеем z-5 и кнопками формы), который идёт ниже в DOM и перекрывал меню (разные stacking-контексты, z-index 1001 меню не помогал). Поднял ряд дат `.form__info-row` через `position:relative; z-index:1` выше `.form__data` -> меню рисуется поверх серого и кнопок. Воспроизводилось при незаполненных датах (форма залочена, гейт виден) - как раз когда меню и нужно.