### PR TITLE
feat(onboarding): инфраструктура тура и каркас на Обзоре (#657)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "@tiptap/vue-3": "^2.27.2",
         "chart.js": "^4.5.1",
         "dompurify": "^3.4.1",
+        "driver.js": "^1.4.0",
         "exceljs": "^4.4.0",
         "jszip": "^3.10.1",
         "mitt": "^3.0.1",
@@ -2537,6 +2538,12 @@
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
+    },
+    "node_modules/driver.js": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/driver.js/-/driver.js-1.4.0.tgz",
+      "integrity": "sha512-Gm64jm6PmcU+si21sQhBrTAM1JvUrR0QhNmjkprNLxohOBzul9+pNHXgQaT9lW84gwg9GMLB3NZGuGolsz5uew==",
+      "license": "MIT"
     },
     "node_modules/duplexer2": {
       "version": "0.1.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "@tiptap/vue-3": "^2.27.2",
     "chart.js": "^4.5.1",
     "dompurify": "^3.4.1",
+    "driver.js": "^1.4.0",
     "exceljs": "^4.4.0",
     "jszip": "^3.10.1",
     "mitt": "^3.0.1",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -38,6 +38,7 @@
     <ConfirmDialog />
     <DirtyConfirmModal />
     <DeleteNotifications />
+    <OnboardingTour v-if="isAuthenticated" />
   </div>
 </template>
 
@@ -52,6 +53,7 @@ import ToastContainer from './components/ToastContainer.vue';
 import ConfirmDialog from './components/ConfirmDialog.vue';
 import DirtyConfirmModal from './components/DirtyConfirmModal.vue';
 import DeleteNotifications from './components/DeleteNotifications.vue';
+import OnboardingTour from './components/onboarding/OnboardingTour.vue';
 
 export default {
   name: "App",
@@ -63,6 +65,7 @@ export default {
     ConfirmDialog,
     DirtyConfirmModal,
     DeleteNotifications,
+    OnboardingTour,
   },
   computed: {
     isAuthenticated() {

--- a/frontend/src/assets/onboarding.css
+++ b/frontend/src/assets/onboarding.css
@@ -1,0 +1,146 @@
+/*
+ * Брендирование driver.js-поповера онбординг-тура. Класс ob-popover навешивается
+ * на .driver-popover через popoverClass. Все анимации - только transform/opacity.
+ */
+
+.driver-popover.ob-popover {
+  border-radius: 20px;
+  box-shadow: var(--shadow-md);
+  padding: 20px 22px 16px;
+  max-width: 360px;
+  font-family: 'Montserrat', sans-serif;
+}
+
+.driver-popover.ob-popover .driver-popover-title {
+  font-size: 16px;
+  font-weight: 700;
+  color: #1a1a1a;
+}
+
+.driver-popover.ob-popover .driver-popover-description {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--color-text);
+}
+
+.driver-popover.ob-popover .driver-popover-arrow {
+  color: #fff;
+}
+
+/* --- Кнопки навигации (pill-стиль под бренд) --- */
+.driver-popover.ob-popover .driver-popover-navigation-btns {
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.driver-popover.ob-popover .driver-popover-prev-btn,
+.driver-popover.ob-popover .driver-popover-next-btn {
+  text-shadow: none;
+  border-radius: var(--radius-pill);
+  border: 1px solid transparent;
+  padding: 7px 18px;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.2;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.driver-popover.ob-popover .driver-popover-next-btn {
+  background: var(--color-primary);
+  color: #fff;
+  border-color: var(--color-primary);
+}
+
+.driver-popover.ob-popover .driver-popover-next-btn:hover {
+  background: var(--color-primary-hover);
+  border-color: var(--color-primary-hover);
+}
+
+.driver-popover.ob-popover .driver-popover-prev-btn {
+  background: #fff;
+  color: var(--color-primary);
+  border-color: var(--color-primary);
+}
+
+.driver-popover.ob-popover .driver-popover-prev-btn:hover {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.driver-popover.ob-popover .driver-popover-prev-btn.driver-popover-btn-disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.driver-popover.ob-popover .driver-popover-close-btn {
+  color: var(--color-text-muted);
+  transition: color 0.15s ease;
+}
+
+.driver-popover.ob-popover .driver-popover-close-btn:hover {
+  color: var(--color-primary);
+}
+
+/* --- Кастомный прогресс-блок (рисуем сами, штатный showProgress выключен) --- */
+.ob-popover__progress {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  width: 100%;
+  margin-bottom: 12px;
+}
+
+.ob-popover__step-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-text-muted);
+}
+
+.ob-popover__bar {
+  position: relative;
+  height: 4px;
+  width: 100%;
+  background: var(--color-border);
+  border-radius: var(--radius-pill);
+  overflow: hidden;
+}
+
+.ob-popover__bar-fill {
+  height: 100%;
+  width: 100%;
+  background: var(--color-primary);
+  border-radius: var(--radius-pill);
+  transform-origin: left center;
+  transition: transform 0.2s ease;
+}
+
+.ob-popover__next-hint {
+  font-size: 11px;
+  color: var(--color-text-muted);
+}
+
+.ob-popover__skip {
+  align-self: flex-start;
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: color 0.15s ease, opacity 0.15s ease;
+}
+
+.ob-popover__skip:hover {
+  color: var(--color-primary);
+  opacity: 0.85;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ob-popover__bar-fill {
+    transition: none;
+  }
+}

--- a/frontend/src/components/news/DocumentsBlock.vue
+++ b/frontend/src/components/news/DocumentsBlock.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="docs-block">
+  <div
+    class="docs-block"
+    data-testid="ob-documents"
+  >
     <div class="docs-block__head">
       <span class="docs-block__title">Документы</span>
     </div>

--- a/frontend/src/components/onboarding/OnboardingButton.vue
+++ b/frontend/src/components/onboarding/OnboardingButton.vue
@@ -1,0 +1,58 @@
+<script setup>
+import { computed } from 'vue';
+import { useOnboardingStore } from '@/stores/onboarding';
+
+const store = useOnboardingStore();
+const canShow = computed(() => store.canShowTour);
+
+function startTour() {
+  store.start({ manual: true });
+}
+</script>
+
+<template>
+  <button
+    v-if="canShow"
+    type="button"
+    class="lk-button lk-button--secondary ob-start-button"
+    data-testid="ob-start-button"
+    @click="startTour"
+  >
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    >
+      <circle
+        cx="12"
+        cy="12"
+        r="9"
+        stroke="currentColor"
+        stroke-width="1.8"
+      />
+      <path
+        d="M9.5 9.2a2.6 2.6 0 1 1 3.6 2.4c-.7.3-1.1.7-1.1 1.5v.4"
+        stroke="currentColor"
+        stroke-width="1.8"
+        stroke-linecap="round"
+      />
+      <circle
+        cx="12"
+        cy="16.6"
+        r="1"
+        fill="currentColor"
+      />
+    </svg>
+    <span>Обучение</span>
+  </button>
+</template>
+
+<style scoped>
+.ob-start-button {
+  height: 25px;
+  padding: 0 14px;
+  font-size: 13px;
+}
+</style>

--- a/frontend/src/components/onboarding/OnboardingTour.vue
+++ b/frontend/src/components/onboarding/OnboardingTour.vue
@@ -1,0 +1,78 @@
+<script setup>
+import { watch, onBeforeUnmount } from 'vue';
+import { useRoute } from 'vue-router';
+import { useOnboardingStore } from '@/stores/onboarding';
+import { useOnboarding } from '@/composables/useOnboarding';
+import { collectSegment } from '@/components/onboarding/onboardingSteps';
+
+const store = useOnboardingStore();
+const route = useRoute();
+const { waitForElement, createDriver } = useOnboarding();
+
+let driverObj = null;
+let waitController = null;
+
+async function startSegment() {
+  const segmentSteps = collectSegment(store.steps, store.currentIndex, route.path);
+  if (!segmentSteps.length) {
+    store.stop();
+    return;
+  }
+
+  const segmentStartIndex = store.currentIndex;
+  // Первый шаг с целью: дожидаемся её появления, иначе деградируем в центр-модал,
+  // чтобы driver не падал на отсутствующем элементе.
+  const firstStep = segmentSteps[0];
+  if (firstStep.element) {
+    waitController = new AbortController();
+    const el = await waitForElement(firstStep.element, 2500, waitController.signal);
+    waitController = null;
+    // Тур могли остановить (Esc/logout/повторный старт) пока ждали элемент -
+    // не поднимаем driver-зомби поверх неактивного тура.
+    if (!store.isActive) return;
+    if (!el) segmentSteps[0] = { ...firstStep, element: null };
+  }
+
+  driverObj = createDriver(segmentSteps, {
+    startIndex: segmentStartIndex,
+    onIndexChange: (globalIndex) => store.setIndex(globalIndex),
+    onDestroyed: handleDestroyed,
+  });
+  driverObj.drive(0);
+}
+
+function handleDestroyed() {
+  driverObj = null;
+  // Срез 1: сегмент один (news), конец сегмента = конец тура.
+  // Запись флага completed (для авто-запуска) - срез 6; ручной запуск флаг не трогает.
+  store.stop();
+}
+
+function teardown() {
+  if (waitController) {
+    waitController.abort();
+    waitController = null;
+  }
+  if (driverObj) {
+    driverObj.destroy();
+    driverObj = null;
+  }
+}
+
+watch(
+  () => store.isActive,
+  (active) => {
+    if (active) startSegment();
+    else teardown();
+  },
+);
+
+onBeforeUnmount(teardown);
+</script>
+
+<template>
+  <div
+    style="display: none"
+    data-testid="ob-host"
+  />
+</template>

--- a/frontend/src/components/onboarding/__tests__/OnboardingButton.spec.js
+++ b/frontend/src/components/onboarding/__tests__/OnboardingButton.spec.js
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import OnboardingButton from '../OnboardingButton.vue';
+import { useOnboardingStore } from '@/stores/onboarding';
+import { useAuthStore } from '@/stores/auth';
+
+function createMockJWT(payload, expiresInSeconds = 3600) {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const body = btoa(JSON.stringify({
+    ...payload,
+    exp: Math.floor(Date.now() / 1000) + expiresInSeconds,
+  }));
+  return `${header}.${body}.fake-signature`;
+}
+
+describe('OnboardingButton', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    localStorage.clear();
+  });
+
+  it('не рендерит кнопку для неаутентифицированного юзера', () => {
+    const wrapper = mount(OnboardingButton);
+    expect(wrapper.find('[data-testid="ob-start-button"]').exists()).toBe(false);
+  });
+
+  it('рендерит кнопку когда canShowTour=true', () => {
+    useAuthStore().setTokens(createMockJWT({ username: 'admin' }));
+    const wrapper = mount(OnboardingButton);
+
+    const btn = wrapper.find('[data-testid="ob-start-button"]');
+    expect(btn.exists()).toBe(true);
+    expect(btn.text()).toContain('Обучение');
+  });
+
+  it('клик запускает тур в ручном режиме', async () => {
+    useAuthStore().setTokens(createMockJWT({ username: 'admin' }));
+    const store = useOnboardingStore();
+    const startSpy = vi.spyOn(store, 'start');
+
+    const wrapper = mount(OnboardingButton);
+    await wrapper.find('[data-testid="ob-start-button"]').trigger('click');
+
+    expect(startSpy).toHaveBeenCalledWith({ manual: true });
+    expect(store.isActive).toBe(true);
+    expect(store.isManual).toBe(true);
+  });
+});

--- a/frontend/src/components/onboarding/__tests__/onboardingSteps.spec.js
+++ b/frontend/src/components/onboarding/__tests__/onboardingSteps.spec.js
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { onboardingSteps, ONBOARDING_VERSION, collectSegment } from '../onboardingSteps';
+
+describe('onboardingSteps', () => {
+  it('версия тура - целое число >= 1', () => {
+    expect(Number.isInteger(ONBOARDING_VERSION)).toBe(true);
+    expect(ONBOARDING_VERSION).toBeGreaterThanOrEqual(1);
+  });
+
+  it('каждый шаг имеет непустые id, title и строковый description', () => {
+    for (const step of onboardingSteps) {
+      expect(typeof step.id).toBe('string');
+      expect(step.id.length).toBeGreaterThan(0);
+      expect(typeof step.title).toBe('string');
+      expect(step.title.length).toBeGreaterThan(0);
+      expect(typeof step.description).toBe('string');
+      expect(step.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('element - либо строка-селектор, либо null', () => {
+    for (const step of onboardingSteps) {
+      const ok = step.element === null || (typeof step.element === 'string' && step.element.length > 0);
+      expect(ok).toBe(true);
+    }
+  });
+
+  it('route у каждого шага - непустая строка', () => {
+    for (const step of onboardingSteps) {
+      expect(typeof step.route).toBe('string');
+      expect(step.route.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('нет дублей id', () => {
+    const ids = onboardingSteps.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('есть хотя бы один центр-модал (element null) для старта', () => {
+    const hasCenterModal = onboardingSteps.some((s) => s.element === null);
+    expect(hasCenterModal).toBe(true);
+  });
+});
+
+describe('collectSegment', () => {
+  const steps = [
+    { id: 'a', route: '/news' },
+    { id: 'b', route: '/news' },
+    { id: 'c', route: '/personal-cabinet' },
+    { id: 'd', route: '/personal-cabinet' },
+    { id: 'e', route: '/carsview' },
+  ];
+
+  it('берёт подряд идущие шаги с одним route начиная с индекса', () => {
+    expect(collectSegment(steps, 0, '/news').map((s) => s.id)).toEqual(['a', 'b']);
+  });
+
+  it('останавливается на границе сегмента (другой route)', () => {
+    expect(collectSegment(steps, 2, '/personal-cabinet').map((s) => s.id)).toEqual(['c', 'd']);
+  });
+
+  it('пустой массив если route стартового шага не совпадает с активным', () => {
+    expect(collectSegment(steps, 0, '/carsview')).toEqual([]);
+  });
+
+  it('одиночный сегмент в конце массива', () => {
+    expect(collectSegment(steps, 4, '/carsview').map((s) => s.id)).toEqual(['e']);
+  });
+
+  it('реальная конфигурация: весь сегмент news собирается с нулевого индекса', () => {
+    const seg = collectSegment(onboardingSteps, 0, '/news');
+    expect(seg.length).toBe(onboardingSteps.filter((s) => s.route === '/news').length);
+  });
+});

--- a/frontend/src/components/onboarding/onboardingSteps.js
+++ b/frontend/src/components/onboarding/onboardingSteps.js
@@ -1,0 +1,73 @@
+/**
+ * Версия тура. Записывается в localStorage-флаг завершения и сверяется при
+ * чтении: повышение версии (новые шаги) заставит тур считаться непройденным
+ * и переиграться при авто-запуске. Поднимать при добавлении/изменении шагов.
+ */
+export const ONBOARDING_VERSION = 1;
+
+/**
+ * Плоский упорядоченный массив шагов тура. Движок группирует ПОДРЯД идущие
+ * шаги с одинаковым `route` в «сегмент» драйвера; смена `route` = граница
+ * сегмента (cross-page переход достраивается отдельным срезом).
+ *
+ * Поля шага:
+ * - `id`         уникальный строковый ключ;
+ * - `route`      путь страницы, на которой шаг живёт;
+ * - `element`    CSS-селектор цели или `null` (центр-модал без подсветки);
+ * - `title`      заголовок поповера;
+ * - `description` HTML-тело поповера (прогоняется через sanitizeHtml);
+ * - `demo`       необязательный ключ скриншота (используется будущими срезами).
+ *
+ * @type {Array<{ id: string, route: string, element: string|null, title: string, description: string, demo?: string }>}
+ */
+export const onboardingSteps = [
+  {
+    id: 'start',
+    route: '/news',
+    element: null,
+    title: 'Добро пожаловать!',
+    description:
+      'Коротко проведём по основным возможностям системы бюро пропусков. Это займёт пару минут. Двигайтесь кнопкой «Далее» или стрелками, выйти можно в любой момент клавишей Esc.',
+  },
+  {
+    id: 'news',
+    route: '/news',
+    element: '[data-testid="ob-news"]',
+    title: 'Новости системы',
+    description:
+      'Здесь публикуются новости системы и важные объявления. Заглядывайте сюда, чтобы быть в курсе изменений.',
+  },
+  {
+    id: 'guide',
+    route: '/news',
+    element: '[data-testid="ob-guide"]',
+    title: 'Руководство пользователя',
+    description:
+      'Пошаговая инструкция по работе с системой: как подать заявку и пользоваться разделами. Откройте, если что-то непонятно.',
+  },
+  {
+    id: 'documents',
+    route: '/news',
+    element: '[data-testid="ob-documents"]',
+    title: 'Документы',
+    description: 'Полезные документы и шаблоны, доступные для скачивания.',
+  },
+];
+
+/**
+ * Подряд идущие шаги начиная с `startIndex`, чей `route` совпадает с активной
+ * страницей. Граница сегмента - первый шаг с другим route (cross-page переход).
+ *
+ * @param {Array<{ route: string }>} steps
+ * @param {number} startIndex глобальный индекс первого шага сегмента
+ * @param {string} routePath активный путь роутера
+ * @returns {Array<object>}
+ */
+export function collectSegment(steps, startIndex, routePath) {
+  const segment = [];
+  for (let i = startIndex; i < steps.length; i += 1) {
+    if (steps[i].route !== routePath) break;
+    segment.push(steps[i]);
+  }
+  return segment;
+}

--- a/frontend/src/composables/useOnboarding.js
+++ b/frontend/src/composables/useOnboarding.js
@@ -1,0 +1,178 @@
+import { driver } from 'driver.js';
+import 'driver.js/dist/driver.css';
+import { sanitizeHtml } from '@/utils/sanitize.js';
+import { useOnboardingStore } from '@/stores/onboarding';
+
+/**
+ * Тонкая обёртка над driver.js: ожидание целевого элемента, сборка тела
+ * поповера и конфигурация инстанса с кастомным прогресс-блоком в футере.
+ */
+export function useOnboarding() {
+  /**
+   * @returns {boolean} пользователь просит уменьшить анимации.
+   */
+  function prefersReducedMotion() {
+    try {
+      return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Дождаться появления и видимости элемента в DOM. Резолвит элементом или
+   * `null` по таймауту - тур никогда не падает из-за отсутствующей цели.
+   * `signal` позволяет хосту отменить ожидание (teardown/logout) и не оставить
+   * висящий интервал.
+   *
+   * @param {string} selector
+   * @param {number} [timeout]
+   * @param {AbortSignal} [signal]
+   * @returns {Promise<Element|null>}
+   */
+  function waitForElement(selector, timeout = 2500, signal) {
+    return new Promise((resolve) => {
+      const isReady = (el) =>
+        el && (el.offsetParent !== null || el.getBoundingClientRect().width > 0);
+
+      if (signal?.aborted) {
+        resolve(null);
+        return;
+      }
+
+      const immediate = document.querySelector(selector);
+      if (isReady(immediate)) {
+        resolve(immediate);
+        return;
+      }
+
+      const start = Date.now();
+      const cleanup = () => {
+        clearInterval(intervalId);
+        signal?.removeEventListener('abort', onAbort);
+      };
+      const onAbort = () => {
+        cleanup();
+        resolve(null);
+      };
+      const intervalId = setInterval(() => {
+        const el = document.querySelector(selector);
+        if (isReady(el)) {
+          cleanup();
+          resolve(el);
+          return;
+        }
+        if (Date.now() - start >= timeout) {
+          cleanup();
+          resolve(null);
+        }
+      }, 100);
+      signal?.addEventListener('abort', onAbort);
+    });
+  }
+
+  /**
+   * Тело поповера. Сейчас - только санитизированный текст шага; будущие срезы
+   * добавят `<img>` для `step.demo`.
+   *
+   * @param {{ description: string }} step
+   * @returns {string}
+   */
+  function buildPopoverHtml(step) {
+    return sanitizeHtml(step.description);
+  }
+
+  function buildProgressBlock(globalIndex, total, nextTitle, onSkip) {
+    const block = document.createElement('div');
+    block.className = 'ob-popover__progress';
+
+    const label = document.createElement('div');
+    label.className = 'ob-popover__step-label';
+    label.textContent = `Шаг ${globalIndex} из ${total}`;
+
+    const bar = document.createElement('div');
+    bar.className = 'ob-popover__bar';
+    const fill = document.createElement('div');
+    fill.className = 'ob-popover__bar-fill';
+    // Заполнение через scaleX (анимируем transform, не width - правило проекта).
+    fill.style.transform = `scaleX(${total ? globalIndex / total : 0})`;
+    bar.appendChild(fill);
+
+    block.appendChild(label);
+    block.appendChild(bar);
+
+    if (nextTitle) {
+      const hint = document.createElement('div');
+      hint.className = 'ob-popover__next-hint';
+      hint.textContent = `Далее: ${nextTitle}`;
+      block.appendChild(hint);
+    }
+
+    const skip = document.createElement('button');
+    skip.type = 'button';
+    skip.className = 'ob-popover__skip';
+    skip.textContent = 'Пропустить';
+    skip.addEventListener('click', onSkip);
+    block.appendChild(skip);
+
+    return block;
+  }
+
+  /**
+   * Сконфигурировать driver-инстанс для одного сегмента (подряд идущих шагов
+   * с общим route).
+   *
+   * @param {Array<object>} stepsForSegment
+   * @param {{ startIndex?: number, onIndexChange?: (globalIndex: number) => void, onDestroyed?: () => void }} [options]
+   * @returns {import('driver.js').Driver}
+   */
+  function createDriver(stepsForSegment, { startIndex = 0, onIndexChange, onDestroyed } = {}) {
+    const driverObj = driver({
+      showProgress: false,
+      animate: !prefersReducedMotion(),
+      allowClose: true,
+      overlayOpacity: 0.7,
+      stagePadding: 6,
+      stageRadius: 12,
+      popoverClass: 'ob-popover',
+      nextBtnText: 'Далее',
+      prevBtnText: 'Назад',
+      doneBtnText: 'Готово',
+      steps: stepsForSegment.map((s) => ({
+        element: s.element || undefined,
+        popover: {
+          title: s.title,
+          description: buildPopoverHtml(s),
+        },
+      })),
+      onPopoverRender(popover) {
+        const localIndex = driverObj.getActiveIndex() ?? 0;
+        const globalIndex = startIndex + localIndex + 1;
+        const total = useOnboardingStore().totalSteps;
+        const nextStep = stepsForSegment[localIndex + 1];
+        const nextTitle = nextStep ? nextStep.title : '';
+
+        const block = buildProgressBlock(globalIndex, total, nextTitle, () => {
+          driverObj.destroy();
+        });
+        popover.footer.insertBefore(block, popover.footer.firstChild);
+      },
+      onHighlighted() {
+        const localIndex = driverObj.getActiveIndex() ?? 0;
+        onIndexChange?.(startIndex + localIndex);
+      },
+      onDestroyed() {
+        onDestroyed?.();
+      },
+    });
+
+    return driverObj;
+  }
+
+  return {
+    prefersReducedMotion,
+    waitForElement,
+    buildPopoverHtml,
+    createDriver,
+  };
+}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -10,6 +10,7 @@ import { useMaintenanceStore } from '@/stores/maintenance'
 import { installBeforeUnloadGuard } from '@/utils/dirtyTracker'
 import './assets/tokens.css'
 import './assets/forms.css'
+import './assets/onboarding.css'
 
 const app = createApp(App)
 app.config.globalProperties.$bus = bus

--- a/frontend/src/stores/__tests__/onboarding.spec.js
+++ b/frontend/src/stores/__tests__/onboarding.spec.js
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import { useOnboardingStore } from '../onboarding';
+import { useAuthStore } from '../auth';
+import { onboardingSteps, ONBOARDING_VERSION } from '@/components/onboarding/onboardingSteps';
+
+const STORAGE_KEY = 'onboarding-tour';
+
+function createMockJWT(payload, expiresInSeconds = 3600) {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const body = btoa(JSON.stringify({
+    ...payload,
+    exp: Math.floor(Date.now() / 1000) + expiresInSeconds,
+  }));
+  return `${header}.${body}.fake-signature`;
+}
+
+describe('onboarding store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('start / stop', () => {
+    it('start() активирует тур и сбрасывает индекс на 0', () => {
+      const store = useOnboardingStore();
+      store.setIndex(3);
+      store.start();
+
+      expect(store.isActive).toBe(true);
+      expect(store.currentIndex).toBe(0);
+    });
+
+    it('start() идемпотентен при уже активном туре', () => {
+      const store = useOnboardingStore();
+      store.start();
+      store.setIndex(2);
+      store.start();
+
+      expect(store.isActive).toBe(true);
+      expect(store.currentIndex).toBe(2);
+    });
+
+    it('start({ manual: true }) выставляет isManual', () => {
+      const store = useOnboardingStore();
+      store.start({ manual: true });
+      expect(store.isManual).toBe(true);
+    });
+
+    it('start() без аргумента оставляет isManual false', () => {
+      const store = useOnboardingStore();
+      store.start();
+      expect(store.isManual).toBe(false);
+    });
+
+    it('stop() деактивирует тур', () => {
+      const store = useOnboardingStore();
+      store.start();
+      store.stop();
+      expect(store.isActive).toBe(false);
+    });
+  });
+
+  describe('setIndex / reset', () => {
+    it('setIndex меняет currentIndex', () => {
+      const store = useOnboardingStore();
+      store.setIndex(2);
+      expect(store.currentIndex).toBe(2);
+      expect(store.currentStep).toBe(onboardingSteps[2]);
+    });
+
+    it('reset сбрасывает активность и индекс', () => {
+      const store = useOnboardingStore();
+      store.start();
+      store.setIndex(2);
+      store.reset();
+
+      expect(store.isActive).toBe(false);
+      expect(store.currentIndex).toBe(0);
+    });
+  });
+
+  describe('totalSteps', () => {
+    it('равен длине onboardingSteps', () => {
+      const store = useOnboardingStore();
+      expect(store.totalSteps).toBe(onboardingSteps.length);
+    });
+  });
+
+  describe('markCompleted / hasCompleted', () => {
+    it('markCompleted пишет корректный JSON-флаг в localStorage', () => {
+      const store = useOnboardingStore();
+      store.markCompleted();
+
+      const raw = localStorage.getItem(STORAGE_KEY);
+      expect(JSON.parse(raw)).toEqual({ completed: true, version: ONBOARDING_VERSION });
+    });
+
+    it('hasCompleted true после markCompleted', () => {
+      const store = useOnboardingStore();
+      store.markCompleted();
+      expect(store.hasCompleted()).toBe(true);
+    });
+
+    it('hasCompleted false когда флага нет', () => {
+      const store = useOnboardingStore();
+      expect(store.hasCompleted()).toBe(false);
+    });
+
+    it('hasCompleted false при чужой версии флага', () => {
+      const store = useOnboardingStore();
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ completed: true, version: 0 }));
+      expect(store.hasCompleted()).toBe(false);
+    });
+
+    it('hasCompleted false при битом JSON', () => {
+      const store = useOnboardingStore();
+      localStorage.setItem(STORAGE_KEY, 'not-json');
+      expect(store.hasCompleted()).toBe(false);
+    });
+
+    it('markCompleted не падает когда localStorage.setItem кидает', () => {
+      const store = useOnboardingStore();
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('storage disabled');
+      });
+
+      expect(() => store.markCompleted()).not.toThrow();
+    });
+  });
+
+  describe('canShowTour', () => {
+    it('false когда юзер не аутентифицирован', () => {
+      const store = useOnboardingStore();
+      expect(store.canShowTour).toBe(false);
+    });
+
+    it('true когда auth.isAuthenticated и зеркалит его значение', () => {
+      const auth = useAuthStore();
+      auth.setTokens(createMockJWT({ username: 'admin' }, 3600));
+
+      const store = useOnboardingStore();
+      expect(store.canShowTour).toBe(auth.isAuthenticated);
+      expect(store.canShowTour).toBe(true);
+    });
+
+    it('false при истёкшем токене', () => {
+      const auth = useAuthStore();
+      auth.setTokens(createMockJWT({ username: 'admin' }, -100));
+
+      const store = useOnboardingStore();
+      expect(store.canShowTour).toBe(false);
+    });
+  });
+});

--- a/frontend/src/stores/onboarding.js
+++ b/frontend/src/stores/onboarding.js
@@ -1,0 +1,99 @@
+import { defineStore } from 'pinia';
+import { ref, computed } from 'vue';
+import { useAuthStore } from '@/stores/auth';
+import { onboardingSteps, ONBOARDING_VERSION } from '@/components/onboarding/onboardingSteps';
+
+const STORAGE_KEY = 'onboarding-tour';
+
+/**
+ * Стор онбординг-тура. Держит ГЛОБАЛЬНЫЙ индекс активного шага по всему
+ * массиву onboardingSteps; хост-компонент режет массив на сегменты по route
+ * и водит driver.js внутри текущего сегмента.
+ */
+export const useOnboardingStore = defineStore('onboarding', () => {
+  const isActive = ref(false);
+  const currentIndex = ref(0);
+  // Авто-запуск (срез 6) ставит флаг завершения даже при пропуске, ручной — нет.
+  const isManual = ref(false);
+
+  const steps = computed(() => onboardingSteps);
+  const totalSteps = computed(() => steps.value.length);
+  const currentStep = computed(() => steps.value[currentIndex.value] || null);
+
+  const canShowTour = computed(() => {
+    const auth = useAuthStore();
+    return auth.isAuthenticated;
+  });
+
+  /**
+   * Тур пройден только если сохранённый флаг помечен completed И его версия
+   * совпадает с текущей. Чтение в try/catch: приватный режим / отключённый
+   * storage кидают при доступе.
+   *
+   * @returns {boolean}
+   */
+  function hasCompleted() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return false;
+      const parsed = JSON.parse(raw);
+      return parsed.completed === true && parsed.version === ONBOARDING_VERSION;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Запустить тур с первого шага. Идемпотентно: повторный вызов при активном
+   * туре ничего не делает.
+   *
+   * @param {{ manual?: boolean }} [options]
+   */
+  function start({ manual = false } = {}) {
+    if (isActive.value) return;
+    isManual.value = manual;
+    currentIndex.value = 0;
+    isActive.value = true;
+  }
+
+  function stop() {
+    isActive.value = false;
+  }
+
+  function setIndex(i) {
+    currentIndex.value = i;
+  }
+
+  function markCompleted() {
+    try {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ completed: true, version: ONBOARDING_VERSION }),
+      );
+    } catch {
+      // storage недоступен (приватный режим / квота) - тур всё равно отработал,
+      // просто переиграется при следующем авто-запуске. Не критично.
+    }
+  }
+
+  function reset() {
+    isActive.value = false;
+    currentIndex.value = 0;
+  }
+
+  return {
+    isActive,
+    currentIndex,
+    steps,
+    totalSteps,
+    currentStep,
+    canShowTour,
+    isManual,
+    hasCompleted,
+    start,
+    stop,
+    setIndex,
+    markCompleted,
+    reset,
+  };
+});

--- a/frontend/src/views/NewsAndReview.vue
+++ b/frontend/src/views/NewsAndReview.vue
@@ -3,12 +3,16 @@
     <div class="content-wrapper">
       <!-- Левая колонка - Новости -->
       <div class="left-column">
-        <div class="news-container">
+        <div
+          class="news-container"
+          data-testid="ob-news"
+        >
           <div class="news-header">
             <h2 class="news-title">
               Последние новости
             </h2>
             <div class="header-actions">
+              <OnboardingButton />
               <button
                 class="manage-btn"
                 @click="openManageModal"
@@ -70,6 +74,7 @@
       <div class="right-column">
         <div
           class="guide-card"
+          data-testid="ob-guide"
           :style="{ animationDelay: '0.2s' }"
           @click="openGuide"
         >
@@ -572,6 +577,7 @@ import { ADMIN_GUIDE_SECTIONS } from '../components/news/adminGuideSections.js'
 import { useAuthStore } from '@/stores/auth'
 import { sanitizeHtml } from '@/utils/sanitize.js'
 import DocumentsBlock from '../components/news/DocumentsBlock.vue'
+import OnboardingButton from '../components/onboarding/OnboardingButton.vue'
 
 export default {
   name: 'LatestNews',
@@ -582,6 +588,7 @@ export default {
     UserGuideModal,
     TextConstructor,
     DocumentsBlock,
+    OnboardingButton,
   },
   data() {
     return {


### PR DESCRIPTION
## Срез 1/6 эпика онбординг-тура (issue #657, п.5 ТЗ 46-edits)

Закладывает расширяемую FE-only инфраструктуру интерактивного тура на движке **driver.js**. Доступен любому авторизованному пользователю (гейта по роли нет).

### Что добавлено
- `driver.js@^1` в зависимости.
- `stores/onboarding.js` — Pinia setup-store: глобальный индекс шага, сквозной прогресс, версионированный localStorage-флаг (try/catch), `canShowTour = isAuthenticated`.
- `composables/useOnboarding.js` — обёртка driver.js: `createDriver`, `waitForElement` (с AbortSignal), `buildPopoverHtml` (через sanitizeHtml), `prefersReducedMotion`.
- `components/onboarding/OnboardingTour.vue` — невизуальный хост в App.vue (segment по route, деградация в центр-модал при отсутствии цели, чистый teardown).
- `components/onboarding/OnboardingButton.vue` — кнопка «Обучение» на странице новостей.
- `onboardingSteps.js` — декларативные шаги + чистая `collectSegment`; сегмент `news` (старт/новости/руководство/документы).
- `assets/onboarding.css` — брендинг поповера на токенах, анимации только transform/opacity.
- data-testid: `ob-news`, `ob-guide`, `ob-documents`, `ob-start-button`.

### Проверки
- ESLint изменённых файлов: 0 ошибок.
- Vitest: 31 passed (стор/шаги/collectSegment/кнопка).
- Playwright по live-стеку (vite -> backend): логин -> кнопка -> 4 шага с корректными заголовками, прогрессом «Шаг X из N», суффиксом «Далее», спотлайтом на правильных элементах; Готово закрывает, кнопка перезапускает, Esc выходит.

Следующие срезы: шапка+навбар, cross-page переходы, скриншоты фейк-данных, автозапуск, финал.