### PR TITLE
fix(create-application): откат rich-text в сопроводительном письме до доработки TextConstructor (#46)

### DIFF
--- a/frontend/src/components/ApplicationDetail/ApplicationDetail.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationDetail.vue
@@ -109,10 +109,9 @@
           <!-- Сообщение заявки -->
           <div class="message-section">
             <h4>Сообщение к заявке {{ applicationData.application_number }}</h4>
-            <div
-              class="message-content"
-              v-html="applicationData.message ? sanitizeHtml(applicationData.message) : 'Сообщение отсутствует'"
-            />
+            <div class="message-content">
+              {{ applicationData.message || 'Сообщение отсутствует' }}
+            </div>
           </div>
 
           <!-- Детали выбранного вложения -->
@@ -344,7 +343,6 @@
 <script>
 import { apiRequest } from '@/api/client'
 import { markAsRead } from '@/api/applications'
-import { sanitizeHtml } from '@/utils/sanitize'
 import { useDeletionsStore } from '@/stores/deletions'
 import { useUiStore } from '@/stores/ui'
 import ApplicationAttachments from './ApplicationAttachments.vue'
@@ -516,8 +514,6 @@ export default {
         this.loadCommonData();
     },
     methods: {
-        sanitizeHtml,
-
         handleActionCompleted({ success, message, type }) {
             this.showNotification(message, type || (success ? 'success' : 'error'));
             if (success) {
@@ -1530,66 +1526,8 @@ export default {
     font-size: 15px;
     line-height: 150%;
     color: #000;
+    white-space: pre-wrap;
 }
-
-.message-content :deep(ul),
-.message-content :deep(ol) {
-    padding-left: 24px;
-    margin: 6px 0;
-}
-
-.message-content :deep(li) {
-    line-height: 1.5;
-    margin: 2px 0;
-}
-
-.message-content :deep(em) {
-    font-style: italic;
-}
-
-.message-content :deep(u) {
-    text-decoration: underline;
-}
-
-.message-content :deep(strong) {
-    font-weight: 600;
-}
-
-.message-content :deep(h1),
-.message-content :deep(.heading-h1) {
-    font-size: 22px;
-    font-weight: 700;
-    margin: 12px 0 6px;
-    line-height: 1.2;
-    color: #000;
-}
-
-.message-content :deep(h2),
-.message-content :deep(.heading-h2) {
-    font-size: 18px;
-    font-weight: 600;
-    margin: 10px 0 5px;
-    line-height: 1.3;
-    color: #000;
-}
-
-.message-content :deep(.black-text) { color: #000; }
-.message-content :deep(.red-text) { color: #FF0000; }
-.message-content :deep(.green-text) { color: #079D1D; }
-.message-content :deep(.blue-text) { color: #4F5BDF; }
-
-.message-content :deep(.font-size-10) { font-size: 10px; }
-.message-content :deep(.font-size-12) { font-size: 12px; }
-.message-content :deep(.font-size-14) { font-size: 14px; }
-.message-content :deep(.font-size-16) { font-size: 16px; }
-.message-content :deep(.font-size-18) { font-size: 18px; }
-.message-content :deep(.font-size-20) { font-size: 20px; }
-
-.message-content :deep(.font-weight-300) { font-weight: 300; }
-.message-content :deep(.font-weight-400) { font-weight: 400; }
-.message-content :deep(.font-weight-500) { font-weight: 500; }
-.message-content :deep(.font-weight-600) { font-weight: 600; }
-.message-content :deep(.font-weight-900) { font-weight: 900; }
 
 .basic-info-section {
     background: white;

--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -64,10 +64,10 @@
         <!-- 1 ряд: Письмо сопроводительное, Согласие, Отправка -->
         <div class="form__header">
           <div class="header__content">
-            <TextConstructor
-              v-model="message"
+            <textarea 
+              v-model="message" 
               placeholder="Введите сопроводительное письмо / сообщение"
-              :disable-images="true"
+              class="form__textarea"
             />
             <div class="header__right">
               <div class="consent-section">
@@ -378,7 +378,6 @@
 <script>
 import { sanitizeHtml } from '@/utils/sanitize'
 import { apiRequest } from '@/api/client'
-import TextConstructor from '@/components/TextConstructor.vue'
 import { useAuthStore } from '@/stores/auth'
 import { formatPhoneNumberImmediately, formatPhoneNumber, clearPhoneFormat } from '@/composables/usePhoneFormat'
 import BlankSelector from '../BlankSelector.vue';
@@ -408,8 +407,7 @@ export default {
         ItemsList,
         UniversalBindingModal,
         ApplicationSuccessModal,
-        CustomFieldsSection,
-        TextConstructor
+        CustomFieldsSection
     },
     data() {
         return {

--- a/frontend/src/components/TextConstructor.vue
+++ b/frontend/src/components/TextConstructor.vue
@@ -186,10 +186,7 @@
         </button>
       </div>
 
-      <div
-        v-if="!disableImages"
-        class="toolbar-group"
-      >
+      <div class="toolbar-group">
         <button
           type="button"
           class="toolbar-btn image-btn"
@@ -416,10 +413,6 @@ export default {
     maxImageBytes: {
       type: Number,
       default: DEFAULT_MAX_IMAGE_BYTES
-    },
-    disableImages: {
-      type: Boolean,
-      default: false
     }
   },
   emits: ['update:modelValue'],


### PR DESCRIPTION
По запросу: вернуть старый инпут сопроводительного письма в оформлении/подаче заявки, отложить п.27 до доработки TextConstructor.

Реверт п.27 (PR #613): CreateApplication.vue снова с обычным textarea, рендер сообщения в ApplicationDetail - plain text, проп disableImages из TextConstructor убран.

п.33 (новости/объявления) не затронут - там TextConstructor остаётся.