### PR TITLE
feat(history): разрез по датам в истории (#46)

### DIFF
--- a/frontend/src/components/ApplicationApproverHistoryModal.vue
+++ b/frontend/src/components/ApplicationApproverHistoryModal.vue
@@ -150,38 +150,46 @@
               v-else
               class="history-timeline"
             >
-              <div
-                v-for="(item, index) in filteredHistory"
-                :key="item.id"
-                class="history-item"
+              <template
+                v-for="group in historyGroupedByDate"
+                :key="group.date"
               >
+                <div class="history-date-separator">
+                  {{ group.date }}
+                </div>
                 <div
-                  class="timeline-dot"
-                  :class="getActionClass(item.action_type)"
-                />
-                <div
-                  v-if="index < filteredHistory.length - 1"
-                  class="timeline-line"
-                />
-
-                <div class="history-content">
-                  <div class="history-header">
-                    <span class="user-name">{{ item.actor_name || 'Система' }}</span>
-                    <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
-                  </div>
-
-                  <div class="action-text">
-                    {{ getActionText(item) }}
-                  </div>
-
+                  v-for="(item, i) in group.items"
+                  :key="item.id"
+                  class="history-item"
+                >
                   <div
-                    v-if="item.approver_name"
-                    class="action-comment"
-                  >
-                    Принимающий: {{ item.approver_name }}
+                    class="timeline-dot"
+                    :class="getActionClass(item.action_type)"
+                  />
+                  <div
+                    v-if="i < group.items.length - 1"
+                    class="timeline-line"
+                  />
+
+                  <div class="history-content">
+                    <div class="history-header">
+                      <span class="user-name">{{ item.actor_name || 'Система' }}</span>
+                      <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                    </div>
+
+                    <div class="action-text">
+                      {{ getActionText(item) }}
+                    </div>
+
+                    <div
+                      v-if="item.approver_name"
+                      class="action-comment"
+                    >
+                      Принимающий: {{ item.approver_name }}
+                    </div>
                   </div>
                 </div>
-              </div>
+              </template>
             </div>
           </div>
         </div>
@@ -295,6 +303,22 @@ export default {
         const timeB = new Date(b.created_at).getTime();
         return this.sortOrder === 'desc' ? timeB - timeA : timeA - timeB;
       });
