### PR TITLE
feat(notifications): звуковое оповещение о новой заявке (#46)

### DIFF
--- a/frontend/src/components/AccountComponent.vue
+++ b/frontend/src/components/AccountComponent.vue
@@ -42,7 +42,7 @@
     <div class="dashboard-row">
       <!-- Блок заявок -->
       <div class="applications-wrapper">
-        <UserApplications 
+        <UserApplications
           :user-organization-id="userOrganizationId"
           :user-company-id="userCompanyId"
           :user-id="userId"
@@ -51,6 +51,67 @@
           class="dashboard-card-animated"
         />
       </div>
+
+      <!-- Настройки звука -->
+      <div class="sound-settings dashboard-card-animated">
+        <div class="sound-settings__header">
+          <h3 class="sound-settings__title">
+            Звук
+          </h3>
+          <label
+            class="sound-toggle"
+            :aria-label="soundStore.enabled ? 'Выключить звук' : 'Включить звук'"
+          >
+            <input
+              type="checkbox"
+              class="sound-toggle__input"
+              :checked="soundStore.enabled"
+              @change="soundStore.setEnabled($event.target.checked)"
+            >
+            <span class="sound-toggle__track" />
+          </label>
+        </div>
+
+        <template v-if="soundStore.enabled">
+          <div class="sound-settings__field">
+            <label class="sound-settings__label">Пресет</label>
+            <select
+              class="lk-select"
+              :value="soundStore.selectedPreset"
+              @change="soundStore.setPreset($event.target.value)"
+            >
+              <option
+                v-for="p in soundPresets"
+                :key="p.value"
+                :value="p.value"
+              >
+                {{ p.label }}
+              </option>
+            </select>
+          </div>
+
+          <div class="sound-settings__field">
+            <label class="sound-settings__label">Громкость {{ Math.round(soundStore.volume * 100) }}%</label>
+            <input
+              type="range"
+              class="sound-volume"
+              min="0"
+              max="1"
+              step="0.05"
+              :value="soundStore.volume"
+              @input="soundStore.setVolume($event.target.value)"
+            >
+          </div>
+
+          <button
+            type="button"
+            class="lk-button lk-button--ghost sound-settings__preview"
+            @click="previewSound"
+          >
+            Прослушать
+          </button>
+        </template>
+      </div>
     </div>
   </div>
 </template>
@@ -58,6 +119,8 @@
 <script>
 import { apiRequest } from '@/api/client'
 import { useAuthStore } from '@/stores/auth'
+import { useSoundStore } from '@/stores/sound'
+import { playPreset, SOUND_PRESETS } from '@/utils/notificationSound'
 import UserApplications from './UserApplications.vue';
 import UserProfileHeader from './UserProfileHeader.vue';
 import UserNotificationsInline from './UserNotificationsInline.vue';
@@ -71,9 +134,14 @@ export default {
     SkeletonTransition,
     SkeletonBlock,
   },
+  setup() {
+    const soundStore = useSoundStore()
+    return { soundStore }
+  },
   data() {
     return {
       loading: true,
+      soundPresets: SOUND_PRESETS,
       organization: "",
       company: "",
       username: "",
@@ -161,6 +229,10 @@ export default {
         this.loading = false;
       }
     },
+    previewSound() {
+      playPreset(this.soundStore.selectedPreset, this.soundStore.volume)
+    },
+
     updateUserData(userData) {
       this.organization = userData.organization || "";
       this.company = userData.company || "";
@@ -251,6 +323,107 @@ export default {
     opacity: 1;
     transform: translateY(0);
   }
+}
+
+/* Блок настроек звука */
+.sound-settings {
+  margin-top: 15px;
+  background: #fff;
+  border: 1px solid var(--color-border);
+  border-radius: 30px;
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  flex-shrink: 0;
+  animation-delay: 0.15s;
+}
+
+.sound-settings__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.sound-settings__title {
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0;
+  color: #1a1a1a;
+}
+
+/* Toggle-переключатель в стиле карточек ЛК */
+.sound-toggle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.sound-toggle__input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.sound-toggle__track {
+  display: inline-block;
+  width: 36px;
+  height: 20px;
+  background: var(--color-border);
+  border-radius: 999px;
+  transition: background 0.2s ease;
+  position: relative;
+}
+
+.sound-toggle__track::after {
+  content: '';
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 14px;
+  height: 14px;
+  background: #fff;
+  border-radius: 50%;
+  transition: transform 0.2s ease;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.15);
+}
+
+.sound-toggle__input:checked + .sound-toggle__track {
+  background: var(--color-primary);
+}
+
+.sound-toggle__input:checked + .sound-toggle__track::after {
+  transform: translateX(16px);
+}
+
+.sound-settings__field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sound-settings__label {
+  font-size: 12px;
+  color: var(--color-text-muted);
+  font-weight: 500;
+}
+
+.sound-volume {
+  width: 100%;
+  accent-color: var(--color-primary);
+  cursor: pointer;
+  height: 4px;
+  border-radius: 4px;
+}
+
+.sound-settings__preview {
+  align-self: flex-start;
+  font-size: 12px;
+  padding: 6px 16px;
 }
 
 /* Адаптивность */

--- a/frontend/src/components/NavMenu.vue
+++ b/frontend/src/components/NavMenu.vue
@@ -552,6 +552,8 @@ import { apiRequest } from '@/api/client'
 import { getUnreadCount } from '@/api/applications'
 import { useAuthStore } from '@/stores/auth'
 import { useUiStore } from '@/stores/ui'
+import { useSoundStore } from '@/stores/sound'
+import { playPreset } from '@/utils/notificationSound'
 import NavIcon from '@/components/icons/NavIcon.vue'
 
 export default {
@@ -563,7 +565,8 @@ export default {
     // Администрирования, uiStore - состояния рельса (пин/hide, персист).
     const authStore = useAuthStore()
     const uiStore = useUiStore()
-    return { authStore, uiStore }
+    const soundStore = useSoundStore()
+    return { authStore, uiStore, soundStore }
   },
   data() {
     return {
@@ -702,6 +705,11 @@ export default {
     },
   },
   watch: {
+    newApplicationsCount(newVal, oldVal) {
+      if (newVal > oldVal && this.soundStore.enabled) {
+        playPreset(this.soundStore.selectedPreset, this.soundStore.volume)
+      }
+    },
     // Закрываем drawer при переходе по пункту меню; покинули раздел Админки
     // (клик «РАБОТА»/кабинет) - закрываем колонку.
     '$route'() {

--- a/frontend/src/stores/sound.js
+++ b/frontend/src/stores/sound.js
@@ -1,0 +1,49 @@
+import { defineStore } from 'pinia'
+import { ref, watch } from 'vue'
+
+const STORAGE_KEY = 'sound-prefs'
+
+function loadPrefs() {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY)) || {}
+  } catch {
+    return {}
+  }
+}
+
+export const useSoundStore = defineStore('sound', () => {
+  const saved = loadPrefs()
+
+  const enabled = ref(saved.enabled ?? false)
+  const selectedPreset = ref(saved.selectedPreset ?? 'soft')
+  const volume = ref(typeof saved.volume === 'number' ? saved.volume : 0.6)
+
+  watch([enabled, selectedPreset, volume], ([en, preset, vol]) => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ enabled: en, selectedPreset: preset, volume: vol }))
+    } catch {
+      // localStorage недоступен (приватный режим) - персист best-effort, не критично.
+    }
+  })
+
+  function setEnabled(value) {
+    enabled.value = value
+  }
+
+  function setPreset(preset) {
+    selectedPreset.value = preset
+  }
+
+  function setVolume(value) {
+    volume.value = Math.max(0, Math.min(1, Number(value)))
+  }
+
+  return {
+    enabled,
+    selectedPreset,
+    volume,
+    setEnabled,
+    setPreset,
+    setVolume,
+  }
+})

