### PR TITLE
fix(applications): полировка письма заявки по ревью (#46) [polish-r1]

### DIFF
--- a/frontend/src/components/ApplicationDetail/ApplicationDetail.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationDetail.vue
@@ -116,25 +116,6 @@
                 class="lk-button lk-button--secondary message-open-btn"
                 @click="showMessageModal = true"
               >
-                <svg
-                  width="15"
-                  height="15"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                >
-                  <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
-                  <polyline points="15 3 21 3 21 9" />
-                  <line
-                    x1="10"
-                    y1="14"
-                    x2="21"
-                    y2="3"
-                  />
-                </svg>
                 Открыть в окне
               </button>
             </div>
@@ -1584,6 +1565,7 @@ export default {
     border-radius: 20px;
     padding: 15px;
     box-shadow: 0 2px 12px rgba(0, 0, 0, 0.06);
+    overflow: hidden;
 }
 
 .message-section-header {
@@ -1591,7 +1573,9 @@ export default {
     align-items: center;
     justify-content: space-between;
     gap: 10px;
-    margin-bottom: 8px;
+    margin: -15px -15px 12px;
+    padding: 12px 15px;
+    border-bottom: 1px solid #e6e6e6;
 }
 
 .message-section h4 {
@@ -1603,6 +1587,7 @@ export default {
 
 .message-open-btn {
     flex-shrink: 0;
+    padding: 4px 18px;
 }
 
 .message-content {

--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -67,7 +67,6 @@
             <TextConstructor
               v-model="message"
               class="form__message-tc"
-              :collapsible-toolbar="true"
               :rows="2"
               placeholder="Введите сопроводительное письмо / сообщение"
             />
@@ -2271,9 +2270,10 @@ export default {
         align-items: flex-start;
     }
 
-    .form__message-tc {
+    .create__form .form__message-tc {
         width: 55%;
         margin-bottom: 0;
+        border-radius: 30px;
     }
 
     .header__right {

--- a/frontend/src/components/TextConstructor.vue
+++ b/frontend/src/components/TextConstructor.vue
@@ -1,61 +1,9 @@
 <template>
   <div
     class="text-constructor"
-    :class="{ 'is-disabled': disabled, 'has-collapsible-toolbar': collapsibleToolbar }"
+    :class="{ 'is-disabled': disabled }"
   >
-    <button
-      v-if="collapsibleToolbar"
-      type="button"
-      class="toolbar-toggle"
-      :class="{ 'is-open': toolbarExpanded }"
-      :disabled="disabled"
-      :aria-expanded="toolbarExpanded ? 'true' : 'false'"
-      @click="toolbarExpanded = !toolbarExpanded"
-    >
-      <svg
-        class="toolbar-toggle-icon"
-        width="16"
-        height="16"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-      >
-        <polyline points="4 7 4 4 20 4 20 7" />
-        <line
-          x1="9"
-          y1="20"
-          x2="15"
-          y2="20"
-        />
-        <line
-          x1="12"
-          y1="4"
-          x2="12"
-          y2="20"
-        />
-      </svg>
-      <span>Форматирование</span>
-      <svg
-        class="toolbar-toggle-chevron"
-        width="14"
-        height="14"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-      >
-        <polyline points="6 9 12 15 18 9" />
-      </svg>
-    </button>
-    <div
-      v-show="showToolbar"
-      class="editor-toolbar"
-    >
+    <div class="editor-toolbar">
       <div class="toolbar-group">
         <button
           type="button"
@@ -502,13 +450,9 @@ const props = defineProps({
   rows: { type: Number, default: 4 },
   disabled: { type: Boolean, default: false },
   maxImageBytes: { type: Number, default: 5 * 1024 * 1024 },
-  collapsibleToolbar: { type: Boolean, default: false },
 });
 
 const emit = defineEmits(['update:modelValue']);
-
-const toolbarExpanded = ref(false);
-const showToolbar = computed(() => !props.collapsibleToolbar || toolbarExpanded.value);
 
 const fontSizes = ['10px', '12px', '14px', '16px', '18px', '20px'];
 const fontWeights = [
@@ -724,56 +668,6 @@ defineExpose({ editor });
   border-bottom: 1px solid var(--color-border);
 }
 
-.toolbar-toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  margin: 8px 10px;
-  padding: 6px 12px;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  background: #fff;
-  color: #1a1a1a;
-  font-size: 13px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
-}
-
-.toolbar-toggle:hover:not(:disabled) {
-  background: #f4f5ff;
-  border-color: var(--color-primary);
-  color: var(--color-primary);
-}
-
-.toolbar-toggle.is-open {
-  background: var(--color-primary);
-  border-color: var(--color-primary);
-  color: #fff;
-}
-
-.toolbar-toggle:disabled {
-  opacity: 0.45;
-  cursor: not-allowed;
-}
-
-.toolbar-toggle-chevron {
-  transition: transform 0.2s ease;
-}
-
-.toolbar-toggle.is-open .toolbar-toggle-chevron {
-  transform: rotate(180deg);
-}
-
-.has-collapsible-toolbar .editor-toolbar {
-  animation: tc-toolbar-in 0.2s ease;
-}
-
-@keyframes tc-toolbar-in {
-  from { opacity: 0; transform: translateY(-6px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-
 .toolbar-group {
   display: flex;
   align-items: center;
@@ -954,6 +848,16 @@ defineExpose({ editor });
   padding: 6px 14px 10px;
   color: #d92d20;
   font-size: 12px;
+}
+
+.preview-modal-content {
+  padding: 24px 28px;
+  max-height: 70vh;
+  overflow-y: auto;
+  font-size: 15px;
+  line-height: 1.6;
+  color: #1a1a1a;
+  word-break: break-word;
 }
 
 /* Рендер форматирования внутри редактора и в модалке предпросмотра (round-trip с потребителями) */

--- a/frontend/src/components/__tests__/TextConstructor.spec.js
+++ b/frontend/src/components/__tests__/TextConstructor.spec.js
@@ -290,26 +290,4 @@ describe('TextConstructor', () => {
     expect(out).toContain('text-align-center');
     expect(out).not.toContain('style=');
   });
-
-  it('по умолчанию тулбар виден, кнопки-тоггла нет', () => {
-    const wrapper = mountConstructor();
-    expect(wrapper.find('.toolbar-toggle').exists()).toBe(false);
-    expect(wrapper.find('.editor-toolbar').isVisible()).toBe(true);
-  });
-
-  it('collapsibleToolbar скрывает тулбар и показывает кнопку-тоггл', () => {
-    const wrapper = mountConstructor({ collapsibleToolbar: true });
-    expect(wrapper.find('.toolbar-toggle').exists()).toBe(true);
-    expect(wrapper.find('.editor-toolbar').isVisible()).toBe(false);
-  });
-
-  it('клик по тогглу разворачивает и сворачивает тулбар', async () => {
-    const wrapper = mountConstructor({ collapsibleToolbar: true });
-    const toggle = wrapper.find('.toolbar-toggle');
-    await toggle.trigger('click');
-    expect(wrapper.find('.editor-toolbar').isVisible()).toBe(true);
-    expect(toggle.classes()).toContain('is-open');
-    await toggle.trigger('click');
-    expect(wrapper.find('.editor-toolbar').isVisible()).toBe(false);
-  });
 });


### PR DESCRIPTION
Полировка rich-text сопроводительного письма по ревью пользователя (раунд polish-r1 эпика 46-textconstructor).

## Изменения
- **CreateApplication**: тулбар TextConstructor в письме теперь **всегда видим** - убрал сворачивание (кнопку «Форматирование»), оно занимало пустое место. Полностью выпилил проп `collapsibleToolbar` из TextConstructor (больше не используется). Инпут письма скруглён до **30px**.
- **ApplicationDetail**: заголовок «Сообщение к заявке» + кнопка «Открыть в окне» вынесены в **шапку с border-bottom** (сообщение визуально отрезано), `.message-section` получил `overflow:hidden` для чистого скругления шапки. У кнопки убрана иконка, padding `4px 18px`.
- **TextConstructor**: окно предпросмотра получило отступы (`24px 28px`), max-height и скролл - контент больше не впритык к краям (`.base-modal__body` имеет `padding:0`).

## Верификация
- vitest 30/30 (удалил 3 теста на выпиленный collapsibleToolbar), eslint 0.
- Playwright по живому стеку: CreateApplication (тулбар всегда виден, тоггла нет, radius 30px, предпросмотр padding 24px 28px); ApplicationDetail (шапка border-bottom + overflow:hidden, кнопка без иконки padding 4px 18px pill).
- Скриншоты check-r1-*.

## Ревью
code-reviewer: 1 RED (`.message-section` без `overflow:hidden` -> шапка вылезет за скругление) - исправлено. Висячих ссылок на удалённый collapsibleToolbar нет, импорты чисты, специфичность 30px подтверждена.