### PR TITLE
fix(employees): дедуп человека в таблице людей - одна строка с макс. сроком (#46)

### DIFF
--- a/internal/handlers/employees_dedup_test.go
+++ b/internal/handlers/employees_dedup_test.go
@@ -1,0 +1,230 @@
+package handlers_test
+
+// TestEmployeeDedup_* проверяют дедупликацию сотрудников в GetActiveEmployeesForTable:
+// человек с несколькими активными вложениями должен показываться одной строкой
+// с максимальным entry_date_to. Живёт в handlers_test (а не services), потому что
+// CI гоняет пакеты параллельно (-p 4) на общей auto_registry_test, и CleanDB из
+// соседнего пакета снёс бы наши строки. Внутри одного пакета handlers_test тесты
+// идут сериально, поэтому CleanDB изолирует прогон.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"systemburo/internal/services"
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEmployeeDedup_OnePersonTwoAttachments: один человек (одинаковый hmac паспорта),
+// два активных вложения с разными entry_date_to - ожидаем ОДНУ строку с большей датой.
+func TestEmployeeDedup_OnePersonTwoAttachments(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	today := time.Now()
+	dateFrom := today.AddDate(0, 0, -1).Format("2006-01-02") // вчера - оба вложения активны
+	dateTo1 := today.AddDate(0, 0, 5).Format("2006-01-02")   // сегодня+5
+	dateTo2 := today.AddDate(0, 0, 15).Format("2006-01-02")  // сегодня+15 (большая)
+
+	// Организация
+	var orgID int64
+	require.NoError(t, db.Raw(
+		`INSERT INTO organizations (name) VALUES ('DedupOrg') RETURNING id`,
+	).Scan(&orgID).Error)
+
+	// Пользователь-отправитель (минимальный)
+	var senderUserID int64
+	require.NoError(t, db.Raw(
+		`INSERT INTO users (username, password, type_id, organization_id)
+		 VALUES ('dedup_sender', 'x', 1, ?) RETURNING id`, orgID,
+	).Scan(&senderUserID).Error)
+
+	// Заявка (confirmation=approved, status=in_work)
+	confirmation := "Согласовано"
+	status := "В работе"
+	var appID int64
+	require.NoError(t, db.Raw(
+		`INSERT INTO applications (organization_id, sender_user_id, confirmation, status)
+		 VALUES (?, ?, ?, ?) RETURNING id`,
+		orgID, senderUserID, confirmation, status,
+	).Scan(&appID).Error)
+
+	// system_table (тип people)
+	dn := "Dedup Table"
+	var tableID int64
+	require.NoError(t, db.Raw(
+		`INSERT INTO system_tables (name, display_name, table_type, is_active, created_at, updated_at)
+		 VALUES ('dedup_table', ?, 'people', true, NOW(), NOW()) RETURNING id`, dn,
+	).Scan(&tableID).Error)
+
+	// Уникальный HMAC паспорта (имитируем - просто строка)
+	passHMAC := "dedup_test_hmac_abc123"
+
+	// Вложение 1 - entry_date_to = dateTo1
+	var att1ID int64
+	require.NoError(t, db.Raw(
+		`INSERT INTO attachments (application_id, attachment_type, entry_date_from, entry_date_to,
+		  entry_time_from, entry_time_to, created_at, updated_at)
+		 VALUES (?, 'people', ?, ?, '08:00', '18:00', NOW(), NOW()) RETURNING id`,
+		appID, dateFrom, dateTo1,
+	).Scan(&att1ID).Error)
+
+	// Сотрудник 1 - привязан к вложению 1
+	ln1, fn1 := "Дедупов", "Тест"
+	statusActive := 1
+	var emp1ID int64
+	require.NoError(t, db.Raw(
+		`INSERT INTO employees (attachment_id, last_name, first_name, status,
+		  passport_series_number_hmac, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, NOW(), NOW()) RETURNING id`,
+		att1ID, ln1, fn1, statusActive, passHMAC,
+	).Scan(&emp1ID).Error)
+
+	// Привязка сотрудника 1 к таблице
+	require.NoError(t, db.Exec(
+		`INSERT INTO employee_target_tables (employee_id, table_id) VALUES (?, ?)`,
+		emp1ID, tableID,
+	).Error)
+
+	// Вложение 2 - entry_date_to = dateTo2 (большая)
+	var att2ID int64
+	require.NoError(t, db.Raw(
+		`INSERT INTO attachments (application_id, attachment_type, entry_date_from, entry_date_to,
+		  entry_time_from, entry_time_to, created_at, updated_at)
+		 VALUES (?, 'people', ?, ?, '09:00', '19:00', NOW(), NOW()) RETURNING id`,
+		appID, dateFrom, dateTo2,
+	).Scan(&att2ID).Error)
+
+	// Сотрудник 2 - тот же человек (тот же hmac), другое вложение
+	var emp2ID int64
+	require.NoError(t, db.Raw(
+		`INSERT INTO employees (attachment_id, last_name, first_name, status,
+		  passport_series_number_hmac, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, NOW(), NOW()) RETURNING id`,
+		att2ID, ln1, fn1, statusActive, passHMAC,
+	).Scan(&emp2ID).Error)
+
+	// Привязка сотрудника 2 к таблице
+	require.NoError(t, db.Exec(
+		`INSERT INTO employee_target_tables (employee_id, table_id) VALUES (?, ?)`,
+		emp2ID, tableID,
+	).Error)
+
+	// Вызов сервиса
+	svc := services.NewEmployeeService(db)
+	result, err := svc.GetActiveEmployeesForTable(context.Background(), int(tableID))
+	require.NoError(t, err)
+
+	// Ожидаем ОДНУ строку - человек схлопнулся
+	require.Len(t, result, 1, "один человек с двумя вложениями должен давать одну строку")
+
+	// Строка должна содержать МАКСИМАЛЬНУЮ дату (dateTo2 = сегодня+15)
+	assert.Equal(t, dateTo2, *result[0].EntryDateTo,
+		"entry_date_to должен быть от вложения с большей датой")
+}
+
+// TestEmployeeDedup_NullPassportNotCollapsed: сотрудник без паспорта (hmac IS NULL)
+// в двух вложениях - обе строки должны остаться, схлопывания нет.
+func TestEmployeeDedup_NullPassportNotCollapsed(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	today := time.Now()
+	dateFrom := today.AddDate(0, 0, -1).Format("2006-01-02")
+	dateTo1 := today.AddDate(0, 0, 5).Format("2006-01-02")
+	dateTo2 := today.AddDate(0, 0, 15).Format("2006-01-02")
+
+	// Организация
+	var orgID int64
+	require.NoError(t, db.Raw(
+		`INSERT INTO organizations (name) VALUES ('DedupNullOrg') RETURNING id`,
+	).Scan(&orgID).Error)
+
+	// Пользователь-отправитель
+	var senderUserID int64
+	require.NoError(t, db.Raw(
+		`INSERT INTO users (username, password, type_id, organization_id)
+		 VALUES ('dedup_null_sender', 'x', 1, ?) RETURNING id`, orgID,
+	).Scan(&senderUserID).Error)
+
+	// Заявка
+	confirmation := "Согласовано"
+	status := "В работе"
+	var appID int64
+	require.NoError(t, db.Raw(
+		`INSERT INTO applications (organization_id, sender_user_id, confirmation, status)
+		 VALUES (?, ?, ?, ?) RETURNING id`,
+		orgID, senderUserID, confirmation, status,
+	).Scan(&appID).Error)
+
+	// system_table
+	dn := "Dedup Null Table"
+	var tableID int64
+	require.NoError(t, db.Raw(
+		`INSERT INTO system_tables (name, display_name, table_type, is_active, created_at, updated_at)
+		 VALUES ('dedup_null_table', ?, 'people', true, NOW(), NOW()) RETURNING id`, dn,
+	).Scan(&tableID).Error)
+
+	statusActive := 1
+
+	// Вложение 1
+	var att1ID int64
+	require.NoError(t, db.Raw(
+		`INSERT INTO attachments (application_id, attachment_type, entry_date_from, entry_date_to,
+		  created_at, updated_at)
+		 VALUES (?, 'people', ?, ?, NOW(), NOW()) RETURNING id`,
+		appID, dateFrom, dateTo1,
+	).Scan(&att1ID).Error)
+
+	// Сотрудник "По факту" (hmac IS NULL)
+	ln := "Бесфактный"
+	var emp1ID int64
+	require.NoError(t, db.Raw(
+		`INSERT INTO employees (attachment_id, last_name, first_name, status,
+		  passport_series_number_hmac, created_at, updated_at)
+		 VALUES (?, ?, 'Иван', ?, NULL, NOW(), NOW()) RETURNING id`,
+		att1ID, ln, statusActive,
+	).Scan(&emp1ID).Error)
+
+	require.NoError(t, db.Exec(
+		`INSERT INTO employee_target_tables (employee_id, table_id) VALUES (?, ?)`,
+		emp1ID, tableID,
+	).Error)
+
+	// Вложение 2
+	var att2ID int64
+	require.NoError(t, db.Raw(
+		`INSERT INTO attachments (application_id, attachment_type, entry_date_from, entry_date_to,
+		  created_at, updated_at)
+		 VALUES (?, 'people', ?, ?, NOW(), NOW()) RETURNING id`,
+		appID, dateFrom, dateTo2,
+	).Scan(&att2ID).Error)
+
+	// Второй сотрудник "По факту" - тоже NULL hmac
+	var emp2ID int64
+	require.NoError(t, db.Raw(
+		`INSERT INTO employees (attachment_id, last_name, first_name, status,
+		  passport_series_number_hmac, created_at, updated_at)
+		 VALUES (?, ?, 'Пётр', ?, NULL, NOW(), NOW()) RETURNING id`,
+		att2ID, ln, statusActive,
+	).Scan(&emp2ID).Error)
+
+	require.NoError(t, db.Exec(
+		`INSERT INTO employee_target_tables (employee_id, table_id) VALUES (?, ?)`,
+		emp2ID, tableID,
+	).Error)
+
+	// Вызов сервиса
+	svc := services.NewEmployeeService(db)
+	result, err := svc.GetActiveEmployeesForTable(context.Background(), int(tableID))
+	require.NoError(t, err)
+
+	// Ожидаем ДВЕ строки - NULL-паспорт не схлопывается
+	assert.Len(t, result, 2, "сотрудники без паспорта (hmac NULL) не должны схлопываться")
+}

--- a/internal/services/employee_service.go
+++ b/internal/services/employee_service.go
@@ -175,44 +175,71 @@ func (s *employeeService) GetActiveEmployeesForTable(ctx context.Context, tableI
 	}
 
 	rows := make([]employeeRow, 0)
+	// Оконная функция считается после GROUP BY: для каждого непустого паспорта
+	// оставляем строку с максимальным entry_date_to (rn=1). Строки с NULL-паспортом
+	// ("По факту") не схлопываем - условие (hmac IS NULL OR rn = 1).
 	err := s.db.WithContext(ctx).Raw(`
 		SELECT
-			e.id,
-			e.last_name,
-			e.first_name,
-			e.middle_name,
-			COALESCE(o.name, co.name) AS organization,
-			COALESCE(co.name, '') AS company,
-			c.name AS citizenship_name,
-			e.position,
-			(
-				SELECT STRING_AGG(DISTINCT st.display_name, ', ' ORDER BY st.display_name)
-				FROM employee_target_tables ett2
-				JOIN system_tables st ON ett2.table_id = st.id
-				WHERE ett2.employee_id = e.id
-			) AS pass_places,
-			a.entry_date_to,
-			CONCAT(a.entry_time_from, ' - ', a.entry_time_to) AS pass_time,
-			e.status,
-			app.id AS application_id,
-			app.application_number AS application_number
-		FROM employees e
-		JOIN employee_target_tables ett ON e.id = ett.employee_id
-		JOIN attachments a ON e.attachment_id = a.id
-		JOIN applications app ON a.application_id = app.id
-		LEFT JOIN organizations o ON app.organization_id = o.id
-		LEFT JOIN companies co ON app.company_id = co.id
-		LEFT JOIN citizenships c ON e.citizenship_id = c.id
-		WHERE ett.table_id = ?
-		AND e.status = 1
-		AND app.confirmation = ?
-		AND app.status IN (?, ?)
-		AND CURRENT_DATE BETWEEN a.entry_date_from::date AND a.entry_date_to::date
-		GROUP BY e.id, e.last_name, e.first_name, e.middle_name,
-				 o.name, co.name, c.name, e.position,
-				 a.entry_date_to, a.entry_time_from,
-				 a.entry_time_to, e.status, app.id, app.application_number
-		ORDER BY e.last_name, e.first_name
+			id,
+			last_name,
+			first_name,
+			middle_name,
+			organization,
+			company,
+			citizenship_name,
+			position,
+			pass_places,
+			entry_date_to,
+			pass_time,
+			status,
+			application_id,
+			application_number
+		FROM (
+			SELECT
+				e.id,
+				e.last_name,
+				e.first_name,
+				e.middle_name,
+				COALESCE(o.name, co.name) AS organization,
+				COALESCE(co.name, '') AS company,
+				c.name AS citizenship_name,
+				e.position,
+				(
+					SELECT STRING_AGG(DISTINCT st.display_name, ', ' ORDER BY st.display_name)
+					FROM employee_target_tables ett2
+					JOIN system_tables st ON ett2.table_id = st.id
+					WHERE ett2.employee_id = e.id
+				) AS pass_places,
+				a.entry_date_to,
+				CONCAT(a.entry_time_from, ' - ', a.entry_time_to) AS pass_time,
+				e.status,
+				app.id AS application_id,
+				app.application_number AS application_number,
+				e.passport_series_number_hmac,
+				ROW_NUMBER() OVER (
+					PARTITION BY e.passport_series_number_hmac
+					ORDER BY a.entry_date_to DESC NULLS LAST, e.id DESC
+				) AS rn
+			FROM employees e
+			JOIN employee_target_tables ett ON e.id = ett.employee_id
+			JOIN attachments a ON e.attachment_id = a.id
+			JOIN applications app ON a.application_id = app.id
+			LEFT JOIN organizations o ON app.organization_id = o.id
+			LEFT JOIN companies co ON app.company_id = co.id
+			LEFT JOIN citizenships c ON e.citizenship_id = c.id
+			WHERE ett.table_id = ?
+			AND e.status = 1
+			AND app.confirmation = ?
+			AND app.status IN (?, ?)
+			AND CURRENT_DATE BETWEEN a.entry_date_from::date AND a.entry_date_to::date
+			GROUP BY e.id, e.last_name, e.first_name, e.middle_name,
+					 o.name, co.name, c.name, e.position,
+					 a.entry_date_to, a.entry_time_from,
+					 a.entry_time_to, e.status, app.id, app.application_number,
+					 e.passport_series_number_hmac
+		) sub
+		WHERE sub.passport_series_number_hmac IS NULL OR sub.rn = 1
+		ORDER BY last_name, first_name
 	`, tableID, models.ConfirmationApproved, models.StatusInWork, models.StatusCompleted).Scan(&rows).Error
 	if err != nil {
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching active employees")


### PR DESCRIPTION
Пункт 35 ТЗ (по уточнению: дедуп в таблице людей).

Человек с несколькими активными вложениями показывался в KPP-таблице несколько раз. Теперь одна строка с МАКСИМАЛЬНЫМ сроком: запрос обёрнут в подзапрос с `ROW_NUMBER() OVER (PARTITION BY passport_series_number_hmac ORDER BY entry_date_to DESC)`, по непустому паспорту остаётся одна строка; люди без паспорта (NULL hmac, "По факту") не схлопываются.

Доступ до макс-даты и так работал (вложения независимы) - правка про отображение. Тесты: дедуп + null-паспорт, make test зелёный (+ существующие GetActiveEmployeesForTable не сломаны).