### PR TITLE
feat(analytics): переключатель таблица/график в результате отчёта (#632)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@tiptap/pm": "^2.27.2",
         "@tiptap/starter-kit": "^2.27.2",
         "@tiptap/vue-3": "^2.27.2",
+        "chart.js": "^4.5.1",
         "dompurify": "^3.4.1",
         "exceljs": "^4.4.0",
         "jszip": "^3.10.1",
@@ -759,6 +760,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
@@ -2290,6 +2297,18 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/chokidar": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "@tiptap/pm": "^2.27.2",
     "@tiptap/starter-kit": "^2.27.2",
     "@tiptap/vue-3": "^2.27.2",
+    "chart.js": "^4.5.1",
     "dompurify": "^3.4.1",
     "exceljs": "^4.4.0",
     "jszip": "^3.10.1",

--- a/frontend/src/components/statistics/ReportChart.vue
+++ b/frontend/src/components/statistics/ReportChart.vue
@@ -1,0 +1,162 @@
+<template>
+  <div class="rc">
+    <div
+      v-if="libError"
+      class="rc__msg rc__msg--error"
+    >
+      Не удалось загрузить библиотеку графиков
+    </div>
+    <canvas
+      v-else
+      ref="canvasEl"
+    />
+  </div>
+</template>
+
+<script setup>
+import { ref, watch, onMounted, onBeforeUnmount } from 'vue';
+
+const props = defineProps({
+  // Строки агрегатного отчёта: [{ label, value }].
+  rows: { type: Array, default: () => [] },
+  // Тип графика: 'bar' | 'pie' | 'line'.
+  type: { type: String, default: 'bar' },
+  // Единица измерения метрики (для подписи набора данных).
+  unit: { type: String, default: '' },
+});
+
+const canvasEl = ref(null);
+const libError = ref(false);
+
+let chart = null;
+let ChartCtor = null;
+// Гонка ленивой загрузки: пока import резолвится, props могут смениться и watch
+// запустит второй render. Токен гарантирует, что устаревший render не создаст
+// второй Chart поверх актуального (иначе два инстанса на одном canvas).
+let renderSeq = 0;
+
+const PALETTE = [
+  '#4F5BDF', '#28a745', '#ffc107', '#dc3545', '#17a2b8',
+  '#6f42c1', '#fd7e14', '#20c997', '#e83e8c', '#6610f2',
+];
+
+async function loadLib() {
+  if (ChartCtor) return ChartCtor;
+  try {
+    const mod = await import('chart.js/auto');
+    ChartCtor = mod.Chart || mod.default;
+    return ChartCtor;
+  } catch {
+    libError.value = true;
+    return null;
+  }
+}
+
+function lineBarOptions() {
+  return {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: { legend: { display: false } },
+    scales: {
+      y: { beginAtZero: true, ticks: { precision: 0 } },
+      x: { ticks: { autoSkip: true, maxRotation: 0 } },
+    },
+  };
+}
+
+function buildConfig() {
+  const labels = props.rows.map((r) => r.label);
+  const data = props.rows.map((r) => Number(r.value) || 0);
+  const datasetLabel = `Количество${props.unit ? `, ${props.unit}` : ''}`;
+
+  if (props.type === 'pie') {
+    return {
+      type: 'pie',
+      data: {
+        labels,
+        datasets: [{
+          data,
+          backgroundColor: labels.map((_, i) => PALETTE[i % PALETTE.length]),
+          borderColor: '#fff',
+          borderWidth: 2,
+        }],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: { legend: { position: 'right' } },
+      },
+    };
+  }
+
+  if (props.type === 'line') {
+    return {
+      type: 'line',
+      data: {
+        labels,
+        datasets: [{
+          label: datasetLabel,
+          data,
+          borderColor: '#4F5BDF',
+          backgroundColor: 'rgba(79, 91, 223, 0.12)',
+          fill: true,
+          tension: 0.3,
+          pointRadius: 3,
+        }],
+      },
+      options: lineBarOptions(),
+    };
+  }
+
+  return {
+    type: 'bar',
+    data: {
+      labels,
+      datasets: [{
+        label: datasetLabel,
+        data,
+        backgroundColor: labels.map((_, i) => PALETTE[i % PALETTE.length]),
+        borderRadius: 6,
+        maxBarThickness: 48,
+      }],
+    },
+    options: lineBarOptions(),
+  };
+}
+
+async function render() {
+  const seq = ++renderSeq;
+  const Ctor = await loadLib();
+  if (seq !== renderSeq || !Ctor || !canvasEl.value) return;
+  if (chart) { chart.destroy(); chart = null; }
+  chart = new Ctor(canvasEl.value, buildConfig());
+}
+
+onMounted(render);
+// rows/unit приходят из API новой ссылкой при каждом отчёте, type меняется кликом —
+// глубокое наблюдение не нужно, перерисовываем по смене любой из ссылок.
+watch(() => [props.rows, props.type, props.unit], render);
+onBeforeUnmount(() => {
+  if (chart) { chart.destroy(); chart = null; }
+});
+</script>
+
+<style scoped>
+.rc {
+  position: relative;
+  height: 360px;
+  width: 100%;
+}
+
+.rc__msg {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--color-text-muted);
+}
+
+.rc__msg--error {
+  color: #c0392b;
+}
+</style>

