### PR TITLE
fix(statistics): разбор вложений по типам и время лент дашборда (#632)

### DIFF
--- a/frontend/src/api/statistics.js
+++ b/frontend/src/api/statistics.js
@@ -6,7 +6,8 @@ import { apiRequest } from './client';
  * @param {string} to   - дата конца в формате YYYY-MM-DD
  * @returns {Promise<{
  *   total_applications: number,
- *   by_attachment_type: Record<string, number>,
+ *   by_attachment_type: Array<{name: string, count: number}>,
+ *   by_status: Array<{status: string, count: number}>,
  *   processed: number,
  *   in_work: number,
  *   cars_entered: number,
@@ -55,8 +56,8 @@ export async function getTimeline({ from, to, metric, granularity }) {
  * Получить последние проходы/проезды.
  * @param {number} [limit=15] - максимальное количество записей на тип
  * @returns {Promise<{
- *   people: Array<{subject: string, organization: string, place: string, time: string, action_type: 'entry'|'exit'}>,
- *   cars:   Array<{subject: string, mark: string, organization: string, place: string, time: string, action_type: 'entry'|'exit'}>,
+ *   people: Array<{subject: string, organization: string, place: string, created_at: string, action_type: 'entry'|'exit'}>,
+ *   cars:   Array<{subject: string, mark: string, organization: string, place: string, created_at: string, action_type: 'entry'|'exit'}>,
  * }>}
  */
 export async function getRecentPassages(limit = 15) {

--- a/frontend/src/components/statistics/StatisticsDashboard.vue
+++ b/frontend/src/components/statistics/StatisticsDashboard.vue
@@ -222,7 +222,7 @@
                 </div>
               </div>
               <div class="dashboard__feed-right">
-                <div class="dashboard__feed-time">{{ formatTime(row.time) }}</div>
+                <div class="dashboard__feed-time">{{ formatTime(row.created_at) }}</div>
                 <span
                   class="dashboard__dir-badge"
                   :class="row.action_type === 'entry' ? 'dashboard__dir-badge--in' : 'dashboard__dir-badge--out'"
@@ -272,7 +272,7 @@
                 </div>
               </div>
               <div class="dashboard__feed-right">
-                <div class="dashboard__feed-time">{{ formatTime(row.time) }}</div>
+                <div class="dashboard__feed-time">{{ formatTime(row.created_at) }}</div>
                 <span
                   class="dashboard__dir-badge"
                   :class="row.action_type === 'entry' ? 'dashboard__dir-badge--in' : 'dashboard__dir-badge--out'"
@@ -349,15 +349,15 @@ const chartData = computed(() =>
 
 // ---- вычисляемые из summary ----
 const attachmentsTotal = computed(() => {
-  const map = summary.value.by_attachment_type;
-  if (!map || typeof map !== 'object') return 0;
-  return Object.values(map).reduce((s, v) => s + (v || 0), 0);
+  const list = summary.value.by_attachment_type;
+  if (!Array.isArray(list)) return 0;
+  return list.reduce((s, item) => s + (item?.count || 0), 0);
 });
 
 const attachmentBreakdown = computed(() => {
-  const map = summary.value.by_attachment_type;
-  if (!map || typeof map !== 'object') return [];
-  return Object.entries(map).map(([label, count]) => ({ label, count }));
+  const list = summary.value.by_attachment_type;
+  if (!Array.isArray(list)) return [];
+  return list.map((item) => ({ label: item.name, count: item.count }));
 });
 
 // ---- форматирование ----


### PR DESCRIPTION
Фикс-форвард к A2 (#640). Два рантайм-бага, не ловившиеся билдом:
1. `by_attachment_type` обрабатывался как объект (Object.values/entries), бэк отдаёт массив `[{name,count}]` -> плитка давала NaN. Теперь reduce/map по массиву.
2. Живые ленты читали `row.time`, бэк отдаёт `created_at` -> время показывалось `—`. Читаем `created_at`.
JSDoc в api/statistics.js приведён к реальной форме. Найдено пост-ревью после авто-мержа A2.