### PR TITLE
feat(analytics): конструктор отчётов - гид и живой результат таблицей (#632)

### DIFF
--- a/frontend/src/api/statistics.js
+++ b/frontend/src/api/statistics.js
@@ -64,3 +64,40 @@ export async function getRecentPassages(limit = 15) {
   const res = await apiRequest(`/statistics/recent-passages?limit=${limit}`);
   return res.json();
 }
+
+/**
+ * Получить каталог конструктора отчётов: whitelist метрик, разрезов, фильтров
+ * и list-сущностей с подставленными значениями динамических справочников.
+ * @returns {Promise<{
+ *   metrics: Array<{key: string, label: string, unit?: string, dimensions: string[]}>,
+ *   dimensions: Array<{key: string, label: string}>,
+ *   filters: Array<{key: string, label: string, type: 'date'|'enum'|'dict', options?: Array<{value: string, label: string}>}>,
+ *   list_entities: Array<{key: string, label: string, columns: Array<{key: string, label: string}>, filters: string[]}>,
+ *   granularities: Array<{value: string, label: string}>,
+ * }>}
+ */
+export async function getReportCatalog() {
+  const res = await apiRequest('/statistics/metrics');
+  const data = await res.json();
+  if (!res.ok) throw new Error(data?.message || 'Не удалось загрузить каталог отчётов');
+  return data;
+}
+
+/**
+ * Исполнить отчёт конструктора.
+ * @param {{
+ *   mode: 'aggregate'|'list', metric?: string, dimension?: string, granularity?: string,
+ *   entity?: string, filters?: Array<{key: string, values?: string[], from?: string, to?: string}>,
+ *   sort?: string, limit?: number
+ * }} request
+ * @returns {Promise<object>} ReportResponse (aggregate) или ReportListResponse (list)
+ */
+export async function runReport(request) {
+  const res = await apiRequest('/statistics/report', {
+    method: 'POST',
+    body: JSON.stringify(request),
+  });
+  const data = await res.json();
+  if (!res.ok) throw new Error(data?.message || 'Не удалось построить отчёт');
+  return data;
+}

--- a/frontend/src/components/statistics/ReportBuilder.vue
+++ b/frontend/src/components/statistics/ReportBuilder.vue
@@ -1,0 +1,368 @@
+<template>
+  <div class="rb">
+    <!-- Тип отчёта -->
+    <div class="rb__type">
+      <span class="rb__section-label">Тип отчёта</span>
+      <FilterTabs
+        v-model="form.mode"
+        :tabs="modeTabs"
+      />
+      <span class="rb__hint">{{ form.mode === 'aggregate'
+        ? 'Посчитать показатель в выбранном разрезе.'
+        : 'Выгрузить строки сущности столбцами.' }}</span>
+    </div>
+
+    <!-- Параметры -->
+    <div class="rb__grid">
+      <template v-if="form.mode === 'aggregate'">
+        <label class="rb__field">
+          <span class="rb__field-label">Что считаем</span>
+          <BaseDropdown
+            v-model="form.metric"
+            :options="catalog.metrics"
+            label-key="label"
+            value-key="key"
+          />
+        </label>
+        <label class="rb__field">
+          <span class="rb__field-label">Разрез</span>
+          <BaseDropdown
+            v-model="form.dimension"
+            :options="dimensionOptions"
+            label-key="label"
+            value-key="key"
+          />
+        </label>
+        <label
+          v-if="form.dimension === 'period'"
+          class="rb__field"
+        >
+          <span class="rb__field-label">Шаг</span>
+          <BaseDropdown
+            v-model="form.granularity"
+            :options="catalog.granularities"
+            label-key="label"
+            value-key="value"
+          />
+        </label>
+      </template>
+
+      <label
+        v-else
+        class="rb__field"
+      >
+        <span class="rb__field-label">Что выгружаем</span>
+        <BaseDropdown
+          v-model="form.entity"
+          :options="catalog.list_entities"
+          label-key="label"
+          value-key="key"
+        />
+      </label>
+    </div>
+
+    <!-- list-фильтры из каталога (date_range = период из шапки, не дублируем) -->
+    <div
+      v-if="listFilterFields.length"
+      class="rb__filters"
+    >
+      <div
+        v-for="f in listFilterFields"
+        :key="f.key"
+        class="rb__filter"
+      >
+        <span class="rb__field-label">{{ f.label }}</span>
+        <div class="rb__pills">
+          <button
+            v-for="opt in f.options"
+            :key="opt.value"
+            type="button"
+            class="rb__pill"
+            :class="{ 'rb__pill--on': isSelected(f.key, opt.value) }"
+            @click="toggleFilter(f.key, opt.value)"
+          >
+            {{ opt.label }}
+          </button>
+          <span
+            v-if="!f.options.length"
+            class="rb__pills-empty"
+          >нет значений в справочнике</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Итог + действия -->
+    <div class="rb__footer">
+      <p class="rb__summary">
+        {{ summary }}
+      </p>
+      <div class="rb__actions">
+        <label class="rb__limit">
+          <span>Строк</span>
+          <input
+            v-model="form.limit"
+            type="number"
+            min="1"
+            max="1000"
+            placeholder="100"
+            class="lk-input rb__limit-input"
+          >
+        </label>
+        <button
+          type="button"
+          class="lk-button lk-button--primary"
+          :disabled="!canRun || loading"
+          @click="run"
+        >
+          {{ loading ? 'Строим…' : 'Построить отчёт' }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { reactive, computed, watch } from 'vue';
+import FilterTabs from '@/components/ui/FilterTabs.vue';
+import BaseDropdown from '@/components/ui/BaseDropdown.vue';
+import { buildReportRequest } from '@/composables/useReportRequest';
+
+const props = defineProps({
+  catalog: { type: Object, required: true },
+  period: { type: Object, default: () => ({ from: '', to: '' }) },
+  loading: { type: Boolean, default: false },
+});
+
+const emit = defineEmits(['run']);
+
+const modeTabs = [
+  { key: 'aggregate', label: 'Сводка по разрезу' },
+  { key: 'list', label: 'Выгрузка строк' },
+];
+
+const form = reactive({
+  mode: 'aggregate',
+  metric: props.catalog.metrics?.[0]?.key || '',
+  dimension: '',
+  granularity: 'day',
+  entity: props.catalog.list_entities?.[0]?.key || '',
+  filters: {},
+  limit: '',
+});
+
+const filterByKey = computed(() => {
+  const map = {};
+  for (const f of props.catalog.filters || []) map[f.key] = f;
+  return map;
+});
+
+const selectedMetric = computed(
+  () => (props.catalog.metrics || []).find((m) => m.key === form.metric) || null,
+);
+
+const dimensionOptions = computed(() => {
+  const dims = selectedMetric.value?.dimensions || [];
+  return (props.catalog.dimensions || []).filter((d) => dims.includes(d.key));
+});
+
+const selectedEntity = computed(
+  () => (props.catalog.list_entities || []).find((e) => e.key === form.entity) || null,
+);
+
+const listFilterFields = computed(() => {
+  if (form.mode !== 'list') return [];
+  const keys = selectedEntity.value?.filters || [];
+  return keys
+    .filter((k) => k !== 'date_range')
+    .map((k) => filterByKey.value[k])
+    .filter(Boolean)
+    .map((f) => ({ ...f, options: f.options || [] }));
+});
+
+// Aggregate per-metric фильтры пока не в каталоге -> отдаём только период (срез B3b).
+const applicableFilters = computed(() =>
+  form.mode === 'list' ? selectedEntity.value?.filters || [] : ['date_range'],
+);
+
+// Разрез должен принадлежать выбранной метрике — иначе движок отклонит запрос.
+watch(selectedMetric, (m) => {
+  if (!m) {
+    form.dimension = '';
+    return;
+  }
+  if (!m.dimensions.includes(form.dimension)) {
+    form.dimension = m.dimensions[0] || '';
+  }
+}, { immediate: true });
+
+// Смена выгружаемой сущности обнуляет выбранные фильтры — у разных сущностей
+// разный набор применимых фильтров, чужие значения сбивали бы с толку.
+watch(() => form.entity, () => {
+  form.filters = {};
+});
+
+const canRun = computed(() =>
+  form.mode === 'aggregate'
+    ? Boolean(form.metric && form.dimension)
+    : Boolean(form.entity),
+);
+
+const periodLabel = computed(() => {
+  const { from, to } = props.period || {};
+  if (from && to) return `${from} — ${to}`;
+  if (from) return `с ${from}`;
+  if (to) return `по ${to}`;
+  return 'весь период';
+});
+
+const summary = computed(() => {
+  if (form.mode === 'aggregate') {
+    const metric = selectedMetric.value?.label || '—';
+    const dim = dimensionOptions.value.find((d) => d.key === form.dimension)?.label || '—';
+    return `Считаем «${metric}» в разрезе «${dim}», период: ${periodLabel.value}.`;
+  }
+  // Период упоминаем только если сущность его поддерживает (машины/люди — нет).
+  const supportsPeriod = (selectedEntity.value?.filters || []).includes('date_range');
+  const periodPart = supportsPeriod ? `, период: ${periodLabel.value}` : '';
+  return `Выгрузка строк: «${selectedEntity.value?.label || '—'}»${periodPart}.`;
+});
+
+function isSelected(key, value) {
+  return (form.filters[key] || []).includes(value);
+}
+
+function toggleFilter(key, value) {
+  const current = form.filters[key] ? [...form.filters[key]] : [];
+  const idx = current.indexOf(value);
+  if (idx >= 0) current.splice(idx, 1);
+  else current.push(value);
+  form.filters = { ...form.filters, [key]: current };
+}
+
+function run() {
+  emit('run', buildReportRequest(form, props.period, applicableFilters.value));
+}
+</script>
+
+<style scoped>
+.rb {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.rb__section-label,
+.rb__field-label {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+}
+
+.rb__type {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.rb__hint {
+  font-size: 13px;
+  color: var(--color-text-muted);
+}
+
+.rb__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.rb__field {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.rb__filters {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding-top: 4px;
+}
+
+.rb__filter {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+
+.rb__pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.rb__pill {
+  padding: 5px 13px;
+  border: 1px solid var(--color-border);
+  background: #fff;
+  border-radius: var(--radius-pill);
+  font-size: 13px;
+  font-family: inherit;
+  color: var(--color-text);
+  cursor: pointer;
+  transition: background 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+}
+
+.rb__pill:hover {
+  border-color: var(--color-primary);
+}
+
+.rb__pill--on {
+  background: var(--color-primary);
+  color: #fff;
+  border-color: var(--color-primary);
+}
+
+.rb__pills-empty {
+  font-size: 13px;
+  color: var(--color-text-muted);
+  font-style: italic;
+}
+
+.rb__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  padding-top: 4px;
+  border-top: 1px solid var(--color-border);
+}
+
+.rb__summary {
+  margin: 0;
+  font-size: 14px;
+  color: var(--color-text);
+  flex: 1;
+  min-width: 240px;
+}
+
+.rb__actions {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.rb__limit {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--color-text-muted);
+}
+
+.rb__limit-input {
+  width: 84px;
+}
+</style>

--- a/frontend/src/components/statistics/ReportResult.vue
+++ b/frontend/src/components/statistics/ReportResult.vue
@@ -1,0 +1,245 @@
+<template>
+  <div class="rr">
+    <!-- Загрузка -->
+    <div
+      v-if="loading"
+      class="rr__state"
+    >
+      <LoaderSpinner />
+      <span>Строим отчёт…</span>
+    </div>
+
+    <!-- Ошибка -->
+    <div
+      v-else-if="error"
+      class="rr__state rr__state--error"
+    >
+      {{ error }}
+    </div>
+
+    <!-- Пусто (отчёт ещё не построен) -->
+    <div
+      v-else-if="!result"
+      class="rr__state rr__empty"
+    >
+      <svg
+        width="44"
+        height="44"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M3 3v18h18" />
+        <path d="M7 14l3-4 3 3 4-6" />
+      </svg>
+      <p>Здесь появится ваш отчёт</p>
+      <span>Задайте параметры выше и нажмите «Построить отчёт».</span>
+    </div>
+
+    <!-- Агрегатный отчёт -->
+    <template v-else-if="result.mode === 'aggregate'">
+      <div class="rr__table-wrap">
+        <table class="rr__table">
+          <thead>
+            <tr>
+              <th>Значение разреза</th>
+              <th class="rr__num">
+                Количество{{ result.unit ? `, ${result.unit}` : '' }}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="(row, i) in result.rows"
+              :key="i"
+            >
+              <td>{{ row.label }}</td>
+              <td class="rr__num">
+                {{ formatNumber(row.value) }}
+              </td>
+            </tr>
+            <tr v-if="!result.rows.length">
+              <td
+                colspan="2"
+                class="rr__norows"
+              >
+                Нет данных за выбранный период
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="rr__footer">
+        Итого: <b>{{ formatNumber(result.total) }}</b>{{ result.unit ? ` ${result.unit}` : '' }}
+        <span class="rr__footer-sep">·</span> строк: {{ result.rows.length }}
+      </div>
+    </template>
+
+    <!-- Выгрузка строк (list) -->
+    <template v-else>
+      <div class="rr__table-wrap">
+        <table class="rr__table">
+          <thead>
+            <tr>
+              <th
+                v-for="col in (result.columns || [])"
+                :key="col.key"
+              >
+                {{ col.label }}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="(row, i) in result.rows"
+              :key="i"
+            >
+              <td
+                v-for="col in (result.columns || [])"
+                :key="col.key"
+              >
+                {{ formatCell(row[col.key]) }}
+              </td>
+            </tr>
+            <tr v-if="!result.rows.length">
+              <td
+                :colspan="(result.columns || []).length || 1"
+                class="rr__norows"
+              >
+                Нет данных за выбранный период
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="rr__footer">
+        Всего: <b>{{ result.total }}</b>
+        <span class="rr__footer-sep">·</span> показано строк: {{ result.rows.length }}
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import LoaderSpinner from '@/components/ui/LoaderSpinner.vue';
+
+defineProps({
+  result: { type: Object, default: null },
+  loading: { type: Boolean, default: false },
+  error: { type: String, default: '' },
+});
+
+function formatNumber(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n.toLocaleString('ru-RU') : value;
+}
+
+function formatCell(value) {
+  if (value === null || value === undefined || value === '') return '—';
+  return value;
+}
+</script>
+
+<style scoped>
+.rr {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.rr__state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  min-height: 220px;
+  text-align: center;
+  color: var(--color-text-muted);
+}
+
+.rr__state--error {
+  color: #c0392b;
+}
+
+.rr__empty svg {
+  opacity: 0.35;
+}
+
+.rr__empty p {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.rr__empty span {
+  font-size: 13px;
+  max-width: 320px;
+}
+
+.rr__table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.rr__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.rr__table thead th {
+  position: sticky;
+  top: 0;
+  background: var(--color-bg);
+  text-align: left;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  padding: 11px 14px;
+  white-space: nowrap;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.rr__table tbody td {
+  padding: 10px 14px;
+  color: var(--color-text);
+  border-bottom: 1px solid var(--color-border);
+  vertical-align: top;
+}
+
+.rr__table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.rr__table tbody tr:hover td {
+  background: var(--color-bg);
+}
+
+.rr__num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.rr__norows {
+  text-align: center;
+  color: var(--color-text-muted);
+  padding: 24px 14px;
+}
+
+.rr__footer {
+  font-size: 14px;
+  color: var(--color-text);
+}
+
+.rr__footer-sep {
+  color: var(--color-text-muted);
+  margin: 0 4px;
+}
+</style>

--- a/frontend/src/components/statistics/ReportsTab.vue
+++ b/frontend/src/components/statistics/ReportsTab.vue
@@ -1,0 +1,139 @@
+<template>
+  <div class="reports">
+    <!-- Загрузка каталога -->
+    <div
+      v-if="catalogLoading"
+      class="reports__state"
+    >
+      <LoaderSpinner />
+      <span>Загружаем конструктор отчётов…</span>
+    </div>
+
+    <div
+      v-else-if="catalogError"
+      class="reports__state reports__state--error"
+    >
+      {{ catalogError }}
+    </div>
+
+    <template v-else-if="catalog">
+      <section class="reports__block">
+        <h2 class="reports__heading">
+          Сформировать отчёт
+        </h2>
+        <p class="reports__lead">
+          Выберите показатель и разрез или выгрузку строк — результат появится ниже. Период берётся из фильтра вверху.
+        </p>
+        <ReportBuilder
+          :catalog="catalog"
+          :period="period"
+          :loading="running"
+          @run="onRun"
+        />
+      </section>
+
+      <section class="reports__block reports__block--result">
+        <h2 class="reports__heading">
+          Результат
+        </h2>
+        <ReportResult
+          :result="result"
+          :loading="running"
+          :error="runError"
+        />
+      </section>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue';
+import ReportBuilder from './ReportBuilder.vue';
+import ReportResult from './ReportResult.vue';
+import LoaderSpinner from '@/components/ui/LoaderSpinner.vue';
+import { getReportCatalog, runReport } from '@/api/statistics';
+
+const props = defineProps({
+  from: { type: String, default: '' },
+  to: { type: String, default: '' },
+});
+
+const period = computed(() => ({ from: props.from, to: props.to }));
+
+const catalog = ref(null);
+const catalogLoading = ref(true);
+const catalogError = ref('');
+
+const result = ref(null);
+const running = ref(false);
+const runError = ref('');
+
+onMounted(async () => {
+  try {
+    catalog.value = await getReportCatalog();
+  } catch (e) {
+    catalogError.value = e?.message || 'Не удалось загрузить каталог отчётов';
+  } finally {
+    catalogLoading.value = false;
+  }
+});
+
+async function onRun(request) {
+  running.value = true;
+  runError.value = '';
+  try {
+    result.value = await runReport(request);
+  } catch (e) {
+    result.value = null;
+    runError.value = e?.message || 'Не удалось построить отчёт. Проверьте параметры.';
+  } finally {
+    running.value = false;
+  }
+}
+</script>
+
+<style scoped>
+.reports {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.reports__state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  min-height: 240px;
+  color: var(--color-text-muted);
+}
+
+.reports__state--error {
+  color: #c0392b;
+}
+
+.reports__block {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.reports__block--result {
+  border-top: 1px solid var(--color-border);
+  padding-top: 24px;
+}
+
+.reports__heading {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.reports__lead {
+  margin: 0 0 12px;
+  font-size: 13px;
+  color: var(--color-text-muted);
+}
+</style>

--- a/frontend/src/components/statistics/__tests__/ReportBuilder.spec.js
+++ b/frontend/src/components/statistics/__tests__/ReportBuilder.spec.js
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
+import ReportBuilder from '../ReportBuilder.vue';
+import FilterTabs from '@/components/ui/FilterTabs.vue';
+import BaseDropdown from '@/components/ui/BaseDropdown.vue';
+
+const CATALOG = {
+  metrics: [
+    { key: 'car_entries_count', label: 'Въезды машин', unit: 'шт', dimensions: ['unload_place', 'period'] },
+    { key: 'applications_count', label: 'Количество заявок', unit: 'шт', dimensions: ['status', 'period'] },
+  ],
+  dimensions: [
+    { key: 'unload_place', label: 'Место разгрузки' },
+    { key: 'status', label: 'Статус заявки' },
+    { key: 'period', label: 'Период (дата)' },
+  ],
+  filters: [
+    { key: 'date_range', label: 'Период', type: 'date' },
+    { key: 'organization', label: 'Организация', type: 'dict', options: [{ value: 'ООО А', label: 'ООО А' }] },
+    { key: 'status', label: 'Статус заявки', type: 'enum', options: [{ value: 'Завершено', label: 'Завершено' }] },
+  ],
+  list_entities: [
+    {
+      key: 'work_applications',
+      label: 'Заявка на работы',
+      columns: [{ key: 'number', label: 'Номер' }],
+      filters: ['date_range', 'organization', 'status'],
+    },
+    { key: 'cars', label: 'Машины', columns: [{ key: 'car_number', label: 'Номер' }], filters: ['organization'] },
+  ],
+  granularities: [{ value: 'day', label: 'По дням' }, { value: 'week', label: 'По неделям' }],
+};
+
+const PERIOD = { from: '2026-06-01', to: '2026-06-07' };
+
+function mountBuilder() {
+  return mount(ReportBuilder, { props: { catalog: CATALOG, period: PERIOD } });
+}
+
+function clickBuild(wrapper) {
+  return wrapper.find('button.lk-button--primary').trigger('click');
+}
+
+function lastRun(wrapper) {
+  const runs = wrapper.emitted('run');
+  return runs[runs.length - 1][0];
+}
+
+describe('ReportBuilder', () => {
+  it('по умолчанию строит aggregate первой метрики с её первым разрезом и периодом', async () => {
+    const wrapper = mountBuilder();
+    await nextTick();
+    await clickBuild(wrapper);
+
+    const req = lastRun(wrapper);
+    expect(req.mode).toBe('aggregate');
+    expect(req.metric).toBe('car_entries_count');
+    expect(req.dimension).toBe('unload_place'); // первый разрез метрики
+    expect(req.filters).toContainEqual({ key: 'date_range', from: '2026-06-01', to: '2026-06-07' });
+  });
+
+  it('в режиме list строит запрос сущности с выбранным фильтром', async () => {
+    const wrapper = mountBuilder();
+    wrapper.findComponent(FilterTabs).vm.$emit('update:modelValue', 'list');
+    await nextTick();
+
+    // Фильтры сущности отрисованы (организация + статус, date_range = период из шапки)
+    const pills = wrapper.findAll('.rb__pill');
+    expect(pills.length).toBe(2);
+
+    // Выбираем организацию
+    const orgPill = pills.find((p) => p.text() === 'ООО А');
+    await orgPill.trigger('click');
+    await clickBuild(wrapper);
+
+    const req = lastRun(wrapper);
+    expect(req.mode).toBe('list');
+    expect(req.entity).toBe('work_applications');
+    expect(req.filters).toContainEqual({ key: 'organization', values: ['ООО А'] });
+    expect(req.filters).toContainEqual({ key: 'date_range', from: '2026-06-01', to: '2026-06-07' });
+  });
+
+  it('сбрасывает выбранные фильтры при смене выгружаемой сущности', async () => {
+    const wrapper = mountBuilder();
+    wrapper.findComponent(FilterTabs).vm.$emit('update:modelValue', 'list');
+    await nextTick();
+
+    // Выбрали организацию у work_applications
+    const orgPill = wrapper.findAll('.rb__pill').find((p) => p.text() === 'ООО А');
+    await orgPill.trigger('click');
+
+    // Переключились на машины (у них набор фильтров другой) и обратно
+    const entityDropdown = wrapper.findAllComponents(BaseDropdown)[0];
+    entityDropdown.vm.$emit('update:modelValue', 'cars');
+    await nextTick();
+    entityDropdown.vm.$emit('update:modelValue', 'work_applications');
+    await nextTick();
+    await clickBuild(wrapper);
+
+    // Фильтр организации не должен переехать через смену сущности
+    expect(lastRun(wrapper).filters.find((f) => f.key === 'organization')).toBeUndefined();
+  });
+
+  it('сбрасывает разрез на валидный при смене метрики', async () => {
+    const wrapper = mountBuilder();
+    await nextTick();
+    // applications_count не поддерживает unload_place -> разрез должен переключиться на status.
+    // Меняем метрику через emit первого BaseDropdown (script setup не экспонирует form).
+    const metricDropdown = wrapper.findAllComponents(BaseDropdown)[0];
+    metricDropdown.vm.$emit('update:modelValue', 'applications_count');
+    await nextTick();
+    await clickBuild(wrapper);
+
+    expect(lastRun(wrapper).dimension).toBe('status');
+  });
+});

--- a/frontend/src/composables/__tests__/useReportRequest.spec.js
+++ b/frontend/src/composables/__tests__/useReportRequest.spec.js
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { buildReportRequest } from '../useReportRequest';
+
+const PERIOD = { from: '2026-06-01', to: '2026-06-07' };
+
+describe('buildReportRequest', () => {
+  describe('aggregate', () => {
+    it('собирает метрику+разрез и период фильтром date_range', () => {
+      const req = buildReportRequest(
+        { mode: 'aggregate', metric: 'car_entries_count', dimension: 'unload_place' },
+        PERIOD,
+        ['date_range'],
+      );
+      expect(req.mode).toBe('aggregate');
+      expect(req.metric).toBe('car_entries_count');
+      expect(req.dimension).toBe('unload_place');
+      expect(req.filters).toContainEqual({ key: 'date_range', from: '2026-06-01', to: '2026-06-07' });
+    });
+
+    it('добавляет granularity только для разреза period', () => {
+      const period = buildReportRequest(
+        { mode: 'aggregate', metric: 'applications_count', dimension: 'period', granularity: 'week' },
+        PERIOD, ['date_range'],
+      );
+      expect(period.granularity).toBe('week');
+
+      const status = buildReportRequest(
+        { mode: 'aggregate', metric: 'applications_count', dimension: 'status', granularity: 'week' },
+        PERIOD, ['date_range'],
+      );
+      expect(status.granularity).toBeUndefined();
+    });
+
+    it('не шлёт date_range, если период пустой', () => {
+      const req = buildReportRequest(
+        { mode: 'aggregate', metric: 'applications_count', dimension: 'status' },
+        { from: '', to: '' }, ['date_range'],
+      );
+      expect(req.filters).toEqual([]);
+    });
+  });
+
+  describe('list', () => {
+    it('включает date_range, когда сущность его поддерживает', () => {
+      const req = buildReportRequest(
+        { mode: 'list', entity: 'work_applications' },
+        PERIOD, ['date_range', 'organization', 'status'],
+      );
+      expect(req.mode).toBe('list');
+      expect(req.entity).toBe('work_applications');
+      expect(req.filters).toContainEqual({ key: 'date_range', from: '2026-06-01', to: '2026-06-07' });
+    });
+
+    it('НЕ включает date_range, если сущность его не поддерживает (машины/люди)', () => {
+      const req = buildReportRequest(
+        { mode: 'list', entity: 'cars' },
+        PERIOD, ['organization', 'unload_place'],
+      );
+      expect(req.filters.find((f) => f.key === 'date_range')).toBeUndefined();
+    });
+  });
+
+  describe('фильтры значений', () => {
+    it('включает только применимые ключи с непустыми значениями', () => {
+      const req = buildReportRequest(
+        {
+          mode: 'list',
+          entity: 'work_applications',
+          filters: {
+            organization: ['ООО Ромашка', '  '],
+            status: [],
+            citizenship: ['РФ'], // не применим к work_applications
+          },
+        },
+        { from: '', to: '' },
+        ['date_range', 'organization', 'status'],
+      );
+      expect(req.filters).toContainEqual({ key: 'organization', values: ['ООО Ромашка'] });
+      expect(req.filters.find((f) => f.key === 'status')).toBeUndefined();
+      expect(req.filters.find((f) => f.key === 'citizenship')).toBeUndefined();
+    });
+  });
+
+  describe('limit', () => {
+    it('нормализует лимит: пусто -> 0, дробь -> floor, потолок 1000', () => {
+      expect(buildReportRequest({ mode: 'list', entity: 'cars', limit: null }, {}, []).limit).toBe(0);
+      expect(buildReportRequest({ mode: 'list', entity: 'cars', limit: '' }, {}, []).limit).toBe(0);
+      expect(buildReportRequest({ mode: 'list', entity: 'cars', limit: '50.9' }, {}, []).limit).toBe(50);
+      expect(buildReportRequest({ mode: 'list', entity: 'cars', limit: 5000 }, {}, []).limit).toBe(1000);
+      expect(buildReportRequest({ mode: 'list', entity: 'cars', limit: -3 }, {}, []).limit).toBe(0);
+    });
+  });
+});

--- a/frontend/src/composables/useReportRequest.js
+++ b/frontend/src/composables/useReportRequest.js
@@ -1,0 +1,68 @@
+/**
+ * Сборка тела запроса POST /statistics/report из состояния конструктора отчётов.
+ *
+ * Период передаётся фильтром date_range{from,to} — движок (и aggregate, и list)
+ * сам спец-кейсит его по своей tsColumn. date_range добавляется только если он
+ * применим к выбранному срезу: для list — входит ли в entity.filters (у машин и
+ * людей его нет, движок вернёт 400), для aggregate — всегда (у каждой метрики есть
+ * временная колонка). dict/enum-значения попадают только по применимым ключам;
+ * пустые значения отбрасываются — пустой фильтр движок и так пропускает.
+ *
+ * @param {{
+ *   mode: 'aggregate'|'list',
+ *   metric?: string, dimension?: string, granularity?: string,
+ *   entity?: string, sort?: string, limit?: number|string|null,
+ *   filters?: Record<string, string[]>
+ * }} state
+ * @param {{from?: string, to?: string}} [period]
+ * @param {string[]} [applicableFilters] — ключи фильтров, валидные для текущего среза
+ * @returns {object} тело запроса ReportRequest
+ */
+export function buildReportRequest(state, period = {}, applicableFilters = []) {
+  const allowed = new Set(applicableFilters);
+  const filters = [];
+
+  const from = period.from || '';
+  const to = period.to || '';
+  if (allowed.has('date_range') && (from || to)) {
+    filters.push({ key: 'date_range', from, to });
+  }
+
+  for (const [key, values] of Object.entries(state.filters || {})) {
+    if (key === 'date_range' || !allowed.has(key)) continue;
+    const clean = (values || []).filter((v) => v != null && String(v).trim() !== '');
+    if (clean.length) filters.push({ key, values: clean });
+  }
+
+  const limit = normalizeLimit(state.limit);
+
+  if (state.mode === 'list') {
+    return { mode: 'list', entity: state.entity || '', filters, limit };
+  }
+
+  const req = {
+    mode: 'aggregate',
+    metric: state.metric || '',
+    dimension: state.dimension || '',
+    filters,
+    limit,
+  };
+  // Гранулярность осмысленна только для временного разреза.
+  if (state.dimension === 'period' && state.granularity) {
+    req.granularity = state.granularity;
+  }
+  if (state.sort) req.sort = state.sort;
+  return req;
+}
+
+/**
+ * Нормализует лимит строк: пусто/невалидно -> 0 (бэк применит дефолт 100),
+ * иначе целое в диапазоне [1, 1000].
+ * @param {number|string|null|undefined} limit
+ * @returns {number}
+ */
+function normalizeLimit(limit) {
+  const n = Number(limit);
+  if (!Number.isFinite(n) || n <= 0) return 0;
+  return Math.min(Math.floor(n), 1000);
+}

--- a/frontend/src/views/StatisticsView.vue
+++ b/frontend/src/views/StatisticsView.vue
@@ -76,29 +76,15 @@
           />
         </div>
 
-        <!-- Отчёты (заглушка) -->
+        <!-- Отчёты -->
         <div
           v-else
-          class="statistics__panel statistics__placeholder"
+          class="statistics__panel"
         >
-          <div class="statistics__placeholder-inner">
-            <svg
-              width="48"
-              height="48"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              aria-hidden="true"
-            >
-              <path d="M3 3v18h18" />
-              <path d="M7 14l3-4 3 3 4-6" />
-            </svg>
-            <p>Раздел в разработке</p>
-            <span>Готовые отчёты и конструктор выборок появятся здесь в ближайших обновлениях.</span>
-          </div>
+          <ReportsTab
+            :from="fromStr"
+            :to="toStr"
+          />
         </div>
       </div>
     </div>
@@ -117,6 +103,7 @@ import AdminPageShell from '@/views/admin/AdminPageShell.vue';
 import DateFilter from '@/components/DateFilter.vue';
 import RefreshButton from '@/components/RefreshButton.vue';
 import StatisticsDashboard from '@/components/statistics/StatisticsDashboard.vue';
+import ReportsTab from '@/components/statistics/ReportsTab.vue';
 import AnalyticsInstructionModal from '@/components/statistics/AnalyticsInstructionModal.vue';
 
 // ---- вкладки ----
@@ -286,40 +273,6 @@ function onRefresh() {
 
 .statistics__panel {
   padding: 26px 28px 40px;
-}
-
-/* Заглушка отчётов */
-.statistics__placeholder {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 300px;
-}
-
-.statistics__placeholder-inner {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 12px;
-  text-align: center;
-  color: var(--color-text-muted);
-}
-
-.statistics__placeholder-inner svg {
-  opacity: 0.35;
-}
-
-.statistics__placeholder-inner p {
-  font-size: 16px;
-  font-weight: 700;
-  color: var(--color-text);
-  margin: 0;
-}
-
-.statistics__placeholder-inner span {
-  font-size: 13px;
-  line-height: 1.5;
-  max-width: 340px;
 }
 
 /* management-header / management-title подхватываются из AdminPageShell :deep */


### PR DESCRIPTION
## Что

Срез **B3a** эпика #632 (вкладка «Аналитика»). Вкладка «Отчёты» была заглушкой - теперь это функциональный гид-конструктор:

- **Тип отчёта** (переключатель): «Сводка по разрезу» (aggregate) или «Выгрузка строк» (list).
- **aggregate**: метрика -> разрез (только допустимые для метрики) -> шаг (granularity, только для разреза «Период»).
- **list**: сущность (Заявка на работы / Заявки / Машины / Люди) + фильтры из каталога сущности (pill-мультиселект).
- **Период** берётся из фильтра в шапке «Аналитики» и передаётся фильтром `date_range` (движок сам спец-кейсит его по своей дате-колонке; для машин/людей период не применяется - в summary он не упоминается).
- **Результат** строится живой таблицей через `POST /statistics/report`: aggregate - «значение разреза / количество» + итог; list - многоколоночная выгрузка + «всего». Состояния загрузки/ошибки/пусто.

Бэкенд (движок aggregate+list, каталог `GET /statistics/metrics`) был смержен ранее (#642/#645/#649), здесь только FE.

## Декомпозиция

Полный B3 (галерея готовых отчётов + гид + результат с графиком) - >650 LOC, поэтому разбит:
- **B3a (этот PR)**: функциональный гид + результат таблицей. dev остаётся рабочим - вкладка функциональна.
- **B3b (следующий)**: галерея готовых отчётов (пресеты заполняют гид) + helper-блок + переключатель Таблица/График (Chart.js) + доделка aggregate per-metric фильтров (расширение каталога).

## Переиспользование / конвенции

`FilterTabs`, `BaseDropdown`, `LoaderSpinner` из `ui/*`; `.lk-button`/`.lk-input`; токены из `tokens.css`. Envelope - через `apiRequest`; новые api-функции проверяют `res.ok` и бросают (apiRequest не бросает на 400). Логика сборки запроса вынесена в чистый `useReportRequest` (юнит-тест), компонент покрыт mount-тестом (оба режима, сброс разреза/фильтров).

## Проверки

- vitest: `useReportRequest` (8) + `ReportBuilder` (4 mount-теста) - зелёные.
- eslint - 0 ошибок.
- Ревью `code-reviewer` = **GO**, без блокеров. 4 жёлтых замечания исправлены (summary без периода для машин/людей; защитный рендер list-результата; сброс фильтров при смене сущности; доп. assert лимита).
- `/ship-check` на staging - после мержа в dev (деплой).