--- a/frontend/src/utils/notificationSound.js
+++ b/frontend/src/utils/notificationSound.js
@@ -1,0 +1,94 @@
+/**
+ * Синтез коротких звуковых пресетов через Web Audio API.
+ * Не требует бинарных файлов — тоны генерируются программно.
+ *
+ * Autoplay-политика: первый AudioContext до user-gesture браузер может заблокировать.
+ * Ошибки намеренно подавляются (best-effort) — приложение не должно ломаться из-за звука.
+ */
+
+let _ctx = null
+
+function getAudioContext() {
+  if (!_ctx) {
+    try {
+      _ctx = new (window.AudioContext || window.webkitAudioContext)()
+    } catch {
+      return null
+    }
+  }
+  // Некоторые браузеры suspend'ят контекст до первого user-gesture
+  if (_ctx.state === 'suspended') {
+    _ctx.resume().catch(() => {})
+  }
+  return _ctx
+}
+
+/**
+ * Воспроизвести один тон заданной частоты и длительности.
+ * @param {AudioContext} ctx
+ * @param {number} freq - частота в Гц
+ * @param {number} startAt - время начала в секундах (ctx.currentTime-базированное)
+ * @param {number} duration - длительность тона в секундах
+ * @param {number} volume - громкость 0..1
+ * @param {'sine'|'triangle'} type - тип волны
+ */
+function playTone(ctx, freq, startAt, duration, volume, type = 'sine') {
+  const osc = ctx.createOscillator()
+  const gain = ctx.createGain()
+
+  osc.connect(gain)
+  gain.connect(ctx.destination)
+
+  osc.type = type
+  osc.frequency.setValueAtTime(freq, startAt)
+
+  gain.gain.setValueAtTime(0, startAt)
+  gain.gain.linearRampToValueAtTime(volume, startAt + 0.01)
+  gain.gain.exponentialRampToValueAtTime(0.001, startAt + duration)
+
+  osc.start(startAt)
+  osc.stop(startAt + duration + 0.05)
+}
+
+const PRESETS = {
+  /** Один мягкий тон ~600 Гц */
+  soft(ctx, volume) {
+    const t = ctx.currentTime
+    playTone(ctx, 600, t, 0.4, volume, 'sine')
+  },
+
+  /** Два коротких бипа */
+  double(ctx, volume) {
+    const t = ctx.currentTime
+    playTone(ctx, 880, t, 0.15, volume, 'sine')
+    playTone(ctx, 880, t + 0.22, 0.15, volume, 'sine')
+  },
+
+  /** Высокий короткий «динь» */
+  ding(ctx, volume) {
+    const t = ctx.currentTime
+    playTone(ctx, 1320, t, 0.3, volume, 'triangle')
+  },
+}
+
+/**
+ * Воспроизвести пресет.
+ * @param {'soft'|'double'|'ding'} preset
+ * @param {number} volume - 0..1
+ */
+export function playPreset(preset, volume) {
+  try {
+    const ctx = getAudioContext()
+    if (!ctx) return
+    const fn = PRESETS[preset] || PRESETS.soft
+    fn(ctx, Math.max(0, Math.min(1, volume)))
+  } catch {
+    // autoplay-блок или нет Web Audio — не критично
+  }
+}
+
+export const SOUND_PRESETS = [
+  { value: 'soft',   label: 'Мягкий' },
+  { value: 'double', label: 'Двойной' },
+  { value: 'ding',   label: 'Динь' },
+]


