### PR TITLE
feat(statistics): эндпоинты сводки и таймлайна для дашборда аналитики (#632)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -188,6 +188,7 @@ func main() {
 	documentFileService := services.NewDocumentFileService(cfg.UploadPath)
 	documentGroupService := services.NewDocumentGroupService(db)
 	documentService := services.NewDocumentService(db, documentFileService, settingsService)
+	statisticsService := services.NewStatisticsService(db)
 
 	// Handlers
 	authHandler := handlers.NewAuthHandler(authService, maintenanceService, cfg.CookieSecure, cfg.JWTRefreshTTL)
@@ -229,6 +230,7 @@ func main() {
 	trashHandler := handlers.NewTrashHandler(trashService, trashDBRef)
 	documentGroupHandler := handlers.NewDocumentGroupHandler(documentGroupService)
 	documentHandler := handlers.NewDocumentHandler(documentService, documentFileService)
+	statisticsHandler := handlers.NewStatisticsHandler(statisticsService)
 
 	// Swagger UI: http://localhost:8090/swagger/index.html
 	if cfg.SwaggerEnabled {
@@ -286,6 +288,7 @@ func main() {
 		Trash:               trashHandler,
 		DocumentGroups:      documentGroupHandler,
 		Documents:           documentHandler,
+		Statistics:          statisticsHandler,
 		PermResolver:        permissionResolver,
 		DenialLog:           accessDenialService,
 		MaintenanceBlock:    maintenanceBlock,

--- a/internal/handlers/statistics.go
+++ b/internal/handlers/statistics.go
@@ -1,0 +1,111 @@
+package handlers
+
+import (
+	"net/http"
+	"time"
+
+	"systemburo/internal/services"
+
+	"github.com/labstack/echo/v4"
+)
+
+// StatisticsHandler — HTTP-обработчики статистики дашборда.
+type StatisticsHandler struct {
+	service services.StatisticsService
+}
+
+// NewStatisticsHandler создаёт новый экземпляр StatisticsHandler.
+func NewStatisticsHandler(service services.StatisticsService) *StatisticsHandler {
+	return &StatisticsHandler{service: service}
+}
+
+// parseDateRange парсит from/to из query-параметров (формат YYYY-MM-DD).
+// По умолчанию — последние 7 дней. from -> начало дня, to -> конец дня (23:59:59).
+func parseDateRange(c echo.Context) (from, to time.Time) {
+	now := time.Now().UTC()
+	toDefault := time.Date(now.Year(), now.Month(), now.Day(), 23, 59, 59, 0, time.UTC)
+	fromDefault := toDefault.AddDate(0, 0, -6).Truncate(24 * time.Hour)
+
+	fromStr := c.QueryParam("from")
+	toStr := c.QueryParam("to")
+
+	if fromStr == "" && toStr == "" {
+		return fromDefault, toDefault
+	}
+
+	from = fromDefault
+	to = toDefault
+
+	if fromStr != "" {
+		if t, err := time.ParseInLocation("2006-01-02", fromStr, time.UTC); err == nil {
+			from = t // уже начало дня (00:00:00) в UTC
+		}
+	}
+	if toStr != "" {
+		if t, err := time.ParseInLocation("2006-01-02", toStr, time.UTC); err == nil {
+			to = time.Date(t.Year(), t.Month(), t.Day(), 23, 59, 59, 0, time.UTC)
+		}
+	}
+
+	return from, to
+}
+
+// GetSummary godoc
+// @Summary      Сводная статистика дашборда
+// @Tags         statistics
+// @Produce      json
+// @Security     BearerAuth
+// @Param        from query string false "Начало периода (YYYY-MM-DD), по умолчанию 7 дней назад"
+// @Param        to   query string false "Конец периода (YYYY-MM-DD), по умолчанию сегодня"
+// @Success      200 {object} Response
+// @Failure      401 {object} models.HTTPError
+// @Failure      403 {object} models.HTTPError
+// @Router       /statistics/summary [get]
+func (h *StatisticsHandler) GetSummary(c echo.Context) error {
+	from, to := parseDateRange(c)
+	if from.After(to) {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid date range")
+	}
+	summary, err := h.service.GetSummary(c.Request().Context(), from, to)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, summary)
+}
+
+// GetTimeline godoc
+// @Summary      Данные для графика по метрике
+// @Tags         statistics
+// @Produce      json
+// @Security     BearerAuth
+// @Param        from        query string false "Начало периода (YYYY-MM-DD)"
+// @Param        to          query string false "Конец периода (YYYY-MM-DD)"
+// @Param        metric      query string false "Метрика: applications, car_entries, people_entries" default(applications)
+// @Param        granularity query string false "Гранулярность: day, week, month" default(day)
+// @Success      200 {array} models.StatsTimelinePoint
+// @Failure      400 {object} models.HTTPError
+// @Failure      401 {object} models.HTTPError
+// @Failure      403 {object} models.HTTPError
+// @Router       /statistics/timeline [get]
+func (h *StatisticsHandler) GetTimeline(c echo.Context) error {
+	from, to := parseDateRange(c)
+	if from.After(to) {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid date range")
+	}
+
+	metric := c.QueryParam("metric")
+	if metric == "" {
+		metric = "applications"
+	}
+	granularity := c.QueryParam("granularity")
+	if granularity == "" {
+		granularity = "day"
+	}
+
+	points, err := h.service.GetTimeline(c.Request().Context(), from, to, metric, granularity)
+	if err != nil {
+		// Неизвестные metric/granularity -> 400 без эха пользовательского ввода в ответ.
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid metric or granularity")
+	}
+	return RespondSuccess(c, points)
+}

--- a/internal/models/statistics.go
+++ b/internal/models/statistics.go
@@ -1,0 +1,48 @@
+package models
+
+// AttachmentTypeCount — количество вложений по типу за период.
+type AttachmentTypeCount struct {
+	Name  string `json:"name"`
+	Count int64  `json:"count"`
+}
+
+// StatusCount — количество заявок по статусу за период.
+type StatusCount struct {
+	Status string `json:"status"`
+	Count  int64  `json:"count"`
+}
+
+// StatsSummary — сводная статистика дашборда за период.
+type StatsSummary struct {
+	// Данные (заявки, въезды, товары)
+	TotalApplications   int64                 `json:"total_applications"`
+	ByAttachmentType    []AttachmentTypeCount  `json:"by_attachment_type"`
+	ByStatus            []StatusCount          `json:"by_status"`
+	Processed           int64                 `json:"processed"`
+	InWork              int64                 `json:"in_work"`
+	CarsEntered         int64                 `json:"cars_entered"`
+	PeopleEntered       int64                 `json:"people_entered"`
+	AvgCarsPerDay       float64               `json:"avg_cars_per_day"`
+	ItemsSum            int64                 `json:"items_sum"`
+	CarsOnTerritory     int64                 `json:"cars_on_territory"`
+	PeopleOnTerritory   int64                 `json:"people_on_territory"`
+
+	// Система (пользователи, справочники)
+	UsersOnline        int64 `json:"users_online"`
+	ActiveUsers        int64 `json:"active_users"`
+	BannedUsers        int64 `json:"banned_users"`
+	OpenFeedback       int64 `json:"open_feedback"`
+	ActiveUnloadPlaces int64 `json:"active_unload_places"`
+	BlacklistCars      int64 `json:"blacklist_cars"`
+	BlacklistPeople    int64 `json:"blacklist_people"`
+	UniqueCars         int64 `json:"unique_cars"`
+	UniquePeople       int64 `json:"unique_people"`
+}
+
+// StatsTimelinePoint — одна точка графика (дата + количество).
+// Имя StatsTimelinePoint используется вместо TimelinePoint, т.к.
+// TimelinePoint уже занят в request_logs.go.
+type StatsTimelinePoint struct {
+	Date  string `json:"date"`
+	Count int64  `json:"count"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -53,6 +53,7 @@ type Dependencies struct {
 	Trash               *handlers.TrashHandler
 	DocumentGroups      *handlers.DocumentGroupHandler
 	Documents           *handlers.DocumentHandler
+	Statistics          *handlers.StatisticsHandler
 
 	// Services (для middleware и audit)
 	PermResolver *services.PermissionResolver
@@ -107,6 +108,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	trash := d.Trash
 	docGroups := d.DocumentGroups
 	docs := d.Documents
+	statistics := d.Statistics
 	permResolver := d.PermResolver
 	denialLog := d.DenialLog
 	maintenanceBlock := d.MaintenanceBlock
@@ -577,5 +579,13 @@ func Setup(e *echo.Echo, d Dependencies) {
 		docsGroup.GET("/:id/download", docs.Download)
 
 		protected.GET("/public/documents", docs.GetPublic)
+	}
+
+	// Статистика дашборда (#632). Доступ ограничен page.statistics.
+	if statistics != nil {
+		requireStats := mw.RequirePermissionV2(permResolver, denialLog, services.KeyPageStatistics)
+		statsGroup := protected.Group("/statistics")
+		statsGroup.GET("/summary", statistics.GetSummary, requireStats)
+		statsGroup.GET("/timeline", statistics.GetTimeline, requireStats)
 	}
 }

--- a/internal/services/statistics_service.go
+++ b/internal/services/statistics_service.go
@@ -1,0 +1,284 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"systemburo/internal/models"
+
+	"gorm.io/gorm"
+)
+
+// StatisticsService — интерфейс бизнес-логики статистики дашборда.
+type StatisticsService interface {
+	GetSummary(ctx context.Context, from, to time.Time) (*models.StatsSummary, error)
+	GetTimeline(ctx context.Context, from, to time.Time, metric, granularity string) ([]models.StatsTimelinePoint, error)
+}
+
+type statisticsService struct {
+	db *gorm.DB
+}
+
+// NewStatisticsService создаёт реализацию StatisticsService.
+func NewStatisticsService(db *gorm.DB) StatisticsService {
+	return &statisticsService{db: db}
+}
+
+// GetSummary возвращает сводную статистику за период [from, to].
+func (s *statisticsService) GetSummary(ctx context.Context, from, to time.Time) (*models.StatsSummary, error) {
+	var summary models.StatsSummary
+
+	// total_applications
+	if err := s.db.WithContext(ctx).
+		Table("applications").
+		Where("sending_datetime BETWEEN ? AND ?", from, to).
+		Count(&summary.TotalApplications).Error; err != nil {
+		return nil, fmt.Errorf("statistics: count applications: %w", err)
+	}
+
+	// by_attachment_type
+	summary.ByAttachmentType = make([]models.AttachmentTypeCount, 0)
+	if err := s.db.WithContext(ctx).
+		Table("attachments a").
+		Joins("JOIN applications app ON app.id = a.application_id").
+		Joins("LEFT JOIN unique_attachments ua ON ua.id = a.unique_attachment_id").
+		Where("app.sending_datetime BETWEEN ? AND ?", from, to).
+		Select("COALESCE(ua.display_name, a.attachment_display_name, a.attachment_type) AS name, COUNT(*) AS count").
+		Group("COALESCE(ua.display_name, a.attachment_display_name, a.attachment_type)").
+		Order("count DESC").
+		Scan(&summary.ByAttachmentType).Error; err != nil {
+		return nil, fmt.Errorf("statistics: by_attachment_type: %w", err)
+	}
+
+	// by_status
+	summary.ByStatus = make([]models.StatusCount, 0)
+	if err := s.db.WithContext(ctx).
+		Table("applications").
+		Where("sending_datetime BETWEEN ? AND ?", from, to).
+		Select("status, COUNT(*) AS count").
+		Group("status").
+		Scan(&summary.ByStatus).Error; err != nil {
+		return nil, fmt.Errorf("statistics: by_status: %w", err)
+	}
+
+	// processed (терминальные статусы)
+	terminalStatuses := []string{
+		models.StatusCompleted,
+		models.StatusApproved,
+		models.StatusRejected,
+		models.StatusRefused,
+	}
+	if err := s.db.WithContext(ctx).
+		Table("applications").
+		Where("sending_datetime BETWEEN ? AND ? AND status IN ?", from, to, terminalStatuses).
+		Count(&summary.Processed).Error; err != nil {
+		return nil, fmt.Errorf("statistics: processed: %w", err)
+	}
+
+	// in_work (активные статусы)
+	inWorkStatuses := []string{
+		models.StatusProcessing,
+		models.StatusInWork,
+		models.StatusApproval,
+	}
+	if err := s.db.WithContext(ctx).
+		Table("applications").
+		Where("sending_datetime BETWEEN ? AND ? AND status IN ?", from, to, inWorkStatuses).
+		Count(&summary.InWork).Error; err != nil {
+		return nil, fmt.Errorf("statistics: in_work: %w", err)
+	}
+
+	// cars_entered
+	if err := s.db.WithContext(ctx).
+		Table("cars_history").
+		Where("action_type = 'entry' AND created_at BETWEEN ? AND ?", from, to).
+		Count(&summary.CarsEntered).Error; err != nil {
+		return nil, fmt.Errorf("statistics: cars_entered: %w", err)
+	}
+
+	// people_entered
+	if err := s.db.WithContext(ctx).
+		Table("employees_history").
+		Where("action_type = 'entry' AND created_at BETWEEN ? AND ?", from, to).
+		Count(&summary.PeopleEntered).Error; err != nil {
+		return nil, fmt.Errorf("statistics: people_entered: %w", err)
+	}
+
+	// avg_cars_per_day
+	days := int(to.Sub(from).Hours()/24) + 1
+	if days < 1 {
+		days = 1
+	}
+	summary.AvgCarsPerDay = float64(summary.CarsEntered) / float64(days)
+
+	// items_sum
+	var itemsSum struct{ Sum int64 }
+	if err := s.db.WithContext(ctx).
+		Table("items i").
+		Joins("JOIN attachments a ON a.id = i.attachment_id").
+		Joins("JOIN applications app ON app.id = a.application_id").
+		Where("app.sending_datetime BETWEEN ? AND ?", from, to).
+		Select("COALESCE(SUM(i.count), 0) AS sum").
+		Scan(&itemsSum).Error; err != nil {
+		return nil, fmt.Errorf("statistics: items_sum: %w", err)
+	}
+	summary.ItemsSum = itemsSum.Sum
+
+	// cars_on_territory (territory_status = 1)
+	if err := s.db.WithContext(ctx).
+		Table("cars").
+		Where("territory_status = 1").
+		Count(&summary.CarsOnTerritory).Error; err != nil {
+		return nil, fmt.Errorf("statistics: cars_on_territory: %w", err)
+	}
+
+	// people_on_territory (territory_status = 1)
+	if err := s.db.WithContext(ctx).
+		Table("employees").
+		Where("territory_status = 1").
+		Count(&summary.PeopleOnTerritory).Error; err != nil {
+		return nil, fmt.Errorf("statistics: people_on_territory: %w", err)
+	}
+
+	// users_online: онлайн = вход за последние 15 минут, прокси без сессий.
+	onlineThreshold := time.Now().UTC().Add(-15 * time.Minute)
+	if err := s.db.WithContext(ctx).
+		Table("users").
+		Where("last_login_at >= ?", onlineThreshold).
+		Count(&summary.UsersOnline).Error; err != nil {
+		return nil, fmt.Errorf("statistics: users_online: %w", err)
+	}
+
+	// active_users
+	if err := s.db.WithContext(ctx).
+		Table("users").
+		Where("is_active = true AND is_banned = false").
+		Count(&summary.ActiveUsers).Error; err != nil {
+		return nil, fmt.Errorf("statistics: active_users: %w", err)
+	}
+
+	// banned_users
+	if err := s.db.WithContext(ctx).
+		Table("users").
+		Where("is_banned = true").
+		Count(&summary.BannedUsers).Error; err != nil {
+		return nil, fmt.Errorf("statistics: banned_users: %w", err)
+	}
+
+	// open_feedback
+	if err := s.db.WithContext(ctx).
+		Table("feedback").
+		Where("status = ?", models.FeedbackOpen).
+		Count(&summary.OpenFeedback).Error; err != nil {
+		return nil, fmt.Errorf("statistics: open_feedback: %w", err)
+	}
+
+	// active_unload_places
+	if err := s.db.WithContext(ctx).
+		Table("unload_places").
+		Where("is_active = true").
+		Count(&summary.ActiveUnloadPlaces).Error; err != nil {
+		return nil, fmt.Errorf("statistics: active_unload_places: %w", err)
+	}
+
+	// blacklist_cars
+	if err := s.db.WithContext(ctx).
+		Table("vehicle_blacklists").
+		Where("is_active = true").
+		Count(&summary.BlacklistCars).Error; err != nil {
+		return nil, fmt.Errorf("statistics: blacklist_cars: %w", err)
+	}
+
+	// blacklist_people
+	if err := s.db.WithContext(ctx).
+		Table("person_blacklists").
+		Where("is_active = true").
+		Count(&summary.BlacklistPeople).Error; err != nil {
+		return nil, fmt.Errorf("statistics: blacklist_people: %w", err)
+	}
+
+	// unique_cars
+	if err := s.db.WithContext(ctx).
+		Table("unique_cars").
+		Count(&summary.UniqueCars).Error; err != nil {
+		return nil, fmt.Errorf("statistics: unique_cars: %w", err)
+	}
+
+	// unique_people
+	if err := s.db.WithContext(ctx).
+		Table("unique_employees").
+		Count(&summary.UniquePeople).Error; err != nil {
+		return nil, fmt.Errorf("statistics: unique_people: %w", err)
+	}
+
+	return &summary, nil
+}
+
+// timelineSource описывает источник данных для GetTimeline.
+type timelineSource struct {
+	table    string
+	tsColumn string
+	filter   string // опциональный WHERE-фрагмент (безопасная константа, не пользовательский ввод)
+}
+
+// resolveTimelineSource возвращает параметры запроса по metric/granularity из whitelist.
+// Вынесена отдельно для тестируемости без БД.
+func resolveTimelineSource(metric, granularity string) (src timelineSource, unit string, err error) {
+	metricMap := map[string]timelineSource{
+		"applications":    {table: "applications", tsColumn: "sending_datetime", filter: ""},
+		"car_entries":     {table: "cars_history", tsColumn: "created_at", filter: "action_type='entry'"},
+		"people_entries":  {table: "employees_history", tsColumn: "created_at", filter: "action_type='entry'"},
+	}
+	granularityMap := map[string]string{
+		"day":   "day",
+		"week":  "week",
+		"month": "month",
+	}
+
+	src, ok := metricMap[metric]
+	if !ok {
+		return timelineSource{}, "", fmt.Errorf("statistics: unknown metric %q", metric)
+	}
+	unit, ok = granularityMap[granularity]
+	if !ok {
+		return timelineSource{}, "", fmt.Errorf("statistics: unknown granularity %q", granularity)
+	}
+	return src, unit, nil
+}
+
+// GetTimeline возвращает точки графика за период [from, to].
+// metric и granularity проходят через whitelist — конкатенация пользовательского ввода в SQL исключена.
+func (s *statisticsService) GetTimeline(ctx context.Context, from, to time.Time, metric, granularity string) ([]models.StatsTimelinePoint, error) {
+	src, unit, err := resolveTimelineSource(metric, granularity)
+	if err != nil {
+		return nil, err
+	}
+
+	// table, tsColumn и unit берутся только из whitelist-карт — безопасно подставлять в SQL.
+	// from, to и значения filter передаются через ? плейсхолдеры.
+	selectExpr := fmt.Sprintf(
+		"to_char(date_trunc('%s', %s), 'YYYY-MM-DD') AS date, COUNT(*) AS count",
+		unit, src.tsColumn,
+	)
+	groupExpr := fmt.Sprintf("date_trunc('%s', %s)", unit, src.tsColumn)
+
+	tx := s.db.WithContext(ctx).
+		Table(src.table).
+		Select(selectExpr).
+		Where(fmt.Sprintf("%s BETWEEN ? AND ?", src.tsColumn), from, to)
+
+	if src.filter != "" {
+		tx = tx.Where(src.filter)
+	}
+
+	points := make([]models.StatsTimelinePoint, 0)
+	if err := tx.
+		Group(groupExpr).
+		Order(groupExpr + " ASC").
+		Scan(&points).Error; err != nil {
+		return nil, fmt.Errorf("statistics: timeline: %w", err)
+	}
+
+	return points, nil
+}

--- a/internal/services/statistics_service_test.go
+++ b/internal/services/statistics_service_test.go
@@ -1,0 +1,63 @@
+package services
+
+import (
+	"testing"
+)
+
+func TestResolveTimelineSource_ValidInputs(t *testing.T) {
+	tests := []struct {
+		metric      string
+		granularity string
+		wantTable   string
+		wantCol     string
+		wantUnit    string
+	}{
+		{"applications", "day", "applications", "sending_datetime", "day"},
+		{"applications", "week", "applications", "sending_datetime", "week"},
+		{"applications", "month", "applications", "sending_datetime", "month"},
+		{"car_entries", "day", "cars_history", "created_at", "day"},
+		{"people_entries", "week", "employees_history", "created_at", "week"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.metric+"/"+tc.granularity, func(t *testing.T) {
+			src, unit, err := resolveTimelineSource(tc.metric, tc.granularity)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if src.table != tc.wantTable {
+				t.Errorf("table: got %q, want %q", src.table, tc.wantTable)
+			}
+			if src.tsColumn != tc.wantCol {
+				t.Errorf("tsColumn: got %q, want %q", src.tsColumn, tc.wantCol)
+			}
+			if unit != tc.wantUnit {
+				t.Errorf("unit: got %q, want %q", unit, tc.wantUnit)
+			}
+		})
+	}
+}
+
+func TestResolveTimelineSource_InvalidInputs(t *testing.T) {
+	tests := []struct {
+		metric      string
+		granularity string
+		desc        string
+	}{
+		{"unknown_metric", "day", "неизвестный metric"},
+		{"applications", "hour", "неизвестная granularity"},
+		{"'; DROP TABLE applications; --", "day", "SQL-инъекция в metric"},
+		{"applications", "day; DROP TABLE cars", "SQL-инъекция в granularity"},
+		{"", "day", "пустой metric"},
+		{"applications", "", "пустая granularity"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			_, _, err := resolveTimelineSource(tc.metric, tc.granularity)
+			if err == nil {
+				t.Errorf("ожидалась ошибка для metric=%q granularity=%q, но её нет", tc.metric, tc.granularity)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Срез A1 эпика «Аналитика» (#632). Бэкенд-фундамент дашборда.

## Что
- `internal/services/statistics_service.go` — `GetSummary` (метрики дашборда: всего заявок, вложения по типам через `unique_attachments`, разбивка по статусам, обработано/в работе, машин заехало / людей прошло (entry), сумма товаров, на территории `territory_status=1`, системные: онлайн/активные/забаненные/обращения/места/ЧС/уникальные) и `GetTimeline` (график по метрике applications/car_entries/people_entries × гранулярности day/week/month).
- `internal/handlers/statistics.go`, роут-группа `/statistics` с `RequirePermissionV2(KeyPageStatistics)`, DI в `main.go`, DTO в `models/statistics.go`.

## Решения
- Без org-scoping — осознанно (право `page.statistics` = доступ ко всем данным, подтверждено владельцем).
- `migrate.go` НЕ затронут: индексы производительности вынесены в отдельный срез.
- Защита от инъекций: `metric`/`granularity` строго через whitelist `resolveTimelineSource` (table/column/unit только из карт-констант), покрыто юнит-тестом.

## Проверка
- Контейнер go-backend: `go build ./...`, `go vet`, `go test -run Timeline` — зелёные.
- SQL-запросы (by_attachment_type join, by_status, items_sum, timeline date_trunc) выверены прямым прогоном по локальной БД.
- Учтены находки ревью: убрал эхо ввода в ошибке (фикс. сообщение), валидация from>to, struct-scan для items_sum, group по выражению. Отложено (suggestion): read-only транзакция на 16 запросов — для дашборда несогласованность некритична.

Телефон ответственного и индексы — в следующих срезах. FE-дашборд (A2) поверх этих эндпоинтов.