### PR TITLE
feat(text-constructor): жирность и выравнивание в тулбаре (#46)

### DIFF
--- a/frontend/src/components/AnnouncementModal.vue
+++ b/frontend/src/components/AnnouncementModal.vue
@@ -280,4 +280,7 @@ export default {
 .announcement-body-html :deep(ul),
 .announcement-body-html :deep(ol) { padding-left: 1.5em; margin: 0.5em 0; }
 .announcement-body-html :deep(img) { max-width: 100%; height: auto; border-radius: 8px; }
+.announcement-body-html :deep(.text-align-left) { text-align: left; }
+.announcement-body-html :deep(.text-align-center) { text-align: center; }
+.announcement-body-html :deep(.text-align-right) { text-align: right; }
 </style>

--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -2189,6 +2189,10 @@ export default {
         border-radius: 8px;
     }
 
+    .text-constructor-content :deep(.text-align-left) { text-align: left; }
+    .text-constructor-content :deep(.text-align-center) { text-align: center; }
+    .text-constructor-content :deep(.text-align-right) { text-align: right; }
+
     .create {
         padding: 20px;
     }

--- a/frontend/src/components/TablesComponent.vue
+++ b/frontend/src/components/TablesComponent.vue
@@ -891,12 +891,16 @@ export default {
     line-height: 1.2 !important;
 }
 
-.text-constructor-content :deep(.heading-h2) { 
-    font-size: 20px !important; 
+.text-constructor-content :deep(.heading-h2) {
+    font-size: 20px !important;
     font-weight: 600 !important;
     margin: 8px 0 6px 0 !important;
     line-height: 1.3 !important;
 }
+
+.text-constructor-content :deep(.text-align-left) { text-align: left !important; }
+.text-constructor-content :deep(.text-align-center) { text-align: center !important; }
+.text-constructor-content :deep(.text-align-right) { text-align: right !important; }
 
 /* Hint specific styles */
 .hint-content :deep(*) {
@@ -907,6 +911,10 @@ export default {
 .hint-content :deep(.red-text) { color: #FFB3B3 !important; }
 .hint-content :deep(.green-text) { color: #B3FFC6 !important; }
 .hint-content :deep(.blue-text) { color: #B3C6FF !important; }
+
+.hint-content :deep(.text-align-left) { text-align: left !important; }
+.hint-content :deep(.text-align-center) { text-align: center !important; }
+.hint-content :deep(.text-align-right) { text-align: right !important; }
 
 /* Instruction Modal */
 .modal-overlay {

--- a/frontend/src/components/TextConstructor.vue
+++ b/frontend/src/components/TextConstructor.vue
@@ -8,6 +8,16 @@
         <button
           type="button"
           class="toolbar-btn"
+          :class="{ active: editor && editor.isActive('bold') }"
+          data-tooltip="Жирный"
+          :disabled="disabled"
+          @click="runCommand((c) => c.toggleBold())"
+        >
+          <strong>B</strong>
+        </button>
+        <button
+          type="button"
+          class="toolbar-btn"
           :class="{ active: editor && editor.isActive('italic') }"
           data-tooltip="Курсив"
           :disabled="disabled"
@@ -70,6 +80,129 @@
           @click="runCommand((c) => c.toggleHeading({ level: 2 }))"
         >
           h2
+        </button>
+      </div>
+
+      <div class="toolbar-group align-group">
+        <button
+          type="button"
+          class="toolbar-btn align-btn"
+          :class="{ active: editor && editor.isActive({ textAlign: 'left' }) }"
+          data-tooltip="По левому краю"
+          :disabled="disabled"
+          @click="runCommand((c) => c.setTextAlignClass('left'))"
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            aria-hidden="true"
+          >
+            <rect
+              x="2"
+              y="3"
+              width="12"
+              height="1.6"
+              rx="0.8"
+              fill="currentColor"
+            />
+            <rect
+              x="2"
+              y="7.2"
+              width="8"
+              height="1.6"
+              rx="0.8"
+              fill="currentColor"
+            />
+            <rect
+              x="2"
+              y="11.4"
+              width="11"
+              height="1.6"
+              rx="0.8"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <button
+          type="button"
+          class="toolbar-btn align-btn"
+          :class="{ active: editor && editor.isActive({ textAlign: 'center' }) }"
+          data-tooltip="По центру"
+          :disabled="disabled"
+          @click="runCommand((c) => c.setTextAlignClass('center'))"
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            aria-hidden="true"
+          >
+            <rect
+              x="2"
+              y="3"
+              width="12"
+              height="1.6"
+              rx="0.8"
+              fill="currentColor"
+            />
+            <rect
+              x="4"
+              y="7.2"
+              width="8"
+              height="1.6"
+              rx="0.8"
+              fill="currentColor"
+            />
+            <rect
+              x="2.5"
+              y="11.4"
+              width="11"
+              height="1.6"
+              rx="0.8"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <button
+          type="button"
+          class="toolbar-btn align-btn"
+          :class="{ active: editor && editor.isActive({ textAlign: 'right' }) }"
+          data-tooltip="По правому краю"
+          :disabled="disabled"
+          @click="runCommand((c) => c.setTextAlignClass('right'))"
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            aria-hidden="true"
+          >
+            <rect
+              x="2"
+              y="3"
+              width="12"
+              height="1.6"
+              rx="0.8"
+              fill="currentColor"
+            />
+            <rect
+              x="6"
+              y="7.2"
+              width="8"
+              height="1.6"
+              rx="0.8"
+              fill="currentColor"
+            />
+            <rect
+              x="3"
+              y="11.4"
+              width="11"
+              height="1.6"
+              rx="0.8"
+              fill="currentColor"
+            />
+          </svg>
         </button>
       </div>
 
@@ -274,6 +407,7 @@ import {
   FontWeightClass,
   ClassHeading,
   ConstructorImage,
+  TextAlignClass,
 } from './text-constructor/extensions';
 
 const ALLOWED_IMAGE_TYPES = [
@@ -328,6 +462,7 @@ const editor = useEditor({
     FontSizeClass,
     FontWeightClass,
     ConstructorImage,
+    TextAlignClass,
     Placeholder.configure({ placeholder: () => props.placeholder }),
   ],
   onUpdate: ({ editor: instance }) => {
@@ -543,6 +678,16 @@ defineExpose({ editor });
   cursor: not-allowed;
 }
 
+.align-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.align-btn svg {
+  display: block;
+}
+
 .color-btn.black-text { color: #000; }
 .color-btn.red-text { color: #ff0000; }
 .color-btn.green-text { color: #079d1d; }
@@ -709,6 +854,13 @@ defineExpose({ editor });
 .preview-modal-content :deep(.font-weight-600) { font-weight: 600; }
 .editor-content :deep(.font-weight-900),
 .preview-modal-content :deep(.font-weight-900) { font-weight: 900; }
+
+.editor-content :deep(.text-align-left),
+.preview-modal-content :deep(.text-align-left) { text-align: left; }
+.editor-content :deep(.text-align-center),
+.preview-modal-content :deep(.text-align-center) { text-align: center; }
+.editor-content :deep(.text-align-right),
+.preview-modal-content :deep(.text-align-right) { text-align: right; }
 
 .editor-content :deep(img),
 .preview-modal-content :deep(img) {

--- a/frontend/src/components/__tests__/TextConstructor.spec.js
+++ b/frontend/src/components/__tests__/TextConstructor.spec.js
@@ -211,4 +211,42 @@ describe('TextConstructor', () => {
     const italicBtn = wrapper.findAll('.toolbar-btn').find((b) => b.attributes('data-tooltip') === 'Курсив');
     expect(italicBtn).toBeTruthy();
   });
+
+  it('тулбар содержит кнопку Жирный и три кнопки выравнивания', () => {
+    const wrapper = mountConstructor();
+    const tooltips = wrapper.findAll('.toolbar-btn').map((b) => b.attributes('data-tooltip'));
+    expect(tooltips).toContain('Жирный');
+    expect(tooltips).toContain('По левому краю');
+    expect(tooltips).toContain('По центру');
+    expect(tooltips).toContain('По правому краю');
+  });
+
+  it('кнопка Жирный оборачивает выделение в <strong>', async () => {
+    const wrapper = mountConstructor({ modelValue: '<p>текст</p>' });
+    await flushPromises();
+    wrapper.vm.editor.commands.selectAll();
+    wrapper.vm.editor.commands.toggleBold();
+    expect(wrapper.vm.editor.getHTML()).toContain('<strong>');
+  });
+
+  it('выравнивание добавляет класс text-align-* на абзац', async () => {
+    const wrapper = mountConstructor({ modelValue: '<p>текст</p>' });
+    await flushPromises();
+    wrapper.vm.editor.commands.setTextAlignClass('center');
+    expect(wrapper.vm.editor.getHTML()).toContain('text-align-center');
+  });
+
+  it('round-trip: сохранённое выравнивание (класс) переживает загрузку', async () => {
+    const wrapper = mountConstructor({ modelValue: '<p class="text-align-right">справа</p>' });
+    await flushPromises();
+    expect(wrapper.vm.editor.getHTML()).toContain('text-align-right');
+  });
+
+  it('round-trip: inline-style выравнивание сериализуется в класс', async () => {
+    const wrapper = mountConstructor({ modelValue: '<p style="text-align: center">центр</p>' });
+    await flushPromises();
+    const out = wrapper.vm.editor.getHTML();
+    expect(out).toContain('text-align-center');
+    expect(out).not.toContain('style=');
+  });
 });

--- a/frontend/src/components/text-constructor/extensions.js
+++ b/frontend/src/components/text-constructor/extensions.js
@@ -1,4 +1,4 @@
-import { Mark, mergeAttributes } from '@tiptap/core';
+import { Extension, Mark, mergeAttributes } from '@tiptap/core';
 import { VueNodeViewRenderer } from '@tiptap/vue-3';
 import Heading from '@tiptap/extension-heading';
 import Image from '@tiptap/extension-image';
@@ -30,6 +30,8 @@ export const FONT_WEIGHT_CLASSES = [
   'font-weight-600',
   'font-weight-900',
 ];
+export const TEXT_ALIGN_TYPES = ['paragraph', 'heading'];
+export const TEXT_ALIGNMENTS = ['left', 'center', 'right'];
 
 /**
  * Фабрика марки, которая хранит один класс из набора на `<span>` и round-trip'ит его.
@@ -158,5 +160,64 @@ export const ConstructorImage = Image.extend({
 
   addNodeView() {
     return VueNodeViewRenderer(ResizableImage);
+  },
+});
+
+/**
+ * Выравнивание абзацев и заголовков через CSS-класс `text-align-left|center|right`,
+ * а НЕ inline-style. Консистентно с остальными марками TextConstructor (цвет/размер/жирность
+ * тоже class-based) и не завязывается на санитизацию значений inline-style. Глобальный
+ * атрибут вешается на paragraph/heading; потребители рендерят его через `:deep(.text-align-*)`.
+ * parseHTML дополнительно понимает inline `style="text-align:..."` - на случай уже сохранённого
+ * чужого контента, но сериализует всегда в класс.
+ */
+export const TextAlignClass = Extension.create({
+  name: 'textAlignClass',
+
+  addOptions() {
+    return {
+      types: TEXT_ALIGN_TYPES,
+      alignments: TEXT_ALIGNMENTS,
+    };
+  },
+
+  addGlobalAttributes() {
+    return [
+      {
+        types: this.options.types,
+        attributes: {
+          textAlign: {
+            default: null,
+            parseHTML: (element) => {
+              const cls = this.options.alignments.find((a) =>
+                element.classList.contains(`text-align-${a}`)
+              );
+              if (cls) return cls;
+              const styleAlign = element.style?.textAlign;
+              return this.options.alignments.includes(styleAlign) ? styleAlign : null;
+            },
+            renderHTML: (attributes) =>
+              attributes.textAlign ? { class: `text-align-${attributes.textAlign}` } : {},
+          },
+        },
+      },
+    ];
+  },
+
+  addCommands() {
+    return {
+      setTextAlignClass:
+        (alignment) =>
+        ({ commands }) => {
+          if (!this.options.alignments.includes(alignment)) return false;
+          return this.options.types.every((type) =>
+            commands.updateAttributes(type, { textAlign: alignment })
+          );
+        },
+      unsetTextAlignClass:
+        () =>
+        ({ commands }) =>
+          this.options.types.every((type) => commands.resetAttributes(type, 'textAlign')),
+    };
   },
 });

--- a/frontend/src/utils/__tests__/sanitize.spec.js
+++ b/frontend/src/utils/__tests__/sanitize.spec.js
@@ -27,6 +27,13 @@ describe('sanitizeHtml', () => {
     expect(out).toContain('font-weight-600');
   });
 
+  it('сохраняет <strong> и классы выравнивания (bold + align round-trip)', () => {
+    const html = '<p class="text-align-center"><strong>жирный по центру</strong></p>';
+    const out = sanitizeHtml(html);
+    expect(out).toContain('<strong>');
+    expect(out).toContain('text-align-center');
+  });
+
   it('вырезает скрипты и обработчики событий', () => {
     expect(sanitizeHtml('<script>alert(1)</script><p>ok</p>')).not.toContain('<script');
     expect(sanitizeHtml('<img src="x" onerror="alert(1)">')).not.toContain('onerror');

--- a/frontend/src/views/NewsAndReview.vue
+++ b/frontend/src/views/NewsAndReview.vue
@@ -1669,4 +1669,7 @@ export default {
 .news-body-html :deep(ul),
 .news-body-html :deep(ol) { padding-left: 1.5em; margin: 0.5em 0; }
 .news-body-html :deep(img) { max-width: 100%; height: auto; border-radius: 8px; }
+.news-body-html :deep(.text-align-left) { text-align: left; }
+.news-body-html :deep(.text-align-center) { text-align: center; }
+.news-body-html :deep(.text-align-right) { text-align: right; }
 </style>


### PR DESCRIPTION
Срез 4 под-эпика **46-textconstructor** (доработка TextConstructor, родительский #46 / 46-edits).

## Что добавил
- **Bold** в тулбар (`toggleBold` из StarterKit -> `<strong>`), рядом с курсивом/подчёркиванием.
- **Выравнивание** абзацев и заголовков: лево / центр / право (inline-SVG иконки).

## Как сделано
- Выравнивание - кастомное Tiptap-расширение `TextAlignClass` (глобальный атрибут `textAlign` на paragraph/heading), которое рендерит **CSS-класс** `text-align-left|center|right`, а не inline-style. Консистентно с остальными марками TC (цвет/размер/жирность тоже class-based) и с решением image-resize в этом же эпике - не завязываемся на санитизацию значений inline-style. `parseHTML` дополнительно понимает legacy `style="text-align:..."`, но сериализует всегда в класс.
- sanitize не правил: `<strong>` и атрибут `class` проходят DOMPurify html-профиль по умолчанию. Контракт зафиксирован тестом в `sanitize.spec.js`.
- Классы выравнивания проведены в `:deep(.text-align-*)` всех потребителей v-html: TextConstructor (editor + preview), TablesComponent (инструкция + подсказка), NewsAndReview, AnnouncementModal, CreateApplication.

## Проверка
- vitest скоупом: 25/25 зелёных (TextConstructor 20 + sanitize 5), вкл. новые тесты: Bold -> `<strong>`, выравнивание -> класс `text-align-*`, round-trip класса и legacy inline-style, контракт sanitize.
- eslint по изменённым файлам - 0 ошибок (SVG-атрибуты разложены `--fix`).
- code-reviewer: GO, must-fix нет.

Браузерная WYSIWYG-проверка - комплексно в финале эпика (по договорённости batch-final).