### PR TITLE
style(create-application): раскладка письма в шапку формы (#46) [polish-r3]

### DIFF
--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -67,95 +67,98 @@
             <TextConstructor
               v-model="message"
               class="form__message-tc"
-              :rows="2"
+              :rows="3"
               placeholder="Введите сопроводительное письмо / сообщение"
-            />
-            <div class="header__right">
-              <div class="consent-section">
-                <div class="consent-checkbox">
-                  <input
-                    id="consent"
-                    v-model="consentGiven"
-                    type="checkbox"
-                    data-testid="create-app-consent-checkbox"
-                    required
-                  >
-                  <label for="consent">
-                    Даю <span class="blue">согласие</span> на обработку, хранение, передачу
-                    персональных данных, изложенных в заявке
-                  </label>
-                </div>
-                <div
-                  class="submit-button-container"
-                  :data-testid="'create-app-submit-wrapper'"
-                  @mouseenter="tooltipMouseEnter"
-                  @mouseleave="tooltipMouseLeave"
-                >
-                  <button
-                    class="send-all-btn"
-                    data-testid="create-app-button-submit"
-                    :disabled="!canSubmit"
-                    @click="submitApplication"
-                  >
-                    Отправить заявку
-                  </button>
-                  <div
-                    v-if="showSubmitTooltip && !canSubmit && tooltipSections.length"
-                    class="submit-tooltip"
-                    @mouseenter="tooltipMouseEnter"
-                    @mouseleave="tooltipMouseLeave"
-                    @click="handleTooltipClick"
-                  >
-                    <div class="tooltip-content">
-                      <div
-                        v-for="(section, idx) in tooltipSections"
-                        :key="idx"
-                        class="tooltip-section"
+            >
+              <template #header-actions>
+                <div class="header__right">
+                  <div class="consent-section">
+                    <div class="consent-checkbox">
+                      <input
+                        id="consent"
+                        v-model="consentGiven"
+                        type="checkbox"
+                        data-testid="create-app-consent-checkbox"
+                        required
                       >
-                        <div
-                          v-if="section.type === 'global'"
-                          class="tooltip-global"
-                        >
-                          <div class="tooltip-section-title">
-                            Необходимо заполнить:
+                      <label for="consent">
+                        Даю <span class="blue">согласие</span> на обработку, хранение, передачу
+                        персональных данных, изложенных в заявке
+                      </label>
+                    </div>
+                    <div
+                      class="submit-button-container"
+                      :data-testid="'create-app-submit-wrapper'"
+                      @mouseenter="tooltipMouseEnter"
+                      @mouseleave="tooltipMouseLeave"
+                    >
+                      <button
+                        class="send-all-btn"
+                        data-testid="create-app-button-submit"
+                        :disabled="!canSubmit"
+                        @click="submitApplication"
+                      >
+                        Отправить заявку
+                      </button>
+                      <div
+                        v-if="showSubmitTooltip && !canSubmit && tooltipSections.length"
+                        class="submit-tooltip"
+                        @mouseenter="tooltipMouseEnter"
+                        @mouseleave="tooltipMouseLeave"
+                        @click="handleTooltipClick"
+                      >
+                        <div class="tooltip-content">
+                          <div
+                            v-for="(section, idx) in tooltipSections"
+                            :key="idx"
+                            class="tooltip-section"
+                          >
+                            <div
+                              v-if="section.type === 'global'"
+                              class="tooltip-global"
+                            >
+                              <div class="tooltip-section-title">
+                                Необходимо заполнить:
+                              </div>
+                              <ul>
+                                <li
+                                  v-for="(msg, i) in section.messages"
+                                  :key="i"
+                                >
+                                  {{ msg }}
+                                </li>
+                              </ul>
+                            </div>
+                            <div
+                              v-else-if="section.type === 'attachment'"
+                              class="tooltip-attachment"
+                            >
+                              <div class="tooltip-attachment-title">
+                                <span
+                                  class="attachment-clickable"
+                                  :data-attachment-key="section.attachmentKey"
+                                  @click="handleTooltipAttachmentClick(section)"
+                                >
+                                  Вложение "{{ section.attachmentName }}"
+                                </span>
+                              </div>
+                              <ul>
+                                <li
+                                  v-for="(msg, i) in section.messages"
+                                  :key="i"
+                                >
+                                  {{ msg }}
+                                </li>
+                              </ul>
+                            </div>
                           </div>
-                          <ul>
-                            <li
-                              v-for="(msg, i) in section.messages"
-                              :key="i"
-                            >
-                              {{ msg }}
-                            </li>
-                          </ul>
-                        </div>
-                        <div
-                          v-else-if="section.type === 'attachment'"
-                          class="tooltip-attachment"
-                        >
-                          <div class="tooltip-attachment-title">
-                            <span
-                              class="attachment-clickable"
-                              :data-attachment-key="section.attachmentKey"
-                              @click="handleTooltipAttachmentClick(section)"
-                            >
-                              Вложение "{{ section.attachmentName }}"
-                            </span>
-                          </div>
-                          <ul>
-                            <li
-                              v-for="(msg, i) in section.messages"
-                              :key="i"
-                            >
-                              {{ msg }}
-                            </li>
-                          </ul>
                         </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </div>
+              </template>
+            </TextConstructor>
           </div>
         </div>
 
@@ -2271,23 +2274,28 @@ export default {
     }
 
     .create__form .form__message-tc {
-        width: 55%;
+        width: 100%;
         margin-bottom: 0;
         border-radius: 30px;
     }
 
+    /* Инструменты редактора в форме заявки - компактнее */
+    .create__form :deep(.toolbar-btn) {
+        min-width: 28px;
+        height: 28px;
+        font-size: 13px;
+        padding: 0 6px;
+    }
+
     .header__right {
         display: flex;
-        flex-direction: column;
-        gap: 10px;
-        flex: 1;
+        align-items: center;
     }
 
     .consent-section {
         display: flex;
         align-items: center;
-        gap: 20px;
-        height: 100%;
+        gap: 16px;
     }
 
     .consent-checkbox {

--- a/frontend/src/components/TextConstructor.vue
+++ b/frontend/src/components/TextConstructor.vue
@@ -389,6 +389,12 @@
           ⎚
         </button>
       </div>
+      <div
+        v-if="$slots['header-actions']"
+        class="tc-header-actions"
+      >
+        <slot name="header-actions" />
+      </div>
     </div>
 
     <EditorContent
@@ -687,6 +693,14 @@ defineExpose({ editor });
   gap: 8px;
   padding: 8px 10px;
   border-bottom: 1px solid var(--color-border);
+}
+
+/* Слот действий справа от инструментов (напр. согласие + отправка в форме заявки). */
+.tc-header-actions {
+  margin-left: auto;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
 }
 
 .toolbar-group {


### PR DESCRIPTION
Раскладка блока сопроводительного письма в форме заявки по batch-ревью (polish-r3). Подтверждено макетом: строка1 = инструменты редактора (мельче) слева + согласие/Отправить справа; строка2 = поле письма во всю ширину.

## Изменения
- **TextConstructor.vue**: именованный слот `header-actions` как последний flex-элемент `.editor-toolbar` (`v-if="$slots['header-actions']"`), `.tc-header-actions { margin-left:auto; flex-shrink:0 }` - двигает контент слота вправо от кнопок и не даёт ему сжиматься. Без слота (4 других потребителя) - поведение прежнее.
- **CreateApplication.vue**: блок «согласие + Отправить + tooltip» перенесён в `<template #header-actions>` (обработчики/данные живут в scope родителя). `:rows` 2->3, `.form__message-tc` width 55%->100%, кнопки тулбара компактнее (`.create__form :deep(.toolbar-btn)` 28px), `.header__right`/`.consent-section` упрощены. Большой дифф - реиндент перенесённого блока на +4.

## Верификация
- vitest 27/27, eslint 0 (7 pre-existing warnings в файле, не мои).
- Playwright по живому стеку: тулбар слева (кнопки 28px) + согласие/Отправить справа в одной строке, поле письма во всю ширину (1128px) под ними; submit и согласие на месте. Скриншот check-r3-letter-layout.png.

## Ревью
code-reviewer GO, RED нет. 2 yellow: 28px-кнопки < WCAG (приемлемо для десктоп-формы, явный запрос юзера); сжатие блока на 800-1000px - добавил flex-shrink:0. Обработчики слота в scope родителя живы, tooltip не клипается, другие потребители TC не затронуты.