### PR TITLE
fix(analytics): гонка устаревшего ответа в автозагрузке дашборда (#632)

### DIFF
--- a/frontend/src/components/statistics/StatisticsDashboard.vue
+++ b/frontend/src/components/statistics/StatisticsDashboard.vue
@@ -351,19 +351,29 @@ function formatTime(iso) {
 }
 
 // ---- загрузка данных ----
+// Токены последовательности: быстрое переключение периода/метрики/гранулярности
+// пускает несколько запросов параллельно; результат пишет только последний, иначе
+// медленный ответ предыдущего выбора затирает актуальный (last-resolve-wins).
+let summarySeq = 0;
+let timelineSeq = 0;
+
 async function loadSummary() {
+  const seq = ++summarySeq;
   summaryLoading.value = true;
   try {
     const data = await getSummary(props.from, props.to);
+    if (seq !== summarySeq) return;
     summary.value = data || {};
   } catch {
+    if (seq !== summarySeq) return;
     summary.value = {};
   } finally {
-    summaryLoading.value = false;
+    if (seq === summarySeq) summaryLoading.value = false;
   }
 }
 
 async function loadTimeline() {
+  const seq = ++timelineSeq;
   timelineLoading.value = true;
   try {
     const data = await getTimeline({
@@ -372,11 +382,13 @@ async function loadTimeline() {
       metric: activeMetric.value,
       granularity: activeGranularity.value,
     });
+    if (seq !== timelineSeq) return;
     timeline.value = Array.isArray(data) ? data : [];
   } catch {
+    if (seq !== timelineSeq) return;
     timeline.value = [];
   } finally {
-    timelineLoading.value = false;
+    if (seq === timelineSeq) timelineLoading.value = false;
   }
 }
 

--- a/frontend/src/components/statistics/__tests__/StatisticsDashboard.spec.js
+++ b/frontend/src/components/statistics/__tests__/StatisticsDashboard.spec.js
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { nextTick } from 'vue';
+
+// Управляемые промисы getTimeline: фабрика vi.mock поднимается над импортами,
+// поэтому состояние выносим в hoisted.
+const { state } = vi.hoisted(() => ({ state: { deferred: [] } }));
+
+vi.mock('@/api/statistics.js', () => ({
+  getSummary: () => Promise.resolve({}),
+  getRecentPassages: () => Promise.resolve({ people: [], cars: [] }),
+  getTimeline: () => new Promise((resolve) => { state.deferred.push(resolve); }),
+}));
+
+import StatisticsDashboard from '../StatisticsDashboard.vue';
+import RealTimeChart from '@/components/RealTimeChart.vue';
+
+describe('StatisticsDashboard — гонка таймлайна', () => {
+  it('при быстрой смене метрики рисует данные последнего запроса, медленный предыдущий игнорирует', async () => {
+    state.deferred.length = 0;
+    const wrapper = mount(StatisticsDashboard, {
+      props: { from: '2026-06-01', to: '2026-06-07' },
+      global: { stubs: { RealTimeChart: true, RefreshButton: true } },
+    });
+    await nextTick(); // onMounted -> loadTimeline (seq 1, deferred)
+
+    // Быстрое переключение метрики -> второй loadTimeline (seq 2).
+    await wrapper.findAll('.dashboard__seg-btn')[1].trigger('click');
+    await nextTick();
+
+    expect(state.deferred).toHaveLength(2);
+
+    // Последний запрос (seq 2) приходит ПЕРВЫМ, устаревший seq 1 — позже.
+    state.deferred[1]([{ date: '2026-06-02', count: 222 }]);
+    await flushPromises();
+    state.deferred[0]([{ date: '2026-06-01', count: 111 }]);
+    await flushPromises();
+
+    const chart = wrapper.findComponent(RealTimeChart);
+    const data = chart.props('data');
+    expect(data).toHaveLength(1);
+    expect(data[0].count).toBe(222); // не 111 от устаревшего ответа
+  });
+});


### PR DESCRIPTION
## Срез fix-dash-timeline-race эпика 37-analytics

`StatisticsDashboard.vue` авто-перезагружал график и сводку через `watch` по метрике/гранулярности/периоду без защиты от гонки. Быстрое переключение пускало несколько `loadTimeline`/`loadSummary` параллельно, и медленный ответ предыдущего выбора затирал актуальный (last-resolve-wins -> на экране данные не той метрики).

Фикс: токен последовательности (`++seq`, результат пишет только последний запрос) в `loadTimeline` и `loadSummary`. Тот же паттерн, что в уже смерженном `ReportsTab.onRun`.

### Тест
`StatisticsDashboard.spec.js`: два параллельных `loadTimeline` (смена метрики), ответ последнего приходит первым, устаревший — позже; график показывает данные последнего (222), не устаревшего (111). Прогон vitest по файлу зелёный, eslint 0 errors.