### PR TITLE
fix(documents): полиш по ревью - радиус эталона, drag в фильтре, экранирование, tx-порядок (#39)

### DIFF
--- a/frontend/src/components/DocumentsManagement.vue
+++ b/frontend/src/components/DocumentsManagement.vue
@@ -692,7 +692,11 @@ export default {
           published_at: this.editForm.published_at || null,
           is_visible: this.editForm.is_visible,
         };
-        await updateDocument(this.selectedDoc.id, payload);
+        const result = await updateDocument(this.selectedDoc.id, payload);
+        if (result?.message) {
+          this.editError = result.message;
+          return;
+        }
         const title = this.editForm.title;
         // Обновляем в локальном массиве
         const idx = this.documents.findIndex((d) => d.id === this.selectedDoc.id);
@@ -767,11 +771,14 @@ export default {
     },
     onDragOver(idx) {
       if (this.dragDocIdx === null || this.dragDocIdx === idx) return;
-      const arr = this.filteredDocuments;
-      const moved = arr[this.dragDocIdx];
-      arr.splice(this.dragDocIdx, 1);
-      arr.splice(idx, 0, moved);
-      // Синхронизируем с основным массивом (filteredDocuments computed — только чтение по ссылке)
+      const visible = this.filteredDocuments;
+      const movedDoc = visible[this.dragDocIdx];
+      const targetDoc = visible[idx];
+      const from = this.documents.indexOf(movedDoc);
+      if (from === -1) return;
+      this.documents.splice(from, 1);
+      const to = this.documents.indexOf(targetDoc);
+      this.documents.splice(to === -1 ? this.documents.length : to, 0, movedDoc);
       this.dragDocIdx = idx;
     },
     async onDragEnd() {
@@ -783,9 +790,8 @@ export default {
       const ids = this.filteredDocuments.map((d) => d.id);
       try {
         await reorderDocuments(groupId, ids);
-      } catch (e) {
-        // Порядок не критичен — тихо логируем
-        console.warn('reorderDocuments failed:', e);
+      } catch {
+        // порядок документов не критичен для пользователя — ошибку не показываем
       }
     },
 
@@ -959,8 +965,8 @@ export default {
         this.groups = [...this.editableGroups.map((g) => ({
           id: g.id, name: g.name, doc_count: g.doc_count, sort_order: g.sort_order,
         }))];
-      } catch (e) {
-        console.warn('reorderDocumentGroups failed:', e);
+      } catch {
+        // порядок групп не критичен для пользователя — ошибку не показываем
       }
     },
 
@@ -989,7 +995,7 @@ export default {
   display: flex;
   flex-direction: column;
   background: #fff;
-  border-radius: 16px;
+  border-radius: 35px;
   border: 1px solid #e6e6e6;
   overflow: hidden;
 }

--- a/internal/handlers/documents.go
+++ b/internal/handlers/documents.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"systemburo/internal/models"
 	"systemburo/internal/services"
@@ -228,8 +229,9 @@ func (h *DocumentHandler) Download(c echo.Context) error {
 	}
 
 	filePath := filepath.Join(h.fileSvc.UploadDir(), doc.StoredName)
+	safeName := strings.ReplaceAll(doc.FileName, `"`, `\"`)
 	c.Response().Header().Set("Content-Disposition",
-		fmt.Sprintf(`attachment; filename="%s"`, doc.FileName))
+		fmt.Sprintf(`attachment; filename="%s"`, safeName))
 	c.Response().Header().Set("Content-Type", doc.MimeType)
 	return c.File(filePath)
 }

--- a/internal/services/document_service.go
+++ b/internal/services/document_service.go
@@ -227,14 +227,17 @@ func (s *documentService) Delete(ctx context.Context, id int) error {
 
 	storedName := doc.StoredName
 
-	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	if err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Delete(&models.Document{}, id).Error; err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка удаления документа")
 		}
-		// Удаляем файл с диска после успешного удаления из БД
-		s.fileSvc.Delete(storedName)
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
+	// Удаляем файл с диска только после успешного коммита транзакции
+	s.fileSvc.Delete(storedName)
+	return nil
 }
 
 func (s *documentService) Reorder(ctx context.Context, req models.ReorderDocumentsRequest) error {
@@ -357,6 +360,9 @@ func (s *documentService) getItem(ctx context.Context, id int) (*models.Document
 	var item models.DocumentListItem
 	if err := s.selectQuery(s.db.WithContext(ctx)).Where("d.id = ?", id).Scan(&item).Error; err != nil {
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения документа")
+	}
+	if item.ID == 0 {
+		return nil, echo.NewHTTPError(http.StatusNotFound, "Документ не найден")
 	}
 	return &item, nil
 }


### PR DESCRIPTION
Фиксы замечаний ревью п.39: border-radius карточки 16->35px (эталон), убраны 2 console.warn, saveDoc показывает ошибку при 4xx (не "сохранён"), drag-сортировка документов работает при фильтре по группе (реордер в реактивном this.documents), Content-Disposition экранирует кавычки в имени, fileSvc.Delete вынесен после commit транзакции, getItem 404 при ID=0. make test (документы) зелёный.