### PR TITLE
feat(tables): фильтр "Компания" в таблицах (#46)

### DIFF
--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -490,6 +490,7 @@ export default {
     tableId: { type: Number, default: null },
     searchQuery: { type: String, default: '' },
     selectedOrganizationId: { type: [Number, String], default: null },
+    selectedCompanyId: { type: [Number, String], default: null },
     selectedUnloadingPlaceId: { type: [Number, String], default: null },
     dateRangeStart: { type: Date, default: null },
     dateRangeEnd: { type: Date, default: null },
@@ -558,6 +559,9 @@ export default {
       if (this.selectedOrganizationId) {
         filtered = filtered.filter(item => item.organization_id == this.selectedOrganizationId);
       }
+      if (this.selectedCompanyId) {
+        filtered = filtered.filter(item => item.company_id == this.selectedCompanyId);
+      }
       if (this.selectedUnloadingPlaceId) {
         filtered = filtered.filter(item => {
           const carId = item.id;
@@ -615,6 +619,7 @@ export default {
       return !!(
         this.searchQuery ||
         this.selectedOrganizationId ||
+        this.selectedCompanyId ||
         this.selectedUnloadingPlaceId ||
         this.selectedDate ||
         (this.dateRangeStart && this.dateRangeEnd)

--- a/frontend/src/components/FactTable.vue
+++ b/frontend/src/components/FactTable.vue
@@ -382,6 +382,7 @@ export default {
     tableData: { type: Object, default: null },
     searchQuery: { type: String, default: '' },
     selectedOrganizationId: { type: [Number, String], default: null },
+    selectedCompanyId: { type: [Number, String], default: null },
     selectedUnloadingPlaceId: { type: [Number, String], default: null },
     dateRangeStart: { type: Date, default: null },
     dateRangeEnd: { type: Date, default: null },
@@ -431,6 +432,9 @@ export default {
       }
       if (this.selectedOrganizationId) {
         filtered = filtered.filter(item => item.organization_id == this.selectedOrganizationId);
+      }
+      if (this.selectedCompanyId) {
+        filtered = filtered.filter(item => item.company_id == this.selectedCompanyId);
       }
       if (this.selectedUnloadingPlaceId && this.tableType === 'cars') {
         filtered = filtered.filter(item => {
@@ -495,6 +499,7 @@ export default {
       return !!(
         this.searchQuery ||
         this.selectedOrganizationId ||
+        this.selectedCompanyId ||
         (this.tableType === 'cars' && this.selectedUnloadingPlaceId) ||
         this.selectedDate ||
         (this.dateRangeStart && this.dateRangeEnd)

--- a/frontend/src/components/OrganizationFilter.vue
+++ b/frontend/src/components/OrganizationFilter.vue
@@ -42,15 +42,15 @@
           ref="listContainer"
           class="dropdown-list"
         >
-          <div 
+          <div
             class="dropdown-item"
             :class="{ 'dropdown-item--selected': !internalValue }"
-            @click="selectItem(null, 'Все организации')"
+            @click="selectItem(null, allLabel)"
           >
             <span
               class="item-text"
-              title="Все организации"
-            >Все организации</span>
+              :title="allLabel"
+            >{{ allLabel }}</span>
           </div>
                     
           <div 
@@ -90,6 +90,17 @@ export default {
         organizations: {
             type: Array,
             default: () => []
+        },
+        // Add-only пропсы, чтобы переиспользовать фильтр под другую сущность
+        // (например "Компания"), не плодя копию компонента. Дефолты сохраняют
+        // прежнее поведение фильтра организаций.
+        allLabel: {
+            type: String,
+            default: 'Все организации'
+        },
+        placeholderText: {
+            type: String,
+            default: 'Организация'
         }
     },
     emits: ['change', 'input'],
@@ -105,7 +116,7 @@ export default {
     computed: {
         displayText() {
             if (this.selectedName && this.selectedName.trim()) return this.selectedName;
-            return 'Организация';
+            return this.placeholderText;
         },
         
         filteredOrganizations() {

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -522,6 +522,10 @@ export default {
       type: [Number, String],
       default: null
     },
+    selectedCompanyId: {
+      type: [Number, String],
+      default: null
+    },
     selectedUnloadingPlace: {
       type: String,
       default: ''
@@ -610,6 +614,10 @@ export default {
         filtered = filtered.filter(item => item.organization_id == this.selectedOrganizationId);
       }
 
+      if (this.selectedCompanyId) {
+        filtered = filtered.filter(item => item.company_id == this.selectedCompanyId);
+      }
+
       if (this.selectedDate) {
         const selectedDateStr = this.selectedDate.toISOString().split('T')[0];
         filtered = filtered.filter(item => item.entry_date_to === selectedDateStr);
@@ -671,6 +679,7 @@ export default {
       return !!(
         this.searchQuery ||
         this.selectedOrganizationId ||
+        this.selectedCompanyId ||
         this.selectedDate ||
         (this.dateRangeStart && this.dateRangeEnd)
       );

--- a/frontend/src/components/TablesComponent.vue
+++ b/frontend/src/components/TablesComponent.vue
@@ -83,6 +83,17 @@
           @change="handleOrganizationChange"
         />
 
+        <!-- Компания через тот же компонент (reuse OrganizationFilter) -->
+        <OrganizationFilter
+          v-if="showOrganizationFilter"
+          ref="companyFilter"
+          v-model="selectedCompanyId"
+          :organizations="companies"
+          all-label="Все компании"
+          placeholder-text="Компания"
+          @change="handleCompanyChange"
+        />
+
         <!-- Место разгрузки через компонент -->
         <UnloadingPlaceFilter
           v-if="showUnloadingFilter"
@@ -143,7 +154,8 @@
           :table-id="tableData?.table?.id"
           :table-data="tableData"
           :search-query="searchQuery"
-          :selected-organization="selectedOrganizationName"
+          :selected-organization-id="selectedOrganizationId"
+          :selected-company-id="selectedCompanyId"
           :selected-unloading-place="selectedUnloadingPlaceName"
           :date-range-start="dateRangeStart"
           :date-range-end="dateRangeEnd"
@@ -173,6 +185,7 @@
         :table-id="tableData?.table?.id"
         :search-query="searchQuery"
         :selected-organization-id="selectedOrganizationId"
+        :selected-company-id="selectedCompanyId"
         :selected-unloading-place-id="selectedUnloadingPlaceId"
         :date-range-start="dateRangeStart"
         :date-range-end="dateRangeEnd"
@@ -182,12 +195,13 @@
         @refresh-data="refreshData"
         @open-application="handleOpenApplication"
       />
-            
+
       <PeopleTable
         v-if="tableType === 'people'"
         :table-name="tableSystemName"
         :search-query="searchQuery"
         :selected-organization-id="selectedOrganizationId"
+        :selected-company-id="selectedCompanyId"
         :selected-unloading-place-id="selectedUnloadingPlaceId"
         :date-range-start="dateRangeStart"
         :date-range-end="dateRangeEnd"
@@ -241,11 +255,14 @@ export default {
             searchQuery: '',
             selectedOrganizationId: null,
             selectedOrganizationName: '',
+            selectedCompanyId: null,
+            selectedCompanyName: '',
             selectedUnloadingPlaceId: null,
             selectedUnloadingPlaceName: '',
 
             organizations: [],
-            
+            companies: [],
+
             showInstruction: false,
             selectedDate: null,
             dateRangeStart: null,
@@ -300,8 +317,9 @@ export default {
         },
         
         hasActiveFilters() {
-            return !!this.searchQuery.trim() || 
-                   !!this.selectedOrganizationId || 
+            return !!this.searchQuery.trim() ||
+                   !!this.selectedOrganizationId ||
+                   !!this.selectedCompanyId ||
                    !!this.selectedUnloadingPlaceId ||
                    !!this.selectedDate ||
                    (this.dateRangeStart && this.dateRangeEnd);
@@ -369,8 +387,9 @@ export default {
                     const data = await response.json();
                     console.log('Table data received:', data);
                     this.tableData = data;
-                    
+
                     await this.fetchOrganizationsForTable();
+                    await this.fetchCompaniesForTable();
                 } else {
                     console.error('Table not found');
                     this.$router.push('/404');
@@ -398,12 +417,34 @@ export default {
             }
         },
 
+        async fetchCompaniesForTable() {
+            try {
+                const response = await apiRequest("/companies", {
+                    method: "GET",
+                });
+
+                if (response.ok) {
+                    this.companies = await response.json();
+                } else {
+                    console.error("Ошибка при загрузке компаний");
+                }
+            } catch (error) {
+                console.error("Ошибка сети при загрузке компаний:", error);
+            }
+        },
+
         handleOrganizationChange({ id, name }) {
             this.selectedOrganizationId = id;
             this.selectedOrganizationName = name;
             this.applyFilters();
         },
-        
+
+        handleCompanyChange({ id, name }) {
+            this.selectedCompanyId = id;
+            this.selectedCompanyName = name;
+            this.applyFilters();
+        },
+
         handleUnloadingPlaceChange({ id, name }) {
             this.selectedUnloadingPlaceId = id;
             this.selectedUnloadingPlaceName = name;
@@ -451,7 +492,11 @@ export default {
             if (this.$refs.organizationFilter && this.$refs.organizationFilter.reset) {
                 this.$refs.organizationFilter.reset();
             }
-            
+
+            if (this.$refs.companyFilter && this.$refs.companyFilter.reset) {
+                this.$refs.companyFilter.reset();
+            }
+
             if (this.$refs.unloadingPlaceFilter && this.$refs.unloadingPlaceFilter.reset) {
                 this.$refs.unloadingPlaceFilter.reset();
             }


### PR DESCRIPTION
Срез эпика 46-edits, п.31.

## Что
В Таблицах (view /table/:tableName) рядом с фильтром организации добавлен фильтр "Компания". Фильтрация клиентская по item.company_id в CarsTable/PeopleTable/FactTable - зеркалит существующий фильтр по organization_id, без бэка.

## Как
- OrganizationFilter переиспользован через add-only пропсы allLabel/placeholderText (дефолты сохраняют прежнее поведение; ApplicationsCenter использует его без изменений).
- TablesComponent: грузит /companies, прокидывает selectedCompanyId в Cars/People/Fact.
- Заодно починена мёртвая проводка в FactTable: туда отдавалось имя организации в несуществующий проп selected-organization вместо selected-organization-id - фильтр по организации на таблице по факту не работал. Теперь прокидываются selectedOrganizationId и selectedCompanyId.

## Проверено локально (vite + Playwright, бэкенд 8090)
- Тулбар без переполнения на 1440px: Поиск | Организация | Компания | Место разгрузки | Дата.
- Дропдаун "Компания": "Все компании" + список компаний из /companies, стиль идентичен фильтру организации.
- Функционально: 4 строки -> 2 после выбора "ИП Петров П.П.", все видимые строки соответствуют компании.
- eslint по 5 файлам: 0 ошибок.