### PR TITLE
feat(documents): бэкенд управления документами (#39)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -185,6 +185,9 @@ func main() {
 	attachmentBlankService := services.NewAttachmentBlankService(db)
 	trashService := services.NewTrashService(db)
 	trashDBRef := services.NewTrashDBRef(db)
+	documentFileService := services.NewDocumentFileService(cfg.UploadPath)
+	documentGroupService := services.NewDocumentGroupService(db)
+	documentService := services.NewDocumentService(db, documentFileService, settingsService)
 
 	// Handlers
 	authHandler := handlers.NewAuthHandler(authService, maintenanceService, cfg.CookieSecure, cfg.JWTRefreshTTL)
@@ -224,6 +227,8 @@ func main() {
 	attachmentTemplateHandler := handlers.NewAttachmentTemplateHandler(attachmentTemplateService, attachmentFieldConfigService)
 	attachmentBlankHandler := handlers.NewAttachmentBlankHandler(attachmentBlankService)
 	trashHandler := handlers.NewTrashHandler(trashService, trashDBRef)
+	documentGroupHandler := handlers.NewDocumentGroupHandler(documentGroupService)
+	documentHandler := handlers.NewDocumentHandler(documentService, documentFileService)
 
 	// Swagger UI: http://localhost:8090/swagger/index.html
 	if cfg.SwaggerEnabled {
@@ -279,6 +284,8 @@ func main() {
 		AttachmentTemplates: attachmentTemplateHandler,
 		AttachmentBlanks:    attachmentBlankHandler,
 		Trash:               trashHandler,
+		DocumentGroups:      documentGroupHandler,
+		Documents:           documentHandler,
 		PermResolver:        permissionResolver,
 		DenialLog:           accessDenialService,
 		MaintenanceBlock:    maintenanceBlock,

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -147,6 +147,10 @@ func AllModels() []interface{} {
 		// PD consent & audit (152-FZ)
 		&models.PDConsent{},
 		&models.PDAuditLog{},
+
+		// Documents (#39)
+		&models.DocumentGroup{},
+		&models.Document{},
 	}
 }
 

--- a/internal/handlers/document_groups.go
+++ b/internal/handlers/document_groups.go
@@ -1,0 +1,134 @@
+package handlers
+
+import (
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+
+	"github.com/labstack/echo/v4"
+)
+
+// DocumentGroupHandler -- HTTP-обработчики групп документов.
+type DocumentGroupHandler struct {
+	service services.DocumentGroupService
+}
+
+// NewDocumentGroupHandler создаёт новый DocumentGroupHandler.
+func NewDocumentGroupHandler(service services.DocumentGroupService) *DocumentGroupHandler {
+	return &DocumentGroupHandler{service: service}
+}
+
+// List godoc
+// @Summary      Список групп документов с количеством документов
+// @Tags         document-groups
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200 {array} models.DocumentGroupWithCount
+// @Failure      401 {object} models.HTTPError
+// @Router       /document-groups [get]
+func (h *DocumentGroupHandler) List(c echo.Context) error {
+	groups, err := h.service.List(c.Request().Context())
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, groups)
+}
+
+// Create godoc
+// @Summary      Создание группы документов
+// @Tags         document-groups
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        request body models.CreateDocumentGroupRequest true "Данные группы"
+// @Success      201 {object} models.DocumentGroup
+// @Failure      400 {object} models.HTTPError
+// @Failure      401 {object} models.HTTPError
+// @Failure      409 {object} models.HTTPError
+// @Router       /document-groups [post]
+func (h *DocumentGroupHandler) Create(c echo.Context) error {
+	userID := GetUserID(c)
+	var req models.CreateDocumentGroupRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	group, err := h.service.Create(c.Request().Context(), userID, req)
+	if err != nil {
+		return err
+	}
+	return RespondCreated(c, group)
+}
+
+// Update godoc
+// @Summary      Переименование группы документов
+// @Tags         document-groups
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID группы"
+// @Param        request body models.UpdateDocumentGroupRequest true "Новое название"
+// @Success      200 {object} models.DocumentGroup
+// @Failure      400 {object} models.HTTPError
+// @Failure      401 {object} models.HTTPError
+// @Failure      404 {object} models.HTTPError
+// @Failure      409 {object} models.HTTPError
+// @Router       /document-groups/{id} [put]
+func (h *DocumentGroupHandler) Update(c echo.Context) error {
+	userID := GetUserID(c)
+	id, err := ParseID(c, "id")
+	if err != nil {
+		return err
+	}
+	var req models.UpdateDocumentGroupRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	group, err := h.service.Update(c.Request().Context(), userID, id, req)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, group)
+}
+
+// Delete godoc
+// @Summary      Удаление группы документов
+// @Description  Документы группы переходят в «Прочее» (group_id = NULL)
+// @Tags         document-groups
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID группы"
+// @Success      200 {string} string "Группа удалена"
+// @Failure      401 {object} models.HTTPError
+// @Failure      404 {object} models.HTTPError
+// @Router       /document-groups/{id} [delete]
+func (h *DocumentGroupHandler) Delete(c echo.Context) error {
+	id, err := ParseID(c, "id")
+	if err != nil {
+		return err
+	}
+	if err := h.service.Delete(c.Request().Context(), id); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Группа документов удалена")
+}
+
+// Reorder godoc
+// @Summary      Изменение порядка групп документов
+// @Tags         document-groups
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        request body models.ReorderDocumentGroupsRequest true "Новый порядок ID групп"
+// @Success      200 {string} string "Порядок обновлён"
+// @Failure      400 {object} models.HTTPError
+// @Failure      401 {object} models.HTTPError
+// @Router       /document-groups/reorder [put]
+func (h *DocumentGroupHandler) Reorder(c echo.Context) error {
+	var req models.ReorderDocumentGroupsRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	if err := h.service.Reorder(c.Request().Context(), req); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Порядок групп обновлён")
+}

--- a/internal/handlers/documents.go
+++ b/internal/handlers/documents.go
@@ -1,0 +1,271 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"strconv"
+
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+
+	"github.com/labstack/echo/v4"
+)
+
+// DocumentHandler -- HTTP-обработчики документов.
+type DocumentHandler struct {
+	service services.DocumentService
+	fileSvc services.DocumentFileService
+}
+
+// NewDocumentHandler создаёт новый DocumentHandler.
+func NewDocumentHandler(service services.DocumentService, fileSvc services.DocumentFileService) *DocumentHandler {
+	return &DocumentHandler{service: service, fileSvc: fileSvc}
+}
+
+// List godoc
+// @Summary      Список документов для админки
+// @Tags         documents
+// @Produce      json
+// @Security     BearerAuth
+// @Param        group_id query int false "Фильтр по группе"
+// @Param        include_hidden query int false "Включить скрытые (1=да)"
+// @Success      200 {array} models.DocumentListItem
+// @Failure      401 {object} models.HTTPError
+// @Router       /documents [get]
+func (h *DocumentHandler) List(c echo.Context) error {
+	var groupID *int
+	if raw := c.QueryParam("group_id"); raw != "" {
+		id, err := strconv.Atoi(raw)
+		if err != nil || id <= 0 {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid group_id")
+		}
+		groupID = &id
+	}
+	includeHidden := c.QueryParam("include_hidden") == "1"
+
+	items, err := h.service.List(c.Request().Context(), groupID, includeHidden)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, items)
+}
+
+// Upload godoc
+// @Summary      Загрузка документа (multipart)
+// @Tags         documents
+// @Accept       multipart/form-data
+// @Produce      json
+// @Security     BearerAuth
+// @Param        file formData file true "Файл документа"
+// @Param        title formData string true "Название"
+// @Param        description formData string false "Описание"
+// @Param        group_id formData int false "ID группы"
+// @Param        published_at formData string false "Дата публикации (RFC3339)"
+// @Param        sort_order formData int false "Порядок"
+// @Success      201 {object} models.DocumentListItem
+// @Failure      400 {object} models.HTTPError
+// @Failure      401 {object} models.HTTPError
+// @Router       /documents [post]
+func (h *DocumentHandler) Upload(c echo.Context) error {
+	userID := GetUserID(c)
+
+	file, err := c.FormFile("file")
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Файл не передан")
+	}
+
+	req, err := bindUploadRequest(c)
+	if err != nil {
+		return err
+	}
+
+	item, err := h.service.Upload(c.Request().Context(), userID, req, file)
+	if err != nil {
+		return err
+	}
+	return RespondCreated(c, item)
+}
+
+// UpdateMeta godoc
+// @Summary      Обновление метаданных документа
+// @Tags         documents
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID документа"
+// @Param        request body models.UpdateDocumentMetaRequest true "Данные для обновления"
+// @Success      200 {object} models.DocumentListItem
+// @Failure      400 {object} models.HTTPError
+// @Failure      401 {object} models.HTTPError
+// @Failure      404 {object} models.HTTPError
+// @Router       /documents/{id} [put]
+func (h *DocumentHandler) UpdateMeta(c echo.Context) error {
+	userID := GetUserID(c)
+	id, err := ParseID(c, "id")
+	if err != nil {
+		return err
+	}
+	var req models.UpdateDocumentMetaRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	item, err := h.service.UpdateMeta(c.Request().Context(), userID, id, req)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, item)
+}
+
+// ReplaceFile godoc
+// @Summary      Замена файла документа
+// @Tags         documents
+// @Accept       multipart/form-data
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID документа"
+// @Param        file formData file true "Новый файл"
+// @Success      200 {object} models.DocumentListItem
+// @Failure      400 {object} models.HTTPError
+// @Failure      401 {object} models.HTTPError
+// @Failure      404 {object} models.HTTPError
+// @Router       /documents/{id}/file [put]
+func (h *DocumentHandler) ReplaceFile(c echo.Context) error {
+	userID := GetUserID(c)
+	id, err := ParseID(c, "id")
+	if err != nil {
+		return err
+	}
+	file, err := c.FormFile("file")
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Файл не передан")
+	}
+	item, err := h.service.ReplaceFile(c.Request().Context(), userID, id, file)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, item)
+}
+
+// Delete godoc
+// @Summary      Удаление документа (файл + запись в БД)
+// @Tags         documents
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID документа"
+// @Success      200 {string} string "Документ удалён"
+// @Failure      401 {object} models.HTTPError
+// @Failure      404 {object} models.HTTPError
+// @Router       /documents/{id} [delete]
+func (h *DocumentHandler) Delete(c echo.Context) error {
+	id, err := ParseID(c, "id")
+	if err != nil {
+		return err
+	}
+	if err := h.service.Delete(c.Request().Context(), id); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Документ удалён")
+}
+
+// Reorder godoc
+// @Summary      Изменение порядка документов внутри группы
+// @Tags         documents
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        request body models.ReorderDocumentsRequest true "group_id + массив ID"
+// @Success      200 {string} string "Порядок обновлён"
+// @Failure      400 {object} models.HTTPError
+// @Failure      401 {object} models.HTTPError
+// @Router       /documents/reorder [put]
+func (h *DocumentHandler) Reorder(c echo.Context) error {
+	var req models.ReorderDocumentsRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	if err := h.service.Reorder(c.Request().Context(), req); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Порядок документов обновлён")
+}
+
+// GetPublic godoc
+// @Summary      Публичный список документов (только видимые, сгруппированы)
+// @Tags         documents
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200 {array} models.PublicDocumentGroup
+// @Failure      401 {object} models.HTTPError
+// @Router       /public/documents [get]
+func (h *DocumentHandler) GetPublic(c echo.Context) error {
+	groups, err := h.service.GetPublic(c.Request().Context())
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, groups)
+}
+
+// Download godoc
+// @Summary      Скачивание файла документа
+// @Tags         documents
+// @Produce      application/octet-stream
+// @Security     BearerAuth
+// @Param        id path int true "ID документа"
+// @Success      200 {file} binary
+// @Failure      401 {object} models.HTTPError
+// @Failure      404 {object} models.HTTPError
+// @Router       /documents/{id}/download [get]
+func (h *DocumentHandler) Download(c echo.Context) error {
+	id, err := ParseID(c, "id")
+	if err != nil {
+		return err
+	}
+
+	doc, err := h.service.GetByID(c.Request().Context(), id)
+	if err != nil {
+		return err
+	}
+
+	filePath := filepath.Join(h.fileSvc.UploadDir(), doc.StoredName)
+	c.Response().Header().Set("Content-Disposition",
+		fmt.Sprintf(`attachment; filename="%s"`, doc.FileName))
+	c.Response().Header().Set("Content-Type", doc.MimeType)
+	return c.File(filePath)
+}
+
+// bindUploadRequest парсит поля multipart-формы для Upload.
+func bindUploadRequest(c echo.Context) (models.UploadDocumentRequest, error) {
+	req := models.UploadDocumentRequest{}
+	req.Title = c.FormValue("title")
+
+	if desc := c.FormValue("description"); desc != "" {
+		req.Description = &desc
+	}
+
+	if gidRaw := c.FormValue("group_id"); gidRaw != "" {
+		gid, err := strconv.Atoi(gidRaw)
+		if err != nil || gid <= 0 {
+			return req, echo.NewHTTPError(http.StatusBadRequest, "invalid group_id")
+		}
+		req.GroupID = &gid
+	}
+
+	if pat := c.FormValue("published_at"); pat != "" {
+		req.PublishedAt = &pat
+	}
+
+	if soRaw := c.FormValue("sort_order"); soRaw != "" {
+		so, err := strconv.Atoi(soRaw)
+		if err == nil {
+			req.SortOrder = so
+		}
+	}
+
+	// Валидация: title обязателен
+	if req.Title == "" {
+		return req, echo.NewHTTPError(http.StatusBadRequest, "Поле title обязательно")
+	}
+
+	return req, nil
+}

