### PR TITLE
fix(docker): подтянул openssl в проде, чтобы trivy не падал

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN go mod tidy && \
     CGO_ENABLED=0 go build -ldflags="-s -w" -o seed ./cmd/seed
 
 FROM alpine:3.23 AS production
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates && apk upgrade --no-cache
 RUN addgroup -S -g 1001 appgroup && \
     adduser -S -u 1001 -G appgroup appuser
 WORKDIR /app


### PR DESCRIPTION
## Что чинит

Security-workflow (Trivy Image Scan) падал HIGH x2 на одном CVE:

- `CVE-2026-45447` - heap use-after-free в OpenSSL `PKCS7_verify()`
- пакеты `libcrypto3` и `libssl3` версии `3.5.6-r0` из снапшота `alpine:3.23`, тянутся как зависимость `ca-certificates`
- исправлено в `3.5.7-r0` (Trivy Status: fixed)

## Фикс

В production-стейдж добавлен `apk upgrade --no-cache` после `apk add ca-certificates` - на билде поднимает OpenSSL до `3.5.7-r0`.

Проверил на чистом `alpine:3.23`: до апгрейда `libcrypto3/libssl3 3.5.6-r0`, после - `3.5.7-r0`. Скан на CVE-2026-45447 зелёный.

## Влияние на рантайм

Нулевое. Прод-бинарь собран `CGO_ENABLED=0` (статичный Go), системный OpenSSL не линкуется и не вызывается; `PKCS7_verify` из приложения недостижим. Это гигиена образа, не живой вектор.