### PR TITLE
feat(analytics): применимые фильтры метрик в каталоге отчётов (#632)

### DIFF
--- a/internal/models/report_catalog.go
+++ b/internal/models/report_catalog.go
@@ -18,12 +18,15 @@ type ReportOption struct {
 // ReportMetricInfo — метрика агрегатного отчёта (что измеряем).
 // Group — тематическая группа карточек метрик в гиде (Заявки/Машины/Люди/...).
 // Dimensions перечисляет ключи разрезов, по которым эту метрику можно группировать.
+// Filters — ключи фильтров, применимых к этой метрике (шаг "Фильтры" гида); все
+// исполнимы движком (date_range + per-metric whitelist).
 type ReportMetricInfo struct {
 	Key        string   `json:"key"`
 	Label      string   `json:"label"`
 	Unit       string   `json:"unit,omitempty"`
 	Group      string   `json:"group,omitempty"`
 	Dimensions []string `json:"dimensions"`
+	Filters    []string `json:"filters,omitempty"`
 }
 
 // ReportDimensionInfo — разрез (ось группировки) агрегатного отчёта.

--- a/internal/services/report_catalog.go
+++ b/internal/services/report_catalog.go
@@ -276,6 +276,24 @@ func (d dynamicReportOptions) optionsFor(src optionsSource) []models.ReportOptio
 	}
 }
 
+// metricApplicableFilters выводит список применимых к метрике фильтров ИЗ схемы
+// движка (aggMetricRegistry) — единый источник, исключающий рассинхрон каталога и
+// исполнителя. date_range применим ко всем метрикам (по tsColumn); остальные —
+// только те, что движок умеет резолвить для этой метрики. Порядок — reportFilterOrder.
+func metricApplicableFilters(metric string) []string {
+	schema, ok := aggMetricRegistry[metric]
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(reportFilterOrder))
+	for _, f := range reportFilterOrder {
+		if _, resolvable := schema.filters[f]; f == "date_range" || resolvable {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
 // buildReportCatalog собирает каталог из whitelist-реестров и подгруженных
 // значений справочников. Чистая функция (без БД) — тестируется напрямую.
 func buildReportCatalog(dyn dynamicReportOptions) models.ReportCatalog {
@@ -295,6 +313,7 @@ func buildReportCatalog(dyn dynamicReportOptions) models.ReportCatalog {
 			Unit:       def.unit,
 			Group:      def.group,
 			Dimensions: def.dimensions,
+			Filters:    metricApplicableFilters(key),
 		})
 	}
 

--- a/internal/services/report_catalog_test.go
+++ b/internal/services/report_catalog_test.go
@@ -84,6 +84,55 @@ func TestReportRegistries_Consistency(t *testing.T) {
 	}
 }
 
+// TestMetricApplicableFilters проверяет, что каталог отдаёт per-metric фильтры,
+// каждый из них исполним движком (date_range или есть в aggMetricRegistry.filters),
+// date_range присутствует у всех метрик, а порядок совпадает с reportFilterOrder.
+func TestMetricApplicableFilters(t *testing.T) {
+	cat := buildReportCatalog(dynamicReportOptions{})
+	for _, m := range cat.Metrics {
+		if len(m.Filters) == 0 {
+			t.Errorf("метрика %q без применимых фильтров", m.Key)
+			continue
+		}
+		var hasDateRange bool
+		schema := aggMetricRegistry[m.Key]
+		prev := -1
+		for _, f := range m.Filters {
+			if f == "date_range" {
+				hasDateRange = true
+			} else {
+				if _, ok := schema.filters[f]; !ok {
+					t.Errorf("метрика %q публикует фильтр %q, не исполнимый движком", m.Key, f)
+				}
+				if _, ok := reportFilterRegistry[f]; !ok {
+					t.Errorf("метрика %q публикует фильтр %q без записи в каталоге фильтров", m.Key, f)
+				}
+			}
+			// порядок — подпоследовательность reportFilterOrder.
+			idx := indexOf(reportFilterOrder, f)
+			if idx < 0 {
+				t.Errorf("фильтр %q вне reportFilterOrder", f)
+			} else if idx <= prev {
+				t.Errorf("метрика %q: фильтры не в порядке reportFilterOrder (%v)", m.Key, m.Filters)
+			} else {
+				prev = idx
+			}
+		}
+		if !hasDateRange {
+			t.Errorf("метрика %q: date_range должен быть применим (период по tsColumn)", m.Key)
+		}
+	}
+}
+
+func indexOf(list []string, v string) int {
+	for i, s := range list {
+		if s == v {
+			return i
+		}
+	}
+	return -1
+}
+
 // TestBuildReportCatalog_DynamicOptions проверяет подстановку значений
 // динамических справочников в соответствующие dict-фильтры.
 func TestBuildReportCatalog_DynamicOptions(t *testing.T) {


### PR DESCRIPTION
## Срез B3d (BE-only) эпика 37-analytics

Движок отчётов уже умеет per-metric фильтры (`aggMetricSchema.filters`: status/organization/company/attachment_type/citizenship/unload_place), но каталог `GET /statistics/metrics` их не публиковал, и конструктор для aggregate слал только `date_range`.

### Что сделано
- `ReportMetricInfo.Filters` в каталоге — ключи фильтров, применимых к метрике.
- Список **выводится из схемы движка** (`metricApplicableFilters`): `date_range` (применим ко всем по `tsColumn`) + per-metric whitelist из `aggMetricRegistry`, в порядке `reportFilterOrder`. Единый источник — рассинхрон каталога и исполнителя невозможен by-design.

### Важно про риск
**Нового SQL нет.** Срез только публикует УЖЕ существующий и протестированный whitelist движка. Поверхность SQL-инъекций не меняется.

Результат per-metric: applications_count→[date_range,status,organization,company,attachment_type]; car_entries_count→+unload_place; people_entries_count→+citizenship; items_sum→[date_range,organization,company].

### Тест
`TestMetricApplicableFilters`: каждый опубликованный фильтр исполним движком, `date_range` есть у всех, порядок = подпоследовательность `reportFilterOrder`. Go scoped зелёные, gofmt/vet чисто.

FE-рендер этих фильтров чипсами — срез GR3 (шаг «Фильтры» гида, общий для list/aggregate).