### PR TITLE
feat(text-constructor): перевёл редактор на Tiptap WYSIWYG (#46)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,13 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@tiptap/extension-heading": "^2.27.2",
+        "@tiptap/extension-image": "^2.27.2",
+        "@tiptap/extension-placeholder": "^2.27.2",
+        "@tiptap/extension-underline": "^2.27.2",
+        "@tiptap/pm": "^2.27.2",
+        "@tiptap/starter-kit": "^2.27.2",
+        "@tiptap/vue-3": "^2.27.2",
         "dompurify": "^3.4.1",
         "exceljs": "^4.4.0",
         "jszip": "^3.10.1",
@@ -816,6 +823,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@remirror/core-constants": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
+      "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
+      "license": "MIT"
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.17",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
@@ -1087,6 +1110,427 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tiptap/core": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.27.2.tgz",
+      "integrity": "sha512-ABL1N6eoxzDzC1bYvkMbvyexHacszsKdVPYqhl5GwHLOvpZcv9VE9QaKwDILTyz5voCA0lGcAAXZp+qnXOk5lQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-blockquote": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-2.27.2.tgz",
+      "integrity": "sha512-oIGZgiAeA4tG3YxbTDfrmENL4/CIwGuP3THtHsNhwRqwsl9SfMk58Ucopi2GXTQSdYXpRJ0ahE6nPqB5D6j/Zw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-bold": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-2.27.2.tgz",
+      "integrity": "sha512-bR7J5IwjCGQ0s3CIxyMvOCnMFMzIvsc5OVZKscTN5UkXzFsaY6muUAIqtKxayBUucjtUskm5qZowJITCeCb1/A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-bubble-menu": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-2.27.2.tgz",
+      "integrity": "sha512-VkwlCOcr0abTBGzjPXklJ92FCowG7InU8+Od9FyApdLNmn0utRYGRhw0Zno6VgE9EYr1JY4BRnuSa5f9wlR72w==",
+      "license": "MIT",
+      "dependencies": {
+        "tippy.js": "^6.3.7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-bullet-list": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-2.27.2.tgz",
+      "integrity": "sha512-gmFuKi97u5f8uFc/GQs+zmezjiulZmFiDYTh3trVoLRoc2SAHOjGEB7qxdx7dsqmMN7gwiAWAEVurLKIi1lnnw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-code": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-2.27.2.tgz",
+      "integrity": "sha512-7X9AgwqiIGXoZX7uvdHQsGsjILnN/JaEVtqfXZnPECzKGaWHeK/Ao4sYvIIIffsyZJA8k5DC7ny2/0sAgr2TuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-code-block": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-2.27.2.tgz",
+      "integrity": "sha512-KgvdQHS4jXr79aU3wZOGBIZYYl9vCB7uDEuRFV4so2rYrfmiYMw3T8bTnlNEEGe4RUeAms1i4fdwwvQp9nR1Dw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-document": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-2.27.2.tgz",
+      "integrity": "sha512-CFhAYsPnyYnosDC4639sCJnBUnYH4Cat9qH5NZWHVvdgtDwu8GZgZn2eSzaKSYXWH1vJ9DSlCK+7UyC3SNXIBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-dropcursor": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-2.27.2.tgz",
+      "integrity": "sha512-oEu/OrktNoQXq1x29NnH/GOIzQZm8ieTQl3FK27nxfBPA89cNoH4mFEUmBL5/OFIENIjiYG3qWpg6voIqzswNw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-floating-menu": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-2.27.2.tgz",
+      "integrity": "sha512-GUN6gPIGXS7ngRJOwdSmtBRBDt9Kt9CM/9pSwKebhLJ+honFoNA+Y6IpVyDvvDMdVNgBchiJLs6qA5H97gAePQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tippy.js": "^6.3.7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-gapcursor": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-2.27.2.tgz",
+      "integrity": "sha512-/c9VF1HBxj+AP54XGVgCmD9bEGYc5w5OofYCFQgM7l7PB1J00A4vOke0oPkHJnqnOOyPlFaxO/7N6l3XwFcnKA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-hard-break": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-2.27.2.tgz",
+      "integrity": "sha512-kSRVGKlCYK6AGR0h8xRkk0WOFGXHIIndod3GKgWU49APuIGDiXd8sziXsSlniUsWmqgDmDXcNnSzPcV7AQ8YNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-heading": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-2.27.2.tgz",
+      "integrity": "sha512-iM3yeRWuuQR/IRQ1djwNooJGfn9Jts9zF43qZIUf+U2NY8IlvdNsk2wTOdBgh6E0CamrStPxYGuln3ZS4fuglw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-history": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-history/-/extension-history-2.27.2.tgz",
+      "integrity": "sha512-+hSyqERoFNTWPiZx4/FCyZ/0eFqB9fuMdTB4AC/q9iwu3RNWAQtlsJg5230bf/qmyO6bZxRUc0k8p4hrV6ybAw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-horizontal-rule": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-2.27.2.tgz",
+      "integrity": "sha512-WGWUSgX+jCsbtf9Y9OCUUgRZYuwjVoieW5n6mAUohJ9/6gc6sGIOrUpBShf+HHo6WD+gtQjRd+PssmX3NPWMpg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-image": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-2.27.2.tgz",
+      "integrity": "sha512-5zL/BY41FIt72azVrCrv3n+2YJ/JyO8wxCcA4Dk1eXIobcgVyIdo4rG39gCqIOiqziAsqnqoj12QHTBtHsJ6mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-italic": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-2.27.2.tgz",
+      "integrity": "sha512-1OFsw2SZqfaqx5Fa5v90iNlPRcqyt+lVSjBwTDzuPxTPFY4Q0mL89mKgkq2gVHYNCiaRkXvFLDxaSvBWbmthgg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-list-item": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-2.27.2.tgz",
+      "integrity": "sha512-eJNee7IEGXMnmygM5SdMGDC8m/lMWmwNGf9fPCK6xk0NxuQRgmZHL6uApKcdH6gyNcRPHCqvTTkhEP7pbny/fg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-ordered-list": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-2.27.2.tgz",
+      "integrity": "sha512-M7A4tLGJcLPYdLC4CI2Gwl8LOrENQW59u3cMVa+KkwG1hzSJyPsbDpa1DI6oXPC2WtYiTf22zrbq3gVvH+KA2w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-paragraph": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-2.27.2.tgz",
+      "integrity": "sha512-elYVn2wHJJ+zB9LESENWOAfI4TNT0jqEN34sMA/hCtA4im1ZG2DdLHwkHIshj/c4H0dzQhmsS/YmNC5Vbqab/A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-placeholder": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-2.27.2.tgz",
+      "integrity": "sha512-IjsgSVYJRjpAKmIoapU0E2R4E2FPY3kpvU7/1i7PUYisylqejSJxmtJPGYw0FOMQY9oxnEEvfZHMBA610tqKpg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-strike": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-2.27.2.tgz",
+      "integrity": "sha512-HHIjhafLhS2lHgfAsCwC1okqMsQzR4/mkGDm4M583Yftyjri1TNA7lzhzXWRFWiiMfJxKtdjHjUAQaHuteRTZw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-text": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-2.27.2.tgz",
+      "integrity": "sha512-Xk7nYcigljAY0GO9hAQpZ65ZCxqOqaAlTPDFcKerXmlkQZP/8ndx95OgUb1Xf63kmPOh3xypurGS2is3v0MXSA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-text-style": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-2.27.2.tgz",
+      "integrity": "sha512-Omk+uxjJLyEY69KStpCw5fA9asvV+MGcAX2HOxyISDFoLaL49TMrNjhGAuz09P1L1b0KGXo4ml7Q3v/Lfy4WPA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-underline": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-2.27.2.tgz",
+      "integrity": "sha512-gPOsbAcw1S07ezpAISwoO8f0RxpjcSH7VsHEFDVuXm4ODE32nhvSinvHQjv2icRLOXev+bnA7oIBu7Oy859gWQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/pm": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.27.2.tgz",
+      "integrity": "sha512-kaEg7BfiJPDQMKbjVIzEPO3wlcA+pZb2tlcK9gPrdDnEFaec2QTF1sXz2ak2IIb2curvnIrQ4yrfHgLlVA72wA==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-changeset": "^2.3.0",
+        "prosemirror-collab": "^1.3.1",
+        "prosemirror-commands": "^1.6.2",
+        "prosemirror-dropcursor": "^1.8.1",
+        "prosemirror-gapcursor": "^1.3.2",
+        "prosemirror-history": "^1.4.1",
+        "prosemirror-inputrules": "^1.4.0",
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-markdown": "^1.13.1",
+        "prosemirror-menu": "^1.2.4",
+        "prosemirror-model": "^1.23.0",
+        "prosemirror-schema-basic": "^1.2.3",
+        "prosemirror-schema-list": "^1.4.1",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-tables": "^1.6.4",
+        "prosemirror-trailing-node": "^3.0.0",
+        "prosemirror-transform": "^1.10.2",
+        "prosemirror-view": "^1.37.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/starter-kit": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-2.27.2.tgz",
+      "integrity": "sha512-bb0gJvPoDuyRUQ/iuN52j1//EtWWttw+RXAv1uJxfR0uKf8X7uAqzaOOgwjknoCIDC97+1YHwpGdnRjpDkOBxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tiptap/core": "^2.27.2",
+        "@tiptap/extension-blockquote": "^2.27.2",
+        "@tiptap/extension-bold": "^2.27.2",
+        "@tiptap/extension-bullet-list": "^2.27.2",
+        "@tiptap/extension-code": "^2.27.2",
+        "@tiptap/extension-code-block": "^2.27.2",
+        "@tiptap/extension-document": "^2.27.2",
+        "@tiptap/extension-dropcursor": "^2.27.2",
+        "@tiptap/extension-gapcursor": "^2.27.2",
+        "@tiptap/extension-hard-break": "^2.27.2",
+        "@tiptap/extension-heading": "^2.27.2",
+        "@tiptap/extension-history": "^2.27.2",
+        "@tiptap/extension-horizontal-rule": "^2.27.2",
+        "@tiptap/extension-italic": "^2.27.2",
+        "@tiptap/extension-list-item": "^2.27.2",
+        "@tiptap/extension-ordered-list": "^2.27.2",
+        "@tiptap/extension-paragraph": "^2.27.2",
+        "@tiptap/extension-strike": "^2.27.2",
+        "@tiptap/extension-text": "^2.27.2",
+        "@tiptap/extension-text-style": "^2.27.2",
+        "@tiptap/pm": "^2.27.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/vue-3": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/vue-3/-/vue-3-2.27.2.tgz",
+      "integrity": "sha512-NahnVLTAQsbLaNU9nGLdGCr88nAeQZJTejjBVQc3EzMdijmE46R44Rosj6O/pj3e7eLj1/gYvc+U/hIVbxMpoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tiptap/extension-bubble-menu": "^2.27.2",
+        "@tiptap/extension-floating-menu": "^2.27.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0",
+        "vue": "^3.0.0"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1135,6 +1579,28 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
@@ -1621,6 +2087,12 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1939,6 +2411,12 @@
         "node": ">= 10"
       }
     },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
