### PR TITLE
fix(analytics): починил график дашборда на невалидном цвете Canvas (#632)

### DIFF
--- a/frontend/src/components/statistics/StatisticsDashboard.vue
+++ b/frontend/src/components/statistics/StatisticsDashboard.vue
@@ -156,7 +156,7 @@
         v-else
         :data="chartData"
         :height="300"
-        :color="'var(--color-primary)'"
+        color="#4F5BDF"
         interval-label="ед."
       />
     </div>


### PR DESCRIPTION
## Что ломалось
На вкладке Дашборд (Аналитика) line-график не рисовался. `StatisticsDashboard.vue` передавал в `RealTimeChart` `:color="'var(--color-primary)'"`, но компонент рисует через Canvas API, который не резолвит CSS-переменные. В `RealTimeChart.vue:158` `this.color + '30'` давало невалидный `'var(--color-primary)30'` для `gradient.addColorStop`, а `ctx.strokeStyle = this.color` (стр.189) тоже не понимал var() — заливка и линия отваливались.

Pre-existing регрессия от #647 (polish-r1-dash), не от конструктора отчётов #651. Найдено ship-check'ом среза B3a.

## Фикс
Передаю hex `#4F5BDF` (= значение `--color-primary` в `tokens.css`) — ровно как в рабочем графике Центра заявок (`RequestsView.vue:76` `color="#4F5BDF"`). Шаренный `RealTimeChart.vue` не трогал: второе его использование уже шлёт hex и работает.

## Проверка
- Греп: больше нигде CSS-var не уходит в `color`-проп графика — фикс единичный.
- ship-check на staging после деплоя (FE-изменение).

Эпик 37-analytics, срез `fix-dash-chart`.