### PR TITLE
feat(text-constructor): выравнивание и обтекание картинок (#46) [polish-r2]

### DIFF
--- a/frontend/src/components/AnnouncementModal.vue
+++ b/frontend/src/components/AnnouncementModal.vue
@@ -281,6 +281,10 @@ export default {
 .announcement-body-html :deep(ol) { padding-left: 1.5em; margin: 0.5em 0; }
 .announcement-body-html :deep(img) { max-width: 100%; border-radius: 8px; }
 .announcement-body-html :deep(img:not([height])) { height: auto; }
+.announcement-body-html :deep(.constructor-image.img-align-left) { float: left; margin: 0 14px 10px 0; }
+.announcement-body-html :deep(.constructor-image.img-align-right) { float: right; margin: 0 0 10px 14px; }
+.announcement-body-html :deep(.constructor-image.img-align-center) { display: block; margin: 10px auto; float: none; }
+.announcement-body-html::after { content: ''; display: block; clear: both; }
 .announcement-body-html :deep(.text-align-left) { text-align: left; }
 .announcement-body-html :deep(.text-align-center) { text-align: center; }
 .announcement-body-html :deep(.text-align-right) { text-align: right; }

--- a/frontend/src/components/ApplicationDetail/ApplicationDetail.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationDetail.vue
@@ -1624,6 +1624,10 @@ export default {
     height: auto;
 }
 
+.message-preview :deep(.constructor-image.img-align-left) { float: left; margin: 0 14px 10px 0; }
+.message-preview :deep(.constructor-image.img-align-right) { float: right; margin: 0 0 10px 14px; }
+.message-preview :deep(.constructor-image.img-align-center) { display: block; margin: 10px auto; float: none; }
+
 .message-preview :deep(p) { margin: 4px 0; }
 
 .message-preview :deep(ul),

--- a/frontend/src/components/ApplicationDetail/ApplicationMessageModal.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationMessageModal.vue
@@ -184,6 +184,11 @@ onBeforeUnmount(() => {
   height: auto;
 }
 
+.text-constructor-content :deep(.constructor-image.img-align-left) { float: left; margin: 0 14px 10px 0; }
+.text-constructor-content :deep(.constructor-image.img-align-right) { float: right; margin: 0 0 10px 14px; }
+.text-constructor-content :deep(.constructor-image.img-align-center) { display: block; margin: 10px auto; float: none; }
+.text-constructor-content::after { content: ''; display: block; clear: both; }
+
 .text-constructor-content :deep(strong) { font-weight: 700; }
 .text-constructor-content :deep(em) { font-style: italic; }
 .text-constructor-content :deep(u) { text-decoration: underline; }

--- a/frontend/src/components/TablesComponent.vue
+++ b/frontend/src/components/TablesComponent.vue
@@ -856,6 +856,11 @@ export default {
     height: auto;
 }
 
+.text-constructor-content :deep(.constructor-image.img-align-left) { float: left; margin: 0 14px 10px 0; }
+.text-constructor-content :deep(.constructor-image.img-align-right) { float: right; margin: 0 0 10px 14px; }
+.text-constructor-content :deep(.constructor-image.img-align-center) { display: block; margin: 10px auto; float: none; }
+.text-constructor-content::after { content: ''; display: block; clear: both; }
+
 .text-constructor-content :deep(strong) {
     font-weight: 600 !important;
 }

--- a/frontend/src/components/TextConstructor.vue
+++ b/frontend/src/components/TextConstructor.vue
@@ -87,10 +87,10 @@
         <button
           type="button"
           class="toolbar-btn align-btn"
-          :class="{ active: editor && editor.isActive({ textAlign: 'left' }) }"
+          :class="{ active: isAlignActive('left') }"
           data-tooltip="По левому краю"
           :disabled="disabled"
-          @click="runCommand((c) => c.setTextAlignClass('left'))"
+          @click="applyAlign('left')"
         >
           <svg
             width="16"
@@ -127,10 +127,10 @@
         <button
           type="button"
           class="toolbar-btn align-btn"
-          :class="{ active: editor && editor.isActive({ textAlign: 'center' }) }"
+          :class="{ active: isAlignActive('center') }"
           data-tooltip="По центру"
           :disabled="disabled"
-          @click="runCommand((c) => c.setTextAlignClass('center'))"
+          @click="applyAlign('center')"
         >
           <svg
             width="16"
@@ -167,10 +167,10 @@
         <button
           type="button"
           class="toolbar-btn align-btn"
-          :class="{ active: editor && editor.isActive({ textAlign: 'right' }) }"
+          :class="{ active: isAlignActive('right') }"
           data-tooltip="По правому краю"
           :disabled="disabled"
-          @click="runCommand((c) => c.setTextAlignClass('right'))"
+          @click="applyAlign('right')"
         >
           <svg
             width="16"
@@ -549,6 +549,27 @@ function applyColor(colorClass) {
   runCommand((c) => c.setColorClass(colorClass));
 }
 
+/**
+ * Выравнивание: если выделена картинка - выравниваем её (float left/right или center),
+ * иначе выравниваем текущий абзац/заголовок. Кнопки тулбара общие для текста и картинки.
+ */
+function applyAlign(alignment) {
+  if (props.disabled || !editor.value) return;
+  if (editor.value.isActive('image')) {
+    runCommand((c) => c.setImageAlign(alignment));
+  } else {
+    runCommand((c) => c.setTextAlignClass(alignment));
+  }
+}
+
+function isAlignActive(alignment) {
+  if (!editor.value) return false;
+  return (
+    editor.value.isActive('image', { align: alignment }) ||
+    editor.value.isActive({ textAlign: alignment })
+  );
+}
+
 function toggleFontSizeDropdown() {
   if (props.disabled) return;
   fontSizeDropdownOpen.value = !fontSizeDropdownOpen.value;
@@ -836,6 +857,13 @@ defineExpose({ editor });
   word-break: break-word;
 }
 
+/* Чтобы плавающие (float) картинки не вылезали за пределы редактора. */
+.editor-content :deep(.ProseMirror)::after {
+  content: '';
+  display: block;
+  clear: both;
+}
+
 .editor-content :deep(.ProseMirror p.is-editor-empty:first-child::before) {
   content: attr(data-placeholder);
   float: left;
@@ -925,5 +953,28 @@ defineExpose({ editor });
 .editor-content :deep(img:not([height])),
 .preview-modal-content :deep(img:not([height])) {
   height: auto;
+}
+
+/* Выравнивание картинок (float-обтекание) в предпросмотре */
+.preview-modal-content :deep(.constructor-image.img-align-left) {
+  float: left;
+  margin: 0 14px 10px 0;
+}
+
+.preview-modal-content :deep(.constructor-image.img-align-right) {
+  float: right;
+  margin: 0 0 10px 14px;
+}
+
+.preview-modal-content :deep(.constructor-image.img-align-center) {
+  display: block;
+  float: none;
+  margin: 10px auto;
+}
+
+.preview-modal-content::after {
+  content: '';
+  display: block;
+  clear: both;
 }
 </style>

--- a/frontend/src/components/__tests__/TextConstructor.spec.js
+++ b/frontend/src/components/__tests__/TextConstructor.spec.js
@@ -290,4 +290,33 @@ describe('TextConstructor', () => {
     expect(out).toContain('text-align-center');
     expect(out).not.toContain('style=');
   });
+
+  it('round-trip: выравнивание картинки сохраняется в классе img-align-*', async () => {
+    const wrapper = mountConstructor({
+      modelValue: '<img src="data:image/png;base64,ZmFrZQ==" class="constructor-image img-align-right">',
+    });
+    await flushPromises();
+    expect(wrapper.vm.editor.getHTML()).toContain('img-align-right');
+  });
+
+  it('setImageAlign выставляет класс выравнивания на выделенную картинку', async () => {
+    const wrapper = mountConstructor({
+      modelValue: '<img src="data:image/png;base64,ZmFrZQ==" class="constructor-image">',
+    });
+    await flushPromises();
+    wrapper.vm.editor.commands.setNodeSelection(0);
+    wrapper.vm.editor.commands.setImageAlign('center');
+    expect(wrapper.vm.editor.getHTML()).toContain('img-align-center');
+  });
+
+  it('round-trip: выравнивание и ширина картинки сохраняются вместе', async () => {
+    const wrapper = mountConstructor({
+      modelValue:
+        '<img src="data:image/png;base64,ZmFrZQ==" class="constructor-image img-align-left" width="240">',
+    });
+    await flushPromises();
+    const out = wrapper.vm.editor.getHTML();
+    expect(out).toContain('img-align-left');
+    expect(out).toContain('width="240"');
+  });
 });

--- a/frontend/src/components/text-constructor/ResizableImage.vue
+++ b/frontend/src/components/text-constructor/ResizableImage.vue
@@ -1,7 +1,7 @@
 <template>
   <node-view-wrapper
     class="ci-image"
-    :class="{ 'is-selected': isEditable && selected }"
+    :class="[{ 'is-selected': isEditable && selected }, alignClass]"
   >
     <span class="ci-image-frame">
       <img
@@ -11,6 +11,7 @@
         class="constructor-image"
         :style="imgStyle"
         draggable="false"
+        data-drag-handle
       >
       <span
         v-for="handle in HANDLES"
@@ -55,6 +56,10 @@ const dragSize = ref(null);
 let stopDrag = null;
 
 const isEditable = computed(() => Boolean(props.editor?.isEditable));
+
+const alignClass = computed(() =>
+  props.node.attrs.align ? `img-align-${props.node.attrs.align}` : ''
+);
 
 const imgStyle = computed(() => {
   const width = dragSize.value?.width ?? props.node.attrs.width;
@@ -140,6 +145,25 @@ onBeforeUnmount(() => {
 <style scoped>
 .ci-image {
   display: block;
+}
+
+.ci-image.img-align-left {
+  float: left;
+  margin: 0 14px 10px 0;
+  max-width: 100%;
+}
+
+.ci-image.img-align-right {
+  float: right;
+  margin: 0 0 10px 14px;
+  max-width: 100%;
+}
+
+.ci-image.img-align-center {
+  display: block;
+  float: none;
+  margin: 10px auto;
+  text-align: center;
 }
 
 .ci-image-frame {

--- a/frontend/src/components/text-constructor/extensions.js
+++ b/frontend/src/components/text-constructor/extensions.js
@@ -32,6 +32,7 @@ export const FONT_WEIGHT_CLASSES = [
 ];
 export const TEXT_ALIGN_TYPES = ['paragraph', 'heading'];
 export const TEXT_ALIGNMENTS = ['left', 'center', 'right'];
+export const IMAGE_ALIGNMENTS = ['left', 'center', 'right'];
 
 /**
  * Фабрика марки, которая хранит один класс из набора на `<span>` и round-trip'ит его.
@@ -171,11 +172,30 @@ export const ConstructorImage = Image.extend({
         parseHTML: (element) => parseImageDimension(element, 'height'),
         renderHTML: (attributes) => (attributes.height > 0 ? { height: attributes.height } : {}),
       },
+      align: {
+        default: null,
+        parseHTML: (element) =>
+          IMAGE_ALIGNMENTS.find((a) => element.classList.contains(`img-align-${a}`)) || null,
+        renderHTML: (attributes) =>
+          attributes.align ? { class: `img-align-${attributes.align}` } : {},
+      },
     };
   },
 
   addNodeView() {
     return VueNodeViewRenderer(ResizableImage);
+  },
+
+  addCommands() {
+    return {
+      ...this.parent?.(),
+      setImageAlign:
+        (align) =>
+        ({ commands }) => {
+          if (align !== null && !IMAGE_ALIGNMENTS.includes(align)) return false;
+          return commands.updateAttributes(this.name, { align });
+        },
+    };
   },
 });
 

--- a/frontend/src/utils/__tests__/sanitize.spec.js
+++ b/frontend/src/utils/__tests__/sanitize.spec.js
@@ -24,6 +24,15 @@ describe('sanitizeHtml', () => {
     expect(out).toContain('height="200"');
   });
 
+  it('сохраняет класс выравнивания картинки img-align-* (round-trip обтекания)', () => {
+    const html =
+      '<img class="constructor-image img-align-right" src="data:image/png;base64,ZmFrZQ==" alt="x" width="320">';
+    const out = sanitizeHtml(html);
+    expect(out).toContain('img-align-right');
+    expect(out).toContain('constructor-image');
+    expect(out).toContain('width="320"');
+  });
+
   it('сохраняет классы форматирования (цвета, размер, жирность)', () => {
     const html =
       '<span class="red-text">a</span>' +

--- a/frontend/src/views/NewsAndReview.vue
+++ b/frontend/src/views/NewsAndReview.vue
@@ -1670,6 +1670,10 @@ export default {
 .news-body-html :deep(ol) { padding-left: 1.5em; margin: 0.5em 0; }
 .news-body-html :deep(img) { max-width: 100%; border-radius: 8px; }
 .news-body-html :deep(img:not([height])) { height: auto; }
+.news-body-html :deep(.constructor-image.img-align-left) { float: left; margin: 0 14px 10px 0; }
+.news-body-html :deep(.constructor-image.img-align-right) { float: right; margin: 0 0 10px 14px; }
+.news-body-html :deep(.constructor-image.img-align-center) { display: block; margin: 10px auto; float: none; }
+.news-body-html::after { content: ''; display: block; clear: both; }
 .news-body-html :deep(.text-align-left) { text-align: left; }
 .news-body-html :deep(.text-align-center) { text-align: center; }
 .news-body-html :deep(.text-align-right) { text-align: right; }


### PR DESCRIPTION
Выравнивание и обтекание картинок в TextConstructor по batch-ревью (polish-r2 эпика 46-textconstructor). Решение пользователя: выравнивание лево/центр/право + обтекание текстом (float), несколько картинок рядом - НЕ свободное абсолютное позиционирование.

## Изменения
- **extensions.js (ConstructorImage)**: атрибут `align` (parse из класса `img-align-{left,center,right}`, render в класс на img), команда `setImageAlign`. mergeAttributes склеивает с `constructor-image`/`width`/`height` без конфликта.
- **ResizableImage.vue (NodeView)**: float в редакторе через класс на node-view-wrapper; на img добавлен `data-drag-handle` (img остаётся `draggable=false`, перетаскивание идёт через draggable node-view-wrapper - канонический Tiptap node-drag, без нативного browser-ghost).
- **TextConstructor.vue**: кнопки выравнивания тулбара работают и для картинки (`applyAlign`: если выделена картинка -> `setImageAlign`, иначе `setTextAlignClass`); `isAlignActive` учитывает оба. Clearfix в редакторе и предпросмотре + float-правила предпросмотра.
- **Потребители** (TablesComponent, AnnouncementModal, NewsAndReview, ApplicationDetail `.message-preview`, ApplicationMessageModal): float-правила `.constructor-image.img-align-*` + clearfix - выравнивание рендерится одинаково везде.

## Верификация
- vitest 34/34 (+round-trip img-align, +align+width вместе, +setImageAlign, +sanitize img-align), eslint 0.
- Playwright по живому стеку: выравнивание лево/центр/право применяется (класс + computed float); две картинки (left+right float) встают РЯДОМ, текст обтекает - подтверждено геометрией и скриншотом в модалке заявки; рендер float в потребителе корректный.
- DnD-репозиция: механизм wired по Tiptap (wrapper draggable=true + data-drag-handle на img, node draggable:true) - но Playwright синтетическим dragTo ProseMirror-DnD НЕ воспроизводит, перемещение автоматически не подтверждено. **Проверить перетаскивание руками на staging.**

## Ревью
code-reviewer: GO, RED нет. 3 yellow исправлены: draggable=true -> false на img (убрал нативный browser-drag), +тест sanitize на img-align, +round-trip тест align+width.