### PR TITLE
fix(documents): обводка и заголовок админ-компонента под эталон (#39)

### DIFF
--- a/frontend/src/components/DocumentsManagement.vue
+++ b/frontend/src/components/DocumentsManagement.vue
@@ -989,7 +989,9 @@ export default {
   display: flex;
   flex-direction: column;
   background: #fff;
-  border-radius: 30px;
+  border-radius: 16px;
+  border: 1px solid #e6e6e6;
+  overflow: hidden;
 }
 
 /* --- Шапка --- */
@@ -1005,9 +1007,9 @@ export default {
 
 .management-title {
   margin: 0;
-  font-size: 16px;
-  font-weight: 700;
-  color: #1a1a1a;
+  font-size: 1.2em;
+  font-weight: 600;
+  color: #000;
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
Юзер заметил: у админ-компонента Документы не было обводки и заголовок отличался от остальных admin-компонентов.

Причина: корневой .documents-container не задавал border (AdminPageShell его не рисует - :deep(.dashboard-card) ставит только radius/height/flex, border идёт из собственного класса компонента, как у TableConstructor/Citizenship). Заголовок был 16px/700/#1a1a1a вместо эталонного 1.2em/600/#000.

Проверка: computed-стили корня и .management-title теперь 1:1 с соседним admin-компонентом (Citizenship) - border 1px solid rgb(230,230,230), radius 35px, title 19.2px/600/rgb(0,0,0).