### PR TITLE
feat(analytics): шаги фильтров и периода в мастере отчётов (#632)

### DIFF
--- a/frontend/src/components/statistics/ReportBuilder.vue
+++ b/frontend/src/components/statistics/ReportBuilder.vue
@@ -114,32 +114,90 @@
       </label>
     </div>
 
-    <!-- list-фильтры из каталога (date_range = период из шапки, не дублируем) -->
+    <!-- Шаг 3: фильтры (чипсы, применимые к выбранным метрикам/сущности) -->
     <div
-      v-if="listFilterFields.length"
-      class="rb__filters"
+      v-if="filterFields.length"
+      class="rb__step"
     >
-      <div
-        v-for="f in listFilterFields"
-        :key="f.key"
-        class="rb__filter"
-      >
-        <span class="rb__field-label">{{ f.label }}</span>
-        <div class="rb__pills">
+      <div class="rb__step-head">
+        <span
+          v-if="form.mode === 'aggregate'"
+          class="rb__step-num"
+        >3</span>
+        <span class="rb__step-name">Фильтры</span>
+        <span class="rb__step-opt">необязательно</span>
+      </div>
+      <div class="rb__filters">
+        <div
+          v-for="f in filterFields"
+          :key="f.key"
+          class="rb__filter"
+        >
+          <span class="rb__field-label">{{ f.label }}</span>
+          <div class="rb__pills">
+            <button
+              v-for="opt in f.options"
+              :key="opt.value"
+              type="button"
+              class="rb__pill"
+              :class="{ 'rb__pill--on': isSelected(f.key, opt.value) }"
+              @click="toggleFilter(f.key, opt.value)"
+            >
+              {{ opt.label }}
+            </button>
+            <span
+              v-if="!f.options.length"
+              class="rb__pills-empty"
+            >нет значений в справочнике</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Шаг 4: период (пресеты + произвольный диапазон, локальный для отчёта) -->
+    <div
+      v-if="periodApplicable"
+      class="rb__step"
+    >
+      <div class="rb__step-head">
+        <span
+          v-if="form.mode === 'aggregate'"
+          class="rb__step-num"
+        >4</span>
+        <span class="rb__step-name">Период</span>
+      </div>
+      <div class="rb__period">
+        <div class="rb__period-presets">
           <button
-            v-for="opt in f.options"
-            :key="opt.value"
+            v-for="p in periodPresets"
+            :key="p.key"
             type="button"
             class="rb__pill"
-            :class="{ 'rb__pill--on': isSelected(f.key, opt.value) }"
-            @click="toggleFilter(f.key, opt.value)"
+            :class="{ 'rb__pill--on': activePeriodPreset === p.key }"
+            @click="applyPeriodPreset(p.key)"
           >
-            {{ opt.label }}
+            {{ p.label }}
           </button>
-          <span
-            v-if="!f.options.length"
-            class="rb__pills-empty"
-          >нет значений в справочнике</span>
+        </div>
+        <div class="rb__period-dates">
+          <label class="rb__date">
+            <span class="rb__field-label">С</span>
+            <input
+              v-model="form.period.from"
+              type="date"
+              class="lk-input"
+              @change="activePeriodPreset = 'custom'"
+            >
+          </label>
+          <label class="rb__date">
+            <span class="rb__field-label">По</span>
+            <input
+              v-model="form.period.to"
+              type="date"
+              class="lk-input"
+              @change="activePeriodPreset = 'custom'"
+            >
+          </label>
         </div>
       </div>
     </div>
@@ -181,13 +239,15 @@
 </template>
 
 <script setup>
-import { reactive, computed, watch, nextTick } from 'vue';
+import { reactive, ref, computed, watch, nextTick } from 'vue';
 import FilterTabs from '@/components/ui/FilterTabs.vue';
 import BaseDropdown from '@/components/ui/BaseDropdown.vue';
 import { buildReportRequest } from '@/composables/useReportRequest';
 
 const props = defineProps({
   catalog: { type: Object, required: true },
+  // Начальный период (из шапки фильтров). Дальше отчёт ведёт период локально в
+  // шаге 4 — дашборд и отчёт могут смотреть на разные диапазоны.
   period: { type: Object, default: () => ({ from: '', to: '' }) },
   loading: { type: Boolean, default: false },
   // Пресет из галереи: { mode, metric?/metrics?, dimension?, granularity?, entity? }.
@@ -209,8 +269,17 @@ const form = reactive({
   granularity: 'day',
   entity: props.catalog.list_entities?.[0]?.key || '',
   filters: {},
+  period: { from: props.period?.from || '', to: props.period?.to || '' },
   limit: '',
 });
+
+const periodPresets = [
+  { key: 'week', label: 'Эта неделя' },
+  { key: 'month', label: 'Этот месяц' },
+  { key: 'year', label: 'Этот год' },
+  { key: 'all', label: 'Весь период' },
+];
+const activePeriodPreset = ref('');
 
 const filterByKey = computed(() => {
   const map = {};
@@ -264,24 +333,30 @@ const selectedEntity = computed(
   () => (props.catalog.list_entities || []).find((e) => e.key === form.entity) || null,
 );
 
-const listFilterFields = computed(() => {
-  if (form.mode !== 'list') return [];
-  const keys = selectedEntity.value?.filters || [];
-  return keys
+// Применимые фильтры текущего среза: list — фильтры сущности, aggregate —
+// объединение per-metric фильтров выбранных метрик (каталог B3d, движок применяет
+// каждый к тем метрикам, что его поддерживают). Включает date_range.
+const applicableFilters = computed(() => {
+  if (form.mode === 'list') return selectedEntity.value?.filters || [];
+  const set = new Set();
+  for (const m of selectedMetrics.value) (m.filters || []).forEach((k) => set.add(k));
+  // Порядок — по каталогу фильтров, чтобы чипсы шли стабильно.
+  return (props.catalog.filters || []).map((f) => f.key).filter((k) => set.has(k));
+});
+
+// Поля-чипсы шага 3: применимые фильтры без date_range (период — отдельный шаг).
+const filterFields = computed(() =>
+  applicableFilters.value
     .filter((k) => k !== 'date_range')
     .map((k) => filterByKey.value[k])
     .filter(Boolean)
-    .map((f) => ({ ...f, options: f.options || [] }));
-});
+    .map((f) => ({ ...f, options: f.options || [] })));
+
+const periodApplicable = computed(() => applicableFilters.value.includes('date_range'));
 
 const granularityTabs = computed(
   () => (props.catalog.granularities || []).map((g) => ({ key: g.value, label: g.label })),
 );
-
-// Aggregate per-metric фильтры пока не рендерятся в гиде (шаг GR3) -> отдаём только
-// период. list — применимые фильтры выбранной сущности.
-const applicableFilters = computed(() =>
-  form.mode === 'list' ? selectedEntity.value?.filters || [] : ['date_range']);
 
 // Разрез должен оставаться валидным для текущего набора метрик. При невалидном
 // дефолтим на первый реальный разрез (полезнее «без разреза»), иначе на none.
@@ -297,13 +372,26 @@ watch(() => form.entity, () => {
   form.filters = {};
 });
 
+// При смене метрик (aggregate) убираем значения фильтров, ставших неприменимыми,
+// чтобы не слать в движок фильтр по метрике, которая его не поддерживает.
+watch(applicableFilters, (keys) => {
+  const allowed = new Set(keys);
+  const next = {};
+  let changed = false;
+  for (const [k, v] of Object.entries(form.filters)) {
+    if (allowed.has(k)) next[k] = v;
+    else changed = true;
+  }
+  if (changed) form.filters = next;
+});
+
 const canRun = computed(() =>
   form.mode === 'aggregate'
     ? form.metrics.length > 0 && Boolean(form.dimension)
     : Boolean(form.entity));
 
 const periodLabel = computed(() => {
-  const { from, to } = props.period || {};
+  const { from, to } = form.period;
   if (from && to) return `${from} — ${to}`;
   if (from) return `с ${from}`;
   if (to) return `по ${to}`;
@@ -311,14 +399,13 @@ const periodLabel = computed(() => {
 });
 
 const summary = computed(() => {
+  // Период упоминаем только когда срез его поддерживает (есть date_range в applicable).
+  const periodPart = periodApplicable.value ? `, период: ${periodLabel.value}` : '';
   if (form.mode === 'aggregate') {
     const names = selectedMetrics.value.map((m) => m.label).join(', ') || '—';
     const dim = availableDimensions.value.find((d) => d.key === form.dimension)?.label || '—';
-    return `Считаем: ${names}; разрез «${dim}», период: ${periodLabel.value}.`;
+    return `Считаем: ${names}; разрез «${dim}»${periodPart}.`;
   }
-  // Период упоминаем только если сущность его поддерживает (машины/люди — нет).
-  const supportsPeriod = (selectedEntity.value?.filters || []).includes('date_range');
-  const periodPart = supportsPeriod ? `, период: ${periodLabel.value}` : '';
   return `Выгрузка строк: «${selectedEntity.value?.label || '—'}»${periodPart}.`;
 });
 
@@ -381,9 +468,37 @@ function toggleFilter(key, value) {
   form.filters = { ...form.filters, [key]: current };
 }
 
+/**
+ * Диапазон дат для пресета периода. «all» -> пустой диапазон (весь период).
+ * @param {'week'|'month'|'year'|'all'} kind
+ * @returns {{from: string, to: string}}
+ */
+function computePeriod(kind) {
+  if (kind === 'all') return { from: '', to: '' };
+  const now = new Date();
+  const fmt = (dt) => `${dt.getFullYear()}-${String(dt.getMonth() + 1).padStart(2, '0')}-${String(dt.getDate()).padStart(2, '0')}`;
+  const to = fmt(now);
+  if (kind === 'week') {
+    const monday = new Date(now);
+    monday.setDate(now.getDate() - ((now.getDay() + 6) % 7)); // Пн = начало недели
+    return { from: fmt(monday), to };
+  }
+  if (kind === 'month') return { from: fmt(new Date(now.getFullYear(), now.getMonth(), 1)), to };
+  if (kind === 'year') return { from: fmt(new Date(now.getFullYear(), 0, 1)), to };
+  return { from: '', to: '' };
+}
+
+function applyPeriodPreset(kind) {
+  const range = computePeriod(kind);
+  form.period.from = range.from;
+  form.period.to = range.to;
+  activePeriodPreset.value = kind;
+}
+
 // Снимок состояния формы для индикатора шагов мастера (родитель считает по нему
 // прогресс). metric — ключ первой выбранной метрики: шаг «что считаем» закрыт,
-// когда выбрана хотя бы одна. immediate — чтобы степпер был корректен сразу.
+// когда выбрана хотя бы одна. periodFilled — задан ли диапазон. immediate —
+// чтобы степпер был корректен сразу.
 const filterCount = computed(
   () => Object.values(form.filters).reduce((n, vals) => n + (vals?.length || 0), 0),
 );
@@ -394,6 +509,8 @@ watch(
     dimension: form.dimension,
     entity: form.entity,
     filterCount: filterCount.value,
+    periodApplicable: periodApplicable.value,
+    periodFilled: Boolean(form.period.from && form.period.to),
   }),
   (snapshot) => emit('change', snapshot),
   { immediate: true, deep: true },
@@ -403,7 +520,7 @@ function run() {
   // Защита инварианта: run() зовётся не только кнопкой (ещё из watch пресета),
   // поэтому проверяем canRun здесь, а не полагаемся на :disabled кнопки.
   if (!canRun.value) return;
-  emit('run', buildReportRequest(form, props.period, applicableFilters.value));
+  emit('run', buildReportRequest(form, form.period, applicableFilters.value));
 }
 </script>
 
@@ -464,6 +581,12 @@ function run() {
   font-size: 15px;
   font-weight: 700;
   color: var(--color-text);
+}
+
+.rb__step-opt {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-text-muted);
 }
 
 .rb__group-title {
@@ -645,6 +768,7 @@ function run() {
   flex-direction: column;
   gap: 16px;
   padding-top: 4px;
+  margin-left: 36px;
 }
 
 .rb__filter {
@@ -685,6 +809,32 @@ function run() {
   font-size: 13px;
   color: var(--color-text-muted);
   font-style: italic;
+}
+
+/* Период */
+.rb__period {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin-left: 36px;
+}
+
+.rb__period-presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.rb__period-dates {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+}
+
+.rb__date {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
 }
 
 .rb__preview {
@@ -759,7 +909,9 @@ function run() {
   }
 
   .rb__group-title,
-  .rb__gran {
+  .rb__gran,
+  .rb__filters,
+  .rb__period {
     margin-left: 0;
   }
 }

--- a/frontend/src/components/statistics/ReportsTab.vue
+++ b/frontend/src/components/statistics/ReportsTab.vue
@@ -94,13 +94,14 @@ const presetPayload = ref(null);
 const activePresetId = ref('');
 
 // Снимок состояния мастера для индикатора шагов.
-const builderState = ref({ mode: 'aggregate', metric: '', dimension: '', entity: '', filterCount: 0 });
+const builderState = ref({ mode: 'aggregate', metric: '', dimension: '', entity: '', filterCount: 0, periodApplicable: true, periodFilled: false });
 
 const STEP_LABELS = ['1 · Что считаем', '2 · По чему разбиваем', '3 · Фильтры', '4 · Период'];
 
 // Состояние шагов по заполненности формы: done — данные есть, current — первый
 // незаполненный, upcoming — дальше. В list-режиме разрез не применим -> шаг 2
-// считается выполненным по выбранной сущности.
+// считается выполненным по выбранной сущности. Период, неприменимый к срезу
+// (машины/люди без date_range), считается пройденным — заполнять нечего.
 const steps = computed(() => {
   const s = builderState.value;
   const isList = s.mode === 'list';
@@ -108,7 +109,7 @@ const steps = computed(() => {
     isList ? Boolean(s.entity) : Boolean(s.metric),
     isList ? Boolean(s.entity) : Boolean(s.dimension),
     s.filterCount > 0,
-    Boolean(period.value.from && period.value.to),
+    s.periodApplicable === false ? true : Boolean(s.periodFilled),
   ];
   const currentIdx = done.indexOf(false);
   return STEP_LABELS.map((label, i) => ({

--- a/frontend/src/components/statistics/__tests__/ReportBuilder.spec.js
+++ b/frontend/src/components/statistics/__tests__/ReportBuilder.spec.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { mount, flushPromises } from '@vue/test-utils';
 import { nextTick } from 'vue';
 import ReportBuilder from '../ReportBuilder.vue';
@@ -7,8 +7,8 @@ import BaseDropdown from '@/components/ui/BaseDropdown.vue';
 
 const CATALOG = {
   metrics: [
-    { key: 'car_entries_count', label: 'Въезды машин', unit: 'шт', group: 'Машины', dimensions: ['unload_place', 'period'] },
-    { key: 'applications_count', label: 'Количество заявок', unit: 'шт', group: 'Заявки', dimensions: ['status', 'period'] },
+    { key: 'car_entries_count', label: 'Въезды машин', unit: 'шт', group: 'Машины', dimensions: ['unload_place', 'period'], filters: ['date_range', 'organization'] },
+    { key: 'applications_count', label: 'Количество заявок', unit: 'шт', group: 'Заявки', dimensions: ['status', 'period'], filters: ['date_range', 'status', 'organization'] },
   ],
   dimensions: [
     { key: 'none', label: 'Без разреза' },
@@ -59,6 +59,10 @@ function dimRadioByLabel(wrapper, label) {
 }
 
 describe('ReportBuilder', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('по умолчанию выбрана первая метрика, разрез — её первый реальный, строит metrics[]', async () => {
     const wrapper = mountBuilder();
     await nextTick();
@@ -125,8 +129,8 @@ describe('ReportBuilder', () => {
     wrapper.findComponent(FilterTabs).vm.$emit('update:modelValue', 'list');
     await nextTick();
 
-    const pills = wrapper.findAll('.rb__pill');
-    expect(pills.length).toBe(2); // организация + статус, date_range = период из шапки
+    const pills = wrapper.find('.rb__filters').findAll('.rb__pill');
+    expect(pills.length).toBe(2); // организация + статус, date_range = период (шаг 4)
 
     const orgPill = pills.find((p) => p.text() === 'ООО А');
     await orgPill.trigger('click');
@@ -144,7 +148,7 @@ describe('ReportBuilder', () => {
     wrapper.findComponent(FilterTabs).vm.$emit('update:modelValue', 'list');
     await nextTick();
 
-    const orgPill = wrapper.findAll('.rb__pill').find((p) => p.text() === 'ООО А');
+    const orgPill = wrapper.find('.rb__filters').findAll('.rb__pill').find((p) => p.text() === 'ООО А');
     await orgPill.trigger('click');
 
     const entityDropdown = wrapper.findAllComponents(BaseDropdown)[0];
@@ -184,6 +188,63 @@ describe('ReportBuilder', () => {
     expect(req.mode).toBe('list');
     expect(req.entity).toBe('cars');
     expect(req.filters.find((f) => f.key === 'date_range')).toBeUndefined();
+  });
+
+  it('шаг «Фильтры» в aggregate показывает применимые к метрике чипсы и шлёт выбранный', async () => {
+    const wrapper = mountBuilder();
+    await nextTick();
+    // car_entries_count -> применимый фильтр organization (date_range вынесен в период).
+    const filterPills = wrapper.find('.rb__filters').findAll('.rb__pill');
+    const orgPill = filterPills.find((p) => p.text() === 'ООО А');
+    expect(orgPill).toBeTruthy();
+    await orgPill.trigger('click');
+    await clickBuild(wrapper);
+
+    expect(lastRun(wrapper).filters).toContainEqual({ key: 'organization', values: ['ООО А'] });
+  });
+
+  it('снятие метрики чистит фильтр, который поддерживала только она', async () => {
+    const wrapper = mountBuilder();
+    await nextTick();
+    // Добавили applications_count — единственную метрику, поддерживающую status.
+    await metricInputs(wrapper)[1].trigger('change'); // metrics = [car, apps]
+    await nextTick();
+    const statusPill = wrapper.find('.rb__filters').findAll('.rb__pill').find((p) => p.text() === 'Завершено');
+    await statusPill.trigger('click');
+    // Сняли applications_count -> status больше не применим -> значение чистится.
+    await metricInputs(wrapper)[1].trigger('change'); // metrics = [car]
+    await nextTick();
+    await clickBuild(wrapper);
+
+    expect(lastRun(wrapper).filters.find((f) => f.key === 'status')).toBeUndefined();
+  });
+
+  it('фильтр, применимый ко всему набору метрик, переживает смену метрик', async () => {
+    const wrapper = mountBuilder();
+    await nextTick();
+    // organization поддерживают обе метрики.
+    const orgPill = wrapper.find('.rb__filters').findAll('.rb__pill').find((p) => p.text() === 'ООО А');
+    await orgPill.trigger('click');
+    await metricInputs(wrapper)[1].trigger('change'); // добавили applications_count
+    await nextTick();
+    await clickBuild(wrapper);
+
+    expect(lastRun(wrapper).filters).toContainEqual({ key: 'organization', values: ['ООО А'] });
+  });
+
+  it('пресет периода «Этот год» задаёт диапазон с начала года', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 5, 18)); // 18 июня 2026, локальное время
+    const wrapper = mountBuilder();
+    await nextTick();
+
+    const yearBtn = wrapper.find('.rb__period-presets').findAll('.rb__pill').find((b) => b.text() === 'Этот год');
+    await yearBtn.trigger('click');
+    await clickBuild(wrapper);
+
+    const dr = lastRun(wrapper).filters.find((f) => f.key === 'date_range');
+    expect(dr.from).toBe('2026-01-01');
+    expect(dr.to).toBe('2026-06-18');
   });
 
   it('повторное применение пресета новым объектом (тот же контент) строит заново', async () => {

--- a/frontend/src/components/statistics/__tests__/ReportsTab.spec.js
+++ b/frontend/src/components/statistics/__tests__/ReportsTab.spec.js
@@ -23,6 +23,7 @@ vi.mock('@/api/statistics', () => ({
 import ReportsTab from '../ReportsTab.vue';
 import ReportBuilder from '../ReportBuilder.vue';
 import ReportResult from '../ReportResult.vue';
+import ReportStepper from '../ReportStepper.vue';
 
 describe('ReportsTab', () => {
   it('при двух параллельных запусках показывает результат последнего, медленный предыдущий игнорирует', async () => {
@@ -45,5 +46,33 @@ describe('ReportsTab', () => {
     await flushPromises();
 
     expect(wrapper.findComponent(ReportResult).props('result').total).toBe(7);
+  });
+
+  it('снимок мастера с заполненным периодом закрывает шаг «Период» степпера', async () => {
+    const wrapper = mount(ReportsTab, { props: { from: '', to: '' } });
+    await flushPromises();
+
+    const builder = wrapper.findComponent(ReportBuilder);
+    builder.vm.$emit('change', {
+      mode: 'aggregate', metric: 'applications_count', dimension: 'status', entity: '', filterCount: 0, periodFilled: true,
+    });
+    await nextTick();
+
+    const periodStep = wrapper.findComponent(ReportStepper).props('steps')[3];
+    expect(periodStep.label).toContain('Период');
+    expect(periodStep.state).toBe('done');
+  });
+
+  it('в list-режиме без периода шаг «Период» считается пройденным', async () => {
+    const wrapper = mount(ReportsTab, { props: { from: '', to: '' } });
+    await flushPromises();
+
+    const builder = wrapper.findComponent(ReportBuilder);
+    builder.vm.$emit('change', {
+      mode: 'list', metric: '', dimension: '', entity: 'cars', filterCount: 0, periodApplicable: false, periodFilled: false,
+    });
+    await nextTick();
+
+    expect(wrapper.findComponent(ReportStepper).props('steps')[3].state).toBe('done');
   });
 });


### PR DESCRIPTION
## Что

Срез GR3 эпика #632 — добил шаги 3-4 гида отчётов:

**Шаг 3 «Фильтры»** — чипсы применимых фильтров (необязательно). Для сводки (aggregate) — объединение per-metric `metric.filters` из каталога (B3d); движок применяет каждый фильтр к тем метрикам, что его поддерживают. Для выгрузки (list) — фильтры сущности. `date_range` из чипсов исключён (это шаг «Период»). При смене метрик значения фильтров, ставших неприменимыми, очищаются.

**Шаг 4 «Период»** — локальный период мастера: пресеты «Эта неделя / Этот месяц / Этот год / Весь период» + произвольный диапазон двумя `<input type="date">`. Период теперь ведёт сам отчёт (инициализируется из шапки, дальше автономен) — дашборд и отчёт могут смотреть на разные диапазоны. Степпер берёт заполненность периода из снимка мастера; для срезов без даты (машины/люди) шаг «Период» считается пройденным.

## По ревью (code-reviewer, вердикт go)

- summary в aggregate уважает `periodApplicable` (не пишет «период», когда дата неприменима).
- Тест очистки переписан на реальный сценарий (снятие единственной метрики, поддерживавшей фильтр) + отдельный тест сохранения общего фильтра.
- Шаг «Период» степпера = `done`, когда период неприменим (`periodApplicable` в снимке).

## Проверка

- `vitest` statistics + composables — 179 тестов зелёные (новые: фильтры aggregate, очистка, пресет периода через fake-таймер, проводка степпера).
- ESLint по диффу — 0 ошибок.
- Расчёт дат: локальные getFullYear/getMonth/getDate (без UTC-сдвига), Пн как начало недели.