### PR TITLE
feat(statistics): движок агрегатных отчётов POST /statistics/report (#632)

### DIFF
--- a/internal/handlers/statistics.go
+++ b/internal/handlers/statistics.go
@@ -181,6 +181,9 @@ func (h *StatisticsHandler) RunReport(c echo.Context) error {
 		// list-режим (выгрузка строк) добавляется отдельным срезом.
 		return echo.NewHTTPError(http.StatusBadRequest, "unsupported report mode")
 	}
+	if req.Metric == "" || req.Dimension == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "metric and dimension are required")
+	}
 
 	res, err := h.service.RunReport(c.Request().Context(), req)
 	if err != nil {

--- a/internal/handlers/statistics.go
+++ b/internal/handlers/statistics.go
@@ -1,10 +1,12 @@
 package handlers
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 	"time"
 
+	"systemburo/internal/models"
 	"systemburo/internal/services"
 
 	"github.com/labstack/echo/v4"
@@ -151,4 +153,42 @@ func (h *StatisticsHandler) GetMetrics(c echo.Context) error {
 		return err
 	}
 	return RespondSuccess(c, catalog)
+}
+
+// RunReport godoc
+// @Summary      Исполнение отчёта конструктора
+// @Description  Агрегатный отчёт: метрика x разрез x фильтры x период (mode=aggregate)
+// @Tags         statistics
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        request body models.ReportRequest true "Параметры отчёта"
+// @Success      200 {object} Response
+// @Failure      400 {object} models.HTTPError
+// @Failure      401 {object} models.HTTPError
+// @Failure      403 {object} models.HTTPError
+// @Router       /statistics/report [post]
+func (h *StatisticsHandler) RunReport(c echo.Context) error {
+	var req models.ReportRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
+	}
+
+	if req.Mode == "" {
+		req.Mode = "aggregate"
+	}
+	if req.Mode != "aggregate" {
+		// list-режим (выгрузка строк) добавляется отдельным срезом.
+		return echo.NewHTTPError(http.StatusBadRequest, "unsupported report mode")
+	}
+
+	res, err := h.service.RunReport(c.Request().Context(), req)
+	if err != nil {
+		if errors.Is(err, services.ErrInvalidReportRequest) {
+			// Не эхаем ввод: неизвестная метрика/разрез/фильтр -> generic 400.
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid report request")
+		}
+		return err
+	}
+	return RespondSuccess(c, res)
 }

