### PR TITLE
feat(text-constructor): мульти-ресайз картинок - 8 маркеров, свободная ширина+высота (#46)

### DIFF
--- a/frontend/src/components/AnnouncementModal.vue
+++ b/frontend/src/components/AnnouncementModal.vue
@@ -279,7 +279,8 @@ export default {
 .announcement-body-html :deep(p) { margin: 0.5em 0; }
 .announcement-body-html :deep(ul),
 .announcement-body-html :deep(ol) { padding-left: 1.5em; margin: 0.5em 0; }
-.announcement-body-html :deep(img) { max-width: 100%; height: auto; border-radius: 8px; }
+.announcement-body-html :deep(img) { max-width: 100%; border-radius: 8px; }
+.announcement-body-html :deep(img:not([height])) { height: auto; }
 .announcement-body-html :deep(.text-align-left) { text-align: left; }
 .announcement-body-html :deep(.text-align-center) { text-align: center; }
 .announcement-body-html :deep(.text-align-right) { text-align: right; }

--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -2185,8 +2185,11 @@ export default {
 
     .text-constructor-content :deep(img) {
         max-width: 100%;
-        height: auto;
         border-radius: 8px;
+    }
+
+    .text-constructor-content :deep(img:not([height])) {
+        height: auto;
     }
 
     .text-constructor-content :deep(.text-align-left) { text-align: left; }

--- a/frontend/src/components/TablesComponent.vue
+++ b/frontend/src/components/TablesComponent.vue
@@ -820,8 +820,11 @@ export default {
 
 .text-constructor-content :deep(img) {
     max-width: 100%;
-    height: auto;
     border-radius: 8px;
+}
+
+.text-constructor-content :deep(img:not([height])) {
+    height: auto;
 }
 
 .text-constructor-content :deep(strong) {

--- a/frontend/src/components/TextConstructor.vue
+++ b/frontend/src/components/TextConstructor.vue
@@ -909,7 +909,11 @@ defineExpose({ editor });
 .editor-content :deep(img),
 .preview-modal-content :deep(img) {
   max-width: 100%;
-  height: auto;
   border-radius: 8px;
+}
+
+.editor-content :deep(img:not([height])),
+.preview-modal-content :deep(img:not([height])) {
+  height: auto;
 }
 </style>

--- a/frontend/src/components/__tests__/TextConstructor.spec.js
+++ b/frontend/src/components/__tests__/TextConstructor.spec.js
@@ -206,6 +206,47 @@ describe('TextConstructor', () => {
     expect(out).not.toContain('width=');
   });
 
+  it('round-trip: ширина и высота картинки сохраняются (свободный ресайз)', async () => {
+    const html =
+      '<img class="constructor-image" src="data:image/png;base64,ZmFrZQ==" alt="pic" width="320" height="200">';
+    const wrapper = mountConstructor({ modelValue: html });
+    await flushPromises();
+
+    const out = wrapper.vm.editor.getHTML();
+    expect(out).toContain('width="320"');
+    expect(out).toContain('height="200"');
+  });
+
+  it('высоту из inline-style парсит и сериализует в атрибут height', async () => {
+    const html =
+      '<img class="constructor-image" src="data:image/png;base64,ZmFrZQ==" alt="pic" style="height: 150px">';
+    const wrapper = mountConstructor({ modelValue: html });
+    await flushPromises();
+
+    const out = wrapper.vm.editor.getHTML();
+    expect(out).toContain('height="150"');
+  });
+
+  it('картинка без размера не получает атрибут height', async () => {
+    const html =
+      '<img class="constructor-image" src="data:image/png;base64,ZmFrZQ==" alt="pic">';
+    const wrapper = mountConstructor({ modelValue: html });
+    await flushPromises();
+
+    const out = wrapper.vm.editor.getHTML();
+    expect(out).not.toContain('height=');
+  });
+
+  it('нулевая высота не сериализуется (невалидный размер)', async () => {
+    const html =
+      '<img class="constructor-image" src="data:image/png;base64,ZmFrZQ==" alt="pic" height="0">';
+    const wrapper = mountConstructor({ modelValue: html });
+    await flushPromises();
+
+    const out = wrapper.vm.editor.getHTML();
+    expect(out).not.toContain('height=');
+  });
+
   it('кнопки форматирования имеют data-tooltip', () => {
     const wrapper = mountConstructor();
     const italicBtn = wrapper.findAll('.toolbar-btn').find((b) => b.attributes('data-tooltip') === 'Курсив');

--- a/frontend/src/components/text-constructor/ResizableImage.vue
+++ b/frontend/src/components/text-constructor/ResizableImage.vue
@@ -13,10 +13,13 @@
         draggable="false"
       >
       <span
-        v-if="isEditable && selected"
+        v-for="handle in HANDLES"
+        v-show="isEditable && selected"
+        :key="handle.key"
         class="ci-resize-handle"
-        title="Потяните, чтобы изменить размер"
-        @mousedown="startResize"
+        :class="`ci-handle-${handle.key}`"
+        title="Потяните, чтобы изменить размер (Shift - пропорционально)"
+        @mousedown="(event) => startResize(event, handle)"
       />
     </span>
   </node-view-wrapper>
@@ -28,18 +31,38 @@ import { NodeViewWrapper, nodeViewProps } from '@tiptap/vue-3';
 
 const props = defineProps(nodeViewProps);
 
-const MIN_WIDTH = 40;
+const MIN_SIZE = 40;
+
+/**
+ * 8 маркеров ресайза. `sx`/`sy` - знак влияния перемещения курсора на ширину/высоту:
+ * ширина += sx * dx, высота += sy * dy. Для левого/верхнего ребра знак отрицательный,
+ * чтобы движение наружу увеличивало размер (как в Word). Стороны меняют одну ось.
+ */
+const HANDLES = [
+  { key: 'nw', sx: -1, sy: -1 },
+  { key: 'n', sx: 0, sy: -1 },
+  { key: 'ne', sx: 1, sy: -1 },
+  { key: 'e', sx: 1, sy: 0 },
+  { key: 'se', sx: 1, sy: 1 },
+  { key: 's', sx: 0, sy: 1 },
+  { key: 'sw', sx: -1, sy: 1 },
+  { key: 'w', sx: -1, sy: 0 },
+];
 
 const imgEl = ref(null);
-/** Ширина во время перетаскивания (px); коммитим в атрибут ноды только на mouseup. */
-const dragWidth = ref(null);
+/** Размер во время перетаскивания (px); коммитим в атрибуты ноды только на mouseup. */
+const dragSize = ref(null);
 let stopDrag = null;
 
 const isEditable = computed(() => Boolean(props.editor?.isEditable));
 
 const imgStyle = computed(() => {
-  const width = dragWidth.value ?? props.node.attrs.width;
-  return width ? { width: `${width}px` } : {};
+  const width = dragSize.value?.width ?? props.node.attrs.width;
+  const height = dragSize.value?.height ?? props.node.attrs.height;
+  const style = {};
+  if (width) style.width = `${width}px`;
+  if (height) style.height = `${height}px`;
+  return style;
 });
 
 /** Верхняя граница ширины - доступная ширина области редактора (контент-бокс ProseMirror). */
@@ -48,30 +71,55 @@ function maxWidth() {
   if (!pm) return Number.POSITIVE_INFINITY;
   const cs = window.getComputedStyle(pm);
   const padding = (parseFloat(cs.paddingLeft) || 0) + (parseFloat(cs.paddingRight) || 0);
-  return Math.max(MIN_WIDTH, pm.clientWidth - padding);
+  return Math.max(MIN_SIZE, pm.clientWidth - padding);
 }
 
-function startResize(event) {
+function startResize(event, handle) {
   if (!isEditable.value || !imgEl.value) return;
   if (stopDrag) stopDrag();
+  // Гасим всплытие, чтобы перетаскивание маркера не запускало drag-перемещение ноды.
   event.preventDefault();
   event.stopPropagation();
 
+  const rect = imgEl.value.getBoundingClientRect();
   const startX = event.clientX;
-  const startWidth = imgEl.value.getBoundingClientRect().width;
+  const startY = event.clientY;
+  const startWidth = rect.width;
+  const startHeight = rect.height;
+  const ratio = startHeight > 0 ? startWidth / startHeight : 1;
   const limit = maxWidth();
 
   const onMove = (e) => {
-    const next = Math.round(startWidth + (e.clientX - startX));
-    dragWidth.value = Math.max(MIN_WIDTH, Math.min(next, limit));
+    let width = startWidth + handle.sx * (e.clientX - startX);
+    let height = startHeight + handle.sy * (e.clientY - startY);
+
+    if (e.shiftKey) {
+      // Пропорция: сторона, меняющая только высоту, ведёт ширину; в остальных случаях ведёт ширина.
+      if (handle.sx === 0) {
+        width = height * ratio;
+      } else {
+        height = width / ratio;
+      }
+    }
+
+    width = Math.max(MIN_SIZE, Math.min(Math.round(width), limit));
+    height = Math.max(MIN_SIZE, Math.round(height));
+    // У границы редактора ширина упёрлась в лимит - пересчитываем высоту, чтобы Shift-пропорция не ломалась.
+    if (e.shiftKey && handle.sx !== 0) {
+      height = Math.max(MIN_SIZE, Math.round(width / ratio));
+    }
+
+    dragSize.value = { width, height };
   };
+
   const onUp = () => {
-    if (dragWidth.value != null) {
-      props.updateAttributes({ width: dragWidth.value });
-      dragWidth.value = null;
+    if (dragSize.value) {
+      props.updateAttributes({ width: dragSize.value.width, height: dragSize.value.height });
+      dragSize.value = null;
     }
     teardown();
   };
+
   function teardown() {
     document.removeEventListener('mousemove', onMove);
     document.removeEventListener('mouseup', onUp);
@@ -110,18 +158,26 @@ onBeforeUnmount(() => {
 .ci-image.is-selected .ci-image-frame img {
   outline: 2px solid #4f5bdf;
   outline-offset: 2px;
+  cursor: move;
 }
 
 .ci-resize-handle {
   position: absolute;
-  right: -7px;
-  bottom: -7px;
-  width: 14px;
-  height: 14px;
+  width: 12px;
+  height: 12px;
   background: #4f5bdf;
   border: 2px solid #fff;
   border-radius: 50%;
-  cursor: nwse-resize;
   box-shadow: 0 1px 3px rgba(15, 23, 42, 0.25);
+  z-index: 1;
 }
+
+.ci-handle-nw { top: -6px; left: -6px; cursor: nwse-resize; }
+.ci-handle-ne { top: -6px; right: -6px; cursor: nesw-resize; }
+.ci-handle-se { right: -6px; bottom: -6px; cursor: nwse-resize; }
+.ci-handle-sw { bottom: -6px; left: -6px; cursor: nesw-resize; }
+.ci-handle-n { top: -6px; left: 50%; transform: translateX(-50%); cursor: ns-resize; }
+.ci-handle-s { bottom: -6px; left: 50%; transform: translateX(-50%); cursor: ns-resize; }
+.ci-handle-e { top: 50%; right: -6px; transform: translateY(-50%); cursor: ew-resize; }
+.ci-handle-w { top: 50%; left: -6px; transform: translateY(-50%); cursor: ew-resize; }
 </style>

--- a/frontend/src/components/text-constructor/extensions.js
+++ b/frontend/src/components/text-constructor/extensions.js
@@ -118,13 +118,35 @@ export const ClassHeading = Heading.extend({
 });
 
 /**
+ * Парсит размер картинки (`width`/`height`) из HTML-атрибута, а если его нет - из inline-style
+ * `<dim>:Npx`. Возвращает целое число px > 0 либо null. Хранение и сериализация идут в HTML-атрибут
+ * (он проходит whitelist DOMPurify); inline-style понимаем только ради уже сохранённого чужого контента.
+ * @param {HTMLElement} element
+ * @param {'width'|'height'} attr
+ * @returns {number|null}
+ */
+function parseImageDimension(element, attr) {
+  const raw = element.getAttribute(attr);
+  if (raw && /^\d+(?:\.\d+)?$/.test(raw)) {
+    const value = Math.round(parseFloat(raw));
+    return value > 0 ? value : null;
+  }
+  const styleValue = element.style?.[attr] || '';
+  const match = styleValue.match(/^(\d+(?:\.\d+)?)px$/);
+  if (!match) return null;
+  const value = Math.round(parseFloat(match[1]));
+  return value > 0 ? value : null;
+}
+
+/**
  * Image с классом `constructor-image` и поддержкой data:URL (картинки вставляются в base64).
  *
- * Размер настраивается перетаскиванием маркера (NodeView `ResizableImage.vue`): ширина хранится
- * в HTML-атрибуте `width` (число px) и round-trip'ит через него. Атрибут `width` проходит санитайзер
- * DOMPurify по умолчанию (см. utils/sanitize.js + sanitize.spec.js), поэтому размер переживает
- * сохранение/перезагрузку. Без заданной ширины картинка рендерится в натуральном размере и
- * ограничена `max-width:100%` у потребителей (не растягивается на максимум).
+ * Размер настраивается перетаскиванием маркеров (NodeView `ResizableImage.vue`): 8 маркеров
+ * (4 угла + 4 стороны), свободный ресайз ширины и высоты независимо, Shift = пропорционально.
+ * Ширина и высота хранятся в HTML-атрибутах `width`/`height` (число px) и round-trip'ят через них.
+ * Эти атрибуты проходят санитайзер DOMPurify по умолчанию (см. utils/sanitize.js + sanitize.spec.js),
+ * поэтому размер переживает сохранение/перезагрузку. Без заданных размеров картинка рендерится в
+ * натуральном размере и ограничена `max-width:100%` у потребителей (не растягивается на максимум).
  */
 export const ConstructorImage = Image.extend({
   addOptions() {
@@ -141,19 +163,13 @@ export const ConstructorImage = Image.extend({
       ...this.parent?.(),
       width: {
         default: null,
-        parseHTML: (element) => {
-          const attr = element.getAttribute('width');
-          if (attr && /^\d+(?:\.\d+)?$/.test(attr)) {
-            const value = Math.round(parseFloat(attr));
-            return value > 0 ? value : null;
-          }
-          const styleWidth = element.style?.width || '';
-          const match = styleWidth.match(/^(\d+(?:\.\d+)?)px$/);
-          if (!match) return null;
-          const value = Math.round(parseFloat(match[1]));
-          return value > 0 ? value : null;
-        },
+        parseHTML: (element) => parseImageDimension(element, 'width'),
         renderHTML: (attributes) => (attributes.width > 0 ? { width: attributes.width } : {}),
+      },
+      height: {
+        default: null,
+        parseHTML: (element) => parseImageDimension(element, 'height'),
+        renderHTML: (attributes) => (attributes.height > 0 ? { height: attributes.height } : {}),
       },
     };
   },

--- a/frontend/src/utils/__tests__/sanitize.spec.js
+++ b/frontend/src/utils/__tests__/sanitize.spec.js
@@ -16,6 +16,14 @@ describe('sanitizeHtml', () => {
     expect(out).toContain('data:image/png;base64,');
   });
 
+  it('сохраняет атрибуты width и height у картинки (свободный ресайз round-trip)', () => {
+    const html =
+      '<img class="constructor-image" src="data:image/png;base64,ZmFrZQ==" alt="x" width="320" height="200">';
+    const out = sanitizeHtml(html);
+    expect(out).toContain('width="320"');
+    expect(out).toContain('height="200"');
+  });
+
   it('сохраняет классы форматирования (цвета, размер, жирность)', () => {
     const html =
       '<span class="red-text">a</span>' +

--- a/frontend/src/utils/sanitize.js
+++ b/frontend/src/utils/sanitize.js
@@ -8,8 +8,8 @@ import DOMPurify from 'dompurify'
  * Используется для admin-editable контента (инструкции в таблицах, текстовый
  * конструктор) - input не доверенный, хотя authored админом.
  *
- * Ресайз картинок (TextConstructor) хранит ширину в HTML-атрибуте `width` (число px) -
- * он входит в whitelist html-профиля DOMPurify и не вырезается, поэтому размер картинки
+ * Ресайз картинок (TextConstructor) хранит размер в HTML-атрибутах `width`/`height` (число px) -
+ * оба входят в whitelist html-профиля DOMPurify и не вырезаются, поэтому размер картинки
  * переживает санитизацию и round-trip. Контракт зафиксирован в utils/__tests__/sanitize.spec.js.
  *
  * @param {string} dirty - исходный HTML

--- a/frontend/src/views/NewsAndReview.vue
+++ b/frontend/src/views/NewsAndReview.vue
@@ -1668,7 +1668,8 @@ export default {
 .news-body-html :deep(p) { margin: 0.5em 0; }
 .news-body-html :deep(ul),
 .news-body-html :deep(ol) { padding-left: 1.5em; margin: 0.5em 0; }
-.news-body-html :deep(img) { max-width: 100%; height: auto; border-radius: 8px; }
+.news-body-html :deep(img) { max-width: 100%; border-radius: 8px; }
+.news-body-html :deep(img:not([height])) { height: auto; }
 .news-body-html :deep(.text-align-left) { text-align: left; }
 .news-body-html :deep(.text-align-center) { text-align: center; }
 .news-body-html :deep(.text-align-right) { text-align: right; }


### PR DESCRIPTION
## Что

Срез `image-multi-resize` под-эпика 46-textconstructor (тред 46-edits, питает п.9). Картинки в TextConstructor получили полноценный ресайз:

- **8 маркеров** вместо одного: 4 угла + 4 стороны (раньше только bottom-right).
- **Свободный ресайз** - ширина и высота меняются независимо (раньше width-only с жёсткой пропорцией через `height:auto`).
- **Shift зажат = пропорционально** (сохраняется исходное соотношение сторон).
- **Перемещение перетаскиванием** и **несколько картинок** - встроено в Tiptap Image (`draggable: true`), отдельного кода не потребовало.

## Как

- `ResizableImage.vue` (NodeView): 8 маркеров через `v-for`, геометрия по знакам `sx/sy` на ребро, Shift пересчитывает вторую ось по `ratio`, лимит ширины - контент-бокс редактора.
- `extensions.js` (`ConstructorImage`): добавлен атрибут `height` (зеркало `width`), парсинг размера вынесен в `parseImageDimension`. Размеры хранятся в HTML-атрибутах `width`/`height` (проходят whitelist DOMPurify), не в inline-style.
- `sanitize.js`: `height` проходит санитизацию по умолчанию (как `width`) - контракт зафиксирован тестом.
- Render-CSS 5 потребителей (preview/editor TextConstructor, TablesComponent, CreateApplication, NewsAndReview, AnnouncementModal): `height:auto` теперь только для `img:not([height])` - явная высота рендерится, старый контент без высоты сохраняет авто-пропорцию.

## Проверка

- vitest 30/30 (5 новых round-trip-тестов на width+height, inline-style height, нулевую/отсутствующую высоту), eslint 0 ошибок.
- Функциональная проверка геометрии (Playwright, throwaway-харнес, headless): 8 маркеров видимы при выделении; E +120 -> ширина 420 при высоте 180 без изменений; S +60 -> высота 240 при ширине 420; Shift se: 420x240 (1.750) -> 510x291 (1.753), пропорция сохранена; 0 ошибок в консоли. Скриншот выделенной картинки с 8 маркерами снят.