### PR TITLE
feat(analytics): страница Аналитика - дашборд, плитки метрик, график, живые ленты (#632)

### DIFF
--- a/frontend/src/api/statistics.js
+++ b/frontend/src/api/statistics.js
@@ -1,0 +1,65 @@
+import { apiRequest } from './client';
+
+/**
+ * Получить сводку метрик за период.
+ * @param {string} from - дата начала в формате YYYY-MM-DD
+ * @param {string} to   - дата конца в формате YYYY-MM-DD
+ * @returns {Promise<{
+ *   total_applications: number,
+ *   by_attachment_type: Record<string, number>,
+ *   processed: number,
+ *   in_work: number,
+ *   cars_entered: number,
+ *   avg_cars_per_day: number,
+ *   people_entered: number,
+ *   items_sum: number,
+ *   cars_on_territory: number,
+ *   people_on_territory: number,
+ *   users_online: number,
+ *   active_users: number,
+ *   banned_users: number,
+ *   open_feedback: number,
+ *   active_unload_places: number,
+ *   blacklist_cars: number,
+ *   blacklist_people: number,
+ *   unique_cars: number,
+ *   unique_people: number,
+ * }>}
+ */
+export async function getSummary(from, to) {
+  const params = new URLSearchParams();
+  if (from) params.set('from', from);
+  if (to) params.set('to', to);
+  const res = await apiRequest(`/statistics/summary?${params}`);
+  return res.json();
+}
+
+/**
+ * Получить временной ряд метрики.
+ * @param {{from: string, to: string, metric: string, granularity: string}} opts
+ *   metric: 'applications' | 'people_entries' | 'car_entries'
+ *   granularity: 'day' | 'week' | 'month'
+ * @returns {Promise<Array<{date: string, count: number}>>}
+ */
+export async function getTimeline({ from, to, metric, granularity }) {
+  const params = new URLSearchParams();
+  if (from) params.set('from', from);
+  if (to) params.set('to', to);
+  if (metric) params.set('metric', metric);
+  if (granularity) params.set('granularity', granularity);
+  const res = await apiRequest(`/statistics/timeline?${params}`);
+  return res.json();
+}
+
+/**
+ * Получить последние проходы/проезды.
+ * @param {number} [limit=15] - максимальное количество записей на тип
+ * @returns {Promise<{
+ *   people: Array<{subject: string, organization: string, place: string, time: string, action_type: 'entry'|'exit'}>,
+ *   cars:   Array<{subject: string, mark: string, organization: string, place: string, time: string, action_type: 'entry'|'exit'}>,
+ * }>}
+ */
+export async function getRecentPassages(limit = 15) {
+  const res = await apiRequest(`/statistics/recent-passages?limit=${limit}`);
+  return res.json();
+}

--- a/frontend/src/components/NavMenu.vue
+++ b/frontend/src/components/NavMenu.vue
@@ -270,7 +270,7 @@
             </div>
           </div>
 
-          <!-- АНАЛИТИКА (пока заглушки - роутов нет) -->
+          <!-- АНАЛИТИКА -->
           <div
             v-show="sectionVisible.analytics"
             class="nav-section"
@@ -279,23 +279,11 @@
               АНАЛИТИКА
             </div>
             <div
-              v-show="matches('Статистика')"
-              class="nav-item disabled"
-              title="Скоро"
-              aria-disabled="true"
-            >
-              <NavIcon
-                name="statistics"
-                :size="18"
-                class="nav-icon"
-              />
-              <span class="nav-text">Статистика</span>
-            </div>
-            <div
               v-show="matches('Аналитика')"
-              class="nav-item disabled"
-              title="Скоро"
-              aria-disabled="true"
+              class="nav-item"
+              :class="{ active: isActive('/analytics') }"
+              data-testid="nav-link-analytics"
+              @click="$router.push('/analytics')"
             >
               <NavIcon
                 name="analytics"

--- a/frontend/src/components/statistics/AnalyticsInstructionModal.vue
+++ b/frontend/src/components/statistics/AnalyticsInstructionModal.vue
@@ -1,0 +1,152 @@
+<template>
+  <BaseModal
+    :show="show"
+    title="Как пользоваться Аналитикой"
+    width="620px"
+    @close="$emit('close')"
+  >
+    <div class="instruction">
+      <section class="instruction__section">
+        <h4 class="instruction__heading">Дашборд</h4>
+        <p class="instruction__text">
+          Дашборд показывает текущее состояние системы и ключевые показатели за выбранный период.
+        </p>
+        <ul class="instruction__list">
+          <li>
+            <strong>Метрики «Данные»</strong> — заявки, вложения по типам, статусы обработки,
+            проезды машин и проходы людей. Все числа относятся к выбранному периоду (фильтр
+            в шапке).
+          </li>
+          <li>
+            <strong>Метрики «Система»</strong> — технические показатели: пользователи, чёрные
+            списки, уникальные записи в базе. Они не зависят от периода.
+          </li>
+          <li>
+            <strong>График динамики</strong> — визуализирует тренд выбранной метрики (заявки,
+            проходы людей или проезды машин) с разбивкой по дням, неделям или месяцам.
+          </li>
+          <li>
+            <strong>Живые ленты</strong> — «Проход людей» и «Проезд машин» обновляются каждые
+            10 секунд и показывают последние события в реальном времени.
+          </li>
+        </ul>
+        <p class="instruction__tip">
+          Зелёная пульсирующая точка рядом с заголовком ленты означает, что данные обновляются
+          автоматически. Если нужно принудительно обновить метрики, нажмите «Обновить» в шапке.
+        </p>
+      </section>
+
+      <section class="instruction__section">
+        <h4 class="instruction__heading">Как сформировать отчёт</h4>
+        <p class="instruction__text">
+          Раздел «Отчёты» (в разработке) позволит строить произвольные выборки по данным бюро.
+          Порядок работы будет такой:
+        </p>
+        <ol class="instruction__ordered">
+          <li>
+            <strong>Что считаем / выгружаем</strong> — выберите тип результата: сводная цифра,
+            таблица-список или график.
+          </li>
+          <li>
+            <strong>По чему разбить (разрез)</strong> — укажите измерение: по организации,
+            месту разгрузки, типу вложения, статусу и т.д.
+          </li>
+          <li>
+            <strong>Фильтры</strong> — необязательно. Сузьте выборку по конкретной организации,
+            месту, типу вложения или другому атрибуту.
+          </li>
+          <li>
+            <strong>Период</strong> — тот же фильтр дат, что и на дашборде.
+          </li>
+          <li>
+            <strong>Экспорт в Excel</strong> — готовый отчёт можно скачать одной кнопкой.
+          </li>
+        </ol>
+      </section>
+
+      <section class="instruction__section instruction__section--last">
+        <h4 class="instruction__heading">Смена периода</h4>
+        <p class="instruction__text">
+          Фильтр периода в шапке страницы применяется сразу к дашборду. Доступны быстрые
+          пресеты (сегодня, эта неделя, этот месяц) и ручной выбор диапазона. После смены
+          периода данные обновляются автоматически.
+        </p>
+      </section>
+    </div>
+  </BaseModal>
+</template>
+
+<script setup>
+import BaseModal from '@/components/ui/BaseModal.vue';
+
+defineProps({
+  show: {
+    type: Boolean,
+    required: true,
+  },
+});
+
+defineEmits(['close']);
+</script>
+
+<style scoped>
+.instruction {
+  padding: 20px 24px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.instruction__section {
+  padding-bottom: 20px;
+  margin-bottom: 20px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.instruction__section--last {
+  border-bottom: none;
+  padding-bottom: 0;
+  margin-bottom: 0;
+}
+
+.instruction__heading {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--color-text);
+  margin: 0 0 8px;
+}
+
+.instruction__text {
+  font-size: 13px;
+  color: var(--color-text);
+  line-height: 1.55;
+  margin: 0 0 10px;
+}
+
+.instruction__list,
+.instruction__ordered {
+  font-size: 13px;
+  color: var(--color-text);
+  line-height: 1.55;
+  padding-left: 20px;
+  margin: 0 0 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.instruction__list li,
+.instruction__ordered li {
+  padding-left: 2px;
+}
+
+.instruction__tip {
+  font-size: 12px;
+  color: var(--color-text-muted);
+  line-height: 1.5;
+  background: var(--color-bg);
+  border-radius: var(--radius-sm);
+  padding: 8px 12px;
+  margin: 0;
+}
+</style>

--- a/frontend/src/components/statistics/StatisticsDashboard.vue
+++ b/frontend/src/components/statistics/StatisticsDashboard.vue
@@ -1,0 +1,828 @@
+<template>
+  <div class="dashboard">
+
+    <!-- ===== ГРУППА: ДАННЫЕ ===== -->
+    <div class="dashboard__group">
+      <div class="dashboard__group-head">
+        <h2 class="dashboard__group-title">Данные</h2>
+        <span class="dashboard__group-chip">бизнес-показатели за период</span>
+        <span class="dashboard__group-rule" />
+      </div>
+
+      <div
+        v-if="summaryLoading"
+        class="dashboard__tiles"
+      >
+        <div
+          v-for="n in 10"
+          :key="n"
+          class="dashboard__tile dashboard__tile--skeleton"
+        />
+      </div>
+
+      <div
+        v-else
+        class="dashboard__tiles"
+      >
+        <div class="dashboard__tile">
+          <div class="dashboard__tile-label">Всего заявок</div>
+          <div class="dashboard__tile-val">{{ fmt(summary.total_applications) }}</div>
+        </div>
+        <div class="dashboard__tile">
+          <div class="dashboard__tile-label">Вложения (всего)</div>
+          <div class="dashboard__tile-val">{{ fmt(attachmentsTotal) }}</div>
+          <div
+            v-if="attachmentBreakdown.length"
+            class="dashboard__tile-breakdown"
+          >
+            <span
+              v-for="item in attachmentBreakdown"
+              :key="item.label"
+              class="dashboard__breakdown-item"
+            >{{ item.label }}: {{ item.count }}</span>
+          </div>
+        </div>
+        <div class="dashboard__tile">
+          <div class="dashboard__tile-label">Обработано</div>
+          <div class="dashboard__tile-val">{{ fmt(summary.processed) }}</div>
+        </div>
+        <div class="dashboard__tile">
+          <div class="dashboard__tile-label">В работе</div>
+          <div class="dashboard__tile-val">{{ fmt(summary.in_work) }}</div>
+        </div>
+        <div class="dashboard__tile">
+          <div class="dashboard__tile-label">Машин заехало</div>
+          <div class="dashboard__tile-val">{{ fmt(summary.cars_entered) }}</div>
+        </div>
+        <div class="dashboard__tile">
+          <div class="dashboard__tile-label">Среднее машин / день</div>
+          <div class="dashboard__tile-val">{{ fmtAvg(summary.avg_cars_per_day) }}</div>
+        </div>
+        <div class="dashboard__tile">
+          <div class="dashboard__tile-label">Людей прошло</div>
+          <div class="dashboard__tile-val">{{ fmt(summary.people_entered) }}</div>
+        </div>
+        <div class="dashboard__tile">
+          <div class="dashboard__tile-label">Сумма товаров</div>
+          <div class="dashboard__tile-val">{{ fmt(summary.items_sum) }}</div>
+        </div>
+        <div class="dashboard__tile">
+          <div class="dashboard__tile-label">Машин на территории</div>
+          <div class="dashboard__tile-val">{{ fmt(summary.cars_on_territory) }}</div>
+        </div>
+        <div class="dashboard__tile">
+          <div class="dashboard__tile-label">Людей на территории</div>
+          <div class="dashboard__tile-val">{{ fmt(summary.people_on_territory) }}</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ===== ГРУППА: СИСТЕМА ===== -->
+    <div class="dashboard__group">
+      <div class="dashboard__group-head">
+        <h2 class="dashboard__group-title">Система</h2>
+        <span class="dashboard__group-chip">технические показатели</span>
+        <span class="dashboard__group-rule" />
+      </div>
+
+      <div
+        v-if="summaryLoading"
+        class="dashboard__tiles"
+      >
+        <div
+          v-for="n in 9"
+          :key="n"
+          class="dashboard__tile dashboard__tile--skeleton"
+        />
+      </div>
+
+      <div
+        v-else
+        class="dashboard__tiles"
+      >
+        <div class="dashboard__tile">
+          <div class="dashboard__tile-label">Пользователей онлайн</div>
+          <div class="dashboard__tile-val">{{ fmt(summary.users_online) }}</div>
+        </div>
+        <div class="dashboard__tile">
+          <div class="dashboard__tile-label">Активных пользователей</div>
+          <div class="dashboard__tile-val">{{ fmt(summary.active_users) }}</div>
+        </div>
+        <div class="dashboard__tile">
+          <div class="dashboard__tile-label">Заблокировано</div>
+          <div class="dashboard__tile-val">{{ fmt(summary.banned_users) }}</div>
+        </div>
+        <div class="dashboard__tile">
+          <div class="dashboard__tile-label">Открытых обращений</div>
+          <div class="dashboard__tile-val">{{ fmt(summary.open_feedback) }}</div>
+        </div>
+        <div class="dashboard__tile">
+          <div class="dashboard__tile-label">Активных мест разгрузки</div>
+          <div class="dashboard__tile-val">{{ fmt(summary.active_unload_places) }}</div>
+        </div>
+        <div class="dashboard__tile">
+          <div class="dashboard__tile-label">ЧС: машины</div>
+          <div class="dashboard__tile-val">{{ fmt(summary.blacklist_cars) }}</div>
+        </div>
+        <div class="dashboard__tile">
+          <div class="dashboard__tile-label">ЧС: люди</div>
+          <div class="dashboard__tile-val">{{ fmt(summary.blacklist_people) }}</div>
+        </div>
+        <div class="dashboard__tile">
+          <div class="dashboard__tile-label">Уникальных машин</div>
+          <div class="dashboard__tile-val">{{ fmt(summary.unique_cars) }}</div>
+        </div>
+        <div class="dashboard__tile">
+          <div class="dashboard__tile-label">Уникальных людей</div>
+          <div class="dashboard__tile-val">{{ fmt(summary.unique_people) }}</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ===== ГРАФИК ===== -->
+    <div class="dashboard__chart-card">
+      <div class="dashboard__chart-head">
+        <div>
+          <h3 class="dashboard__chart-title">{{ chartTitle }}</h3>
+          <div class="dashboard__chart-sub">{{ chartSubtitle }}</div>
+        </div>
+        <div class="dashboard__chart-controls">
+          <div class="dashboard__seg">
+            <button
+              v-for="m in metricOptions"
+              :key="m.value"
+              class="dashboard__seg-btn"
+              :class="{ 'dashboard__seg-btn--active': activeMetric === m.value }"
+              @click="activeMetric = m.value"
+            >
+              {{ m.label }}
+            </button>
+          </div>
+          <div class="dashboard__seg">
+            <button
+              v-for="g in granularityOptions"
+              :key="g.value"
+              class="dashboard__seg-btn"
+              :class="{ 'dashboard__seg-btn--active': activeGranularity === g.value }"
+              @click="activeGranularity = g.value"
+            >
+              {{ g.label }}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div
+        v-if="timelineLoading"
+        class="dashboard__chart-skeleton"
+      />
+      <RealTimeChart
+        v-else
+        :data="chartData"
+        :height="300"
+        :color="'var(--color-primary)'"
+        interval-label="ед."
+      />
+    </div>
+
+    <!-- ===== ЖИВЫЕ ЛЕНТЫ ===== -->
+    <div class="dashboard__feeds">
+
+      <!-- Лента людей -->
+      <div class="dashboard__feed">
+        <div class="dashboard__feed-head">
+          <h3 class="dashboard__feed-title">
+            <span class="dashboard__live-dot" />
+            Проход людей
+          </h3>
+          <span class="dashboard__feed-meta">обновление каждые 10 сек · UTC+3</span>
+        </div>
+
+        <div class="dashboard__feed-list">
+          <template v-if="feedLoading">
+            <div
+              v-for="n in 5"
+              :key="n"
+              class="dashboard__feed-row dashboard__feed-row--skeleton"
+            />
+          </template>
+          <template v-else-if="peopleFeed.length === 0">
+            <div class="dashboard__feed-empty">Нет записей</div>
+          </template>
+          <template v-else>
+            <div
+              v-for="(row, idx) in peopleFeed"
+              :key="idx"
+              class="dashboard__feed-row"
+            >
+              <div class="dashboard__feed-main">
+                <div class="dashboard__feed-name">{{ row.subject }}</div>
+                <div class="dashboard__feed-sub">
+                  {{ row.organization }}<template v-if="row.place && row.place !== '—'"> · {{ row.place }}</template>
+                </div>
+              </div>
+              <div class="dashboard__feed-right">
+                <div class="dashboard__feed-time">{{ formatTime(row.time) }}</div>
+                <span
+                  class="dashboard__dir-badge"
+                  :class="row.action_type === 'entry' ? 'dashboard__dir-badge--in' : 'dashboard__dir-badge--out'"
+                >
+                  {{ row.action_type === 'entry' ? 'Вход' : 'Выход' }}
+                </span>
+              </div>
+            </div>
+          </template>
+        </div>
+      </div>
+
+      <!-- Лента машин -->
+      <div class="dashboard__feed">
+        <div class="dashboard__feed-head">
+          <h3 class="dashboard__feed-title">
+            <span class="dashboard__live-dot" />
+            Проезд машин
+          </h3>
+          <span class="dashboard__feed-meta">обновление каждые 10 сек · UTC+3</span>
+        </div>
+
+        <div class="dashboard__feed-list">
+          <template v-if="feedLoading">
+            <div
+              v-for="n in 5"
+              :key="n"
+              class="dashboard__feed-row dashboard__feed-row--skeleton"
+            />
+          </template>
+          <template v-else-if="carsFeed.length === 0">
+            <div class="dashboard__feed-empty">Нет записей</div>
+          </template>
+          <template v-else>
+            <div
+              v-for="(row, idx) in carsFeed"
+              :key="idx"
+              class="dashboard__feed-row"
+            >
+              <div class="dashboard__plate">{{ row.subject }}</div>
+              <div class="dashboard__feed-main">
+                <div class="dashboard__feed-name">
+                  {{ row.mark || '' }}
+                </div>
+                <div class="dashboard__feed-sub">
+                  {{ row.organization }}<template v-if="row.place && row.place !== '—'"> · {{ row.place }}</template>
+                </div>
+              </div>
+              <div class="dashboard__feed-right">
+                <div class="dashboard__feed-time">{{ formatTime(row.time) }}</div>
+                <span
+                  class="dashboard__dir-badge"
+                  :class="row.action_type === 'entry' ? 'dashboard__dir-badge--in' : 'dashboard__dir-badge--out'"
+                >
+                  {{ row.action_type === 'entry' ? 'Въезд' : 'Выезд' }}
+                </span>
+              </div>
+            </div>
+          </template>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue';
+import RealTimeChart from '@/components/RealTimeChart.vue';
+import { getSummary, getTimeline, getRecentPassages } from '@/api/statistics.js';
+
+const props = defineProps({
+  from: {
+    type: String,
+    default: '',
+  },
+  to: {
+    type: String,
+    default: '',
+  },
+});
+
+// ---- состояние данных ----
+const summary = ref({});
+const summaryLoading = ref(false);
+
+const timeline = ref([]);
+const timelineLoading = ref(false);
+
+const peopleFeed = ref([]);
+const carsFeed = ref([]);
+const feedLoading = ref(false);
+
+// ---- переключатели графика ----
+const metricOptions = [
+  { label: 'Заявки', value: 'applications' },
+  { label: 'Проходы людей', value: 'people_entries' },
+  { label: 'Проезды машин', value: 'car_entries' },
+];
+const granularityOptions = [
+  { label: 'День', value: 'day' },
+  { label: 'Неделя', value: 'week' },
+  { label: 'Месяц', value: 'month' },
+];
+const activeMetric = ref('applications');
+const activeGranularity = ref('day');
+
+const chartTitles = {
+  applications: 'Динамика заявок',
+  people_entries: 'Динамика проходов людей',
+  car_entries: 'Динамика проездов машин',
+};
+
+const chartTitle = computed(() => chartTitles[activeMetric.value] ?? '');
+const chartSubtitle = computed(() => {
+  const labels = { day: 'по дням', week: 'по неделям', month: 'по месяцам' };
+  const period = [props.from, props.to].filter(Boolean).join(' — ');
+  return [period, labels[activeGranularity.value]].filter(Boolean).join(' · ');
+});
+
+// RealTimeChart ожидает [{timestamp, count}], бэк отдаёт [{date, count}]
+const chartData = computed(() =>
+  (timeline.value || []).map((d) => ({ timestamp: d.date, count: d.count }))
+);
+
+// ---- вычисляемые из summary ----
+const attachmentsTotal = computed(() => {
+  const map = summary.value.by_attachment_type;
+  if (!map || typeof map !== 'object') return 0;
+  return Object.values(map).reduce((s, v) => s + (v || 0), 0);
+});
+
+const attachmentBreakdown = computed(() => {
+  const map = summary.value.by_attachment_type;
+  if (!map || typeof map !== 'object') return [];
+  return Object.entries(map).map(([label, count]) => ({ label, count }));
+});
+
+// ---- форматирование ----
+function fmt(val) {
+  if (val == null) return '—';
+  return Number(val).toLocaleString('ru-RU');
+}
+
+function fmtAvg(val) {
+  if (val == null) return '—';
+  return Math.round(Number(val)).toLocaleString('ru-RU');
+}
+
+function formatTime(iso) {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  // Смещение UTC+3
+  const utc3 = new Date(d.getTime() + 3 * 60 * 60 * 1000);
+  return utc3.toISOString().substring(11, 19);
+}
+
+// ---- загрузка данных ----
+async function loadSummary() {
+  summaryLoading.value = true;
+  try {
+    const data = await getSummary(props.from, props.to);
+    summary.value = data || {};
+  } catch {
+    summary.value = {};
+  } finally {
+    summaryLoading.value = false;
+  }
+}
+
+async function loadTimeline() {
+  timelineLoading.value = true;
+  try {
+    const data = await getTimeline({
+      from: props.from,
+      to: props.to,
+      metric: activeMetric.value,
+      granularity: activeGranularity.value,
+    });
+    timeline.value = Array.isArray(data) ? data : [];
+  } catch {
+    timeline.value = [];
+  } finally {
+    timelineLoading.value = false;
+  }
+}
+
+async function loadFeed() {
+  feedLoading.value = true;
+  try {
+    const data = await getRecentPassages(15);
+    peopleFeed.value = Array.isArray(data?.people) ? data.people : [];
+    carsFeed.value = Array.isArray(data?.cars) ? data.cars : [];
+  } catch {
+    peopleFeed.value = [];
+    carsFeed.value = [];
+  } finally {
+    feedLoading.value = false;
+  }
+}
+
+// ---- публичный метод для обновления из родителя ----
+async function refresh() {
+  await Promise.all([loadSummary(), loadTimeline(), loadFeed()]);
+}
+
+defineExpose({ refresh });
+
+// ---- реакция на смену периода ----
+watch([() => props.from, () => props.to], () => {
+  loadSummary();
+  loadTimeline();
+});
+
+// ---- реакция на смену настроек графика ----
+watch([activeMetric, activeGranularity], () => {
+  loadTimeline();
+});
+
+// ---- polling живых лент (10 сек) ----
+let feedInterval = null;
+
+onMounted(() => {
+  loadSummary();
+  loadTimeline();
+  loadFeed();
+  feedInterval = setInterval(loadFeed, 10000);
+});
+
+onUnmounted(() => {
+  if (feedInterval) clearInterval(feedInterval);
+});
+</script>
+
+<style scoped>
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+}
+
+/* ===== ГРУППЫ ===== */
+.dashboard__group {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.dashboard__group-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.dashboard__group-title {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--color-text);
+  margin: 0;
+  white-space: nowrap;
+}
+
+.dashboard__group-chip {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  padding: 3px 10px;
+  border-radius: var(--radius-pill);
+  white-space: nowrap;
+}
+
+.dashboard__group-rule {
+  flex: 1;
+  height: 1px;
+  background: var(--color-border);
+}
+
+/* ===== ПЛИТКИ ===== */
+.dashboard__tiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(158px, 1fr));
+  gap: 12px;
+}
+
+.dashboard__tile {
+  background: #fff;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 12px 14px;
+  cursor: default;
+  transition: border-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease;
+  animation: tile-in 0.35s ease both;
+}
+
+.dashboard__tile:hover {
+  border-color: var(--color-primary);
+  box-shadow: var(--shadow-md);
+  transform: translateY(-2px);
+}
+
+@keyframes tile-in {
+  from { opacity: 0; transform: translateY(10px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.dashboard__tile--skeleton {
+  background: var(--color-skeleton);
+  min-height: 72px;
+  border: none;
+  cursor: default;
+  animation: skeleton-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes skeleton-pulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.55; }
+}
+
+.dashboard__tile-label {
+  font-size: 11px;
+  color: var(--color-text-muted);
+  font-weight: 500;
+  line-height: 1.3;
+}
+
+.dashboard__tile-val {
+  font-size: 26px;
+  font-weight: 700;
+  color: var(--color-text);
+  margin-top: 6px;
+  line-height: 1;
+}
+
+.dashboard__tile-breakdown {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 6px;
+}
+
+.dashboard__breakdown-item {
+  font-size: 10px;
+  color: var(--color-text-muted);
+  background: var(--color-bg);
+  border-radius: var(--radius-pill);
+  padding: 2px 7px;
+  border: 1px solid var(--color-border);
+}
+
+/* ===== ГРАФИК ===== */
+.dashboard__chart-card {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 20px 22px;
+  background: #fff;
+}
+
+.dashboard__chart-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  flex-wrap: wrap;
+  margin-bottom: 18px;
+}
+
+.dashboard__chart-title {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--color-text);
+  margin: 0;
+}
+
+.dashboard__chart-sub {
+  font-size: 12px;
+  color: var(--color-text-muted);
+  margin-top: 2px;
+}
+
+.dashboard__chart-controls {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.dashboard__seg {
+  display: inline-flex;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-pill);
+  padding: 3px;
+  gap: 2px;
+}
+
+.dashboard__seg-btn {
+  border: none;
+  background: transparent;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-text-muted);
+  padding: 5px 12px;
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  transition: background 0.18s ease, color 0.18s ease;
+}
+
+.dashboard__seg-btn:hover {
+  color: var(--color-primary);
+}
+
+.dashboard__seg-btn--active {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.dashboard__chart-skeleton {
+  height: 300px;
+  background: var(--color-skeleton);
+  border-radius: var(--radius-sm);
+  animation: skeleton-pulse 1.4s ease-in-out infinite;
+}
+
+/* ===== ЖИВЫЕ ЛЕНТЫ ===== */
+.dashboard__feeds {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+}
+
+@media (max-width: 1100px) {
+  .dashboard__feeds {
+    grid-template-columns: 1fr;
+  }
+}
+
+.dashboard__feed {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+}
+
+.dashboard__feed-head {
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--color-border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.dashboard__feed-title {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--color-text);
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.dashboard__live-dot {
+  display: inline-block;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--color-success);
+  flex-shrink: 0;
+  animation: live-pulse 1.8s ease-in-out infinite;
+}
+
+@keyframes live-pulse {
+  0%   { box-shadow: 0 0 0 0 rgba(40, 167, 69, 0.55); }
+  70%  { box-shadow: 0 0 0 8px rgba(40, 167, 69, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(40, 167, 69, 0); }
+}
+
+.dashboard__feed-meta {
+  font-size: 11px;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+
+.dashboard__feed-list {
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+.dashboard__feed-list::-webkit-scrollbar {
+  width: 6px;
+}
+
+.dashboard__feed-list::-webkit-scrollbar-thumb {
+  background: #e1e3f0;
+  border-radius: var(--radius-pill);
+}
+
+.dashboard__feed-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 11px 18px;
+  border-bottom: 1px solid #f2f3fa;
+  animation: row-in 0.3s ease;
+}
+
+@keyframes row-in {
+  from { opacity: 0; transform: translateY(-6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.dashboard__feed-row--skeleton {
+  min-height: 56px;
+  background: var(--color-skeleton);
+  border-bottom: 1px solid #fff;
+  animation: skeleton-pulse 1.4s ease-in-out infinite;
+}
+
+.dashboard__feed-main {
+  min-width: 0;
+  flex: 1;
+}
+
+.dashboard__feed-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.dashboard__feed-sub {
+  font-size: 11px;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 2px;
+}
+
+.dashboard__feed-right {
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.dashboard__feed-time {
+  font-size: 11px;
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.dashboard__dir-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 3px 8px;
+  border-radius: var(--radius-pill);
+  margin-top: 4px;
+}
+
+.dashboard__dir-badge--in {
+  background: rgba(40, 167, 69, 0.12);
+  color: var(--color-success);
+}
+
+.dashboard__dir-badge--out {
+  background: var(--color-bg);
+  color: var(--color-text-muted);
+  border: 1px solid var(--color-border);
+}
+
+/* Номерной знак машины */
+.dashboard__plate {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 64px;
+  padding: 3px 8px;
+  border: 2px solid var(--color-text);
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--color-text);
+  letter-spacing: 0.04em;
+  background: #fff;
+  text-transform: uppercase;
+}
+
+.dashboard__feed-empty {
+  padding: 24px 18px;
+  font-size: 13px;
+  color: var(--color-text-muted);
+  text-align: center;
+}
+</style>

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -197,6 +197,12 @@ const routes = [
     meta: { requiresAuth: true, requiresBuro: true, permission: 'page.admin' }
   },
   {
+    path: '/analytics',
+    name: 'analytics',
+    component: () => import('./views/StatisticsView.vue'),
+    meta: { requiresAuth: true, requiresBuro: true, permission: 'page.statistics' }
+  },
+  {
     path: '/500',
     name: 'Error500',
     component: () => import('./views/Error500.vue'),

--- a/frontend/src/views/StatisticsView.vue
+++ b/frontend/src/views/StatisticsView.vue
@@ -1,0 +1,332 @@
+<template>
+  <AdminPageShell>
+    <div class="statistics dashboard-card">
+
+      <!-- ===== ШАПКА ===== -->
+      <div class="management-header statistics__header">
+        <div class="statistics__header-left">
+          <h1 class="management-title">Аналитика</h1>
+        </div>
+        <div class="statistics__header-right">
+          <button
+            class="lk-button lk-button--ghost"
+            @click="showInstruction = true"
+          >
+            <svg
+              width="15"
+              height="15"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <circle cx="12" cy="12" r="10" />
+              <path d="M12 16v-4M12 8h.01" />
+            </svg>
+            Инструкция
+          </button>
+          <DateFilter
+            mode="range"
+            :date-range-start="rangeStart"
+            :date-range-end="rangeEnd"
+            @update:date-range-start="rangeStart = $event"
+            @update:date-range-end="rangeEnd = $event"
+            @apply="onPeriodApply"
+          />
+          <RefreshButton
+            :loading="false"
+            @refresh="onRefresh"
+          />
+        </div>
+      </div>
+
+      <!-- ===== ВКЛАДКИ ===== -->
+      <div class="statistics__tabs">
+        <button
+          class="statistics__tab"
+          :class="{ 'statistics__tab--active': activeTab === 'dashboard' }"
+          @click="activeTab = 'dashboard'"
+        >
+          Дашборд
+        </button>
+        <button
+          class="statistics__tab"
+          :class="{ 'statistics__tab--active': activeTab === 'reports' }"
+          @click="activeTab = 'reports'"
+        >
+          Отчёты
+        </button>
+      </div>
+
+      <!-- ===== ТЕЛО ===== -->
+      <div class="statistics__body">
+
+        <!-- Дашборд -->
+        <div
+          v-if="activeTab === 'dashboard'"
+          class="statistics__panel"
+        >
+          <StatisticsDashboard
+            ref="dashboardRef"
+            :from="fromStr"
+            :to="toStr"
+          />
+        </div>
+
+        <!-- Отчёты (заглушка) -->
+        <div
+          v-else
+          class="statistics__panel statistics__placeholder"
+        >
+          <div class="statistics__placeholder-inner">
+            <svg
+              width="48"
+              height="48"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M3 3v18h18" />
+              <path d="M7 14l3-4 3 3 4-6" />
+            </svg>
+            <p>Раздел в разработке</p>
+            <span>Готовые отчёты и конструктор выборок появятся здесь в ближайших обновлениях.</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Модалка инструкции -->
+    <AnalyticsInstructionModal
+      :show="showInstruction"
+      @close="showInstruction = false"
+    />
+  </AdminPageShell>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue';
+import AdminPageShell from '@/views/admin/AdminPageShell.vue';
+import DateFilter from '@/components/DateFilter.vue';
+import RefreshButton from '@/components/RefreshButton.vue';
+import StatisticsDashboard from '@/components/statistics/StatisticsDashboard.vue';
+import AnalyticsInstructionModal from '@/components/statistics/AnalyticsInstructionModal.vue';
+
+// ---- вкладки ----
+const activeTab = ref('dashboard');
+
+// ---- модалка инструкции ----
+const showInstruction = ref(false);
+
+// ---- период: дефолт — текущая неделя (пн — сегодня) ----
+function weekStart() {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  const day = d.getDay() || 7;
+  d.setDate(d.getDate() - day + 1);
+  return d;
+}
+
+const rangeStart = ref(weekStart());
+const rangeEnd = ref((() => { const d = new Date(); d.setHours(23, 59, 59, 999); return d; })());
+
+function padTwo(n) {
+  return String(n).padStart(2, '0');
+}
+
+function toDateStr(d) {
+  if (!d) return '';
+  return `${d.getFullYear()}-${padTwo(d.getMonth() + 1)}-${padTwo(d.getDate())}`;
+}
+
+const fromStr = computed(() => toDateStr(rangeStart.value));
+const toStr = computed(() => toDateStr(rangeEnd.value));
+
+// ---- ссылка на дашборд для вызова refresh ----
+const dashboardRef = ref(null);
+
+function onPeriodApply() {
+  // fromStr/toStr уже обновились через v-model, дашборд реагирует через watch
+}
+
+function onRefresh() {
+  if (dashboardRef.value) {
+    dashboardRef.value.refresh();
+  }
+}
+</script>
+
+<style scoped>
+.statistics {
+  border: 1px solid var(--color-border);
+  background: #fff;
+  border-radius: 35px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  height: 100%;
+}
+
+.statistics__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--color-border);
+  flex-shrink: 0;
+}
+
+.statistics__header-left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.statistics__header-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+/* Кнопка «Инструкция» в стиле проекта */
+.lk-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border-radius: var(--radius-pill);
+  padding: 6px 14px;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+  white-space: nowrap;
+  line-height: 1;
+}
+
+.lk-button--ghost {
+  background: transparent;
+  color: var(--color-text-muted);
+  border-color: var(--color-border);
+}
+
+.lk-button--ghost:hover {
+  background: var(--color-bg);
+  color: var(--color-text);
+}
+
+/* ===== ВКЛАДКИ ===== */
+.statistics__tabs {
+  display: flex;
+  gap: 0;
+  padding: 0 24px;
+  border-bottom: 1px solid var(--color-border);
+  flex-shrink: 0;
+}
+
+.statistics__tab {
+  border: none;
+  background: transparent;
+  font-family: inherit;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  padding: 14px 18px;
+  cursor: pointer;
+  position: relative;
+  transition: color 0.18s ease;
+}
+
+.statistics__tab:hover {
+  color: var(--color-text);
+}
+
+.statistics__tab--active {
+  color: var(--color-primary);
+}
+
+.statistics__tab--active::after {
+  content: '';
+  position: absolute;
+  left: 14px;
+  right: 14px;
+  bottom: -1px;
+  height: 3px;
+  border-radius: 3px 3px 0 0;
+  background: var(--color-primary);
+}
+
+/* ===== ТЕЛО ===== */
+.statistics__body {
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+}
+
+.statistics__body::-webkit-scrollbar {
+  width: 8px;
+}
+
+.statistics__body::-webkit-scrollbar-thumb {
+  background: #e1e3f0;
+  border-radius: var(--radius-pill);
+  border: 2px solid #fff;
+}
+
+.statistics__panel {
+  padding: 26px 28px 40px;
+}
+
+/* Заглушка отчётов */
+.statistics__placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 300px;
+}
+
+.statistics__placeholder-inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  text-align: center;
+  color: var(--color-text-muted);
+}
+
+.statistics__placeholder-inner svg {
+  opacity: 0.35;
+}
+
+.statistics__placeholder-inner p {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--color-text);
+  margin: 0;
+}
+
+.statistics__placeholder-inner span {
+  font-size: 13px;
+  line-height: 1.5;
+  max-width: 340px;
+}
+
+/* management-header / management-title подхватываются из AdminPageShell :deep */
+.management-title {
+  font-size: 1.2em;
+  font-weight: 600;
+  color: #000;
+  margin: 0;
+}
+</style>


### PR DESCRIPTION
## Что сделано

- Новая страница `/analytics` (StatisticsView.vue) с вкладками «Дашборд» и «Отчёты»
- Дашборд: 10 плиток «Данные» + 9 плиток «Система» (без отказов доступа)
- График динамики через RealTimeChart с переключателем метрики (заявки/люди/машины) и гранулярности (день/неделя/месяц)
- Живые ленты «Проход людей» и «Проезд машин» с polling 10 сек: номерные знаки машин как визуальный прямоугольник с рамкой, у людей аватарок нет
- Терминология: люди - «Вход»/«Выход», машины - «Въезд»/«Выезд»
- Модалка инструкции (AnalyticsInstructionModal) через BaseModal
- API-модуль statistics.js с getSummary/getTimeline/getRecentPassages
- Роут /analytics с meta {requiresAuth, requiresBuro, permission:'page.statistics'}
- Навигационный пункт «Аналитика» активирован (убран disabled/title="Скоро")

## Технические детали

- Все CSS-токены из tokens.css, без хардкода цветов
- Анимации только transform+opacity
- Polling чистится в onUnmounted
- DateFilter в режиме range, дефолт - текущая неделя (пн-сегодня)
- Вкладка «Отчёты» - заглушка, реализация в отдельном срезе