### PR TITLE
feat(statistics): живые ленты проходов людей и проездов машин (#632)

### DIFF
--- a/internal/handlers/statistics.go
+++ b/internal/handlers/statistics.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"strconv"
 	"time"
 
 	"systemburo/internal/services"
@@ -108,4 +109,28 @@ func (h *StatisticsHandler) GetTimeline(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid metric or granularity")
 	}
 	return RespondSuccess(c, points)
+}
+
+// GetRecentPassages godoc
+// @Summary      Последние проходы людей и проезды машин (живые ленты)
+// @Tags         statistics
+// @Produce      json
+// @Security     BearerAuth
+// @Param        limit query int false "Количество последних записей (1-50, по умолчанию 15)"
+// @Success      200 {object} Response
+// @Failure      401 {object} models.HTTPError
+// @Failure      403 {object} models.HTTPError
+// @Router       /statistics/recent-passages [get]
+func (h *StatisticsHandler) GetRecentPassages(c echo.Context) error {
+	limit := 0
+	if v := c.QueryParam("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			limit = n
+		}
+	}
+	passages, err := h.service.GetRecentPassages(c.Request().Context(), limit)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, passages)
 }

--- a/internal/models/statistics.go
+++ b/internal/models/statistics.go
@@ -1,5 +1,7 @@
 package models
 
