### PR TITLE
fix(text-constructor): рендер форматированного текста не вываливает картинки за контейнер (#46)

### DIFF
--- a/frontend/src/components/AnnouncementModal.vue
+++ b/frontend/src/components/AnnouncementModal.vue
@@ -272,11 +272,12 @@ export default {
 .announcement-body-html {
   line-height: 1.6;
 }
+.announcement-body-html :deep(*) { overflow-wrap: break-word; }
 .announcement-body-html :deep(h1),
 .announcement-body-html :deep(h2),
 .announcement-body-html :deep(h3) { font-weight: 600; margin: 0.75em 0 0.4em; }
 .announcement-body-html :deep(p) { margin: 0.5em 0; }
 .announcement-body-html :deep(ul),
 .announcement-body-html :deep(ol) { padding-left: 1.5em; margin: 0.5em 0; }
-.announcement-body-html :deep(img) { max-width: 100%; border-radius: 8px; }
+.announcement-body-html :deep(img) { max-width: 100%; height: auto; border-radius: 8px; }
 </style>

--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -2179,6 +2179,16 @@ export default {
 </script>
 
 <style scoped>
+    .text-constructor-content :deep(*) {
+        overflow-wrap: break-word;
+    }
+
+    .text-constructor-content :deep(img) {
+        max-width: 100%;
+        height: auto;
+        border-radius: 8px;
+    }
+
     .create {
         padding: 20px;
     }

--- a/frontend/src/components/TablesComponent.vue
+++ b/frontend/src/components/TablesComponent.vue
@@ -815,6 +815,13 @@ export default {
 /* Text Constructor Content Styles */
 .text-constructor-content :deep(*) {
     line-height: 150%;
+    overflow-wrap: break-word;
+}
+
+.text-constructor-content :deep(img) {
+    max-width: 100%;
+    height: auto;
+    border-radius: 8px;
 }
 
 .text-constructor-content :deep(strong) {

--- a/frontend/src/views/NewsAndReview.vue
+++ b/frontend/src/views/NewsAndReview.vue
@@ -1661,11 +1661,12 @@ export default {
 .news-body-html {
     line-height: 1.6;
 }
+.news-body-html :deep(*) { overflow-wrap: break-word; }
 .news-body-html :deep(h1),
 .news-body-html :deep(h2),
 .news-body-html :deep(h3) { font-weight: 600; margin: 0.75em 0 0.4em; }
 .news-body-html :deep(p) { margin: 0.5em 0; }
 .news-body-html :deep(ul),
 .news-body-html :deep(ol) { padding-left: 1.5em; margin: 0.5em 0; }
-.news-body-html :deep(img) { max-width: 100%; border-radius: 8px; }
+.news-body-html :deep(img) { max-width: 100%; height: auto; border-radius: 8px; }
 </style>


### PR DESCRIPTION
Срез 1/7 под-эпика доработки TextConstructor (часть п.8/п.27 эпика 46-edits).

## Что чинит
В местах, где через `v-html` рендерится вывод редактора TextConstructor, картинки и длинные строки не были ограничены по ширине - крупное изображение вываливало контейнер модалки/карточки. Добавил защитные CSS-гарды.

## Изменения (чисто-CSS, аддитивно)
- `TablesComponent.vue` - инструкция к таблицам и подсказка (класс `.text-constructor-content` покрывает оба).
- `CreateApplication.vue` - инструкция вложения при создании заявки.
- `NewsAndReview.vue` - тело новости (был `max-width`, добавил `height:auto` + `overflow-wrap`).
- `AnnouncementModal.vue` - выровнял с остальными (`height:auto` + `overflow-wrap`).

Правило: `img { max-width:100%; height:auto; border-radius }` и `* { overflow-wrap:break-word }` через `:deep()`. Preview самого `TextConstructor.vue` уже был защищён (`max-width`+`height:auto`).

## Ревью
code-reviewer: GO. Два YELLOW, оба не блокируют: (1) "нет height:auto в preview TextConstructor" - ложное срабатывание, height:auto там уже есть (строка 1396, проверено); (2) trailing newline в двух файлах - pre-existing, не вношу ради минимального диффа.

## Проверка
Покрыты все потребительские места вывода TextConstructor (греп `v-html`+`sanitize*`). Изменение defensive-CSS, layout не меняет. Полная FE-верификация - комплексно в конце эпика 46-edits.