### PR TITLE
fix(text-constructor): Shift держит пропорцию у боковых маркеров на границе (#46)

### DIFF
--- a/frontend/src/components/text-constructor/ResizableImage.vue
+++ b/frontend/src/components/text-constructor/ResizableImage.vue
@@ -104,8 +104,9 @@ function startResize(event, handle) {
 
     width = Math.max(MIN_SIZE, Math.min(Math.round(width), limit));
     height = Math.max(MIN_SIZE, Math.round(height));
-    // У границы редактора ширина упёрлась в лимит - пересчитываем высоту, чтобы Shift-пропорция не ломалась.
-    if (e.shiftKey && handle.sx !== 0) {
+    // При Shift держим пропорцию даже у границы редактора: высоту всегда пересчитываем из
+    // финальной (возможно урезанной лимитом) ширины - симметрично для угловых и боковых маркеров.
+    if (e.shiftKey) {
       height = Math.max(MIN_SIZE, Math.round(width / ratio));
     }
 


### PR DESCRIPTION
Follow-up к #643 (мульти-ресайз картинок). Пост-коррекция высоты под урезанную лимитом редактора ширину применялась только к угловым маркерам (`handle.sx !== 0`), поэтому Shift у вертикальных маркеров (верх/низ) ломал пропорцию у края редактора. Сделал пересчёт симметричным для всех маркеров.

Замечание поднято при ревью #643; коммит не успел в squash-мерж (dev не protected, auto-merge схватил первый коммит до пуша фикса), выношу отдельным PR.

Проверка: vitest 30/30, eslint 0; функционально (Playwright-харнес) Shift+боковой маркер держит пропорцию 1.75 у границы.