+    },
     "node_modules/css-tree": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
@@ -2171,6 +2649,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/eslint": {
       "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
@@ -2337,18 +2827,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/eslint/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
@@ -3544,6 +4022,25 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/listenercount": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
@@ -3682,12 +4179,57 @@
         "url": "https://github.com/sponsors/sxzz"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.1",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
@@ -3862,6 +4404,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -4159,6 +4707,201 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
+    "node_modules/prosemirror-changeset": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz",
+      "integrity": "sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-collab": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.3.1.tgz",
+      "integrity": "sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-commands": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+      "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "node_modules/prosemirror-dropcursor": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz",
+      "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "node_modules/prosemirror-gapcursor": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
+      "integrity": "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+      "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-inputrules": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz",
+      "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-markdown": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.4.tgz",
+      "integrity": "sha512-D98dm4cQ3Hs6EmjK500TdAOew4Z03EV71ajEFiWra3Upr7diytJsjF4mPV2dW+eK5uNectiRj0xFxYI9NLXDbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/markdown-it": "^14.0.0",
+        "markdown-it": "^14.0.0",
+        "prosemirror-model": "^1.25.0"
+      }
+    },
+    "node_modules/prosemirror-menu": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.3.2.tgz",
+      "integrity": "sha512-6VgUJTYod0nMBlCaYJGhXGLu7Gt4AvcwcOq0YfJCY/6Uh+3S7UsWhpy6rJFCBFOmonq1hD8KyWOtZhkppd4YPg==",
+      "license": "MIT",
+      "dependencies": {
+        "crelt": "^1.0.0",
+        "prosemirror-commands": "^1.0.0",
+        "prosemirror-history": "^1.0.0",
+        "prosemirror-state": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.25.9",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.9.tgz",
+      "integrity": "sha512-pRTklkDDMMRopyoAcrr9wV/8g/RYgrLHBuJAb5hlEuYZRdm5yqmPjWId83fpBwPpSFqEdja0H7Dfd7z1X/npcA==",
+      "license": "MIT",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-schema-basic": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-basic/-/prosemirror-schema-basic-1.2.4.tgz",
+      "integrity": "sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.25.0"
+      }
+    },
+    "node_modules/prosemirror-schema-list": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+      "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.7.3"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-tables": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
+      "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.4",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-transform": "^1.10.5",
+        "prosemirror-view": "^1.41.4"
+      }
+    },
+    "node_modules/prosemirror-trailing-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-3.0.0.tgz",
+      "integrity": "sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remirror/core-constants": "3.0.0",
+        "escape-string-regexp": "^4.0.0"
+      },
+      "peerDependencies": {
+        "prosemirror-model": "^1.22.1",
+        "prosemirror-state": "^1.4.2",
+        "prosemirror-view": "^1.33.8"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+      "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.41.9",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.9.tgz",
+      "integrity": "sha512-clTunTX+eaLbr87L1V1QPheRlEQJyTlL3gXe9x3jQIk3rL0RVWxviDGz8tFaydwIVm+hKhYCyr+R/zBtWr9s6A==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.25.8",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
     "node_modules/proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -4171,6 +4914,15 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -4301,6 +5053,12 @@
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
       "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
       "license": "MIT"
     },
     "node_modules/safe-buffer": {
@@ -4553,6 +5311,15 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tippy.js": {
+      "version": "6.3.7",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
+      "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@popperjs/core": "^2.9.0"
+      }
+    },
     "node_modules/tldts": {
       "version": "7.0.28",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
@@ -4635,6 +5402,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
     },
     "node_modules/ufo": {
       "version": "1.6.3",
@@ -5042,6 +5815,12 @@
       "peerDependencies": {
         "vue": "3.x"
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,13 @@
     "test:run": "vitest run"
   },
   "dependencies": {
+    "@tiptap/extension-heading": "^2.27.2",
+    "@tiptap/extension-image": "^2.27.2",
+    "@tiptap/extension-placeholder": "^2.27.2",
+    "@tiptap/extension-underline": "^2.27.2",
+    "@tiptap/pm": "^2.27.2",
+    "@tiptap/starter-kit": "^2.27.2",
+    "@tiptap/vue-3": "^2.27.2",
     "dompurify": "^3.4.1",
     "exceljs": "^4.4.0",
     "jszip": "^3.10.1",

--- a/frontend/src/components/TextConstructor.vue
+++ b/frontend/src/components/TextConstructor.vue
@@ -8,18 +8,20 @@
         <button
           type="button"
           class="toolbar-btn"
+          :class="{ active: editor && editor.isActive('italic') }"
           data-tooltip="Курсив"
           :disabled="disabled"
-          @click="formatText('italic')"
+          @click="runCommand((c) => c.toggleItalic())"
         >
           <em>I</em>
         </button>
         <button
           type="button"
           class="toolbar-btn"
+          :class="{ active: editor && editor.isActive('underline') }"
           data-tooltip="Подчеркивание"
           :disabled="disabled"
-          @click="formatText('underline')"
+          @click="runCommand((c) => c.toggleUnderline())"
         >
           <u>U</u>
         </button>
@@ -29,29 +31,22 @@
         <button
           type="button"
           class="toolbar-btn"
+          :class="{ active: editor && editor.isActive('bulletList') }"
           data-tooltip="Маркированный список"
           :disabled="disabled"
-          @click="insertList('ul')"
+          @click="runCommand((c) => c.toggleBulletList())"
         >
           • L
         </button>
         <button
           type="button"
           class="toolbar-btn"
+          :class="{ active: editor && editor.isActive('orderedList') }"
           data-tooltip="Нумерованный список"
           :disabled="disabled"
-          @click="insertList('ol')"
+          @click="runCommand((c) => c.toggleOrderedList())"
         >
           1. L
-        </button>
-        <button
-          type="button"
-          class="toolbar-btn"
-          data-tooltip="Добавить элемент списка"
-          :disabled="disabled"
-          @click="insertListItem()"
-        >
-          Li
         </button>
       </div>
 
@@ -59,18 +54,20 @@
         <button
           type="button"
           class="toolbar-btn"
+          :class="{ active: editor && editor.isActive('heading', { level: 1 }) }"
           data-tooltip="Заголовок h1"
           :disabled="disabled"
-          @click="insertHeading('h1')"
+          @click="runCommand((c) => c.toggleHeading({ level: 1 }))"
         >
           h1
         </button>
         <button
           type="button"
           class="toolbar-btn"
+          :class="{ active: editor && editor.isActive('heading', { level: 2 }) }"
           data-tooltip="Заголовок h2"
           :disabled="disabled"
-          @click="insertHeading('h2')"
+          @click="runCommand((c) => c.toggleHeading({ level: 2 }))"
         >
           h2
         </button>
@@ -79,8 +76,6 @@
       <div class="toolbar-group">
         <div
           class="custom-select"
-          @mouseenter="showTooltip = true"
-          @mouseleave="showTooltip = false"
         >
           <div
             class="select-header"
@@ -114,8 +109,6 @@
       <div class="toolbar-group">
         <div
           class="custom-select fixed-width-select"
-          @mouseenter="showTooltip = true"
-          @mouseleave="showTooltip = false"
         >
           <div
             class="select-header"
@@ -153,7 +146,7 @@
           class="toolbar-btn color-btn black-text"
           data-tooltip="Черный"
           :disabled="disabled"
-          @click="insertColor('black-text')"
+          @click="applyColor('black-text')"
         >
           A
         </button>
@@ -162,7 +155,7 @@
           class="toolbar-btn color-btn red-text"
           data-tooltip="Красный"
           :disabled="disabled"
-          @click="insertColor('red-text')"
+          @click="applyColor('red-text')"
         >
           A
         </button>
@@ -171,7 +164,7 @@
           class="toolbar-btn color-btn green-text"
           data-tooltip="Зеленый"
           :disabled="disabled"
-          @click="insertColor('green-text')"
+          @click="applyColor('green-text')"
         >
           A
         </button>
@@ -180,7 +173,7 @@
           class="toolbar-btn color-btn blue-text"
           data-tooltip="Синий"
           :disabled="disabled"
-          @click="insertColor('blue-text')"
+          @click="applyColor('blue-text')"
         >
           A
         </button>
@@ -211,7 +204,7 @@
           class="toolbar-btn"
           data-tooltip="Перенос строки"
           :disabled="disabled"
-          @click="insertBreak()"
+          @click="runCommand((c) => c.setHardBreak())"
         >
           ↵
         </button>
@@ -222,8 +215,8 @@
           type="button"
           class="toolbar-btn undo-btn"
           data-tooltip="Назад (Ctrl+Z)"
-          :disabled="disabled || historyIndex === 0"
-          @click="undo()"
+          :disabled="disabled || !canUndo"
+          @click="runCommand((c) => c.undo())"
         >
           ↶
         </button>
@@ -239,22 +232,11 @@
       </div>
     </div>
 
-    <div class="textarea-container">
-      <textarea
-        ref="textarea"
-        :value="modelValue"
-        :placeholder="placeholder"
-        :rows="rows"
-        :disabled="disabled"
-        class="constructor-textarea"
-        @input="handleInput"
-        @keydown.ctrl.z.prevent="handleCtrlZ"
-      />
-      <div
-        class="resize-handle"
-        @mousedown="startResize"
-      />
-    </div>
+    <EditorContent
+      :editor="editor"
+      class="editor-content"
+      :style="{ minHeight: minContentHeight }"
+    />
 
     <div
       v-if="imageError"
@@ -264,105 +246,6 @@
       {{ imageError }}
     </div>
 
-    <div
-      v-if="imageBlocks.length > 1"
-      class="image-blocks"
-    >
-      <div class="image-blocks__header">
-        <span class="image-blocks__title">Расположение изображений</span>
-        <span class="image-blocks__hint">перетащите карточку или используйте стрелки</span>
-      </div>
-      <div class="image-blocks__list">
-        <div
-          v-for="(block, index) in imageBlocks"
-          :key="block.id"
-          class="image-block"
-          :class="{
-            'image-block--dragging': draggingIndex === index,
-            'image-block--target': dragOverIndex === index && draggingIndex !== index
-          }"
-          draggable="true"
-          @dragstart="onBlockDragStart(index, $event)"
-          @dragover.prevent="onBlockDragOver(index)"
-          @dragleave="onBlockDragLeave"
-          @drop.prevent="onBlockDrop(index)"
-          @dragend="onBlockDragEnd"
-        >
-          <span class="image-block__handle" aria-hidden="true">
-            <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-              <circle cx="4" cy="3" r="1.4" fill="currentColor" />
-              <circle cx="4" cy="7" r="1.4" fill="currentColor" />
-              <circle cx="4" cy="11" r="1.4" fill="currentColor" />
-              <circle cx="10" cy="3" r="1.4" fill="currentColor" />
-              <circle cx="10" cy="7" r="1.4" fill="currentColor" />
-              <circle cx="10" cy="11" r="1.4" fill="currentColor" />
-            </svg>
-          </span>
-          <img
-            :src="block.src"
-            class="image-block__preview"
-            :alt="`Изображение ${index + 1}`"
-          />
-          <span class="image-block__index">#{{ index + 1 }}</span>
-          <div class="image-block__actions">
-            <button
-              type="button"
-              class="image-block__btn"
-              :disabled="index === 0"
-              title="Переместить выше"
-              @click="moveImageBlock(index, index - 1)"
-            >
-              ↑
-            </button>
-            <button
-              type="button"
-              class="image-block__btn"
-              :disabled="index === imageBlocks.length - 1"
-              title="Переместить ниже"
-              @click="moveImageBlock(index, index + 1)"
-            >
-              ↓
-            </button>
-            <button
-              type="button"
-              class="image-block__btn image-block__btn--danger"
-              title="Удалить"
-              @click="removeImageBlock(index)"
-            >
-              ×
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div
-      v-if="modelValue"
-      class="editor-preview"
-    >
-      <div class="preview-header">
-        <h5>Предпросмотр</h5>
-        <button
-          type="button"
-          class="preview-expand-btn"
-          @click="openPreviewModal"
-        >
-          Открыть в окне
-        </button>
-      </div>
-      <div class="preview-content-container">
-        <div
-          ref="previewContent"
-          class="preview-content"
-          v-html="sanitizedContent"
-        />
-        <div
-          class="resize-handle preview-resize"
-          @mousedown="startPreviewResize"
-        />
-      </div>
-    </div>
-
     <BaseModal
       :show="previewModalOpen"
       title="Предпросмотр контента"
@@ -370,618 +253,231 @@
       @close="previewModalOpen = false"
     >
       <div
-        class="preview-modal-content"
+        class="preview-modal-content text-constructor-content"
         v-html="sanitizedContent"
       />
     </BaseModal>
   </div>
 </template>
 
-<script>
+<script setup>
+import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue';
+import { useEditor, EditorContent } from '@tiptap/vue-3';
+import StarterKit from '@tiptap/starter-kit';
+import Underline from '@tiptap/extension-underline';
+import Placeholder from '@tiptap/extension-placeholder';
 import { sanitizeHtml } from '@/utils/sanitize';
 import BaseModal from '@/components/ui/BaseModal.vue';
+import {
+  ColorClass,
+  FontSizeClass,
+  FontWeightClass,
+  ClassHeading,
+  ConstructorImage,
+} from './text-constructor/extensions';
 
-const DEFAULT_MAX_IMAGE_BYTES = 5 * 1024 * 1024;
 const ALLOWED_IMAGE_TYPES = [
   'image/png',
   'image/jpeg',
   'image/gif',
   'image/webp',
-  'image/svg+xml'
+  'image/svg+xml',
 ];
 
-export default {
-  name: 'TextConstructor',
-  components: { BaseModal },
-  props: {
-    modelValue: {
-      type: String,
-      default: ''
-    },
-    placeholder: {
-      type: String,
-      default: 'Введите текст...'
-    },
-    rows: {
-      type: Number,
-      default: 4
-    },
-    disabled: {
-      type: Boolean,
-      default: false
-    },
-    maxImageBytes: {
-      type: Number,
-      default: DEFAULT_MAX_IMAGE_BYTES
+const props = defineProps({
+  modelValue: { type: String, default: '' },
+  placeholder: { type: String, default: 'Введите текст...' },
+  rows: { type: Number, default: 4 },
+  disabled: { type: Boolean, default: false },
+  maxImageBytes: { type: Number, default: 5 * 1024 * 1024 },
+});
+
+const emit = defineEmits(['update:modelValue']);
+
+const fontSizes = ['10px', '12px', '14px', '16px', '18px', '20px'];
+const fontWeights = [
+  { label: 'Black', value: '900' },
+  { label: 'Bold', value: '600' },
+  { label: 'Medium', value: '500' },
+  { label: 'Regular', value: '400' },
+  { label: 'Light', value: '300' },
+];
+
+const selectedFontSize = ref('14px');
+const selectedFontWeight = ref({ label: 'Regular', value: '400' });
+const fontSizeDropdownOpen = ref(false);
+const fontWeightDropdownOpen = ref(false);
+const previewModalOpen = ref(false);
+const imageError = ref('');
+const imageInput = ref(null);
+const canUndo = ref(false);
+let imageErrorTimer = null;
+let onDocClick = null;
+
+const minContentHeight = computed(() => `${Math.max(1, props.rows) * 26}px`);
+const sanitizedContent = computed(() => sanitizeHtml(props.modelValue));
+
+const editor = useEditor({
+  content: props.modelValue || '',
+  editable: !props.disabled,
+  extensions: [
+    StarterKit.configure({ heading: false }),
+    Underline,
+    ClassHeading,
+    ColorClass,
+    FontSizeClass,
+    FontWeightClass,
+    ConstructorImage,
+    Placeholder.configure({ placeholder: () => props.placeholder }),
+  ],
+  onUpdate: ({ editor: instance }) => {
+    canUndo.value = instance.can().undo();
+    const html = instance.isEmpty ? '' : instance.getHTML();
+    if (html !== props.modelValue) {
+      emit('update:modelValue', html);
     }
   },
-  emits: ['update:modelValue'],
-  data() {
-    return {
-      selectedFontSize: '14px',
-      fontSizeDropdownOpen: false,
-      fontSizes: ['10px', '12px', '14px', '16px', '18px', '20px'],
-      fontWeightDropdownOpen: false,
-      selectedFontWeight: { label: 'Regular', value: '400' },
-      fontWeights: [
-        { label: 'Black', value: '900' },
-        { label: 'Bold', value: '600' },
-        { label: 'Medium', value: '500' },
-        { label: 'Regular', value: '400' },
-        { label: 'Light', value: '300' }
-      ],
-      showTooltip: true,
-      history: [''],
-      historyIndex: 0,
-      isResizing: false,
-      isPreviewResizing: false,
-      startHeight: 0,
-      startY: 0,
-      previewStartHeight: 0,
-      previewMinHeight: 150,
-      previewMaxHeight: 350,
-      imageError: '',
-      imageErrorTimer: null,
-      previewModalOpen: false,
-      onDocClick: null,
-      draggingIndex: null,
-      dragOverIndex: null,
-      imageMatchRegex: /<img\b[^>]*>/gi
-    };
-  },
-  computed: {
-    sanitizedContent() {
-      return sanitizeHtml(this.modelValue);
-    },
-    imageBlocks() {
-      const html = this.modelValue || '';
-      const matches = html.match(this.imageMatchRegex) || [];
-      return matches.map((tag, idx) => {
-        const srcMatch = tag.match(/src=["']([^"']+)["']/i);
-        return {
-          id: `img-${idx}-${(srcMatch ? srcMatch[1] : '').slice(0, 20)}`,
-          tag,
-          src: srcMatch ? srcMatch[1] : ''
-        };
-      });
-    }
-  },
-  watch: {
-    modelValue(newValue) {
-      if (this.history[this.historyIndex] !== newValue) {
-        this.history = [newValue];
-        this.historyIndex = 0;
-      }
-    }
-  },
-  mounted() {
-    this.history = [this.modelValue];
-    this.historyIndex = 0;
-
-    this.$nextTick(() => {
-      if (this.$refs.previewContent) {
-        this.$refs.previewContent.style.height = this.previewMinHeight + 'px';
-        this.$refs.previewContent.style.minHeight = this.previewMinHeight + 'px';
-        this.$refs.previewContent.style.maxHeight = this.previewMaxHeight + 'px';
-      }
-    });
-
-    this.onDocClick = (e) => {
-      if (!this.$el.contains(e.target)) {
-        this.fontSizeDropdownOpen = false;
-        this.fontWeightDropdownOpen = false;
-        this.showTooltip = true;
-      }
-    };
-    document.addEventListener('click', this.onDocClick);
-  },
-  beforeUnmount() {
-    if (this.onDocClick) {
-      document.removeEventListener('click', this.onDocClick);
-    }
-    document.removeEventListener('mousemove', this.handleResize);
-    document.removeEventListener('mouseup', this.stopResize);
-    document.removeEventListener('mousemove', this.handlePreviewResize);
-    document.removeEventListener('mouseup', this.stopPreviewResize);
-    if (this.imageErrorTimer) {
-      clearTimeout(this.imageErrorTimer);
-    }
-  },
-  methods: {
-    /**
-     * Извлекает все <img> теги из modelValue, заменяя их плейсхолдерами,
-     * чтобы потом восстановить в произвольном порядке.
-     * @returns {{ skeleton: string, imgs: string[] }}
-     */
-    extractImageSkeleton() {
-      const imgs = [];
-      const skeleton = (this.modelValue || '').replace(this.imageMatchRegex, (match) => {
-        imgs.push(match);
-        return ` IMG_${imgs.length - 1} `;
-      });
-      return { skeleton, imgs };
-    },
-
-    /**
-     * Восстанавливает HTML по skeleton'у с переупорядоченными изображениями.
-     * @param {string} skeleton
-     * @param {string[]} imgs
-     */
-    rebuildHtmlFromSkeleton(skeleton, imgs) {
-      return skeleton.replace(/ IMG_(\d+) /g, (_, i) => imgs[Number(i)] || '');
-    },
-
-    moveImageBlock(from, to) {
-      if (to < 0 || to >= this.imageBlocks.length) return;
-      const { skeleton, imgs } = this.extractImageSkeleton();
-      const [moved] = imgs.splice(from, 1);
-      imgs.splice(to, 0, moved);
-      const next = this.rebuildHtmlFromSkeleton(skeleton, imgs);
-      this.addToHistory(next);
-      this.$emit('update:modelValue', next);
-    },
-
-    removeImageBlock(index) {
-      const { skeleton, imgs } = this.extractImageSkeleton();
-      imgs.splice(index, 1);
-      const next = this.rebuildHtmlFromSkeleton(skeleton, imgs);
-      this.addToHistory(next);
-      this.$emit('update:modelValue', next);
-    },
-
-    onBlockDragStart(index, event) {
-      this.draggingIndex = index;
-      if (event.dataTransfer) {
-        event.dataTransfer.effectAllowed = 'move';
-      }
-    },
-
-    onBlockDragOver(index) {
-      this.dragOverIndex = index;
-    },
-
-    onBlockDragLeave() {
-      this.dragOverIndex = null;
-    },
-
-    onBlockDrop(targetIndex) {
-      if (this.draggingIndex === null || this.draggingIndex === targetIndex) {
-        this.dragOverIndex = null;
-        return;
-      }
-      this.moveImageBlock(this.draggingIndex, targetIndex);
-      this.draggingIndex = null;
-      this.dragOverIndex = null;
-    },
-
-    onBlockDragEnd() {
-      this.draggingIndex = null;
-      this.dragOverIndex = null;
-    },
-
-    handleInput(event) {
-      this.addToHistory(event.target.value);
-      this.$emit('update:modelValue', event.target.value);
-    },
-
-    handleCtrlZ() {
-      this.undo();
-    },
-
-    addToHistory(value) {
-      this.history = this.history.slice(0, this.historyIndex + 1);
-      this.history.push(value);
-      this.historyIndex++;
-    },
-
-    undo() {
-      if (this.historyIndex > 0) {
-        this.historyIndex--;
-        const previousValue = this.history[this.historyIndex];
-        this.$emit('update:modelValue', previousValue);
-
-        this.$nextTick(() => {
-          if (!this.$refs.textarea) return;
-          this.$refs.textarea.value = previousValue;
-          const textarea = this.$refs.textarea;
-          const currentScrollPos = textarea.scrollTop;
-          textarea.focus();
-          textarea.scrollTop = currentScrollPos;
-        });
-      }
-    },
-
-    startResize(e) {
-      this.isResizing = true;
-      this.startY = e.clientY;
-      this.startHeight = this.$refs.textarea.offsetHeight;
-
-      document.addEventListener('mousemove', this.handleResize);
-      document.addEventListener('mouseup', this.stopResize);
-      e.preventDefault();
-    },
-
-    handleResize(e) {
-      if (!this.isResizing) return;
-
-      const deltaY = e.clientY - this.startY;
-      const newHeight = Math.max(150, Math.min(350, this.startHeight + deltaY));
-
-      this.$refs.textarea.style.height = newHeight + 'px';
-    },
-
-    stopResize() {
-      this.isResizing = false;
-      document.removeEventListener('mousemove', this.handleResize);
-      document.removeEventListener('mouseup', this.stopResize);
-    },
-
-    startPreviewResize(e) {
-      this.isPreviewResizing = true;
-      this.startY = e.clientY;
-      this.previewStartHeight = this.$refs.previewContent.offsetHeight;
-
-      document.addEventListener('mousemove', this.handlePreviewResize);
-      document.addEventListener('mouseup', this.stopPreviewResize);
-      e.preventDefault();
-    },
-
-    handlePreviewResize(e) {
-      if (!this.isPreviewResizing) return;
-
-      const deltaY = e.clientY - this.startY;
-      const newHeight = Math.max(this.previewMinHeight, Math.min(this.previewMaxHeight, this.previewStartHeight + deltaY));
-
-      this.$refs.previewContent.style.height = newHeight + 'px';
-    },
-
-    stopPreviewResize() {
-      this.isPreviewResizing = false;
-      document.removeEventListener('mousemove', this.handlePreviewResize);
-      document.removeEventListener('mouseup', this.stopPreviewResize);
-    },
-
-    insertAtCursor(text, opts = {}) {
-      const textarea = this.$refs.textarea;
-      if (!textarea) return;
-      const start = textarea.selectionStart;
-      const end = textarea.selectionEnd;
-      const currentScrollPos = textarea.scrollTop;
-      const newValue = textarea.value.substring(0, start) + text + textarea.value.substring(end);
-      this.addToHistory(newValue);
-      this.$emit('update:modelValue', newValue);
-
-      this.$nextTick(() => {
-        textarea.focus();
-        const cursor = opts.selectStart != null
-          ? opts.selectStart
-          : start + text.length;
-        textarea.setSelectionRange(cursor, cursor);
-        textarea.scrollTop = currentScrollPos;
-      });
-    },
-
-    formatText(type) {
-      if (this.disabled) return;
-      const textarea = this.$refs.textarea;
-      const start = textarea.selectionStart;
-      const end = textarea.selectionEnd;
-      const selectedText = textarea.value.substring(start, end);
-
-      if (!selectedText) return;
-
-      let formattedText = '';
-      switch (type) {
-        case 'italic':
-          formattedText = `<em>${selectedText}</em>`;
-          break;
-        case 'underline':
-          formattedText = `<u>${selectedText}</u>`;
-          break;
-      }
-
-      const currentScrollPos = textarea.scrollTop;
-      const newValue = textarea.value.substring(0, start) + formattedText + textarea.value.substring(end);
-      this.addToHistory(newValue);
-      this.$emit('update:modelValue', newValue);
-
-      this.$nextTick(() => {
-        textarea.focus();
-        textarea.setSelectionRange(start + formattedText.length, start + formattedText.length);
-        textarea.scrollTop = currentScrollPos;
-      });
-    },
-
-    insertList(type) {
-      if (this.disabled) return;
-      const textarea = this.$refs.textarea;
-      const start = textarea.selectionStart;
-      const end = textarea.selectionEnd;
-      const selectedText = textarea.value.substring(start, end);
-
-      const currentScrollPos = textarea.scrollTop;
-
-      let list;
-      if (selectedText) {
-        const items = selectedText.split('\n').filter(item => item.trim());
-        const listItems = items.map(item => `  <li>${item.trim()}</li>`).join('\n');
-        list = type === 'ul'
-          ? `<ul>\n${listItems}\n</ul>`
-          : `<ol>\n${listItems}\n</ol>`;
-      } else {
-        list = type === 'ul'
-          ? `<ul>\n  <li>Элемент списка</li>\n</ul>`
-          : `<ol>\n  <li>Элемент списка</li>\n</ol>`;
-      }
-
-      const newValue = textarea.value.substring(0, start) + list + textarea.value.substring(end);
-      this.addToHistory(newValue);
-      this.$emit('update:modelValue', newValue);
-
-      this.$nextTick(() => {
-        textarea.focus();
-        const newPosition = start + list.indexOf('<li>') + 4;
-        textarea.setSelectionRange(newPosition, newPosition);
-        textarea.scrollTop = currentScrollPos;
-      });
-    },
-
-    insertListItem() {
-      if (this.disabled) return;
-      const textarea = this.$refs.textarea;
-      const start = textarea.selectionStart;
-      const value = textarea.value;
-
-      const currentScrollPos = textarea.scrollTop;
-
-      const textBeforeCursor = value.substring(0, start);
-      const lastNewLine = textBeforeCursor.lastIndexOf('\n');
-      const currentLineStart = lastNewLine + 1;
-      const currentLine = textBeforeCursor.substring(currentLineStart);
-
-      let listItem;
-      if (currentLine.trim().startsWith('<li>') && currentLine.includes('</li>')) {
-        const lineEnd = textBeforeCursor.indexOf('</li>', currentLineStart) + 5;
-        listItem = '\n  <li>Новый элемент списка</li>';
-        const newValue = value.substring(0, lineEnd) + listItem + value.substring(lineEnd);
-        this.addToHistory(newValue);
-        this.$emit('update:modelValue', newValue);
-
-        this.$nextTick(() => {
-          textarea.focus();
-          const newPosition = lineEnd + listItem.length;
-          textarea.setSelectionRange(newPosition, newPosition);
-          textarea.scrollTop = currentScrollPos;
-        });
-      } else {
-        listItem = '<li>Новый элемент списка</li>';
-        const newValue = value.substring(0, start) + listItem + value.substring(start);
-        this.addToHistory(newValue);
-        this.$emit('update:modelValue', newValue);
-
-        this.$nextTick(() => {
-          textarea.focus();
-          const newPosition = start + listItem.length;
-          textarea.setSelectionRange(newPosition, newPosition);
-          textarea.scrollTop = currentScrollPos;
-        });
-      }
-    },
-
-    insertHeading(level) {
-      if (this.disabled) return;
-      const textarea = this.$refs.textarea;
-      const start = textarea.selectionStart;
-      const end = textarea.selectionEnd;
-      const selectedText = textarea.value.substring(start, end) || 'Заголовок';
-
-      const currentScrollPos = textarea.scrollTop;
-
-      const heading = `<${level} class="heading-${level}">${selectedText}</${level}>`;
-      const newValue = textarea.value.substring(0, start) + heading + textarea.value.substring(end);
-      this.addToHistory(newValue);
-      this.$emit('update:modelValue', newValue);
-
-      this.$nextTick(() => {
-        textarea.focus();
-        textarea.scrollTop = currentScrollPos;
-      });
-    },
-
-    insertColor(colorClass) {
-      if (this.disabled) return;
-      const textarea = this.$refs.textarea;
-      const start = textarea.selectionStart;
-      const end = textarea.selectionEnd;
-      const selectedText = textarea.value.substring(start, end);
-
-      if (!selectedText) return;
-
-      const currentScrollPos = textarea.scrollTop;
-
-      const coloredText = `<span class="${colorClass}">${selectedText}</span>`;
-      const newValue = textarea.value.substring(0, start) + coloredText + textarea.value.substring(end);
-      this.addToHistory(newValue);
-      this.$emit('update:modelValue', newValue);
-
-      this.$nextTick(() => {
-        textarea.focus();
-        textarea.scrollTop = currentScrollPos;
-      });
-    },
-
-    insertBreak() {
-      if (this.disabled) return;
-      this.insertAtCursor('<br>');
-    },
-
-    triggerImagePicker() {
-      if (this.disabled) return;
-      this.clearImageError();
-      if (this.$refs.imageInput) {
-        this.$refs.imageInput.value = '';
-        this.$refs.imageInput.click();
-      }
-    },
-
-    /**
-     * Обрабатывает выбор файла, валидирует тип и размер,
-     * читает в data:URL и вставляет тег <img> в textarea.
-     */
-    async handleImageSelected(event) {
-      const file = event.target?.files?.[0];
-      if (!file) return;
-
-      if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
-        this.setImageError('Неподдерживаемый формат. Разрешены: PNG, JPEG, GIF, WEBP, SVG.');
-        return;
-      }
-      if (file.size > this.maxImageBytes) {
-        const maxMb = Math.round(this.maxImageBytes / (1024 * 1024));
-        this.setImageError(`Файл слишком большой. Максимальный размер: ${maxMb} МБ.`);
-        return;
-      }
-
-      try {
-        const dataUrl = await this.readFileAsDataUrl(file);
-        const safeAlt = (file.name || 'image')
-          .replace(/[<>"'&]/g, '')
-          .slice(0, 100);
-        const imgTag = `<img src="${dataUrl}" alt="${safeAlt}" class="constructor-image">`;
-        this.insertAtCursor(imgTag);
-      } catch (err) {
-        this.setImageError('Не удалось прочитать файл. Попробуйте ещё раз.');
-        console.error('TextConstructor image read error:', err);
-      } finally {
-        if (this.$refs.imageInput) {
-          this.$refs.imageInput.value = '';
-        }
-      }
-    },
-
-    readFileAsDataUrl(file) {
-      return new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onload = () => resolve(String(reader.result));
-        reader.onerror = () => reject(reader.error || new Error('FileReader error'));
-        reader.readAsDataURL(file);
-      });
-    },
-
-    setImageError(msg) {
-      this.imageError = msg;
-      if (this.imageErrorTimer) clearTimeout(this.imageErrorTimer);
-      this.imageErrorTimer = setTimeout(() => {
-        this.imageError = '';
-      }, 4500);
-    },
-
-    clearImageError() {
-      this.imageError = '';
-      if (this.imageErrorTimer) {
-        clearTimeout(this.imageErrorTimer);
-        this.imageErrorTimer = null;
-      }
-    },
-
-    openPreviewModal() {
-      if (!this.modelValue) return;
-      this.previewModalOpen = true;
-    },
-
-    toggleFontSizeDropdown() {
-      if (this.disabled) return;
-      this.fontSizeDropdownOpen = !this.fontSizeDropdownOpen;
-      this.fontWeightDropdownOpen = false;
-      this.showTooltip = !this.fontSizeDropdownOpen;
-    },
-
-    selectFontSize(size) {
-      this.selectedFontSize = size;
-      this.fontSizeDropdownOpen = false;
-      this.showTooltip = true;
-      this.applyFontSize();
-    },
-
-    applyFontSize() {
-      const textarea = this.$refs.textarea;
-      const start = textarea.selectionStart;
-      const end = textarea.selectionEnd;
-      const selectedText = textarea.value.substring(start, end);
-
-      if (!selectedText) return;
-
-      const currentScrollPos = textarea.scrollTop;
-
-      const fontSizeClass = `font-size-${this.selectedFontSize.replace('px', '')}`;
-      const sizedText = `<span class="${fontSizeClass}">${selectedText}</span>`;
-      const newValue = textarea.value.substring(0, start) + sizedText + textarea.value.substring(end);
-      this.addToHistory(newValue);
-      this.$emit('update:modelValue', newValue);
-
-      this.$nextTick(() => {
-        textarea.focus();
-        textarea.scrollTop = currentScrollPos;
-      });
-    },
-
-    toggleFontWeightDropdown() {
-      if (this.disabled) return;
-      this.fontWeightDropdownOpen = !this.fontWeightDropdownOpen;
-      this.fontSizeDropdownOpen = false;
-      this.showTooltip = !this.fontWeightDropdownOpen;
-    },
-
-    selectFontWeight(weight) {
-      this.selectedFontWeight = weight;
-      this.fontWeightDropdownOpen = false;
-      this.showTooltip = true;
-      this.applyFontWeight();
-    },
-
-    applyFontWeight() {
-      const textarea = this.$refs.textarea;
-      const start = textarea.selectionStart;
-      const end = textarea.selectionEnd;
-      const selectedText = textarea.value.substring(start, end);
-
-      if (!selectedText) return;
-
-      const currentScrollPos = textarea.scrollTop;
-
-      const weightClass = `font-weight-${this.selectedFontWeight.value}`;
-      const weightedText = `<span class="${weightClass}">${selectedText}</span>`;
-      const newValue = textarea.value.substring(0, start) + weightedText + textarea.value.substring(end);
-      this.addToHistory(newValue);
-      this.$emit('update:modelValue', newValue);
-
-      this.$nextTick(() => {
-        textarea.focus();
-        textarea.scrollTop = currentScrollPos;
-      });
+});
+
+watch(
+  () => props.modelValue,
+  (value) => {
+    const instance = editor.value;
+    if (!instance) return;
+    const current = instance.isEmpty ? '' : instance.getHTML();
+    if ((value || '') !== current) {
+      instance.commands.setContent(value || '', false);
     }
   }
-};
+);
+
+watch(
+  () => props.disabled,
+  (value) => {
+    editor.value?.setEditable(!value);
+  }
+);
+
+onMounted(() => {
+  onDocClick = (event) => {
+    const root = editor.value?.options?.element?.closest('.text-constructor');
+    if (root && !root.contains(event.target)) {
+      fontSizeDropdownOpen.value = false;
+      fontWeightDropdownOpen.value = false;
+    }
+  };
+  document.addEventListener('click', onDocClick);
+});
+
+onBeforeUnmount(() => {
+  if (onDocClick) document.removeEventListener('click', onDocClick);
+  if (imageErrorTimer) clearTimeout(imageErrorTimer);
+  editor.value?.destroy();
+});
+
+/**
+ * Запускает chain-команду на редакторе с фокусом, если редактор активен.
+ * @param {(chain: import('@tiptap/core').ChainedCommands) => import('@tiptap/core').ChainedCommands} build
+ */
+function runCommand(build) {
+  if (props.disabled || !editor.value) return;
+  build(editor.value.chain().focus()).run();
+}
+
+function applyColor(colorClass) {
+  runCommand((c) => c.setColorClass(colorClass));
+}
+
+function toggleFontSizeDropdown() {
+  if (props.disabled) return;
+  fontSizeDropdownOpen.value = !fontSizeDropdownOpen.value;
+  fontWeightDropdownOpen.value = false;
+}
+
+function selectFontSize(size) {
+  selectedFontSize.value = size;
+  fontSizeDropdownOpen.value = false;
+  runCommand((c) => c.setFontSizeClass(`font-size-${size.replace('px', '')}`));
+}
+
+function toggleFontWeightDropdown() {
+  if (props.disabled) return;
+  fontWeightDropdownOpen.value = !fontWeightDropdownOpen.value;
+  fontSizeDropdownOpen.value = false;
+}
+
+function selectFontWeight(weight) {
+  selectedFontWeight.value = weight;
+  fontWeightDropdownOpen.value = false;
+  runCommand((c) => c.setFontWeightClass(`font-weight-${weight.value}`));
+}
+
+function openPreviewModal() {
+  if (!props.modelValue) return;
+  previewModalOpen.value = true;
+}
+
+function triggerImagePicker() {
+  if (props.disabled) return;
+  clearImageError();
+  if (imageInput.value) {
+    imageInput.value.value = '';
+    imageInput.value.click();
+  }
+}
+
+function readFileAsDataUrl(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result));
+    reader.onerror = () => reject(reader.error || new Error('FileReader error'));
+    reader.readAsDataURL(file);
+  });
+}
+
+async function handleImageSelected(event) {
+  const file = event.target?.files?.[0];
+  if (!file) return;
+
+  if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
+    setImageError('Неподдерживаемый формат. Разрешены: PNG, JPEG, GIF, WEBP, SVG.');
+    return;
+  }
+  if (file.size > props.maxImageBytes) {
+    const maxMb = Math.round(props.maxImageBytes / (1024 * 1024));
+    setImageError(`Файл слишком большой. Максимальный размер: ${maxMb} МБ.`);
+    return;
+  }
+
+  try {
+    const dataUrl = await readFileAsDataUrl(file);
+    const safeAlt = (file.name || 'image').replace(/[<>"'&]/g, '').slice(0, 100);
+    runCommand((c) => c.setImage({ src: dataUrl, alt: safeAlt }));
+  } catch (err) {
+    setImageError('Не удалось прочитать файл. Попробуйте ещё раз.');
+    console.error('TextConstructor image read error:', err);
+  } finally {
+    if (imageInput.value) imageInput.value.value = '';
+  }
+}
+
+function setImageError(message) {
+  imageError.value = message;
+  if (imageErrorTimer) clearTimeout(imageErrorTimer);
+  imageErrorTimer = setTimeout(() => {
+    imageError.value = '';
+  }, 4500);
+}
+
+function clearImageError() {
+  imageError.value = '';
+  if (imageErrorTimer) {
+    clearTimeout(imageErrorTimer);
+    imageErrorTimer = null;
+  }
+}
+
+defineExpose({ editor });
 </script>
 
 <style scoped>
@@ -994,76 +490,52 @@ export default {
 }
 
 .text-constructor:focus-within {
-  border-color: #4F5BDF;
+  border-color: #4f5bdf;
   box-shadow: 0 0 0 3px rgba(79, 91, 223, 0.12);
 }
 
 .text-constructor.is-disabled {
-  opacity: 0.65;
-  background: #f7f7f9;
+  opacity: 0.7;
 }
 
 .editor-toolbar {
   display: flex;
+  flex-wrap: wrap;
+  align-items: center;
   gap: 8px;
   padding: 8px 10px;
   border-bottom: 1px solid #e6e6e6;
-  align-items: center;
-  flex-wrap: nowrap;
-  background: #fafafa;
-  border-radius: 12px 12px 0 0;
 }
 
 .toolbar-group {
   display: flex;
-  gap: 4px;
   align-items: center;
-  padding-right: 8px;
-  border-right: 1px solid #e6e6e6;
-}
-
-.toolbar-group:last-child {
-  border-right: none;
-  padding-right: 0;
-}
-
-.toolbar-group.lists-group {
-  width: 130px;
-  justify-content: space-between;
+  gap: 4px;
 }
 
 .toolbar-btn {
-  padding: 4px 6px;
-  border: 1px solid #ddd;
-  background: white;
-  border-radius: 8px;
-  cursor: pointer;
-  font-size: 12px;
-  font-family: inherit;
-  color: #1a1a1a;
-  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease, transform 0.05s ease;
-  min-width: 32px;
-  height: 28px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
   position: relative;
+  min-width: 32px;
+  height: 32px;
+  padding: 0 8px;
+  border: 1px solid #e6e6e6;
+  border-radius: 8px;
+  background: #fff;
+  color: #1a1a1a;
+  font-size: 14px;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, opacity 0.15s ease;
 }
 
 .toolbar-btn:hover:not(:disabled) {
-  background: #eef0ff;
-  border-color: #4F5BDF;
-  color: #4F5BDF;
+  background: #f4f5ff;
+  border-color: #4f5bdf;
 }
 
-.toolbar-btn:active:not(:disabled) {
-  transform: translateY(1px);
-}
-
-.toolbar-btn:focus-visible {
-  outline: none;
-  border-color: #4F5BDF;
-  box-shadow: 0 0 0 2px rgba(79, 91, 223, 0.25);
+.toolbar-btn.active {
+  background: #4f5bdf;
+  border-color: #4f5bdf;
+  color: #fff;
 }
 
 .toolbar-btn:disabled {
@@ -1071,612 +543,177 @@ export default {
   cursor: not-allowed;
 }
 
-.image-btn {
-  font-weight: 600;
-  letter-spacing: 0.5px;
+.color-btn.black-text { color: #000; }
+.color-btn.red-text { color: #ff0000; }
+.color-btn.green-text { color: #079d1d; }
+.color-btn.blue-text { color: #4f5bdf; }
+
+.color-btn.active,
+.color-btn:hover:not(:disabled) {
+  color: inherit;
+}
+
+.toolbar-btn[data-tooltip]:hover::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 4px 8px;
+  background: #1a1a1a;
+  color: #fff;
+  font-size: 11px;
+  white-space: nowrap;
+  border-radius: 6px;
+  pointer-events: none;
+  z-index: 10;
 }
 
 .image-input {
   display: none;
 }
 
-.undo-btn {
-  background: #f8f9fa;
-  border-color: #e9ecef;
-}
-
-.undo-btn:hover:not(:disabled) {
-  background: #eef0ff;
-  border-color: #4F5BDF;
-}
-
-.preview-btn {
-  background: #f8f9fa;
-  border-color: #e9ecef;
-}
-
-.preview-btn:hover:not(:disabled) {
-  background: #eef0ff;
-  border-color: #4F5BDF;
-  color: #4F5BDF;
-}
-
-/* Tooltip pattern, общий для кнопок и селектов */
-.toolbar-btn:hover:not(:disabled)::after,
-.custom-select:hover .select-header::after {
-  content: attr(data-tooltip);
-  position: absolute;
-  bottom: -32px;
-  left: 50%;
-  transform: translateX(-50%);
-  background: #1a1a1a;
-  color: white;
-  padding: 4px 8px;
-  border-radius: 6px;
-  font-size: 11px;
-  white-space: nowrap;
-  z-index: 1000;
-  font-weight: normal;
-  font-family: inherit;
-  pointer-events: none;
-  opacity: 0;
-  animation: tooltipFadeIn 0.15s ease forwards;
-}
-
-@keyframes tooltipFadeIn {
-  to { opacity: 1; }
-}
-
 .custom-select {
   position: relative;
-  width: fit-content;
-}
-
-.custom-select .select-header::after {
-  content: none;
-}
-
-.custom-select:hover .select-header::after {
-  content: attr(data-tooltip);
-}
-
-.custom-select:hover .select-header[data-tooltip=""]::after {
-  content: none;
 }
 
 .custom-select.fixed-width-select {
-  width: 78px;
+  width: 92px;
 }
-
-.color-btn {
-  font-weight: bold;
-}
-
-.black-text { color: #000 !important; }
-.red-text { color: #FF0000 !important; }
-.green-text { color: #079D1D !important; }
-.blue-text { color: #4F5BDF !important; }
 
 .select-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 4px 8px;
-  border: 1px solid #ddd;
+  gap: 6px;
+  min-width: 64px;
+  height: 32px;
+  padding: 0 10px;
+  border: 1px solid #e6e6e6;
   border-radius: 8px;
-  background: white;
+  background: #fff;
   cursor: pointer;
-  font-size: 12px;
-  font-family: inherit;
-  height: 28px;
-  transition: border-color 0.15s ease, background-color 0.15s ease;
-  position: relative;
-  width: 100%;
+  font-size: 13px;
 }
 
 .select-header:hover {
-  border-color: #4F5BDF;
-  background: #f8f9ff;
-}
-
-.select-value {
-  color: #000;
+  border-color: #4f5bdf;
 }
 
 .select-arrow {
-  width: 5px;
-  height: 5px;
-  transition: transform 0.2s ease;
-  margin-left: 4px;
-  transform: rotate(90deg);
+  width: 10px;
+  height: 10px;
+  transition: transform 0.15s ease;
 }
 
 .select-arrow.rotated {
-  transform: rotate(-90deg);
+  transform: rotate(180deg);
 }
 
 .select-dropdown {
   position: absolute;
-  top: 100%;
+  top: calc(100% + 4px);
   left: 0;
   right: 0;
-  background: white;
-  border: 1px solid #e6e6e6;
-  border-radius: 10px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
-  z-index: 1000;
-  margin-top: 4px;
-  max-height: 200px;
+  z-index: 20;
+  max-height: 220px;
   overflow-y: auto;
-  padding: 4px;
+  background: #fff;
+  border: 1px solid #e6e6e6;
+  border-radius: 8px;
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.12);
 }
 
 .select-option {
   padding: 6px 10px;
-  font-size: 12px;
+  font-size: 13px;
   cursor: pointer;
-  transition: background-color 0.15s ease;
-  color: #000;
-  border-radius: 6px;
 }
 
-.select-option:hover {
-  background: #eef0ff;
-}
-
+.select-option:hover,
 .select-option.active {
-  background: #4F5BDF;
-  color: white;
+  background: #f4f5ff;
+  color: #4f5bdf;
 }
 
-.textarea-container {
-  position: relative;
-  overflow: hidden;
+.editor-content {
+  padding: 12px 14px;
 }
 
-.constructor-textarea {
-  width: 100%;
-  padding: 14px;
-  border: none;
-  font-family: inherit;
-  font-size: 14px;
-  line-height: 1.5;
-  border-radius: 0;
-  min-height: 150px;
-  max-height: 350px;
-  resize: none;
-  display: block;
-  overflow-y: auto;
-  background: transparent;
-  color: #1a1a1a;
-}
-
-.constructor-textarea:focus {
+.editor-content :deep(.ProseMirror) {
   outline: none;
+  min-height: inherit;
+  line-height: 150%;
+  word-break: break-word;
 }
 
-.constructor-textarea:disabled {
-  cursor: not-allowed;
-  background: transparent;
-}
-
-.constructor-textarea::placeholder {
-  color: #9aa0a6;
-  font-style: italic;
-}
-
-.constructor-textarea::-webkit-scrollbar {
-  display: none;
-}
-
-.constructor-textarea {
-  -ms-overflow-style: none;
-  scrollbar-width: none;
-}
-
-.resize-handle {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  height: 8px;
-  background: transparent;
-  cursor: ns-resize;
-  z-index: 10;
-  transition: background-color 0.15s ease, opacity 0.15s ease;
-}
-
-.resize-handle:hover {
-  background: #4F5BDF;
-  opacity: 0.3;
-}
-
-.resize-handle:active {
-  background: #4F5BDF;
-  opacity: 0.5;
+.editor-content :deep(.ProseMirror p.is-editor-empty:first-child::before) {
+  content: attr(data-placeholder);
+  float: left;
+  height: 0;
+  color: #9aa0aa;
+  pointer-events: none;
 }
 
 .constructor-error {
-  margin: 10px 12px 0;
-  padding: 8px 12px;
-  border-radius: 8px;
-  background: #fff1f1;
-  border: 1px solid #f5c2c2;
-  color: #b3261e;
+  padding: 6px 14px 10px;
+  color: #d92d20;
   font-size: 12px;
 }
 
-.editor-preview {
-  border-top: 1px solid #e6e6e6;
-  background: #fafafa;
-  border-radius: 0 0 12px 12px;
-}
+/* Рендер форматирования внутри редактора и в модалке предпросмотра (round-trip с потребителями) */
+.editor-content :deep(strong),
+.preview-modal-content :deep(strong) { font-weight: 600; }
+.editor-content :deep(em),
+.preview-modal-content :deep(em) { font-style: italic; }
+.editor-content :deep(u),
+.preview-modal-content :deep(u) { text-decoration: underline; }
+.editor-content :deep(ul),
+.editor-content :deep(ol),
+.preview-modal-content :deep(ul),
+.preview-modal-content :deep(ol) { padding-left: 20px; }
+.editor-content :deep(h1),
+.preview-modal-content :deep(h1) { font-size: 24px; font-weight: 700; margin: 0 0 8px; line-height: 1.2; }
+.editor-content :deep(h2),
+.preview-modal-content :deep(h2) { font-size: 20px; font-weight: 600; margin: 8px 0 6px; line-height: 1.3; }
 
-.preview-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 12px 12px 8px 12px;
-}
+.editor-content :deep(.black-text),
+.preview-modal-content :deep(.black-text) { color: #000; }
+.editor-content :deep(.red-text),
+.preview-modal-content :deep(.red-text) { color: #ff0000; }
+.editor-content :deep(.green-text),
+.preview-modal-content :deep(.green-text) { color: #079d1d; }
+.editor-content :deep(.blue-text),
+.preview-modal-content :deep(.blue-text) { color: #4f5bdf; }
 
-.preview-header h5 {
-  margin: 0;
-  color: #000;
-  font-size: 0.9em;
-  font-weight: 600;
-}
+.editor-content :deep(.font-size-10),
+.preview-modal-content :deep(.font-size-10) { font-size: 10px; }
+.editor-content :deep(.font-size-12),
+.preview-modal-content :deep(.font-size-12) { font-size: 12px; }
+.editor-content :deep(.font-size-14),
+.preview-modal-content :deep(.font-size-14) { font-size: 14px; }
+.editor-content :deep(.font-size-16),
+.preview-modal-content :deep(.font-size-16) { font-size: 16px; }
+.editor-content :deep(.font-size-18),
+.preview-modal-content :deep(.font-size-18) { font-size: 18px; }
+.editor-content :deep(.font-size-20),
+.preview-modal-content :deep(.font-size-20) { font-size: 20px; }
 
-.preview-expand-btn {
-  background: transparent;
-  border: 1px solid transparent;
-  color: #4F5BDF;
-  font-family: inherit;
-  font-size: 12px;
-  cursor: pointer;
-  padding: 4px 10px;
-  border-radius: 8px;
-  transition: background-color 0.15s ease, border-color 0.15s ease;
-}
+.editor-content :deep(.font-weight-300),
+.preview-modal-content :deep(.font-weight-300) { font-weight: 300; }
+.editor-content :deep(.font-weight-400),
+.preview-modal-content :deep(.font-weight-400) { font-weight: 400; }
+.editor-content :deep(.font-weight-500),
+.preview-modal-content :deep(.font-weight-500) { font-weight: 500; }
+.editor-content :deep(.font-weight-600),
+.preview-modal-content :deep(.font-weight-600) { font-weight: 600; }
+.editor-content :deep(.font-weight-900),
+.preview-modal-content :deep(.font-weight-900) { font-weight: 900; }
 
-.preview-expand-btn:hover {
-  background: #eef0ff;
-  border-color: #4F5BDF;
-}
-
-.preview-content-container {
-  position: relative;
-  padding: 0 12px 12px 12px;
-}
-
-.preview-content {
-  background: white;
-  padding: 12px;
-  border-radius: 10px;
-  border: 1px solid #e6e6e6;
-  overflow-y: auto;
-  min-height: 150px;
-  max-height: 350px;
-  resize: none;
-}
-
-.preview-resize {
-  position: absolute;
-  bottom: 12px;
-  left: 12px;
-  right: 12px;
-  height: 8px;
-  background: transparent;
-  cursor: ns-resize;
-  z-index: 10;
-}
-
-.preview-resize:hover {
-  background: #4F5BDF;
-  opacity: 0.3;
-}
-
-.preview-resize:active {
-  background: #4F5BDF;
-  opacity: 0.5;
-}
-
-.preview-modal-content {
-  font-family: inherit;
-  font-size: 14px;
-  line-height: 1.5;
-  color: #1a1a1a;
-  max-height: 70vh;
-  overflow-y: auto;
-}
-
-/* Изображения внутри редактора и preview */
-.preview-content :deep(img),
+.editor-content :deep(img),
 .preview-modal-content :deep(img) {
   max-width: 100%;
   height: auto;
-  border-radius: 10px;
-  margin: 6px 0;
-  display: inline-block;
-}
-
-.preview-content :deep(.constructor-image),
-.preview-modal-content :deep(.constructor-image) {
-  border: 1px solid #e6e6e6;
-}
-
-/* Размеры и жирность шрифта */
-.font-size-10 { font-size: 10px !important; }
-.font-size-12 { font-size: 12px !important; }
-.font-size-14 { font-size: 14px !important; }
-.font-size-16 { font-size: 16px !important; }
-.font-size-18 { font-size: 18px !important; }
-.font-size-20 { font-size: 20px !important; }
-
-.font-weight-300 { font-weight: 300 !important; }
-.font-weight-400 { font-weight: 400 !important; }
-.font-weight-500 { font-weight: 500 !important; }
-.font-weight-600 { font-weight: 600 !important; }
-.font-weight-900 { font-weight: 900 !important; }
-
-.heading-h1,
-.heading-h1 :deep(*) {
-  font-size: 24px !important;
-  font-weight: 700 !important;
-  color: #000 !important;
-  margin: 16px 0 8px 0 !important;
-  line-height: 1.2 !important;
-}
-
-.heading-h2,
-.heading-h2 :deep(*) {
-  font-size: 20px !important;
-  font-weight: 600 !important;
-  color: #000 !important;
-  margin: 14px 0 6px 0 !important;
-  line-height: 1.3 !important;
-}
-
-.preview-content :deep(*),
-.preview-modal-content :deep(*) {
-  font-size: 14px;
-  max-font-size: 20px !important;
-  min-font-size: 10px !important;
-}
-
-.preview-content :deep(.font-size-10),
-.preview-modal-content :deep(.font-size-10) { font-size: 10px !important; }
-.preview-content :deep(.font-size-12),
-.preview-modal-content :deep(.font-size-12) { font-size: 12px !important; }
-.preview-content :deep(.font-size-14),
-.preview-modal-content :deep(.font-size-14) { font-size: 14px !important; }
-.preview-content :deep(.font-size-16),
-.preview-modal-content :deep(.font-size-16) { font-size: 16px !important; }
-.preview-content :deep(.font-size-18),
-.preview-modal-content :deep(.font-size-18) { font-size: 18px !important; }
-.preview-content :deep(.font-size-20),
-.preview-modal-content :deep(.font-size-20) { font-size: 20px !important; }
-
-.preview-content :deep(.font-weight-300),
-.preview-modal-content :deep(.font-weight-300) { font-weight: 300 !important; }
-.preview-content :deep(.font-weight-400),
-.preview-modal-content :deep(.font-weight-400) { font-weight: 400 !important; }
-.preview-content :deep(.font-weight-500),
-.preview-modal-content :deep(.font-weight-500) { font-weight: 500 !important; }
-.preview-content :deep(.font-weight-600),
-.preview-modal-content :deep(.font-weight-600) { font-weight: 600 !important; }
-.preview-content :deep(.font-weight-900),
-.preview-modal-content :deep(.font-weight-900) { font-weight: 900 !important; }
-
-.preview-content :deep(.black-text),
-.preview-modal-content :deep(.black-text) { color: #000 !important; }
-.preview-content :deep(.red-text),
-.preview-modal-content :deep(.red-text) { color: #FF0000 !important; }
-.preview-content :deep(.green-text),
-.preview-modal-content :deep(.green-text) { color: #079D1D !important; }
-.preview-content :deep(.blue-text),
-.preview-modal-content :deep(.blue-text) { color: #4F5BDF !important; }
-
-.preview-content :deep(.heading-h1),
-.preview-content :deep(.heading-h1 *),
-.preview-modal-content :deep(.heading-h1),
-.preview-modal-content :deep(.heading-h1 *) {
-  font-size: 24px !important;
-  font-weight: 700 !important;
-  color: #000 !important;
-  margin: 10px 0 8px 0 !important;
-  line-height: 1.2 !important;
-}
-
-.preview-content :deep(.heading-h2),
-.preview-content :deep(.heading-h2 *),
-.preview-modal-content :deep(.heading-h2),
-.preview-modal-content :deep(.heading-h2 *) {
-  font-size: 20px !important;
-  font-weight: 600 !important;
-  color: #000 !important;
-  margin: 8px 0 6px 0 !important;
-  line-height: 1.3 !important;
-}
-
-.heading-h1 strong,
-.heading-h2 strong,
-.preview-content :deep(.heading-h1 strong),
-.preview-content :deep(.heading-h2 strong),
-.preview-modal-content :deep(.heading-h1 strong),
-.preview-modal-content :deep(.heading-h2 strong) {
-  font-size: inherit !important;
-  font-weight: inherit !important;
-  color: inherit !important;
-}
-
-.preview-content :deep(ul),
-.preview-content :deep(ol),
-.preview-modal-content :deep(ul),
-.preview-modal-content :deep(ol) {
-  padding-left: 24px !important;
-}
-
-.preview-content :deep(li),
-.preview-modal-content :deep(li) {
-  line-height: 1.4 !important;
-}
-
-.editor-toolbar::-webkit-scrollbar {
-  display: none;
-}
-
-.editor-toolbar {
-  -ms-overflow-style: none;
-  scrollbar-width: none;
-}
-
-@media (max-width: 768px) {
-  .editor-toolbar {
-    flex-wrap: wrap;
-    gap: 4px;
-  }
-
-  .toolbar-group {
-    padding-right: 4px;
-    margin-right: 4px;
-  }
-
-  .toolbar-group.lists-group {
-    width: 110px;
-  }
-
-  .toolbar-btn {
-    min-width: 28px;
-    height: 26px;
-    font-size: 11px;
-    padding: 4px 6px;
-  }
-
-  .custom-select.fixed-width-select {
-    width: 70px;
-  }
-
-  .select-header {
-    font-size: 11px;
-    padding: 4px 6px;
-  }
-}
-
-.image-blocks {
-  margin-top: 12px;
-  padding: 12px;
-  border: 1px dashed var(--color-border);
-  border-radius: var(--radius-md);
-  background: var(--color-bg-secondary);
-}
-
-.image-blocks__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  gap: 8px;
-  margin-bottom: 10px;
-  flex-wrap: wrap;
-}
-
-.image-blocks__title {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--color-text);
-}
-
-.image-blocks__hint {
-  font-size: 11px;
-  color: var(--color-text-muted);
-}
-
-.image-blocks__list {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.image-block {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 6px 10px;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  background: #fff;
-  cursor: grab;
-  transition: border-color 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease;
-}
-
-.image-block:hover {
-  border-color: var(--color-primary);
-}
-
-.image-block--dragging {
-  opacity: 0.4;
-  cursor: grabbing;
-}
-
-.image-block--target {
-  border-color: var(--color-primary);
-  box-shadow: var(--shadow-focus);
-}
-
-.image-block__handle {
-  color: var(--color-text-muted);
-  flex-shrink: 0;
-  display: flex;
-}
-
-.image-block__preview {
-  width: 40px;
-  height: 40px;
-  object-fit: cover;
-  border-radius: var(--radius-sm);
-  flex-shrink: 0;
-  border: 1px solid var(--color-border);
-}
-
-.image-block__index {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--color-primary);
-  min-width: 24px;
-}
-
-.image-block__actions {
-  margin-left: auto;
-  display: flex;
-  gap: 4px;
-}
-
-.image-block__btn {
-  width: 28px;
-  height: 28px;
-  border: 1px solid var(--color-border);
-  background: #fff;
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  font-size: 14px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
-}
-
-.image-block__btn:hover:not(:disabled) {
-  background: var(--color-primary);
-  border-color: var(--color-primary);
-  color: #fff;
-}
-
-.image-block__btn:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-}
-
-.image-block__btn--danger:hover:not(:disabled) {
-  background: var(--color-danger);
-  border-color: var(--color-danger);
+  border-radius: 8px;
 }
 </style>

--- a/frontend/src/components/__tests__/TextConstructor.spec.js
+++ b/frontend/src/components/__tests__/TextConstructor.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mount } from '@vue/test-utils';
+import { mount, flushPromises } from '@vue/test-utils';
 import TextConstructor from '../TextConstructor.vue';
 
 function mountConstructor(props = {}) {
@@ -50,13 +50,11 @@ describe('TextConstructor', () => {
     expect(imageBtn.attributes('data-tooltip')).toBe('Вставить изображение');
   });
 
-  it('disabled пропс блокирует toolbar-кнопки и textarea', () => {
+  it('disabled пропс блокирует toolbar-кнопки', () => {
     const wrapper = mountConstructor({ disabled: true, modelValue: 'hi' });
-    const textarea = wrapper.find('.constructor-textarea');
-    expect(textarea.attributes('disabled')).toBeDefined();
     const buttons = wrapper.findAll('.toolbar-btn');
-    // image, format, lists, headings, colors, break, undo
-    const disabledOnes = buttons.filter(b => b.attributes('disabled') !== undefined);
+    const disabledOnes = buttons.filter((b) => b.attributes('disabled') !== undefined);
+    // italic, underline, lists, headings, colors, image, break, undo - всё кроме preview
     expect(disabledOnes.length).toBeGreaterThan(5);
   });
 
@@ -67,7 +65,7 @@ describe('TextConstructor', () => {
   });
 
   it('preview-кнопка активна когда есть контент', () => {
-    const wrapper = mountConstructor({ modelValue: 'Hello' });
+    const wrapper = mountConstructor({ modelValue: '<p>Hello</p>' });
     const previewBtn = wrapper.find('.preview-btn');
     expect(previewBtn.attributes('disabled')).toBeUndefined();
   });
@@ -108,77 +106,68 @@ describe('TextConstructor', () => {
     expect(wrapper.emitted('update:modelValue')).toBeUndefined();
   });
 
-  it('валидное изображение вставляет <img src="data:..."> через update:modelValue', async () => {
+  it('валидное изображение вставляет <img> с data:URL и классом constructor-image', async () => {
     const wrapper = mountConstructor();
+    await flushPromises();
     const input = wrapper.find('input.image-input');
 
     const file = new File(['fakebytes'], 'pic.png', { type: 'image/png' });
     Object.defineProperty(input.element, 'files', { value: [file], configurable: true });
     await input.trigger('change');
-    // ждём цепочку microtask -> reader.onload -> handleImageSelected await
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushPromises();
     await wrapper.vm.$nextTick();
 
     const emitted = wrapper.emitted('update:modelValue');
     expect(emitted).toBeTruthy();
     const lastValue = emitted[emitted.length - 1][0];
-    expect(lastValue).toContain('<img src="data:image/png;base64,');
+    expect(lastValue).toContain('data:image/png;base64,');
     expect(lastValue).toContain('alt="pic.png"');
     expect(lastValue).toContain('class="constructor-image"');
   });
 
   it('alt атрибут изображения санитизируется от опасных символов', async () => {
     const wrapper = mountConstructor();
+    await flushPromises();
     const input = wrapper.find('input.image-input');
 
-    const file = new File(['x'], '<script>"name".png', { type: 'image/png' });
+    const file = new File(['fakebytes'], 'a<b>"&\'.png', { type: 'image/png' });
     Object.defineProperty(input.element, 'files', { value: [file], configurable: true });
     await input.trigger('change');
-    // ждём цепочку microtask -> reader.onload -> handleImageSelected await
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushPromises();
     await wrapper.vm.$nextTick();
 
     const emitted = wrapper.emitted('update:modelValue');
-    const lastValue = emitted[emitted.length - 1][0];
-    expect(lastValue).not.toContain('<script>');
-    expect(lastValue).not.toContain('"name"');
-  });
-
-  it('форматирование italic оборачивает выделенный текст', async () => {
-    const wrapper = mountConstructor({ modelValue: 'hello world' });
-    const textarea = wrapper.find('.constructor-textarea');
-    textarea.element.setSelectionRange(0, 5);
-    await wrapper.findAll('.toolbar-btn')[0].trigger('click'); // italic
-
-    const emitted = wrapper.emitted('update:modelValue');
     expect(emitted).toBeTruthy();
-    expect(emitted[emitted.length - 1][0]).toContain('<em>hello</em>');
+    const lastValue = emitted[emitted.length - 1][0];
+    expect(lastValue).not.toContain('<b>');
+    expect(lastValue).toContain('alt="ab.png"');
   });
 
-  it('undo возвращает предыдущее значение', async () => {
-    const wrapper = mountConstructor({ modelValue: 'a' });
-    const textarea = wrapper.find('.constructor-textarea');
-    await textarea.setValue('ab');
-    await textarea.setValue('abc');
+  it('round-trip: сохранённый HTML с классами не теряет форматирование', async () => {
+    const html =
+      '<h1 class="heading-h1">Заголовок</h1>' +
+      '<p><span class="red-text">красный</span> ' +
+      '<span class="font-size-18">крупный</span> ' +
+      '<span class="font-weight-600">жирный</span></p>' +
+      '<ul><li>пункт</li></ul>' +
+      '<img class="constructor-image" src="data:image/png;base64,ZmFrZQ==" alt="pic">';
+    const wrapper = mountConstructor({ modelValue: html });
+    await flushPromises();
 
-    await wrapper.vm.undo();
-    const emitted = wrapper.emitted('update:modelValue');
-    const last = emitted[emitted.length - 1][0];
-    expect(last).toBe('ab');
+    const out = wrapper.vm.editor.getHTML();
+    expect(out).toContain('heading-h1');
+    expect(out).toContain('red-text');
+    expect(out).toContain('font-size-18');
+    expect(out).toContain('font-weight-600');
+    expect(out).toContain('<ul>');
+    expect(out).toContain('<li>');
+    expect(out).toContain('constructor-image');
+    expect(out).toContain('data:image/png;base64,');
   });
 
   it('кнопки форматирования имеют data-tooltip', () => {
     const wrapper = mountConstructor();
-    const tooltips = wrapper.findAll('.toolbar-btn')
-      .map(b => b.attributes('data-tooltip'))
-      .filter(Boolean);
-    expect(tooltips.length).toBeGreaterThan(5);
-    expect(tooltips).toContain('Курсив');
-    expect(tooltips).toContain('Заголовок h1');
-    expect(tooltips).toContain('Вставить изображение');
+    const italicBtn = wrapper.findAll('.toolbar-btn').find((b) => b.attributes('data-tooltip') === 'Курсив');
+    expect(italicBtn).toBeTruthy();
   });
 });

--- a/frontend/src/components/text-constructor/extensions.js
+++ b/frontend/src/components/text-constructor/extensions.js
@@ -1,0 +1,129 @@
+import { Mark, mergeAttributes } from '@tiptap/core';
+import Heading from '@tiptap/extension-heading';
+import Image from '@tiptap/extension-image';
+
+/**
+ * Класс-ориентированные марки TextConstructor.
+ *
+ * Существующий контент (инструкции к таблицам, новости, объявления) сохранён в БД как HTML
+ * с CSS-классами: `<span class="red-text">`, `<span class="font-size-14">`,
+ * `<span class="font-weight-600">`, `<h1 class="heading-h1">`, `<img class="constructor-image">`.
+ * Потребители рендерят его через v-html с :deep(.red-text)-стилями. Чтобы переход на Tiptap
+ * не ломал уже сохранённый контент (round-trip), эти марки парсят и рендерят те же классы 1:1.
+ */
+
+export const COLOR_CLASSES = ['black-text', 'red-text', 'green-text', 'blue-text'];
+export const FONT_SIZE_CLASSES = [
+  'font-size-10',
+  'font-size-12',
+  'font-size-14',
+  'font-size-16',
+  'font-size-18',
+  'font-size-20',
+];
+export const FONT_WEIGHT_CLASSES = [
+  'font-weight-300',
+  'font-weight-400',
+  'font-weight-500',
+  'font-weight-600',
+  'font-weight-900',
+];
+
+/**
+ * Фабрика марки, которая хранит один класс из набора на `<span>` и round-trip'ит его.
+ * @param {object} cfg
+ * @param {string} cfg.name имя марки
+ * @param {string} cfg.attr имя атрибута, где лежит класс
+ * @param {string[]} cfg.classes допустимый набор классов
+ * @param {string} cfg.setCommand имя команды установки
+ * @param {string} cfg.unsetCommand имя команды снятия
+ */
+function createClassMark({ name, attr, classes, setCommand, unsetCommand }) {
+  return Mark.create({
+    name,
+
+    addAttributes() {
+      return {
+        [attr]: {
+          default: null,
+          parseHTML: (element) => classes.find((cls) => element.classList.contains(cls)) || null,
+          renderHTML: (attributes) => (attributes[attr] ? { class: attributes[attr] } : {}),
+        },
+      };
+    },
+
+    parseHTML() {
+      return classes.map((cls) => ({ tag: `span.${cls}` }));
+    },
+
+    renderHTML({ HTMLAttributes }) {
+      return ['span', mergeAttributes(HTMLAttributes), 0];
+    },
+
+    addCommands() {
+      return {
+        [setCommand]: (value) => ({ commands }) => commands.setMark(name, { [attr]: value }),
+        [unsetCommand]: () => ({ commands }) => commands.unsetMark(name),
+      };
+    },
+  });
+}
+
+export const ColorClass = createClassMark({
+  name: 'colorClass',
+  attr: 'colorClass',
+  classes: COLOR_CLASSES,
+  setCommand: 'setColorClass',
+  unsetCommand: 'unsetColorClass',
+});
+
+export const FontSizeClass = createClassMark({
+  name: 'fontSizeClass',
+  attr: 'fontSizeClass',
+  classes: FONT_SIZE_CLASSES,
+  setCommand: 'setFontSizeClass',
+  unsetCommand: 'unsetFontSizeClass',
+});
+
+export const FontWeightClass = createClassMark({
+  name: 'fontWeightClass',
+  attr: 'fontWeightClass',
+  classes: FONT_WEIGHT_CLASSES,
+  setCommand: 'setFontWeightClass',
+  unsetCommand: 'unsetFontWeightClass',
+});
+
+/**
+ * Heading, который рендерит `<hN class="heading-hN">` (как старый редактор) и парсит обратно.
+ * Только уровни 1 и 2 - как в тулбаре.
+ */
+export const ClassHeading = Heading.extend({
+  addOptions() {
+    return {
+      ...this.parent?.(),
+      levels: [1, 2],
+    };
+  },
+
+  renderHTML({ node, HTMLAttributes }) {
+    const level = this.options.levels.includes(node.attrs.level)
+      ? node.attrs.level
+      : this.options.levels[0];
+    return [`h${level}`, mergeAttributes(HTMLAttributes, { class: `heading-h${level}` }), 0];
+  },
+});
+
+/**
+ * Image с классом `constructor-image` и поддержкой data:URL (картинки вставляются в base64).
+ * Размер картинки настраивается в отдельном срезе (image-resize); здесь - паритет со старым редактором.
+ */
+export const ConstructorImage = Image.extend({
+  addOptions() {
+    return {
+      ...this.parent?.(),
+      inline: false,
+      allowBase64: true,
+      HTMLAttributes: { class: 'constructor-image' },
+    };
+  },
+});


### PR DESCRIPTION
Срез 2/7 под-эпика доработки TextConstructor (часть п.9/п.27 эпика 46-edits).

## Что меняет
Старый `TextConstructor.vue` (textarea, в который вставлялись сырые HTML-теги, + отдельная панель предпросмотра) заменён на полноценный WYSIWYG на Tiptap (@tiptap/vue-3 v2.27, `<script setup>` + useEditor). Пользователь сразу видит форматированный текст, а не теги - это и был блокер для возврата rich-text в сопроводительное письмо (п.27).

## Контракт сохранён 1:1
Props (`modelValue`, `placeholder`, `rows`, `disabled`, `maxImageBytes`) и `emit('update:modelValue')` не менялись, поэтому 4 потребителя (`TableConstructor`, `TableConstructorCreateModal`, `AttachmentsManagement`, `NewsAndReview`) не правились.

## Round-trip уже сохранённого HTML
Кастомные Tiptap-марки (`text-constructor/extensions.js`) парсят и рендерят те же классы, что лежат в БД: `red/green/blue/black-text`, `font-size-10..20`, `font-weight-300..900`, `heading-h1/h2`, `constructor-image` (base64), `<em>/<u>/<strong>`, списки, `<br>`. Старый контент открывается и пересохраняется без потери форматирования (есть тест round-trip).

## Намеренно убрано
Инлайн-панель живого предпросмотра (WYSIWYG сам и есть предпросмотр; модалка полного предпросмотра осталась), панель переупорядочивания картинок (в WYSIWYG позиция правится в контенте), ручки ресайза textarea, кнопка "Li" и ручной Ctrl+Z (Tiptap History нативно). Bold-кнопка - в срезе 4 (toolbar-bold-align).

## Проверка
- vitest 11/11 (включая round-trip с классами и картинкой), eslint чисто.
- code-reviewer: GO, блокеров нет.

## Известные мелочи (не блокеры)
- При первом пересохранении старого контента вложенные span'ы (цвет+размер) нормализуются Tiptap в фиксированный порядок - визуально идентично, потребители стилизуют классы независимо.
- `rows="4"` в потребителях - строка против `type:Number` (dev-warning, pre-existing, не трогал, чтобы не расширять скоуп среза).

Браузерную проверку WYSIWYG (редактирование существующих инструкций/новостей, вставка картинок, 4 контекста монтирования) - в комплексном прогоне в конце эпика 46-edits.