### PR TITLE
feat(onboarding): шаги шапки и навигации в туре (#657)

### DIFF
--- a/frontend/src/components/NavMenu.vue
+++ b/frontend/src/components/NavMenu.vue
@@ -13,6 +13,7 @@
       class="nav-menu"
       role="navigation"
       aria-label="Основная навигация"
+      data-testid="ob-nav-rail"
       :class="{
         expanded: railExpanded,
         'nav-menu--pinned': uiStore.sidebarExpanded,
@@ -172,6 +173,7 @@
           <div
             v-show="sectionVisible.data"
             class="nav-section"
+            data-testid="ob-nav-group-data"
           >
             <div class="section-title">
               УПРАВЛЕНИЕ ДАННЫМИ
@@ -629,7 +631,9 @@ export default {
     railExpanded() {
       if (this.uiStore.sidebarHidden) return false;
       if (this.adminOpen) return false;
-      return this.uiStore.sidebarExpanded || this.isExpanded;
+      // tourForceExpand - оверлейный разворот для онбординг-тура: расширяет рельс
+      // как hover-превью, БЕЗ сдвига контента (--nav-ml зависит только от пина).
+      return this.uiStore.sidebarExpanded || this.isExpanded || this.uiStore.tourForceExpand;
     },
     // Множество путей Админки - по нему route-watcher решает, закрывать ли колонку
     // (переход на «РАБОТА»/кабинет закрывает, переключение между разделами - нет).

--- a/frontend/src/components/TheHeader/TheHeader.vue
+++ b/frontend/src/components/TheHeader/TheHeader.vue
@@ -48,16 +48,21 @@
         v-if="activeAnnouncement"
         class="broadcast"
         :class="{ 'broadcast--important': activeAnnouncement.is_important }"
+        data-testid="ob-header-broadcast"
         @click="showAnnouncement = true"
       >
         {{ activeAnnouncement.is_important ? 'Важное объявление' : 'Объявление' }}
       </button>
-      <p class="time">
+      <p
+        class="time"
+        data-testid="ob-header-time"
+      >
         {{ currentDateTime }}
       </p>
       <div
         class="user__notifications"
         :class="{ 'user__notifications--active': showNotifications }"
+        data-testid="ob-header-notifications"
         @click.stop="showNotifications = !showNotifications"
       >
         <img

--- a/frontend/src/components/onboarding/OnboardingTour.vue
+++ b/frontend/src/components/onboarding/OnboardingTour.vue
@@ -2,15 +2,55 @@
 import { watch, onBeforeUnmount } from 'vue';
 import { useRoute } from 'vue-router';
 import { useOnboardingStore } from '@/stores/onboarding';
+import { useUiStore } from '@/stores/ui';
 import { useOnboarding } from '@/composables/useOnboarding';
 import { collectSegment } from '@/components/onboarding/onboardingSteps';
 
 const store = useOnboardingStore();
+const ui = useUiStore();
 const route = useRoute();
 const { waitForElement, createDriver } = useOnboarding();
 
 let driverObj = null;
 let waitController = null;
+// Прежнее состояние рельса до того как тур его развернул - чтобы вернуть как было.
+let railSaved = null;
+
+/**
+ * Рельс нужен развёрнутым на nav-шаге И на шаге прямо перед ним: разворачиваем
+ * заранее, чтобы к моменту подсветки рельс уже доехал до полной ширины и driver
+ * померил рамку спотлайта корректно (иначе ловим элемент в середине анимации).
+ */
+function railNeeded(globalIndex) {
+  const cur = store.steps[globalIndex];
+  const next = store.steps[globalIndex + 1];
+  return Boolean(cur?.expandRail || next?.expandRail);
+}
+
+/**
+ * Развернуть/вернуть рельс под текущую позицию. Разворот - ОВЕРЛЕЙНЫЙ
+ * (tourForceExpand), без сдвига контента: reflow от пина дёргал бы спотлайт
+ * соседних шагов. sidebarHidden снимаем, иначе скрытый рельс не покажется.
+ */
+function applyRail(globalIndex) {
+  if (railNeeded(globalIndex)) {
+    if (!railSaved) {
+      railSaved = { force: ui.tourForceExpand, hidden: ui.sidebarHidden };
+    }
+    ui.tourForceExpand = true;
+    ui.sidebarHidden = false;
+  } else {
+    restoreRail();
+  }
+}
+
+function restoreRail() {
+  if (railSaved) {
+    ui.tourForceExpand = railSaved.force;
+    ui.sidebarHidden = railSaved.hidden;
+    railSaved = null;
+  }
+}
 
 async function startSegment() {
   const segmentSteps = collectSegment(store.steps, store.currentIndex, route.path);
@@ -35,7 +75,10 @@ async function startSegment() {
 
   driverObj = createDriver(segmentSteps, {
     startIndex: segmentStartIndex,
-    onIndexChange: (globalIndex) => store.setIndex(globalIndex),
+    onIndexChange: (globalIndex) => {
+      store.setIndex(globalIndex);
+      applyRail(globalIndex);
+    },
     onDestroyed: handleDestroyed,
   });
   driverObj.drive(0);
@@ -57,6 +100,7 @@ function teardown() {
     driverObj.destroy();
     driverObj = null;
   }
+  restoreRail();
 }
 
 watch(

--- a/frontend/src/components/onboarding/__tests__/onboardingSteps.spec.js
+++ b/frontend/src/components/onboarding/__tests__/onboardingSteps.spec.js
@@ -41,6 +41,26 @@ describe('onboardingSteps', () => {
     const hasCenterModal = onboardingSteps.some((s) => s.element === null);
     expect(hasCenterModal).toBe(true);
   });
+
+  it('expandRail только у nav-шагов и только true', () => {
+    const railSteps = onboardingSteps.filter((s) => s.expandRail);
+    expect(railSteps.length).toBeGreaterThan(0);
+    for (const s of railSteps) {
+      expect(s.expandRail).toBe(true);
+      expect(s.id.startsWith('nav-')).toBe(true);
+    }
+  });
+
+  it('есть шаги шапки и навигации с целевыми селекторами', () => {
+    const ids = onboardingSteps.map((s) => s.id);
+    for (const id of ['header-broadcast', 'header-time', 'header-notifications', 'header-feedback', 'header-submit', 'nav-rail', 'nav-group-data']) {
+      expect(ids).toContain(id);
+    }
+    // у каждого шага шапки/навигации - строковый селектор цели (не центр-модал)
+    for (const s of onboardingSteps.filter((x) => x.id.startsWith('header-') || x.id.startsWith('nav-'))) {
+      expect(typeof s.element).toBe('string');
+    }
+  });
 });
 
 describe('collectSegment', () => {

--- a/frontend/src/components/onboarding/onboardingSteps.js
+++ b/frontend/src/components/onboarding/onboardingSteps.js
@@ -16,9 +16,11 @@ export const ONBOARDING_VERSION = 1;
  * - `element`    CSS-селектор цели или `null` (центр-модал без подсветки);
  * - `title`      заголовок поповера;
  * - `description` HTML-тело поповера (прогоняется через sanitizeHtml);
- * - `demo`       необязательный ключ скриншота (используется будущими срезами).
+ * - `demo`       необязательный ключ скриншота (используется будущими срезами);
+ * - `expandRail` если true - хост разворачивает свёрнутый рельс навигации на
+ *                время шага и возвращает прежнее состояние при выходе.
  *
- * @type {Array<{ id: string, route: string, element: string|null, title: string, description: string, demo?: string }>}
+ * @type {Array<{ id: string, route: string, element: string|null, title: string, description: string, demo?: string, expandRail?: boolean }>}
  */
 export const onboardingSteps = [
   {
@@ -51,6 +53,57 @@ export const onboardingSteps = [
     element: '[data-testid="ob-documents"]',
     title: 'Документы',
     description: 'Полезные документы и шаблоны, доступные для скачивания.',
+  },
+  {
+    id: 'header-broadcast',
+    route: '/news',
+    element: '[data-testid="ob-header-broadcast"]',
+    title: 'Объявления',
+    description: 'Здесь появляется кнопка важного объявления, когда администрация публикует что-то срочное. Нажмите, чтобы прочитать.',
+  },
+  {
+    id: 'header-time',
+    route: '/news',
+    element: '[data-testid="ob-header-time"]',
+    title: 'Дата и время',
+    description: 'Текущие дата и время системы - удобно сверяться при оформлении заявок.',
+  },
+  {
+    id: 'header-notifications',
+    route: '/news',
+    element: '[data-testid="ob-header-notifications"]',
+    title: 'Уведомления',
+    description: 'Колокольчик показывает количество непрочитанных уведомлений: смена статуса заявки, ответы согласующих и другие события. Нажмите, чтобы открыть список.',
+  },
+  {
+    id: 'header-feedback',
+    route: '/news',
+    element: '[data-testid="header-button-feedback"]',
+    title: 'Сообщить о проблеме',
+    description: 'Заметили ошибку или есть предложение - напишите нам прямо отсюда, не покидая систему.',
+  },
+  {
+    id: 'header-submit',
+    route: '/news',
+    element: '[data-testid="header-button-submit-app"]',
+    title: 'Подать заявку',
+    description: 'Быстрый переход к оформлению новой заявки на пропуск - кнопка доступна из любого раздела.',
+  },
+  {
+    id: 'nav-rail',
+    route: '/news',
+    element: '[data-testid="ob-nav-rail"]',
+    title: 'Навигация',
+    description: 'Боковое меню - главный способ перемещаться по системе. Наведите курсор, чтобы развернуть его с подписями разделов.',
+    expandRail: true,
+  },
+  {
+    id: 'nav-group-data',
+    route: '/news',
+    element: '[data-testid="ob-nav-group-data"]',
+    title: 'Управление данными',
+    description: 'Раздел «Управление данными»: таблицы системы, ваши сотрудники и автомобили. Отсюда вы ведёте справочники, по которым оформляются пропуска.',
+    expandRail: true,
   },
 ];
 

--- a/frontend/src/stores/ui.js
+++ b/frontend/src/stores/ui.js
@@ -19,6 +19,9 @@ export const useUiStore = defineStore('ui', () => {
   const navPrefs = loadNavPrefs()
   const sidebarExpanded = ref(navPrefs.pinned ?? false)
   const sidebarHidden = ref(navPrefs.hidden ?? false)
+  // Временный оверлейный разворот рельса (онбординг-тур). Не персистится и не
+  // влияет на --nav-ml: рельс расширяется поверх контента, без reflow.
+  const tourForceExpand = ref(false)
 
   watch([sidebarExpanded, sidebarHidden], ([pinned, hidden]) => {
     try {
@@ -87,6 +90,7 @@ export const useUiStore = defineStore('ui', () => {
     toasts,
     sidebarExpanded,
     sidebarHidden,
+    tourForceExpand,
     toggleSidebarPinned,
     hideSidebar,
     showSidebar,


### PR DESCRIPTION
## Срез 2/6 эпика онбординг-тура (issue #657)

Расширяет тур шагами по шапке и боковому меню. Сегмент news теперь 11 шагов (4 + 7 новых), всё на /news (chrome присутствует), cross-page - в срезе 3.

### Новые шаги
- Шапка: объявление, дата/время, уведомления, «Сообщить о проблеме», «Подать заявку».
- Навигация: рельс целиком + группа «Управление данными» (Таблицы/Сотрудники/Авто).

### Поведение
- На nav-шагах рельс разворачивается **оверлеем** (новый флаг `ui.tourForceExpand`), БЕЗ сдвига контента (`--nav-ml` зависит только от пина) - убирает reflow и дёрганье спотлайта.
- Разворот включается на шаг раньше (на «Подать заявку»), чтобы к nav-шагу рельс уже доехал до полной ширины и driver померил рамку корректно - без re-measure хаков.
- Прежнее состояние рельса (force/hidden) сохраняется и восстанавливается при ЛЮБОМ выходе (Готово/Esc/logout/unmount).

### data-testid
- TheHeader: `ob-header-broadcast` (под v-if объявления - деградирует в центр при отсутствии), `ob-header-time`, `ob-header-notifications`. Reuse: `header-button-feedback`, `header-button-submit-app`.
- NavMenu: `ob-nav-rail` (.nav-menu), `ob-nav-group-data` (секция «Управление данными»).

### Проверки
- ESLint изменённых: 0 ошибок. Vitest: 33 passed (+ инвариант expandRail только у nav-шагов).
- Playwright по live-стеку: **40/40** - все 11 шагов (заголовок/прогресс/спотлайт same-node), рельс разворачивается оверлеем (expanded) на nav-шагах и ВОЗВРАЩАЕТСЯ после Готово И после Esc посреди nav-шага; консоль чистая (кроме известных 401/refresh-token, 404/public-documents).

Ревью-агент пометил must-fix про `.value` на Pinia-ref - опровергнуто эмпирически: setup-стор разворачивает refs на инстансе, `ui.tourForceExpand = bool` реактивно (класс `expanded` корректно появляется/уходит), `.value` здесь сломал бы.