### PR TITLE
feat(registry): колонки Организация/Компания во вкладках Авто/Сотрудники и имя привязки (#46)

### DIFF
--- a/frontend/src/components/EmployeeEditModal.vue
+++ b/frontend/src/components/EmployeeEditModal.vue
@@ -260,7 +260,7 @@
                       v-model="bindToOrganization"
                       type="checkbox"
                     >
-                    <span>Привязать к организации</span>
+                    <span>Привязать к организации<template v-if="ownershipInfo.organization_name"> «{{ ownershipInfo.organization_name }}»</template></span>
                   </label>
                   <label
                     v-if="ownershipInfo && ownershipInfo.has_company"
@@ -270,7 +270,7 @@
                       v-model="bindToCompany"
                       type="checkbox"
                     >
-                    <span>Привязать к компании</span>
+                    <span>Привязать к компании<template v-if="ownershipInfo.company_name"> «{{ ownershipInfo.company_name }}»</template></span>
                   </label>
                   <div class="user-binding">
                     <span class="user-binding-text"><strong class="red">Внимание!</strong> При привязке сотрудника к организации или компании, он будет доступен для отображения и использования для всех сотрудников, привязанных к организации/компании. </span>

--- a/frontend/src/views/CarsView.vue
+++ b/frontend/src/views/CarsView.vue
@@ -180,13 +180,47 @@
                 <p :class="{ 'active-sort': sortField === 'status' }">
                   Статус
                 </p>
-                <img 
-                  src="@/assets/icons/sort.png" 
-                  class="sort-icon" 
-                  :class="{ 
+                <img
+                  src="@/assets/icons/sort.png"
+                  class="sort-icon"
+                  :class="{
                     'sorted': sortField === 'status',
                     'desc': sortField === 'status' && sortDirection === 'desc'
-                  }" 
+                  }"
+                >
+              </div>
+              <div
+                v-if="currentFilter === 'organization' || currentFilter === 'all_system'"
+                class="header-col org-col"
+                @click="sortBy('organization_name')"
+              >
+                <p :class="{ 'active-sort': sortField === 'organization_name' }">
+                  Организация
+                </p>
+                <img
+                  src="@/assets/icons/sort.png"
+                  class="sort-icon"
+                  :class="{
+                    'sorted': sortField === 'organization_name',
+                    'desc': sortField === 'organization_name' && sortDirection === 'desc'
+                  }"
+                >
+              </div>
+              <div
+                v-if="currentFilter === 'company' || currentFilter === 'all_system'"
+                class="header-col company-col"
+                @click="sortBy('company_name')"
+              >
+                <p :class="{ 'active-sort': sortField === 'company_name' }">
+                  Компания
+                </p>
+                <img
+                  src="@/assets/icons/sort.png"
+                  class="sort-icon"
+                  :class="{
+                    'sorted': sortField === 'company_name',
+                    'desc': sortField === 'company_name' && sortDirection === 'desc'
+                  }"
                 >
               </div>
               <div class="header-col actions-col">
@@ -239,6 +273,20 @@
                         v-else
                         :status="car.status ? 'Активна' : 'Неактивна'"
                       />
+                    </div>
+                    <div
+                      v-if="currentFilter === 'organization' || currentFilter === 'all_system'"
+                      class="car-col org-col"
+                      :title="car.organization_name || ''"
+                    >
+                      {{ car.organization_name || '—' }}
+                    </div>
+                    <div
+                      v-if="currentFilter === 'company' || currentFilter === 'all_system'"
+                      class="car-col company-col"
+                      :title="car.company_name || ''"
+                    >
+                      {{ car.company_name || '—' }}
                     </div>
                     <div class="car-col actions-col">
                       <button
@@ -503,23 +551,23 @@
                       v-if="ownershipInfo && ownershipInfo.has_organization"
                       class="binding-option"
                     >
-                      <input 
-                        v-model="bindToOrganization" 
+                      <input
+                        v-model="bindToOrganization"
                         type="checkbox"
                         :disabled="bindToCompany"
                       >
-                      <span>Привязать к организации</span>
+                      <span>Привязать к организации<template v-if="ownershipInfo.organization_name"> «{{ ownershipInfo.organization_name }}»</template></span>
                     </label>
                     <label
                       v-if="ownershipInfo && ownershipInfo.has_company"
                       class="binding-option"
                     >
