### PR TITLE
feat(analytics): мастер отчётов с шагами и сайдбаром наборов (#632)

### DIFF
--- a/frontend/src/components/statistics/ReportBuilder.vue
+++ b/frontend/src/components/statistics/ReportBuilder.vue
@@ -144,7 +144,7 @@ const props = defineProps({
   preset: { type: Object, default: null },
 });
 
-const emit = defineEmits(['run']);
+const emit = defineEmits(['run', 'change']);
 
 const modeTabs = [
   { key: 'aggregate', label: 'Сводка по разрезу' },
@@ -276,6 +276,23 @@ function toggleFilter(key, value) {
   else current.push(value);
   form.filters = { ...form.filters, [key]: current };
 }
+
+// Снимок состояния формы для индикатора шагов мастера (родитель считает по нему
+// прогресс). immediate — чтобы степпер был корректен сразу после монтирования.
+const filterCount = computed(
+  () => Object.values(form.filters).reduce((n, vals) => n + (vals?.length || 0), 0),
+);
+watch(
+  () => ({
+    mode: form.mode,
+    metric: form.metric,
+    dimension: form.dimension,
+    entity: form.entity,
+    filterCount: filterCount.value,
+  }),
+  (snapshot) => emit('change', snapshot),
+  { immediate: true, deep: true },
+);
 
 function run() {
   emit('run', buildReportRequest(form, props.period, applicableFilters.value));

--- a/frontend/src/components/statistics/ReportGallery.vue
+++ b/frontend/src/components/statistics/ReportGallery.vue
@@ -1,6 +1,12 @@
 <template>
-  <div class="gallery">
-    <p class="gallery__lead">
+  <div
+    class="gallery"
+    :class="{ 'gallery--compact': compact }"
+  >
+    <p
+      v-if="!compact"
+      class="gallery__lead"
+    >
       Готовые отчёты — нажмите карточку, чтобы заполнить конструктор и сразу увидеть результат.
       Период берётся из фильтра вверху, а любой отчёт можно доработать в конструкторе ниже.
     </p>
@@ -28,6 +34,9 @@ import { REPORT_PRESETS, presetAvailable } from './reportPresets';
 const props = defineProps({
   catalog: { type: Object, default: null },
   activeId: { type: String, default: '' },
+  // compact — вариант для сайдбара мастера: без вводного текста, карточки в один
+  // столбец и плотнее (resultHint скрыт, чтобы влезть в узкую колонку).
+  compact: { type: Boolean, default: false },
 });
 
 defineEmits(['apply']);
@@ -99,5 +108,32 @@ const availablePresets = computed(() =>
   font-size: 12px;
   font-weight: 600;
   color: var(--color-primary);
+}
+
+/* Компактный сайдбар-вариант: один столбец, плотные карточки, без resultHint. */
+.gallery--compact {
+  gap: 8px;
+}
+
+.gallery--compact .gallery__grid {
+  grid-template-columns: 1fr;
+  gap: 8px;
+}
+
+.gallery--compact .gallery__card {
+  gap: 4px;
+  padding: 13px 14px;
+}
+
+.gallery--compact .gallery__card-title {
+  font-size: 13px;
+}
+
+.gallery--compact .gallery__card-desc {
+  font-size: 11px;
+}
+
+.gallery--compact .gallery__card-result {
+  display: none;
 }
 </style>

--- a/frontend/src/components/statistics/ReportStepper.vue
+++ b/frontend/src/components/statistics/ReportStepper.vue
@@ -1,0 +1,119 @@
+<template>
+  <div class="stepper">
+    <template
+      v-for="(step, i) in steps"
+      :key="step.label"
+    >
+      <div
+        v-if="i > 0"
+        class="step-line"
+        :class="{ 'step-line--filled': steps[i - 1].state === 'done' }"
+      />
+      <div
+        class="step"
+        :class="`step--${step.state}`"
+      >
+        <span class="step-dot">
+          <svg
+            v-if="step.state === 'done'"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="3"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          ><path d="M20 6 9 17l-5-5" /></svg>
+          <template v-else>{{ i + 1 }}</template>
+        </span>
+        <span class="step-label">{{ step.label }}</span>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+/**
+ * Шаги мастера отчётов: визуальный индикатор прогресса. Состояние шага считает
+ * родитель (ReportsTab) по заполненности формы — компонент только рисует.
+ * @typedef {{ label: string, state: 'done' | 'current' | 'upcoming' }} Step
+ */
+defineProps({
+  steps: { type: Array, required: true },
+});
+</script>
+
+<style scoped>
+.stepper {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 18px 24px;
+  background: #fbfbfe;
+  border-bottom: 1px solid var(--color-border);
+  overflow-x: auto;
+}
+
+.step {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.step-dot {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: #fff;
+  border: 2px solid var(--color-border);
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 13px;
+  color: var(--color-text-muted);
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.step-dot svg {
+  width: 14px;
+  height: 14px;
+}
+
+.step--done .step-dot {
+  background: var(--color-success);
+  border-color: var(--color-success);
+  color: #fff;
+}
+
+.step--current .step-dot {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: #fff;
+  box-shadow: 0 0 0 4px rgba(79, 91, 223, 0.15);
+}
+
+.step-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+
+.step--current .step-label,
+.step--done .step-label {
+  color: var(--color-text);
+}
+
+.step-line {
+  flex: 1;
+  height: 2px;
+  background: var(--color-border);
+  min-width: 18px;
+  border-radius: 2px;
+  transition: background 0.2s ease;
+}
+
+.step-line--filled {
+  background: var(--color-success);
+}
+</style>

--- a/frontend/src/components/statistics/ReportsTab.vue
+++ b/frontend/src/components/statistics/ReportsTab.vue
@@ -17,43 +17,49 @@
     </div>
 
     <template v-else-if="catalog">
-      <section class="reports__block">
-        <h2 class="reports__heading">
-          Готовые отчёты
-        </h2>
-        <ReportGallery
-          :catalog="catalog"
-          :active-id="activePresetId"
-          @apply="onApplyPreset"
-        />
-      </section>
+      <div class="reports-layout">
+        <!-- Сайдбар: готовые наборы + мои шаблоны -->
+        <aside class="presets-col">
+          <h3 class="col-heading">
+            Готовые наборы
+          </h3>
+          <ReportGallery
+            :catalog="catalog"
+            :active-id="activePresetId"
+            compact
+            @apply="onApplyPreset"
+          />
 
-      <section class="reports__block">
-        <h2 class="reports__heading">
-          Сформировать отчёт
-        </h2>
-        <p class="reports__lead">
-          Выберите показатель и разрез или выгрузку строк — результат появится ниже. Период берётся из фильтра вверху.
-        </p>
-        <ReportBuilder
-          :catalog="catalog"
-          :period="period"
-          :loading="running"
-          :preset="presetPayload"
-          @run="onRun"
-        />
-      </section>
+          <h3 class="col-heading col-heading--mt">
+            Мои шаблоны
+          </h3>
+          <div class="template-placeholder">
+            Сохранённые наборы появятся здесь. Соберите отчёт в мастере и сохраните его как шаблон.
+          </div>
+        </aside>
 
-      <section class="reports__block reports__block--result">
-        <h2 class="reports__heading">
-          Результат
-        </h2>
-        <ReportResult
-          :result="result"
-          :loading="running"
-          :error="runError"
-        />
-      </section>
+        <!-- Мастер -->
+        <section class="wizard">
+          <ReportStepper :steps="steps" />
+          <div class="wizard-body">
+            <ReportBuilder
+              :catalog="catalog"
+              :period="period"
+              :loading="running"
+              :preset="presetPayload"
+              @run="onRun"
+              @change="onBuilderChange"
+            />
+          </div>
+        </section>
+      </div>
+
+      <!-- Результат (полная ширина под мастером) -->
+      <ReportResult
+        :result="result"
+        :loading="running"
+        :error="runError"
+      />
     </template>
   </div>
 </template>
@@ -63,6 +69,7 @@ import { ref, computed, onMounted } from 'vue';
 import ReportBuilder from './ReportBuilder.vue';
 import ReportResult from './ReportResult.vue';
 import ReportGallery from './ReportGallery.vue';
+import ReportStepper from './ReportStepper.vue';
 import LoaderSpinner from '@/components/ui/LoaderSpinner.vue';
 import { getReportCatalog, runReport } from '@/api/statistics';
 
@@ -85,6 +92,34 @@ const runError = ref('');
 // чтобы watch в ReportBuilder сработал повторно и перезаполнил конструктор.
 const presetPayload = ref(null);
 const activePresetId = ref('');
+
+// Снимок состояния мастера для индикатора шагов.
+const builderState = ref({ mode: 'aggregate', metric: '', dimension: '', entity: '', filterCount: 0 });
+
+const STEP_LABELS = ['1 · Что считаем', '2 · По чему разбиваем', '3 · Фильтры', '4 · Период'];
+
+// Состояние шагов по заполненности формы: done — данные есть, current — первый
+// незаполненный, upcoming — дальше. В list-режиме разрез не применим -> шаг 2
+// считается выполненным по выбранной сущности.
+const steps = computed(() => {
+  const s = builderState.value;
+  const isList = s.mode === 'list';
+  const done = [
+    isList ? Boolean(s.entity) : Boolean(s.metric),
+    isList ? Boolean(s.entity) : Boolean(s.dimension),
+    s.filterCount > 0,
+    Boolean(period.value.from && period.value.to),
+  ];
+  const currentIdx = done.indexOf(false);
+  return STEP_LABELS.map((label, i) => ({
+    label,
+    state: done[i] ? 'done' : i === currentIdx ? 'current' : 'upcoming',
+  }));
+});
+
+function onBuilderChange(snapshot) {
+  builderState.value = snapshot;
+}
 
 function onApplyPreset(preset) {
   activePresetId.value = preset.id;
@@ -127,7 +162,7 @@ async function onRun(request) {
 .reports {
   display: flex;
   flex-direction: column;
-  gap: 28px;
+  gap: 20px;
 }
 
 .reports__state {
@@ -144,27 +179,64 @@ async function onRun(request) {
   color: #c0392b;
 }
 
-.reports__block {
+.reports-layout {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 20px;
+  align-items: start;
+}
+
+.presets-col {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
+  min-width: 0;
 }
 
-.reports__block--result {
-  border-top: 1px solid var(--color-border);
-  padding-top: 24px;
-}
-
-.reports__heading {
-  margin: 0;
-  font-size: 16px;
+.col-heading {
+  margin: 4px 2px 8px;
+  font-size: 12px;
   font-weight: 700;
-  color: var(--color-text);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted);
 }
 
-.reports__lead {
-  margin: 0 0 12px;
-  font-size: 13px;
+.col-heading--mt {
+  margin-top: 18px;
+}
+
+.template-placeholder {
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 14px;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.45;
   color: var(--color-text-muted);
+}
+
+.wizard {
+  min-width: 0;
+  background: #fff;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.wizard-body {
+  padding: 24px;
+}
+
+@media (max-width: 1180px) {
+  .reports-layout {
+    grid-template-columns: 240px 1fr;
+  }
+}
+
+@media (max-width: 880px) {
+  .reports-layout {
+    grid-template-columns: 1fr;
+  }
 }
 </style>

--- a/frontend/src/components/statistics/__tests__/ReportStepper.spec.js
+++ b/frontend/src/components/statistics/__tests__/ReportStepper.spec.js
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import ReportStepper from '../ReportStepper.vue';
+
+const STEPS = [
+  { label: '1 · Что считаем', state: 'done' },
+  { label: '2 · По чему разбиваем', state: 'current' },
+  { label: '3 · Фильтры', state: 'upcoming' },
+  { label: '4 · Период', state: 'upcoming' },
+];
+
+describe('ReportStepper', () => {
+  it('рисует точку, подпись и соединитель для каждого шага', () => {
+    const wrapper = mount(ReportStepper, { props: { steps: STEPS } });
+    expect(wrapper.findAll('.step')).toHaveLength(4);
+    // соединителей на один меньше, чем шагов.
+    expect(wrapper.findAll('.step-line')).toHaveLength(3);
+    expect(wrapper.text()).toContain('Что считаем');
+    expect(wrapper.text()).toContain('Период');
+  });
+
+  it('done-шаг показывает галочку, upcoming — номер; классы состояний навешаны', () => {
+    const wrapper = mount(ReportStepper, { props: { steps: STEPS } });
+    const steps = wrapper.findAll('.step');
+    expect(steps[0].classes()).toContain('step--done');
+    expect(steps[0].find('svg').exists()).toBe(true); // галочка
+    expect(steps[1].classes()).toContain('step--current');
+    expect(steps[2].find('svg').exists()).toBe(false); // номер, не галочка
+    expect(steps[3].find('.step-dot').text()).toBe('4');
+    // соединитель после done-шага залит.
+    expect(wrapper.findAll('.step-line')[0].classes()).toContain('step-line--filled');
+  });
+});


### PR DESCRIPTION
## Что

Перестроил вкладку «Отчёты» под мокап гида (срез GR1 эпика #632):

- Двухколоночная раскладка `reports-layout` (280px сайдбар + мастер). Слева «Готовые наборы» (галерея в компактном режиме) и плейсхолдер «Мои шаблоны». Справа карточка-мастер.
- Новый `ReportStepper.vue` — индикатор 4 шагов (что считаем → разрез → фильтры → период). Тупой компонент: рисует прогресс, состояние шагов считает родитель.
- `ReportsTab` отдаёт `steps` по снимку формы. `ReportBuilder` эмитит снимок через `change` (mode/metric/dimension/entity/filterCount). В list-режиме шаг «разрез» закрывается выбором сущности.
- `ReportGallery` получил `compact` для узкого сайдбара (один столбец, без вводного текста и resultHint).
- Результат вынесен на полную ширину под мастером. Адаптив: 240px на ≤1180px, одна колонка на ≤880px.

Внутренности мастера пока прежний `ReportBuilder` (дропдауны) — карточки метрик и радио-разрезы придут в GR2, фильтры-чипсы и период с футером в GR3.

## Проверка

- `vitest src/components/statistics/` — 8 файлов / 29 тестов зелёные (вкл. переписанный `ReportsTab.spec`).
- Новая спека `ReportStepper.spec` — рендер шагов, галочка у done / номер у upcoming, классы состояний, залитый соединитель.
- ESLint по диффу — 0 ошибок.