### PR TITLE
feat(history): разрез по датам в истории - часть 2 (#46)

### DIFF
--- a/frontend/src/components/ApplicationDetail/ApplicationHistory.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationHistory.vue
@@ -125,83 +125,91 @@
               v-else
               class="history-timeline"
             >
-              <div 
-                v-for="(item, index) in filteredHistory" 
-                :key="item.id" 
-                class="history-item"
+              <template
+                v-for="group in historyGroupedByDate"
+                :key="group.date"
               >
+                <div class="history-date-separator">
+                  {{ group.date }}
+                </div>
                 <div
-                  class="timeline-dot"
-                  :class="getActionClass(item.action_type)"
-                />
-                <div
-                  v-if="index < filteredHistory.length - 1"
-                  class="timeline-line"
-                />
-                            
-                <div class="history-content">
-                  <div class="history-header">
-                    <!-- Для системных действий показываем "Система" -->
-                    <span
-                      v-if="item.action_type === 'confirmation_change' || item.action_type === 'status_change' || !item.user_id"
-                      class="user-name system-name"
+                  v-for="(item, i) in group.items"
+                  :key="item.id"
+                  class="history-item"
+                >
+                  <div
+                    class="timeline-dot"
+                    :class="getActionClass(item.action_type)"
+                  />
+                  <div
+                    v-if="i < group.items.length - 1"
+                    class="timeline-line"
+                  />
+
+                  <div class="history-content">
+                    <div class="history-header">
+                      <!-- Для системных действий показываем "Система" -->
+                      <span
+                        v-if="item.action_type === 'confirmation_change' || item.action_type === 'status_change' || !item.user_id"
+                        class="user-name system-name"
+                      >
+                        Система
+                      </span>
+                      <span
+                        v-else
+                        class="user-name"
+                      >{{ item.user_name }}</span>
+                      <span class="action-time">{{ formatTime(item.created_at) }}</span>
+                    </div>
+
+                    <div class="action-text">
+                      {{ getActionText(item) }}
+                    </div>
+
+                    <!-- Для пересылки показываем дополнительную информацию -->
+                    <div
+                      v-if="item.action_type === 'assigned_responsible' && item.metadata?.forwarded_by"
+                      class="forward-info"
                     >
-                      Система
-                    </span>
-                    <span
-                      v-else
-                      class="user-name"
-                    >{{ item.user_name }}</span>
-                    <span class="action-time">{{ formatTime(item.created_at) }}</span>
-                  </div>
-                                
-                  <div class="action-text">
-                    {{ getActionText(item) }}
-                  </div>
-                                
-                  <!-- Для пересылки показываем дополнительную информацию -->
-                  <div
-                    v-if="item.action_type === 'assigned_responsible' && item.metadata?.forwarded_by"
-                    class="forward-info"
-                  >
-                    Переслано пользователем {{ item.metadata.forwarded_by }}
-                  </div>
-                                
-                  <!-- Для просмотра показываем дополнительную информацию -->
-                  <div
-                    v-if="item.action_type === 'assigned_viewer' && item.metadata?.forwarded_by"
-                    class="forward-info"
-                  >
-                    Переслано пользователем {{ item.metadata.forwarded_by }}
-                  </div>
-                                
-                  <!-- Бейдж обязательного согласования -->
-                  <div
-                    v-if="item.metadata?.required_approval"
-                    class="required-badge"
-                  >
-                    Обязательно
-                  </div>
-                                
-                  <!-- Статус изменения -->
-                  <div
-                    v-if="item.old_value && item.new_value && item.old_value !== item.new_value"
-                    class="status-change"
-                  >
-                    <span class="old-status">{{ item.old_value }}</span>
-                    <span class="arrow">→</span>
-                    <span class="new-status">{{ item.new_value }}</span>
-                  </div>
-                                
-                  <!-- Комментарий (если есть) -->
-                  <div
-                    v-if="item.comment && item.action_type !== 'revoke_approval'"
-                    class="action-comment"
-                  >
-                    {{ item.comment }}
+                      Переслано пользователем {{ item.metadata.forwarded_by }}
+                    </div>
+
+                    <!-- Для просмотра показываем дополнительную информацию -->
+                    <div
+                      v-if="item.action_type === 'assigned_viewer' && item.metadata?.forwarded_by"
+                      class="forward-info"
+                    >
+                      Переслано пользователем {{ item.metadata.forwarded_by }}
+                    </div>
+
+                    <!-- Бейдж обязательного согласования -->
+                    <div
+                      v-if="item.metadata?.required_approval"
+                      class="required-badge"
+                    >
+                      Обязательно
+                    </div>
+
+                    <!-- Статус изменения -->
+                    <div
+                      v-if="item.old_value && item.new_value && item.old_value !== item.new_value"
+                      class="status-change"
+                    >
+                      <span class="old-status">{{ item.old_value }}</span>
+                      <span class="arrow">→</span>
+                      <span class="new-status">{{ item.new_value }}</span>
+                    </div>
+
+                    <!-- Комментарий (если есть) -->
+                    <div
+                      v-if="item.comment && item.action_type !== 'revoke_approval'"
+                      class="action-comment"
+                    >
+                      {{ item.comment }}
+                    </div>
                   </div>
                 </div>
-              </div>
+              </template>
             </div>
           </div>
         </div>
@@ -310,6 +318,23 @@ export default {
                     return timeA - timeB;
                 }
             });