-                      <input 
-                        v-model="bindToCompany" 
+                      <input
+                        v-model="bindToCompany"
                         type="checkbox"
                         :disabled="bindToOrganization"
                       >
-                      <span>Привязать к компании</span>
+                      <span>Привязать к компании<template v-if="ownershipInfo.company_name"> «{{ ownershipInfo.company_name }}»</template></span>
                     </label>
                     <div class="user-binding">
                       <span class="user-binding-text"><strong class="red">Внимание!</strong> При привязке автомобиля к организации или компании, он будет доступен для отображения и использования для всех сотрудников, привязанных к организации/компании. </span>
@@ -694,11 +742,21 @@ export default {
                         valueA = a.status;
                         valueB = b.status;
                         break;
-                        
+
+                    case 'organization_name':
+                        valueA = (a.organization_name || '').toLowerCase();
+                        valueB = (b.organization_name || '').toLowerCase();
+                        break;
+
+                    case 'company_name':
+                        valueA = (a.company_name || '').toLowerCase();
+                        valueB = (b.company_name || '').toLowerCase();
+                        break;
+
                     default:
                         return 0;
                 }
-                
+
                 if (valueA < valueB) {
                     return this.sortDirection === 'asc' ? -1 : 1;
                 }
@@ -1678,6 +1736,22 @@ export default {
     width: 10%;
     min-width: 80px;
     justify-content: center;
+}
+
+.org-col {
+    width: 18%;
+    min-width: 120px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.company-col {
+    width: 18%;
+    min-width: 120px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 /* Тело таблицы */

--- a/frontend/src/views/EmployeeView.vue
+++ b/frontend/src/views/EmployeeView.vue
@@ -163,13 +163,47 @@
                 <p :class="{ 'active-sort': sortField === 'status' }">
                   Статус
                 </p>
-                <img 
-                  src="@/assets/icons/sort.png" 
-                  class="sort-icon" 
-                  :class="{ 
+                <img
+                  src="@/assets/icons/sort.png"
+                  class="sort-icon"
+                  :class="{
                     'sorted': sortField === 'status',
                     'desc': sortField === 'status' && sortDirection === 'desc'
-                  }" 
+                  }"
+                >
+              </div>
+              <div
+                v-if="currentFilter === 'organization' || currentFilter === 'all_system'"
+                class="header-col org-col"
+                @click="sortBy('organization_name')"
+              >
+                <p :class="{ 'active-sort': sortField === 'organization_name' }">
+                  Организация
+                </p>
+                <img
+                  src="@/assets/icons/sort.png"
+                  class="sort-icon"
+                  :class="{
+                    'sorted': sortField === 'organization_name',
+                    'desc': sortField === 'organization_name' && sortDirection === 'desc'
+                  }"
+                >
+              </div>
+              <div
+                v-if="currentFilter === 'company' || currentFilter === 'all_system'"
+                class="header-col company-col"
+                @click="sortBy('company_name')"
+              >
+                <p :class="{ 'active-sort': sortField === 'company_name' }">
+                  Компания
+                </p>
+                <img
+                  src="@/assets/icons/sort.png"
+                  class="sort-icon"
+                  :class="{
+                    'sorted': sortField === 'company_name',
+                    'desc': sortField === 'company_name' && sortDirection === 'desc'
+                  }"
                 >
               </div>
               <div class="header-col actions-col">
@@ -225,6 +259,20 @@
                         v-else
                         :status="employee.status ? 'Активен' : 'Неактивен'"
                       />
+                    </div>
+                    <div
+                      v-if="currentFilter === 'organization' || currentFilter === 'all_system'"
+                      class="employee-col org-col"
+                      :title="employee.organization_name || ''"
+                    >
+                      {{ employee.organization_name || '—' }}
+                    </div>
+                    <div
+                      v-if="currentFilter === 'company' || currentFilter === 'all_system'"
+                      class="employee-col company-col"
+                      :title="employee.company_name || ''"
+                    >
+                      {{ employee.company_name || '—' }}
                     </div>
                     <div class="employee-col actions-col">
                       <button
