### PR TITLE
fix(cabinet): блок заявок ЛК в высоту экрана с отступом снизу, внутренний скролл (#46)

### DIFF
--- a/frontend/src/components/AccountComponent.vue
+++ b/frontend/src/components/AccountComponent.vue
@@ -199,7 +199,10 @@ export default {
         return;
       }
       const top = el.getBoundingClientRect().top;
-      const height = Math.max(0, Math.round(window.innerHeight - top));
+      // 15px - отступ снизу чтобы блок заявок не прилипал к краю экрана.
+      // Padding 15px сверху уже входит в el, поэтому вычитаем только снизу.
+      const BOTTOM_GAP = 15;
+      const height = Math.max(0, Math.round(window.innerHeight - top - BOTTOM_GAP));
       // Защита от ResizeObserver-петли: пишем стиль только при реальном изменении.
       if (height === this.lastDashboardHeight) return;
       this.lastDashboardHeight = height;
@@ -261,10 +264,13 @@ export default {
   padding: 15px;
   position: relative;
   /* Высоту на desktop задаёт applyDashboardHeight под доступный вьюпорт;
-     flex-колонка тянет блок заявок на остаток высоты. На <=1200px высота
-     сбрасывается и блок снова в естественном потоке (страница скроллится). */
+     flex-колонка тянет блок заявок на остаток высоты. overflow:hidden
+     обязателен - без него flex-дети могут расти за пределы установленной
+     высоты. На <=1200px высота сбрасывается и блок снова в естественном
+     потоке (страница скроллится). */
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 }
 
 /* Стили для строк */
@@ -294,6 +300,7 @@ export default {
   padding: 15px 0;
   flex: 1;
   min-height: 0;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
 }

--- a/frontend/src/components/UserApplications.vue
+++ b/frontend/src/components/UserApplications.vue
@@ -1078,7 +1078,7 @@ export default {
 
 .applications-list-content {
   flex: 1;
-  overflow-y: auto;
+  /* Скролл только на .applications-body - не создаём вложенный скролл здесь */
   position: relative;
 }
 


### PR DESCRIPTION
По запросу: "Мои заявки" вылезали за экран вниз. Причина - .account-dashboard/.dashboard-row без overflow:hidden не передавали ограничение высоты (задаётся JS applyDashboardHeight = innerHeight - top). Добавлен overflow:hidden + BOTTOM_GAP=15 (отступ снизу), убран двойной скролл (только .applications-body скроллится). Адаптив <=1200px не тронут (там фикс-высота).