### PR TITLE
fix(documents): фикс eslint-ошибок, блокировавших деплой (#39)

### DIFF
--- a/frontend/src/api/documents.js
+++ b/frontend/src/api/documents.js
@@ -1,4 +1,4 @@
-import { apiRequest, apiRequestRaw } from './client';
+import { apiRequest } from './client';
 import { useAuthStore } from '@/stores/auth';
 
 /**

--- a/frontend/src/components/DocumentsManagement.vue
+++ b/frontend/src/components/DocumentsManagement.vue
@@ -692,7 +692,7 @@ export default {
           published_at: this.editForm.published_at || null,
           is_visible: this.editForm.is_visible,
         };
-        const updated = await updateDocument(this.selectedDoc.id, payload);
+        await updateDocument(this.selectedDoc.id, payload);
         const title = this.editForm.title;
         // Обновляем в локальном массиве
         const idx = this.documents.findIndex((d) => d.id === this.selectedDoc.id);

--- a/frontend/src/components/news/DocumentsBlock.vue
+++ b/frontend/src/components/news/DocumentsBlock.vue
@@ -177,7 +177,7 @@ export default {
         );
         // Случайный набор видимых разделов на каждую загрузку, остальное в «Ещё» (по ТЗ п.39).
         this.shuffledGroups = this.shuffle([...this.groups]);
-      } catch (e) {
+      } catch {
         useDeletionsStore().notify({ prefix: 'Ошибка загрузки документов', bold: '', type: 'error' });
       } finally {
         this.loading = false;


### PR DESCRIPTION
После мержа #616/#617 docker-build и deploy-staging не запускались - eslint падал на трёх no-unused-vars (apiRequestRaw, отброшенный результат updateDocument, неиспользуемая привязка catch). Убрал мёртвые переменные. Локально eslint src/ - 0 errors.