--- a/frontend/src/components/statistics/ReportResult.vue
+++ b/frontend/src/components/statistics/ReportResult.vue
@@ -42,7 +42,57 @@
 
     <!-- Агрегатный отчёт -->
     <template v-else-if="result.mode === 'aggregate'">
-      <div class="rr__table-wrap">
+      <div class="rr__toolbar">
+        <div class="rr__seg">
+          <button
+            type="button"
+            class="rr__seg-btn"
+            :class="{ 'rr__seg-btn--active': view === 'table' }"
+            data-testid="rr-view-table"
+            @click="view = 'table'"
+          >
+            Таблица
+          </button>
+          <button
+            type="button"
+            class="rr__seg-btn"
+            :class="{ 'rr__seg-btn--active': view === 'chart' }"
+            :disabled="!hasRows"
+            data-testid="rr-view-chart"
+            @click="view = 'chart'"
+          >
+            График
+          </button>
+        </div>
+        <div
+          v-if="view === 'chart' && hasRows"
+          class="rr__seg"
+        >
+          <button
+            v-for="opt in chartTypeOptions"
+            :key="opt.value"
+            type="button"
+            class="rr__seg-btn"
+            :class="{ 'rr__seg-btn--active': chartType === opt.value }"
+            :data-testid="`rr-chart-${opt.value}`"
+            @click="chartType = opt.value"
+          >
+            {{ opt.label }}
+          </button>
+        </div>
+      </div>
+
+      <ReportChart
+        v-if="view === 'chart' && hasRows"
+        :rows="result.rows"
+        :type="chartType"
+        :unit="result.unit || ''"
+      />
+
+      <div
+        v-else
+        class="rr__table-wrap"
+      >
         <table class="rr__table">
           <thead>
             <tr>
@@ -125,13 +175,38 @@
 </template>
 
 <script setup>
+import { ref, computed, watch } from 'vue';
 import LoaderSpinner from '@/components/ui/LoaderSpinner.vue';
+import ReportChart from './ReportChart.vue';
 
