### PR TITLE
fix(documents): блок /news - 3 документа без обрезка и разделители (#39)

### DIFF
--- a/frontend/src/components/news/DocumentsBlock.vue
+++ b/frontend/src/components/news/DocumentsBlock.vue
@@ -336,8 +336,10 @@ export default {
 
 /* --- Список документов --- */
 .docs-block__list {
-  padding: 6px;
-  max-height: 188px;
+  padding: 0;
+  /* Ровно 3 строки документа (высота строки фикс. через .doc-row min-height),
+     4-я и далее - скроллом. Гарантирует, что минимум 3 документа видны без обрезка. */
+  max-height: 171px;
   overflow-y: auto;
 }
 
@@ -362,15 +364,19 @@ export default {
   display: flex;
   align-items: center;
   gap: 13px;
-  padding: 10px 12px;
-  border-radius: 16px;
-  border: 1px solid transparent;
-  transition: background 0.15s ease, border-color 0.15s ease;
+  height: 57px;
+  box-sizing: border-box;
+  padding: 0 14px;
+  border-bottom: 1px solid #f0f0f0;
+  transition: background 0.15s ease;
+}
+
+.doc-row:last-child {
+  border-bottom: none;
 }
 
 .doc-row:hover {
   background: #fafbff;
-  border-color: #eceefb;
 }
 
 .doc-row__icon {


### PR DESCRIPTION
По замечаниям к блоку Документы на Обзор и новости: (1) минимум 3 документа должны помещаться идеально - зафиксировал высоту строки 57px и max-height списка 171px (ровно 3x57), 4-я и далее скроллом, обрезка нет (list height кратна строке); (2) разделение списка - строки-карточки заменены на edge-to-edge с border-bottom 1px #f0f0f0, как в админке.

Проверка computed: rowHeight 57, listClientH 171, fullyVisible 3, list%row 0, border-bottom 1px rgb(240,240,240).