### PR TITLE
feat(analytics): мультиметрик-результат и график по выбранной метрике (#632)

### DIFF
--- a/frontend/src/components/statistics/ReportChart.vue
+++ b/frontend/src/components/statistics/ReportChart.vue
@@ -23,6 +23,8 @@ const props = defineProps({
   type: { type: String, default: 'bar' },
   // Единица измерения метрики (для подписи набора данных).
   unit: { type: String, default: '' },
+  // Подпись серии (имя метрики); по умолчанию — «Количество».
+  label: { type: String, default: '' },
 });
 
 const canvasEl = ref(null);
@@ -67,7 +69,8 @@ function lineBarOptions() {
 function buildConfig() {
   const labels = props.rows.map((r) => r.label);
   const data = props.rows.map((r) => Number(r.value) || 0);
-  const datasetLabel = `Количество${props.unit ? `, ${props.unit}` : ''}`;
+  const base = props.label || 'Количество';
+  const datasetLabel = `${base}${props.unit ? `, ${props.unit}` : ''}`;
 
   if (props.type === 'pie') {
     return {
@@ -135,7 +138,7 @@ async function render() {
 onMounted(render);
 // rows/unit приходят из API новой ссылкой при каждом отчёте, type меняется кликом —
 // глубокое наблюдение не нужно, перерисовываем по смене любой из ссылок.
-watch(() => [props.rows, props.type, props.unit], render);
+watch(() => [props.rows, props.type, props.unit, props.label], render);
 onBeforeUnmount(() => {
   if (chart) { chart.destroy(); chart = null; }
 });

--- a/frontend/src/components/statistics/ReportResult.vue
+++ b/frontend/src/components/statistics/ReportResult.vue
@@ -80,13 +80,31 @@
             {{ opt.label }}
           </button>
         </div>
+        <!-- Выбор метрики для графика, если их несколько (график рисует одну серию) -->
+        <div
+          v-if="view === 'chart' && hasRows && aggColumns.length > 1"
+          class="rr__seg rr__seg--metrics"
+        >
+          <button
+            v-for="col in aggColumns"
+            :key="col.key"
+            type="button"
+            class="rr__seg-btn"
+            :class="{ 'rr__seg-btn--active': chartMetric === col.key }"
+            :data-testid="`rr-metric-${col.key}`"
+            @click="chartMetric = col.key"
+          >
+            {{ col.label }}
+          </button>
+        </div>
       </div>
 
       <ReportChart
         v-if="view === 'chart' && hasRows"
-        :rows="result.rows"
+        :rows="chartRows"
         :type="chartType"
-        :unit="result.unit || ''"
+        :unit="chartUnit"
+        :label="chartLabel"
       />
 
       <div
@@ -96,36 +114,55 @@
         <table class="rr__table">
           <thead>
             <tr>
-              <th>Значение разреза</th>
-              <th class="rr__num">
-                Количество{{ result.unit ? `, ${result.unit}` : '' }}
+              <th>{{ dimensionHeader }}</th>
+              <th
+                v-for="col in aggColumns"
+                :key="col.key"
+                class="rr__num"
+              >
+                {{ col.label }}{{ col.unit ? `, ${col.unit}` : '' }}
               </th>
             </tr>
           </thead>
           <tbody>
             <tr
-              v-for="(row, i) in result.rows"
+              v-for="(row, i) in aggRows"
               :key="i"
             >
               <td>{{ row.label }}</td>
-              <td class="rr__num">
-                {{ formatNumber(row.value) }}
+              <td
+                v-for="col in aggColumns"
+                :key="col.key"
+                class="rr__num"
+              >
+                {{ formatNumber(cellValue(row, col.key)) }}
               </td>
             </tr>
-            <tr v-if="!result.rows.length">
+            <tr v-if="!aggRows.length">
               <td
-                colspan="2"
+                :colspan="aggColumns.length + 1"
                 class="rr__norows"
               >
                 Нет данных за выбранный период
               </td>
             </tr>
           </tbody>
+          <tfoot v-if="aggRows.length && showTotals">
+            <tr>
+              <td>Итого</td>
+              <td
+                v-for="col in aggColumns"
+                :key="col.key"
+                class="rr__num"
+              >
+                <b>{{ formatNumber(aggTotals[col.key] ?? 0) }}</b>
+              </td>
+            </tr>
+          </tfoot>
         </table>
       </div>
       <div class="rr__footer">
-        Итого: <b>{{ formatNumber(result.total) }}</b>{{ result.unit ? ` ${result.unit}` : '' }}
-        <span class="rr__footer-sep">·</span> строк: {{ result.rows.length }}
+        строк: {{ aggRows.length }}
       </div>
     </template>
 
@@ -187,8 +224,48 @@ const props = defineProps({
 
 const view = ref('table'); // 'table' | 'chart'
 const chartType = ref('bar'); // 'bar' | 'pie' | 'line'
+const chartMetric = ref(''); // ключ колонки-метрики, отображаемой на графике
 
-const hasRows = computed(() => (props.result?.rows?.length || 0) > 0);
+// Мультиметрика и одиночная сводка приведены к единому виду: колонки-метрики +
+// строки {label, values:{колонка->число}} + итоги по колонкам. Legacy-форма
+// (rows[{label,value}]/total/unit) синтезируется в одну колонку «value», поэтому
+// таблица и график не зависят от того, в каком формате пришёл ответ.
+const aggColumns = computed(() => {
+  const r = props.result;
+  // mode-guard: у list-результата свои columns — они не метрики, сюда не берём.
+  if (r?.mode === 'aggregate' && r?.columns?.length) return r.columns;
+  return [{ key: 'value', label: 'Количество', unit: r?.unit || '' }];
+});
+
+const aggRows = computed(() => {
+  const r = props.result;
+  if (r?.metric_rows) return r.metric_rows;
+  return (r?.rows || []).map((row) => ({ label: row.label, values: { value: row.value } }));
+});
+
+const aggTotals = computed(() => {
+  const r = props.result;
+  if (r?.totals) return r.totals;
+  return { value: r?.total ?? 0 };
+});
+
+const hasRows = computed(() => aggRows.value.length > 0);
+
+// «Без разреза» -> единственная строка уже итоговая, отдельный футер итогов лишний.
+const showTotals = computed(() => props.result?.dimension !== 'none');
+
+const dimensionHeader = computed(() => (props.result?.dimension === 'none' ? 'Итог' : 'Значение разреза'));
+
+// График рисует одну серию — берём выбранную метрику-колонку.
+const chartColumn = computed(
+  () => aggColumns.value.find((c) => c.key === chartMetric.value) || aggColumns.value[0] || null,
+);
+const chartRows = computed(() => {
+  const key = chartColumn.value?.key;
+  return aggRows.value.map((row) => ({ label: row.label, value: cellValue(row, key) }));
+});
+const chartUnit = computed(() => chartColumn.value?.unit || '');
+const chartLabel = computed(() => (aggColumns.value.length > 1 ? chartColumn.value?.label || '' : ''));
 
 // Временной разрез рисуем линией, остальные — столбцы/круговая.
 const chartTypeOptions = computed(() => (
@@ -198,15 +275,21 @@ const chartTypeOptions = computed(() => (
 ));
 
 // Новый результат: list/пусто — только таблица; aggregate — сбрасываем тип
-// графика на дефолт по разрезу (period -> линия, иначе столбцы), вид оставляем
-// как выбрал пользователь, чтобы повторный отчёт не сбрасывал его на таблицу.
+// графика на дефолт по разрезу (period -> линия, иначе столбцы) и метрику графика
+// на первую колонку. Вид оставляем как выбрал пользователь, чтобы повторный отчёт
+// не сбрасывал его на таблицу.
 watch(() => props.result, (r) => {
   if (r?.mode !== 'aggregate') {
     view.value = 'table';
     return;
   }
   chartType.value = r.dimension === 'period' ? 'line' : 'bar';
+  chartMetric.value = aggColumns.value[0]?.key || '';
 }, { immediate: true });
+
+function cellValue(row, key) {
+  return row?.values?.[key] ?? 0;
+}
 
 function formatNumber(value) {
   const n = Number(value);
@@ -271,6 +354,13 @@ function formatCell(value) {
   border-radius: var(--radius-pill);
   padding: 3px;
   gap: 2px;
+}
+
+/* Метрик может быть много -> перенос на несколько строк; pill-радиус на
+   многострочном блоке смотрится криво, поэтому скругление поменьше. */
+.rr__seg--metrics {
+  flex-wrap: wrap;
+  border-radius: var(--radius-md);
 }
 
 .rr__seg-btn {
@@ -338,6 +428,14 @@ function formatCell(value) {
 
 .rr__table tbody tr:hover td {
   background: var(--color-bg);
+}
+
+.rr__table tfoot td {
+  padding: 11px 14px;
+  color: var(--color-text);
+  border-top: 2px solid var(--color-border);
+  background: var(--color-bg);
+  white-space: nowrap;
 }
 
 .rr__num {

--- a/frontend/src/components/statistics/__tests__/ReportResult.spec.js
+++ b/frontend/src/components/statistics/__tests__/ReportResult.spec.js
@@ -7,7 +7,7 @@ import ReportResult from '../ReportResult.vue';
 // он не нужен, подменяем стабом и читаем переданные ему props.
 const chartStub = {
   name: 'ReportChart',
-  props: ['rows', 'type', 'unit'],
+  props: ['rows', 'type', 'unit', 'label'],
   template: '<div class="chart-stub" />',
 };
 
@@ -21,6 +21,28 @@ function mountResult(result) {
 const aggPeriod = { mode: 'aggregate', dimension: 'period', unit: 'шт', rows: [{ label: 'Пн', value: 2 }], total: 2 };
 const aggStatus = { mode: 'aggregate', dimension: 'status', unit: 'шт', rows: [{ label: 'Завершено', value: 5 }], total: 5 };
 const listRes = { mode: 'list', columns: [{ key: 'a', label: 'A' }], rows: [{ a: 'x' }], total: 1 };
+
+// Мультиметрика (формат движка GR0): columns + metric_rows{label,values} + totals.
+const aggMulti = {
+  mode: 'aggregate',
+  dimension: 'organization',
+  columns: [
+    { key: 'applications_count', label: 'Количество заявок', unit: 'шт' },
+    { key: 'items_sum', label: 'Количество товаров', unit: 'шт' },
+  ],
+  metric_rows: [
+    { label: 'ООО А', values: { applications_count: 10, items_sum: 120 } },
+    { label: 'ООО Б', values: { applications_count: 4, items_sum: 30 } },
+  ],
+  totals: { applications_count: 14, items_sum: 150 },
+};
+const aggNone = {
+  mode: 'aggregate',
+  dimension: 'none',
+  columns: [{ key: 'applications_count', label: 'Количество заявок', unit: 'шт' }],
+  metric_rows: [{ label: 'Итого', values: { applications_count: 14 } }],
+  totals: { applications_count: 14 },
+};
 
 describe('ReportResult — переключатель Таблица/График', () => {
   it('list-режим: переключателя нет, только таблица', () => {
@@ -72,6 +94,75 @@ describe('ReportResult — переключатель Таблица/Графи�
     expect(w.findComponent(chartStub).exists()).toBe(false);
     expect(w.find('.rr__table').exists()).toBe(true);
     expect(w.find('[data-testid="rr-view-chart"]').attributes('disabled')).toBeDefined();
+  });
+
+  it('мультиметрика: колонка на метрику, значения по строкам и итоговая строка', () => {
+    const w = mountResult(aggMulti);
+    const headers = w.findAll('.rr__table thead th').map((th) => th.text());
+    expect(headers[0]).toBe('Значение разреза');
+    expect(headers[1]).toContain('Количество заявок');
+    expect(headers[2]).toContain('Количество товаров');
+
+    const firstRow = w.findAll('.rr__table tbody tr')[0].findAll('td').map((td) => td.text());
+    expect(firstRow).toEqual(['ООО А', '10', '120']);
+
+    const footRow = w.findAll('.rr__table tfoot td').map((td) => td.text());
+    expect(footRow).toEqual(['Итого', '14', '150']);
+  });
+
+  it('мультиметрика: график показывает селектор метрик и рисует выбранную', async () => {
+    const w = mountResult(aggMulti);
+    await w.find('[data-testid="rr-view-chart"]').trigger('click');
+    await nextTick();
+
+    // По умолчанию первая метрика.
+    expect(w.findComponent(chartStub).props('rows')).toEqual([
+      { label: 'ООО А', value: 10 }, { label: 'ООО Б', value: 4 },
+    ]);
+    expect(w.findComponent(chartStub).props('label')).toBe('Количество заявок');
+
+    // Переключаем на вторую метрику.
+    await w.find('[data-testid="rr-metric-items_sum"]').trigger('click');
+    await nextTick();
+    expect(w.findComponent(chartStub).props('rows')).toEqual([
+      { label: 'ООО А', value: 120 }, { label: 'ООО Б', value: 30 },
+    ]);
+    expect(w.findComponent(chartStub).props('label')).toBe('Количество товаров');
+  });
+
+  it('разрез «без разреза»: заголовок «Итог», без отдельной строки итогов', () => {
+    const w = mountResult(aggNone);
+    expect(w.findAll('.rr__table thead th')[0].text()).toBe('Итог');
+    expect(w.find('.rr__table tfoot').exists()).toBe(false);
+    const row = w.findAll('.rr__table tbody tr')[0].findAll('td').map((td) => td.text());
+    expect(row).toEqual(['Итого', '14']);
+  });
+
+  it('одиночная метрика (legacy rows): селектора метрик нет', async () => {
+    const w = mountResult(aggStatus);
+    await w.find('[data-testid="rr-view-chart"]').trigger('click');
+    await nextTick();
+    expect(w.find('[data-testid="rr-metric-value"]').exists()).toBe(false);
+    expect(w.findComponent(chartStub).props('rows')).toEqual([{ label: 'Завершено', value: 5 }]);
+  });
+
+  it('после сброса в null и нового мультиметрик-отчёта график берёт первую метрику', async () => {
+    const w = mountResult(aggMulti);
+    await w.find('[data-testid="rr-view-chart"]').trigger('click');
+    await w.find('[data-testid="rr-metric-items_sum"]').trigger('click');
+    await nextTick();
+    expect(w.findComponent(chartStub).props('label')).toBe('Количество товаров');
+
+    // Новый запуск: result -> null (пустой экран, вид сбрасывается на таблицу) ->
+    // снова мультиметрика -> открываем график: метрика снова первая.
+    await w.setProps({ result: null });
+    await nextTick();
+    await w.setProps({ result: aggMulti });
+    await nextTick();
+    await w.find('[data-testid="rr-view-chart"]').trigger('click');
+    await nextTick();
+
+    expect(w.findComponent(chartStub).props('label')).toBe('Количество заявок');
   });
 
   it('смена разреза period->status сбрасывает тип графика на столбцы', async () => {


### PR DESCRIPTION
## Что

Финальный срез GR4 эпика #632 — результат гида под мультиметрики:

**Таблица** — колонка на каждую выбранную метрику (`result.columns` из движка GR0), значения по строкам разреза (`result.metric_rows`), итоговая строка из `result.totals`. Legacy-форма (одна метрика: `rows`/`total`/`unit`) синтезируется в ту же структуру через `aggColumns`/`aggRows`/`aggTotals` — таблица и график не зависят от формата ответа.

**График** — рисует одну серию, поэтому при нескольких метриках появился селектор «какую метрику показать» (`ReportChart` получил prop `label` с именем серии). Переключатель Таблица/График и типы (столбцы/линия/круговая) из B3c сохранены.

**Разрез «без разреза» (none)** — заголовок «Итог», единственная строка уже итоговая, отдельная строка итогов скрыта.

## По ревью (code-reviewer, вердикт go)

- `aggColumns` берёт columns только при `mode==='aggregate'` (у list свои columns).
- Итоги с фолбэком `?? 0` на случай неполного `totals`.
- Тест перехода result→null→мультиметрика (метрика графика сбрасывается на первую).

## Проверка

- `vitest` statistics — 42 теста зелёные (мультиметрика: колонки/итоги, селектор графика, none, legacy, сброс).
- ESLint по диффу — 0 ошибок.
- Ship-check на staging — после мержа (финал визуала гида).