+        },
+
+        historyGroupedByDate() {
+            const groups = [];
+            const seen = new Map();
+            this.filteredHistory.forEach((item) => {
+                const date = new Date(item.created_at).toLocaleDateString('ru-RU', {
+                    day: 'numeric', month: 'long', year: 'numeric',
+                });
+                if (!seen.has(date)) {
+                    const group = { date, items: [] };
+                    groups.push(group);
+                    seen.set(date, group);
+                }
+                seen.get(date).items.push(item);
+            });
+            return groups;
         },
 
         // Данные для экспорта в формате таблицы
@@ -1034,6 +1059,17 @@ export default {
 
 .history-timeline {
     position: relative;
+}
+
+.history-date-separator {
+    font-size: 11px;
+    font-weight: 600;
+    color: #a2a2a2;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 8px 0 4px;
+    margin-bottom: 4px;
+    border-bottom: 1px solid #f0f0f0;
 }
 
 .history-item {

--- a/frontend/src/components/CitizenshipHistoryModal.vue
+++ b/frontend/src/components/CitizenshipHistoryModal.vue
@@ -150,52 +150,60 @@
               v-else
               class="history-timeline"
             >
-              <div
-                v-for="(item, index) in displayHistory"
-                :key="item.id"
-                class="history-item"
+              <template
+                v-for="group in historyGroupedByDate"
+                :key="group.date"
               >
+                <div class="history-date-separator">
+                  {{ group.date }}
+                </div>
                 <div
-                  class="timeline-dot"
-                  :class="getActionClass(item.action_type)"
-                />
-                <div
-                  v-if="index < displayHistory.length - 1"
-                  class="timeline-line"
-                />
-
-                <div class="history-content">
-                  <div class="history-header">
-                    <span class="user-name">{{ item.actor_name || 'Система' }}</span>
-                    <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
-                  </div>
-
-                  <div class="action-text">
-                    {{ getActionText(item) }}
-                  </div>
-
+                  v-for="(item, i) in group.items"
+                  :key="item.id"
+                  class="history-item"
+                >
                   <div
-                    v-if="item.changes.length"
-                    class="change-list"
-                  >
+                    class="timeline-dot"
+                    :class="getActionClass(item.action_type)"
+                  />
+                  <div
+                    v-if="i < group.items.length - 1"
+                    class="timeline-line"
+                  />
+
+                  <div class="history-content">
+                    <div class="history-header">
+                      <span class="user-name">{{ item.actor_name || 'Система' }}</span>
+                      <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                    </div>
+
+                    <div class="action-text">
+                      {{ getActionText(item) }}
+                    </div>
+
                     <div
-                      v-for="(change, ci) in item.changes"
-                      :key="ci"
-                      class="change-row"
+                      v-if="item.changes.length"
+                      class="change-list"
                     >
-                      <span class="change-label">{{ change.label }}:</span>
-                      <template v-if="change.kind === 'single'">
-                        <span class="change-new">{{ change.value }}</span>
-                      </template>
-                      <template v-else>
-                        <span class="change-old">{{ change.old }}</span>
-                        <span class="change-arrow">→</span>
-                        <span class="change-new">{{ change.new }}</span>
-                      </template>
+                      <div
+                        v-for="(change, ci) in item.changes"
+                        :key="ci"
+                        class="change-row"
+                      >
+                        <span class="change-label">{{ change.label }}:</span>
+                        <template v-if="change.kind === 'single'">
+                          <span class="change-new">{{ change.value }}</span>
+                        </template>
+                        <template v-else>
+                          <span class="change-old">{{ change.old }}</span>
+                          <span class="change-arrow">→</span>
+                          <span class="change-new">{{ change.new }}</span>
+                        </template>
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
+              </template>
             </div>
           </div>
         </div>
@@ -335,6 +343,23 @@ export default {
     // шаблоне дважды на item (v-if + v-for).
     displayHistory() {
       return this.filteredHistory.map((item) => ({ ...item, changes: this.getChanges(item) }));
+    },
+
+    historyGroupedByDate() {
+      const groups = [];
+      const seen = new Map();
+      this.displayHistory.forEach((item) => {
+        const date = new Date(item.created_at).toLocaleDateString('ru-RU', {
+          day: 'numeric', month: 'long', year: 'numeric',
+        });
+        if (!seen.has(date)) {
+          const group = { date, items: [] };
+          groups.push(group);
+          seen.set(date, group);
+        }
+        seen.get(date).items.push(item);
+      });
+      return groups;
     },
 
     formattedCurrentDateTime() {
@@ -926,6 +951,17 @@ export default {
   position: relative;
   padding-left: 20px;
   min-height: 100px;
+}
+
+.history-date-separator {
+  font-size: 11px;
+  font-weight: 600;
+  color: #a2a2a2;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 8px 0 4px;
+  margin-bottom: 4px;
+  border-bottom: 1px solid #f0f0f0;
 }
 
 .history-item {

--- a/frontend/src/components/LicensePlateFormatHistoryModal.vue
+++ b/frontend/src/components/LicensePlateFormatHistoryModal.vue
@@ -150,52 +150,60 @@
               v-else
               class="history-timeline"
             >
-              <div
-                v-for="(item, index) in displayHistory"
-                :key="item.id"
-                class="history-item"
+              <template
+                v-for="group in historyGroupedByDate"
+                :key="group.date"
               >
+                <div class="history-date-separator">
+                  {{ group.date }}
+                </div>
                 <div
-                  class="timeline-dot"
-                  :class="getActionClass(item.action_type)"
-                />
-                <div
-                  v-if="index < displayHistory.length - 1"
-                  class="timeline-line"
-                />
-
-                <div class="history-content">
-                  <div class="history-header">
-                    <span class="user-name">{{ item.actor_name || 'Система' }}</span>
-                    <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
-                  </div>
-
-                  <div class="action-text">
-                    {{ getActionText(item) }}
-                  </div>
-
+                  v-for="(item, i) in group.items"
+                  :key="item.id"
+                  class="history-item"
+                >
                   <div
-                    v-if="item.changes.length"
-                    class="change-list"
-                  >
+                    class="timeline-dot"
+                    :class="getActionClass(item.action_type)"
+                  />
+                  <div
+                    v-if="i < group.items.length - 1"
+                    class="timeline-line"
+                  />
+
+                  <div class="history-content">
+                    <div class="history-header">
+                      <span class="user-name">{{ item.actor_name || 'Система' }}</span>
+                      <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                    </div>
+
+                    <div class="action-text">
+                      {{ getActionText(item) }}
+                    </div>
+
                     <div
-                      v-for="(change, ci) in item.changes"
-                      :key="ci"
-                      class="change-row"
+                      v-if="item.changes.length"
+                      class="change-list"
                     >
-                      <span class="change-label">{{ change.label }}:</span>
-                      <template v-if="change.kind === 'single'">
-                        <span class="change-new">{{ change.value }}</span>
-                      </template>
-                      <template v-else>
-                        <span class="change-old">{{ change.old }}</span>
-                        <span class="change-arrow">→</span>
-                        <span class="change-new">{{ change.new }}</span>
-                      </template>
+                      <div
+                        v-for="(change, ci) in item.changes"
+                        :key="ci"
+                        class="change-row"
+                      >
+                        <span class="change-label">{{ change.label }}:</span>
+                        <template v-if="change.kind === 'single'">
+                          <span class="change-new">{{ change.value }}</span>
+                        </template>
+                        <template v-else>
+                          <span class="change-old">{{ change.old }}</span>
+                          <span class="change-arrow">→</span>
+                          <span class="change-new">{{ change.new }}</span>
+                        </template>
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
+              </template>
             </div>
           </div>
         </div>
@@ -363,6 +371,23 @@ export default {
     // шаблоне дважды на item (v-if + v-for).
     displayHistory() {
       return this.filteredHistory.map((item) => ({ ...item, changes: this.getChanges(item) }));
+    },
+
+    historyGroupedByDate() {
+      const groups = [];
+      const seen = new Map();
+      this.displayHistory.forEach((item) => {
+        const date = new Date(item.created_at).toLocaleDateString('ru-RU', {
+          day: 'numeric', month: 'long', year: 'numeric',
+        });
+        if (!seen.has(date)) {
+          const group = { date, items: [] };
+          groups.push(group);
+          seen.set(date, group);
+        }
+        seen.get(date).items.push(item);
+      });
+      return groups;
     },
 
     formattedCurrentDateTime() {
@@ -960,6 +985,17 @@ export default {
   position: relative;
   padding-left: 20px;
   min-height: 100px;
+}
+
+.history-date-separator {
+  font-size: 11px;
+  font-weight: 600;
+  color: #a2a2a2;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 8px 0 4px;
+  margin-bottom: 4px;
+  border-bottom: 1px solid #f0f0f0;
 }
 
 .history-item {

--- a/frontend/src/components/UniqueAttachmentHistoryModal.vue
+++ b/frontend/src/components/UniqueAttachmentHistoryModal.vue
@@ -150,52 +150,60 @@
               v-else
               class="history-timeline"
             >
-              <div
-                v-for="(item, index) in displayHistory"
-                :key="item.id"
-                class="history-item"
+              <template
+                v-for="group in historyGroupedByDate"
+                :key="group.date"
               >
+                <div class="history-date-separator">
+                  {{ group.date }}
+                </div>
                 <div
-                  class="timeline-dot"
-                  :class="getActionClass(item.action_type)"
-                />
-                <div
-                  v-if="index < displayHistory.length - 1"
-                  class="timeline-line"
-                />
-
-                <div class="history-content">
-                  <div class="history-header">
-                    <span class="user-name">{{ item.actor_name || 'Система' }}</span>
-                    <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
-                  </div>
-
-                  <div class="action-text">
-                    {{ getActionText(item) }}
-                  </div>
-
+                  v-for="(item, i) in group.items"
+                  :key="item.id"
+                  class="history-item"
+                >
                   <div
-                    v-if="item.changes.length"
-                    class="change-list"
-                  >
+                    class="timeline-dot"
+                    :class="getActionClass(item.action_type)"
+                  />
+                  <div
+                    v-if="i < group.items.length - 1"
+                    class="timeline-line"
+                  />
+
+                  <div class="history-content">
+                    <div class="history-header">
+                      <span class="user-name">{{ item.actor_name || 'Система' }}</span>
+                      <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                    </div>
+
+                    <div class="action-text">
+                      {{ getActionText(item) }}
+                    </div>
+
                     <div
-                      v-for="(change, ci) in item.changes"
-                      :key="ci"
-                      class="change-row"
+                      v-if="item.changes.length"
+                      class="change-list"
                     >
-                      <span class="change-label">{{ change.label }}:</span>
-                      <template v-if="change.kind === 'single'">
-                        <span class="change-new">{{ change.value }}</span>
-                      </template>
-                      <template v-else>
-                        <span class="change-old">{{ change.old }}</span>
-                        <span class="change-arrow">→</span>
-                        <span class="change-new">{{ change.new }}</span>
-                      </template>
+                      <div
+                        v-for="(change, ci) in item.changes"
+                        :key="ci"
+                        class="change-row"
+                      >
+                        <span class="change-label">{{ change.label }}:</span>
+                        <template v-if="change.kind === 'single'">
+                          <span class="change-new">{{ change.value }}</span>
+                        </template>
+                        <template v-else>
+                          <span class="change-old">{{ change.old }}</span>
+                          <span class="change-arrow">→</span>
+                          <span class="change-new">{{ change.new }}</span>
+                        </template>
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
+              </template>
             </div>
           </div>
         </div>
@@ -341,6 +349,23 @@ export default {
     // шаблоне дважды на item (v-if + v-for).
     displayHistory() {
       return this.filteredHistory.map((item) => ({ ...item, changes: this.getChanges(item) }));
+    },
+
+    historyGroupedByDate() {
+      const groups = [];
+      const seen = new Map();
+      this.displayHistory.forEach((item) => {
+        const date = new Date(item.created_at).toLocaleDateString('ru-RU', {
+          day: 'numeric', month: 'long', year: 'numeric',
+        });
+        if (!seen.has(date)) {
+          const group = { date, items: [] };
+          groups.push(group);
+          seen.set(date, group);
+        }
+        seen.get(date).items.push(item);
+      });
+      return groups;
     },
 
     formattedCurrentDateTime() {
@@ -936,6 +961,17 @@ export default {
   position: relative;
   padding-left: 20px;
   min-height: 100px;
+}
+
+.history-date-separator {
+  font-size: 11px;
+  font-weight: 600;
+  color: #a2a2a2;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 8px 0 4px;
+  margin-bottom: 4px;
+  border-bottom: 1px solid #f0f0f0;
 }
 
 .history-item {

--- a/frontend/src/components/admin/blacklist/BlacklistHistoryModalBase.vue
+++ b/frontend/src/components/admin/blacklist/BlacklistHistoryModalBase.vue
@@ -143,69 +143,77 @@
             v-else
             class="history-timeline"
           >
-            <div
-              v-for="(item, index) in filteredHistory"
-              :key="item.id"
-              class="history-item"
+            <template
+              v-for="group in historyGroupedByDate"
+              :key="group.date"
             >
+              <div class="history-date-separator">
+                {{ group.date }}
+              </div>
               <div
-                class="timeline-dot"
-                :class="getActionClass(item.action_type)"
-              />
-              <div
-                v-if="index < filteredHistory.length - 1"
-                class="timeline-line"
-              />
-
-              <div class="history-content">
+                v-for="(item, i) in group.items"
+                :key="item.id"
+                class="history-item"
+              >
                 <div
-                  v-if="getEntityLabel(item)"
-                  class="history-entity"
-                >
-                  {{ getEntityLabel(item) }}
-                </div>
-
-                <div class="history-header">
-                  <span class="user-name">{{ item.user_name || 'Система' }}</span>
-                  <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
-                </div>
-
-                <div class="action-text">
-                  {{ getActionText(item) }}
-                </div>
-
+                  class="timeline-dot"
+                  :class="getActionClass(item.action_type)"
+                />
                 <div
-                  v-if="getReasonDiff(item)"
-                  class="action-diff"
-                >
-                  <span class="diff-old">{{ getReasonDiff(item).from }}</span>
-                  <svg
-                    class="diff-arrow"
-                    viewBox="0 0 24 24"
-                    width="16"
-                    height="16"
-                    aria-hidden="true"
+                  v-if="i < group.items.length - 1"
+                  class="timeline-line"
+                />
+
+                <div class="history-content">
+                  <div
+                    v-if="getEntityLabel(item)"
+                    class="history-entity"
                   >
-                    <path
-                      d="M4 12h14M13 6l6 6-6 6"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="2"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                  </svg>
-                  <span class="diff-new">{{ getReasonDiff(item).to }}</span>
-                </div>
+                    {{ getEntityLabel(item) }}
+                  </div>
 
-                <div
-                  v-else-if="getActionComment(item)"
-                  class="action-comment"
-                >
-                  {{ getActionComment(item) }}
+                  <div class="history-header">
+                    <span class="user-name">{{ item.user_name || 'Система' }}</span>
+                    <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                  </div>
+
+                  <div class="action-text">
+                    {{ getActionText(item) }}
+                  </div>
+
+                  <div
+                    v-if="getReasonDiff(item)"
+                    class="action-diff"
+                  >
+                    <span class="diff-old">{{ getReasonDiff(item).from }}</span>
+                    <svg
+                      class="diff-arrow"
+                      viewBox="0 0 24 24"
+                      width="16"
+                      height="16"
+                      aria-hidden="true"
+                    >
+                      <path
+                        d="M4 12h14M13 6l6 6-6 6"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                    <span class="diff-new">{{ getReasonDiff(item).to }}</span>
+                  </div>
+
+                  <div
+                    v-else-if="getActionComment(item)"
+                    class="action-comment"
+                  >
+                    {{ getActionComment(item) }}
+                  </div>
                 </div>
               </div>
-            </div>
+            </template>
           </div>
         </div>
       </div>
@@ -329,6 +337,23 @@ export default {
         const timeB = new Date(b.created_at).getTime();
         return this.sortOrder === 'desc' ? timeB - timeA : timeA - timeB;
       });
+    },
+
+    historyGroupedByDate() {
+      const groups = [];
+      const seen = new Map();
+      this.filteredHistory.forEach((item) => {
+        const date = new Date(item.created_at).toLocaleDateString('ru-RU', {
+          day: 'numeric', month: 'long', year: 'numeric',
+        });
+        if (!seen.has(date)) {
+          const group = { date, items: [] };
+          groups.push(group);
+          seen.set(date, group);
+        }
+        seen.get(date).items.push(item);
+      });
+      return groups;
     },
 
     formattedCurrentDateTime() {
@@ -911,6 +936,17 @@ export default {
   position: relative;
   padding-left: 20px;
   min-height: 100px;
+}
+
+.history-date-separator {
+  font-size: 11px;
+  font-weight: 600;
+  color: #a2a2a2;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 8px 0 4px;
+  margin-bottom: 4px;
+  border-bottom: 1px solid #f0f0f0;
 }
 
 .history-item {


### PR DESCRIPTION
## Что сделано

Разрез по датам в 5 компонентах истории (продолжение п.3 эпика #46).

**Компоненты с `displayHistory` (computed pre-fills changes):**
- `CitizenshipHistoryModal.vue`
- `LicensePlateFormatHistoryModal.vue`
- `UniqueAttachmentHistoryModal.vue`

**Компоненты с `filteredHistory` напрямую:**
- `ApplicationDetail/ApplicationHistory.vue`
- `admin/blacklist/BlacklistHistoryModalBase.vue` (покрывает PersonBlacklist + VehicleBlacklist)

## Как работает

Inline `historyGroupedByDate` computed в каждом компоненте: группирует исходный список в `[{ date, items }]`. Дата форматируется как «16 июня 2026 г.» через `toLocaleDateString('ru-RU', { day: 'numeric', month: 'long', year: 'numeric' })`.

В template плоский `v-for` заменён на `<template v-for="group">` + вложенный `v-for="(item, i) in group.items"`. Timeline-line привязана к `i < group.items.length - 1` (разрывается между датами).