### PR TITLE
feat(tables): кольцо-loader на месте данных в Авто/Сотрудники и PeopleTable (#46)

### DIFF
--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -243,16 +243,14 @@
           v-if="isLoading"
           class="loading-message"
         >
-          <div class="loader" />
-          <p>Загрузка сотрудников...</p>
+          <LoaderSpinner label="Загрузка сотрудников…" />
         </div>
 
         <div
           v-if="refreshing && !isLoading"
           class="refresh-overlay"
         >
-          <div class="loader" />
-          <p>Обновление...</p>
+          <LoaderSpinner label="Обновление…" />
         </div>
 
         <div
@@ -493,6 +491,7 @@ import EmployeeDetailsModal from './CreateApplication/EmployeeDetailsModal.vue';
 import EmployeesTableHistoryModal from './CreateApplication/EmployeesTableHistoryModal.vue';
 import StatusBadge from './ui/StatusBadge.vue';
 import EnlargedToggle from './ui/EnlargedToggle.vue';
+import LoaderSpinner from './ui/LoaderSpinner.vue';
 import ExcelJS from 'exceljs';
 
 const ENLARGED_KEY_PREFIX = 'enlarged-mode:people:';
@@ -504,7 +503,8 @@ export default {
     EmployeeDetailsModal,
     EmployeesTableHistoryModal,
     StatusBadge,
-    EnlargedToggle
+    EnlargedToggle,
+    LoaderSpinner
   },
   setup() {
     const { isPortrait, isCompact } = useOrientation();
@@ -1694,20 +1694,6 @@ export default {
   align-items: center;
   justify-content: center;
   gap: 12px;
-}
-
-.loader {
-  width: 30px;
-  height: 30px;
-  border: 3px solid #f3f3f3;
-  border-top: 3px solid #4F5BDF;
-  border-radius: 50%;
-  animation: spin 1s linear infinite;
-}
-
-@keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
 }
 
 .fade-list-enter-active,

--- a/frontend/src/views/CarsView.vue
+++ b/frontend/src/views/CarsView.vue
@@ -231,15 +231,15 @@
                     
           <!-- Тело таблицы -->
           <div class="cars-container">
-            <SkeletonTransition :loading="loading">
-              <template #skeleton>
-                <SkeletonTable
-                  :rows="6"
-                  :columns="5"
-                />
-              </template>
+            <div class="cars-table-area">
               <div
-                v-if="filteredCars.length > 0"
+                v-if="loading"
+                class="loading-message"
+              >
+                <LoaderSpinner label="Загрузка машин…" />
+              </div>
+              <div
+                v-else-if="filteredCars.length > 0"
                 class="cars-body"
               >
                 <div
@@ -330,7 +330,7 @@
               >
                 {{ hasActiveFilters ? 'Нет данных по выбранным фильтрам' : 'Автомобилей нет' }}
               </p>
-            </SkeletonTransition>
+            </div>
           </div>
         </div>
       </div>
@@ -620,8 +620,7 @@
 import { apiRequest } from '@/api/client'
 import SearchComponent from '@/components/SearchComponent.vue';
 import RefreshButton from '@/components/RefreshButton.vue';
-import SkeletonTransition from '@/components/ui/SkeletonTransition.vue';
-import SkeletonTable from '@/components/ui/SkeletonTable.vue';
+import LoaderSpinner from '@/components/ui/LoaderSpinner.vue';
 import StatusBadge from '@/components/ui/StatusBadge.vue';
 import ConfirmationModal from '@/components/ConfirmationModal.vue';
 import VehicleDetailsModal from '@/components/CreateApplication/VehicleDetailsModal.vue';
@@ -632,8 +631,7 @@ export default {
     components: {
         SearchComponent,
         RefreshButton,
-        SkeletonTransition,
-        SkeletonTable,
+        LoaderSpinner,
         StatusBadge,
         ConfirmationModal,
         VehicleDetailsModal,
@@ -1881,6 +1879,28 @@ export default {
     display: flex;
     align-items: center;
     justify-content: center;
+}
+
+/* Обёртка тела таблицы (заменила SkeletonTransition): держит flex-контекст, чтобы
+   .cars-body растягивался и скроллился, а кольцо/пусто центрировались по высоте. */
+.cars-table-area {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+}
+
+.loading-message {
+    text-align: center;
+    color: #a2a2a2;
+    padding: 40px 20px;
+    font-size: 14px;
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
 }
 
 .help__text {

--- a/frontend/src/views/EmployeeView.vue
+++ b/frontend/src/views/EmployeeView.vue
@@ -214,15 +214,15 @@
                     
           <!-- Тело таблицы -->
           <div class="employees-container">
-            <SkeletonTransition :loading="loading">
-              <template #skeleton>
-                <SkeletonTable
-                  :rows="6"
-                  :columns="5"
-                />
-              </template>
+            <div class="employees-table-area">
               <div
-                v-if="filteredEmployees.length > 0"
+                v-if="loading"
+                class="loading-message"
+              >
+                <LoaderSpinner label="Загрузка сотрудников…" />
+              </div>
+              <div
+                v-else-if="filteredEmployees.length > 0"
                 class="employees-body"
               >
                 <div
@@ -309,7 +309,7 @@
               >
                 {{ hasActiveFilters ? 'Нет данных по выбранным фильтрам' : 'Сотрудников нет' }}
               </p>
-            </SkeletonTransition>
+            </div>
           </div>
         </div>
       </div>
@@ -385,8 +385,7 @@
 import { apiRequest } from '@/api/client'
 import SearchComponent from '@/components/SearchComponent.vue';
 import RefreshButton from '@/components/RefreshButton.vue';
-import SkeletonTransition from '@/components/ui/SkeletonTransition.vue';
-import SkeletonTable from '@/components/ui/SkeletonTable.vue';
+import LoaderSpinner from '@/components/ui/LoaderSpinner.vue';
 import StatusBadge from '@/components/ui/StatusBadge.vue';
 import EmployeeEditModal from '@/components/EmployeeEditModal.vue';
 import EmployeeDetailsModal from '@/components/CreateApplication/EmployeeDetailsModal.vue';
@@ -397,8 +396,7 @@ export default {
     components: {
         SearchComponent,
         RefreshButton,
-        SkeletonTransition,
-        SkeletonTable,
+        LoaderSpinner,
         StatusBadge,
         EmployeeEditModal,
         EmployeeDetailsModal,
@@ -1153,6 +1151,28 @@ export default {
     display: flex;
     align-items: center;
     justify-content: center;
+}
+
+/* Обёртка тела таблицы (заменила SkeletonTransition): держит flex-контекст, чтобы
+   .employees-body растягивался и скроллился, а кольцо/пусто центрировались по высоте. */
+.employees-table-area {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+}
+
+.loading-message {
+    text-align: center;
+    color: #a2a2a2;
+    padding: 40px 20px;
+    font-size: 14px;
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
 }
 
 .help__text {


### PR DESCRIPTION
Пункт 32 ТЗ (остаток - кольцо на месте данных; кнопка-перезарядка уже была в #578/579).

Привёл загрузку к эталону FactTable во всех таблицах, где её ещё не было:
- **Вкладки Автомобили/Сотрудники** (CarsView/EmployeeView): показывали скелетон таблицы -> заменил на кольцо LoaderSpinner. SkeletonTransition/SkeletonTable убрал, обёртку тела заменил на div с flex-контекстом (чтобы тело растягивалось/скроллилось как раньше).
- **Таблица сотрудников** (PeopleTable): кастомный `<div class="loader">` -> LoaderSpinner (как у соседа CarsTable). Мёртвую .loader-разметку и @keyframes spin вычистил.

Уже готовы (не трогал): Центр (#581), ЛК, CarsTable, Администрация.

FE-only. Тесты на скелетон/лоадер в этих view не завязаны (проверено). Визуал проверяешь комплексно в конце.