-defineProps({
+const props = defineProps({
   result: { type: Object, default: null },
   loading: { type: Boolean, default: false },
   error: { type: String, default: '' },
 });
+
+const view = ref('table'); // 'table' | 'chart'
+const chartType = ref('bar'); // 'bar' | 'pie' | 'line'
+
+const hasRows = computed(() => (props.result?.rows?.length || 0) > 0);
+
+// Временной разрез рисуем линией, остальные — столбцы/круговая.
+const chartTypeOptions = computed(() => (
+  props.result?.dimension === 'period'
+    ? [{ value: 'line', label: 'Линия' }, { value: 'bar', label: 'Столбцы' }]
+    : [{ value: 'bar', label: 'Столбцы' }, { value: 'pie', label: 'Круговая' }]
+));
+
+// Новый результат: list/пусто — только таблица; aggregate — сбрасываем тип
+// графика на дефолт по разрезу (period -> линия, иначе столбцы), вид оставляем
+// как выбрал пользователь, чтобы повторный отчёт не сбрасывал его на таблицу.
+watch(() => props.result, (r) => {
+  if (r?.mode !== 'aggregate') {
+    view.value = 'table';
+    return;
+  }
+  chartType.value = r.dimension === 'period' ? 'line' : 'bar';
+}, { immediate: true });
 
 function formatNumber(value) {
   const n = Number(value);
@@ -180,6 +255,49 @@ function formatCell(value) {
 .rr__empty span {
   font-size: 13px;
   max-width: 320px;
+}
+
+.rr__toolbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.rr__seg {
+  display: inline-flex;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-pill);
+  padding: 3px;
+  gap: 2px;
+}
+
+.rr__seg-btn {
+  border: none;
+  background: transparent;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-text-muted);
+  padding: 5px 12px;
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  transition: background 0.18s ease, color 0.18s ease;
+}
+
+.rr__seg-btn:hover:not(:disabled) {
+  color: var(--color-primary);
+}
+
+.rr__seg-btn--active {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.rr__seg-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
 }
 
 .rr__table-wrap {

--- a/frontend/src/components/statistics/__tests__/ReportChart.spec.js
+++ b/frontend/src/components/statistics/__tests__/ReportChart.spec.js
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+
+// chart.js/auto не установлен в worktree и требует реального canvas — мокаем
+// конструктор, чтобы проверить именно buildConfig (тип/данные/палитра), а не
+// рендер в jsdom. instances в hoisted: фабрика vi.mock поднимается над импортами.
+const { instances } = vi.hoisted(() => ({ instances: [] }));
+vi.mock('chart.js/auto', () => ({
+  Chart: class {
+    constructor(canvas, config) {
+      this.canvas = canvas;
+      this.config = config;
+      instances.push(this);
+    }
+
+    destroy() {}
+  },
+}));
+
+import ReportChart from '../ReportChart.vue';
+
+const ROWS = [{ label: 'A', value: 5 }, { label: 'B', value: 3 }];
+
+describe('ReportChart', () => {
+  it('строит bar: метки/значения из строк, палитра по бакетам', async () => {
+    instances.length = 0;
+    mount(ReportChart, { props: { rows: ROWS, type: 'bar', unit: 'шт' } });
+    await flushPromises();
+
+    expect(instances).toHaveLength(1);
+    const cfg = instances[0].config;
+    expect(cfg.type).toBe('bar');
+    expect(cfg.data.labels).toEqual(['A', 'B']);
+    expect(cfg.data.datasets[0].data).toEqual([5, 3]);
+    expect(cfg.data.datasets[0].backgroundColor).toHaveLength(2);
+  });
+
+  it('строит line для временного разреза с заливкой', async () => {
+    instances.length = 0;
+    mount(ReportChart, { props: { rows: ROWS, type: 'line', unit: '' } });
+    await flushPromises();
+
+    const cfg = instances[0].config;
+    expect(cfg.type).toBe('line');
+    expect(cfg.data.datasets[0].fill).toBe(true);
+  });
+
+  it('строит pie с массивом цветов по числу сегментов', async () => {
+    instances.length = 0;
+    mount(ReportChart, { props: { rows: ROWS, type: 'pie' } });
+    await flushPromises();
+
+    const cfg = instances[0].config;
+    expect(cfg.type).toBe('pie');
+    expect(cfg.data.datasets[0].backgroundColor).toHaveLength(2);
+  });
+
+  it('пересоздаёт график при смене типа, уничтожая предыдущий', async () => {
+    instances.length = 0;
+    const wrapper = mount(ReportChart, { props: { rows: ROWS, type: 'bar' } });
+    await flushPromises();
+    const spy = vi.spyOn(instances[0], 'destroy');
+
+    await wrapper.setProps({ type: 'pie' });
+    await flushPromises();
+
+    expect(spy).toHaveBeenCalled();
+    expect(instances).toHaveLength(2);
+    expect(instances[1].config.type).toBe('pie');
+  });
+});

--- a/frontend/src/components/statistics/__tests__/ReportResult.spec.js
+++ b/frontend/src/components/statistics/__tests__/ReportResult.spec.js
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
+import ReportResult from '../ReportResult.vue';
+
+// ReportChart лениво тянет chart.js + canvas — в юнит-тесте логики переключателя
+// он не нужен, подменяем стабом и читаем переданные ему props.
+const chartStub = {
+  name: 'ReportChart',
+  props: ['rows', 'type', 'unit'],
+  template: '<div class="chart-stub" />',
+};
+
+function mountResult(result) {
+  return mount(ReportResult, {
+    props: { result },
+    global: { stubs: { ReportChart: chartStub } },
+  });
+}
+
+const aggPeriod = { mode: 'aggregate', dimension: 'period', unit: 'шт', rows: [{ label: 'Пн', value: 2 }], total: 2 };
+const aggStatus = { mode: 'aggregate', dimension: 'status', unit: 'шт', rows: [{ label: 'Завершено', value: 5 }], total: 5 };
+const listRes = { mode: 'list', columns: [{ key: 'a', label: 'A' }], rows: [{ a: 'x' }], total: 1 };
+
+describe('ReportResult — переключатель Таблица/График', () => {
+  it('list-режим: переключателя нет, только таблица', () => {
+    const w = mountResult(listRes);
+    expect(w.find('[data-testid="rr-view-chart"]').exists()).toBe(false);
+    expect(w.find('.rr__table').exists()).toBe(true);
+  });
+
+  it('aggregate: переключатель есть, по умолчанию таблица', () => {
+    const w = mountResult(aggStatus);
+    expect(w.find('[data-testid="rr-view-chart"]').exists()).toBe(true);
+    expect(w.find('.rr__table').exists()).toBe(true);
+    expect(w.findComponent(chartStub).exists()).toBe(false);
+  });
+
+  it('aggregate разрез: типы графика — столбцы и круговая', async () => {
+    const w = mountResult(aggStatus);
+    await w.find('[data-testid="rr-view-chart"]').trigger('click');
+    await nextTick();
+    expect(w.find('[data-testid="rr-chart-bar"]').exists()).toBe(true);
+    expect(w.find('[data-testid="rr-chart-pie"]').exists()).toBe(true);
+    expect(w.find('[data-testid="rr-chart-line"]').exists()).toBe(false);
+    expect(w.findComponent(chartStub).props('type')).toBe('bar');
+  });
+
+  it('aggregate период: по умолчанию линия, доступны линия и столбцы', async () => {
+    const w = mountResult(aggPeriod);
+    await w.find('[data-testid="rr-view-chart"]').trigger('click');
+    await nextTick();
+    expect(w.find('[data-testid="rr-chart-line"]').exists()).toBe(true);
+    expect(w.find('[data-testid="rr-chart-bar"]').exists()).toBe(true);
+    expect(w.find('[data-testid="rr-chart-pie"]').exists()).toBe(false);
+    expect(w.findComponent(chartStub).props('type')).toBe('line');
+  });
+
+  it('aggregate с 0 строк: кнопка График недоступна', () => {
+    const w = mountResult({ ...aggStatus, rows: [], total: 0 });
+    expect(w.find('[data-testid="rr-view-chart"]').attributes('disabled')).toBeDefined();
+  });
+
+  it('в режиме график пришёл пустой результат: график убран, таблица и блокировка кнопки', async () => {
+    const w = mountResult(aggStatus);
+    await w.find('[data-testid="rr-view-chart"]').trigger('click');
+    await nextTick();
+    expect(w.findComponent(chartStub).exists()).toBe(true);
+
+    await w.setProps({ result: { ...aggStatus, rows: [], total: 0 } });
+    await nextTick();
+    expect(w.findComponent(chartStub).exists()).toBe(false);
+    expect(w.find('.rr__table').exists()).toBe(true);
+    expect(w.find('[data-testid="rr-view-chart"]').attributes('disabled')).toBeDefined();
+  });
+
+  it('смена разреза period->status сбрасывает тип графика на столбцы', async () => {
+    const w = mountResult(aggPeriod);
+    await w.find('[data-testid="rr-view-chart"]').trigger('click');
+    await nextTick();
+    expect(w.findComponent(chartStub).props('type')).toBe('line');
+
+    await w.setProps({ result: aggStatus });
+    await nextTick();
+    // вид сохраняется (график), тип переключился на дефолт нового разреза
+    expect(w.findComponent(chartStub).exists()).toBe(true);
+    expect(w.findComponent(chartStub).props('type')).toBe('bar');
+  });
+});


### PR DESCRIPTION
Срез B3c эпика аналитики (#632, тег `37-analytics`). Результат агрегатного отчёта теперь можно смотреть не только таблицей, но и графиком.

## Что сделано
- Переключатель **Таблица / График** в результате aggregate-отчёта. Тип графика по разрезу: `period` -> линия (доступны линия/столбцы), остальные разрезы -> столбцы (доступны столбцы/круговая).
- list-режим без изменений: только таблица, переключателя графика нет.
- Пустой результат (0 строк) — кнопка «График» заблокирована, показывается таблица.
- Новый компонент `ReportChart.vue` на Chart.js (bar/pie/line). Сегментированный контрол по образцу `.dashboard__seg`, цвета/радиусы из токенов.

## Chart.js — ленивая загрузка
Новая зависимость `chart.js@^4.5.1`. Грузится динамическим `import('chart.js/auto')` внутри `ReportChart` — vite выносит её в отдельный чанк (`auto-*.js`, ~200KB raw / ~70KB gzip), который тянется только при первом показе графика, не в основном бандле и не на других страницах.

## Защита от гонок и утечек
- Seq-токен в `ReportChart`: гонка ленивого импорта + быстрой смены props не плодит два Chart на одном canvas (урок #632).
- `chart.destroy()` на unmount и перед каждым пересозданием; родитель доп. размонтирует компонент через `v-if` при переключении на таблицу.

## Проверки
- Юниты: `ReportChart.spec.js` (buildConfig bar/pie/line, пересоздание с destroy) + `ReportResult.spec.js` (видимость переключателя по режиму, дефолт типа по разрезу, блокировка при 0 строк, переход график->пустой результат). Локально 11 зелёных, весь модуль statistics — 32 зелёных.
- Линт чистый. `vite build` проходит, chart.js корректно бандлится отдельным чанком.
- Docker Build в CI валидирует установку нового пакета; ship-check на staging после мержа.