### PR TITLE
feat(statistics): list-режим движка отчётов POST /statistics/report (#632)

### DIFF
--- a/internal/handlers/statistics.go
+++ b/internal/handlers/statistics.go
@@ -157,7 +157,7 @@ func (h *StatisticsHandler) GetMetrics(c echo.Context) error {
 
 // RunReport godoc
 // @Summary      Исполнение отчёта конструктора
-// @Description  Агрегатный отчёт: метрика x разрез x фильтры x период (mode=aggregate)
+// @Description  mode=aggregate: метрика x разрез x фильтры x период. mode=list: выгрузка строк сущности.
 // @Tags         statistics
 // @Accept       json
 // @Produce      json
@@ -177,21 +177,36 @@ func (h *StatisticsHandler) RunReport(c echo.Context) error {
 	if req.Mode == "" {
 		req.Mode = "aggregate"
 	}
-	if req.Mode != "aggregate" {
-		// list-режим (выгрузка строк) добавляется отдельным срезом.
+
+	switch req.Mode {
+	case "aggregate":
+		if req.Metric == "" || req.Dimension == "" {
+			return echo.NewHTTPError(http.StatusBadRequest, "metric and dimension are required")
+		}
+		res, err := h.service.RunReport(c.Request().Context(), req)
+		if err != nil {
+			return mapReportError(err)
+		}
+		return RespondSuccess(c, res)
+	case "list":
+		if req.Entity == "" {
+			return echo.NewHTTPError(http.StatusBadRequest, "entity is required")
+		}
+		res, err := h.service.RunReportList(c.Request().Context(), req)
+		if err != nil {
+			return mapReportError(err)
+		}
+		return RespondSuccess(c, res)
+	default:
 		return echo.NewHTTPError(http.StatusBadRequest, "unsupported report mode")
 	}
-	if req.Metric == "" || req.Dimension == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "metric and dimension are required")
-	}
+}
 
-	res, err := h.service.RunReport(c.Request().Context(), req)
-	if err != nil {
-		if errors.Is(err, services.ErrInvalidReportRequest) {
-			// Не эхаем ввод: неизвестная метрика/разрез/фильтр -> generic 400.
-			return echo.NewHTTPError(http.StatusBadRequest, "invalid report request")
-		}
-		return err
+// mapReportError маппит ошибку движка отчётов в HTTP. Невалидный запрос (неизвестная
+// метрика/разрез/сущность/фильтр) -> generic 400 без эха пользовательского ввода.
+func mapReportError(err error) error {
+	if errors.Is(err, services.ErrInvalidReportRequest) {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid report request")
 	}
-	return RespondSuccess(c, res)
+	return err
 }

--- a/internal/handlers/statistics_report_list_integration_test.go
+++ b/internal/handlers/statistics_report_list_integration_test.go
@@ -1,0 +1,112 @@
+package handlers_test
+
+import (
+	"context"
+	"testing"
+
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// toInt64 приводит числовое значение из []map (pgx отдаёт COUNT как int64) к int64.
+func toInt64(t *testing.T, v any) int64 {
+	t.Helper()
+	switch n := v.(type) {
+	case int64:
+		return n
+	case int32:
+		return int64(n)
+	case int:
+		return int64(n)
+	default:
+		t.Fatalf("ожидалось числовое значение, got %T (%v)", v, v)
+		return 0
+	}
+}
+
+// TestRunReportList_WorkApplications проверяет реальный GORM-путь list-движка
+// (B2b): сидирует сценарий «Заявка на работы» и убеждается, что плейсхолдер
+// подписи кастомного поля (ILIKE ?) и аргумент базового фильтра типа вложения
+// связываются в правильном порядке, а скан в []map отдаёт ожидаемые значения.
+func TestRunReportList_WorkApplications(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	org := models.Organization{Name: "Тест-орг B2b", IsActive: true}
+	require.NoError(t, db.Create(&org).Error)
+
+	last, first, phone := "Мякотных", "Сергей", "+79990001122"
+	resp := models.User{Username: "b2b_resp", TypeID: 1, IsActive: true,
+		LastName: &last, FirstName: &first, Phone: &phone}
+	require.NoError(t, db.Create(&resp).Error)
+
+	uaName, uaDisplay := "work", "Заявка на работы"
+	ua := models.UniqueAttachment{AttachmentType: "people", Name: &uaName, DisplayName: &uaDisplay, IsActive: true}
+	require.NoError(t, db.Create(&ua).Error)
+
+	acf := models.AttachmentCustomField{UniqueAttachmentID: ua.ID, Label: "Наименование работ", IsActive: true}
+	require.NoError(t, db.Create(&acf).Error)
+
+	status := models.StatusInWork
+	number := "TST/B2B/001"
+	app := models.Application{ApplicationNumber: &number, OrganizationID: org.ID,
+		SenderUserID: resp.ID, ResponsibleUserID: &resp.ID, Status: &status}
+	require.NoError(t, db.Create(&app).Error)
+
+	dateFrom, dateTo, timeFrom, timeTo := "2026-06-01", "2026-06-05", "09:00", "18:00"
+	att := models.Attachment{ApplicationID: app.ID, AttachmentType: "people", UniqueAttachmentID: &ua.ID,
+		EntryDateFrom: &dateFrom, EntryDateTo: &dateTo, EntryTimeFrom: &timeFrom, EntryTimeTo: &timeTo}
+	require.NoError(t, db.Create(&att).Error)
+
+	require.NoError(t, db.Create(&models.AttachmentCustomValue{
+		AttachmentID: att.ID, CustomFieldID: acf.ID, Value: "Монтаж кровли"}).Error)
+
+	// Двое сотрудников по этому вложению -> people_count = 2.
+	for _, ln := range []string{"Кафанова", "Сидоров"} {
+		name := ln
+		require.NoError(t, db.Create(&models.Employee{AttachmentID: &att.ID, LastName: &name}).Error)
+	}
+
+	svc := services.NewStatisticsService(db)
+	res, err := svc.RunReportList(context.Background(), models.ReportRequest{Mode: "list", Entity: "work_applications"})
+	require.NoError(t, err)
+	require.Equal(t, "list", res.Mode)
+	require.Equal(t, "work_applications", res.Entity)
+	require.Len(t, res.Columns, 7)
+	require.Len(t, res.Rows, 1, "ожидалась одна work-заявка")
+
+	row := res.Rows[0]
+	assert.Equal(t, number, row["number"])
+	assert.Equal(t, "Тест-орг B2b", row["org_or_company"])
+	assert.Equal(t, "Монтаж кровли", row["work_name"], "наименование работ через ILIKE ?-плейсхолдер")
+	assert.Contains(t, row["responsible"], "Мякотных")
+	assert.Contains(t, row["responsible"], phone)
+	assert.Equal(t, "2026-06-01 - 2026-06-05", row["work_period"])
+	assert.Equal(t, "09:00 - 18:00", row["work_time"])
+	assert.Equal(t, int64(2), toInt64(t, row["people_count"]))
+}
+
+// TestRunReportList_AllEntitiesExecute убеждается, что SQL КАЖДОЙ сущности list-режима
+// исполняется через GORM без рантайм-ошибки и возвращает столбцы по каталогу.
+// Ловит ошибки сборки/связывания запроса, которые юнит-тест плана не видит.
+func TestRunReportList_AllEntitiesExecute(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	svc := services.NewStatisticsService(db)
+	for _, entity := range []string{"work_applications", "applications", "cars", "people"} {
+		t.Run(entity, func(t *testing.T) {
+			res, err := svc.RunReportList(context.Background(), models.ReportRequest{Mode: "list", Entity: entity})
+			require.NoError(t, err)
+			assert.Equal(t, entity, res.Entity)
+			assert.NotEmpty(t, res.Columns)
+			assert.NotNil(t, res.Rows)
+		})
+	}
+}

--- a/internal/models/report.go
+++ b/internal/models/report.go
@@ -38,3 +38,15 @@ type ReportResponse struct {
 	Rows      []ReportAggregateRow `json:"rows"`
 	Total     int64                `json:"total"`
 }
+
+// ReportListResponse — результат list-отчёта (mode=list): выгрузка строк сущности.
+// Columns задаёт порядок и подписи столбцов (из каталога B1), Rows — значения
+// строк парами ключ->значение (ключи совпадают с Columns[].Key). Total — число
+// возвращённых строк (с учётом лимита).
+type ReportListResponse struct {
+	Mode    string             `json:"mode"`
+	Entity  string             `json:"entity"`
+	Columns []ReportColumnInfo `json:"columns"`
+	Rows    []map[string]any   `json:"rows"`
+	Total   int                `json:"total"`
+}

--- a/internal/services/report_list_engine.go
+++ b/internal/services/report_list_engine.go
@@ -1,0 +1,262 @@
+package services
+
+import (
+	"strings"
+
+	"systemburo/internal/models"
+)
+
+// Движок исполнения list-отчётов (B2b): выгрузка строк сущности с фиксированным
+// whitelist столбцов и фильтров. Как и агрегатный движок (report_engine.go), все
+// SQL-выражения здесь — статические константы кода; пользовательский ввод сверяется
+// по ключам реестров и передаётся только через ? плейсхолдеры. Подписи и порядок
+// столбцов берутся из каталога B1 (reportListEntityRegistry) — единый источник
+// правды для UI и движка; тест ловит расхождение ключей каталога и схем исполнения.
+
+// workAttachmentDisplayName — отображаемое имя типа вложения «Заявка на работы».
+// Сущность work_applications = вложения этого типа. Значение data-driven (имена
+// типов задаются оператором в справочнике unique_attachments); при иной
+// формулировке на проде — поправить здесь.
+const workAttachmentDisplayName = "Заявка на работы"
+
+// workNameFieldPattern — ILIKE-шаблон подписи кастомного поля «Наименование работ».
+// «Наименование работ» — это кастомное поле типа вложения (attachment_custom_fields),
+// его значение хранится в attachment_custom_values. Подбираем поле по подписи, т.к.
+// id поля зависит от данных конкретного стенда. Передаётся в SQL как аргумент-плейсхолдер.
+const workNameFieldPattern = "наименование работ%"
+
+// colExprDef — SQL-выражение одного столбца list-режима (алиасится AS <key>).
+// args заполняется только для выражений с ? плейсхолдером (передаются в Select).
+type colExprDef struct {
+	expr string
+	args []any
+}
+
+// listExecSchema — план сборки list-запроса для одной сущности. joins применяются
+// всегда (1:1 LEFT JOIN — ограничены лимитом выборки; агрегаты по дочерним строкам
+// считаются скоррелированными подзапросами, чтобы не плодить fan-out).
+type listExecSchema struct {
+	base         string
+	baseWhere    whereClause           // безопасная константа (+ опц. аргумент)
+	joins        []string              // всегда добавляются
+	tsColumn     string                // колонка для фильтра date_range ("" — фильтр недоступен)
+	colExpr      map[string]colExprDef // ключ столбца -> SQL-выражение
+	filterExpr   map[string]string     // ключ фильтра -> SQL-выражение (для IN)
+	defaultOrder string
+}
+
+var listExecRegistry = map[string]listExecSchema{
+	"work_applications": {
+		base:      "attachments att",
+		baseWhere: whereClause{expr: "ua.display_name = ?", args: []any{workAttachmentDisplayName}},
+		joins: []string{
+			"JOIN applications app ON app.id = att.application_id",
+			"LEFT JOIN unique_attachments ua ON ua.id = att.unique_attachment_id",
+			"LEFT JOIN organizations org ON org.id = app.organization_id",
+			"LEFT JOIN companies comp ON comp.id = app.company_id",
+			"LEFT JOIN users ru ON ru.id = app.responsible_user_id",
+		},
+		tsColumn: "app.sending_datetime",
+		colExpr: map[string]colExprDef{
+			"number":         {expr: "COALESCE(app.application_number, '')"},
+			"org_or_company": {expr: "COALESCE(NULLIF(org.name, ''), comp.name, '')"},
+			"work_name": {
+				expr: "COALESCE((SELECT acv.value FROM attachment_custom_values acv " +
+					"JOIN attachment_custom_fields acf ON acf.id = acv.custom_field_id " +
+					"WHERE acv.attachment_id = att.id AND acf.label ILIKE ? " +
+					"ORDER BY acf.sort_order, acf.id LIMIT 1), '')",
+				args: []any{workNameFieldPattern},
+			},
+			"responsible": {expr: "COALESCE(NULLIF(TRIM(CONCAT_WS(' ', ru.last_name, ru.first_name, ru.middle_name)), ''), '') " +
+				"|| CASE WHEN COALESCE(ru.phone, '') <> '' THEN ', тел. ' || ru.phone ELSE '' END"},
+			"work_period": {expr: "CASE WHEN COALESCE(att.entry_date_from, att.entry_date_to, '') = '' THEN '' " +
+				"ELSE COALESCE(att.entry_date_from, '') || ' - ' || COALESCE(att.entry_date_to, '') END"},
+			"work_time": {expr: "CASE WHEN COALESCE(att.entry_time_from, att.entry_time_to, '') = '' THEN '' " +
+				"ELSE COALESCE(att.entry_time_from, '') || ' - ' || COALESCE(att.entry_time_to, '') END"},
+			"people_count": {expr: "(SELECT COUNT(*) FROM employees emp WHERE emp.attachment_id = att.id AND emp.is_purged = false)"},
+		},
+		filterExpr: map[string]string{
+			"organization": "org.name",
+			"status":       "app.status",
+		},
+		defaultOrder: "att.id DESC",
+	},
+	"applications": {
+		base: "applications app",
+		joins: []string{
+			"LEFT JOIN organizations org ON org.id = app.organization_id",
+			"LEFT JOIN companies comp ON comp.id = app.company_id",
+		},
+		tsColumn: "app.sending_datetime",
+		colExpr: map[string]colExprDef{
+			"number":            {expr: "COALESCE(app.application_number, '')"},
+			"status":            {expr: "COALESCE(app.status, '')"},
+			"organization":      {expr: "COALESCE(org.name, '')"},
+			"company":           {expr: "COALESCE(comp.name, '')"},
+			"sending_datetime":  {expr: "COALESCE(to_char(app.sending_datetime, 'YYYY-MM-DD HH24:MI'), '')"},
+			"attachments_count": {expr: "(SELECT COUNT(*) FROM attachments a2 WHERE a2.application_id = app.id)"},
+		},
+		filterExpr: map[string]string{
+			"status":       "app.status",
+			"organization": "org.name",
+			"company":      "comp.name",
+		},
+		defaultOrder: "app.sending_datetime DESC NULLS LAST",
+	},
+	"cars": {
+		base:      "cars c",
+		baseWhere: whereClause{expr: "c.is_purged = false"},
+		joins: []string{
+			"LEFT JOIN attachments att ON att.id = c.attachment_id",
+			"LEFT JOIN applications app ON app.id = att.application_id",
+			"LEFT JOIN organizations org ON org.id = app.organization_id",
+			"LEFT JOIN companies comp ON comp.id = app.company_id",
+		},
+		colExpr: map[string]colExprDef{
+			"car_number":       {expr: "COALESCE(c.car_number, '')"},
+			"mark":             {expr: "COALESCE(NULLIF(c.mark_name, ''), c.car_brand, '')"},
+			"organization":     {expr: "COALESCE(org.name, comp.name, '')"},
+			"place":            {expr: "COALESCE(c.unload_place, '')"},
+			"territory_status": {expr: "CASE WHEN c.territory_status = 1 THEN 'На территории' ELSE 'Нет' END"},
+		},
+		filterExpr: map[string]string{
+			"organization": "org.name",
+			"unload_place": "c.unload_place",
+		},
+		defaultOrder: "c.id DESC",
+	},
+	"people": {
+		base:      "employees e",
+		baseWhere: whereClause{expr: "e.is_purged = false"},
+		joins: []string{
+			"LEFT JOIN citizenships cz ON cz.id = e.citizenship_id",
+			"LEFT JOIN attachments att ON att.id = e.attachment_id",
+			"LEFT JOIN applications app ON app.id = att.application_id",
+			"LEFT JOIN organizations org ON org.id = app.organization_id",
+			"LEFT JOIN companies comp ON comp.id = app.company_id",
+		},
+		colExpr: map[string]colExprDef{
+			"full_name":    {expr: "TRIM(CONCAT_WS(' ', e.last_name, e.first_name, e.middle_name))"},
+			"organization": {expr: "COALESCE(org.name, comp.name, '')"},
+			"citizenship":  {expr: "COALESCE(cz.name, '')"},
+			"place": {expr: "COALESCE((SELECT STRING_AGG(DISTINCT st.display_name, ', ' ORDER BY st.display_name) " +
+				"FROM employee_target_tables ett JOIN system_tables st ON st.id = ett.table_id " +
+				"WHERE ett.employee_id = e.id), '')"},
+			"territory_status": {expr: "CASE WHEN e.territory_status = 1 THEN 'На территории' ELSE 'Нет' END"},
+		},
+		filterExpr: map[string]string{
+			"organization": "org.name",
+			"citizenship":  "cz.name",
+		},
+		defaultOrder: "e.id DESC",
+	},
+}
+
+// listPlan — резолвленный план list-запроса (только whitelist-выражения).
+// selectArgs — аргументы плейсхолдеров SELECT (в порядке появления столбцов).
+type listPlan struct {
+	table      string
+	selectStr  string
+	selectArgs []any
+	joins      []string
+	wheres     []whereClause
+	orderStr   string
+	limit      int
+	columns    []models.ReportColumnInfo
+}
+
+// buildListPlan собирает план list-отчёта из whitelist-схем. Чистая функция (без
+// БД) — тестируется напрямую. Порядок и подписи столбцов берутся из каталога B1,
+// SQL-выражения — из listExecRegistry. Неизвестная сущность/фильтр или столбец
+// каталога без выражения -> ErrInvalidReportRequest.
+func buildListPlan(req models.ReportRequest) (*listPlan, error) {
+	exec, ok := listExecRegistry[req.Entity]
+	if !ok {
+		return nil, errInvalidReport("entity")
+	}
+	catalog, ok := reportListEntityRegistry[req.Entity]
+	if !ok {
+		return nil, errInvalidReport("entity")
+	}
+
+	plan := &listPlan{
+		table: exec.base,
+		joins: append([]string{}, exec.joins...),
+	}
+
+	selects := make([]string, 0, len(catalog.columns))
+	cols := make([]models.ReportColumnInfo, 0, len(catalog.columns))
+	for _, c := range catalog.columns {
+		def, ok := exec.colExpr[c.key]
+		if !ok {
+			// Каталог объявил столбец, для которого нет SQL-выражения — баг конфигурации.
+			return nil, errInvalidReport("column")
+		}
+		selects = append(selects, def.expr+" AS "+c.key)
+		plan.selectArgs = append(plan.selectArgs, def.args...)
+		cols = append(cols, models.ReportColumnInfo{Key: c.key, Label: c.label})
+	}
+	plan.selectStr = strings.Join(selects, ", ")
+	plan.columns = cols
+
+	if exec.baseWhere.expr != "" {
+		plan.wheres = append(plan.wheres, exec.baseWhere)
+	}
+
+	allowed := make(map[string]bool, len(catalog.filters))
+	for _, f := range catalog.filters {
+		allowed[f] = true
+	}
+	for _, f := range req.Filters {
+		if !allowed[f.Key] {
+			return nil, errInvalidReport("filter")
+		}
+		wc, err := resolveListFilter(exec, f)
+		if err != nil {
+			return nil, err
+		}
+		if wc == nil { // пустой фильтр (нет значений/границ) — пропускаем
+			continue
+		}
+		plan.wheres = append(plan.wheres, *wc)
+	}
+
+	plan.orderStr = exec.defaultOrder
+	plan.limit = clampLimit(req.Limit)
+	return plan, nil
+}
+
+// resolveListFilter превращает поле фильтра в WHERE-фрагмент. Возвращает nil без
+// ошибки, если фильтр пустой (нет значений/границ). date_range применяется к
+// tsColumn сущности; остальные — по выражению из filterExpr (IN со срезом-аргументом).
+func resolveListFilter(exec listExecSchema, f models.ReportFilterValue) (*whereClause, error) {
+	if f.Key == "date_range" {
+		if exec.tsColumn == "" {
+			return nil, errInvalidReport("filter")
+		}
+		var parts []string
+		var args []any
+		if t, ok := parseReportDate(f.From, false); ok {
+			parts = append(parts, exec.tsColumn+" >= ?")
+			args = append(args, t)
+		}
+		if t, ok := parseReportDate(f.To, true); ok {
+			parts = append(parts, exec.tsColumn+" <= ?")
+			args = append(args, t)
+		}
+		if len(parts) == 0 {
+			return nil, nil
+		}
+		return &whereClause{expr: strings.Join(parts, " AND "), args: args}, nil
+	}
+
+	expr, ok := exec.filterExpr[f.Key]
+	if !ok {
+		return nil, errInvalidReport("filter")
+	}
+	vals := nonEmpty(f.Values)
+	if len(vals) == 0 {
+		return nil, nil
+	}
+	return &whereClause{expr: expr + " IN ?", args: []any{vals}}, nil
+}

--- a/internal/services/report_list_engine_test.go
+++ b/internal/services/report_list_engine_test.go
@@ -1,0 +1,182 @@
+package services
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"systemburo/internal/models"
+)
+
+// TestListEngine_CoversCatalogEntities гарантирует, что для КАЖДОЙ list-сущности
+// каталога (B1) движок умеет собрать план со всеми её столбцами. Иначе UI
+// предложит выгрузку, которая упадёт на исполнении.
+func TestListEngine_CoversCatalogEntities(t *testing.T) {
+	for _, entity := range reportListEntityOrder {
+		req := models.ReportRequest{Mode: "list", Entity: entity}
+		plan, err := buildListPlan(req)
+		if err != nil {
+			t.Errorf("сущность %q: движок не собрал план: %v", entity, err)
+			continue
+		}
+		catCols := reportListEntityRegistry[entity].columns
+		if len(plan.columns) != len(catCols) {
+			t.Errorf("сущность %q: столбцов в плане %d, в каталоге %d", entity, len(plan.columns), len(catCols))
+		}
+		for i, c := range catCols {
+			if plan.columns[i].Key != c.key {
+				t.Errorf("сущность %q: столбец #%d ключ %q != каталог %q", entity, i, plan.columns[i].Key, c.key)
+			}
+			// каждый столбец каталога должен попасть в SELECT под своим алиасом
+			if !strings.Contains(plan.selectStr, " AS "+c.key) {
+				t.Errorf("сущность %q: столбец %q отсутствует в select %q", entity, c.key, plan.selectStr)
+			}
+		}
+	}
+}
+
+// TestListEngine_CatalogFiltersResolvable сверяет, что каждый фильтр, заявленный
+// каталогом для list-сущности, движок умеет применить (date_range или filterExpr).
+func TestListEngine_CatalogFiltersResolvable(t *testing.T) {
+	for _, entity := range reportListEntityOrder {
+		exec, ok := listExecRegistry[entity]
+		if !ok {
+			t.Errorf("сущность каталога %q без схемы исполнения", entity)
+			continue
+		}
+		for _, f := range reportListEntityRegistry[entity].filters {
+			if f == "date_range" {
+				if exec.tsColumn == "" {
+					t.Errorf("сущность %q: фильтр date_range без tsColumn", entity)
+				}
+				continue
+			}
+			if _, ok := exec.filterExpr[f]; !ok {
+				t.Errorf("сущность %q: фильтр %q каталога без выражения исполнения", entity, f)
+			}
+		}
+	}
+}
+
+// TestListEngine_ExecMatchesCatalog — у каждой схемы исполнения есть сущность в
+// каталоге и наоборот (защита от рассинхрона реестров).
+func TestListEngine_ExecMatchesCatalog(t *testing.T) {
+	for _, entity := range reportListEntityOrder {
+		if _, ok := listExecRegistry[entity]; !ok {
+			t.Errorf("сущность каталога %q без схемы исполнения", entity)
+		}
+	}
+	for entity := range listExecRegistry {
+		if _, ok := reportListEntityRegistry[entity]; !ok {
+			t.Errorf("схема исполнения %q без сущности в каталоге", entity)
+		}
+	}
+}
+
+func TestListPlan_WorkApplicationsBaseFilter(t *testing.T) {
+	req := models.ReportRequest{Mode: "list", Entity: "work_applications"}
+	plan, err := buildListPlan(req)
+	if err != nil {
+		t.Fatalf("неожиданная ошибка: %v", err)
+	}
+	// baseWhere ограничивает выборку типом «Заявка на работы» через аргумент-плейсхолдер.
+	var hasBase bool
+	for _, w := range plan.wheres {
+		if strings.Contains(w.expr, "ua.display_name = ?") {
+			hasBase = true
+			if len(w.args) != 1 || w.args[0] != workAttachmentDisplayName {
+				t.Errorf("ожидался аргумент %q, got %v", workAttachmentDisplayName, w.args)
+			}
+		}
+	}
+	if !hasBase {
+		t.Errorf("baseWhere по типу вложения не попал в where: %+v", plan.wheres)
+	}
+	// телефон ответственного добавлен в SELECT (по требованию шаблона).
+	if !strings.Contains(plan.selectStr, "ru.phone") {
+		t.Errorf("ожидался телефон ответственного в select %q", plan.selectStr)
+	}
+	// «наименование работ» подбирается по подписи через плейсхолдер (не конкатенацией).
+	if !strings.Contains(plan.selectStr, "acf.label ILIKE ?") {
+		t.Errorf("ожидался ILIKE ? для подписи поля работ, got %q", plan.selectStr)
+	}
+	if len(plan.selectArgs) != 1 || plan.selectArgs[0] != workNameFieldPattern {
+		t.Errorf("ожидался selectArg %q, got %v", workNameFieldPattern, plan.selectArgs)
+	}
+}
+
+func TestListPlan_FiltersAndDateRange(t *testing.T) {
+	req := models.ReportRequest{
+		Mode:   "list",
+		Entity: "work_applications",
+		Filters: []models.ReportFilterValue{
+			{Key: "status", Values: []string{models.StatusInWork}},
+			{Key: "date_range", From: "2026-06-01", To: "2026-06-17"},
+			{Key: "organization", Values: []string{"  "}}, // только пустое -> пропустить
+		},
+	}
+	plan, err := buildListPlan(req)
+	if err != nil {
+		t.Fatalf("неожиданная ошибка: %v", err)
+	}
+
+	var hasStatus, hasFrom, hasTo, hasOrg bool
+	for _, w := range plan.wheres {
+		if strings.Contains(w.expr, "app.status IN") {
+			hasStatus = true
+		}
+		if strings.Contains(w.expr, "app.sending_datetime >= ?") {
+			hasFrom = true
+		}
+		if strings.Contains(w.expr, "app.sending_datetime <= ?") {
+			hasTo = true
+		}
+		if strings.Contains(w.expr, "org.name IN") {
+			hasOrg = true
+		}
+	}
+	if !hasStatus {
+		t.Errorf("фильтр status не попал в where: %+v", plan.wheres)
+	}
+	if !hasFrom || !hasTo {
+		t.Errorf("date_range не разложился на from/to: %+v", plan.wheres)
+	}
+	if hasOrg {
+		t.Errorf("пустой фильтр organization не должен давать WHERE: %+v", plan.wheres)
+	}
+}
+
+func TestListPlan_RejectsInvalid(t *testing.T) {
+	cases := []struct {
+		name string
+		req  models.ReportRequest
+	}{
+		{"unknown entity", models.ReportRequest{Mode: "list", Entity: "nope"}},
+		{"unknown filter", models.ReportRequest{Mode: "list", Entity: "cars",
+			Filters: []models.ReportFilterValue{{Key: "status", Values: []string{models.StatusInWork}}}}},
+		{"date_range without ts", models.ReportRequest{Mode: "list", Entity: "cars",
+			Filters: []models.ReportFilterValue{{Key: "date_range", From: "2026-06-01"}}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := buildListPlan(tc.req)
+			if err == nil {
+				t.Fatalf("ожидалась ошибка валидации")
+			}
+			if !errors.Is(err, ErrInvalidReportRequest) {
+				t.Errorf("ожидался ErrInvalidReportRequest, got %v", err)
+			}
+		})
+	}
+}
+
+func TestListPlan_LimitClamped(t *testing.T) {
+	req := models.ReportRequest{Mode: "list", Entity: "people", Limit: maxReportLimit + 500}
+	plan, err := buildListPlan(req)
+	if err != nil {
+		t.Fatalf("неожиданная ошибка: %v", err)
+	}
+	if plan.limit != maxReportLimit {
+		t.Errorf("limit не зажат: got %d, want %d", plan.limit, maxReportLimit)
+	}
+}

--- a/internal/services/statistics_service.go
+++ b/internal/services/statistics_service.go
@@ -17,6 +17,7 @@ type StatisticsService interface {
 	GetRecentPassages(ctx context.Context, limit int) (*models.RecentPassages, error)
 	GetReportCatalog(ctx context.Context) (*models.ReportCatalog, error)
 	RunReport(ctx context.Context, req models.ReportRequest) (*models.ReportResponse, error)
+	RunReportList(ctx context.Context, req models.ReportRequest) (*models.ReportListResponse, error)
 }
 
 type statisticsService struct {
@@ -443,5 +444,41 @@ func (s *statisticsService) RunReport(ctx context.Context, req models.ReportRequ
 		Unit:      plan.unit,
 		Rows:      rows,
 		Total:     total,
+	}, nil
+}
+
+// RunReportList исполняет list-отчёт конструктора (mode=list): выгрузка строк
+// сущности с whitelist-столбцами и фильтрами. План собирается чистой buildListPlan
+// из whitelist-схем (report_list_engine.go) — ввод сверяется по ключам и
+// подставляется только через плейсхолдеры. Невалидный запрос -> ErrInvalidReportRequest
+// (400 в handler). Строки сканируются в []map по алиасам столбцов плана.
+func (s *statisticsService) RunReportList(ctx context.Context, req models.ReportRequest) (*models.ReportListResponse, error) {
+	plan, err := buildListPlan(req)
+	if err != nil {
+		return nil, err
+	}
+
+	tx := s.db.WithContext(ctx).Table(plan.table).Select(plan.selectStr, plan.selectArgs...)
+	for _, j := range plan.joins {
+		tx = tx.Joins(j)
+	}
+	for _, w := range plan.wheres {
+		tx = tx.Where(w.expr, w.args...)
+	}
+
+	rows := make([]map[string]any, 0)
+	if err := tx.
+		Order(plan.orderStr).
+		Limit(plan.limit).
+		Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf("statistics: run report list: %w", err)
+	}
+
+	return &models.ReportListResponse{
+		Mode:    "list",
+		Entity:  req.Entity,
+		Columns: plan.columns,
+		Rows:    rows,
+		Total:   len(rows),
 	}, nil
 }


### PR DESCRIPTION
Срез **B2b** эпика 37-analytics (issue #632). Добавляет list-режим в движок отчётов: раньше `mode=list` отдавал 400, теперь работает выгрузка строк сущностей.

## Что сделано
- `report_list_engine.go` (новый): `listExecRegistry` для 4 сущностей (`work_applications`/`applications`/`cars`/`people`) + чистый `buildListPlan`. Whitelist по образцу агрегатного движка B2a: все SQL-фрагменты - статические константы, ввод сверяется по ключам реестров и идёт только через `?`-плейсхолдеры. Подписи и порядок столбцов берутся из каталога B1 (`reportListEntityRegistry`) - единый источник правды.
- `RunReportList` в `statistics_service.go` (скан строк в `[]map`), `ReportListResponse` в моделях, диспатч `mode=list`/`aggregate` в handler.
- Приоритетный шаблон **«Заявка на работы»**: 7 колонок (номер | орг/комп | наименование работ из `attachment_custom_values` | ответственный ФИО+телефон через `app.responsible_user_id->users.phone` | период работ | время работ | кол-во людей).

## Допущения (выверить на staging - там реальные данные)
В seed нет типа вложения «Заявка на работы» и кастомных полей (это staging/prod-данные), поэтому зафиксировал две data-driven привязки константами в `report_list_engine.go`:
- `work_applications` = вложения с `unique_attachments.display_name = 'Заявка на работы'`.
- «Наименование работ» = кастомное поле, чья подпись подходит под `ILIKE 'наименование работ%'` (id поля зависит от стенда).

Если на проде формулировки иные - правятся одной строкой каждая.

## Проверено
- `go build`/`go vet` чистые; `gofmt` чистый.
- Юнит-тесты плана (`report_list_engine_test.go`): покрытие каталога, фильтры/date_range, отказы валидации, clamp лимита.
- **Реальный GORM-путь** (`statistics_report_list_integration_test.go`, реальный postgres): засеян сценарий work-заявки - `work_name`="Монтаж кровли" (доказывает связывание `ILIKE ?`-плейсхолдера), `people_count`=2, период/время, ответственный с телефоном; все 4 сущности исполняются без ошибки.
- Сырой SQL всех 4 сущностей прогнан против сидовой БД руками (psql) - без ошибок.

## Ревью
`code-reviewer` = GO, блокеров нет. Закрыто превентивно: конкатенация подписи поля в SQL переведена на `?`-плейсхолдер (select-args); тест date_range разнесён на независимые from/to. Отложено: индекс под `attachment_custom_fields.label` - в срез **Idx** (трогает migrate.go, ревью человека); большинство колонок подзапросов уже под gorm-индексом.