+import "time"
+
 // AttachmentTypeCount — количество вложений по типу за период.
 type AttachmentTypeCount struct {
 	Name  string `json:"name"`
@@ -45,4 +47,22 @@ type StatsSummary struct {
 type StatsTimelinePoint struct {
 	Date  string `json:"date"`
 	Count int64  `json:"count"`
+}
+
+// RecentPassage — одна отметка прохода/проезда для живой ленты дашборда.
+// ActionType: entry|exit (фронт показывает людям вход/выход, машинам въезд/выезд).
+// CreatedAt в UTC; в UTC+3 переводит фронт.
+type RecentPassage struct {
+	ActionType   string    `json:"action_type"`
+	CreatedAt    time.Time `json:"created_at"`
+	Subject      string    `json:"subject"`         // ФИО (люди) или гос. номер (машины)
+	Mark         string    `json:"mark,omitempty"`  // марка машины
+	Organization string    `json:"organization"`
+	Place        string    `json:"place"`           // таблица системы, где отметка
+}
+
+// RecentPassages — последние проходы людей и проезды машин для живых лент.
+type RecentPassages struct {
+	People []RecentPassage `json:"people"`
+	Cars   []RecentPassage `json:"cars"`
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -587,5 +587,6 @@ func Setup(e *echo.Echo, d Dependencies) {
 		statsGroup := protected.Group("/statistics")
 		statsGroup.GET("/summary", statistics.GetSummary, requireStats)
 		statsGroup.GET("/timeline", statistics.GetTimeline, requireStats)
+		statsGroup.GET("/recent-passages", statistics.GetRecentPassages, requireStats)
 	}
 }

--- a/internal/services/statistics_service.go
+++ b/internal/services/statistics_service.go
@@ -14,6 +14,7 @@ import (
 type StatisticsService interface {
 	GetSummary(ctx context.Context, from, to time.Time) (*models.StatsSummary, error)
 	GetTimeline(ctx context.Context, from, to time.Time, metric, granularity string) ([]models.StatsTimelinePoint, error)
+	GetRecentPassages(ctx context.Context, limit int) (*models.RecentPassages, error)
 }
 
 type statisticsService struct {
@@ -281,4 +282,63 @@ func (s *statisticsService) GetTimeline(ctx context.Context, from, to time.Time,
 	}
 
 	return points, nil
+}
+
+// GetRecentPassages возвращает последние отметки проходов людей и проездов машин
+// (action_type entry/exit) для живых лент дашборда. Место отметки — таблица системы
+// (history.table_id -> system_tables), организация — через вложение/заявку.
+func (s *statisticsService) GetRecentPassages(ctx context.Context, limit int) (*models.RecentPassages, error) {
+	if limit <= 0 {
+		limit = 15
+	}
+	if limit > 50 {
+		limit = 50
+	}
+
+	result := &models.RecentPassages{
+		People: make([]models.RecentPassage, 0),
+		Cars:   make([]models.RecentPassage, 0),
+	}
+
+	if err := s.db.WithContext(ctx).
+		Table("employees_history eh").
+		Joins("JOIN employees e ON e.id = eh.employee_id").
+		Joins("LEFT JOIN attachments a ON a.id = e.attachment_id").
+		Joins("LEFT JOIN applications app ON app.id = a.application_id").
+		Joins("LEFT JOIN organizations org ON org.id = app.organization_id").
+		Joins("LEFT JOIN companies comp ON comp.id = app.company_id").
+		Joins("LEFT JOIN system_tables st ON st.id = eh.table_id").
+		Where("eh.action_type IN ?", []string{"entry", "exit"}).
+		Select("eh.action_type AS action_type, eh.created_at AS created_at, " +
+			"TRIM(CONCAT(e.last_name, ' ', e.first_name, ' ', COALESCE(e.middle_name, ''))) AS subject, " +
+			"'' AS mark, " +
+			"COALESCE(org.name, comp.name, '') AS organization, " +
+			"COALESCE(st.display_name, '') AS place").
+		Order("eh.created_at DESC").
+		Limit(limit).
+		Scan(&result.People).Error; err != nil {
+		return nil, fmt.Errorf("statistics: recent people passages: %w", err)
+	}
+
+	if err := s.db.WithContext(ctx).
+		Table("cars_history ch").
+		Joins("JOIN cars c ON c.id = ch.car_id").
+		Joins("LEFT JOIN attachments a ON a.id = c.attachment_id").
+		Joins("LEFT JOIN applications app ON app.id = a.application_id").
+		Joins("LEFT JOIN organizations org ON org.id = app.organization_id").
+		Joins("LEFT JOIN companies comp ON comp.id = app.company_id").
+		Joins("LEFT JOIN system_tables st ON st.id = ch.table_id").
+		Where("ch.action_type IN ?", []string{"entry", "exit"}).
+		Select("ch.action_type AS action_type, ch.created_at AS created_at, " +
+			"c.car_number AS subject, " +
+			"COALESCE(c.mark_name, '') AS mark, " +
+			"COALESCE(org.name, comp.name, '') AS organization, " +
+			"COALESCE(st.display_name, '') AS place").
+		Order("ch.created_at DESC").
+		Limit(limit).
+		Scan(&result.Cars).Error; err != nil {
+		return nil, fmt.Errorf("statistics: recent car passages: %w", err)
+	}
+
+	return result, nil
 }


### PR DESCRIPTION
Срез A1b эпика «Аналитика» (#632). Бэкенд живых лент дашборда.

## Что
- `GET /statistics/recent-passages?limit=N` (1-50, по умолчанию 15) -> `{people:[...], cars:[...]}`.
- Источник: `cars_history`/`employees_history` с `action_type IN ('entry','exit')`.
- Поля записи: action_type, created_at (UTC), subject (ФИО для людей / гос.номер для машин), mark (марка машины), organization (через attachment->application, COALESCE org/company), place (история.table_id -> system_tables.display_name).
- DTO `RecentPassage`/`RecentPassages` в models/statistics.go.

## Решения
- «Место прохода» = таблица системы, где сделана отметка (выверено: cars_history/employees_history имеют table_id -> system_tables; trash_service это подтверждает).
- Терминология вход/выход (люди) и въезд/выезд (машины) — маппинг на фронте по action_type.
- Время в UTC; перевод в UTC+3 на фронте.

## Проверка
- Контейнер go-backend: build/vet/test зелёные.
- SQL обеих лент выверен прямым прогоном по локальной БД (реальные номера/организации; table_id/mark в сиде пустые -> LEFT JOIN отдаёт пусто, на реальных проходах заполнится).
- Инъекций нет: limit через strconv+клэмп, action_type литералы, значения через GORM-параметры.

Разблокирует живые ленты в FE-дашборде (A2).