### PR TITLE
fix(analytics): марка в ленте машин, скруглил номер, убрал лишние плитки дашборда (#632)

### DIFF
--- a/frontend/src/components/statistics/StatisticsDashboard.vue
+++ b/frontend/src/components/statistics/StatisticsDashboard.vue
@@ -14,7 +14,7 @@
         class="dashboard__tiles"
       >
         <div
-          v-for="n in 10"
+          v-for="n in 9"
           :key="n"
           class="dashboard__tile dashboard__tile--skeleton"
         />
@@ -55,10 +55,6 @@
           <div class="dashboard__tile-val">{{ fmt(summary.cars_entered) }}</div>
         </div>
         <div class="dashboard__tile">
-          <div class="dashboard__tile-label">Среднее машин / день</div>
-          <div class="dashboard__tile-val">{{ fmtAvg(summary.avg_cars_per_day) }}</div>
-        </div>
-        <div class="dashboard__tile">
           <div class="dashboard__tile-label">Людей прошло</div>
           <div class="dashboard__tile-val">{{ fmt(summary.people_entered) }}</div>
         </div>
@@ -90,7 +86,7 @@
         class="dashboard__tiles"
       >
         <div
-          v-for="n in 9"
+          v-for="n in 4"
           :key="n"
           class="dashboard__tile dashboard__tile--skeleton"
         />
@@ -115,26 +111,6 @@
         <div class="dashboard__tile">
           <div class="dashboard__tile-label">Открытых обращений</div>
           <div class="dashboard__tile-val">{{ fmt(summary.open_feedback) }}</div>
-        </div>
-        <div class="dashboard__tile">
-          <div class="dashboard__tile-label">Активных мест разгрузки</div>
-          <div class="dashboard__tile-val">{{ fmt(summary.active_unload_places) }}</div>
-        </div>
-        <div class="dashboard__tile">
-          <div class="dashboard__tile-label">ЧС: машины</div>
-          <div class="dashboard__tile-val">{{ fmt(summary.blacklist_cars) }}</div>
-        </div>
-        <div class="dashboard__tile">
-          <div class="dashboard__tile-label">ЧС: люди</div>
-          <div class="dashboard__tile-val">{{ fmt(summary.blacklist_people) }}</div>
-        </div>
-        <div class="dashboard__tile">
-          <div class="dashboard__tile-label">Уникальных машин</div>
-          <div class="dashboard__tile-val">{{ fmt(summary.unique_cars) }}</div>
-        </div>
-        <div class="dashboard__tile">
-          <div class="dashboard__tile-label">Уникальных людей</div>
-          <div class="dashboard__tile-val">{{ fmt(summary.unique_people) }}</div>
         </div>
       </div>
     </div>
@@ -364,11 +340,6 @@ const attachmentBreakdown = computed(() => {
 function fmt(val) {
   if (val == null) return '—';
   return Number(val).toLocaleString('ru-RU');
-}
-
-function fmtAvg(val) {
-  if (val == null) return '—';
-  return Math.round(Number(val)).toLocaleString('ru-RU');
 }
 
 function formatTime(iso) {
@@ -810,7 +781,7 @@ onUnmounted(() => {
   min-width: 64px;
   padding: 3px 8px;
   border: 2px solid var(--color-text);
-  border-radius: 4px;
+  border-radius: 6px;
   font-size: 11px;
   font-weight: 700;
   color: var(--color-text);

--- a/internal/services/statistics_service.go
+++ b/internal/services/statistics_service.go
@@ -332,7 +332,8 @@ func (s *statisticsService) GetRecentPassages(ctx context.Context, limit int) (*
 		Where("ch.action_type IN ?", []string{"entry", "exit"}).
 		Select("ch.action_type AS action_type, ch.created_at AS created_at, " +
 			"c.car_number AS subject, " +
-			"COALESCE(c.mark_name, '') AS mark, " +
+			// mark_name - актуальное поле, car_brand - устаревший fallback (как в trash/blacklist).
+			"COALESCE(NULLIF(c.mark_name, ''), c.car_brand, '') AS mark, " +
 			"COALESCE(org.name, comp.name, '') AS organization, " +
 			"COALESCE(st.display_name, '') AS place").
 		Order("ch.created_at DESC").


### PR DESCRIPTION
Раунд правок дашборда «Аналитика» по фидбэку владельца (эпик 37-analytics #632, поверх смерженного A2).

## Правки
- **Лента «Проезд машин»: марка теперь видна.** Запрос `recent-passages` читал только `cars.mark_name`, который пуст у большинства машин (марка хранится в устаревшем `car_brand`: Toyota Camry, Kamaz 65117...). Добавил fallback `COALESCE(NULLIF(mark_name,''), car_brand, '')` - ровно как уже сделано в `trash_service`/`vehicle_blacklist_service`. Проверено на БД: марки отдаются.
- **Номерной знак чуть скруглил** (`border-radius` 4px -> 6px).
- **Убрал плитки** (по просьбе владельца): «Среднее машин / день» (группа Данные); «Активных мест разгрузки», «ЧС: машины», «ЧС: люди», «Уникальных машин», «Уникальных людей» (группа Система). Поправил счётчики скелетонов (Данные 10->9, Система 9->4) и удалил осиротевший хелпер `fmtAvg`.

Бэкенд `StatsSummary` поля не трогал (считаются, просто не выводятся) - минимальный дифф.

## Проверено
- BE `go build`/`vet`/`gofmt` чисто; SQL fallback марки выверен прямым запросом к БД (отдаёт Toyota Camry / Kamaz 65117).
- FE: грепом подтверждено отсутствие ссылок на удалённые поля/`fmtAvg`, плиток ровно 13 (Данные 9 + Система 4), марка `row.mark` рендерится, плитка номера 6px.
- Финальная визуальная проверка - на staging после деплоя.