### PR TITLE
feat(analytics): шаги мастера - метрики карточками и разрез сеткой (#632)

### DIFF
--- a/frontend/src/assets/tokens.css
+++ b/frontend/src/assets/tokens.css
@@ -1,6 +1,7 @@
 :root {
   --color-primary: #4F5BDF;
   --color-primary-hover: #3d49c7;
+  --color-primary-tint: rgba(79, 91, 223, 0.08);
   --color-success: #28a745;
   --color-danger: #dc3545;
   --color-warning: #ffc107;

--- a/frontend/src/components/statistics/ReportBuilder.vue
+++ b/frontend/src/components/statistics/ReportBuilder.vue
@@ -8,49 +8,102 @@
         :tabs="modeTabs"
       />
       <span class="rb__hint">{{ form.mode === 'aggregate'
-        ? 'Посчитать показатель в выбранном разрезе.'
+        ? 'Посчитать один или несколько показателей в выбранном разрезе.'
         : 'Выгрузить строки сущности столбцами.' }}</span>
     </div>
 
-    <!-- Параметры -->
-    <div class="rb__grid">
-      <template v-if="form.mode === 'aggregate'">
-        <label class="rb__field">
-          <span class="rb__field-label">Что считаем</span>
-          <BaseDropdown
-            v-model="form.metric"
-            :options="catalog.metrics"
-            label-key="label"
-            value-key="key"
-          />
-        </label>
-        <label class="rb__field">
-          <span class="rb__field-label">Разрез</span>
-          <BaseDropdown
-            v-model="form.dimension"
-            :options="dimensionOptions"
-            label-key="label"
-            value-key="key"
-          />
-        </label>
-        <label
-          v-if="form.dimension === 'period'"
-          class="rb__field"
+    <template v-if="form.mode === 'aggregate'">
+      <!-- Шаг 1: что считаем (мультивыбор метрик карточками, сгруппированы) -->
+      <div class="rb__step">
+        <div class="rb__step-head">
+          <span class="rb__step-num">1</span>
+          <span class="rb__step-name">Что считаем</span>
+        </div>
+        <template
+          v-for="grp in metricGroups"
+          :key="grp.group"
         >
-          <span class="rb__field-label">Шаг</span>
-          <BaseDropdown
-            v-model="form.granularity"
-            :options="catalog.granularities"
-            label-key="label"
-            value-key="value"
-          />
-        </label>
-      </template>
+          <div class="rb__group-title">
+            {{ grp.group }}
+          </div>
+          <div class="rb__metrics">
+            <label
+              v-for="m in grp.metrics"
+              :key="m.key"
+              class="rb__metric"
+              :class="{ 'rb__metric--on': isMetricOn(m.key) }"
+            >
+              <input
+                type="checkbox"
+                class="rb__metric-input"
+                :checked="isMetricOn(m.key)"
+                @change="toggleMetric(m.key)"
+              >
+              <span class="rb__metric-box">
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="3"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                ><path d="M20 6 9 17l-5-5" /></svg>
+              </span>
+              <span class="rb__metric-text">
+                <span class="rb__metric-name">{{ m.label }}</span>
+                <span
+                  v-if="m.unit"
+                  class="rb__metric-unit"
+                >{{ m.unit }}</span>
+              </span>
+            </label>
+          </div>
+        </template>
+      </div>
 
-      <label
-        v-else
-        class="rb__field"
-      >
+      <!-- Шаг 2: по чему разбиваем (радио-сетка, «без разреза» всегда доступен) -->
+      <div class="rb__step">
+        <div class="rb__step-head">
+          <span class="rb__step-num">2</span>
+          <span class="rb__step-name">По чему разбиваем</span>
+        </div>
+        <div class="rb__dims">
+          <label
+            v-for="d in availableDimensions"
+            :key="d.key"
+            class="rb__dim"
+            :class="{ 'rb__dim--on': form.dimension === d.key }"
+          >
+            <input
+              v-model="form.dimension"
+              type="radio"
+              name="rb-dimension"
+              class="rb__dim-input"
+              :value="d.key"
+            >
+            <span class="rb__dim-dot" />
+            {{ d.label }}
+          </label>
+        </div>
+        <div
+          v-if="form.dimension === 'period'"
+          class="rb__gran"
+        >
+          <span class="rb__field-label">Шаг по времени</span>
+          <FilterTabs
+            v-model="form.granularity"
+            :tabs="granularityTabs"
+          />
+        </div>
+      </div>
+    </template>
+
+    <!-- list-режим: что выгружаем -->
+    <div
+      v-else
+      class="rb__grid"
+    >
+      <label class="rb__field">
         <span class="rb__field-label">Что выгружаем</span>
         <BaseDropdown
           v-model="form.entity"
@@ -91,9 +144,7 @@
       </div>
     </div>
 
-    <!-- Превью «что построим»: держит дропдауны параметров отдельно от кнопки -
-         открытое меню метрики/разреза раскрывается над этой панелью, а не над
-         кнопкой, поэтому клик по «Построить» проходит с первого раза. -->
+    <!-- Превью «что построим» -->
     <div class="rb__preview">
       <span class="rb__preview-label">Что построим</span>
       <p class="rb__summary">
@@ -139,7 +190,7 @@ const props = defineProps({
   catalog: { type: Object, required: true },
   period: { type: Object, default: () => ({ from: '', to: '' }) },
   loading: { type: Boolean, default: false },
-  // Пресет из галереи: { mode, metric?, dimension?, granularity?, entity? }.
+  // Пресет из галереи: { mode, metric?/metrics?, dimension?, granularity?, entity? }.
   // Заполняет конструктор и сразу строит отчёт. null — пресет не выбран.
   preset: { type: Object, default: null },
 });
@@ -153,7 +204,7 @@ const modeTabs = [
 
 const form = reactive({
   mode: 'aggregate',
-  metric: props.catalog.metrics?.[0]?.key || '',
+  metrics: props.catalog.metrics?.[0]?.key ? [props.catalog.metrics[0].key] : [],
   dimension: '',
   granularity: 'day',
   entity: props.catalog.list_entities?.[0]?.key || '',
@@ -167,13 +218,46 @@ const filterByKey = computed(() => {
   return map;
 });
 
-const selectedMetric = computed(
-  () => (props.catalog.metrics || []).find((m) => m.key === form.metric) || null,
+// Метрики, разложенные по группам каталога (group), порядок групп — по первому
+// появлению. Карточки шага «Что считаем» строятся отсюда, не из мокапа.
+const metricGroups = computed(() => {
+  const order = [];
+  const byGroup = {};
+  for (const m of props.catalog.metrics || []) {
+    const g = m.group || 'Прочее';
+    if (!byGroup[g]) {
+      byGroup[g] = [];
+      order.push(g);
+    }
+    byGroup[g].push(m);
+  }
+  return order.map((g) => ({ group: g, metrics: byGroup[g] }));
+});
+
+const selectedMetrics = computed(
+  () => (props.catalog.metrics || []).filter((m) => form.metrics.includes(m.key)),
 );
 
-const dimensionOptions = computed(() => {
-  const dims = selectedMetric.value?.dimensions || [];
-  return (props.catalog.dimensions || []).filter((d) => dims.includes(d.key));
+// «Без разреза» применим к любой метрике (движок валидирует его отдельной веткой),
+// поэтому всегда доступен; берётся из каталога, с фолбэком на случай отсутствия.
+const dimNoneOption = computed(
+  () => (props.catalog.dimensions || []).find((d) => d.key === 'none') || { key: 'none', label: 'Без разреза' },
+);
+
+// Доступные разрезы: «без разреза» + пересечение dimensions всех выбранных метрик
+// (общий разрез корректен для каждой), в порядке каталога.
+const availableDimensions = computed(() => {
+  const sel = selectedMetrics.value;
+  if (!sel.length) return [dimNoneOption.value];
+  let common = null;
+  for (const m of sel) {
+    const set = new Set(m.dimensions || []);
+    common = common === null ? set : new Set([...common].filter((k) => set.has(k)));
+  }
+  const realDims = (props.catalog.dimensions || []).filter(
+    (d) => d.key !== 'none' && common.has(d.key),
+  );
+  return [dimNoneOption.value, ...realDims];
 });
 
 const selectedEntity = computed(
@@ -190,20 +274,21 @@ const listFilterFields = computed(() => {
     .map((f) => ({ ...f, options: f.options || [] }));
 });
 
-// Aggregate per-metric фильтры пока не в каталоге -> отдаём только период (срез B3d).
-const applicableFilters = computed(() =>
-  form.mode === 'list' ? selectedEntity.value?.filters || [] : ['date_range'],
+const granularityTabs = computed(
+  () => (props.catalog.granularities || []).map((g) => ({ key: g.value, label: g.label })),
 );
 
-// Разрез должен принадлежать выбранной метрике — иначе движок отклонит запрос.
-watch(selectedMetric, (m) => {
-  if (!m) {
-    form.dimension = '';
-    return;
-  }
-  if (!m.dimensions.includes(form.dimension)) {
-    form.dimension = m.dimensions[0] || '';
-  }
+// Aggregate per-metric фильтры пока не рендерятся в гиде (шаг GR3) -> отдаём только
+// период. list — применимые фильтры выбранной сущности.
+const applicableFilters = computed(() =>
+  form.mode === 'list' ? selectedEntity.value?.filters || [] : ['date_range']);
+
+// Разрез должен оставаться валидным для текущего набора метрик. При невалидном
+// дефолтим на первый реальный разрез (полезнее «без разреза»), иначе на none.
+watch(availableDimensions, (dims) => {
+  if (dims.some((d) => d.key === form.dimension)) return;
+  const firstReal = dims.find((d) => d.key !== 'none');
+  form.dimension = (firstReal || dims[0]).key;
 }, { immediate: true });
 
 // Смена выгружаемой сущности обнуляет выбранные фильтры — у разных сущностей
@@ -214,9 +299,8 @@ watch(() => form.entity, () => {
 
 const canRun = computed(() =>
   form.mode === 'aggregate'
-    ? Boolean(form.metric && form.dimension)
-    : Boolean(form.entity),
-);
+    ? form.metrics.length > 0 && Boolean(form.dimension)
+    : Boolean(form.entity));
 
 const periodLabel = computed(() => {
   const { from, to } = props.period || {};
@@ -228,9 +312,9 @@ const periodLabel = computed(() => {
 
 const summary = computed(() => {
   if (form.mode === 'aggregate') {
-    const metric = selectedMetric.value?.label || '—';
-    const dim = dimensionOptions.value.find((d) => d.key === form.dimension)?.label || '—';
-    return `Считаем «${metric}» в разрезе «${dim}», период: ${periodLabel.value}.`;
+    const names = selectedMetrics.value.map((m) => m.label).join(', ') || '—';
+    const dim = availableDimensions.value.find((d) => d.key === form.dimension)?.label || '—';
+    return `Считаем: ${names}; разрез «${dim}», период: ${periodLabel.value}.`;
   }
   // Период упоминаем только если сущность его поддерживает (машины/люди — нет).
   const supportsPeriod = (selectedEntity.value?.filters || []).includes('date_range');
@@ -240,7 +324,17 @@ const summary = computed(() => {
 
 const resultHint = computed(() => {
   if (form.mode === 'aggregate') {
-    return 'Результат: таблица «значение разреза + количество» с итоговой суммой.';
+    const n = selectedMetrics.value.length;
+    // «Без разреза» -> один итоговый ряд без столбца разреза, поэтому формулировка
+    // отличается от разбивки по реальному разрезу.
+    if (form.dimension === 'none') {
+      return n > 1
+        ? `Результат: итоговая строка с ${n} столбцами-метриками.`
+        : 'Результат: одно итоговое значение.';
+    }
+    return n > 1
+      ? `Результат: таблица «разрез + ${n} столбца-метрики» с итогами.`
+      : 'Результат: таблица «разрез + значение» с итогом.';
   }
   const cols = (selectedEntity.value?.columns || []).length;
   return cols
@@ -248,15 +342,15 @@ const resultHint = computed(() => {
     : 'Результат: таблица строк.';
 });
 
-// Применить пресет из галереи и сразу построить отчёт. Разрез/гранулярность
-// сверяются watch'ем selectedMetric (пресеты используют валидные ключи каталога).
+// Применить пресет из галереи и сразу построить отчёт. Разрез сверяется watch'ем
+// availableDimensions (пресеты используют валидные ключи каталога).
 watch(() => props.preset, (p) => {
   if (!p) return;
   form.mode = p.mode || 'aggregate';
   if (p.mode === 'list') {
     form.entity = p.entity || form.entity;
   } else {
-    form.metric = p.metric || form.metric;
+    form.metrics = p.metrics ? [...p.metrics] : (p.metric ? [p.metric] : []);
     form.dimension = p.dimension || '';
     form.granularity = p.granularity || 'day';
   }
@@ -264,6 +358,16 @@ watch(() => props.preset, (p) => {
   form.filters = {};
   nextTick(run);
 });
+
+function isMetricOn(key) {
+  return form.metrics.includes(key);
+}
+
+function toggleMetric(key) {
+  const idx = form.metrics.indexOf(key);
+  if (idx >= 0) form.metrics.splice(idx, 1);
+  else form.metrics.push(key);
+}
 
 function isSelected(key, value) {
   return (form.filters[key] || []).includes(value);
@@ -278,14 +382,15 @@ function toggleFilter(key, value) {
 }
 
 // Снимок состояния формы для индикатора шагов мастера (родитель считает по нему
-// прогресс). immediate — чтобы степпер был корректен сразу после монтирования.
+// прогресс). metric — ключ первой выбранной метрики: шаг «что считаем» закрыт,
+// когда выбрана хотя бы одна. immediate — чтобы степпер был корректен сразу.
 const filterCount = computed(
   () => Object.values(form.filters).reduce((n, vals) => n + (vals?.length || 0), 0),
 );
 watch(
   () => ({
     mode: form.mode,
-    metric: form.metric,
+    metric: form.metrics[0] || '',
     dimension: form.dimension,
     entity: form.entity,
     filterCount: filterCount.value,
@@ -295,6 +400,9 @@ watch(
 );
 
 function run() {
+  // Защита инварианта: run() зовётся не только кнопкой (ещё из watch пресета),
+  // поэтому проверяем canRun здесь, а не полагаемся на :disabled кнопки.
+  if (!canRun.value) return;
   emit('run', buildReportRequest(form, props.period, applicableFilters.value));
 }
 </script>
@@ -303,7 +411,7 @@ function run() {
 .rb {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 22px;
 }
 
 .rb__section-label,
@@ -324,6 +432,200 @@ function run() {
 .rb__hint {
   font-size: 13px;
   color: var(--color-text-muted);
+}
+
+/* Шаги мастера */
+.rb__step {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.rb__step-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 6px;
+}
+
+.rb__step-num {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  color: #fff;
+  font-size: 13px;
+  font-weight: 700;
+  display: grid;
+  place-items: center;
+}
+
+.rb__step-name {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.rb__group-title {
+  margin: 14px 0 9px 36px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted);
+}
+
+.rb__group-title:first-of-type {
+  margin-top: 2px;
+}
+
+.rb__metrics {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+  margin-left: 36px;
+}
+
+.rb__metric {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px 14px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: #fff;
+  cursor: pointer;
+  transition: border-color 0.18s ease, background 0.18s ease;
+}
+
+.rb__metric:hover {
+  border-color: #c9cdf0;
+  background: #fcfcff;
+}
+
+.rb__metric--on {
+  border-color: var(--color-primary);
+  background: var(--color-primary-tint);
+}
+
+.rb__metric-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.rb__metric-box {
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  margin-top: 1px;
+  border: 2px solid var(--color-border);
+  border-radius: 6px;
+  background: #fff;
+  display: grid;
+  place-items: center;
+  color: #fff;
+  transition: background 0.18s ease, border-color 0.18s ease;
+}
+
+.rb__metric-box svg {
+  width: 13px;
+  height: 13px;
+  opacity: 0;
+  transition: opacity 0.18s ease;
+}
+
+.rb__metric--on .rb__metric-box {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+}
+
+.rb__metric--on .rb__metric-box svg {
+  opacity: 1;
+}
+
+.rb__metric-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.rb__metric-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.rb__metric-unit {
+  font-size: 11px;
+  color: var(--color-text-muted);
+}
+
+/* Разрезы */
+.rb__dims {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 9px;
+  margin-left: 36px;
+}
+
+.rb__dim {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 10px 12px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: #fff;
+  font-size: 13px;
+  color: var(--color-text);
+  cursor: pointer;
+  transition: border-color 0.18s ease, background 0.18s ease, color 0.18s ease;
+}
+
+.rb__dim:hover {
+  border-color: #c9cdf0;
+}
+
+.rb__dim--on {
+  border-color: var(--color-primary);
+  background: var(--color-primary-tint);
+  color: var(--color-primary);
+}
+
+.rb__dim-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.rb__dim-dot {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--color-border);
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+}
+
+.rb__dim--on .rb__dim-dot {
+  border-color: var(--color-primary);
+}
+
+.rb__dim--on .rb__dim-dot::after {
+  content: '';
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-primary);
+}
+
+.rb__gran {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 14px 0 0 36px;
 }
 
 .rb__grid {
@@ -385,13 +687,10 @@ function run() {
   font-style: italic;
 }
 
-/* Превью-панель резервирует место под открытое меню дропдаунов параметров
-   (метрика/разрез ~до 5 пунктов): меню раскрывается над ней, а не над кнопкой. */
 .rb__preview {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  min-height: 130px;
   padding: 14px 16px;
   background: var(--color-bg);
   border: 1px solid var(--color-border);
@@ -418,12 +717,7 @@ function run() {
   color: var(--color-text-muted);
 }
 
-/* z-index выше меню дропдауна (1000): даже если высокое меню разреза дотянется
-   до футера поверх превью-панели, кнопка остаётся кликабельной с первого раза. */
 .rb__footer {
-  position: relative;
-  z-index: 1001;
-  background: var(--color-surface, #fff);
   display: flex;
   align-items: center;
   justify-content: flex-end;
@@ -441,5 +735,32 @@ function run() {
 
 .rb__limit-input {
   width: 84px;
+}
+
+@media (max-width: 980px) {
+  .rb__metrics {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .rb__dims {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 620px) {
+  .rb__metrics {
+    grid-template-columns: 1fr;
+    margin-left: 0;
+  }
+
+  .rb__dims {
+    grid-template-columns: repeat(2, 1fr);
+    margin-left: 0;
+  }
+
+  .rb__group-title,
+  .rb__gran {
+    margin-left: 0;
+  }
 }
 </style>

--- a/frontend/src/components/statistics/__tests__/ReportBuilder.spec.js
+++ b/frontend/src/components/statistics/__tests__/ReportBuilder.spec.js
@@ -7,10 +7,11 @@ import BaseDropdown from '@/components/ui/BaseDropdown.vue';
 
 const CATALOG = {
   metrics: [
-    { key: 'car_entries_count', label: 'Въезды машин', unit: 'шт', dimensions: ['unload_place', 'period'] },
-    { key: 'applications_count', label: 'Количество заявок', unit: 'шт', dimensions: ['status', 'period'] },
+    { key: 'car_entries_count', label: 'Въезды машин', unit: 'шт', group: 'Машины', dimensions: ['unload_place', 'period'] },
+    { key: 'applications_count', label: 'Количество заявок', unit: 'шт', group: 'Заявки', dimensions: ['status', 'period'] },
   ],
   dimensions: [
+    { key: 'none', label: 'Без разреза' },
     { key: 'unload_place', label: 'Место разгрузки' },
     { key: 'status', label: 'Статус заявки' },
     { key: 'period', label: 'Период (дата)' },
@@ -47,17 +48,76 @@ function lastRun(wrapper) {
   return runs[runs.length - 1][0];
 }
 
+/** Чекбоксы метрик в порядке каталога (по группам — порядок появления групп). */
+function metricInputs(wrapper) {
+  return wrapper.findAll('.rb__metric-input');
+}
+
+/** Радио-разрез по его подписи. */
+function dimRadioByLabel(wrapper, label) {
+  return wrapper.findAll('.rb__dim').find((d) => d.text().includes(label)).find('.rb__dim-input');
+}
+
 describe('ReportBuilder', () => {
-  it('по умолчанию строит aggregate первой метрики с её первым разрезом и периодом', async () => {
+  it('по умолчанию выбрана первая метрика, разрез — её первый реальный, строит metrics[]', async () => {
     const wrapper = mountBuilder();
     await nextTick();
     await clickBuild(wrapper);
 
     const req = lastRun(wrapper);
     expect(req.mode).toBe('aggregate');
-    expect(req.metric).toBe('car_entries_count');
-    expect(req.dimension).toBe('unload_place'); // первый разрез метрики
+    expect(req.metrics).toEqual(['car_entries_count']);
+    expect(req.metric).toBeUndefined();
+    expect(req.dimension).toBe('unload_place'); // первый реальный разрез, не «без разреза»
     expect(req.filters).toContainEqual({ key: 'date_range', from: '2026-06-01', to: '2026-06-07' });
+  });
+
+  it('мультивыбор метрик сужает разрезы до общих и шлёт обе метрики', async () => {
+    const wrapper = mountBuilder();
+    await nextTick();
+    // Добавляем вторую метрику. Общий разрез car∩apps = только period (+ «без разреза»).
+    await metricInputs(wrapper)[1].trigger('change');
+    await nextTick();
+
+    // unload_place больше не общий -> разрез автоматически переехал на period.
+    const dims = wrapper.findAll('.rb__dim').map((d) => d.text());
+    expect(dims).toContain('Без разреза');
+    expect(dims).toContain('Период (дата)');
+    expect(dims).not.toContain('Место разгрузки');
+
+    await clickBuild(wrapper);
+    const req = lastRun(wrapper);
+    expect(req.metrics).toEqual(['car_entries_count', 'applications_count']);
+    expect(req.dimension).toBe('period');
+    expect(req.granularity).toBe('day');
+  });
+
+  it('«без разреза» выбирается кликом и уходит в запрос как none', async () => {
+    const wrapper = mountBuilder();
+    await nextTick();
+    await dimRadioByLabel(wrapper, 'Без разреза').setValue();
+    await clickBuild(wrapper);
+
+    const req = lastRun(wrapper);
+    expect(req.metrics).toEqual(['car_entries_count']);
+    expect(req.dimension).toBe('none');
+  });
+
+  it('снятие добавленной метрики возвращает её собственные разрезы', async () => {
+    const wrapper = mountBuilder();
+    await nextTick();
+    // Добавили applications_count -> общий разрез только period, unload_place пропал.
+    await metricInputs(wrapper)[1].trigger('change');
+    await nextTick();
+    expect(wrapper.findAll('.rb__dim').map((d) => d.text())).not.toContain('Место разгрузки');
+
+    // Сняли её обратно -> разрезы car_entries_count снова доступны.
+    await metricInputs(wrapper)[1].trigger('change');
+    await nextTick();
+    expect(wrapper.findAll('.rb__dim').map((d) => d.text())).toContain('Место разгрузки');
+
+    await clickBuild(wrapper);
+    expect(lastRun(wrapper).metrics).toEqual(['car_entries_count']);
   });
 
   it('в режиме list строит запрос сущности с выбранным фильтром', async () => {
@@ -65,11 +125,9 @@ describe('ReportBuilder', () => {
     wrapper.findComponent(FilterTabs).vm.$emit('update:modelValue', 'list');
     await nextTick();
 
-    // Фильтры сущности отрисованы (организация + статус, date_range = период из шапки)
     const pills = wrapper.findAll('.rb__pill');
-    expect(pills.length).toBe(2);
+    expect(pills.length).toBe(2); // организация + статус, date_range = период из шапки
 
-    // Выбираем организацию
     const orgPill = pills.find((p) => p.text() === 'ООО А');
     await orgPill.trigger('click');
     await clickBuild(wrapper);
@@ -86,11 +144,9 @@ describe('ReportBuilder', () => {
     wrapper.findComponent(FilterTabs).vm.$emit('update:modelValue', 'list');
     await nextTick();
 
-    // Выбрали организацию у work_applications
     const orgPill = wrapper.findAll('.rb__pill').find((p) => p.text() === 'ООО А');
     await orgPill.trigger('click');
 
-    // Переключились на машины (у них набор фильтров другой) и обратно
     const entityDropdown = wrapper.findAllComponents(BaseDropdown)[0];
     entityDropdown.vm.$emit('update:modelValue', 'cars');
     await nextTick();
@@ -98,24 +154,10 @@ describe('ReportBuilder', () => {
     await nextTick();
     await clickBuild(wrapper);
 
-    // Фильтр организации не должен переехать через смену сущности
     expect(lastRun(wrapper).filters.find((f) => f.key === 'organization')).toBeUndefined();
   });
 
-  it('сбрасывает разрез на валидный при смене метрики', async () => {
-    const wrapper = mountBuilder();
-    await nextTick();
-    // applications_count не поддерживает unload_place -> разрез должен переключиться на status.
-    // Меняем метрику через emit первого BaseDropdown (script setup не экспонирует form).
-    const metricDropdown = wrapper.findAllComponents(BaseDropdown)[0];
-    metricDropdown.vm.$emit('update:modelValue', 'applications_count');
-    await nextTick();
-    await clickBuild(wrapper);
-
-    expect(lastRun(wrapper).dimension).toBe('status');
-  });
-
-  it('применяет aggregate-пресет и сразу строит отчёт', async () => {
+  it('применяет aggregate-пресет (одиночная метрика) и сразу строит metrics[]', async () => {
     const wrapper = mount(ReportBuilder, { props: { catalog: CATALOG, period: PERIOD, preset: null } });
     await nextTick();
 
@@ -126,7 +168,7 @@ describe('ReportBuilder', () => {
 
     const req = lastRun(wrapper);
     expect(req.mode).toBe('aggregate');
-    expect(req.metric).toBe('applications_count');
+    expect(req.metrics).toEqual(['applications_count']);
     expect(req.dimension).toBe('status');
     expect(req.filters).toContainEqual({ key: 'date_range', from: '2026-06-01', to: '2026-06-07' });
   });
@@ -141,7 +183,6 @@ describe('ReportBuilder', () => {
     const req = lastRun(wrapper);
     expect(req.mode).toBe('list');
     expect(req.entity).toBe('cars');
-    // У машин нет date_range -> период не попадает в запрос.
     expect(req.filters.find((f) => f.key === 'date_range')).toBeUndefined();
   });
 
@@ -153,8 +194,6 @@ describe('ReportBuilder', () => {
     await flushPromises();
     const firstCount = wrapper.emitted('run').length;
 
-    // ReportsTab отдаёт { ...preset.form } на каждый клик — новый объект с тем же
-    // содержимым должен повторно дёрнуть watch и построить отчёт заново.
     await wrapper.setProps({ preset: { mode: 'aggregate', metric: 'applications_count', dimension: 'status' } });
     await flushPromises();
     expect(wrapper.emitted('run').length).toBe(firstCount + 1);

--- a/frontend/src/composables/__tests__/useReportRequest.spec.js
+++ b/frontend/src/composables/__tests__/useReportRequest.spec.js
@@ -31,6 +31,34 @@ describe('buildReportRequest', () => {
       expect(status.granularity).toBeUndefined();
     });
 
+    it('шлёт metrics[] при мультивыборе и опускает одиночный metric', () => {
+      const req = buildReportRequest(
+        { mode: 'aggregate', metrics: ['applications_count', 'items_sum'], dimension: 'organization' },
+        PERIOD, ['date_range'],
+      );
+      expect(req.metrics).toEqual(['applications_count', 'items_sum']);
+      expect(req.metric).toBeUndefined();
+      expect(req.dimension).toBe('organization');
+    });
+
+    it('отбрасывает пустые ключи метрик и при пустом metrics откатывается на metric', () => {
+      const empty = buildReportRequest(
+        { mode: 'aggregate', metrics: ['  ', ''], metric: 'applications_count', dimension: 'status' },
+        PERIOD, ['date_range'],
+      );
+      expect(empty.metrics).toBeUndefined();
+      expect(empty.metric).toBe('applications_count');
+    });
+
+    it('включает granularity для разреза period и при мультивыборе метрик', () => {
+      const req = buildReportRequest(
+        { mode: 'aggregate', metrics: ['applications_count', 'people_entries_count'], dimension: 'period', granularity: 'week' },
+        PERIOD, ['date_range'],
+      );
+      expect(req.metrics).toEqual(['applications_count', 'people_entries_count']);
+      expect(req.granularity).toBe('week');
+    });
+
     it('не шлёт date_range, если период пустой', () => {
       const req = buildReportRequest(
         { mode: 'aggregate', metric: 'applications_count', dimension: 'status' },

--- a/frontend/src/composables/useReportRequest.js
+++ b/frontend/src/composables/useReportRequest.js
@@ -10,7 +10,7 @@
  *
  * @param {{
  *   mode: 'aggregate'|'list',
- *   metric?: string, dimension?: string, granularity?: string,
+ *   metric?: string, metrics?: string[], dimension?: string, granularity?: string,
  *   entity?: string, sort?: string, limit?: number|string|null,
  *   filters?: Record<string, string[]>
  * }} state
@@ -40,13 +40,20 @@ export function buildReportRequest(state, period = {}, applicableFilters = []) {
     return { mode: 'list', entity: state.entity || '', filters, limit };
   }
 
+  // Мультивыбор метрик: каждая метрика -> своя колонка результата (движок отдаёт
+  // metrics-приоритет над metric). Одиночный metric оставлен для пресетов и
+  // обратной совместимости — шлётся, только когда metrics пуст.
+  const metrics = (Array.isArray(state.metrics) ? state.metrics : [])
+    .filter((m) => m != null && String(m).trim() !== '');
+
   const req = {
     mode: 'aggregate',
-    metric: state.metric || '',
     dimension: state.dimension || '',
     filters,
     limit,
   };
+  if (metrics.length) req.metrics = metrics;
+  else req.metric = state.metric || '';
   // Гранулярность осмысленна только для временного разреза.
   if (state.dimension === 'period' && state.granularity) {
     req.granularity = state.granularity;


### PR DESCRIPTION
## Что

Срез GR2 эпика #632 — наполнил мастер отчётов шагами 1-2 (вместо дропдаунов внутри `ReportBuilder`):

**Шаг 1 «Что считаем»** — мультивыбор метрик карточками-чекбоксами, сгруппированными по `group` из каталога (Заявки / Машины / Люди). Выбор шлёт `metrics:[]` — движок (GR0) разворачивает каждую метрику в свою колонку. Карточки строятся из реального каталога API, не из мокапа.

**Шаг 2 «По чему разбиваем»** — разрез радио-сеткой. «Без разреза» (`none`) доступен всегда (движок валидирует его отдельной веткой), остальные разрезы — пересечение `dimensions` выбранных метрик. При невалидном после смены метрик разрез автоматически дефолтит на первый реальный. Для разреза «Период» появляется выбор шага (день/неделя/месяц).

`buildReportRequest` научился собирать `metrics:[]` с откатом на одиночный `metric` — пресеты галереи (single-metric) продолжают работать.

Внутренности list-режима, фильтры (шаг 3) и период (шаг 4) — без изменений, придут в GR3.

## По ревью (code-reviewer)

- 🔴 `run()` получил guard `if (!canRun) return` — защита инварианта (зовётся не только кнопкой, но и из watch пресета).
- `resultHint` для `none`-разреза — отдельная формулировка («итоговая строка», без «разрез +»).
- `--color-primary-tint` в tokens.css вместо хардкода rgba в двух местах.
- Тесты: разделил misleading-кейс на «выбор без разреза» + реальное снятие метрики; добавил granularity+metrics в composable.

## Проверка

- `vitest` statistics + composables — все зелёные (ReportBuilder.spec переписан под карточки/радио, ReportsTab.spec без регресса).
- ESLint по диффу — 0 ошибок.