+    },
+
+    historyGroupedByDate() {
+      const groups = [];
+      const dateMap = new Map();
+      for (const item of this.filteredHistory) {
+        const dateKey = new Date(item.created_at).toLocaleDateString('ru-RU', {
+          day: 'numeric', month: 'long', year: 'numeric',
+        });
+        if (!dateMap.has(dateKey)) {
+          dateMap.set(dateKey, []);
+          groups.push({ date: dateKey, items: dateMap.get(dateKey) });
+        }
+        dateMap.get(dateKey).push(item);
+      }
+      return groups;
     },
 
     formattedCurrentDateTime() {
@@ -502,6 +526,16 @@ export default {
 </script>
 
 <style scoped>
+.history-date-separator {
+  font-size: 11px;
+  font-weight: 600;
+  color: #4F5BDF;
+  padding: 8px 0 4px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid #e6f0ff;
+  letter-spacing: 0.02em;
+}
+
 .modal-overlay {
   position: fixed;
   top: 0;

--- a/frontend/src/components/CarHistoryModal.vue
+++ b/frontend/src/components/CarHistoryModal.vue
@@ -151,72 +151,80 @@
               v-else
               class="history-timeline"
             >
-              <div 
-                v-for="(item, index) in filteredHistory" 
-                :key="item.id" 
-                class="history-item"
+              <template
+                v-for="group in historyGroupedByDate"
+                :key="group.date"
               >
+                <div class="history-date-separator">
+                  {{ group.date }}
+                </div>
                 <div
-                  class="timeline-dot"
-                  :class="getActionClass(item.action_type)"
-                />
-                <div
-                  v-if="index < filteredHistory.length - 1"
-                  class="timeline-line"
-                />
-            
-                <div
-                  class="history-content"
-                  :class="{ 'history-content--link': isApplicationLink(item) }"
-                  @click="handleHistoryClick(item)"
+                  v-for="(item, i) in group.items"
+                  :key="item.id"
+                  class="history-item"
                 >
-                  <div class="history-header">
-                    <span class="user-name">{{ item.user_name || 'Система' }}</span>
-                    <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
-                  </div>
-              
-                  <div class="action-text">
-                    {{ getActionText(item) }}
-                  </div>
-              
                   <div
-                    v-if="item.action_type === 'entry' || item.action_type === 'exit'"
-                    class="action-comment"
-                  >
-                    {{ getActionComment(item) }}
-                  </div>
-              
+                    class="timeline-dot"
+                    :class="getActionClass(item.action_type)"
+                  />
                   <div
-                    v-if="item.comment && item.action_type !== 'entry' && item.action_type !== 'exit'"
-                    class="action-comment"
-                  >
-                    {{ item.comment }}
-                  </div>
-              
+                    v-if="i < group.items.length - 1"
+                    class="timeline-line"
+                  />
+
                   <div
-                    v-if="item.old_value && item.new_value && item.old_value !== item.new_value"
-                    class="value-change"
+                    class="history-content"
+                    :class="{ 'history-content--link': isApplicationLink(item) }"
+                    @click="handleHistoryClick(item)"
                   >
-                    <span class="old-value">{{ item.old_value }}</span>
-                    <span class="arrow">→</span>
-                    <span class="new-value">{{ item.new_value }}</span>
-                  </div>
-              
-                  <div
-                    v-if="item.field_name"
-                    class="field-name"
-                  >
-                    Поле: {{ item.field_name }}
-                  </div>
-              
-                  <div
-                    v-if="item.table_name"
-                    class="place-name"
-                  >
-                    {{ item.table_name }}
+                    <div class="history-header">
+                      <span class="user-name">{{ item.user_name || 'Система' }}</span>
+                      <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                    </div>
+
+                    <div class="action-text">
+                      {{ getActionText(item) }}
+                    </div>
+
+                    <div
+                      v-if="item.action_type === 'entry' || item.action_type === 'exit'"
+                      class="action-comment"
+                    >
+                      {{ getActionComment(item) }}
+                    </div>
+
+                    <div
+                      v-if="item.comment && item.action_type !== 'entry' && item.action_type !== 'exit'"
+                      class="action-comment"
+                    >
+                      {{ item.comment }}
+                    </div>
+
+                    <div
+                      v-if="item.old_value && item.new_value && item.old_value !== item.new_value"
+                      class="value-change"
+                    >
+                      <span class="old-value">{{ item.old_value }}</span>
+                      <span class="arrow">→</span>
+                      <span class="new-value">{{ item.new_value }}</span>
+                    </div>
+
+                    <div
+                      v-if="item.field_name"
+                      class="field-name"
+                    >
+                      Поле: {{ item.field_name }}
+                    </div>
+
+                    <div
+                      v-if="item.table_name"
+                      class="place-name"
+                    >
+                      {{ item.table_name }}
+                    </div>
                   </div>
                 </div>
-              </div>
+              </template>
             </div>
           </div>
         </div>
@@ -365,6 +373,22 @@ export default {
         const timeB = new Date(b.created_at).getTime();
         return this.sortOrder === 'desc' ? timeB - timeA : timeA - timeB;
       });
+    },
+
+    historyGroupedByDate() {
+      const groups = [];
+      const dateMap = new Map();
+      for (const item of this.filteredHistory) {
+        const dateKey = new Date(item.created_at).toLocaleDateString('ru-RU', {
+          day: 'numeric', month: 'long', year: 'numeric',
+        });
+        if (!dateMap.has(dateKey)) {
+          dateMap.set(dateKey, []);
+          groups.push({ date: dateKey, items: dateMap.get(dateKey) });
+        }
+        dateMap.get(dateKey).push(item);
+      }
+      return groups;
     },
 
     exportData() {
@@ -770,6 +794,16 @@ export default {
 </script>
 
 <style scoped>
+.history-date-separator {
+  font-size: 11px;
+  font-weight: 600;
+  color: #4F5BDF;
+  padding: 8px 0 4px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid #e6f0ff;
+  letter-spacing: 0.02em;
+}
+
 .place-name {
   font-size: 11px;
   color: #4F5BDF;

--- a/frontend/src/components/CarsTableHistoryModal.vue
+++ b/frontend/src/components/CarsTableHistoryModal.vue
@@ -192,53 +192,61 @@
               v-else
               class="history-timeline"
             >
-              <div 
-                v-for="(item, index) in filteredHistory" 
-                :key="item.id" 
-                class="history-item"
+              <template
+                v-for="group in historyGroupedByDate"
+                :key="group.date"
               >
+                <div class="history-date-separator">
+                  {{ group.date }}
+                </div>
                 <div
-                  class="timeline-dot"
-                  :class="getActionClass(item.action_type)"
-                />
-                <div
-                  v-if="index < filteredHistory.length - 1"
-                  class="timeline-line"
-                />
-            
-                <div class="history-content">
-                  <div class="history-header">
-                    <span class="car-info">{{ getCarInfo(item) }}</span>
-                    <span class="user-name">{{ item.user_name || 'Система' }}</span>
-                    <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
-                  </div>
-              
-                  <div class="action-text">
-                    {{ getActionText(item) }}
-                  </div>
-              
+                  v-for="(item, i) in group.items"
+                  :key="item.id"
+                  class="history-item"
+                >
                   <div
-                    v-if="item.action_type === 'entry' || item.action_type === 'exit'"
-                    class="action-comment"
-                  >
-                    {{ getActionComment(item) }}
-                  </div>
-              
+                    class="timeline-dot"
+                    :class="getActionClass(item.action_type)"
+                  />
                   <div
-                    v-if="item.comment && item.action_type !== 'entry' && item.action_type !== 'exit'"
-                    class="action-comment"
-                  >
-                    {{ item.comment }}
-                  </div>
+                    v-if="i < group.items.length - 1"
+                    class="timeline-line"
+                  />
 
-                  <div
-                    v-if="item.table_name"
-                    class="place-name"
-                  >
-                    {{ item.table_name }}
+                  <div class="history-content">
+                    <div class="history-header">
+                      <span class="car-info">{{ getCarInfo(item) }}</span>
+                      <span class="user-name">{{ item.user_name || 'Система' }}</span>
+                      <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                    </div>
+
+                    <div class="action-text">
+                      {{ getActionText(item) }}
+                    </div>
+
+                    <div
+                      v-if="item.action_type === 'entry' || item.action_type === 'exit'"
+                      class="action-comment"
+                    >
+                      {{ getActionComment(item) }}
+                    </div>
+
+                    <div
+                      v-if="item.comment && item.action_type !== 'entry' && item.action_type !== 'exit'"
+                      class="action-comment"
+                    >
+                      {{ item.comment }}
+                    </div>
+
+                    <div
+                      v-if="item.table_name"
+                      class="place-name"
+                    >
+                      {{ item.table_name }}
+                    </div>
                   </div>
                 </div>
-              </div>
+              </template>
             </div>
           </div>
         </div>
@@ -372,6 +380,22 @@ export default {
         const timeB = new Date(b.created_at).getTime();
         return this.sortOrder === 'desc' ? timeB - timeA : timeA - timeB;
       });
+    },
+
+    historyGroupedByDate() {
+      const groups = [];
+      const dateMap = new Map();
+      for (const item of this.filteredHistory) {
+        const dateKey = new Date(item.created_at).toLocaleDateString('ru-RU', {
+          day: 'numeric', month: 'long', year: 'numeric',
+        });
+        if (!dateMap.has(dateKey)) {
+          dateMap.set(dateKey, []);
+          groups.push({ date: dateKey, items: dateMap.get(dateKey) });
+        }
+        dateMap.get(dateKey).push(item);
+      }
+      return groups;
     },
 
     exportData() {
@@ -691,6 +715,16 @@ export default {
 </script>
 
 <style scoped>
+.history-date-separator {
+  font-size: 11px;
+  font-weight: 600;
+  color: #4F5BDF;
+  padding: 8px 0 4px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid #e6f0ff;
+  letter-spacing: 0.02em;
+}
+
 .place-name {
   font-size: 11px;
   color: #4F5BDF;

--- a/frontend/src/components/CompanyHistoryModal.vue
+++ b/frontend/src/components/CompanyHistoryModal.vue
@@ -147,38 +147,46 @@
               v-else
               class="history-timeline"
             >
-              <div
-                v-for="(item, index) in filteredHistory"
-                :key="item.id"
-                class="history-item"
+              <template
+                v-for="group in historyGroupedByDate"
+                :key="group.date"
               >
+                <div class="history-date-separator">
+                  {{ group.date }}
+                </div>
                 <div
-                  class="timeline-dot"
-                  :class="getActionClass(item.action_type)"
-                />
-                <div
-                  v-if="index < filteredHistory.length - 1"
-                  class="timeline-line"
-                />
-
-                <div class="history-content">
-                  <div class="history-header">
-                    <span class="user-name">{{ item.actor_name || 'Система' }}</span>
-                    <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
-                  </div>
-
-                  <div class="action-text">
-                    {{ getActionText(item) }}
-                  </div>
-
+                  v-for="(item, i) in group.items"
+                  :key="item.id"
+                  class="history-item"
+                >
                   <div
-                    v-if="getActionComment(item)"
-                    class="action-comment"
-                  >
-                    {{ getActionComment(item) }}
+                    class="timeline-dot"
+                    :class="getActionClass(item.action_type)"
+                  />
+                  <div
+                    v-if="i < group.items.length - 1"
+                    class="timeline-line"
+                  />
+
+                  <div class="history-content">
+                    <div class="history-header">
+                      <span class="user-name">{{ item.actor_name || 'Система' }}</span>
+                      <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                    </div>
+
+                    <div class="action-text">
+                      {{ getActionText(item) }}
+                    </div>
+
+                    <div
+                      v-if="getActionComment(item)"
+                      class="action-comment"
+                    >
+                      {{ getActionComment(item) }}
+                    </div>
                   </div>
                 </div>
-              </div>
+              </template>
             </div>
           </div>
         </div>
@@ -296,6 +304,22 @@ export default {
         const timeB = new Date(b.created_at).getTime();
         return this.sortOrder === 'desc' ? timeB - timeA : timeA - timeB;
       });
+    },
+
+    historyGroupedByDate() {
+      const groups = [];
+      const dateMap = new Map();
+      for (const item of this.filteredHistory) {
+        const dateKey = new Date(item.created_at).toLocaleDateString('ru-RU', {
+          day: 'numeric', month: 'long', year: 'numeric',
+        });
+        if (!dateMap.has(dateKey)) {
+          dateMap.set(dateKey, []);
+          groups.push({ date: dateKey, items: dateMap.get(dateKey) });
+        }
+        dateMap.get(dateKey).push(item);
+      }
+      return groups;
     },
 
     formattedCurrentDateTime() {
@@ -526,6 +550,16 @@ export default {
 </script>
 
 <style scoped>
+.history-date-separator {
+  font-size: 11px;
+  font-weight: 600;
+  color: #4F5BDF;
+  padding: 8px 0 4px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid #e6f0ff;
+  letter-spacing: 0.02em;
+}
+
 .modal-overlay {
   position: fixed;
   top: 0;

--- a/frontend/src/components/CreateApplication/EmployeeHistoryModal.vue
+++ b/frontend/src/components/CreateApplication/EmployeeHistoryModal.vue
@@ -192,71 +192,79 @@
               v-else
               class="history-timeline"
             >
-              <div 
-                v-for="(item, index) in filteredHistory" 
-                :key="item.id" 
-                class="history-item"
+              <template
+                v-for="group in historyGroupedByDate"
+                :key="group.date"
               >
+                <div class="history-date-separator">
+                  {{ group.date }}
+                </div>
                 <div
-                  class="timeline-dot"
-                  :class="getActionClass(item.action_type)"
-                />
-                <div
-                  v-if="index < filteredHistory.length - 1"
-                  class="timeline-line"
-                />
-            
-                <div
-                  class="history-content"
-                  :class="{ 'history-content--link': isApplicationLink(item) }"
-                  @click="handleHistoryClick(item)"
+                  v-for="(item, i) in group.items"
+                  :key="item.id"
+                  class="history-item"
                 >
-                  <div class="history-header">
-                    <span class="user-name">{{ item.user_name || 'Система' }}</span>
-                    <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
-                  </div>
-              
-                  <div class="action-text">
-                    {{ getActionText(item) }}
-                  </div>
-              
                   <div
-                    v-if="item.action_type === 'entry' || item.action_type === 'exit'"
-                    class="action-comment"
-                  >
-                    {{ getActionComment(item) }}
-                  </div>
-              
+                    class="timeline-dot"
+                    :class="getActionClass(item.action_type)"
+                  />
                   <div
-                    v-if="item.comment && item.action_type !== 'entry' && item.action_type !== 'exit'"
-                    class="action-comment"
-                  >
-                    {{ item.comment }}
-                  </div>
-              
+                    v-if="i < group.items.length - 1"
+                    class="timeline-line"
+                  />
+
                   <div
-                    v-if="item.old_value && item.new_value && item.old_value !== item.new_value"
-                    class="value-change"
+                    class="history-content"
+                    :class="{ 'history-content--link': isApplicationLink(item) }"
+                    @click="handleHistoryClick(item)"
                   >
-                    <span class="old-value">{{ item.old_value }}</span>
-                    <span class="arrow">→</span>
-                    <span class="new-value">{{ item.new_value }}</span>
-                  </div>
-              
-                  <div
-                    v-if="item.field_name"
-                    class="field-name"
-                  >
-                    Поле: {{ item.field_name }}
-                  </div>
-                  <div
-                    v-if="item.table_name"
-                    class="place-name"
-                  >
-                    {{ item.table_name }}
+                    <div class="history-header">
+                      <span class="user-name">{{ item.user_name || 'Система' }}</span>
+                      <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                    </div>
+
+                    <div class="action-text">
+                      {{ getActionText(item) }}
+                    </div>
+
+                    <div
+                      v-if="item.action_type === 'entry' || item.action_type === 'exit'"
+                      class="action-comment"
+                    >
+                      {{ getActionComment(item) }}
+                    </div>
+
+                    <div
+                      v-if="item.comment && item.action_type !== 'entry' && item.action_type !== 'exit'"
+                      class="action-comment"
+                    >
+                      {{ item.comment }}
+                    </div>
+
+                    <div
+                      v-if="item.old_value && item.new_value && item.old_value !== item.new_value"
+                      class="value-change"
+                    >
+                      <span class="old-value">{{ item.old_value }}</span>
+                      <span class="arrow">→</span>
+                      <span class="new-value">{{ item.new_value }}</span>
+                    </div>
+
+                    <div
+                      v-if="item.field_name"
+                      class="field-name"
+                    >
+                      Поле: {{ item.field_name }}
+                    </div>
+                    <div
+                      v-if="item.table_name"
+                      class="place-name"
+                    >
+                      {{ item.table_name }}
+                    </div>
                   </div>
                 </div>
-              </div>
+              </template>
             </div>
           </div>
         </div>
@@ -409,6 +417,22 @@ export default {
         const timeB = new Date(b.created_at).getTime();
         return this.sortOrder === 'desc' ? timeB - timeA : timeA - timeB;
       });
+    },
+
+    historyGroupedByDate() {
+      const groups = [];
+      const dateMap = new Map();
+      for (const item of this.filteredHistory) {
+        const dateKey = new Date(item.created_at).toLocaleDateString('ru-RU', {
+          day: 'numeric', month: 'long', year: 'numeric',
+        });
+        if (!dateMap.has(dateKey)) {
+          dateMap.set(dateKey, []);
+          groups.push({ date: dateKey, items: dateMap.get(dateKey) });
+        }
+        dateMap.get(dateKey).push(item);
+      }
+      return groups;
     },
     exportData() {
       return this.filteredHistory.map(item => ({
@@ -777,6 +801,16 @@ export default {
 </script>
 
 <style scoped>
+.history-date-separator {
+  font-size: 11px;
+  font-weight: 600;
+  color: #4F5BDF;
+  padding: 8px 0 4px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid #e6f0ff;
+  letter-spacing: 0.02em;
+}
+
 /* Стили полностью совпадают с предыдущей версией, можно скопировать из EmployeeHistoryModal ранее */
 .modal-overlay {
   position: fixed;

--- a/frontend/src/components/CreateApplication/EmployeesTableHistoryModal.vue
+++ b/frontend/src/components/CreateApplication/EmployeesTableHistoryModal.vue
@@ -192,40 +192,48 @@
               v-else
               class="history-timeline"
             >
-              <div 
-                v-for="(item, index) in filteredHistory" 
-                :key="item.id" 
-                class="history-item"
+              <template
+                v-for="group in historyGroupedByDate"
+                :key="group.date"
               >
+                <div class="history-date-separator">
+                  {{ group.date }}
+                </div>
                 <div
-                  class="timeline-dot"
-                  :class="getActionClass(item.action_type)"
-                />
-                <div
-                  v-if="index < filteredHistory.length - 1"
-                  class="timeline-line"
-                />
-            
-                <div class="history-content">
-                  <div class="history-header">
-                    <span class="employee-info">{{ getEmployeeName(item) }}</span>
-                    <span
-                      v-if="item.table_name"
-                      class="table-name"
-                    >{{ item.table_name }}</span>
-                    <span class="user-name">{{ item.user_name || 'Система' }}</span>
-                    <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
-                  </div>
-              
-                  <div class="action-text">
-                    {{ getActionText(item) }}
-                  </div>
-              
-                  <div class="action-comment">
-                    {{ item.comment || getActionComment(item) }}
+                  v-for="(item, i) in group.items"
+                  :key="item.id"
+                  class="history-item"
+                >
+                  <div
+                    class="timeline-dot"
+                    :class="getActionClass(item.action_type)"
+                  />
+                  <div
+                    v-if="i < group.items.length - 1"
+                    class="timeline-line"
+                  />
+
+                  <div class="history-content">
+                    <div class="history-header">
+                      <span class="employee-info">{{ getEmployeeName(item) }}</span>
+                      <span
+                        v-if="item.table_name"
+                        class="table-name"
+                      >{{ item.table_name }}</span>
+                      <span class="user-name">{{ item.user_name || 'Система' }}</span>
+                      <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                    </div>
+
+                    <div class="action-text">
+                      {{ getActionText(item) }}
+                    </div>
+
+                    <div class="action-comment">
+                      {{ item.comment || getActionComment(item) }}
+                    </div>
                   </div>
                 </div>
-              </div>
+              </template>
             </div>
           </div>
         </div>
@@ -365,6 +373,22 @@ export default {
         const timeB = new Date(b.created_at).getTime();
         return this.sortOrder === 'desc' ? timeB - timeA : timeA - timeB;
       });
+    },
+
+    historyGroupedByDate() {
+      const groups = [];
+      const dateMap = new Map();
+      for (const item of this.filteredHistory) {
+        const dateKey = new Date(item.created_at).toLocaleDateString('ru-RU', {
+          day: 'numeric', month: 'long', year: 'numeric',
+        });
+        if (!dateMap.has(dateKey)) {
+          dateMap.set(dateKey, []);
+          groups.push({ date: dateKey, items: dateMap.get(dateKey) });
+        }
+        dateMap.get(dateKey).push(item);
+      }
+      return groups;
     },
 
     exportData() {
@@ -659,6 +683,16 @@ export default {
 </script>
 
 <style scoped>
+.history-date-separator {
+  font-size: 11px;
+  font-weight: 600;
+  color: #4F5BDF;
+  padding: 8px 0 4px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid #e6f0ff;
+  letter-spacing: 0.02em;
+}
+
 .modal-overlay {
   position: fixed;
   top: 0;

--- a/frontend/src/components/MarkHistoryModal.vue
+++ b/frontend/src/components/MarkHistoryModal.vue
@@ -150,38 +150,46 @@
               v-else
               class="history-timeline"
             >
-              <div
-                v-for="(item, index) in filteredHistory"
-                :key="item.id"
-                class="history-item"
+              <template
+                v-for="group in historyGroupedByDate"
+                :key="group.date"
               >
+                <div class="history-date-separator">
+                  {{ group.date }}
+                </div>
                 <div
-                  class="timeline-dot"
-                  :class="getActionClass(item.action_type)"
-                />
-                <div
-                  v-if="index < filteredHistory.length - 1"
-                  class="timeline-line"
-                />
-
-                <div class="history-content">
-                  <div class="history-header">
-                    <span class="user-name">{{ item.user_name || 'Система' }}</span>
-                    <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
-                  </div>
-
-                  <div class="action-text">
-                    {{ getActionText(item) }}
-                  </div>
-
+                  v-for="(item, i) in group.items"
+                  :key="item.id"
+                  class="history-item"
+                >
                   <div
-                    v-if="getActionComment(item)"
-                    class="action-comment"
-                  >
-                    {{ getActionComment(item) }}
+                    class="timeline-dot"
+                    :class="getActionClass(item.action_type)"
+                  />
+                  <div
+                    v-if="i < group.items.length - 1"
+                    class="timeline-line"
+                  />
+
+                  <div class="history-content">
+                    <div class="history-header">
+                      <span class="user-name">{{ item.user_name || 'Система' }}</span>
+                      <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                    </div>
+
+                    <div class="action-text">
+                      {{ getActionText(item) }}
+                    </div>
+
+                    <div
+                      v-if="getActionComment(item)"
+                      class="action-comment"
+                    >
+                      {{ getActionComment(item) }}
+                    </div>
                   </div>
                 </div>
-              </div>
+              </template>
             </div>
           </div>
         </div>
@@ -299,6 +307,22 @@ export default {
         const timeB = new Date(b.created_at).getTime();
         return this.sortOrder === 'desc' ? timeB - timeA : timeA - timeB;
       });
+    },
+
+    historyGroupedByDate() {
+      const groups = [];
+      const dateMap = new Map();
+      for (const item of this.filteredHistory) {
+        const dateKey = new Date(item.created_at).toLocaleDateString('ru-RU', {
+          day: 'numeric', month: 'long', year: 'numeric',
+        });
+        if (!dateMap.has(dateKey)) {
+          dateMap.set(dateKey, []);
+          groups.push({ date: dateKey, items: dateMap.get(dateKey) });
+        }
+        dateMap.get(dateKey).push(item);
+      }
+      return groups;
     },
 
     formattedCurrentDateTime() {
@@ -528,6 +552,16 @@ export default {
 </script>
 
 <style scoped>
+.history-date-separator {
+  font-size: 11px;
+  font-weight: 600;
+  color: #4F5BDF;
+  padding: 8px 0 4px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid #e6f0ff;
+  letter-spacing: 0.02em;
+}
+
 .modal-overlay {
   position: fixed;
   top: 0;

--- a/frontend/src/components/OrgHistoryModal.vue
+++ b/frontend/src/components/OrgHistoryModal.vue
@@ -147,38 +147,46 @@
               v-else
               class="history-timeline"
             >
-              <div
-                v-for="(item, index) in filteredHistory"
-                :key="item.id"
-                class="history-item"
+              <template
+                v-for="group in historyGroupedByDate"
+                :key="group.date"
               >
+                <div class="history-date-separator">
+                  {{ group.date }}
+                </div>
                 <div
-                  class="timeline-dot"
-                  :class="getActionClass(item.action_type)"
-                />
-                <div
-                  v-if="index < filteredHistory.length - 1"
-                  class="timeline-line"
-                />
-
-                <div class="history-content">
-                  <div class="history-header">
-                    <span class="user-name">{{ item.actor_name || 'Система' }}</span>
-                    <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
-                  </div>
-
-                  <div class="action-text">
-                    {{ getActionText(item) }}
-                  </div>
-
+                  v-for="(item, i) in group.items"
+                  :key="item.id"
+                  class="history-item"
+                >
                   <div
-                    v-if="getActionComment(item)"
-                    class="action-comment"
-                  >
-                    {{ getActionComment(item) }}
+                    class="timeline-dot"
+                    :class="getActionClass(item.action_type)"
+                  />
+                  <div
+                    v-if="i < group.items.length - 1"
+                    class="timeline-line"
+                  />
+
+                  <div class="history-content">
+                    <div class="history-header">
+                      <span class="user-name">{{ item.actor_name || 'Система' }}</span>
+                      <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                    </div>
+
+                    <div class="action-text">
+                      {{ getActionText(item) }}
+                    </div>
+
+                    <div
+                      v-if="getActionComment(item)"
+                      class="action-comment"
+                    >
+                      {{ getActionComment(item) }}
+                    </div>
                   </div>
                 </div>
-              </div>
+              </template>
             </div>
           </div>
         </div>
@@ -296,6 +304,22 @@ export default {
         const timeB = new Date(b.created_at).getTime();
         return this.sortOrder === 'desc' ? timeB - timeA : timeA - timeB;
       });
+    },
+
+    historyGroupedByDate() {
+      const groups = [];
+      const dateMap = new Map();
+      for (const item of this.filteredHistory) {
+        const dateKey = new Date(item.created_at).toLocaleDateString('ru-RU', {
+          day: 'numeric', month: 'long', year: 'numeric',
+        });
+        if (!dateMap.has(dateKey)) {
+          dateMap.set(dateKey, []);
+          groups.push({ date: dateKey, items: dateMap.get(dateKey) });
+        }
+        dateMap.get(dateKey).push(item);
+      }
+      return groups;
     },
 
     formattedCurrentDateTime() {
@@ -526,6 +550,16 @@ export default {
 </script>
 
 <style scoped>
+.history-date-separator {
+  font-size: 11px;
+  font-weight: 600;
+  color: #4F5BDF;
+  padding: 8px 0 4px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid #e6f0ff;
+  letter-spacing: 0.02em;
+}
+
 .modal-overlay {
   position: fixed;
   top: 0;

--- a/frontend/src/components/SystemTableHistoryModal.vue
+++ b/frontend/src/components/SystemTableHistoryModal.vue
@@ -148,38 +148,46 @@
               v-else
               class="history-timeline"
             >
-              <div
-                v-for="(item, index) in filteredHistory"
-                :key="item.id"
-                class="history-item"
+              <template
+                v-for="group in historyGroupedByDate"
+                :key="group.date"
               >
+                <div class="history-date-separator">
+                  {{ group.date }}
+                </div>
                 <div
-                  class="timeline-dot"
-                  :class="getActionClass(item.action_type)"
-                />
-                <div
-                  v-if="index < filteredHistory.length - 1"
-                  class="timeline-line"
-                />
-
-                <div class="history-content">
-                  <div class="history-header">
-                    <span class="user-name">{{ item.user_name || 'Система' }}</span>
-                    <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
-                  </div>
-
-                  <div class="action-text">
-                    {{ getActionText(item) }}
-                  </div>
-
+                  v-for="(item, i) in group.items"
+                  :key="item.id"
+                  class="history-item"
+                >
                   <div
-                    v-if="getActionComment(item)"
-                    class="action-comment"
-                  >
-                    {{ getActionComment(item) }}
+                    class="timeline-dot"
+                    :class="getActionClass(item.action_type)"
+                  />
+                  <div
+                    v-if="i < group.items.length - 1"
+                    class="timeline-line"
+                  />
+
+                  <div class="history-content">
+                    <div class="history-header">
+                      <span class="user-name">{{ item.user_name || 'Система' }}</span>
+                      <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                    </div>
+
+                    <div class="action-text">
+                      {{ getActionText(item) }}
+                    </div>
+
+                    <div
+                      v-if="getActionComment(item)"
+                      class="action-comment"
+                    >
+                      {{ getActionComment(item) }}
+                    </div>
                   </div>
                 </div>
-              </div>
+              </template>
             </div>
           </div>
         </div>
@@ -334,6 +342,22 @@ export default {
         const timeB = new Date(b.created_at).getTime();
         return this.sortOrder === 'desc' ? timeB - timeA : timeA - timeB;
       });
+    },
+
+    historyGroupedByDate() {
+      const groups = [];
+      const dateMap = new Map();
+      for (const item of this.filteredHistory) {
+        const dateKey = new Date(item.created_at).toLocaleDateString('ru-RU', {
+          day: 'numeric', month: 'long', year: 'numeric',
+        });
+        if (!dateMap.has(dateKey)) {
+          dateMap.set(dateKey, []);
+          groups.push({ date: dateKey, items: dateMap.get(dateKey) });
+        }
+        dateMap.get(dateKey).push(item);
+      }
+      return groups;
     },
 
     formattedCurrentDateTime() {
@@ -594,6 +618,16 @@ export default {
 </script>
 
 <style scoped>
+.history-date-separator {
+  font-size: 11px;
+  font-weight: 600;
+  color: #4F5BDF;
+  padding: 8px 0 4px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid #e6f0ff;
+  letter-spacing: 0.02em;
+}
+
 .modal-overlay {
   position: fixed;
   top: 0;

--- a/frontend/src/components/TrashHistoryModal.vue
+++ b/frontend/src/components/TrashHistoryModal.vue
@@ -96,55 +96,63 @@
               v-else
               class="history-timeline"
             >
-              <div
-                v-for="(item, index) in filteredHistory"
-                :key="item.id"
-                class="history-item"
+              <template
+                v-for="group in historyGroupedByDate"
+                :key="group.date"
               >
-                <div
-                  class="timeline-dot"
-                  :class="getActionClass(item.action_type)"
-                />
-                <div
-                  v-if="index < filteredHistory.length - 1"
-                  class="timeline-line"
-                />
-                <div class="history-content">
-                  <div class="history-header">
-                    <span class="action-title">{{ actionTitle(item) }}</span>
-                    <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
-                  </div>
-                  <div class="action-user">
-                    {{ item.user_name || 'Система' }}
-                  </div>
-                  <template v-if="itemDetails(item).length > 1">
-                    <button
-                      class="detail-toggle"
-                      @click="toggleExpand(item.id)"
-                    >
-                      {{ expanded[item.id] ? 'Свернуть' : `Раскрыть (${itemDetails(item).length})` }}
-                    </button>
-                    <ul
-                      v-if="expanded[item.id]"
-                      class="detail-list"
-                    >
-                      <li
-                        v-for="(d, i) in visibleDetails(item)"
-                        :key="i"
-                      >
-                        {{ d.label || ('ID ' + d.id) }}
-                      </li>
-                    </ul>
-                    <button
-                      v-if="expanded[item.id] && visibleDetails(item).length < filteredDetails(item).length"
-                      class="detail-more"
-                      @click="showMore(item.id)"
-                    >
-                      Показать ещё
-                    </button>
-                  </template>
+                <div class="history-date-separator">
+                  {{ group.date }}
                 </div>
-              </div>
+                <div
+                  v-for="(item, i) in group.items"
+                  :key="item.id"
+                  class="history-item"
+                >
+                  <div
+                    class="timeline-dot"
+                    :class="getActionClass(item.action_type)"
+                  />
+                  <div
+                    v-if="i < group.items.length - 1"
+                    class="timeline-line"
+                  />
+                  <div class="history-content">
+                    <div class="history-header">
+                      <span class="action-title">{{ actionTitle(item) }}</span>
+                      <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                    </div>
+                    <div class="action-user">
+                      {{ item.user_name || 'Система' }}
+                    </div>
+                    <template v-if="itemDetails(item).length > 1">
+                      <button
+                        class="detail-toggle"
+                        @click="toggleExpand(item.id)"
+                      >
+                        {{ expanded[item.id] ? 'Свернуть' : `Раскрыть (${itemDetails(item).length})` }}
+                      </button>
+                      <ul
+                        v-if="expanded[item.id]"
+                        class="detail-list"
+                      >
+                        <li
+                          v-for="(d, idx) in visibleDetails(item)"
+                          :key="idx"
+                        >
+                          {{ d.label || ('ID ' + d.id) }}
+                        </li>
+                      </ul>
+                      <button
+                        v-if="expanded[item.id] && visibleDetails(item).length < filteredDetails(item).length"
+                        class="detail-more"
+                        @click="showMore(item.id)"
+                      >
+                        Показать ещё
+                      </button>
+                    </template>
+                  </div>
+                </div>
+              </template>
             </div>
           </div>
         </div>
@@ -201,6 +209,21 @@ export default {
         return this.sortOrder === 'asc' ? da - db : db - da;
       });
       return arr;
+    },
+    historyGroupedByDate() {
+      const groups = [];
+      const dateMap = new Map();
+      for (const item of this.filteredHistory) {
+        const dateKey = new Date(item.created_at).toLocaleDateString('ru-RU', {
+          day: 'numeric', month: 'long', year: 'numeric',
+        });
+        if (!dateMap.has(dateKey)) {
+          dateMap.set(dateKey, []);
+          groups.push({ date: dateKey, items: dateMap.get(dateKey) });
+        }
+        dateMap.get(dateKey).push(item);
+      }
+      return groups;
     },
     formattedCurrentDateTime() {
       return new Date().toLocaleString('ru-RU', {
@@ -347,6 +370,16 @@ export default {
 </script>
 
 <style scoped>
+.history-date-separator {
+  font-size: 11px;
+  font-weight: 600;
+  color: #4F5BDF;
+  padding: 8px 0 4px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid #e6f0ff;
+  letter-spacing: 0.02em;
+}
+
 .modal-overlay {
   position: fixed;
   inset: 0;

--- a/frontend/src/components/UnloadPlaces/UnloadPlaceHistoryModal.vue
+++ b/frontend/src/components/UnloadPlaces/UnloadPlaceHistoryModal.vue
@@ -151,38 +151,46 @@
               v-else
               class="history-timeline"
             >
-              <div
-                v-for="(item, index) in filteredHistory"
-                :key="item.id"
-                class="history-item"
+              <template
+                v-for="group in historyGroupedByDate"
+                :key="group.date"
               >
+                <div class="history-date-separator">
+                  {{ group.date }}
+                </div>
                 <div
-                  class="timeline-dot"
-                  :class="getActionClass(item.action_type)"
-                />
-                <div
-                  v-if="index < filteredHistory.length - 1"
-                  class="timeline-line"
-                />
-
-                <div class="history-content">
-                  <div class="history-header">
-                    <span class="user-name">{{ item.user_name || 'Система' }}</span>
-                    <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
-                  </div>
-
-                  <div class="action-text">
-                    {{ getActionText(item) }}
-                  </div>
-
+                  v-for="(item, i) in group.items"
+                  :key="item.id"
+                  class="history-item"
+                >
                   <div
-                    v-if="getActionComment(item)"
-                    class="action-comment"
-                  >
-                    {{ getActionComment(item) }}
+                    class="timeline-dot"
+                    :class="getActionClass(item.action_type)"
+                  />
+                  <div
+                    v-if="i < group.items.length - 1"
+                    class="timeline-line"
+                  />
+
+                  <div class="history-content">
+                    <div class="history-header">
+                      <span class="user-name">{{ item.user_name || 'Система' }}</span>
+                      <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                    </div>
+
+                    <div class="action-text">
+                      {{ getActionText(item) }}
+                    </div>
+
+                    <div
+                      v-if="getActionComment(item)"
+                      class="action-comment"
+                    >
+                      {{ getActionComment(item) }}
+                    </div>
                   </div>
                 </div>
-              </div>
+              </template>
             </div>
           </div>
         </div>
@@ -299,6 +307,22 @@ export default {
         const timeB = new Date(b.created_at).getTime();
         return this.sortOrder === 'desc' ? timeB - timeA : timeA - timeB;
       });
+    },
+
+    historyGroupedByDate() {
+      const groups = [];
+      const dateMap = new Map();
+      for (const item of this.filteredHistory) {
+        const dateKey = new Date(item.created_at).toLocaleDateString('ru-RU', {
+          day: 'numeric', month: 'long', year: 'numeric',
+        });
+        if (!dateMap.has(dateKey)) {
+          dateMap.set(dateKey, []);
+          groups.push({ date: dateKey, items: dateMap.get(dateKey) });
+        }
+        dateMap.get(dateKey).push(item);
+      }
+      return groups;
     },
 
     formattedCurrentDateTime() {
@@ -539,6 +563,16 @@ export default {
 </script>
 
 <style scoped>
+.history-date-separator {
+  font-size: 11px;
+  font-weight: 600;
+  color: #4F5BDF;
+  padding: 8px 0 4px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid #e6f0ff;
+  letter-spacing: 0.02em;
+}
+
 .modal-overlay {
   position: fixed;
   top: 0;

--- a/frontend/src/components/UserHistoryModal.vue
+++ b/frontend/src/components/UserHistoryModal.vue
@@ -147,38 +147,46 @@
               v-else
               class="history-timeline"
             >
-              <div
-                v-for="(item, index) in filteredHistory"
-                :key="item.id"
-                class="history-item"
+              <template
+                v-for="group in historyGroupedByDate"
+                :key="group.date"
               >
+                <div class="history-date-separator">
+                  {{ group.date }}
+                </div>
                 <div
-                  class="timeline-dot"
-                  :class="getActionClass(item.action_type)"
-                />
-                <div
-                  v-if="index < filteredHistory.length - 1"
-                  class="timeline-line"
-                />
-
-                <div class="history-content">
-                  <div class="history-header">
-                    <span class="user-name">{{ item.actor_name || 'Система' }}</span>
-                    <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
-                  </div>
-
-                  <div class="action-text">
-                    {{ getActionText(item) }}
-                  </div>
-
+                  v-for="(item, i) in group.items"
+                  :key="item.id"
+                  class="history-item"
+                >
                   <div
-                    v-if="getActionComment(item)"
-                    class="action-comment"
-                  >
-                    {{ getActionComment(item) }}
+                    class="timeline-dot"
+                    :class="getActionClass(item.action_type)"
+                  />
+                  <div
+                    v-if="i < group.items.length - 1"
+                    class="timeline-line"
+                  />
+
+                  <div class="history-content">
+                    <div class="history-header">
+                      <span class="user-name">{{ item.actor_name || 'Система' }}</span>
+                      <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                    </div>
+
+                    <div class="action-text">
+                      {{ getActionText(item) }}
+                    </div>
+
+                    <div
+                      v-if="getActionComment(item)"
+                      class="action-comment"
+                    >
+                      {{ getActionComment(item) }}
+                    </div>
                   </div>
                 </div>
-              </div>
+              </template>
             </div>
           </div>
         </div>
@@ -318,6 +326,22 @@ export default {
         const timeB = new Date(b.created_at).getTime();
         return this.sortOrder === 'desc' ? timeB - timeA : timeA - timeB;
       });
+    },
+
+    historyGroupedByDate() {
+      const groups = [];
+      const dateMap = new Map();
+      for (const item of this.filteredHistory) {
+        const dateKey = new Date(item.created_at).toLocaleDateString('ru-RU', {
+          day: 'numeric', month: 'long', year: 'numeric',
+        });
+        if (!dateMap.has(dateKey)) {
+          dateMap.set(dateKey, []);
+          groups.push({ date: dateKey, items: dateMap.get(dateKey) });
+        }
+        dateMap.get(dateKey).push(item);
+      }
+      return groups;
     },
 
     formattedCurrentDateTime() {
@@ -612,6 +636,16 @@ export default {
 </script>
 
 <style scoped>
+.history-date-separator {
+  font-size: 11px;
+  font-weight: 600;
+  color: #4F5BDF;
+  padding: 8px 0 4px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid #e6f0ff;
+  letter-spacing: 0.02em;
+}
+
 .modal-overlay {
   position: fixed;
   top: 0;

--- a/frontend/src/components/UserTypeHistoryModal.vue
+++ b/frontend/src/components/UserTypeHistoryModal.vue
@@ -147,38 +147,46 @@
               v-else
               class="history-timeline"
             >
-              <div
-                v-for="(item, index) in filteredHistory"
-                :key="item.id"
-                class="history-item"
+              <template
+                v-for="group in historyGroupedByDate"
+                :key="group.date"
               >
+                <div class="history-date-separator">
+                  {{ group.date }}
+                </div>
                 <div
-                  class="timeline-dot"
-                  :class="getActionClass(item.action_type)"
-                />
-                <div
-                  v-if="index < filteredHistory.length - 1"
-                  class="timeline-line"
-                />
-
-                <div class="history-content">
-                  <div class="history-header">
-                    <span class="user-name">{{ item.actor_name || 'Система' }}</span>
-                    <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
-                  </div>
-
-                  <div class="action-text">
-                    {{ getActionText(item) }}
-                  </div>
-
+                  v-for="(item, i) in group.items"
+                  :key="item.id"
+                  class="history-item"
+                >
                   <div
-                    v-if="getActionComment(item)"
-                    class="action-comment"
-                  >
-                    {{ getActionComment(item) }}
+                    class="timeline-dot"
+                    :class="getActionClass(item.action_type)"
+                  />
+                  <div
+                    v-if="i < group.items.length - 1"
+                    class="timeline-line"
+                  />
+
+                  <div class="history-content">
+                    <div class="history-header">
+                      <span class="user-name">{{ item.actor_name || 'Система' }}</span>
+                      <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                    </div>
+
+                    <div class="action-text">
+                      {{ getActionText(item) }}
+                    </div>
+
+                    <div
+                      v-if="getActionComment(item)"
+                      class="action-comment"
+                    >
+                      {{ getActionComment(item) }}
+                    </div>
                   </div>
                 </div>
-              </div>
+              </template>
             </div>
           </div>
         </div>
@@ -300,6 +308,22 @@ export default {
         const timeB = new Date(b.created_at).getTime();
         return this.sortOrder === 'desc' ? timeB - timeA : timeA - timeB;
       });
+    },
+
+    historyGroupedByDate() {
+      const groups = [];
+      const dateMap = new Map();
+      for (const item of this.filteredHistory) {
+        const dateKey = new Date(item.created_at).toLocaleDateString('ru-RU', {
+          day: 'numeric', month: 'long', year: 'numeric',
+        });
+        if (!dateMap.has(dateKey)) {
+          dateMap.set(dateKey, []);
+          groups.push({ date: dateKey, items: dateMap.get(dateKey) });
+        }
+        dateMap.get(dateKey).push(item);
+      }
+      return groups;
     },
 
     formattedCurrentDateTime() {
@@ -538,6 +562,16 @@ export default {
 </script>
 
 <style scoped>
+.history-date-separator {
+  font-size: 11px;
+  font-weight: 600;
+  color: #4F5BDF;
+  padding: 8px 0 4px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid #e6f0ff;
+  letter-spacing: 0.02em;
+}
+
 .modal-overlay {
   position: fixed;
   top: 0;


### PR DESCRIPTION
## Что сделано

Добавил группировку записей по дате во все 13 history-модалок.

Во всех файлах:
- новый computed `historyGroupedByDate` строит массив `[{date, items}]` из `filteredHistory`, группируя по дню (`toLocaleDateString ru-RU`)
- плоский `v-for="(item, index) in filteredHistory"` заменён на `<template v-for="group">` -> разделитель даты -> `v-for="(item, i) in group.items"`
- `timeline-line` привязан к `i < group.items.length - 1` - линия обрывается на последней записи группы
- CSS `.history-date-separator`: 11px, #4F5BDF, border-bottom #e6f0ff

## Особенности

- `CarHistoryModal` и `EmployeeHistoryModal`: кликабельность create-записей с `application_id` (`history-content--link`, `open-application`) сохранена
- `TrashHistoryModal`: другая структура (`show`, `@click.self`) - обработана отдельно, внутренний `v-for` по деталям переименован во избежание конфликта переменной `i`
- ESLint: 0 errors, 0 warnings

## Файлы

13 компонентов: SystemTableHistoryModal, CarsTableHistoryModal, CompanyHistoryModal, OrgHistoryModal, MarkHistoryModal, UserHistoryModal, UserTypeHistoryModal, UnloadPlaces/UnloadPlaceHistoryModal, ApplicationApproverHistoryModal, TrashHistoryModal, CreateApplication/EmployeesTableHistoryModal, CarHistoryModal, CreateApplication/EmployeeHistoryModal