--- a/internal/handlers/documents_test.go
+++ b/internal/handlers/documents_test.go
@@ -1,0 +1,358 @@
+package handlers_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"systemburo/internal/config"
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Document Groups ---
+
+func TestDocumentGroups_Unauthorized(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	rec := testutil.GET(t, e, "/document-groups", nil)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestDocumentGroups_CRUD(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	// Пустой список
+	rec := testutil.GET(t, e, "/document-groups", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	list := testutil.ParseSlice(t, rec)
+	assert.Empty(t, list)
+
+	// Создание группы
+	rec = testutil.POST(t, e, "/document-groups", `{"name":"Приказы"}`, h)
+	require.Equal(t, http.StatusCreated, rec.Code)
+	data := testutil.ParseMap(t, rec)
+	groupID := int(data["id"].(float64))
+	assert.Equal(t, "Приказы", data["name"])
+
+	// Список после создания
+	rec = testutil.GET(t, e, "/document-groups", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	list = testutil.ParseSlice(t, rec)
+	require.Len(t, list, 1)
+	assert.Equal(t, "Приказы", list[0]["name"])
+	// count должен быть 0 (нет документов)
+	assert.EqualValues(t, 0, list[0]["count"])
+
+	// Дубль -- конфликт (без учёта регистра)
+	rec = testutil.POST(t, e, "/document-groups", `{"name":"ПРИКАЗЫ"}`, h)
+	assert.Equal(t, http.StatusConflict, rec.Code)
+
+	// Переименование
+	rec = testutil.PUT(t, e, fmt.Sprintf("/document-groups/%d", groupID), `{"name":"Распоряжения"}`, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	data = testutil.ParseMap(t, rec)
+	assert.Equal(t, "Распоряжения", data["name"])
+
+	// Создаём вторую группу
+	rec = testutil.POST(t, e, "/document-groups", `{"name":"Инструкции"}`, h)
+	require.Equal(t, http.StatusCreated, rec.Code)
+	data2 := testutil.ParseMap(t, rec)
+	groupID2 := int(data2["id"].(float64))
+
+	// Переупорядочивание
+	reorderBody := fmt.Sprintf(`{"ids":[%d,%d]}`, groupID2, groupID)
+	rec = testutil.PUT(t, e, "/document-groups/reorder", reorderBody, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Удаление группы
+	rec = testutil.DELETE(t, e, fmt.Sprintf("/document-groups/%d", groupID), h)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Список после удаления -- только вторая группа
+	rec = testutil.GET(t, e, "/document-groups", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	list = testutil.ParseSlice(t, rec)
+	require.Len(t, list, 1)
+	assert.EqualValues(t, groupID2, list[0]["id"])
+}
+
+func TestDocumentGroups_Delete_MovesDocsToOther(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	// Создаём группу
+	rec := testutil.POST(t, e, "/document-groups", `{"name":"Группа для теста"}`, h)
+	require.Equal(t, http.StatusCreated, rec.Code)
+	gData := testutil.ParseMap(t, rec)
+	groupID := int(gData["id"].(float64))
+
+	// Вставляем документ напрямую в БД
+	doc := models.Document{
+		GroupID:    &groupID,
+		Title:      "Тестовый документ",
+		FileName:   "test.pdf",
+		StoredName: "test-uuid.pdf",
+		FileExt:    ".pdf",
+		MimeType:   "application/pdf",
+		FileSize:   1024,
+		IsVisible:  true,
+	}
+	require.NoError(t, db.Create(&doc).Error)
+
+	// Удаляем группу
+	rec = testutil.DELETE(t, e, fmt.Sprintf("/document-groups/%d", groupID), h)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Документ должен быть в «Прочее» (group_id = NULL)
+	var updated models.Document
+	require.NoError(t, db.First(&updated, doc.ID).Error)
+	assert.Nil(t, updated.GroupID, "ожидается group_id = NULL после удаления группы")
+}
+
+// --- Public endpoint ---
+
+func TestDocuments_GetPublic_OnlyVisible(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	visible := models.Document{
+		Title: "Видимый", FileName: "v.pdf", StoredName: "v.pdf",
+		FileExt: ".pdf", MimeType: "application/pdf", FileSize: 100, IsVisible: true,
+	}
+	hidden := models.Document{
+		Title: "Скрытый", FileName: "h.pdf", StoredName: "h.pdf",
+		FileExt: ".pdf", MimeType: "application/pdf", FileSize: 100, IsVisible: false,
+	}
+	require.NoError(t, db.Create(&visible).Error)
+	require.NoError(t, db.Create(&hidden).Error)
+
+	token := testutil.RegisterAndLogin(t, e, "pubuser1", "password123!ABCabc", 1, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	rec := testutil.GET(t, e, "/public/documents", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	groups := testutil.ParseSlice(t, rec)
+	// Одна виртуальная группа «Прочее» с одним видимым документом
+	require.Len(t, groups, 1)
+	docsRaw := groups[0]["documents"].([]interface{})
+	require.Len(t, docsRaw, 1)
+	doc := docsRaw[0].(map[string]interface{})
+	assert.Equal(t, "Видимый", doc["title"])
+}
+
+func TestDocuments_GetPublic_Grouped(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	group := models.DocumentGroup{Name: "Приказы", SortOrder: 0}
+	require.NoError(t, db.Create(&group).Error)
+
+	docInGroup := models.Document{
+		GroupID: &group.ID, Title: "В группе", FileName: "g.pdf",
+		StoredName: "g.pdf", FileExt: ".pdf", MimeType: "application/pdf",
+		FileSize: 100, IsVisible: true, SortOrder: 0,
+	}
+	docNoGroup := models.Document{
+		Title: "Прочее", FileName: "o.pdf",
+		StoredName: "o.pdf", FileExt: ".pdf", MimeType: "application/pdf",
+		FileSize: 100, IsVisible: true, SortOrder: 0,
+	}
+	require.NoError(t, db.Create(&docInGroup).Error)
+	require.NoError(t, db.Create(&docNoGroup).Error)
+
+	token := testutil.RegisterAndLogin(t, e, "pubuser2", "password123!ABCabc", 1, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	rec := testutil.GET(t, e, "/public/documents", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	groups := testutil.ParseSlice(t, rec)
+	// 2 группы: «Приказы» и «Прочее»
+	require.Len(t, groups, 2)
+	assert.Equal(t, "Приказы", groups[0]["name"])
+	assert.Equal(t, "Прочее", groups[1]["name"])
+}
+
+func TestDocuments_GetPublic_Unauthorized(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	rec := testutil.GET(t, e, "/public/documents", nil)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestDocuments_GetPublic_NoOther(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	group := models.DocumentGroup{Name: "Группа", SortOrder: 0}
+	require.NoError(t, db.Create(&group).Error)
+	doc := models.Document{
+		GroupID: &group.ID, Title: "Документ", FileName: "d.pdf",
+		StoredName: "d.pdf", FileExt: ".pdf", MimeType: "application/pdf",
+		FileSize: 100, IsVisible: true,
+	}
+	require.NoError(t, db.Create(&doc).Error)
+
+	token := testutil.RegisterAndLogin(t, e, "pubuser3", "password123!ABCabc", 1, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	rec := testutil.GET(t, e, "/public/documents", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	groups := testutil.ParseSlice(t, rec)
+	require.Len(t, groups, 1)
+	assert.Equal(t, "Группа", groups[0]["name"])
+	// Нет группы «Прочее» когда все документы в группах
+}
+
+// --- Download ---
+
+func TestDocuments_Download_NotFound(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "dluser", "password123!ABCabc", 1, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	rec := testutil.GET(t, e, "/documents/99999/download", h)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// --- Upload validation ---
+
+func TestDocuments_Upload_InvalidExt(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	body, ct := buildMultipartDoc(t, "test.exe", []byte("MZ"), map[string]string{"title": "Тест"})
+	req := httptest.NewRequest(http.MethodPost, "/api/documents", body)
+	req.Header.Set("Content-Type", ct)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestDocuments_Upload_WrongMagic(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	// .pdf расширение, но содержимое не PDF (EXE magic bytes)
+	content := append([]byte{0x4D, 0x5A}, bytes.Repeat([]byte("x"), 100)...)
+	body, ct := buildMultipartDoc(t, "fake.pdf", content, map[string]string{"title": "Тест"})
+	req := httptest.NewRequest(http.MethodPost, "/api/documents", body)
+	req.Header.Set("Content-Type", ct)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// --- Admin-only access ---
+
+func TestDocuments_List_AdminOnly(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "regularuser4docs", "password123!ABCabc", 1, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	rec := testutil.GET(t, e, "/documents", h)
+	// 403 из-за page.admin permission
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+// --- Reorder (service-level) ---
+
+func TestDocuments_Reorder(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	d1 := models.Document{
+		Title: "A", FileName: "a.pdf", StoredName: "a.pdf",
+		FileExt: ".pdf", MimeType: "application/pdf", SortOrder: 0, IsVisible: true,
+	}
+	d2 := models.Document{
+		Title: "B", FileName: "b.pdf", StoredName: "b.pdf",
+		FileExt: ".pdf", MimeType: "application/pdf", SortOrder: 1, IsVisible: true,
+	}
+	require.NoError(t, db.Create(&d1).Error)
+	require.NoError(t, db.Create(&d2).Error)
+
+	ctx := context.Background()
+	fileSvc := services.NewDocumentFileService(t.TempDir())
+	settingsSvc := services.NewSettingsService(db, &config.Config{
+		UploadMaxFileSize: 10 * 1024 * 1024,
+	})
+	svc := services.NewDocumentService(db, fileSvc, settingsSvc)
+
+	err := svc.Reorder(ctx, models.ReorderDocumentsRequest{IDs: []int{d2.ID, d1.ID}})
+	require.NoError(t, err)
+
+	var updated1, updated2 models.Document
+	require.NoError(t, db.First(&updated1, d1.ID).Error)
+	require.NoError(t, db.First(&updated2, d2.ID).Error)
+	// d2 -> sort_order=0, d1 -> sort_order=1
+	assert.Equal(t, 0, updated2.SortOrder)
+	assert.Equal(t, 1, updated1.SortOrder)
+}
+
+// buildMultipartDoc создаёт multipart-тело с файлом и полями формы.
+func buildMultipartDoc(t *testing.T, filename string, fileContent []byte, fields map[string]string) (*bytes.Buffer, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	fw, err := w.CreateFormFile("file", filename)
+	require.NoError(t, err)
+	_, err = fw.Write(fileContent)
+	require.NoError(t, err)
+	for k, v := range fields {
+		require.NoError(t, w.WriteField(k, v))
+	}
+	w.Close()
+	return &buf, w.FormDataContentType()
+}

--- a/internal/handlers/documents_test.go
+++ b/internal/handlers/documents_test.go
@@ -145,10 +145,12 @@ func TestDocuments_GetPublic_OnlyVisible(t *testing.T) {
 	}
 	hidden := models.Document{
 		Title: "Скрытый", FileName: "h.pdf", StoredName: "h.pdf",
-		FileExt: ".pdf", MimeType: "application/pdf", FileSize: 100, IsVisible: false,
+		FileExt: ".pdf", MimeType: "application/pdf", FileSize: 100, IsVisible: true,
 	}
 	require.NoError(t, db.Create(&visible).Error)
 	require.NoError(t, db.Create(&hidden).Error)
+	// IsVisible=false нужно обновить отдельно (GORM пропускает zero-value bool при Create)
+	require.NoError(t, db.Model(&hidden).Update("is_visible", false).Error)
 
 	token := testutil.RegisterAndLogin(t, e, "pubuser1", "password123!ABCabc", 1, td.OrgID, td.CompanyID)
 	h := testutil.AuthHeader(token)

--- a/internal/models/document.go
+++ b/internal/models/document.go
@@ -1,0 +1,127 @@
+package models
+
+import "time"
+
+// DocumentGroup -- группа документов (раздел/категория).
+type DocumentGroup struct {
+	ID        int       `json:"id"`
+	Name      string    `gorm:"size:255;uniqueIndex:uidx_document_groups_name" json:"name"`
+	SortOrder int       `gorm:"default:0" json:"sort_order"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+	CreatedBy *int      `json:"created_by"`
+	UpdatedBy *int      `json:"updated_by"`
+}
+
+// Document -- документ (файл) с метаданными.
+type Document struct {
+	ID          int        `json:"id"`
+	GroupID     *int       `gorm:"index" json:"group_id"`
+	Title       string     `gorm:"size:255" json:"title"`
+	Description *string    `gorm:"type:text" json:"description"`
+	FileName    string     `gorm:"size:255" json:"file_name"`
+	StoredName  string     `gorm:"size:255" json:"stored_name"`
+	FileExt     string     `gorm:"size:10" json:"file_ext"`
+	MimeType    string     `gorm:"size:120" json:"mime_type"`
+	FileSize    int64      `json:"file_size"`
+	PublishedAt time.Time  `json:"published_at"`
+	IsVisible   bool       `gorm:"default:true" json:"is_visible"`
+	SortOrder   int        `gorm:"default:0" json:"sort_order"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+	CreatedBy   *int       `json:"created_by"`
+	UpdatedBy   *int       `json:"updated_by"`
+}
+
+// -- Request/Response DTO --
+
+// CreateDocumentGroupRequest -- запрос на создание группы.
+type CreateDocumentGroupRequest struct {
+	Name string `json:"name" validate:"required,max=255"`
+}
+
+// UpdateDocumentGroupRequest -- запрос на переименование группы.
+type UpdateDocumentGroupRequest struct {
+	Name string `json:"name" validate:"required,max=255"`
+}
+
+// ReorderDocumentGroupsRequest -- запрос на изменение порядка групп.
+type ReorderDocumentGroupsRequest struct {
+	IDs []int `json:"ids" validate:"required,min=1"`
+}
+
+// DocumentGroupWithCount -- группа с количеством документов.
+type DocumentGroupWithCount struct {
+	ID        int       `json:"id"`
+	Name      string    `json:"name"`
+	SortOrder int       `json:"sort_order"`
+	Count     int64     `json:"count"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+	CreatedBy *int      `json:"created_by"`
+	UpdatedBy *int      `json:"updated_by"`
+}
+
+// UploadDocumentRequest -- поля multipart-формы при загрузке документа.
+type UploadDocumentRequest struct {
+	Title       string  `form:"title" validate:"required,max=255"`
+	Description *string `form:"description"`
+	GroupID     *int    `form:"group_id"`
+	PublishedAt *string `form:"published_at"`
+	SortOrder   int     `form:"sort_order"`
+}
+
+// UpdateDocumentMetaRequest -- запрос на обновление метаданных документа.
+type UpdateDocumentMetaRequest struct {
+	Title       *string `json:"title" validate:"omitempty,max=255"`
+	Description *string `json:"description"`
+	GroupID     *int    `json:"group_id"`
+	PublishedAt *string `json:"published_at"`
+	IsVisible   *bool   `json:"is_visible"`
+}
+
+// ReorderDocumentsRequest -- запрос на изменение порядка документов внутри группы.
+type ReorderDocumentsRequest struct {
+	GroupID *int  `json:"group_id"`
+	IDs     []int `json:"ids" validate:"required,min=1"`
+}
+
+// DocumentListItem -- документ для списка в админке.
+type DocumentListItem struct {
+	ID          int        `json:"id"`
+	GroupID     *int       `json:"group_id"`
+	GroupName   *string    `json:"group_name"`
+	Title       string     `json:"title"`
+	Description *string    `json:"description"`
+	FileName    string     `json:"file_name"`
+	FileExt     string     `json:"file_ext"`
+	FileSize    int64      `json:"file_size"`
+	PublishedAt time.Time  `json:"published_at"`
+	IsVisible   bool       `json:"is_visible"`
+	SortOrder   int        `json:"sort_order"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+	CreatedBy   *int       `json:"created_by"`
+	UpdatedBy   *int       `json:"updated_by"`
+}
+
+// PublicDocumentGroup -- группа с документами для публичного эндпоинта.
+type PublicDocumentGroup struct {
+	ID        int               `json:"id"`
+	Name      string            `json:"name"`
+	SortOrder int               `json:"sort_order"`
+	Documents []PublicDocument  `json:"documents"`
+}
+
+// PublicDocument -- документ для публичного эндпоинта (без скрытых).
+type PublicDocument struct {
+	ID          int       `json:"id"`
+	GroupID     *int      `json:"group_id"`
+	Title       string    `json:"title"`
+	Description *string   `json:"description"`
+	FileName    string    `json:"file_name"`
+	FileExt     string    `json:"file_ext"`
+	FileSize    int64     `json:"file_size"`
+	PublishedAt time.Time `json:"published_at"`
+	SortOrder   int       `json:"sort_order"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -51,6 +51,8 @@ type Dependencies struct {
 	AttachmentTemplates *handlers.AttachmentTemplateHandler
 	AttachmentBlanks    *handlers.AttachmentBlankHandler
 	Trash               *handlers.TrashHandler
+	DocumentGroups      *handlers.DocumentGroupHandler
+	Documents           *handlers.DocumentHandler
 
 	// Services (для middleware и audit)
 	PermResolver *services.PermissionResolver
@@ -103,6 +105,8 @@ func Setup(e *echo.Echo, d Dependencies) {
 	attachmentTemplates := d.AttachmentTemplates
 	attachmentBlanks := d.AttachmentBlanks
 	trash := d.Trash
+	docGroups := d.DocumentGroups
+	docs := d.Documents
 	permResolver := d.PermResolver
 	denialLog := d.DenialLog
 	maintenanceBlock := d.MaintenanceBlock
@@ -551,4 +555,27 @@ func Setup(e *echo.Echo, d Dependencies) {
 	adminMaint := protected.Group("/admin")
 	adminMaint.GET("/maintenance", maintenance.GetAdminStatus)
 	adminMaint.PUT("/maintenance", maintenance.ToggleMaintenance)
+
+	// Документы (#39). Admin-операции под page.admin; скачивание и публичный список -- под auth.
+	requireAdmin := mw.RequirePermissionV2(permResolver, denialLog, services.KeyPageAdmin)
+	if docGroups != nil {
+		dgGroup := protected.Group("/document-groups")
+		dgGroup.GET("", docGroups.List, requireAdmin)
+		dgGroup.POST("", docGroups.Create, requireAdmin)
+		dgGroup.PUT("/reorder", docGroups.Reorder, requireAdmin)
+		dgGroup.PUT("/:id", docGroups.Update, requireAdmin)
+		dgGroup.DELETE("/:id", docGroups.Delete, requireAdmin)
+	}
+	if docs != nil {
+		docsGroup := protected.Group("/documents")
+		docsGroup.GET("", docs.List, requireAdmin)
+		docsGroup.POST("", docs.Upload, requireAdmin)
+		docsGroup.PUT("/reorder", docs.Reorder, requireAdmin)
+		docsGroup.PUT("/:id", docs.UpdateMeta, requireAdmin)
+		docsGroup.PUT("/:id/file", docs.ReplaceFile, requireAdmin)
+		docsGroup.DELETE("/:id", docs.Delete, requireAdmin)
+		docsGroup.GET("/:id/download", docs.Download)
+
+		protected.GET("/public/documents", docs.GetPublic)
+	}
 }

--- a/internal/services/document_file_service.go
+++ b/internal/services/document_file_service.go
@@ -1,0 +1,178 @@
+package services
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+)
+
+// allowedDocExtensions -- разрешённые расширения документов.
+var allowedDocExtensions = map[string]bool{
+	".doc":  true,
+	".docx": true,
+	".pdf":  true,
+	".xlsx": true,
+	".pptx": true,
+}
+
+// magic-bytes сигнатуры для семейств форматов
+var (
+	magicPDF   = []byte{0x25, 0x50, 0x44, 0x46}             // %PDF
+	magicOOXML = []byte{0x50, 0x4B, 0x03, 0x04}             // PK..
+	magicOLE2  = []byte{0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1}
+)
+
+// docExtMagicFamily -- к какому семейству magic-bytes относится расширение.
+type magicFamily int
+
+const (
+	familyPDF   magicFamily = iota
+	familyOOXML             // docx, xlsx, pptx
+	familyOLE2              // doc
+)
+
+var extFamily = map[string]magicFamily{
+	".pdf":  familyPDF,
+	".docx": familyOOXML,
+	".xlsx": familyOOXML,
+	".pptx": familyOOXML,
+	".doc":  familyOLE2,
+}
+
+// DocumentFileService -- загрузка и удаление файлов документов.
+type DocumentFileService interface {
+	// Save читает файл из multipart.FileHeader, валидирует, сохраняет на диск.
+	// Возвращает storedName, fileExt, mimeFamily, error.
+	Save(ctx context.Context, file *multipart.FileHeader, maxSize int64) (storedName, fileExt string, err error)
+	// Delete удаляет файл с диска; ошибку не возвращает если файл уже отсутствует.
+	Delete(storedName string)
+	// UploadDir возвращает директорию хранения документов.
+	UploadDir() string
+}
+
+type documentFileService struct {
+	uploadDir string
+}
+
+// NewDocumentFileService создаёт DocumentFileService. uploadPath -- корневая папка uploads.
+func NewDocumentFileService(uploadPath string) DocumentFileService {
+	return &documentFileService{
+		uploadDir: filepath.Join(uploadPath, "documents"),
+	}
+}
+
+func (s *documentFileService) UploadDir() string {
+	return s.uploadDir
+}
+
+func (s *documentFileService) Save(_ context.Context, file *multipart.FileHeader, maxSize int64) (string, string, error) {
+	// Проверяем размер
+	if file.Size > maxSize {
+		maxMB := maxSize / 1024 / 1024
+		return "", "", echo.NewHTTPError(http.StatusBadRequest,
+			fmt.Sprintf("Файл слишком большой. Максимальный размер: %d МБ", maxMB))
+	}
+
+	ext := strings.ToLower(filepath.Ext(file.Filename))
+	if !allowedDocExtensions[ext] {
+		return "", "", echo.NewHTTPError(http.StatusBadRequest,
+			"Недопустимый тип файла. Разрешены: doc, docx, pdf, xlsx, pptx")
+	}
+
+	family, ok := extFamily[ext]
+	if !ok {
+		return "", "", echo.NewHTTPError(http.StatusBadRequest, "Недопустимый тип файла")
+	}
+
+	src, err := file.Open()
+	if err != nil {
+		return "", "", echo.NewHTTPError(http.StatusBadRequest, "Ошибка чтения файла")
+	}
+	defer src.Close()
+
+	// Читаем первые 8 байт для проверки magic-bytes
+	header := make([]byte, 8)
+	n, err := io.ReadFull(src, header)
+	if err != nil && err != io.ErrUnexpectedEOF {
+		return "", "", echo.NewHTTPError(http.StatusBadRequest, "Файл повреждён или пуст")
+	}
+	header = header[:n]
+
+	if !matchesMagic(header, family) {
+		return "", "", echo.NewHTTPError(http.StatusBadRequest,
+			"Содержимое файла не соответствует расширению. Возможно, файл повреждён или переименован")
+	}
+
+	// Перемотка через многочитаемый reader (header + остаток файла)
+	combined := io.MultiReader(bytes.NewReader(header), src)
+
+	if err := os.MkdirAll(s.uploadDir, 0o755); err != nil {
+		return "", "", echo.NewHTTPError(http.StatusInternalServerError, "Ошибка создания директории загрузки")
+	}
+
+	storedName := uuid.New().String() + ext
+	savePath := filepath.Join(s.uploadDir, storedName)
+
+	dst, err := os.Create(savePath)
+	if err != nil {
+		return "", "", echo.NewHTTPError(http.StatusInternalServerError, "Ошибка записи файла")
+	}
+	defer dst.Close()
+
+	if _, err := io.Copy(dst, combined); err != nil {
+		_ = os.Remove(savePath)
+		return "", "", echo.NewHTTPError(http.StatusInternalServerError, "Ошибка записи файла")
+	}
+
+	return storedName, ext, nil
+}
+
+func (s *documentFileService) Delete(storedName string) {
+	if storedName == "" {
+		return
+	}
+	filePath := filepath.Join(s.uploadDir, storedName)
+	if _, err := os.Stat(filePath); err == nil {
+		_ = os.Remove(filePath)
+	}
+}
+
+// matchesMagic проверяет соответствие заголовка файла ожидаемому семейству.
+func matchesMagic(header []byte, family magicFamily) bool {
+	switch family {
+	case familyPDF:
+		return len(header) >= 4 && bytes.Equal(header[:4], magicPDF)
+	case familyOOXML:
+		return len(header) >= 4 && bytes.Equal(header[:4], magicOOXML)
+	case familyOLE2:
+		return len(header) >= 8 && bytes.Equal(header[:8], magicOLE2)
+	}
+	return false
+}
+
+// DetectMimeType возвращает MIME-тип по расширению (для документов).
+func DetectMimeType(ext string) string {
+	switch ext {
+	case ".pdf":
+		return "application/pdf"
+	case ".doc":
+		return "application/msword"
+	case ".docx":
+		return "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+	case ".xlsx":
+		return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+	case ".pptx":
+		return "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+	default:
+		return "application/octet-stream"
+	}
+}

--- a/internal/services/document_file_service_test.go
+++ b/internal/services/document_file_service_test.go
@@ -1,0 +1,216 @@
+package services
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"mime/multipart"
+	"net/textproto"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// makeFileHeader создаёт тестовый multipart.FileHeader с указанным именем и содержимым.
+func makeFileHeader(t *testing.T, name string, content []byte) *multipart.FileHeader {
+	t.Helper()
+
+	// Записываем содержимое во временный файл чтобы multipart.FileHeader умел его открыть
+	tmp, err := os.CreateTemp(t.TempDir(), "testfile-*")
+	if err != nil {
+		t.Fatalf("create temp: %v", err)
+	}
+	if _, err := tmp.Write(content); err != nil {
+		t.Fatalf("write temp: %v", err)
+	}
+	tmp.Close()
+
+	// Эмулируем FileHeader через обёртку
+	return &multipart.FileHeader{
+		Filename: name,
+		Size:     int64(len(content)),
+		Header:   textproto.MIMEHeader{"Content-Type": {"application/octet-stream"}},
+		// Переопределяем Open через workaround: используем специально созданный файл
+	}
+}
+
+// testableFileHeader создаёт *multipart.FileHeader, Open которого возвращает content.
+// multipart.FileHeader хранит путь приватно, поэтому используем tmpdir и патчим Open.
+func testableFile(t *testing.T, dir, name string, content []byte) *multipart.FileHeader {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// Создаём FileHeader с нужными данными через multipart-запись
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	fw, err := w.CreateFormFile("file", name)
+	if err != nil {
+		t.Fatalf("create form file: %v", err)
+	}
+	if _, err := fw.Write(content); err != nil {
+		t.Fatalf("write form: %v", err)
+	}
+	w.Close()
+
+	r := multipart.NewReader(&buf, w.Boundary())
+	form, err := r.ReadForm(int64(len(content)) + 1024)
+	if err != nil {
+		t.Fatalf("read form: %v", err)
+	}
+	files := form.File["file"]
+	if len(files) == 0 {
+		t.Fatal("no files in form")
+	}
+	return files[0]
+}
+
+func TestDocumentFileService_ValidateMagicBytes(t *testing.T) {
+	tests := []struct {
+		name    string
+		fname   string
+		content []byte
+		wantErr bool
+	}{
+		{
+			name:    "pdf_valid",
+			fname:   "doc.pdf",
+			content: append([]byte{0x25, 0x50, 0x44, 0x46}, bytes.Repeat([]byte("x"), 100)...),
+			wantErr: false,
+		},
+		{
+			name:    "docx_valid",
+			fname:   "doc.docx",
+			content: append([]byte{0x50, 0x4B, 0x03, 0x04}, bytes.Repeat([]byte("x"), 100)...),
+			wantErr: false,
+		},
+		{
+			name:    "xlsx_valid",
+			fname:   "sheet.xlsx",
+			content: append([]byte{0x50, 0x4B, 0x03, 0x04}, bytes.Repeat([]byte("x"), 100)...),
+			wantErr: false,
+		},
+		{
+			name:    "pptx_valid",
+			fname:   "pres.pptx",
+			content: append([]byte{0x50, 0x4B, 0x03, 0x04}, bytes.Repeat([]byte("x"), 100)...),
+			wantErr: false,
+		},
+		{
+			name:    "doc_valid_ole2",
+			fname:   "legacy.doc",
+			content: append([]byte{0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1}, bytes.Repeat([]byte("x"), 100)...),
+			wantErr: false,
+		},
+		{
+			name:    "pdf_wrong_ext_docx",
+			fname:   "renamed.docx",
+			content: append([]byte{0x25, 0x50, 0x44, 0x46}, bytes.Repeat([]byte("x"), 100)...),
+			wantErr: true,
+		},
+		{
+			name:    "exe_renamed_as_pdf",
+			fname:   "virus.pdf",
+			content: append([]byte{0x4D, 0x5A, 0x00, 0x00}, bytes.Repeat([]byte("x"), 100)...),
+			wantErr: true,
+		},
+		{
+			name:    "forbidden_extension",
+			fname:   "script.js",
+			content: []byte("alert('xss')"),
+			wantErr: true,
+		},
+		{
+			name:    "doc_with_ooxml_signature",
+			fname:   "fake.doc",
+			content: append([]byte{0x50, 0x4B, 0x03, 0x04}, bytes.Repeat([]byte("x"), 100)...),
+			wantErr: true, // .doc должен иметь OLE2, а не OOXML
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			uploadDir := filepath.Join(dir, "uploads")
+			svc := NewDocumentFileService(dir)
+
+			fh := testableFile(t, t.TempDir(), tc.fname, tc.content)
+
+			_, _, err := svc.Save(context.Background(), fh, 10*1024*1024)
+			if tc.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				} else {
+					// Проверяем что файл создан
+					entries, _ := os.ReadDir(uploadDir)
+					if len(entries) == 0 {
+						t.Error("expected file in upload dir, none found")
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestDocumentFileService_SizeLimit(t *testing.T) {
+	dir := t.TempDir()
+	svc := NewDocumentFileService(dir)
+
+	// 5 байт валидного PDF-заголовка + padding, но заявляем size = 100 MB -> отказ по размеру
+	content := append([]byte{0x25, 0x50, 0x44, 0x46}, bytes.Repeat([]byte("x"), 100)...)
+	fh := testableFile(t, t.TempDir(), "big.pdf", content)
+	fh.Size = 200 * 1024 * 1024 // 200 MB
+
+	_, _, err := svc.Save(context.Background(), fh, 10*1024*1024) // 10 MB limit
+	if err == nil {
+		t.Error("expected size error, got nil")
+	}
+}
+
+func TestMatchesMagic(t *testing.T) {
+	tests := []struct {
+		name   string
+		header []byte
+		family magicFamily
+		want   bool
+	}{
+		{"pdf ok", []byte{0x25, 0x50, 0x44, 0x46, 0x00}, familyPDF, true},
+		{"pdf bad", []byte{0x00, 0x50, 0x44, 0x46, 0x00}, familyPDF, false},
+		{"ooxml ok", []byte{0x50, 0x4B, 0x03, 0x04, 0x00}, familyOOXML, true},
+		{"ooxml bad", []byte{0x50, 0x4B, 0x00, 0x04, 0x00}, familyOOXML, false},
+		{"ole2 ok", []byte{0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1}, familyOLE2, true},
+		{"ole2 short", []byte{0xD0, 0xCF, 0x11, 0xE0}, familyOLE2, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := matchesMagic(tc.header, tc.family)
+			if got != tc.want {
+				t.Errorf("matchesMagic(%x, %d) = %v, want %v", tc.header, tc.family, got, tc.want)
+			}
+		})
+	}
+}
+
+// Проверяем что Delete не паникует на пустом storedName и несуществующем файле.
+func TestDocumentFileService_Delete(t *testing.T) {
+	dir := t.TempDir()
+	svc := NewDocumentFileService(dir)
+
+	svc.Delete("") // не паникует
+	svc.Delete("nonexistent-uuid.pdf") // не паникует
+}
+
+// Smoke-test: стрим реального файла через c.File() использует UploadDir.
+func TestDocumentFileService_UploadDir(t *testing.T) {
+	dir := t.TempDir()
+	svc := NewDocumentFileService(dir)
+	if svc.UploadDir() == "" {
+		t.Error("UploadDir should not be empty")
+	}
+	_ = io.Discard
+}

--- a/internal/services/document_file_service_test.go
+++ b/internal/services/document_file_service_test.go
@@ -132,8 +132,9 @@ func TestDocumentFileService_ValidateMagicBytes(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
-			uploadDir := filepath.Join(dir, "uploads")
 			svc := NewDocumentFileService(dir)
+			// UploadDir = dir/documents
+			uploadDir := svc.UploadDir()
 
 			fh := testableFile(t, t.TempDir(), tc.fname, tc.content)
 
@@ -146,10 +147,10 @@ func TestDocumentFileService_ValidateMagicBytes(t *testing.T) {
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)
 				} else {
-					// Проверяем что файл создан
+					// Проверяем что файл создан в upload dir
 					entries, _ := os.ReadDir(uploadDir)
 					if len(entries) == 0 {
-						t.Error("expected file in upload dir, none found")
+						t.Errorf("expected file in upload dir %s, none found", uploadDir)
 					}
 				}
 			}

--- a/internal/services/document_group_service.go
+++ b/internal/services/document_group_service.go
@@ -1,0 +1,157 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"systemburo/internal/models"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+// DocumentGroupService -- интерфейс управления группами документов.
+type DocumentGroupService interface {
+	List(ctx context.Context) ([]models.DocumentGroupWithCount, error)
+	Create(ctx context.Context, userID int, req models.CreateDocumentGroupRequest) (*models.DocumentGroup, error)
+	Update(ctx context.Context, userID int, id int, req models.UpdateDocumentGroupRequest) (*models.DocumentGroup, error)
+	Delete(ctx context.Context, id int) error
+	Reorder(ctx context.Context, req models.ReorderDocumentGroupsRequest) error
+}
+
+type documentGroupService struct {
+	db *gorm.DB
+}
+
+// NewDocumentGroupService создаёт реализацию DocumentGroupService.
+func NewDocumentGroupService(db *gorm.DB) DocumentGroupService {
+	return &documentGroupService{db: db}
+}
+
+func (s *documentGroupService) List(ctx context.Context) ([]models.DocumentGroupWithCount, error) {
+	results := make([]models.DocumentGroupWithCount, 0)
+	err := s.db.WithContext(ctx).
+		Table("document_groups dg").
+		Select(`dg.id, dg.name, dg.sort_order, dg.created_at, dg.updated_at,
+			dg.created_by, dg.updated_by,
+			COUNT(d.id) AS count`).
+		Joins("LEFT JOIN documents d ON d.group_id = dg.id").
+		Group("dg.id").
+		Order("dg.sort_order ASC, dg.id ASC").
+		Scan(&results).Error
+	if err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения групп документов")
+	}
+	return results, nil
+}
+
+func (s *documentGroupService) Create(ctx context.Context, userID int, req models.CreateDocumentGroupRequest) (*models.DocumentGroup, error) {
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "Название группы не может быть пустым")
+	}
+
+	// Проверяем уникальность без учёта регистра
+	var count int64
+	if err := s.db.WithContext(ctx).Model(&models.DocumentGroup{}).
+		Where("LOWER(name) = LOWER(?)", name).
+		Count(&count).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка проверки уникальности")
+	}
+	if count > 0 {
+		return nil, echo.NewHTTPError(http.StatusConflict, fmt.Sprintf("Группа с названием %q уже существует", name))
+	}
+
+	// Максимальный sort_order для новой группы в конце
+	var maxOrder int
+	s.db.WithContext(ctx).Model(&models.DocumentGroup{}).Select("COALESCE(MAX(sort_order), 0)").Scan(&maxOrder)
+
+	now := time.Now().UTC()
+	group := models.DocumentGroup{
+		Name:      name,
+		SortOrder: maxOrder + 1,
+		CreatedBy: &userID,
+		UpdatedBy: &userID,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := s.db.WithContext(ctx).Create(&group).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка создания группы документов")
+	}
+	return &group, nil
+}
+
+func (s *documentGroupService) Update(ctx context.Context, userID int, id int, req models.UpdateDocumentGroupRequest) (*models.DocumentGroup, error) {
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "Название группы не может быть пустым")
+	}
+
+	var group models.DocumentGroup
+	if err := s.db.WithContext(ctx).First(&group, id).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, echo.NewHTTPError(http.StatusNotFound, "Группа документов не найдена")
+		}
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения группы")
+	}
+
+	// Уникальность нового имени среди других групп
+	var count int64
+	if err := s.db.WithContext(ctx).Model(&models.DocumentGroup{}).
+		Where("LOWER(name) = LOWER(?) AND id != ?", name, id).
+		Count(&count).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка проверки уникальности")
+	}
+	if count > 0 {
+		return nil, echo.NewHTTPError(http.StatusConflict, fmt.Sprintf("Группа с названием %q уже существует", name))
+	}
+
+	if err := s.db.WithContext(ctx).Model(&group).Updates(map[string]interface{}{
+		"name":       name,
+		"updated_by": userID,
+		"updated_at": time.Now().UTC(),
+	}).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка обновления группы документов")
+	}
+	return &group, nil
+}
+
+func (s *documentGroupService) Delete(ctx context.Context, id int) error {
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var count int64
+		if err := tx.Model(&models.DocumentGroup{}).Where("id = ?", id).Count(&count).Error; err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка проверки группы")
+		}
+		if count == 0 {
+			return echo.NewHTTPError(http.StatusNotFound, "Группа документов не найдена")
+		}
+
+		// Документы группы переходят в «Прочее» (group_id = NULL)
+		if err := tx.Model(&models.Document{}).
+			Where("group_id = ?", id).
+			Update("group_id", nil).Error; err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка переноса документов в группу «Прочее»")
+		}
+
+		if err := tx.Delete(&models.DocumentGroup{}, id).Error; err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка удаления группы документов")
+		}
+		return nil
+	})
+}
+
+func (s *documentGroupService) Reorder(ctx context.Context, req models.ReorderDocumentGroupsRequest) error {
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		for i, id := range req.IDs {
+			if err := tx.Model(&models.DocumentGroup{}).
+				Where("id = ?", id).
+				Update("sort_order", i).Error; err != nil {
+				return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка обновления порядка групп")
+			}
+		}
+		return nil
+	})
+}

--- a/internal/services/document_service.go
+++ b/internal/services/document_service.go
@@ -1,0 +1,362 @@
+package services
+
+import (
+	"context"
+	"mime/multipart"
+	"net/http"
+	"strings"
+	"time"
+
+	"systemburo/internal/models"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+// DocumentService -- интерфейс управления документами.
+type DocumentService interface {
+	List(ctx context.Context, groupID *int, includeHidden bool) ([]models.DocumentListItem, error)
+	Upload(ctx context.Context, userID int, req models.UploadDocumentRequest, file *multipart.FileHeader) (*models.DocumentListItem, error)
+	UpdateMeta(ctx context.Context, userID int, id int, req models.UpdateDocumentMetaRequest) (*models.DocumentListItem, error)
+	ReplaceFile(ctx context.Context, userID int, id int, file *multipart.FileHeader) (*models.DocumentListItem, error)
+	Delete(ctx context.Context, id int) error
+	Reorder(ctx context.Context, req models.ReorderDocumentsRequest) error
+	GetPublic(ctx context.Context) ([]models.PublicDocumentGroup, error)
+	GetByID(ctx context.Context, id int) (*models.Document, error)
+}
+
+type documentService struct {
+	db       *gorm.DB
+	fileSvc  DocumentFileService
+	settings SettingsService
+}
+
+// NewDocumentService создаёт реализацию DocumentService.
+func NewDocumentService(db *gorm.DB, fileSvc DocumentFileService, settings SettingsService) DocumentService {
+	return &documentService{db: db, fileSvc: fileSvc, settings: settings}
+}
+
+func (s *documentService) selectQuery(db *gorm.DB) *gorm.DB {
+	return db.
+		Table("documents d").
+		Select(`d.id, d.group_id, dg.name AS group_name,
+			d.title, d.description, d.file_name, d.file_ext, d.file_size,
+			d.published_at, d.is_visible, d.sort_order,
+			d.created_at, d.updated_at, d.created_by, d.updated_by`).
+		Joins("LEFT JOIN document_groups dg ON dg.id = d.group_id")
+}
+
+func (s *documentService) List(ctx context.Context, groupID *int, includeHidden bool) ([]models.DocumentListItem, error) {
+	q := s.selectQuery(s.db.WithContext(ctx))
+	if groupID != nil {
+		q = q.Where("d.group_id = ?", *groupID)
+	}
+	if !includeHidden {
+		q = q.Where("d.is_visible = true")
+	}
+
+	results := make([]models.DocumentListItem, 0)
+	if err := q.Order("d.sort_order ASC, d.id ASC").Scan(&results).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения списка документов")
+	}
+	return results, nil
+}
+
+func (s *documentService) Upload(ctx context.Context, userID int, req models.UploadDocumentRequest, file *multipart.FileHeader) (*models.DocumentListItem, error) {
+	uploadSettings, err := s.settings.GetUploadSettings(ctx)
+	if err != nil {
+		return nil, err
+	}
+	maxSize, _ := uploadSettings["max_file_size"].(int64)
+	if maxSize == 0 {
+		maxSize = 10 * 1024 * 1024
+	}
+
+	storedName, ext, err := s.fileSvc.Save(ctx, file, maxSize)
+	if err != nil {
+		return nil, err
+	}
+
+	publishedAt := time.Now().UTC()
+	if req.PublishedAt != nil && *req.PublishedAt != "" {
+		if t, err := time.Parse(time.RFC3339, *req.PublishedAt); err == nil {
+			publishedAt = t.UTC()
+		}
+	}
+
+	title := strings.TrimSpace(req.Title)
+	if title == "" {
+		s.fileSvc.Delete(storedName)
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "Название документа не может быть пустым")
+	}
+
+	// sort_order: в конце относительно группы
+	var maxOrder int
+	qOrder := s.db.WithContext(ctx).Model(&models.Document{}).Select("COALESCE(MAX(sort_order), 0)")
+	if req.GroupID != nil {
+		qOrder = qOrder.Where("group_id = ?", *req.GroupID)
+	} else {
+		qOrder = qOrder.Where("group_id IS NULL")
+	}
+	qOrder.Scan(&maxOrder)
+
+	now := time.Now().UTC()
+	doc := models.Document{
+		GroupID:     req.GroupID,
+		Title:       title,
+		Description: req.Description,
+		FileName:    file.Filename,
+		StoredName:  storedName,
+		FileExt:     ext,
+		MimeType:    DetectMimeType(ext),
+		FileSize:    file.Size,
+		PublishedAt: publishedAt,
+		IsVisible:   true,
+		SortOrder:   maxOrder + 1,
+		CreatedBy:   &userID,
+		UpdatedBy:   &userID,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+
+	if err := s.db.WithContext(ctx).Create(&doc).Error; err != nil {
+		s.fileSvc.Delete(storedName)
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка сохранения документа")
+	}
+
+	return s.getItem(ctx, doc.ID)
+}
+
+func (s *documentService) UpdateMeta(ctx context.Context, userID int, id int, req models.UpdateDocumentMetaRequest) (*models.DocumentListItem, error) {
+	var doc models.Document
+	if err := s.db.WithContext(ctx).First(&doc, id).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, echo.NewHTTPError(http.StatusNotFound, "Документ не найден")
+		}
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения документа")
+	}
+
+	updates := map[string]interface{}{
+		"updated_by": userID,
+		"updated_at": time.Now().UTC(),
+	}
+	if req.Title != nil {
+		title := strings.TrimSpace(*req.Title)
+		if title == "" {
+			return nil, echo.NewHTTPError(http.StatusBadRequest, "Название документа не может быть пустым")
+		}
+		updates["title"] = title
+	}
+	if req.Description != nil {
+		updates["description"] = req.Description
+	}
+	if req.GroupID != nil {
+		updates["group_id"] = req.GroupID
+	}
+	if req.PublishedAt != nil && *req.PublishedAt != "" {
+		t, err := time.Parse(time.RFC3339, *req.PublishedAt)
+		if err != nil {
+			return nil, echo.NewHTTPError(http.StatusBadRequest, "Неверный формат даты публикации (ожидается RFC3339)")
+		}
+		updates["published_at"] = t.UTC()
+	}
+	if req.IsVisible != nil {
+		updates["is_visible"] = *req.IsVisible
+	}
+
+	if err := s.db.WithContext(ctx).Model(&models.Document{}).Where("id = ?", id).Updates(updates).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка обновления документа")
+	}
+
+	return s.getItem(ctx, id)
+}
+
+func (s *documentService) ReplaceFile(ctx context.Context, userID int, id int, file *multipart.FileHeader) (*models.DocumentListItem, error) {
+	var doc models.Document
+	if err := s.db.WithContext(ctx).First(&doc, id).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, echo.NewHTTPError(http.StatusNotFound, "Документ не найден")
+		}
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения документа")
+	}
+
+	uploadSettings, err := s.settings.GetUploadSettings(ctx)
+	if err != nil {
+		return nil, err
+	}
+	maxSize, _ := uploadSettings["max_file_size"].(int64)
+	if maxSize == 0 {
+		maxSize = 10 * 1024 * 1024
+	}
+
+	newStoredName, ext, err := s.fileSvc.Save(ctx, file, maxSize)
+	if err != nil {
+		return nil, err
+	}
+
+	oldStoredName := doc.StoredName
+	now := time.Now().UTC()
+
+	if err := s.db.WithContext(ctx).Model(&models.Document{}).Where("id = ?", id).Updates(map[string]interface{}{
+		"file_name":   file.Filename,
+		"stored_name": newStoredName,
+		"file_ext":    ext,
+		"mime_type":   DetectMimeType(ext),
+		"file_size":   file.Size,
+		"updated_by":  userID,
+		"updated_at":  now,
+	}).Error; err != nil {
+		s.fileSvc.Delete(newStoredName)
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка обновления документа")
+	}
+
+	// Удаляем старый файл только после успешной записи в БД
+	s.fileSvc.Delete(oldStoredName)
+
+	return s.getItem(ctx, id)
+}
+
+func (s *documentService) Delete(ctx context.Context, id int) error {
+	var doc models.Document
+	if err := s.db.WithContext(ctx).First(&doc, id).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return echo.NewHTTPError(http.StatusNotFound, "Документ не найден")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения документа")
+	}
+
+	storedName := doc.StoredName
+
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Delete(&models.Document{}, id).Error; err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка удаления документа")
+		}
+		// Удаляем файл с диска после успешного удаления из БД
+		s.fileSvc.Delete(storedName)
+		return nil
+	})
+}
+
+func (s *documentService) Reorder(ctx context.Context, req models.ReorderDocumentsRequest) error {
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		for i, id := range req.IDs {
+			q := tx.Model(&models.Document{}).Where("id = ?", id)
+			if req.GroupID != nil {
+				q = tx.Model(&models.Document{}).Where("id = ? AND group_id = ?", id, *req.GroupID)
+			}
+			if err := q.Update("sort_order", i).Error; err != nil {
+				return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка обновления порядка документов")
+			}
+		}
+		return nil
+	})
+}
+
+func (s *documentService) GetPublic(ctx context.Context) ([]models.PublicDocumentGroup, error) {
+	// Загружаем все видимые документы с их группами
+	type row struct {
+		ID          int       `gorm:"column:id"`
+		GroupID     *int      `gorm:"column:group_id"`
+		GroupName   *string   `gorm:"column:group_name"`
+		GroupOrder  *int      `gorm:"column:group_order"`
+		Title       string    `gorm:"column:title"`
+		Description *string   `gorm:"column:description"`
+		FileName    string    `gorm:"column:file_name"`
+		FileExt     string    `gorm:"column:file_ext"`
+		FileSize    int64     `gorm:"column:file_size"`
+		PublishedAt time.Time `gorm:"column:published_at"`
+		SortOrder   int       `gorm:"column:sort_order"`
+	}
+
+	rows := make([]row, 0)
+	err := s.db.WithContext(ctx).
+		Table("documents d").
+		Select(`d.id, d.group_id, dg.name AS group_name, dg.sort_order AS group_order,
+			d.title, d.description, d.file_name, d.file_ext, d.file_size,
+			d.published_at, d.sort_order`).
+		Joins("LEFT JOIN document_groups dg ON dg.id = d.group_id").
+		Where("d.is_visible = true").
+		Order("COALESCE(dg.sort_order, 999999) ASC, dg.id ASC, d.sort_order ASC, d.id ASC").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения документов")
+	}
+
+	// Группируем по group_id; NULL -> виртуальная группа «Прочее» в конце
+	type groupKey struct {
+		id   *int
+		name string
+	}
+	groupMap := make(map[int]*models.PublicDocumentGroup) // id -> group; 0 = «Прочее»
+	groupOrder := make([]int, 0)                          // порядок group_id (0 для Прочего)
+
+	for i := range rows {
+		r := &rows[i]
+		var key int
+		if r.GroupID != nil {
+			key = *r.GroupID
+		} else {
+			key = 0
+		}
+
+		if _, exists := groupMap[key]; !exists {
+			g := &models.PublicDocumentGroup{
+				Documents: make([]models.PublicDocument, 0),
+			}
+			if r.GroupID != nil {
+				g.ID = *r.GroupID
+				if r.GroupName != nil {
+					g.Name = *r.GroupName
+				}
+				if r.GroupOrder != nil {
+					g.SortOrder = *r.GroupOrder
+				}
+			} else {
+				g.ID = 0
+				g.Name = "Прочее"
+				g.SortOrder = 999999
+			}
+			groupMap[key] = g
+			groupOrder = append(groupOrder, key)
+		}
+
+		groupMap[key].Documents = append(groupMap[key].Documents, models.PublicDocument{
+			ID:          r.ID,
+			GroupID:     r.GroupID,
+			Title:       r.Title,
+			Description: r.Description,
+			FileName:    r.FileName,
+			FileExt:     r.FileExt,
+			FileSize:    r.FileSize,
+			PublishedAt: r.PublishedAt,
+			SortOrder:   r.SortOrder,
+		})
+	}
+
+	result := make([]models.PublicDocumentGroup, 0, len(groupOrder))
+	for _, key := range groupOrder {
+		if g, ok := groupMap[key]; ok {
+			result = append(result, *g)
+		}
+	}
+	return result, nil
+}
+
+func (s *documentService) GetByID(ctx context.Context, id int) (*models.Document, error) {
+	var doc models.Document
+	if err := s.db.WithContext(ctx).First(&doc, id).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, echo.NewHTTPError(http.StatusNotFound, "Документ не найден")
+		}
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения документа")
+	}
+	return &doc, nil
+}
+
+func (s *documentService) getItem(ctx context.Context, id int) (*models.DocumentListItem, error) {
+	var item models.DocumentListItem
+	if err := s.selectQuery(s.db.WithContext(ctx)).Where("d.id = ?", id).Scan(&item).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения документа")
+	}
+	return &item, nil
+}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -42,6 +42,7 @@ var tables = []string{
 	"role_default_groups", "permission_groups",
 	"user_permissions", "permissions",
 	"bug_reports",
+	"documents", "document_groups",
 	"request_log", "request_logs", "notifications", "news", "announcements",
 	"feedback", "application_items", "items",
 	"application_blacklist_overrides", "application_blacklist_flags",
@@ -144,6 +145,9 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	attachmentBlankService := services.NewAttachmentBlankService(db)
 	trashService := services.NewTrashService(db)
 	trashDBRef := services.NewTrashDBRef(db)
+	documentFileService := services.NewDocumentFileService("./uploads")
+	documentGroupService := services.NewDocumentGroupService(db)
+	documentService := services.NewDocumentService(db, documentFileService, settingsService)
 
 	// Create all handlers
 	authHandler := handlers.NewAuthHandler(authService, maintenanceService, false, 168*time.Hour)
@@ -185,6 +189,8 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	attachmentTemplateHandler := handlers.NewAttachmentTemplateHandler(attachmentTemplateService, attachmentFieldConfigService)
 	attachmentBlankHandler := handlers.NewAttachmentBlankHandler(attachmentBlankService)
 	trashHandler := handlers.NewTrashHandler(trashService, trashDBRef)
+	documentGroupHandler := handlers.NewDocumentGroupHandler(documentGroupService)
+	documentHandler := handlers.NewDocumentHandler(documentService, documentFileService)
 
 	// Setup Echo with routes (no rate limiter, no logger — clean for tests)
 	e := echo.New()
@@ -230,6 +236,8 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 		AttachmentTemplates: attachmentTemplateHandler,
 		AttachmentBlanks:    attachmentBlankHandler,
 		Trash:               trashHandler,
+		DocumentGroups:      documentGroupHandler,
+		Documents:           documentHandler,
 		PermResolver:        permissionResolver,
 		DenialLog:           accessDenialService,
 		JWTSecret:           []byte(TestJWTSecret),


### PR DESCRIPTION
Часть бэкенда п.39 эпика 46-edits: документы из админ-раздела для показа на /news.

Что внутри:
- Модели DocumentGroup и Document (soft-поля published_at, is_visible, sort_order), аддитивная миграция (две новые таблицы, ничего не пересоздаёт).
- CRUD групп и документов, виртуальная группа Прочее (group_id=null) для несгруппированных.
- Хранение файлов на диск (UPLOAD_PATH), валидация: расширения .doc/.docx/.pdf/.xlsx/.pptx, размер из настроек upload.max_file_size, magic-bytes (PDF/OOXML/OLE2) - чтобы подменённое расширение не прошло.
- Эндпоинты: /document-groups (admin), /documents (admin), /documents/:id/download (auth), /public/documents (auth) - сгруппированный список видимых для блока на /news.
- Права: переиспользует существующий page.admin, новых ключей не вводит.

Проверка: go-тесты сервисов и хендлеров зелёные (magic-bytes, CRUD групп, reorder, публичный эндпоинт, права). Контракт публичного эндпоинта проверен живыми запросами против реального стека.