--- a/internal/models/report.go
+++ b/internal/models/report.go
@@ -1,0 +1,40 @@
+package models
+
+// ReportFilterValue — одно применённое значение фильтра в запросе отчёта.
+// Для dict/enum-фильтров заполняется Values; для date_range — From/To (YYYY-MM-DD).
+type ReportFilterValue struct {
+	Key    string   `json:"key"`
+	Values []string `json:"values,omitempty"`
+	From   string   `json:"from,omitempty"`
+	To     string   `json:"to,omitempty"`
+}
+
+// ReportRequest — запрос конструктора отчётов (POST /statistics/report).
+// Mode=aggregate: Metric+Dimension обязательны (агрегатный разрез).
+// Mode=list: выгрузка строк сущности (Entity) — добавляется отдельным срезом.
+type ReportRequest struct {
+	Mode        string              `json:"mode"`
+	Metric      string              `json:"metric"`
+	Dimension   string              `json:"dimension"`
+	Granularity string              `json:"granularity"`
+	Entity      string              `json:"entity"`
+	Filters     []ReportFilterValue `json:"filters"`
+	Sort        string              `json:"sort"`
+	Limit       int                 `json:"limit"`
+}
+
+// ReportAggregateRow — строка агрегатного отчёта: бакет разреза + значение метрики.
+type ReportAggregateRow struct {
+	Label string `json:"label"`
+	Value int64  `json:"value"`
+}
+
+// ReportResponse — результат агрегатного отчёта: строки по разрезу и итог (сумма значений).
+type ReportResponse struct {
+	Mode      string               `json:"mode"`
+	Metric    string               `json:"metric,omitempty"`
+	Dimension string               `json:"dimension,omitempty"`
+	Unit      string               `json:"unit,omitempty"`
+	Rows      []ReportAggregateRow `json:"rows"`
+	Total     int64                `json:"total"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -589,5 +589,6 @@ func Setup(e *echo.Echo, d Dependencies) {
 		statsGroup.GET("/timeline", statistics.GetTimeline, requireStats)
 		statsGroup.GET("/recent-passages", statistics.GetRecentPassages, requireStats)
 		statsGroup.GET("/metrics", statistics.GetMetrics, requireStats)
+		statsGroup.POST("/report", statistics.RunReport, requireStats)
 	}
 }

--- a/internal/services/report_engine.go
+++ b/internal/services/report_engine.go
@@ -1,0 +1,390 @@
+package services
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"systemburo/internal/models"
+)
+
+// Движок исполнения агрегатных отчётов (B2). Метрики, разрезы и поля фильтров —
+// строго whitelist (схемы ниже): все SQL-фрагменты статические константы кода,
+// а пользовательский ввод сверяется по ключам карт и передаётся только через
+// плейсхолдеры (?). Конкатенации ввода в SQL нет. Допустимые разрезы метрики
+// дублируют каталог B1 (reportMetricRegistry.dimensions) — тест ловит расхождение.
+
+// ErrInvalidReportRequest — запрос отчёта не прошёл валидацию (неизвестная
+// метрика/разрез/фильтр и т.п.). Handler маппит в 400 без эха ввода.
+var ErrInvalidReportRequest = errors.New("invalid report request")
+
+func errInvalidReport(field string) error {
+	return fmt.Errorf("%w: %s", ErrInvalidReportRequest, field)
+}
+
+// joinKind — какой блок join'ов требуется разрезу/фильтру.
+type joinKind int
+
+const (
+	jNone   joinKind = iota // достаточно базовой таблицы
+	jChain                  // основной 1:1 join-блок метрики (org/company/...)
+	jAttach                 // отдельный join к вложениям (fan-out; только applications_count)
+)
+
+const (
+	sortValueDesc = "value_desc"
+	sortValueAsc  = "value_asc"
+	sortLabelAsc  = "label_asc"
+	sortLabelDesc = "label_desc"
+)
+
+const (
+	defaultReportLimit = 100
+	maxReportLimit     = 1000
+)
+
+// aggColumn — SQL-выражение разреза/фильтра и блок join'ов, нужный для доступа к нему.
+type aggColumn struct {
+	expr string
+	join joinKind
+}
+
+// aggMetricSchema — план сборки агрегатного запроса для одной метрики.
+// joinBlock — 1:1 LEFT JOIN'ы (не размножают строки, добавляются по требованию);
+// attachJoin — fan-out join к вложениям, поэтому applications_count считает
+// COUNT(DISTINCT app.id). period/hour_of_day строятся в коде по tsColumn.
+type aggMetricSchema struct {
+	base       string
+	aggExpr    string
+	baseWhere  string
+	tsColumn   string
+	tsJoin     joinKind
+	unit       string
+	joinBlock  []string
+	attachJoin []string
+	dims       map[string]aggColumn
+	filters    map[string]aggColumn
+}
+
+var aggMetricRegistry = map[string]aggMetricSchema{
+	"applications_count": {
+		base:     "applications app",
+		aggExpr:  "COUNT(DISTINCT app.id)",
+		tsColumn: "app.sending_datetime",
+		tsJoin:   jNone,
+		unit:     "шт",
+		joinBlock: []string{
+			"LEFT JOIN organizations org ON org.id = app.organization_id",
+			"LEFT JOIN companies comp ON comp.id = app.company_id",
+		},
+		attachJoin: []string{
+			"JOIN attachments att ON att.application_id = app.id",
+			"LEFT JOIN unique_attachments ua ON ua.id = att.unique_attachment_id",
+		},
+		dims: map[string]aggColumn{
+			"status":          {expr: "app.status", join: jNone},
+			"organization":    {expr: "COALESCE(org.name, '(без организации)')", join: jChain},
+			"company":         {expr: "COALESCE(comp.name, '(без компании)')", join: jChain},
+			"attachment_type": {expr: "COALESCE(ua.display_name, att.attachment_display_name, att.attachment_type)", join: jAttach},
+		},
+		filters: map[string]aggColumn{
+			"status":          {expr: "app.status", join: jNone},
+			"organization":    {expr: "org.name", join: jChain},
+			"company":         {expr: "comp.name", join: jChain},
+			"attachment_type": {expr: "COALESCE(ua.display_name, att.attachment_display_name, att.attachment_type)", join: jAttach},
+		},
+	},
+	"car_entries_count": {
+		base:      "cars_history ch",
+		aggExpr:   "COUNT(*)",
+		baseWhere: "ch.action_type = 'entry'",
+		tsColumn:  "ch.created_at",
+		tsJoin:    jNone,
+		unit:      "шт",
+		joinBlock: []string{
+			"JOIN cars c ON c.id = ch.car_id",
+			"LEFT JOIN attachments att ON att.id = c.attachment_id",
+			"LEFT JOIN applications app ON app.id = att.application_id",
+			"LEFT JOIN organizations org ON org.id = app.organization_id",
+			"LEFT JOIN companies comp ON comp.id = app.company_id",
+			"LEFT JOIN unique_attachments ua ON ua.id = att.unique_attachment_id",
+		},
+		dims: map[string]aggColumn{
+			"unload_place": {expr: "COALESCE(c.unload_place, '(не указано)')", join: jChain},
+			"organization": {expr: "COALESCE(org.name, comp.name, '(без организации)')", join: jChain},
+		},
+		filters: map[string]aggColumn{
+			"organization":    {expr: "org.name", join: jChain},
+			"company":         {expr: "comp.name", join: jChain},
+			"status":          {expr: "app.status", join: jChain},
+			"attachment_type": {expr: "COALESCE(ua.display_name, att.attachment_display_name, att.attachment_type)", join: jChain},
+			"unload_place":    {expr: "c.unload_place", join: jChain},
+		},
+	},
+	"people_entries_count": {
+		base:      "employees_history eh",
+		aggExpr:   "COUNT(*)",
+		baseWhere: "eh.action_type = 'entry'",
+		tsColumn:  "eh.created_at",
+		tsJoin:    jNone,
+		unit:      "шт",
+		joinBlock: []string{
+			"JOIN employees e ON e.id = eh.employee_id",
+			"LEFT JOIN citizenships cz ON cz.id = e.citizenship_id",
+			"LEFT JOIN attachments att ON att.id = e.attachment_id",
+			"LEFT JOIN applications app ON app.id = att.application_id",
+			"LEFT JOIN organizations org ON org.id = app.organization_id",
+			"LEFT JOIN companies comp ON comp.id = app.company_id",
+			"LEFT JOIN unique_attachments ua ON ua.id = att.unique_attachment_id",
+		},
+		dims: map[string]aggColumn{
+			"organization": {expr: "COALESCE(org.name, comp.name, '(без организации)')", join: jChain},
+		},
+		filters: map[string]aggColumn{
+			"organization":    {expr: "org.name", join: jChain},
+			"company":         {expr: "comp.name", join: jChain},
+			"status":          {expr: "app.status", join: jChain},
+			"attachment_type": {expr: "COALESCE(ua.display_name, att.attachment_display_name, att.attachment_type)", join: jChain},
+			"citizenship":     {expr: "cz.name", join: jChain},
+		},
+	},
+	"items_sum": {
+		base:     "items",
+		aggExpr:  "COALESCE(SUM(items.count), 0)",
+		tsColumn: "app.sending_datetime",
+		tsJoin:   jChain,
+		unit:     "шт",
+		joinBlock: []string{
+			"JOIN attachments att ON att.id = items.attachment_id",
+			"LEFT JOIN applications app ON app.id = att.application_id",
+			"LEFT JOIN organizations org ON org.id = app.organization_id",
+			"LEFT JOIN companies comp ON comp.id = app.company_id",
+		},
+		dims: map[string]aggColumn{
+			"organization": {expr: "COALESCE(org.name, '(без организации)')", join: jChain},
+			"company":      {expr: "COALESCE(comp.name, '(без компании)')", join: jChain},
+		},
+		filters: map[string]aggColumn{
+			"organization": {expr: "org.name", join: jChain},
+			"company":      {expr: "comp.name", join: jChain},
+		},
+	},
+}
+
+var aggGranularity = map[string]string{
+	"day":   "day",
+	"week":  "week",
+	"month": "month",
+}
+
+// whereClause — WHERE-фрагмент плана: выражение с плейсхолдерами и его аргументы.
+type whereClause struct {
+	expr string
+	args []any
+}
+
+// aggPlan — резолвленный план агрегатного запроса (только whitelist-выражения).
+type aggPlan struct {
+	table     string
+	selectStr string
+	joins     []string
+	wheres    []whereClause
+	groupExpr string
+	orderStr  string
+	limit     int
+	unit      string
+}
+
+// buildAggregatePlan собирает план агрегатного отчёта из whitelist-схем.
+// Чистая функция (без БД) — тестируется напрямую. Любой неизвестный/недоступный
+// для метрики разрез или фильтр -> ErrInvalidReportRequest.
+func buildAggregatePlan(req models.ReportRequest) (*aggPlan, error) {
+	schema, ok := aggMetricRegistry[req.Metric]
+	if !ok {
+		return nil, errInvalidReport("metric")
+	}
+	if req.Dimension == "" {
+		return nil, errInvalidReport("dimension")
+	}
+	// Разрез должен быть заявлен в каталоге B1 для этой метрики — единый источник
+	// правды для UI и движка.
+	if !contains(reportMetricRegistry[req.Metric].dimensions, req.Dimension) {
+		return nil, errInvalidReport("dimension")
+	}
+
+	groupExpr, labelExpr, dimJoin, err := resolveAggDimension(schema, req.Dimension, req.Granularity)
+	if err != nil {
+		return nil, err
+	}
+
+	var needChain, needAttach bool
+	addJoinNeed(dimJoin, &needChain, &needAttach)
+
+	plan := &aggPlan{
+		table:     schema.base,
+		selectStr: labelExpr + " AS label, " + schema.aggExpr + " AS value",
+		groupExpr: groupExpr,
+		unit:      schema.unit,
+	}
+	if schema.baseWhere != "" {
+		plan.wheres = append(plan.wheres, whereClause{expr: schema.baseWhere})
+	}
+
+	for _, f := range req.Filters {
+		wc, fjoin, ferr := resolveAggFilter(schema, f)
+		if ferr != nil {
+			return nil, ferr
+		}
+		if wc == nil { // пустой фильтр (нет значений/границ) — пропускаем
+			continue
+		}
+		plan.wheres = append(plan.wheres, *wc)
+		addJoinNeed(fjoin, &needChain, &needAttach)
+	}
+
+	if needChain {
+		plan.joins = append(plan.joins, schema.joinBlock...)
+	}
+	if needAttach {
+		plan.joins = append(plan.joins, schema.attachJoin...)
+	}
+
+	plan.orderStr = resolveAggOrder(req.Sort, req.Dimension, groupExpr, schema.aggExpr)
+	plan.limit = clampLimit(req.Limit)
+	return plan, nil
+}
+
+func addJoinNeed(jk joinKind, needChain, needAttach *bool) {
+	switch jk {
+	case jChain:
+		*needChain = true
+	case jAttach:
+		*needAttach = true
+	}
+}
+
+// resolveAggDimension возвращает GROUP BY-выражение, выражение подписи и нужный
+// join. period/hour_of_day строятся по tsColumn метрики; остальные — из карты dims.
+func resolveAggDimension(s aggMetricSchema, dim, granularity string) (group, label string, jk joinKind, err error) {
+	switch dim {
+	case "period":
+		unit := "day"
+		if granularity != "" {
+			u, ok := aggGranularity[granularity]
+			if !ok {
+				return "", "", jNone, errInvalidReport("granularity")
+			}
+			unit = u
+		}
+		group = fmt.Sprintf("date_trunc('%s', %s)", unit, s.tsColumn)
+		label = fmt.Sprintf("to_char(%s, 'YYYY-MM-DD')", group)
+		return group, label, s.tsJoin, nil
+	case "hour_of_day":
+		group = fmt.Sprintf("(EXTRACT(HOUR FROM %s))::int", s.tsColumn)
+		label = group + "::text"
+		return group, label, s.tsJoin, nil
+	default:
+		col, ok := s.dims[dim]
+		if !ok {
+			return "", "", jNone, errInvalidReport("dimension")
+		}
+		return col.expr, col.expr, col.join, nil
+	}
+}
+
+// resolveAggFilter превращает поле фильтра в WHERE-фрагмент. Возвращает nil без
+// ошибки, если фильтр пустой (нет значений/границ) — такой фильтр не применяется.
+func resolveAggFilter(s aggMetricSchema, f models.ReportFilterValue) (*whereClause, joinKind, error) {
+	if f.Key == "date_range" {
+		var parts []string
+		var args []any
+		if t, ok := parseReportDate(f.From, false); ok {
+			parts = append(parts, s.tsColumn+" >= ?")
+			args = append(args, t)
+		}
+		if t, ok := parseReportDate(f.To, true); ok {
+			parts = append(parts, s.tsColumn+" <= ?")
+			args = append(args, t)
+		}
+		if len(parts) == 0 {
+			return nil, jNone, nil
+		}
+		return &whereClause{expr: strings.Join(parts, " AND "), args: args}, s.tsJoin, nil
+	}
+
+	col, ok := s.filters[f.Key]
+	if !ok {
+		return nil, jNone, errInvalidReport("filter")
+	}
+	vals := nonEmpty(f.Values)
+	if len(vals) == 0 {
+		return nil, jNone, nil
+	}
+	return &whereClause{expr: col.expr + " IN ?", args: []any{vals}}, col.join, nil
+}
+
+// resolveAggOrder выбирает ORDER BY из whitelist. По умолчанию временные разрезы
+// (period/hour_of_day) сортируются хронологически, категориальные — по убыванию
+// значения. Неизвестный sort трактуется как дефолт (значения только из констант,
+// ввод не подставляется).
+func resolveAggOrder(sort, dim, groupExpr, aggExpr string) string {
+	switch sort {
+	case sortValueDesc:
+		return aggExpr + " DESC"
+	case sortValueAsc:
+		return aggExpr + " ASC"
+	case sortLabelAsc:
+		return groupExpr + " ASC"
+	case sortLabelDesc:
+		return groupExpr + " DESC"
+	}
+	if dim == "period" || dim == "hour_of_day" {
+		return groupExpr + " ASC"
+	}
+	return aggExpr + " DESC"
+}
+
+func clampLimit(limit int) int {
+	if limit <= 0 {
+		return defaultReportLimit
+	}
+	if limit > maxReportLimit {
+		return maxReportLimit
+	}
+	return limit
+}
+
+// parseReportDate парсит YYYY-MM-DD в UTC. endOfDay=true -> 23:59:59 (для верхней границы).
+func parseReportDate(s string, endOfDay bool) (time.Time, bool) {
+	if s == "" {
+		return time.Time{}, false
+	}
+	t, err := time.ParseInLocation("2006-01-02", s, time.UTC)
+	if err != nil {
+		return time.Time{}, false
+	}
+	if endOfDay {
+		return time.Date(t.Year(), t.Month(), t.Day(), 23, 59, 59, 0, time.UTC), true
+	}
+	return t, true
+}
+
+func nonEmpty(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+func contains(list []string, v string) bool {
+	for _, s := range list {
+		if s == v {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/services/report_engine_test.go
+++ b/internal/services/report_engine_test.go
@@ -173,6 +173,35 @@ func TestAggregatePlan_ItemsSumAlwaysJoins(t *testing.T) {
 	}
 }
 
+func TestAggregatePlan_ItemsSumDateRangeFilterJoins(t *testing.T) {
+	// items_sum: tsColumn=app.sending_datetime лежит за join'ом. Фильтр date_range
+	// должен тянуть joinBlock через свой tsJoin даже без разреза period.
+	req := models.ReportRequest{
+		Metric:    "items_sum",
+		Dimension: "organization",
+		Filters: []models.ReportFilterValue{
+			{Key: "date_range", From: "2026-06-01", To: "2026-06-17"},
+		},
+	}
+	plan, err := buildAggregatePlan(req)
+	if err != nil {
+		t.Fatalf("неожиданная ошибка: %v", err)
+	}
+	joined := strings.Join(plan.joins, " ")
+	if !strings.Contains(joined, "applications app") {
+		t.Errorf("date_range фильтр items_sum должен тянуть join к applications, got %v", plan.joins)
+	}
+	var hasRange bool
+	for _, w := range plan.wheres {
+		if strings.Contains(w.expr, "app.sending_datetime >= ?") {
+			hasRange = true
+		}
+	}
+	if !hasRange {
+		t.Errorf("date_range по app.sending_datetime не попал в where: %+v", plan.wheres)
+	}
+}
+
 func TestAggregatePlan_RejectsInvalid(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/services/report_engine_test.go
+++ b/internal/services/report_engine_test.go
@@ -1,0 +1,237 @@
+package services
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"systemburo/internal/models"
+)
+
+// TestAggregateEngine_CoversCatalogDimensions гарантирует, что движок умеет
+// собрать план для КАЖДОГО разреза, заявленного каталогом B1 для метрики.
+// Иначе UI предложит комбинацию, которая упадёт 500 на исполнении.
+func TestAggregateEngine_CoversCatalogDimensions(t *testing.T) {
+	for _, metric := range reportMetricOrder {
+		for _, dim := range reportMetricRegistry[metric].dimensions {
+			req := models.ReportRequest{Metric: metric, Dimension: dim}
+			plan, err := buildAggregatePlan(req)
+			if err != nil {
+				t.Errorf("metric %q dim %q: движок не собрал план: %v", metric, dim, err)
+				continue
+			}
+			if plan.groupExpr == "" || plan.selectStr == "" {
+				t.Errorf("metric %q dim %q: пустой groupExpr/selectStr", metric, dim)
+			}
+			if !strings.Contains(plan.selectStr, "AS label") || !strings.Contains(plan.selectStr, "AS value") {
+				t.Errorf("metric %q dim %q: некорректный select %q", metric, dim, plan.selectStr)
+			}
+		}
+	}
+}
+
+// TestAggregateEngine_AggExprMatchesCatalog сверяет источники агрегата: каждая
+// метрика каталога (B1) должна иметь схему исполнения (B2) и наоборот.
+func TestAggregateEngine_AggExprMatchesCatalog(t *testing.T) {
+	for _, metric := range reportMetricOrder {
+		if _, ok := aggMetricRegistry[metric]; !ok {
+			t.Errorf("метрика каталога %q без схемы исполнения", metric)
+		}
+	}
+	for metric := range aggMetricRegistry {
+		if _, ok := reportMetricRegistry[metric]; !ok {
+			t.Errorf("схема исполнения %q без метрики в каталоге", metric)
+		}
+	}
+}
+
+func TestAggregatePlan_FiltersAndJoins(t *testing.T) {
+	req := models.ReportRequest{
+		Metric:    "applications_count",
+		Dimension: "organization",
+		Filters: []models.ReportFilterValue{
+			{Key: "status", Values: []string{models.StatusCompleted, models.StatusInWork}},
+		},
+	}
+	plan, err := buildAggregatePlan(req)
+	if err != nil {
+		t.Fatalf("неожиданная ошибка: %v", err)
+	}
+
+	// dim organization -> joinBlock (org/comp) добавлен.
+	joined := strings.Join(plan.joins, " ")
+	if !strings.Contains(joined, "organizations org") || !strings.Contains(joined, "companies comp") {
+		t.Errorf("ожидался join org/company, got %v", plan.joins)
+	}
+	// attachments join НЕ нужен (ни разрез, ни фильтр его не требуют).
+	if strings.Contains(joined, "attachments att") {
+		t.Errorf("лишний join вложений: %v", plan.joins)
+	}
+	// фильтр статуса -> WHERE app.status IN c аргументом-срезом.
+	var found bool
+	for _, w := range plan.wheres {
+		if strings.Contains(w.expr, "app.status IN") {
+			found = true
+			if len(w.args) != 1 {
+				t.Errorf("ожидался 1 аргумент-срез, got %v", w.args)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("фильтр status не попал в where: %+v", plan.wheres)
+	}
+	// COUNT(DISTINCT app.id) защищает от двойного счёта при join'ах.
+	if !strings.Contains(plan.selectStr, "COUNT(DISTINCT app.id)") {
+		t.Errorf("ожидался COUNT(DISTINCT app.id), got %q", plan.selectStr)
+	}
+}
+
+func TestAggregatePlan_AttachmentTypeNeedsAttachJoin(t *testing.T) {
+	req := models.ReportRequest{Metric: "applications_count", Dimension: "attachment_type"}
+	plan, err := buildAggregatePlan(req)
+	if err != nil {
+		t.Fatalf("неожиданная ошибка: %v", err)
+	}
+	joined := strings.Join(plan.joins, " ")
+	if !strings.Contains(joined, "attachments att") || !strings.Contains(joined, "unique_attachments ua") {
+		t.Errorf("ожидался attach-join, got %v", plan.joins)
+	}
+	// org/company join не нужен для одного только attachment_type.
+	if strings.Contains(joined, "organizations org") {
+		t.Errorf("лишний join org: %v", plan.joins)
+	}
+}
+
+func TestAggregatePlan_PeriodAndDateRange(t *testing.T) {
+	req := models.ReportRequest{
+		Metric:      "car_entries_count",
+		Dimension:   "period",
+		Granularity: "week",
+		Filters: []models.ReportFilterValue{
+			{Key: "date_range", From: "2026-06-01", To: "2026-06-17"},
+		},
+	}
+	plan, err := buildAggregatePlan(req)
+	if err != nil {
+		t.Fatalf("неожиданная ошибка: %v", err)
+	}
+	if !strings.Contains(plan.groupExpr, "date_trunc('week', ch.created_at)") {
+		t.Errorf("ожидался date_trunc week, got %q", plan.groupExpr)
+	}
+	// baseWhere метрики (entry) присутствует.
+	var hasBase, hasFrom, hasTo bool
+	for _, w := range plan.wheres {
+		if strings.Contains(w.expr, "ch.action_type = 'entry'") {
+			hasBase = true
+		}
+		if strings.Contains(w.expr, "ch.created_at >= ?") {
+			hasFrom = true
+		}
+		if strings.Contains(w.expr, "ch.created_at <= ?") {
+			hasTo = true
+		}
+	}
+	if !hasBase || !hasFrom || !hasTo {
+		t.Errorf("base/from/to: %v/%v/%v wheres=%+v", hasBase, hasFrom, hasTo, plan.wheres)
+	}
+	// период по умолчанию сортируется хронологически (по groupExpr ASC).
+	if !strings.HasSuffix(plan.orderStr, "ASC") || !strings.Contains(plan.orderStr, "date_trunc") {
+		t.Errorf("ожидалась хронологическая сортировка, got %q", plan.orderStr)
+	}
+	// period без фильтров/разрезов с join не требует join'ов (ts на базовой таблице).
+	if len(plan.joins) != 0 {
+		t.Errorf("для car period join не нужен, got %v", plan.joins)
+	}
+}
+
+func TestAggregatePlan_HourOfDayAndValueSort(t *testing.T) {
+	req := models.ReportRequest{Metric: "people_entries_count", Dimension: "hour_of_day", Sort: sortValueDesc}
+	plan, err := buildAggregatePlan(req)
+	if err != nil {
+		t.Fatalf("неожиданная ошибка: %v", err)
+	}
+	if !strings.Contains(plan.groupExpr, "EXTRACT(HOUR FROM eh.created_at)") {
+		t.Errorf("ожидался EXTRACT HOUR, got %q", plan.groupExpr)
+	}
+	if plan.orderStr != "COUNT(*) DESC" {
+		t.Errorf("ожидался ORDER BY COUNT(*) DESC, got %q", plan.orderStr)
+	}
+}
+
+func TestAggregatePlan_ItemsSumAlwaysJoins(t *testing.T) {
+	req := models.ReportRequest{Metric: "items_sum", Dimension: "period"}
+	plan, err := buildAggregatePlan(req)
+	if err != nil {
+		t.Fatalf("неожиданная ошибка: %v", err)
+	}
+	// tsColumn items_sum (app.sending_datetime) лежит за join'ом -> join обязателен.
+	if len(plan.joins) == 0 || !strings.Contains(strings.Join(plan.joins, " "), "applications app") {
+		t.Errorf("items_sum period требует join к applications, got %v", plan.joins)
+	}
+	if !strings.Contains(plan.selectStr, "SUM(items.count)") {
+		t.Errorf("ожидался SUM(items.count), got %q", plan.selectStr)
+	}
+}
+
+func TestAggregatePlan_RejectsInvalid(t *testing.T) {
+	cases := []struct {
+		name string
+		req  models.ReportRequest
+	}{
+		{"unknown metric", models.ReportRequest{Metric: "nope", Dimension: "status"}},
+		{"empty dimension", models.ReportRequest{Metric: "applications_count"}},
+		{"dimension not in catalog", models.ReportRequest{Metric: "applications_count", Dimension: "hour_of_day"}},
+		{"unknown filter", models.ReportRequest{Metric: "applications_count", Dimension: "status",
+			Filters: []models.ReportFilterValue{{Key: "citizenship", Values: []string{"РФ"}}}}},
+		{"unreachable filter", models.ReportRequest{Metric: "items_sum", Dimension: "organization",
+			Filters: []models.ReportFilterValue{{Key: "status", Values: []string{models.StatusCompleted}}}}},
+		{"bad granularity", models.ReportRequest{Metric: "applications_count", Dimension: "period", Granularity: "year"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := buildAggregatePlan(tc.req)
+			if err == nil {
+				t.Fatalf("ожидалась ошибка валидации")
+			}
+			if !errors.Is(err, ErrInvalidReportRequest) {
+				t.Errorf("ожидался ErrInvalidReportRequest, got %v", err)
+			}
+		})
+	}
+}
+
+func TestAggregatePlan_EmptyFilterSkipped(t *testing.T) {
+	req := models.ReportRequest{
+		Metric:    "applications_count",
+		Dimension: "status",
+		Filters: []models.ReportFilterValue{
+			{Key: "organization", Values: []string{"", "  "}}, // только пустые -> пропустить
+			{Key: "date_range"}, // без границ -> пропустить
+		},
+	}
+	plan, err := buildAggregatePlan(req)
+	if err != nil {
+		t.Fatalf("неожиданная ошибка: %v", err)
+	}
+	// пустые фильтры не дают ни WHERE, ни join'ов.
+	if len(plan.wheres) != 0 {
+		t.Errorf("пустые фильтры не должны давать WHERE: %+v", plan.wheres)
+	}
+	if len(plan.joins) != 0 {
+		t.Errorf("пустые фильтры не должны тянуть join'ы: %v", plan.joins)
+	}
+}
+
+func TestClampLimit(t *testing.T) {
+	cases := []struct{ in, want int }{
+		{0, defaultReportLimit},
+		{-5, defaultReportLimit},
+		{50, 50},
+		{maxReportLimit + 1, maxReportLimit},
+	}
+	for _, c := range cases {
+		if got := clampLimit(c.in); got != c.want {
+			t.Errorf("clampLimit(%d) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/services/statistics_service.go
+++ b/internal/services/statistics_service.go
@@ -16,6 +16,7 @@ type StatisticsService interface {
 	GetTimeline(ctx context.Context, from, to time.Time, metric, granularity string) ([]models.StatsTimelinePoint, error)
 	GetRecentPassages(ctx context.Context, limit int) (*models.RecentPassages, error)
 	GetReportCatalog(ctx context.Context) (*models.ReportCatalog, error)
+	RunReport(ctx context.Context, req models.ReportRequest) (*models.ReportResponse, error)
 }
 
 type statisticsService struct {
@@ -228,9 +229,9 @@ type timelineSource struct {
 // Вынесена отдельно для тестируемости без БД.
 func resolveTimelineSource(metric, granularity string) (src timelineSource, unit string, err error) {
 	metricMap := map[string]timelineSource{
-		"applications":    {table: "applications", tsColumn: "sending_datetime", filter: ""},
-		"car_entries":     {table: "cars_history", tsColumn: "created_at", filter: "action_type='entry'"},
-		"people_entries":  {table: "employees_history", tsColumn: "created_at", filter: "action_type='entry'"},
+		"applications":   {table: "applications", tsColumn: "sending_datetime", filter: ""},
+		"car_entries":    {table: "cars_history", tsColumn: "created_at", filter: "action_type='entry'"},
+		"people_entries": {table: "employees_history", tsColumn: "created_at", filter: "action_type='entry'"},
 	}
 	granularityMap := map[string]string{
 		"day":   "day",
@@ -372,7 +373,7 @@ func (s *statisticsService) loadDynamicReportOptions(ctx context.Context) (dynam
 		if where != "" {
 			tx = tx.Where(where)
 		}
-		if err := tx.Order(column + " ASC").Pluck(column, &names).Error; err != nil {
+		if err := tx.Order(column+" ASC").Pluck(column, &names).Error; err != nil {
 			return nil, fmt.Errorf("statistics: report catalog %s: %w", name, err)
 		}
 		opts := make([]models.ReportOption, 0, len(names))
@@ -400,4 +401,46 @@ func (s *statisticsService) loadDynamicReportOptions(ctx context.Context) (dynam
 	}
 
 	return dyn, nil
+}
+
+// RunReport исполняет агрегатный отчёт конструктора (mode=aggregate): метрика x
+// разрез x фильтры x период x sort/limit. План собирается чистой buildAggregatePlan
+// из whitelist-схем (report_engine.go) — ввод сверяется по ключам и подставляется
+// только через плейсхолдеры. Невалидный запрос -> ErrInvalidReportRequest (400 в handler).
+func (s *statisticsService) RunReport(ctx context.Context, req models.ReportRequest) (*models.ReportResponse, error) {
+	plan, err := buildAggregatePlan(req)
+	if err != nil {
+		return nil, err
+	}
+
+	tx := s.db.WithContext(ctx).Table(plan.table).Select(plan.selectStr)
+	for _, j := range plan.joins {
+		tx = tx.Joins(j)
+	}
+	for _, w := range plan.wheres {
+		tx = tx.Where(w.expr, w.args...)
+	}
+
+	rows := make([]models.ReportAggregateRow, 0)
+	if err := tx.
+		Group(plan.groupExpr).
+		Order(plan.orderStr).
+		Limit(plan.limit).
+		Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf("statistics: run report: %w", err)
+	}
+
+	var total int64
+	for _, r := range rows {
+		total += r.Value
+	}
+
+	return &models.ReportResponse{
+		Mode:      "aggregate",
+		Metric:    req.Metric,
+		Dimension: req.Dimension,
+		Unit:      plan.unit,
+		Rows:      rows,
+		Total:     total,
+	}, nil
 }


### PR DESCRIPTION
Срез **B2a** эпика 37-analytics (#632). Исполнитель отчётов конструктора в режиме `aggregate`.

## Что добавлено
- `POST /statistics/report` (group `/statistics`, право `page.statistics`).
- Движок `aggregate`: метрика x разрез x фильтры x период x sort/limit, `hour_of_day`, join машина->место.
- Метрики: `applications_count`, `car_entries_count`, `people_entries_count`, `items_sum` (источник — whitelist-схемы `report_engine.go`).
- Разрезы и фильтры строго ограничены каталогом B1 (`reportMetricRegistry.dimensions`); тест ловит расхождение каталог<->движок.

## Безопасность SQL
Все SQL-фрагменты — статические константы кода. Пользовательский ввод (метрика/разрез/фильтр/гранулярность/сорт) сверяется по ключам whitelist-карт; значения фильтров и границы дат идут только через плейсхолдеры (`IN ?`, `BETWEEN`). Конкатенации ввода в SQL нет. Невалидный запрос -> `ErrInvalidReportRequest` -> 400 без эха ввода.

## Решения
- **`applications_count` = `COUNT(DISTINCT app.id)`** — fan-out join к вложениям (разрез/фильтр `attachment_type`) не задваивает заявки.
- **Разрез `unload_place` для машин — денормализованная `cars.unload_place`**, не `car_unload_places` (одна машина может иметь несколько мест -> fan-out задвоил бы въезды). Сверено на сиде: сумма по местам = общему числу въездов (9=9).
- 1:1 LEFT JOIN-блоки метрики добавляются только когда разрез/фильтр их требует.

## Проверено
- `go build` + `go vet` + `gofmt` чисто; план-тесты (`report_engine_test.go`) зелёные: покрытие каталог-разрезов, join'ов, period/date_range, hour_of_day, валидации, clampLimit.
- **Реальное исполнение против БД с сидом: 18/18 OK** — все 4 метрики x заявленные разрезы + комбинации фильтров (status/date_range/organization/attachment_type/unload_place/citizenship) исполняются без SQL-ошибок.

## Вне scope
List-режим (выгрузка строк сущностей: `work_applications`/applications/cars/people с пер-сущностными колонками) — отдельный срез **B2b** (`mode=list` пока отдаёт 400).