### PR DESCRIPTION
## Что сделано

Звуковое уведомление при появлении новой заявки (п.4 эпика #46), FE-only без бэкенда и бинарных файлов.

**Новые файлы:**
- `frontend/src/utils/notificationSound.js` - синтез тонов через Web Audio API, 3 пресета: Мягкий (600 Гц), Двойной (два бипа 880 Гц), Динь (1320 Гц, треугольная волна)
- `frontend/src/stores/sound.js` - Pinia store с персистом в localStorage: `enabled`, `selectedPreset`, `volume`

**Изменённые файлы:**
- `NavMenu.vue` - watch `newApplicationsCount(newVal, oldVal)`: при росте и `soundStore.enabled` вызывает `playPreset`
- `AccountComponent.vue` - секция "Звук" в ЛК: toggle вкл/выкл, select пресета, range громкости, кнопка "Прослушать"

## Что проверить

1. Открыть личный кабинет - внизу dashboard появился блок "Звук"
2. Включить переключатель - должны появиться поле пресета, ползунок громкости и кнопка "Прослушать"
3. Нажать "Прослушать" - должен сыграть выбранный тон
4. Сменить пресет / громкость, снова нажать "Прослушать" - звук меняется
5. Перезагрузить страницу - настройки сохранились (localStorage)
6. Когда приходит новая заявка (поллинг раз в 30 сек) и звук включён - воспроизводится тон

Autoplay-блок браузера: первый тон без user-gesture может не сыграть - это ожидаемое поведение (try/catch), кнопка "Прослушать" после любого клика работает гарантированно.