### PR TITLE
style(news): отступ между руководством и документами 20px (#46)

### DIFF
--- a/frontend/src/views/NewsAndReview.vue
+++ b/frontend/src/views/NewsAndReview.vue
@@ -1046,7 +1046,7 @@ export default {
     flex-shrink: 0;
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 20px;
 }
 
 .news-card {


### PR DESCRIPTION
Колонка справа на /news держала gap 10px между карточкой руководства и блоком документов. Поднял до 20px, чтобы блоки визуально не липли друг к другу.

Изменение чисто CSS: `.right-column { gap: 10px -> 20px }` в `NewsAndReview.vue`. Локальный eslint по файлу - 0 ошибок.