### PR TITLE
feat(create-application): разделил поля ответственного и телефона (#46)

### DIFF
--- a/frontend/src/components/CreateApplication/UserInfoRow.vue
+++ b/frontend/src/components/CreateApplication/UserInfoRow.vue
@@ -35,34 +35,34 @@
         {{ errors.company }}
       </div>
     </div>
-    <div class="user__input responsible">
-      <label class="input__label responsible">Ответственное лицо <span class="required">*</span></label>
-      <div
-        class="input contacts"
-        :class="{ 'input--error': errors.responsiblePerson || errors.phone }"
+    <div class="user__input">
+      <label class="input__label">Ответственное лицо <span class="required">*</span></label>
+      <input
+        class="input"
+        placeholder="Введите ФИО"
+        :value="responsiblePerson"
+        :class="{ 'input--error': errors.responsiblePerson }"
+        @input="$emit('update:responsible-person', $event.target.value)"
+        @blur="$emit('validate-field', 'responsiblePerson')"
       >
-        <input 
-          class="contact-input" 
-          placeholder="Введите ФИО" 
-          :value="responsiblePerson"
-          @input="$emit('update:responsible-person', $event.target.value)"
-          @blur="$emit('validate-field', 'responsiblePerson')"
-        >
-        <input 
-          class="contact-input phone" 
-          placeholder="Номер телефона"
-          :value="phoneNumber"
-          @input="handlePhoneInput($event)"
-          @blur="$emit('format-phone')"
-          @focus="$emit('clear-phone')"
-        >
-      </div>
       <div
         v-if="errors.responsiblePerson"
         class="error-message"
       >
         {{ errors.responsiblePerson }}
       </div>
+    </div>
+    <div class="user__input">
+      <label class="input__label">Телефон <span class="required">*</span></label>
+      <input
+        class="input"
+        placeholder="Номер телефона"
+        :value="phoneNumber"
+        :class="{ 'input--error': errors.phone }"
+        @input="handlePhoneInput($event)"
+        @blur="$emit('format-phone')"
+        @focus="$emit('clear-phone')"
+      >
       <div
         v-if="errors.phone"
         class="error-message"
@@ -115,27 +115,6 @@ export default {
     flex-direction: column;
     gap: 5px;
     position: relative;
-}
-
-.responsible {
-    width: 430px !important;
-}
-
-.contacts {
-    display: flex;
-    justify-content: space-between;
-}
-
-.contact-input {
-    border: none;
-    outline: none;
-    background: transparent;
-    width: 60%;
-}
-
-.phone {
-    width: 35%;
-    text-align: end;
 }
 
 .input__label {


### PR DESCRIPTION
## Что сделано

Поле «Ответственное лицо» и поле телефона существовали как один блок: один label + два инпута рядом внутри `.input.contacts`. Теперь это два самостоятельных поля, каждое со своим label, отдельным `.input` и собственным error-сообщением.

## Что не тронуто

- Все `v-model` / emit-события (`update:responsible-person`, `update:phone-number`, `validate-field`, `format-phone`, `clear-phone`)
- `handlePhoneInput` — логика без изменений
- Props, включая `errors`
- Префилл из аккаунта, regex-валидация, состояние `responsiblePerson`/`phoneNumber`

## Файл

`frontend/src/components/CreateApplication/UserInfoRow.vue`