### PR TITLE
feat(analytics): движок отчётов с мультиметриками и группами метрик (#632)

### DIFF
--- a/internal/handlers/statistics.go
+++ b/internal/handlers/statistics.go
@@ -157,7 +157,7 @@ func (h *StatisticsHandler) GetMetrics(c echo.Context) error {
 
 // RunReport godoc
 // @Summary      Исполнение отчёта конструктора
-// @Description  mode=aggregate: метрика x разрез x фильтры x период. mode=list: выгрузка строк сущности.
+// @Description  mode=aggregate: одна/несколько метрик (metrics[]) x разрез (или none) x фильтры x период. mode=list: выгрузка строк сущности.
 // @Tags         statistics
 // @Accept       json
 // @Produce      json
@@ -180,7 +180,7 @@ func (h *StatisticsHandler) RunReport(c echo.Context) error {
 
 	switch req.Mode {
 	case "aggregate":
-		if req.Metric == "" || req.Dimension == "" {
+		if (req.Metric == "" && len(req.Metrics) == 0) || req.Dimension == "" {
 			return echo.NewHTTPError(http.StatusBadRequest, "metric and dimension are required")
 		}
 		res, err := h.service.RunReport(c.Request().Context(), req)

--- a/internal/handlers/statistics_report_multimetric_integration_test.go
+++ b/internal/handlers/statistics_report_multimetric_integration_test.go
@@ -1,0 +1,104 @@
+package handlers_test
+
+import (
+	"context"
+	"testing"
+
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunReport_MultiMetric проверяет реальный GORM-путь мультиметричного движка
+// (GR0): две метрики с РАЗНЫМИ базовыми таблицами (applications -> COUNT,
+// items -> SUM через join) сливаются по разрезу organization в колонки; legacy-поля
+// (первая метрика) и totals согласованы.
+func TestRunReport_MultiMetric(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	org := models.Organization{Name: "Орг-Мульти", IsActive: true}
+	require.NoError(t, db.Create(&org).Error)
+
+	user := models.User{Username: "mm_sender", TypeID: 1, IsActive: true}
+	require.NoError(t, db.Create(&user).Error)
+
+	status := models.StatusCompleted
+	number := "MM/001"
+	app := models.Application{ApplicationNumber: &number, OrganizationID: org.ID,
+		SenderUserID: user.ID, Status: &status}
+	require.NoError(t, db.Create(&app).Error)
+
+	att := models.Attachment{ApplicationID: app.ID, AttachmentType: "items"}
+	require.NoError(t, db.Create(&att).Error)
+
+	cnt := 4
+	require.NoError(t, db.Create(&models.Item{AttachmentID: att.ID, Count: &cnt}).Error)
+
+	svc := services.NewStatisticsService(db)
+	res, err := svc.RunReport(context.Background(), models.ReportRequest{
+		Mode:      "aggregate",
+		Metrics:   []string{"applications_count", "items_sum"},
+		Dimension: "organization",
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, "aggregate", res.Mode)
+	require.Len(t, res.Columns, 2, "две колонки-метрики")
+	assert.Equal(t, "applications_count", res.Columns[0].Key)
+	assert.Equal(t, "items_sum", res.Columns[1].Key)
+
+	require.Len(t, res.MetricRows, 1, "одна организация -> одна строка")
+	row := res.MetricRows[0]
+	assert.Equal(t, "Орг-Мульти", row.Label)
+	assert.Equal(t, int64(1), row.Values["applications_count"])
+	assert.Equal(t, int64(4), row.Values["items_sum"])
+
+	assert.Equal(t, int64(1), res.Totals["applications_count"])
+	assert.Equal(t, int64(4), res.Totals["items_sum"])
+
+	// legacy: первая метрика как Rows/Total/Metric (обратная совместимость с FE).
+	assert.Equal(t, "applications_count", res.Metric)
+	require.Len(t, res.Rows, 1)
+	assert.Equal(t, "Орг-Мульти", res.Rows[0].Label)
+	assert.Equal(t, int64(1), res.Rows[0].Value)
+	assert.Equal(t, int64(1), res.Total)
+}
+
+// TestRunReport_DimensionNone проверяет разрез "без разреза": один итоговый ряд с
+// подписью "Итого" и значением метрики по всей выборке (без GROUP BY).
+func TestRunReport_DimensionNone(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	org := models.Organization{Name: "Орг-Итого", IsActive: true}
+	require.NoError(t, db.Create(&org).Error)
+	user := models.User{Username: "none_sender", TypeID: 1, IsActive: true}
+	require.NoError(t, db.Create(&user).Error)
+
+	status := models.StatusCompleted
+	for _, num := range []string{"N/1", "N/2", "N/3"} {
+		n := num
+		app := models.Application{ApplicationNumber: &n, OrganizationID: org.ID,
+			SenderUserID: user.ID, Status: &status}
+		require.NoError(t, db.Create(&app).Error)
+	}
+
+	svc := services.NewStatisticsService(db)
+	res, err := svc.RunReport(context.Background(), models.ReportRequest{
+		Mode:      "aggregate",
+		Metrics:   []string{"applications_count"},
+		Dimension: "none",
+	})
+	require.NoError(t, err)
+
+	require.Len(t, res.MetricRows, 1, "без разреза -> один ряд")
+	assert.Equal(t, "Итого", res.MetricRows[0].Label)
+	assert.Equal(t, int64(3), res.MetricRows[0].Values["applications_count"])
+	assert.Equal(t, int64(3), res.Totals["applications_count"])
+}

--- a/internal/models/report.go
+++ b/internal/models/report.go
@@ -10,11 +10,15 @@ type ReportFilterValue struct {
 }
 
 // ReportRequest — запрос конструктора отчётов (POST /statistics/report).
-// Mode=aggregate: Metric+Dimension обязательны (агрегатный разрез).
-// Mode=list: выгрузка строк сущности (Entity) — добавляется отдельным срезом.
+// Mode=aggregate: разрез (Dimension) + одна метрика (Metric) ИЛИ несколько (Metrics).
+// Metrics имеет приоритет; если он пуст — берётся Metric (обратная совместимость с
+// одиночным конструктором). Каждая метрика становится колонкой результата.
+// Dimension="none" — без разреза (один итоговый ряд).
+// Mode=list: выгрузка строк сущности (Entity).
 type ReportRequest struct {
 	Mode        string              `json:"mode"`
 	Metric      string              `json:"metric"`
+	Metrics     []string            `json:"metrics,omitempty"`
 	Dimension   string              `json:"dimension"`
 	Granularity string              `json:"granularity"`
 	Entity      string              `json:"entity"`
@@ -29,7 +33,25 @@ type ReportAggregateRow struct {
 	Value int64  `json:"value"`
 }
 
-// ReportResponse — результат агрегатного отчёта: строки по разрезу и итог (сумма значений).
+// ReportMetricColumn — колонка-метрика мультиметричного отчёта (ключ, подпись, единица).
+type ReportMetricColumn struct {
+	Key   string `json:"key"`
+	Label string `json:"label"`
+	Unit  string `json:"unit,omitempty"`
+}
+
+// ReportMetricRow — строка мультиметрик: подпись разреза + значение каждой метрики
+// (по её ключу). Метрики без значения в этом бакете -> 0.
+type ReportMetricRow struct {
+	Label  string           `json:"label"`
+	Values map[string]int64 `json:"values"`
+}
+
+// ReportResponse — результат агрегатного отчёта.
+// Legacy-поля (Metric/Unit/Rows/Total) — для одиночной метрики (текущий FE).
+// Мультиметрики (GR0): Columns — колонки-метрики, MetricRows — строки разреза со
+// значением каждой метрики, Totals — итог по каждой метрике. Эти три заполняются
+// всегда (в т.ч. при одной метрике) — единый формат для гида.
 type ReportResponse struct {
 	Mode      string               `json:"mode"`
 	Metric    string               `json:"metric,omitempty"`
@@ -37,6 +59,10 @@ type ReportResponse struct {
 	Unit      string               `json:"unit,omitempty"`
 	Rows      []ReportAggregateRow `json:"rows"`
 	Total     int64                `json:"total"`
+
+	Columns    []ReportMetricColumn `json:"columns,omitempty"`
+	MetricRows []ReportMetricRow    `json:"metric_rows,omitempty"`
+	Totals     map[string]int64     `json:"totals,omitempty"`
 }
 
 // ReportListResponse — результат list-отчёта (mode=list): выгрузка строк сущности.

--- a/internal/models/report_catalog.go
+++ b/internal/models/report_catalog.go
@@ -16,11 +16,13 @@ type ReportOption struct {
 }
 
 // ReportMetricInfo — метрика агрегатного отчёта (что измеряем).
+// Group — тематическая группа карточек метрик в гиде (Заявки/Машины/Люди/...).
 // Dimensions перечисляет ключи разрезов, по которым эту метрику можно группировать.
 type ReportMetricInfo struct {
 	Key        string   `json:"key"`
 	Label      string   `json:"label"`
 	Unit       string   `json:"unit,omitempty"`
+	Group      string   `json:"group,omitempty"`
 	Dimensions []string `json:"dimensions"`
 }
 

--- a/internal/services/report_catalog.go
+++ b/internal/services/report_catalog.go
@@ -23,14 +23,23 @@ const (
 
 // metricDef — агрегатная метрика. baseTable/aggExpr/baseFilter — безопасные
 // константы для сборки запроса движком B2; dimensions ограничивает разрезы.
+// group — тематическая группа карточек метрик в гиде (шаг "Что считаем").
 type metricDef struct {
 	label      string
 	unit       string
+	group      string
 	baseTable  string
 	aggExpr    string
 	baseFilter string
 	dimensions []string
 }
+
+// Тематические группы метрик (шаг 1 гида). Значения совпадают с подписями карточек.
+const (
+	metricGroupApplications = "Заявки"
+	metricGroupCars         = "Машины"
+	metricGroupPeople       = "Люди"
+)
 
 // dimensionDef — разрез группировки. Конкретное GROUP BY-выражение и join-путь
 // зависят от метрики и резолвятся движком B2; здесь — только подпись для UI.
@@ -72,6 +81,7 @@ var reportMetricRegistry = map[string]metricDef{
 	"applications_count": {
 		label:      "Количество заявок",
 		unit:       "шт",
+		group:      metricGroupApplications,
 		baseTable:  "applications",
 		aggExpr:    "COUNT(*)",
 		dimensions: []string{"status", "organization", "company", "attachment_type", "period"},
@@ -79,6 +89,7 @@ var reportMetricRegistry = map[string]metricDef{
 	"car_entries_count": {
 		label:      "Въезды машин",
 		unit:       "шт",
+		group:      metricGroupCars,
 		baseTable:  "cars_history",
 		aggExpr:    "COUNT(*)",
 		baseFilter: "action_type = 'entry'",
@@ -87,6 +98,7 @@ var reportMetricRegistry = map[string]metricDef{
 	"people_entries_count": {
 		label:      "Входы людей",
 		unit:       "шт",
+		group:      metricGroupPeople,
 		baseTable:  "employees_history",
 		aggExpr:    "COUNT(*)",
 		baseFilter: "action_type = 'entry'",
@@ -95,13 +107,21 @@ var reportMetricRegistry = map[string]metricDef{
 	"items_sum": {
 		label:      "Количество товаров",
 		unit:       "шт",
+		group:      metricGroupApplications,
 		baseTable:  "items",
 		aggExpr:    "COALESCE(SUM(items.count), 0)",
 		dimensions: []string{"organization", "company", "period"},
 	},
 }
 
+// dimNone — универсальный разрез "без разреза": один итоговый ряд без GROUP BY.
+// Применим к любой метрике, поэтому намеренно НЕ входит в metricDef.dimensions
+// (движок валидирует его отдельной веткой). В каталог добавлен как самостоятельный
+// разрез, чтобы гид показал его опцией; UI задействует его в срезе GR2/GR3.
+const dimNone = "none"
+
 var reportDimensionOrder = []string{
+	dimNone,
 	"status",
 	"organization",
 	"company",
@@ -112,6 +132,7 @@ var reportDimensionOrder = []string{
 }
 
 var reportDimensionRegistry = map[string]dimensionDef{
+	dimNone:           {label: "Без разреза"},
 	"status":          {label: "Статус заявки"},
 	"organization":    {label: "Организация"},
 	"company":         {label: "Компания"},
@@ -272,6 +293,7 @@ func buildReportCatalog(dyn dynamicReportOptions) models.ReportCatalog {
 			Key:        key,
 			Label:      def.label,
 			Unit:       def.unit,
+			Group:      def.group,
 			Dimensions: def.dimensions,
 		})
 	}

--- a/internal/services/report_engine.go
+++ b/internal/services/report_engine.go
@@ -3,6 +3,8 @@ package services
 import (
 	"errors"
 	"fmt"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -207,9 +209,10 @@ func buildAggregatePlan(req models.ReportRequest) (*aggPlan, error) {
 	if req.Dimension == "" {
 		return nil, errInvalidReport("dimension")
 	}
-	// Разрез должен быть заявлен в каталоге B1 для этой метрики — единый источник
-	// правды для UI и движка.
-	if !contains(reportMetricRegistry[req.Metric].dimensions, req.Dimension) {
+	// "none" (без разреза) универсален для любой метрики — не входит в каталожный
+	// список разрезов метрики, проверяется отдельно. Остальные разрезы должны быть
+	// заявлены в каталоге B1 для этой метрики (единый источник правды для UI и движка).
+	if req.Dimension != dimNone && !contains(reportMetricRegistry[req.Metric].dimensions, req.Dimension) {
 		return nil, errInvalidReport("dimension")
 	}
 
@@ -250,7 +253,10 @@ func buildAggregatePlan(req models.ReportRequest) (*aggPlan, error) {
 		plan.joins = append(plan.joins, schema.attachJoin...)
 	}
 
-	plan.orderStr = resolveAggOrder(req.Sort, req.Dimension, groupExpr, schema.aggExpr)
+	// Без разреза — один итоговый ряд, сортировка не нужна (groupExpr пуст).
+	if groupExpr != "" {
+		plan.orderStr = resolveAggOrder(req.Sort, req.Dimension, groupExpr, schema.aggExpr)
+	}
 	plan.limit = clampLimit(req.Limit)
 	return plan, nil
 }
@@ -268,6 +274,9 @@ func addJoinNeed(jk joinKind, needChain, needAttach *bool) {
 // join. period/hour_of_day строятся по tsColumn метрики; остальные — из карты dims.
 func resolveAggDimension(s aggMetricSchema, dim, granularity string) (group, label string, jk joinKind, err error) {
 	switch dim {
+	case dimNone:
+		// Без GROUP BY: единственный ряд с константной подписью.
+		return "", "'Итого'", jNone, nil
 	case "period":
 		unit := "day"
 		if granularity != "" {
@@ -387,4 +396,121 @@ func contains(list []string, v string) bool {
 		}
 	}
 	return false
+}
+
+// resolveReportMetrics нормализует список метрик запроса: Metrics приоритетнее
+// одиночного Metric (обратная совместимость), пустые и дубликаты убираются с
+// сохранением порядка. Пустой результат -> ErrInvalidReportRequest. Существование
+// каждой метрики проверяет buildAggregatePlan при сборке её плана.
+func resolveReportMetrics(req models.ReportRequest) ([]string, error) {
+	raw := req.Metrics
+	if len(raw) == 0 && req.Metric != "" {
+		raw = []string{req.Metric}
+	}
+	seen := make(map[string]bool, len(raw))
+	out := make([]string, 0, len(raw))
+	for _, m := range raw {
+		m = strings.TrimSpace(m)
+		if m == "" || seen[m] {
+			continue
+		}
+		seen[m] = true
+		out = append(out, m)
+	}
+	if len(out) == 0 {
+		return nil, errInvalidReport("metric")
+	}
+	return out, nil
+}
+
+// mergeMetricRows сливает построчные результаты метрик в мультиметричные строки
+// (подпись разреза -> значение каждой метрики, отсутствующая метрика -> 0),
+// упорядочивает их и применяет лимит. Итоги (totals) считаются по уже усечённым
+// строкам — как сумма видимых значений каждой метрики. Чистая функция.
+func mergeMetricRows(metrics []string, perMetric map[string][]models.ReportAggregateRow, dim, sortKey string, limit int) ([]models.ReportMetricRow, map[string]int64) {
+	order := make([]string, 0)
+	bucket := make(map[string]map[string]int64)
+	for _, m := range metrics {
+		for _, r := range perMetric[m] {
+			vals, ok := bucket[r.Label]
+			if !ok {
+				vals = make(map[string]int64, len(metrics))
+				bucket[r.Label] = vals
+				order = append(order, r.Label)
+			}
+			vals[m] = r.Value
+		}
+	}
+
+	rows := make([]models.ReportMetricRow, 0, len(order))
+	for _, label := range order {
+		vals := make(map[string]int64, len(metrics))
+		for _, m := range metrics {
+			vals[m] = bucket[label][m] // отсутствие -> 0
+		}
+		rows = append(rows, models.ReportMetricRow{Label: label, Values: vals})
+	}
+
+	orderMetricRows(rows, dim, sortKey, metrics)
+	if limit > 0 && len(rows) > limit {
+		rows = rows[:limit]
+	}
+
+	totals := make(map[string]int64, len(metrics))
+	for _, r := range rows {
+		for _, m := range metrics {
+			totals[m] += r.Values[m]
+		}
+	}
+	return rows, totals
+}
+
+// orderMetricRows упорядочивает мультиметричные строки in-place. Явный sort имеет
+// приоритет: value_* сортирует по СУММЕ метрик строки (единый порядок для всех
+// колонок; сортировать по одной метрике при мультивыборе неоднозначно — какой),
+// label_* — по подписи разреза. Без явного sort: период — хронологически (ISO-даты),
+// час суток — численно, прочие категориальные — по убыванию суммы метрик. Для
+// одиночной метрики сумма = её значение, т.е. порядок совпадает с SQL-сортировкой.
+// Разрез "none" даёт один ряд (порядок не важен).
+func orderMetricRows(rows []models.ReportMetricRow, dim, sortKey string, metrics []string) {
+	rowTotal := func(r models.ReportMetricRow) int64 {
+		var t int64
+		for _, m := range metrics {
+			t += r.Values[m]
+		}
+		return t
+	}
+	switch sortKey {
+	case sortLabelAsc:
+		sort.SliceStable(rows, func(i, j int) bool { return rows[i].Label < rows[j].Label })
+		return
+	case sortLabelDesc:
+		sort.SliceStable(rows, func(i, j int) bool { return rows[i].Label > rows[j].Label })
+		return
+	case sortValueAsc:
+		sort.SliceStable(rows, func(i, j int) bool { return rowTotal(rows[i]) < rowTotal(rows[j]) })
+		return
+	case sortValueDesc:
+		sort.SliceStable(rows, func(i, j int) bool { return rowTotal(rows[i]) > rowTotal(rows[j]) })
+		return
+	}
+	switch dim {
+	case "period":
+		sort.SliceStable(rows, func(i, j int) bool { return rows[i].Label < rows[j].Label })
+	case "hour_of_day":
+		sort.SliceStable(rows, func(i, j int) bool { return hourLabel(rows[i].Label) < hourLabel(rows[j].Label) })
+	case dimNone:
+		// один итоговый ряд — сортировка не нужна
+	default:
+		sort.SliceStable(rows, func(i, j int) bool { return rowTotal(rows[i]) > rowTotal(rows[j]) })
+	}
+}
+
+// hourLabel парсит подпись часа суток ("0".."23") в число для численной сортировки.
+func hourLabel(label string) int {
+	n, err := strconv.Atoi(strings.TrimSpace(label))
+	if err != nil {
+		return 0
+	}
+	return n
 }

--- a/internal/services/report_multimetric_test.go
+++ b/internal/services/report_multimetric_test.go
@@ -1,0 +1,189 @@
+package services
+
+import (
+	"strings"
+	"testing"
+
+	"systemburo/internal/models"
+)
+
+func TestResolveReportMetrics(t *testing.T) {
+	cases := []struct {
+		name    string
+		req     models.ReportRequest
+		want    []string
+		wantErr bool
+	}{
+		{"metrics explicit", models.ReportRequest{Metrics: []string{"applications_count", "items_sum"}}, []string{"applications_count", "items_sum"}, false},
+		{"fallback to single metric", models.ReportRequest{Metric: "car_entries_count"}, []string{"car_entries_count"}, false},
+		{"metrics override single", models.ReportRequest{Metric: "items_sum", Metrics: []string{"applications_count"}}, []string{"applications_count"}, false},
+		{"dedup and trim", models.ReportRequest{Metrics: []string{"applications_count", " applications_count ", "", "  ", "items_sum"}}, []string{"applications_count", "items_sum"}, false},
+		{"empty request", models.ReportRequest{}, nil, true},
+		{"only blanks", models.ReportRequest{Metrics: []string{"", "   "}}, nil, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveReportMetrics(tc.req)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ожидалась ошибка, got %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("неожиданная ошибка: %v", err)
+			}
+			if strings.Join(got, ",") != strings.Join(tc.want, ",") {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMergeMetricRows_CombinesMissingAsZero(t *testing.T) {
+	metrics := []string{"a", "b"}
+	perMetric := map[string][]models.ReportAggregateRow{
+		"a": {{Label: "Орг1", Value: 5}, {Label: "Орг2", Value: 3}},
+		"b": {{Label: "Орг1", Value: 2}, {Label: "Орг3", Value: 7}},
+	}
+	rows, totals := mergeMetricRows(metrics, perMetric, "organization", "", 0)
+
+	// default категориальный: по убыванию суммы метрик. Орг1=7, Орг3=7 (tie ->
+	// стабильно по первому появлению), Орг2=3.
+	wantOrder := []string{"Орг1", "Орг3", "Орг2"}
+	if len(rows) != 3 {
+		t.Fatalf("ожидалось 3 строки, got %d", len(rows))
+	}
+	for i, label := range wantOrder {
+		if rows[i].Label != label {
+			t.Errorf("row[%d]: got %q, want %q", i, rows[i].Label, label)
+		}
+	}
+	// отсутствующая метрика -> 0.
+	byLabel := map[string]models.ReportMetricRow{}
+	for _, r := range rows {
+		byLabel[r.Label] = r
+	}
+	if byLabel["Орг1"].Values["a"] != 5 || byLabel["Орг1"].Values["b"] != 2 {
+		t.Errorf("Орг1: %+v", byLabel["Орг1"].Values)
+	}
+	if byLabel["Орг2"].Values["b"] != 0 {
+		t.Errorf("Орг2 без метрики b должна давать 0, got %d", byLabel["Орг2"].Values["b"])
+	}
+	if byLabel["Орг3"].Values["a"] != 0 {
+		t.Errorf("Орг3 без метрики a должна давать 0, got %d", byLabel["Орг3"].Values["a"])
+	}
+	if totals["a"] != 8 || totals["b"] != 9 {
+		t.Errorf("totals: got %+v, want a=8 b=9", totals)
+	}
+}
+
+func TestMergeMetricRows_PeriodChronological(t *testing.T) {
+	rows, _ := mergeMetricRows(
+		[]string{"a"},
+		map[string][]models.ReportAggregateRow{
+			"a": {{Label: "2026-06-03", Value: 3}, {Label: "2026-06-01", Value: 5}, {Label: "2026-06-02", Value: 1}},
+		},
+		"period", "", 0,
+	)
+	want := []string{"2026-06-01", "2026-06-02", "2026-06-03"}
+	for i, label := range want {
+		if rows[i].Label != label {
+			t.Errorf("period row[%d]: got %q, want %q", i, rows[i].Label, label)
+		}
+	}
+}
+
+func TestMergeMetricRows_HourOfDayNumeric(t *testing.T) {
+	// численная сортировка: "2" < "9" < "10" (строковая дала бы "10","2","9").
+	rows, _ := mergeMetricRows(
+		[]string{"a"},
+		map[string][]models.ReportAggregateRow{
+			"a": {{Label: "9", Value: 1}, {Label: "10", Value: 1}, {Label: "2", Value: 1}},
+		},
+		"hour_of_day", "", 0,
+	)
+	want := []string{"2", "9", "10"}
+	for i, label := range want {
+		if rows[i].Label != label {
+			t.Errorf("hour row[%d]: got %q, want %q", i, rows[i].Label, label)
+		}
+	}
+}
+
+func TestMergeMetricRows_LimitAndTotalsOverVisible(t *testing.T) {
+	rows, totals := mergeMetricRows(
+		[]string{"a"},
+		map[string][]models.ReportAggregateRow{
+			"a": {{Label: "x", Value: 10}, {Label: "y", Value: 5}, {Label: "z", Value: 1}},
+		},
+		"organization", "", 2,
+	)
+	if len(rows) != 2 {
+		t.Fatalf("limit 2: got %d строк", len(rows))
+	}
+	if rows[0].Label != "x" || rows[1].Label != "y" {
+		t.Errorf("ожидался top-2 x,y, got %q,%q", rows[0].Label, rows[1].Label)
+	}
+	// totals считаются по видимым (усечённым) строкам: 10+5, z отброшена.
+	if totals["a"] != 15 {
+		t.Errorf("totals по видимым строкам: got %d, want 15", totals["a"])
+	}
+}
+
+func TestMergeMetricRows_ExplicitLabelSort(t *testing.T) {
+	rows, _ := mergeMetricRows(
+		[]string{"a"},
+		map[string][]models.ReportAggregateRow{
+			"a": {{Label: "Бета", Value: 1}, {Label: "Альфа", Value: 99}},
+		},
+		"organization", sortLabelAsc, 0,
+	)
+	if rows[0].Label != "Альфа" || rows[1].Label != "Бета" {
+		t.Errorf("label_asc должен игнорировать значение: got %q,%q", rows[0].Label, rows[1].Label)
+	}
+}
+
+func TestAggregatePlan_DimensionNone(t *testing.T) {
+	req := models.ReportRequest{Metric: "applications_count", Dimension: dimNone}
+	plan, err := buildAggregatePlan(req)
+	if err != nil {
+		t.Fatalf("неожиданная ошибка: %v", err)
+	}
+	if plan.groupExpr != "" {
+		t.Errorf("none: ожидался пустой groupExpr, got %q", plan.groupExpr)
+	}
+	if plan.orderStr != "" {
+		t.Errorf("none: ожидался пустой orderStr, got %q", plan.orderStr)
+	}
+	if !strings.Contains(plan.selectStr, "'Итого' AS label") {
+		t.Errorf("none: ожидалась константная подпись, got %q", plan.selectStr)
+	}
+	if !strings.Contains(plan.selectStr, "COUNT(DISTINCT app.id) AS value") {
+		t.Errorf("none: ожидался aggExpr метрики, got %q", plan.selectStr)
+	}
+}
+
+func TestAggregatePlan_DimensionNoneKeepsFilters(t *testing.T) {
+	// Без разреза фильтры по-прежнему применяются (WHERE), даже без GROUP BY.
+	req := models.ReportRequest{
+		Metric:    "applications_count",
+		Dimension: dimNone,
+		Filters: []models.ReportFilterValue{
+			{Key: "status", Values: []string{models.StatusCompleted}},
+		},
+	}
+	plan, err := buildAggregatePlan(req)
+	if err != nil {
+		t.Fatalf("неожиданная ошибка: %v", err)
+	}
+	var found bool
+	for _, w := range plan.wheres {
+		if strings.Contains(w.expr, "app.status IN") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("фильтр status должен применяться и без разреза: %+v", plan.wheres)
+	}
+}

--- a/internal/services/statistics_service.go
+++ b/internal/services/statistics_service.go
@@ -405,16 +405,75 @@ func (s *statisticsService) loadDynamicReportOptions(ctx context.Context) (dynam
 	return dyn, nil
 }
 
-// RunReport исполняет агрегатный отчёт конструктора (mode=aggregate): метрика x
-// разрез x фильтры x период x sort/limit. План собирается чистой buildAggregatePlan
-// из whitelist-схем (report_engine.go) — ввод сверяется по ключам и подставляется
-// только через плейсхолдеры. Невалидный запрос -> ErrInvalidReportRequest (400 в handler).
+// RunReport исполняет агрегатный отчёт конструктора (mode=aggregate): одна или
+// несколько метрик (Metrics) x разрез x фильтры x период x sort/limit. Каждая
+// метрика исполняется отдельным агрегатным запросом (у метрик разные базовые
+// таблицы — общий GROUP BY невозможен) и сливается по подписи разреза в Go
+// (report_engine.go, чистая логика). Планы собираются buildAggregatePlan из
+// whitelist-схем: ввод сверяется по ключам и подставляется только через
+// плейсхолдеры. Невалидный запрос -> ErrInvalidReportRequest (400 в handler).
 func (s *statisticsService) RunReport(ctx context.Context, req models.ReportRequest) (*models.ReportResponse, error) {
-	plan, err := buildAggregatePlan(req)
+	metrics, err := resolveReportMetrics(req)
 	if err != nil {
 		return nil, err
 	}
+	multi := len(metrics) > 1
 
+	perMetric := make(map[string][]models.ReportAggregateRow, len(metrics))
+	columns := make([]models.ReportMetricColumn, 0, len(metrics))
+	for _, m := range metrics {
+		mreq := req
+		mreq.Metric = m
+		plan, perr := buildAggregatePlan(mreq)
+		if perr != nil {
+			return nil, perr
+		}
+		// При мультиметриках итоговый лимит применяется после слияния (top-N по
+		// сумме метрик), поэтому каждую метрику грузим широко.
+		if multi {
+			plan.limit = maxReportLimit
+		}
+		rows, rerr := s.execAggregatePlan(ctx, plan)
+		if rerr != nil {
+			return nil, rerr
+		}
+		perMetric[m] = rows
+		columns = append(columns, models.ReportMetricColumn{
+			Key:   m,
+			Label: reportMetricRegistry[m].label,
+			Unit:  plan.unit,
+		})
+	}
+
+	metricRows, totals := mergeMetricRows(metrics, perMetric, req.Dimension, req.Sort, clampLimit(req.Limit))
+
+	// Legacy-поля одиночной метрики (текущий FE читает Rows/Total/Unit): первая
+	// метрика как label/value по уже упорядоченным строкам. Unit берём из той же
+	// колонки (единый источник — план метрики), чтобы columns[].unit и legacy unit
+	// не разъезжались.
+	first := metrics[0]
+	legacyRows := make([]models.ReportAggregateRow, 0, len(metricRows))
+	for _, r := range metricRows {
+		legacyRows = append(legacyRows, models.ReportAggregateRow{Label: r.Label, Value: r.Values[first]})
+	}
+
+	return &models.ReportResponse{
+		Mode:       "aggregate",
+		Metric:     first,
+		Dimension:  req.Dimension,
+		Unit:       columns[0].Unit,
+		Rows:       legacyRows,
+		Total:      totals[first],
+		Columns:    columns,
+		MetricRows: metricRows,
+		Totals:     totals,
+	}, nil
+}
+
+// execAggregatePlan исполняет один резолвленный план агрегата и возвращает строки
+// (подпись разреза + значение метрики). GROUP BY/ORDER применяются только если
+// заданы (разрез "none" даёт один итоговый ряд без них).
+func (s *statisticsService) execAggregatePlan(ctx context.Context, plan *aggPlan) ([]models.ReportAggregateRow, error) {
 	tx := s.db.WithContext(ctx).Table(plan.table).Select(plan.selectStr)
 	for _, j := range plan.joins {
 		tx = tx.Joins(j)
@@ -422,29 +481,18 @@ func (s *statisticsService) RunReport(ctx context.Context, req models.ReportRequ
 	for _, w := range plan.wheres {
 		tx = tx.Where(w.expr, w.args...)
 	}
+	if plan.groupExpr != "" {
+		tx = tx.Group(plan.groupExpr)
+	}
+	if plan.orderStr != "" {
+		tx = tx.Order(plan.orderStr)
+	}
 
 	rows := make([]models.ReportAggregateRow, 0)
-	if err := tx.
-		Group(plan.groupExpr).
-		Order(plan.orderStr).
-		Limit(plan.limit).
-		Scan(&rows).Error; err != nil {
+	if err := tx.Limit(plan.limit).Scan(&rows).Error; err != nil {
 		return nil, fmt.Errorf("statistics: run report: %w", err)
 	}
-
-	var total int64
-	for _, r := range rows {
-		total += r.Value
-	}
-
-	return &models.ReportResponse{
-		Mode:      "aggregate",
-		Metric:    req.Metric,
-		Dimension: req.Dimension,
-		Unit:      plan.unit,
-		Rows:      rows,
-		Total:     total,
-	}, nil
+	return rows, nil
 }
 
 // RunReportList исполняет list-отчёт конструктора (mode=list): выгрузка строк


### PR DESCRIPTION
## Срез GR0 эпика 37-analytics (переделка вкладки Отчёты под мокап «Гид»)

BE-движок отчётов получает мультиметрики — основа для шага «Что считаем» гида (GR2) и мультиколоночного результата (GR4).

### Что сделано
- `POST /statistics/report` принимает `metrics: []string`. Каждая метрика становится колонкой результата, строки разреза несут значение каждой метрики (отсутствие метрики в бакете -> 0).
- Обратная совместимость: одиночный `metric` по-прежнему работает; legacy-поля ответа (`metric`/`unit`/`rows`/`total`) сохранены — текущий `ReportResult.vue` не ломается. Новые поля `columns`/`metric_rows`/`totals` заполняются всегда (единый формат для гида).
- Разрез `none` («без разреза») — один итоговый ряд без GROUP BY (фильтры применяются).
- Поле `group` у метрик каталога (`GET /statistics/metrics`) — для группировки карточек метрик в гиде (Заявки/Машины/Люди).

### Ключевое решение (SQL-риск)
У метрик РАЗНЫЕ базовые таблицы (`applications` / `cars_history` / `employees_history` / `items`), поэтому общий GROUP BY невозможен. Каждая метрика исполняется СВОИМ уже протестированным планом (`buildAggregatePlan`), результаты сливаются по подписи разреза в Go (`mergeMetricRows`, чистая функция). Никакого нового рискового multi-agg SQL; весь ввод — whitelist + плейсхолдеры.

### Тесты
- Unit на чистую логику: `resolveReportMetrics` (приоритет/дедуп/fallback), `mergeMetricRows` (merge, missing->0, порядок период/час/категориальный, лимит, totals по видимым), план разреза `none`.
- 2 GORM-интеграционных на реальной БД: мультиметрики по двум РАЗНЫМ базовым таблицам (`applications_count`+`items_sum`) по `organization`; разрез `none`.
- Go scoped (`services`+`handlers`) зелёные, gofmt/vet чисто.

### Ревью
`code-reviewer` = go (блокеров нет). Применены suggestions: единый источник `unit` (из плана метрики), комментарий к `dimNone` про активацию в UI-срезе, docblock семантики сортировки по сумме метрик.