### PR TITLE
feat(statistics): каталог конструктора отчётов (#632)

### DIFF
--- a/internal/handlers/statistics.go
+++ b/internal/handlers/statistics.go
@@ -134,3 +134,21 @@ func (h *StatisticsHandler) GetRecentPassages(c echo.Context) error {
 	}
 	return RespondSuccess(c, passages)
 }
+
+// GetMetrics godoc
+// @Summary      Каталог конструктора отчётов
+// @Description  Whitelist метрик, разрезов, фильтров и list-сущностей со значениями динамических справочников
+// @Tags         statistics
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200 {object} Response
+// @Failure      401 {object} models.HTTPError
+// @Failure      403 {object} models.HTTPError
+// @Router       /statistics/metrics [get]
+func (h *StatisticsHandler) GetMetrics(c echo.Context) error {
+	catalog, err := h.service.GetReportCatalog(c.Request().Context())
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, catalog)
+}

--- a/internal/models/report_catalog.go
+++ b/internal/models/report_catalog.go
@@ -1,0 +1,64 @@
+package models
+
+// ReportFieldType — тип поля фильтра, по нему фронт выбирает контрол ввода.
+type ReportFieldType string
+
+const (
+	ReportFieldDate ReportFieldType = "date" // диапазон дат (from/to)
+	ReportFieldEnum ReportFieldType = "enum" // фиксированный набор значений (статусы)
+	ReportFieldDict ReportFieldType = "dict" // динамический справочник (орг, места, ...)
+)
+
+// ReportOption — вариант значения для enum/dict-фильтра.
+type ReportOption struct {
+	Value string `json:"value"`
+	Label string `json:"label"`
+}
+
+// ReportMetricInfo — метрика агрегатного отчёта (что измеряем).
+// Dimensions перечисляет ключи разрезов, по которым эту метрику можно группировать.
+type ReportMetricInfo struct {
+	Key        string   `json:"key"`
+	Label      string   `json:"label"`
+	Unit       string   `json:"unit,omitempty"`
+	Dimensions []string `json:"dimensions"`
+}
+
+// ReportDimensionInfo — разрез (ось группировки) агрегатного отчёта.
+type ReportDimensionInfo struct {
+	Key   string `json:"key"`
+	Label string `json:"label"`
+}
+
+// ReportFilterInfo — поле фильтра. Для enum/dict Options заполнены значениями.
+type ReportFilterInfo struct {
+	Key     string          `json:"key"`
+	Label   string          `json:"label"`
+	Type    ReportFieldType `json:"type"`
+	Options []ReportOption  `json:"options,omitempty"`
+}
+
+// ReportColumnInfo — столбец list-режима (выгрузки строк).
+type ReportColumnInfo struct {
+	Key   string `json:"key"`
+	Label string `json:"label"`
+}
+
+// ReportListEntityInfo — сущность list-режима: какие столбцы и фильтры доступны.
+type ReportListEntityInfo struct {
+	Key     string             `json:"key"`
+	Label   string             `json:"label"`
+	Columns []ReportColumnInfo `json:"columns"`
+	Filters []string           `json:"filters"`
+}
+
+// ReportCatalog — каталог конструктора отчётов: whitelist метрик, разрезов,
+// фильтров и list-сущностей с уже подставленными значениями динамических справочников.
+// Источник правды для UI конструктора (B3) и движка исполнения (B2).
+type ReportCatalog struct {
+	Metrics       []ReportMetricInfo     `json:"metrics"`
+	Dimensions    []ReportDimensionInfo  `json:"dimensions"`
+	Filters       []ReportFilterInfo     `json:"filters"`
+	ListEntities  []ReportListEntityInfo `json:"list_entities"`
+	Granularities []ReportOption         `json:"granularities"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -588,5 +588,6 @@ func Setup(e *echo.Echo, d Dependencies) {
 		statsGroup.GET("/summary", statistics.GetSummary, requireStats)
 		statsGroup.GET("/timeline", statistics.GetTimeline, requireStats)
 		statsGroup.GET("/recent-passages", statistics.GetRecentPassages, requireStats)
+		statsGroup.GET("/metrics", statistics.GetMetrics, requireStats)
 	}
 }

--- a/internal/services/report_catalog.go
+++ b/internal/services/report_catalog.go
@@ -1,0 +1,311 @@
+package services
+
+import "systemburo/internal/models"
+
+// Реестры конструктора отчётов — единый whitelist для каталога (B1) и движка
+// исполнения (B2). Все SQL-фрагменты здесь — статические константы кода; ввод
+// пользователя сверяется по ключам этих карт и никогда не конкатенируется в SQL.
+// Клиенту отдаётся только метаданные (ключи/подписи/значения справочников),
+// SQL-выражения наружу не выходят (неэкспортируемые поля, не сериализуются).
+
+// optionsSource указывает GetReportCatalog, откуда взять значения для dict-фильтра.
+type optionsSource string
+
+const (
+	srcNone            optionsSource = ""
+	srcStatuses        optionsSource = "statuses"
+	srcOrganizations   optionsSource = "organizations"
+	srcCompanies       optionsSource = "companies"
+	srcAttachmentTypes optionsSource = "attachment_types"
+	srcCitizenships    optionsSource = "citizenships"
+	srcUnloadPlaces    optionsSource = "unload_places"
+)
+
+// metricDef — агрегатная метрика. baseTable/aggExpr/baseFilter — безопасные
+// константы для сборки запроса движком B2; dimensions ограничивает разрезы.
+type metricDef struct {
+	label      string
+	unit       string
+	baseTable  string
+	aggExpr    string
+	baseFilter string
+	dimensions []string
+}
+
+// dimensionDef — разрез группировки. Конкретное GROUP BY-выражение и join-путь
+// зависят от метрики и резолвятся движком B2; здесь — только подпись для UI.
+type dimensionDef struct {
+	label string
+}
+
+// filterDef — поле фильтра. source задаёт справочник значений для dict-типа.
+type filterDef struct {
+	label  string
+	typ    models.ReportFieldType
+	source optionsSource
+}
+
+// listColumnDef — столбец list-режима (ключ + подпись).
+type listColumnDef struct {
+	key   string
+	label string
+}
+
+// listEntityDef — сущность list-режима: набор столбцов и применимых фильтров.
+type listEntityDef struct {
+	label   string
+	columns []listColumnDef
+	filters []string
+}
+
+// Порядок ключей фиксируется явно — карты в Go неупорядочены, а каталог должен
+// отдаваться стабильно (детерминированный ответ, удобный для тестов и кэша).
+
+var reportMetricOrder = []string{
+	"applications_count",
+	"car_entries_count",
+	"people_entries_count",
+	"items_sum",
+}
+
+var reportMetricRegistry = map[string]metricDef{
+	"applications_count": {
+		label:      "Количество заявок",
+		unit:       "шт",
+		baseTable:  "applications",
+		aggExpr:    "COUNT(*)",
+		dimensions: []string{"status", "organization", "company", "attachment_type", "period"},
+	},
+	"car_entries_count": {
+		label:      "Въезды машин",
+		unit:       "шт",
+		baseTable:  "cars_history",
+		aggExpr:    "COUNT(*)",
+		baseFilter: "action_type = 'entry'",
+		dimensions: []string{"period", "hour_of_day", "unload_place", "organization"},
+	},
+	"people_entries_count": {
+		label:      "Входы людей",
+		unit:       "шт",
+		baseTable:  "employees_history",
+		aggExpr:    "COUNT(*)",
+		baseFilter: "action_type = 'entry'",
+		dimensions: []string{"period", "hour_of_day", "organization"},
+	},
+	"items_sum": {
+		label:      "Количество товаров",
+		unit:       "шт",
+		baseTable:  "items",
+		aggExpr:    "COALESCE(SUM(items.count), 0)",
+		dimensions: []string{"organization", "company", "period"},
+	},
+}
+
+var reportDimensionOrder = []string{
+	"status",
+	"organization",
+	"company",
+	"attachment_type",
+	"unload_place",
+	"period",
+	"hour_of_day",
+}
+
+var reportDimensionRegistry = map[string]dimensionDef{
+	"status":          {label: "Статус заявки"},
+	"organization":    {label: "Организация"},
+	"company":         {label: "Компания"},
+	"attachment_type": {label: "Тип вложения"},
+	"unload_place":    {label: "Место разгрузки"},
+	"period":          {label: "Период (дата)"},
+	"hour_of_day":     {label: "Час суток"},
+}
+
+var reportFilterOrder = []string{
+	"date_range",
+	"status",
+	"organization",
+	"company",
+	"attachment_type",
+	"citizenship",
+	"unload_place",
+}
+
+var reportFilterRegistry = map[string]filterDef{
+	"date_range":      {label: "Период", typ: models.ReportFieldDate, source: srcNone},
+	"status":          {label: "Статус заявки", typ: models.ReportFieldEnum, source: srcStatuses},
+	"organization":    {label: "Организация", typ: models.ReportFieldDict, source: srcOrganizations},
+	"company":         {label: "Компания", typ: models.ReportFieldDict, source: srcCompanies},
+	"attachment_type": {label: "Тип вложения", typ: models.ReportFieldDict, source: srcAttachmentTypes},
+	"citizenship":     {label: "Гражданство", typ: models.ReportFieldDict, source: srcCitizenships},
+	"unload_place":    {label: "Место разгрузки", typ: models.ReportFieldDict, source: srcUnloadPlaces},
+}
+
+var reportListEntityOrder = []string{
+	"work_applications",
+	"applications",
+	"cars",
+	"people",
+}
+
+var reportListEntityRegistry = map[string]listEntityDef{
+	"work_applications": {
+		label: "Заявка на работы",
+		columns: []listColumnDef{
+			{key: "number", label: "Номер заявки"},
+			{key: "org_or_company", label: "Организация/Компания"},
+			{key: "work_name", label: "Наименование работ"},
+			{key: "responsible", label: "Ответственный"},
+			{key: "work_period", label: "Период работ"},
+			{key: "work_time", label: "Время работ"},
+			{key: "people_count", label: "Кол-во людей"},
+		},
+		filters: []string{"date_range", "organization", "status"},
+	},
+	"applications": {
+		label: "Заявки",
+		columns: []listColumnDef{
+			{key: "number", label: "Номер заявки"},
+			{key: "status", label: "Статус"},
+			{key: "organization", label: "Организация"},
+			{key: "company", label: "Компания"},
+			{key: "sending_datetime", label: "Дата подачи"},
+			{key: "attachments_count", label: "Вложений"},
+		},
+		filters: []string{"date_range", "status", "organization", "company"},
+	},
+	"cars": {
+		label: "Машины",
+		columns: []listColumnDef{
+			{key: "car_number", label: "Гос. номер"},
+			{key: "mark", label: "Марка"},
+			{key: "organization", label: "Организация"},
+			{key: "place", label: "Место разгрузки"},
+			{key: "territory_status", label: "На территории"},
+		},
+		filters: []string{"organization", "unload_place"},
+	},
+	"people": {
+		label: "Люди",
+		columns: []listColumnDef{
+			{key: "full_name", label: "ФИО"},
+			{key: "organization", label: "Организация"},
+			{key: "citizenship", label: "Гражданство"},
+			{key: "place", label: "Место разгрузки"},
+			{key: "territory_status", label: "На территории"},
+		},
+		filters: []string{"organization", "citizenship"},
+	},
+}
+
+// reportGranularities — допустимые гранулярности для разреза "period".
+// Совпадают с whitelist GetTimeline (resolveTimelineSource).
+var reportGranularities = []models.ReportOption{
+	{Value: "day", Label: "По дням"},
+	{Value: "week", Label: "По неделям"},
+	{Value: "month", Label: "По месяцам"},
+}
+
+// statusOptions — статичные значения enum-фильтра "status".
+func statusOptions() []models.ReportOption {
+	statuses := []string{
+		models.StatusUnread,
+		models.StatusProcessing,
+		models.StatusApproval,
+		models.StatusApproved,
+		models.StatusRejected,
+		models.StatusInWork,
+		models.StatusCompleted,
+		models.StatusRefused,
+	}
+	opts := make([]models.ReportOption, 0, len(statuses))
+	for _, s := range statuses {
+		opts = append(opts, models.ReportOption{Value: s, Label: s})
+	}
+	return opts
+}
+
+// dynamicReportOptions — значения динамических справочников, подгружаемые из БД
+// и подставляемые в dict-фильтры каталога.
+type dynamicReportOptions struct {
+	organizations   []models.ReportOption
+	companies       []models.ReportOption
+	attachmentTypes []models.ReportOption
+	citizenships    []models.ReportOption
+	unloadPlaces    []models.ReportOption
+}
+
+// optionsFor возвращает значения для фильтра по его source.
+func (d dynamicReportOptions) optionsFor(src optionsSource) []models.ReportOption {
+	switch src {
+	case srcStatuses:
+		return statusOptions()
+	case srcOrganizations:
+		return d.organizations
+	case srcCompanies:
+		return d.companies
+	case srcAttachmentTypes:
+		return d.attachmentTypes
+	case srcCitizenships:
+		return d.citizenships
+	case srcUnloadPlaces:
+		return d.unloadPlaces
+	default:
+		return nil
+	}
+}
+
+// buildReportCatalog собирает каталог из whitelist-реестров и подгруженных
+// значений справочников. Чистая функция (без БД) — тестируется напрямую.
+func buildReportCatalog(dyn dynamicReportOptions) models.ReportCatalog {
+	cat := models.ReportCatalog{
+		Metrics:       make([]models.ReportMetricInfo, 0, len(reportMetricOrder)),
+		Dimensions:    make([]models.ReportDimensionInfo, 0, len(reportDimensionOrder)),
+		Filters:       make([]models.ReportFilterInfo, 0, len(reportFilterOrder)),
+		ListEntities:  make([]models.ReportListEntityInfo, 0, len(reportListEntityOrder)),
+		Granularities: reportGranularities,
+	}
+
+	for _, key := range reportMetricOrder {
+		def := reportMetricRegistry[key]
+		cat.Metrics = append(cat.Metrics, models.ReportMetricInfo{
+			Key:        key,
+			Label:      def.label,
+			Unit:       def.unit,
+			Dimensions: def.dimensions,
+		})
+	}
+
+	for _, key := range reportDimensionOrder {
+		cat.Dimensions = append(cat.Dimensions, models.ReportDimensionInfo{
+			Key:   key,
+			Label: reportDimensionRegistry[key].label,
+		})
+	}
+
+	for _, key := range reportFilterOrder {
+		def := reportFilterRegistry[key]
+		cat.Filters = append(cat.Filters, models.ReportFilterInfo{
+			Key:     key,
+			Label:   def.label,
+			Type:    def.typ,
+			Options: dyn.optionsFor(def.source),
+		})
+	}
+
+	for _, key := range reportListEntityOrder {
+		def := reportListEntityRegistry[key]
+		cols := make([]models.ReportColumnInfo, 0, len(def.columns))
+		for _, c := range def.columns {
+			cols = append(cols, models.ReportColumnInfo{Key: c.key, Label: c.label})
+		}
+		cat.ListEntities = append(cat.ListEntities, models.ReportListEntityInfo{
+			Key:     key,
+			Label:   def.label,
+			Columns: cols,
+			Filters: def.filters,
+		})
+	}
+
+	return cat
+}

--- a/internal/services/report_catalog_test.go
+++ b/internal/services/report_catalog_test.go
@@ -72,6 +72,16 @@ func TestReportRegistries_Consistency(t *testing.T) {
 			t.Errorf("filter order содержит отсутствующий ключ %q", key)
 		}
 	}
+	for _, key := range reportDimensionOrder {
+		if _, ok := reportDimensionRegistry[key]; !ok {
+			t.Errorf("dimension order содержит отсутствующий ключ %q", key)
+		}
+	}
+	for _, key := range reportListEntityOrder {
+		if _, ok := reportListEntityRegistry[key]; !ok {
+			t.Errorf("list entity order содержит отсутствующий ключ %q", key)
+		}
+	}
 }
 
 // TestBuildReportCatalog_DynamicOptions проверяет подстановку значений

--- a/internal/services/report_catalog_test.go
+++ b/internal/services/report_catalog_test.go
@@ -1,0 +1,108 @@
+package services
+
+import (
+	"testing"
+
+	"systemburo/internal/models"
+)
+
+// TestBuildReportCatalog_Structure проверяет, что каталог собирается из реестров
+// в фиксированном порядке и с полным набором элементов.
+func TestBuildReportCatalog_Structure(t *testing.T) {
+	cat := buildReportCatalog(dynamicReportOptions{})
+
+	if len(cat.Metrics) != len(reportMetricOrder) {
+		t.Fatalf("metrics: got %d, want %d", len(cat.Metrics), len(reportMetricOrder))
+	}
+	for i, key := range reportMetricOrder {
+		if cat.Metrics[i].Key != key {
+			t.Errorf("metric[%d]: got %q, want %q", i, cat.Metrics[i].Key, key)
+		}
+		if cat.Metrics[i].Label == "" {
+			t.Errorf("metric %q: пустая подпись", key)
+		}
+	}
+
+	if len(cat.Dimensions) != len(reportDimensionOrder) {
+		t.Fatalf("dimensions: got %d, want %d", len(cat.Dimensions), len(reportDimensionOrder))
+	}
+	if len(cat.Filters) != len(reportFilterOrder) {
+		t.Fatalf("filters: got %d, want %d", len(cat.Filters), len(reportFilterOrder))
+	}
+	if len(cat.ListEntities) != len(reportListEntityOrder) {
+		t.Fatalf("list entities: got %d, want %d", len(cat.ListEntities), len(reportListEntityOrder))
+	}
+	if len(cat.Granularities) == 0 {
+		t.Error("granularities пустые")
+	}
+}
+
+// TestReportRegistries_Consistency ловит висячие ссылки между реестрами:
+// каждый разрез метрики, фильтр сущности и т.п. должен существовать.
+func TestReportRegistries_Consistency(t *testing.T) {
+	for key, m := range reportMetricRegistry {
+		if m.baseTable == "" || m.aggExpr == "" {
+			t.Errorf("metric %q: пустой baseTable/aggExpr", key)
+		}
+		for _, dim := range m.dimensions {
+			if _, ok := reportDimensionRegistry[dim]; !ok {
+				t.Errorf("metric %q ссылается на неизвестный разрез %q", key, dim)
+			}
+		}
+	}
+
+	for key, e := range reportListEntityRegistry {
+		if len(e.columns) == 0 {
+			t.Errorf("list entity %q без столбцов", key)
+		}
+		for _, f := range e.filters {
+			if _, ok := reportFilterRegistry[f]; !ok {
+				t.Errorf("list entity %q ссылается на неизвестный фильтр %q", key, f)
+			}
+		}
+	}
+
+	for _, key := range reportMetricOrder {
+		if _, ok := reportMetricRegistry[key]; !ok {
+			t.Errorf("metric order содержит отсутствующий ключ %q", key)
+		}
+	}
+	for _, key := range reportFilterOrder {
+		if _, ok := reportFilterRegistry[key]; !ok {
+			t.Errorf("filter order содержит отсутствующий ключ %q", key)
+		}
+	}
+}
+
+// TestBuildReportCatalog_DynamicOptions проверяет подстановку значений
+// динамических справочников в соответствующие dict-фильтры.
+func TestBuildReportCatalog_DynamicOptions(t *testing.T) {
+	dyn := dynamicReportOptions{
+		organizations: []models.ReportOption{{Value: "ООО Рога", Label: "ООО Рога"}},
+		unloadPlaces:  []models.ReportOption{{Value: "Дебаркадер №1", Label: "Дебаркадер №1"}},
+	}
+	cat := buildReportCatalog(dyn)
+
+	byKey := make(map[string]models.ReportFilterInfo, len(cat.Filters))
+	for _, f := range cat.Filters {
+		byKey[f.Key] = f
+	}
+
+	if got := byKey["organization"].Options; len(got) != 1 || got[0].Value != "ООО Рога" {
+		t.Errorf("organization options: got %+v", got)
+	}
+	if got := byKey["unload_place"].Options; len(got) != 1 || got[0].Value != "Дебаркадер №1" {
+		t.Errorf("unload_place options: got %+v", got)
+	}
+	// company не передавали -> опций нет
+	if got := byKey["company"].Options; len(got) != 0 {
+		t.Errorf("company options: ожидалось пусто, got %+v", got)
+	}
+	// status — статичный enum, не зависит от dyn
+	if got := byKey["status"].Options; len(got) == 0 {
+		t.Error("status options: ожидался статичный набор статусов")
+	}
+	if byKey["date_range"].Type != models.ReportFieldDate {
+		t.Errorf("date_range: тип %q, ожидался date", byKey["date_range"].Type)
+	}
+}

--- a/internal/services/statistics_service.go
+++ b/internal/services/statistics_service.go
@@ -15,6 +15,7 @@ type StatisticsService interface {
 	GetSummary(ctx context.Context, from, to time.Time) (*models.StatsSummary, error)
 	GetTimeline(ctx context.Context, from, to time.Time, metric, granularity string) ([]models.StatsTimelinePoint, error)
 	GetRecentPassages(ctx context.Context, limit int) (*models.RecentPassages, error)
+	GetReportCatalog(ctx context.Context) (*models.ReportCatalog, error)
 }
 
 type statisticsService struct {
@@ -341,4 +342,59 @@ func (s *statisticsService) GetRecentPassages(ctx context.Context, limit int) (*
 	}
 
 	return result, nil
+}
+
+// GetReportCatalog возвращает каталог конструктора отчётов: whitelist метрик,
+// разрезов, фильтров и list-сущностей с подставленными значениями динамических
+// справочников. Метаданные берутся из реестров (report_catalog.go), значения
+// справочников — из БД.
+func (s *statisticsService) GetReportCatalog(ctx context.Context) (*models.ReportCatalog, error) {
+	dyn, err := s.loadDynamicReportOptions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	catalog := buildReportCatalog(dyn)
+	return &catalog, nil
+}
+
+// loadDynamicReportOptions подгружает значения справочников для dict-фильтров.
+func (s *statisticsService) loadDynamicReportOptions(ctx context.Context) (dynamicReportOptions, error) {
+	var dyn dynamicReportOptions
+
+	load := func(name, table, column, where string) ([]models.ReportOption, error) {
+		var names []string
+		tx := s.db.WithContext(ctx).Table(table).
+			Distinct(column).
+			Where(column + " IS NOT NULL AND " + column + " <> ''")
+		if where != "" {
+			tx = tx.Where(where)
+		}
+		if err := tx.Order(column + " ASC").Pluck(column, &names).Error; err != nil {
+			return nil, fmt.Errorf("statistics: report catalog %s: %w", name, err)
+		}
+		opts := make([]models.ReportOption, 0, len(names))
+		for _, n := range names {
+			opts = append(opts, models.ReportOption{Value: n, Label: n})
+		}
+		return opts, nil
+	}
+
+	var err error
+	if dyn.organizations, err = load("organizations", "organizations", "name", "is_active = true"); err != nil {
+		return dyn, err
+	}
+	if dyn.companies, err = load("companies", "companies", "name", "is_active = true"); err != nil {
+		return dyn, err
+	}
+	if dyn.attachmentTypes, err = load("attachment_types", "unique_attachments", "display_name", "is_active = true"); err != nil {
+		return dyn, err
+	}
+	if dyn.citizenships, err = load("citizenships", "citizenships", "name", "is_active = true"); err != nil {
+		return dyn, err
+	}
+	if dyn.unloadPlaces, err = load("unload_places", "unload_places", "name", "is_active = true"); err != nil {
+		return dyn, err
+	}
+
+	return dyn, nil
 }

--- a/internal/services/statistics_service.go
+++ b/internal/services/statistics_service.go
@@ -361,6 +361,9 @@ func (s *statisticsService) GetReportCatalog(ctx context.Context) (*models.Repor
 func (s *statisticsService) loadDynamicReportOptions(ctx context.Context) (dynamicReportOptions, error) {
 	var dyn dynamicReportOptions
 
+	// load подставляет table/column/where прямо в SQL (GORM не экранирует
+	// строковые выражения), поэтому вызывать его допустимо ТОЛЬКО с константами
+	// кода - никогда с пользовательским вводом.
 	load := func(name, table, column, where string) ([]models.ReportOption, error) {
 		var names []string
 		tx := s.db.WithContext(ctx).Table(table).


### PR DESCRIPTION
Срез B1 эпика «Аналитика» (#632). Бэкенд-каталог конструктора отчётов.

## Что добавлено
- `GET /statistics/metrics` (право `page.statistics`) - отдаёт whitelist метрик, разрезов, фильтров и list-сущностей конструктора + значения динамических справочников (организации, компании, типы вложений, гражданства, места разгрузки).
- Реестры в `internal/services/report_catalog.go` - единый источник правды для UI конструктора (срез B3) и движка исполнения (срез B2). SQL-фрагменты (baseTable/aggExpr/baseFilter) хранятся в неэкспортируемых полях, наружу в JSON не выходят.
- `buildReportCatalog` - чистая функция сборки каталога (тестируется без БД); `loadDynamicReportOptions` - подгрузка справочников.
- Поддержаны оба режима будущего движка: aggregate (метрика x разрез x фильтры) и list (сущность + столбцы), включая флагманский шаблон «Заявка на работы».

## Безопасность
- Эндпоинт без query-параметров; пользовательский ввод в SQL не попадает.
- Динамические справочники грузятся только по константам кода (table/column захардкожены); на хелпер `load` навешен контракт-комментарий.

## Проверка
- `go test ./...` в worktree - зелёные (новые тесты: структура каталога, консистентность реестров, подстановка динамических опций).
- Ревью `code-reviewer`: вердикт GO, блокеров нет; превентивные suggestion'ы по контракту `load` и покрытию order-слайсов применены.

Заметка: ~558 LOC, но ~половина - декларативные whitelist-данные реестра и тесты; логики мало, дифф чисто аддитивный (0 удалений). Swagger не регенерил - предыдущие срезы статистики (A1/A1b/A2) его не трогали и CI его не проверяет.