### PR TITLE
feat(applications): вернул rich-text сопроводительного письма (#46)

### DIFF
--- a/frontend/src/components/ApplicationDetail/ApplicationDetail.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationDetail.vue
@@ -108,11 +108,57 @@
         <div class="detail-main-column">
           <!-- Сообщение заявки -->
           <div class="message-section">
-            <h4>Сообщение к заявке {{ applicationData.application_number }}</h4>
-            <div class="message-content">
-              {{ applicationData.message || 'Сообщение отсутствует' }}
+            <div class="message-section-header">
+              <h4>Сообщение к заявке {{ applicationData.application_number }}</h4>
+              <button
+                v-if="hasMessage"
+                type="button"
+                class="lk-button lk-button--secondary message-open-btn"
+                @click="showMessageModal = true"
+              >
+                <svg
+                  width="15"
+                  height="15"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                  <polyline points="15 3 21 3 21 9" />
+                  <line
+                    x1="10"
+                    y1="14"
+                    x2="21"
+                    y2="3"
+                  />
+                </svg>
+                Открыть в окне
+              </button>
+            </div>
+            <div
+              v-if="hasMessage"
+              ref="messagePreview"
+              class="message-content text-constructor-content message-preview"
+              :class="{ 'is-clamped': messageClamped }"
+              v-html="sanitizedMessage"
+            />
+            <div
+              v-else
+              class="message-content message-empty"
+            >
+              Сообщение отсутствует
             </div>
           </div>
+
+          <ApplicationMessageModal
+            :show="showMessageModal"
+            :message="applicationData.message || ''"
+            :application-number="applicationData.application_number"
+            @close="showMessageModal = false"
+          />
 
           <!-- Детали выбранного вложения -->
           <ApplicationAttachmentDetail
@@ -355,6 +401,8 @@ import BlacklistOverrideModal from './BlacklistOverrideModal.vue'
 import VehicleDetailsModal from '../CreateApplication/VehicleDetailsModal.vue'
 import EmployeeDetailsModal from '../CreateApplication/EmployeeDetailsModal.vue'
 import Badge from '@/components/ui/Badge.vue'
+import { sanitizeHtml } from '@/utils/sanitize'
+import ApplicationMessageModal from './ApplicationMessageModal.vue'
 
 export default {
     name: 'ApplicationDetail',
@@ -368,7 +416,8 @@ export default {
         BlacklistOverrideModal,
         VehicleDetailsModal,
         EmployeeDetailsModal,
-        Badge
+        Badge,
+        ApplicationMessageModal
     },
     props: {
         application: {
@@ -392,6 +441,8 @@ export default {
     data() {
         return {
             applicationData: { ...this.application },
+            showMessageModal: false,
+            messageClamped: false,
             attachments: [],
             selectedAttachment: null,
             attachmentCars: [],
@@ -430,6 +481,16 @@ export default {
         }
     },
     computed: {
+        hasMessage() {
+            const m = this.applicationData?.message;
+            if (!m) return false;
+            return m.includes('<img') || m.replace(/<[^>]*>/g, '').trim().length > 0;
+        },
+
+        sanitizedMessage() {
+            return this.applicationData?.message ? sanitizeHtml(this.applicationData.message) : '';
+        },
+
         isResponsibleUser() {
             if (!this.currentUserId || !this.responsibleUsers.length) return false;
             return this.responsibleUsers.some(user => user.id === this.currentUserId);
@@ -499,6 +560,7 @@ export default {
             handler(newApplication, oldApplication) {
                 if (newApplication && newApplication.id) {
                     this.applicationData = { ...newApplication };
+                    this.showMessageModal = false;
                     this.storageKey = `app_comment_${this.currentUserId}_${newApplication.id}`;
                     this.loadCommentFromLocalStorage();
                     this.loadApplicationDetails(newApplication);
@@ -508,12 +570,21 @@ export default {
                 }
             },
             deep: true
+        },
+        sanitizedMessage() {
+            this.$nextTick(() => this.updateMessageClamp());
         }
     },
     mounted() {
         this.loadCommonData();
+        this.$nextTick(() => this.updateMessageClamp());
     },
     methods: {
+        updateMessageClamp() {
+            const el = this.$refs.messagePreview;
+            this.messageClamped = !!el && el.scrollHeight > el.clientHeight + 2;
+        },
+
         handleActionCompleted({ success, message, type }) {
             this.showNotification(message, type || (success ? 'success' : 'error'));
             if (success) {
@@ -1515,19 +1586,98 @@ export default {
     box-shadow: 0 2px 12px rgba(0, 0, 0, 0.06);
 }
 
+.message-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    margin-bottom: 8px;
+}
+
 .message-section h4 {
+    margin: 0;
     font-size: 14px;
     color: #a2a2a2;
-    padding-bottom: 5px;
     font-weight: 400;
+}
+
+.message-open-btn {
+    flex-shrink: 0;
 }
 
 .message-content {
     font-size: 15px;
     line-height: 150%;
     color: #000;
-    white-space: pre-wrap;
 }
+
+.message-empty {
+    white-space: pre-wrap;
+    color: #a2a2a2;
+}
+
+.message-preview {
+    position: relative;
+    max-height: 150px;
+    overflow: hidden;
+    word-break: break-word;
+}
+
+.message-preview.is-clamped::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 46px;
+    background: linear-gradient(to bottom, rgba(255, 255, 255, 0), #fff);
+    pointer-events: none;
+}
+
+.message-preview :deep(img) {
+    max-width: 100%;
+    height: auto;
+}
+
+.message-preview :deep(p) { margin: 4px 0; }
+
+.message-preview :deep(ul),
+.message-preview :deep(ol) {
+    padding-left: 22px;
+    margin: 6px 0;
+}
+
+.message-preview :deep(strong) { font-weight: 700; }
+.message-preview :deep(em) { font-style: italic; }
+.message-preview :deep(u) { text-decoration: underline; }
+
+.message-preview :deep(h1),
+.message-preview :deep(.heading-h1) { font-size: 20px; font-weight: 700; margin: 6px 0; }
+
+.message-preview :deep(h2),
+.message-preview :deep(.heading-h2) { font-size: 17px; font-weight: 600; margin: 6px 0; }
+
+.message-preview :deep(.black-text) { color: #000 !important; }
+.message-preview :deep(.red-text) { color: #FF0000 !important; }
+.message-preview :deep(.green-text) { color: #079D1D !important; }
+.message-preview :deep(.blue-text) { color: #4F5BDF !important; }
+
+.message-preview :deep(.font-size-10) { font-size: 10px !important; }
+.message-preview :deep(.font-size-12) { font-size: 12px !important; }
+.message-preview :deep(.font-size-14) { font-size: 14px !important; }
+.message-preview :deep(.font-size-16) { font-size: 16px !important; }
+.message-preview :deep(.font-size-18) { font-size: 18px !important; }
+.message-preview :deep(.font-size-20) { font-size: 20px !important; }
+
+.message-preview :deep(.font-weight-300) { font-weight: 300 !important; }
+.message-preview :deep(.font-weight-400) { font-weight: 400 !important; }
+.message-preview :deep(.font-weight-500) { font-weight: 500 !important; }
+.message-preview :deep(.font-weight-600) { font-weight: 600 !important; }
+.message-preview :deep(.font-weight-900) { font-weight: 900 !important; }
+
+.message-preview :deep(.text-align-left) { text-align: left !important; }
+.message-preview :deep(.text-align-center) { text-align: center !important; }
+.message-preview :deep(.text-align-right) { text-align: right !important; }
 
 .basic-info-section {
     background: white;

--- a/frontend/src/components/ApplicationDetail/ApplicationMessageModal.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationMessageModal.vue
@@ -1,0 +1,240 @@
+<template>
+  <Teleport to="body">
+    <transition
+      name="modal-fade"
+      @after-leave="onAfterLeave"
+    >
+      <div
+        v-if="visible"
+        class="modal-overlay"
+        @mousedown="onOverlayMousedown"
+        @mouseup="onOverlayMouseup"
+      >
+        <div
+          class="message-modal"
+          @mousedown.stop
+        >
+          <div class="modal-header">
+            <h3>Сообщение к заявке {{ applicationNumber }}</h3>
+            <button
+              class="modal-close"
+              @click="requestClose"
+            >
+              ×
+            </button>
+          </div>
+          <div class="modal-content">
+            <div
+              class="text-constructor-content"
+              v-html="sanitizedMessage"
+            />
+          </div>
+        </div>
+      </div>
+    </transition>
+  </Teleport>
+</template>
+
+<script setup>
+import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue';
+import { sanitizeHtml } from '@/utils/sanitize';
+import { useOverlayClose } from '@/composables/useOverlayClose';
+
+const props = defineProps({
+  show: { type: Boolean, default: false },
+  message: { type: String, default: '' },
+  applicationNumber: { type: [String, Number], default: '' },
+});
+
+const emit = defineEmits(['close']);
+
+const visible = ref(false);
+const requestClose = () => { visible.value = false; };
+const onAfterLeave = () => { emit('close'); };
+
+const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(requestClose);
+
+const sanitizedMessage = computed(() => sanitizeHtml(props.message));
+
+const onKeydown = (e) => {
+  if (e.key === 'Escape' && visible.value) requestClose();
+};
+
+watch(() => props.show, (val) => { visible.value = val; }, { immediate: true });
+watch(visible, (val) => { document.body.style.overflow = val ? 'hidden' : ''; });
+
+onMounted(() => document.addEventListener('keydown', onKeydown));
+onBeforeUnmount(() => {
+  document.removeEventListener('keydown', onKeydown);
+  document.body.style.overflow = '';
+});
+</script>
+
+<style scoped>
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 20px;
+  z-index: 12000;
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
+}
+
+.modal-fade-enter-active {
+  transition: opacity 0.25s ease;
+}
+
+.modal-fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+  opacity: 0;
+}
+
+.modal-fade-enter-active .message-modal {
+  animation: modal-scale-in 0.25s ease;
+}
+
+.modal-fade-leave-active .message-modal {
+  animation: modal-scale-out 0.2s ease;
+}
+
+@keyframes modal-scale-in {
+  from { transform: scale(0.95); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
+}
+
+@keyframes modal-scale-out {
+  from { transform: scale(1); opacity: 1; }
+  to { transform: scale(0.95); opacity: 0; }
+}
+
+.message-modal {
+  background: #fff;
+  border-radius: 30px;
+  width: 760px;
+  max-width: 95%;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 18px 25px;
+  border-bottom: 1px solid #e6e6e6;
+}
+
+.modal-header h3 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: #000;
+}
+
+.modal-close {
+  background: none;
+  border: none;
+  font-size: 22px;
+  line-height: 1;
+  cursor: pointer;
+  color: #999;
+  padding: 0;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.2s ease;
+}
+
+.modal-close:hover {
+  color: #000;
+}
+
+.modal-content {
+  padding: 25px;
+  overflow-y: auto;
+  flex: 1;
+}
+
+/* Безопасный рендер форматированного сообщения (render-safety) */
+.text-constructor-content {
+  font-size: 15px;
+  line-height: 1.5;
+  color: #000;
+  word-break: break-word;
+}
+
+.text-constructor-content :deep(img) {
+  max-width: 100%;
+  height: auto;
+}
+
+.text-constructor-content :deep(img:not([height])) {
+  height: auto;
+}
+
+.text-constructor-content :deep(strong) { font-weight: 700; }
+.text-constructor-content :deep(em) { font-style: italic; }
+.text-constructor-content :deep(u) { text-decoration: underline; }
+
+.text-constructor-content :deep(ul),
+.text-constructor-content :deep(ol) {
+  padding-left: 22px;
+  margin: 8px 0;
+}
+
+.text-constructor-content :deep(li) { margin: 2px 0; }
+
+.text-constructor-content :deep(h1),
+.text-constructor-content :deep(.heading-h1) {
+  font-size: 24px;
+  font-weight: 700;
+  margin: 12px 0 8px;
+}
+
+.text-constructor-content :deep(h2),
+.text-constructor-content :deep(.heading-h2) {
+  font-size: 20px;
+  font-weight: 600;
+  margin: 10px 0 6px;
+}
+
+.text-constructor-content :deep(h3) {
+  font-size: 17px;
+  font-weight: 600;
+  margin: 8px 0 6px;
+}
+
+.text-constructor-content :deep(.black-text) { color: #000 !important; }
+.text-constructor-content :deep(.red-text) { color: #FF0000 !important; }
+.text-constructor-content :deep(.green-text) { color: #079D1D !important; }
+.text-constructor-content :deep(.blue-text) { color: #4F5BDF !important; }
+
+.text-constructor-content :deep(.font-size-10) { font-size: 10px !important; }
+.text-constructor-content :deep(.font-size-12) { font-size: 12px !important; }
+.text-constructor-content :deep(.font-size-14) { font-size: 14px !important; }
+.text-constructor-content :deep(.font-size-16) { font-size: 16px !important; }
+.text-constructor-content :deep(.font-size-18) { font-size: 18px !important; }
+.text-constructor-content :deep(.font-size-20) { font-size: 20px !important; }
+
+.text-constructor-content :deep(.font-weight-300) { font-weight: 300 !important; }
+.text-constructor-content :deep(.font-weight-400) { font-weight: 400 !important; }
+.text-constructor-content :deep(.font-weight-500) { font-weight: 500 !important; }
+.text-constructor-content :deep(.font-weight-600) { font-weight: 600 !important; }
+.text-constructor-content :deep(.font-weight-900) { font-weight: 900 !important; }
+
+.text-constructor-content :deep(.text-align-left) { text-align: left !important; }
+.text-constructor-content :deep(.text-align-center) { text-align: center !important; }
+.text-constructor-content :deep(.text-align-right) { text-align: right !important; }
+</style>

--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -64,10 +64,12 @@
         <!-- 1 ряд: Письмо сопроводительное, Согласие, Отправка -->
         <div class="form__header">
           <div class="header__content">
-            <textarea 
-              v-model="message" 
+            <TextConstructor
+              v-model="message"
+              class="form__message-tc"
+              :collapsible-toolbar="true"
+              :rows="2"
               placeholder="Введите сопроводительное письмо / сообщение"
-              class="form__textarea"
             />
             <div class="header__right">
               <div class="consent-section">
@@ -338,6 +340,7 @@ import ItemsList from './ItemsList.vue';
 import UniversalBindingModal from './UniversalBindingModal.vue';
 import ApplicationSuccessModal from './ApplicationSuccessModal.vue';
 import CustomFieldsSection from './CustomFieldsSection.vue';
+import TextConstructor from '@/components/TextConstructor.vue';
 
 export default {
     name: 'CreateApplication',
@@ -353,7 +356,8 @@ export default {
         ItemsList,
         UniversalBindingModal,
         ApplicationSuccessModal,
-        CustomFieldsSection
+        CustomFieldsSection,
+        TextConstructor
     },
     data() {
         return {
@@ -2256,7 +2260,7 @@ export default {
 
     .form__header {
         width: 100%;
-        height: 80px;
+        min-height: 80px;
         border-bottom: 1px solid #e6e6e6;
         padding: 15px;
     }
@@ -2264,17 +2268,12 @@ export default {
     .header__content {
         display: flex;
         gap: 20px;
-        height: 100%;
+        align-items: flex-start;
     }
 
-    .form__textarea {
+    .form__message-tc {
         width: 55%;
-        border: 1px solid #e6e6e6;
-        outline: none;
-        border-radius: 15px;
-        height: 50px;
-        padding: 10px;
-        resize: none;
+        margin-bottom: 0;
     }
 
     .header__right {

--- a/frontend/src/components/TextConstructor.vue
+++ b/frontend/src/components/TextConstructor.vue
@@ -1,9 +1,61 @@
 <template>
   <div
     class="text-constructor"
-    :class="{ 'is-disabled': disabled }"
+    :class="{ 'is-disabled': disabled, 'has-collapsible-toolbar': collapsibleToolbar }"
   >
-    <div class="editor-toolbar">
+    <button
+      v-if="collapsibleToolbar"
+      type="button"
+      class="toolbar-toggle"
+      :class="{ 'is-open': toolbarExpanded }"
+      :disabled="disabled"
+      :aria-expanded="toolbarExpanded ? 'true' : 'false'"
+      @click="toolbarExpanded = !toolbarExpanded"
+    >
+      <svg
+        class="toolbar-toggle-icon"
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <polyline points="4 7 4 4 20 4 20 7" />
+        <line
+          x1="9"
+          y1="20"
+          x2="15"
+          y2="20"
+        />
+        <line
+          x1="12"
+          y1="4"
+          x2="12"
+          y2="20"
+        />
+      </svg>
+      <span>Форматирование</span>
+      <svg
+        class="toolbar-toggle-chevron"
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <polyline points="6 9 12 15 18 9" />
+      </svg>
+    </button>
+    <div
+      v-show="showToolbar"
+      class="editor-toolbar"
+    >
       <div class="toolbar-group">
         <button
           type="button"
@@ -450,9 +502,13 @@ const props = defineProps({
   rows: { type: Number, default: 4 },
   disabled: { type: Boolean, default: false },
   maxImageBytes: { type: Number, default: 5 * 1024 * 1024 },
+  collapsibleToolbar: { type: Boolean, default: false },
 });
 
 const emit = defineEmits(['update:modelValue']);
+
+const toolbarExpanded = ref(false);
+const showToolbar = computed(() => !props.collapsibleToolbar || toolbarExpanded.value);
 
 const fontSizes = ['10px', '12px', '14px', '16px', '18px', '20px'];
 const fontWeights = [
@@ -666,6 +722,56 @@ defineExpose({ editor });
   gap: 8px;
   padding: 8px 10px;
   border-bottom: 1px solid var(--color-border);
+}
+
+.toolbar-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 8px 10px;
+  padding: 6px 12px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: #fff;
+  color: #1a1a1a;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.toolbar-toggle:hover:not(:disabled) {
+  background: #f4f5ff;
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.toolbar-toggle.is-open {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: #fff;
+}
+
+.toolbar-toggle:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.toolbar-toggle-chevron {
+  transition: transform 0.2s ease;
+}
+
+.toolbar-toggle.is-open .toolbar-toggle-chevron {
+  transform: rotate(180deg);
+}
+
+.has-collapsible-toolbar .editor-toolbar {
+  animation: tc-toolbar-in 0.2s ease;
+}
+
+@keyframes tc-toolbar-in {
+  from { opacity: 0; transform: translateY(-6px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
 .toolbar-group {

--- a/frontend/src/components/__tests__/TextConstructor.spec.js
+++ b/frontend/src/components/__tests__/TextConstructor.spec.js
@@ -290,4 +290,26 @@ describe('TextConstructor', () => {
     expect(out).toContain('text-align-center');
     expect(out).not.toContain('style=');
   });
+
+  it('по умолчанию тулбар виден, кнопки-тоггла нет', () => {
+    const wrapper = mountConstructor();
+    expect(wrapper.find('.toolbar-toggle').exists()).toBe(false);
+    expect(wrapper.find('.editor-toolbar').isVisible()).toBe(true);
+  });
+
+  it('collapsibleToolbar скрывает тулбар и показывает кнопку-тоггл', () => {
+    const wrapper = mountConstructor({ collapsibleToolbar: true });
+    expect(wrapper.find('.toolbar-toggle').exists()).toBe(true);
+    expect(wrapper.find('.editor-toolbar').isVisible()).toBe(false);
+  });
+
+  it('клик по тогглу разворачивает и сворачивает тулбар', async () => {
+    const wrapper = mountConstructor({ collapsibleToolbar: true });
+    const toggle = wrapper.find('.toolbar-toggle');
+    await toggle.trigger('click');
+    expect(wrapper.find('.editor-toolbar').isVisible()).toBe(true);
+    expect(toggle.classes()).toContain('is-open');
+    await toggle.trigger('click');
+    expect(wrapper.find('.editor-toolbar').isVisible()).toBe(false);
+  });
 });


### PR DESCRIPTION
## Что и зачем
Возвращает rich-text сопроводительного письма заявки (п.27 эпика 46-textconstructor) на улучшенном TextConstructor. Фича была в #613, откачена #620 "до доработки TC" - теперь TC доведён (Tiptap, ресайз картинок, выравнивание), и письмо возвращается. **Финальный срез эпика.**

## Изменения
- **TextConstructor.vue**: новый проп `collapsibleToolbar` (Boolean, default false). Когда true - тулбар скрыт, показывается кнопка-тоггл "Форматирование", клик разворачивает (enter-анимация). Контракт остальных пропсов 1:1 - 4 существующих потребителя не затронуты.
- **CreateApplication.vue**: textarea сопроводительного письма -> `<TextConstructor :collapsible-toolbar :rows="2">` (минималистично, тулбар свёрнут). `.form__header` растёт под развёрнутый тулбар.
- **ApplicationDetail.vue**: блок "Сообщение к заявке" -> компактный форматированный превью (обрезка по высоте + фейд при переполнении) + кнопка "Открыть в окне". Рендер через `sanitizeHtml`.
- **ApplicationMessageModal.vue** (новый): модалка полного сообщения с картинками. Teleport, z-index 12000 (выше стопки детали 10002-10005), useOverlayClose, Escape, scroll-lock, анимация, radius 30px, render-safety (img max-width:100%). Паттерн EmployeeHistoryModal.
- **TextConstructor.spec.js**: +3 теста на collapsibleToolbar.

Картинки в письме РАЗРЕШЕНЫ (решение пользователя 17.06: TC умеет ресайз). Бэкенд-поле `Message *string` цело с #613 - миграция не нужна.

## Верификация (локально, ДО мержа)
- vitest 33/33 (28 TC + 5 sanitize), eslint 0 (мои файлы).
- Playwright по живому стеку:
  - CreateApplication: бланк выбран -> TC встроен, тулбар свёрнут по умолчанию, тоггл "Форматирование" разворачивает, ввод работает, submit на месте (layout цел), хедер растёт.
  - ApplicationDetail (заявке задано форматированное сообщение с картинкой 820px, после - откатил): компактный превью рендерит strong/цвет/h1/список, clamp срабатывает (scrollH 418 > 150), кнопка "Открыть в окне".
  - Модалка: z-index 12000 (Teleport, прямой потомок body), radius 30px, картинка 820px рендерится 710px вписана в 760px (render-safety), форматирование рендерится; закрытие через x / Escape / overlay - все работают.
- Скриншоты сняты до мержа (check-46-p27-*).

## Ревью
code-reviewer 2 прохода. Проход 1: NO-GO, 2 RED - (1) showMessageModal не сбрасывался при смене заявки -> сброс в watch.application; (2) кастомная кнопка -> `.lk-button--secondary` (reuse). Проход 2 (подтверждающий): GO, фиксы корректны, регрессий нет. Остаточные YELLOW (body.overflow timing, z-index=история) - паттерны проекта / не пересекаются, неблокеры.