@@ -421,11 +469,21 @@ export default {
                         valueA = a.status;
                         valueB = b.status;
                         break;
-                        
+
+                    case 'organization_name':
+                        valueA = (a.organization_name || '').toLowerCase();
+                        valueB = (b.organization_name || '').toLowerCase();
+                        break;
+
+                    case 'company_name':
+                        valueA = (a.company_name || '').toLowerCase();
+                        valueB = (b.company_name || '').toLowerCase();
+                        break;
+
                     default:
                         return 0;
                 }
-                
+
                 if (valueA < valueB) {
                     return this.sortDirection === 'asc' ? -1 : 1;
                 }
@@ -956,6 +1014,22 @@ export default {
     width: 15%;
     min-width: 100px;
     justify-content: center;
+}
+
+.org-col {
+    width: 18%;
+    min-width: 120px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.company-col {
+    width: 18%;
+    min-width: 120px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 /* Тело таблицы */

--- a/internal/services/unique_car_service.go
+++ b/internal/services/unique_car_service.go
@@ -38,11 +38,13 @@ func diffUniqueCar(before, after *models.UniqueCar) []fieldChange {
 
 // CarOwnerInfo -- информация о владельце для фильтрации машин.
 type CarOwnerInfo struct {
-	HasOrganization bool `json:"has_organization"`
-	HasCompany      bool `json:"has_company"`
-	OrganizationID  *int `json:"organization_id"`
-	CompanyID       *int `json:"company_id"`
-	UserID          int  `json:"user_id"`
+	HasOrganization  bool    `json:"has_organization"`
+	HasCompany       bool    `json:"has_company"`
+	OrganizationID   *int    `json:"organization_id"`
+	CompanyID        *int    `json:"company_id"`
+	UserID           int     `json:"user_id"`
+	OrganizationName *string `json:"organization_name"`
+	CompanyName      *string `json:"company_name"`
 }
 
 // UniqueCarWithRelations -- машина с данными связанных сущностей.
@@ -155,18 +157,21 @@ func NewUniqueCarService(db *gorm.DB) UniqueCarService {
 // getCarOwnerInfo получает информацию о владельце по username.
 func (s *uniqueCarService) getCarOwnerInfo(ctx context.Context, username string) (*CarOwnerInfo, error) {
 	var result struct {
-		UserID          int  `gorm:"column:user_id"`
-		OrganizationID  *int `gorm:"column:organization_id"`
-		CompanyID       *int `gorm:"column:company_id"`
-		HasOrganization bool `gorm:"column:has_organization"`
-		HasCompany      bool `gorm:"column:has_company"`
+		UserID           int     `gorm:"column:user_id"`
+		OrganizationID   *int    `gorm:"column:organization_id"`
+		CompanyID        *int    `gorm:"column:company_id"`
+		HasOrganization  bool    `gorm:"column:has_organization"`
+		HasCompany       bool    `gorm:"column:has_company"`
+		OrganizationName *string `gorm:"column:organization_name"`
+		CompanyName      *string `gorm:"column:company_name"`
 	}
 
 	err := s.db.WithContext(ctx).
 		Table("users u").
 		Select(`u.id as user_id, u.organization_id, u.company_id,
 			CASE WHEN o.id IS NOT NULL THEN true ELSE false END as has_organization,
-			CASE WHEN c.id IS NOT NULL THEN true ELSE false END as has_company`).
+			CASE WHEN c.id IS NOT NULL THEN true ELSE false END as has_company,
+			o.name as organization_name, c.name as company_name`).
 		Joins("LEFT JOIN organizations o ON u.organization_id = o.id").
 		Joins("LEFT JOIN companies c ON u.company_id = c.id").
 		Where("u.username = ?", username).
@@ -176,11 +181,13 @@ func (s *uniqueCarService) getCarOwnerInfo(ctx context.Context, username string)
 	}
 
 	return &CarOwnerInfo{
-		HasOrganization: result.HasOrganization,
-		HasCompany:      result.HasCompany,
-		OrganizationID:  result.OrganizationID,
-		CompanyID:       result.CompanyID,
-		UserID:          result.UserID,
+		HasOrganization:  result.HasOrganization,
+		HasCompany:       result.HasCompany,
+		OrganizationID:   result.OrganizationID,
+		CompanyID:        result.CompanyID,
+		UserID:           result.UserID,
+		OrganizationName: result.OrganizationName,
+		CompanyName:      result.CompanyName,
 	}, nil
 }
 

--- a/internal/services/unique_employee_service.go
+++ b/internal/services/unique_employee_service.go
@@ -57,11 +57,13 @@ func intPtrToStrPtr(p *int) *string {
 
 // EmployeeOwnerInfo -- информация о владельце для фильтрации сотрудников.
 type EmployeeOwnerInfo struct {
-	HasOrganization bool `json:"has_organization"`
-	HasCompany      bool `json:"has_company"`
-	OrganizationID  *int `json:"organization_id"`
-	CompanyID       *int `json:"company_id"`
-	UserID          int  `json:"user_id"`
+	HasOrganization  bool    `json:"has_organization"`
+	HasCompany       bool    `json:"has_company"`
+	OrganizationID   *int    `json:"organization_id"`
+	CompanyID        *int    `json:"company_id"`
+	UserID           int     `json:"user_id"`
+	OrganizationName *string `json:"organization_name"`
+	CompanyName      *string `json:"company_name"`
 }
 
 // UniqueEmployeeWithRelations -- сотрудник с данными связанных сущностей.
@@ -170,18 +172,21 @@ func NewUniqueEmployeeService(db *gorm.DB) UniqueEmployeeService {
 // getEmployeeOwnerInfo получает информацию о владельце по username.
 func (s *uniqueEmployeeService) getEmployeeOwnerInfo(ctx context.Context, username string) (*EmployeeOwnerInfo, error) {
 	var result struct {
-		UserID          int  `gorm:"column:user_id"`
-		OrganizationID  *int `gorm:"column:organization_id"`
-		CompanyID       *int `gorm:"column:company_id"`
-		HasOrganization bool `gorm:"column:has_organization"`
-		HasCompany      bool `gorm:"column:has_company"`
+		UserID           int     `gorm:"column:user_id"`
+		OrganizationID   *int    `gorm:"column:organization_id"`
+		CompanyID        *int    `gorm:"column:company_id"`
+		HasOrganization  bool    `gorm:"column:has_organization"`
+		HasCompany       bool    `gorm:"column:has_company"`
+		OrganizationName *string `gorm:"column:organization_name"`
+		CompanyName      *string `gorm:"column:company_name"`
 	}
 
 	err := s.db.WithContext(ctx).
 		Table("users u").
 		Select(`u.id as user_id, u.organization_id, u.company_id,
 			CASE WHEN o.id IS NOT NULL THEN true ELSE false END as has_organization,
-			CASE WHEN c.id IS NOT NULL THEN true ELSE false END as has_company`).
+			CASE WHEN c.id IS NOT NULL THEN true ELSE false END as has_company,
+			o.name as organization_name, c.name as company_name`).
 		Joins("LEFT JOIN organizations o ON u.organization_id = o.id").
 		Joins("LEFT JOIN companies c ON u.company_id = c.id").
 		Where("u.username = ?", username).
@@ -191,11 +196,13 @@ func (s *uniqueEmployeeService) getEmployeeOwnerInfo(ctx context.Context, userna
 	}
 
 	return &EmployeeOwnerInfo{
-		HasOrganization: result.HasOrganization,
-		HasCompany:      result.HasCompany,
-		OrganizationID:  result.OrganizationID,
-		CompanyID:       result.CompanyID,
-		UserID:          result.UserID,
+		HasOrganization:  result.HasOrganization,
+		HasCompany:       result.HasCompany,
+		OrganizationID:   result.OrganizationID,
+		CompanyID:        result.CompanyID,
+		UserID:           result.UserID,
+		OrganizationName: result.OrganizationName,
+		CompanyName:      result.CompanyName,
 	}, nil
 }
 


### PR DESCRIPTION
Пункты 11 и 12D ТЗ.

п.11: в inline-таблицах вкладок Авто/Сотрудники колонки «Организация»/«Компания» по фильтру (organization -> Орг, company -> Комп, all_system -> оба, user -> ни одного) + сортировка. FE-only, бэк уже отдавал organization_name/company_name per-row.
п.12D: имя орг/компании в label привязки в модалках добавления. Owner-info эндпоинт имена не отдавал - добавил аддитивно в SELECT getCarOwnerInfo/getEmployeeOwnerInfo (не миграция).

go build/vet/test зелёные. Ревью: go (один 🟡 про сброс сортировки при смене вкладки - pre-existing-стиль, не блокер).