### PR TITLE
feat(onboarding): автозапуск, финал с CTA и полировка тура (#657)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -46,6 +46,7 @@
 import { apiRequest } from '@/api/client'
 import { useAuthStore } from '@/stores/auth'
 import { usePermissionsStore } from '@/stores/permissions'
+import { useOnboardingStore } from '@/stores/onboarding'
 import NavMenu from './components/NavMenu.vue';
 import TheHeader from './components/TheHeader/TheHeader.vue';
 import ScrollTopButton from './components/ScrollTopButton.vue';
@@ -117,6 +118,9 @@ export default {
         authStore.clearTokens()
         const permissionsStore = usePermissionsStore()
         permissionsStore.clearPermissions()
+        // Снять онбординг-тур, если он был активен - иначе overlay driver.js
+        // останется висеть поверх страницы логина.
+        useOnboardingStore().reset()
         if (this.$route.path !== '/') {
           this.$router.push("/");
         }

--- a/frontend/src/assets/onboarding.css
+++ b/frontend/src/assets/onboarding.css
@@ -6,25 +6,44 @@
 .driver-popover.ob-popover {
   border-radius: 20px;
   box-shadow: var(--shadow-md);
-  padding: 20px 22px 16px;
-  max-width: 360px;
+  padding: 22px 24px 18px;
+  max-width: 410px;
+  min-width: 300px;
   font-family: 'Montserrat', sans-serif;
 }
 
 .driver-popover.ob-popover .driver-popover-title {
-  font-size: 16px;
+  font-size: 17px;
   font-weight: 700;
   color: #1a1a1a;
+  padding-right: 18px;
 }
 
 .driver-popover.ob-popover .driver-popover-description {
-  font-size: 13px;
-  line-height: 1.5;
+  font-size: 15px;
+  line-height: 1.55;
   color: var(--color-text);
 }
 
 .driver-popover.ob-popover .driver-popover-arrow {
   color: #fff;
+}
+
+/* Крестик закрытия: фикс позиции и центровки символа */
+.driver-popover.ob-popover .driver-popover-close-btn {
+  top: 14px;
+  right: 15px;
+  width: 22px;
+  height: 22px;
+  line-height: 22px;
+  font-size: 22px;
+  text-align: center;
+  color: var(--color-text-muted);
+  transition: color 0.15s ease;
+}
+
+.driver-popover.ob-popover .driver-popover-close-btn:hover {
+  color: var(--color-primary);
 }
 
 /* --- Демо-скриншот в теле поповера (шаги с пустыми у новичка блоками) --- */
@@ -48,38 +67,101 @@
   text-align: center;
 }
 
-/* --- Кнопки навигации (pill-стиль под бренд) --- */
-.driver-popover.ob-popover .driver-popover-navigation-btns {
-  gap: 8px;
-  margin-top: 4px;
+/* --- Финал: галочка-празднование + CTA --- */
+.driver-popover.ob-popover .ob-popover__celebrate {
+  display: flex;
+  justify-content: center;
+  margin: 4px 0 12px;
 }
 
+.driver-popover.ob-popover .ob-popover__check {
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transform: scale(0);
+  opacity: 0;
+  animation: ob-check-pop 0.4s cubic-bezier(0.34, 1.4, 0.5, 1) forwards;
+}
+
+@keyframes ob-check-pop {
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+.driver-popover.ob-popover .ob-popover__cta {
+  display: block;
+  width: 100%;
+  margin: 14px 0 4px;
+  padding: 11px 16px;
+  border: none;
+  border-radius: var(--radius-pill);
+  background: var(--color-primary);
+  color: #fff;
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.1s ease;
+}
+
+.driver-popover.ob-popover .ob-popover__cta:hover {
+  background: var(--color-primary-hover);
+}
+
+.driver-popover.ob-popover .ob-popover__cta:active {
+  transform: scale(0.98);
+}
+
+/* --- Футер: прогресс сверху, затем ряд "Пропустить ... Назад Далее" --- */
+.driver-popover.ob-popover .driver-popover-footer {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.driver-popover.ob-popover .driver-popover-progress-text {
+  display: none;
+}
+
+.driver-popover.ob-popover .driver-popover-navigation-btns {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+}
+
+/* Кнопки навигации pill-стиль под бренд, выровнены по центру */
 .driver-popover.ob-popover .driver-popover-prev-btn,
 .driver-popover.ob-popover .driver-popover-next-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 34px;
   text-shadow: none;
   border-radius: var(--radius-pill);
   border: 1px solid transparent;
-  padding: 7px 18px;
+  padding: 0 20px;
   font-family: inherit;
   font-size: 13px;
   font-weight: 500;
-  line-height: 1.2;
+  line-height: 1;
   cursor: pointer;
   transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
 }
 
-.driver-popover.ob-popover .driver-popover-next-btn {
-  background: var(--color-primary);
-  color: #fff;
-  border-color: var(--color-primary);
-}
-
-.driver-popover.ob-popover .driver-popover-next-btn:hover {
-  background: var(--color-primary-hover);
-  border-color: var(--color-primary-hover);
-}
-
+/* Назад: прижимает себя и Далее вправо, "Пропустить" остаётся слева */
 .driver-popover.ob-popover .driver-popover-prev-btn {
+  margin-left: auto;
   background: #fff;
   color: var(--color-primary);
   border-color: var(--color-primary);
@@ -95,22 +177,43 @@
   cursor: not-allowed;
 }
 
-.driver-popover.ob-popover .driver-popover-close-btn {
+.driver-popover.ob-popover .driver-popover-next-btn {
+  background: var(--color-primary);
+  color: #fff;
+  border-color: var(--color-primary);
+}
+
+.driver-popover.ob-popover .driver-popover-next-btn:hover {
+  background: var(--color-primary-hover);
+  border-color: var(--color-primary-hover);
+}
+
+/* "Пропустить" - подчёркнуто-вторичная, слева, по центру высоты кнопок */
+.driver-popover.ob-popover .ob-popover__skip {
+  height: 34px;
+  display: inline-flex;
+  align-items: center;
+  background: none;
+  border: none;
+  padding: 0 2px;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--color-text-muted);
+  cursor: pointer;
   transition: color 0.15s ease;
 }
 
-.driver-popover.ob-popover .driver-popover-close-btn:hover {
+.driver-popover.ob-popover .ob-popover__skip:hover {
   color: var(--color-primary);
 }
 
-/* --- Кастомный прогресс-блок (рисуем сами, штатный showProgress выключен) --- */
+/* --- Сквозной прогресс "шаг X из N" + полоска --- */
 .ob-popover__progress {
   display: flex;
   flex-direction: column;
   gap: 7px;
   width: 100%;
-  margin-bottom: 12px;
 }
 
 .ob-popover__step-label {
@@ -142,26 +245,16 @@
   color: var(--color-text-muted);
 }
 
-.ob-popover__skip {
-  align-self: flex-start;
-  background: none;
-  border: none;
-  padding: 0;
-  font-family: inherit;
-  font-size: 11px;
-  font-weight: 500;
-  color: var(--color-text-muted);
-  cursor: pointer;
-  transition: color 0.15s ease, opacity 0.15s ease;
-}
-
-.ob-popover__skip:hover {
-  color: var(--color-primary);
-  opacity: 0.85;
-}
-
 @media (prefers-reduced-motion: reduce) {
-  .ob-popover__bar-fill {
+  .ob-popover__bar-fill,
+  .ob-popover__check,
+  .ob-popover__cta {
     transition: none;
+    animation: none;
+  }
+
+  .driver-popover.ob-popover .ob-popover__check {
+    transform: scale(1);
+    opacity: 1;
   }
 }

--- a/frontend/src/components/onboarding/OnboardingTour.vue
+++ b/frontend/src/components/onboarding/OnboardingTour.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { watch, onBeforeUnmount } from 'vue';
+import { watch, onMounted, onBeforeUnmount } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useOnboardingStore } from '@/stores/onboarding';
 import { useUiStore } from '@/stores/ui';
@@ -23,36 +23,48 @@ let waitController = null;
 let driverGen = 0;
 // Прежнее состояние рельса до того как тур его развернул - чтобы вернуть как было.
 let railSaved = null;
+let railRefreshTimer = null;
 
-/**
- * Рельс нужен развёрнутым на nav-шаге И на шаге прямо перед ним: разворачиваем
- * заранее, чтобы к моменту подсветки рельс уже доехал до полной ширины и driver
- * померил рамку спотлайта корректно (иначе ловим элемент в середине анимации).
- */
-function railNeeded(globalIndex) {
-  const cur = store.steps[globalIndex];
-  const next = store.steps[globalIndex + 1];
-  return Boolean(cur?.expandRail || next?.expandRail);
+function clearRailTimer() {
+  if (railRefreshTimer) {
+    clearTimeout(railRefreshTimer);
+    railRefreshTimer = null;
+  }
 }
 
 /**
- * Развернуть/вернуть рельс под текущую позицию. Разворот - ОВЕРЛЕЙНЫЙ
- * (tourForceExpand), без сдвига контента: reflow от пина дёргал бы спотлайт
- * соседних шагов. sidebarHidden снимаем, иначе скрытый рельс не покажется.
+ * Развернуть/вернуть рельс под текущий шаг. Разворот включается ИМЕННО на nav-шаге
+ * (overlay через tourForceExpand, без сдвига контента). Рельс анимированно
+ * доезжает до полной ширины ~0.25s - после анимации просим driver пересчитать
+ * рамку спотлайта (refresh). Overlay не двигает контент, поэтому refresh
+ * ре-стейджит тот же элемент чисто, без скачка спотлайта на соседний.
  */
 function applyRail(globalIndex) {
-  if (railNeeded(globalIndex)) {
+  const cur = store.steps[globalIndex];
+  if (cur?.expandRail) {
     if (!railSaved) {
       railSaved = { force: ui.tourForceExpand, hidden: ui.sidebarHidden };
     }
     ui.tourForceExpand = true;
     ui.sidebarHidden = false;
+    clearRailTimer();
+    const captured = driverObj;
+    railRefreshTimer = setTimeout(() => {
+      railRefreshTimer = null;
+      // moveTo ре-хайлайтит текущий шаг по селектору (свежий querySelector) -
+      // в отличие от refresh() он заново ставит класс .driver-active-element на
+      // развёрнутый рельс. refresh() ре-стейджит и оставляет подсветку пустой.
+      if (captured && captured === driverObj && store.isActive) {
+        captured.moveTo(captured.getActiveIndex());
+      }
+    }, 300);
   } else {
     restoreRail();
   }
 }
 
 function restoreRail() {
+  clearRailTimer();
   if (railSaved) {
     ui.tourForceExpand = railSaved.force;
     ui.sidebarHidden = railSaved.hidden;
@@ -89,9 +101,16 @@ async function startSegment() {
       applyRail(globalIndex);
     },
     onBoundaryNext: handleBoundaryNext,
+    onCtaClick: finishAndCreateApp,
     onDestroyed: () => handleDestroyed(myGen),
   });
   driverObj.drive(0);
+}
+
+/** CTA финала: завершаем тур и ведём на оформление первой заявки. */
+function finishAndCreateApp() {
+  finishTour();
+  router.push('/new-application').catch(() => {});
 }
 
 /**
@@ -130,13 +149,22 @@ function advanceToSegment(targetRoute) {
 
 function finishTour() {
   // destroy() синхронно зовёт onDestroyed -> handleDestroyed (pendingSegment=false)
-  // -> restoreRail + store.stop. Без инстанса завершаем напрямую.
+  // -> markCompleted (если авто) + stop. Без инстанса завершаем напрямую.
   if (driverObj) {
     driverObj.destroy();
   } else {
     restoreRail();
+    markIfAuto();
     store.stop();
   }
+}
+
+/**
+ * Авто-тур (первый вход) помечаем пройденным даже при выходе/пропуске, чтобы
+ * он не запускался снова. Ручной запуск (кнопка «Обучение») флаг не трогает.
+ */
+function markIfAuto() {
+  if (!store.isManual) store.markCompleted();
 }
 
 function handleDestroyed(gen) {
@@ -146,10 +174,15 @@ function handleDestroyed(gen) {
   // Переход между страницами: тур продолжается, не останавливаем и рельс не трогаем.
   if (store.pendingSegment) return;
   restoreRail();
+  markIfAuto();
   store.stop();
 }
 
 function teardown() {
+  // Тур ещё жив (logout/unmount во время прохождения) - авто-тур помечаем
+  // пройденным здесь: ниже driverGen++ обезвредит отложенный onDestroyed, и тот
+  // до markIfAuto уже не дойдёт. Так автозапуск действительно "один раз".
+  if (driverObj) markIfAuto();
   driverGen += 1;
   if (waitController) {
     waitController.abort();
@@ -186,6 +219,23 @@ const removeAfterEach = router.afterEach((to) => {
     store.stop();
   }
 });
+
+/**
+ * Автозапуск один раз для любого первого входа: на «Обзоре», если юзер
+ * авторизован и тур ещё не пройден (localStorage-флаг). Повторно не сработает -
+ * флаг ставится при любом завершении авто-тура (см. markIfAuto).
+ */
+function maybeAutostart() {
+  if (store.isActive) return;
+  if (route.path !== '/news') return;
+  if (!store.canShowTour) return;
+  if (store.hasCompleted()) return;
+  store.start({ manual: false });
+}
+
+watch(() => route.path, maybeAutostart);
+
+onMounted(maybeAutostart);
 
 onBeforeUnmount(() => {
   removeAfterEach();

--- a/frontend/src/components/onboarding/__tests__/onboardingSteps.spec.js
+++ b/frontend/src/components/onboarding/__tests__/onboardingSteps.spec.js
@@ -88,9 +88,14 @@ describe('collectSegment', () => {
     expect(collectSegment(steps, 4, '/carsview').map((s) => s.id)).toEqual(['e']);
   });
 
-  it('реальная конфигурация: весь сегмент news собирается с нулевого индекса', () => {
+  it('реальная конфигурация: первый сегмент news = contiguous блок с нулевого индекса', () => {
     const seg = collectSegment(onboardingSteps, 0, '/news');
-    expect(seg.length).toBe(onboardingSteps.filter((s) => s.route === '/news').length);
+    // финальный шаг тоже /news, но он в конце (отдельный сегмент) - сегмент с 0
+    // обрывается на первом не-/news шаге, а не собирает все /news скопом.
+    const firstNonNews = onboardingSteps.findIndex((s) => s.route !== '/news');
+    expect(seg.length).toBe(firstNonNews);
+    expect(seg[0].id).toBe('start');
+    expect(seg[seg.length - 1].id).toBe('nav-group-data');
   });
 });
 
@@ -148,14 +153,12 @@ describe('cross-page конфигурация (cars / employees)', () => {
 });
 
 describe('cross-page конфигурация (создание заявки)', () => {
-  it('сегмент /new-application идёт последним и отделён границей', () => {
+  it('сегмент /new-application отделён границей и идёт после сотрудников', () => {
     const first = onboardingSteps.findIndex((s) => s.route === '/new-application');
     expect(first).toBeGreaterThan(0);
     expect(onboardingSteps[first - 1].route).not.toBe('/new-application');
     expect(collectSegment(onboardingSteps, first, '/new-application').map((s) => s.id))
       .toEqual(['createapp-selector', 'createapp-form']);
-    // это финальный сегмент тура
-    expect(first + 2).toBe(onboardingSteps.length);
   });
 
   it('шаг формы несёт демо createForm', () => {
@@ -165,5 +168,35 @@ describe('cross-page конфигурация (создание заявки)', 
   it('идёт после сотрудников', () => {
     const idx = (id) => onboardingSteps.findIndex((s) => s.id === id);
     expect(idx('employees-table')).toBeLessThan(idx('createapp-selector'));
+  });
+});
+
+describe('финальный шаг', () => {
+  const finish = onboardingSteps[onboardingSteps.length - 1];
+
+  it('финал - последний шаг, на Обзоре, подсвечивает кнопку Обучение', () => {
+    expect(finish.id).toBe('finish');
+    expect(finish.route).toBe('/news');
+    expect(finish.element).toBe('[data-testid="ob-start-button"]');
+  });
+
+  it('несёт празднование и CTA на оформление заявки', () => {
+    expect(finish.celebrate).toBe(true);
+    expect(typeof finish.cta).toBe('string');
+    expect(finish.cta.length).toBeGreaterThan(0);
+  });
+
+  it('возвращает тур на /news (граница сегмента после createApp)', () => {
+    const prev = onboardingSteps[onboardingSteps.length - 2];
+    expect(prev.route).toBe('/new-application');
+    expect(finish.route).not.toBe(prev.route);
+  });
+
+  it('celebrate/cta есть только у финального шага', () => {
+    const withCelebrate = onboardingSteps.filter((s) => s.celebrate);
+    const withCta = onboardingSteps.filter((s) => s.cta);
+    expect(withCelebrate).toHaveLength(1);
+    expect(withCta).toHaveLength(1);
+    expect(withCelebrate[0].id).toBe('finish');
   });
 });

--- a/frontend/src/components/onboarding/onboardingSteps.js
+++ b/frontend/src/components/onboarding/onboardingSteps.js
@@ -16,11 +16,13 @@ export const ONBOARDING_VERSION = 1;
  * - `element`    CSS-селектор цели или `null` (центр-модал без подсветки);
  * - `title`      заголовок поповера;
  * - `description` HTML-тело поповера (прогоняется через sanitizeHtml);
- * - `demo`       необязательный ключ скриншота (используется будущими срезами);
+ * - `demo`       необязательный ключ скриншота (мапа в onboardingDemo.js);
  * - `expandRail` если true - хост разворачивает свёрнутый рельс навигации на
- *                время шага и возвращает прежнее состояние при выходе.
+ *                время шага и возвращает прежнее состояние при выходе;
+ * - `celebrate`  если true - в поповере рисуется галочка-празднование (финал);
+ * - `cta`        текст финальной кнопки-CTA (ведёт на оформление заявки).
  *
- * @type {Array<{ id: string, route: string, element: string|null, title: string, description: string, demo?: string, expandRail?: boolean }>}
+ * @type {Array<{ id: string, route: string, element: string|null, title: string, description: string, demo?: string, expandRail?: boolean, celebrate?: boolean, cta?: string }>}
  */
 export const onboardingSteps = [
   {
@@ -59,7 +61,7 @@ export const onboardingSteps = [
     route: '/news',
     element: '[data-testid="ob-header-broadcast"]',
     title: 'Объявления',
-    description: 'Здесь появляется кнопка важного объявления, когда администрация публикует что-то срочное. Нажмите, чтобы прочитать.',
+    description: 'На этой странице может появиться объявление или важное объявление от администрации. Когда оно опубликовано - вы увидите его здесь и сможете открыть, чтобы не пропустить важное.',
   },
   {
     id: 'header-time',
@@ -102,7 +104,7 @@ export const onboardingSteps = [
     route: '/news',
     element: '[data-testid="ob-nav-group-data"]',
     title: 'Управление данными',
-    description: 'Раздел «Управление данными»: таблицы системы, ваши сотрудники и автомобили. Отсюда вы ведёте справочники, по которым оформляются пропуска.',
+    description: 'Раздел «Управление данными»: ваши сотрудники и автомобили. Здесь вы ведёте справочники, по которым оформляются пропуска.',
     expandRail: true,
   },
   {
@@ -185,6 +187,15 @@ export const onboardingSteps = [
     title: 'Заполнение и отправка',
     description: 'После выбора бланка откроется форма: сопроводительное письмо, поля сотрудника и автомобиля, согласие на обработку данных и кнопка отправки. Вот как она выглядит заполненной.',
     demo: 'createForm',
+  },
+  {
+    id: 'finish',
+    route: '/news',
+    element: '[data-testid="ob-start-button"]',
+    title: 'Готово, вы освоились!',
+    description: 'Это всё основное. Запустить обучение заново можно в любой момент - кнопкой «Обучение» вот здесь. Удачной работы!',
+    celebrate: true,
+    cta: 'Подать первую заявку',
   },
 ];
 

--- a/frontend/src/composables/useOnboarding.js
+++ b/frontend/src/composables/useOnboarding.js
@@ -92,7 +92,7 @@ export function useOnboarding() {
     return sanitizeHtml(html);
   }
 
-  function buildProgressBlock(globalIndex, total, nextTitle, onSkip) {
+  function buildProgressBlock(globalIndex, total, nextTitle) {
     const block = document.createElement('div');
     block.className = 'ob-popover__progress';
 
@@ -118,14 +118,37 @@ export function useOnboarding() {
       block.appendChild(hint);
     }
 
+    return block;
+  }
+
+  function buildSkipButton(onSkip) {
     const skip = document.createElement('button');
     skip.type = 'button';
     skip.className = 'ob-popover__skip';
     skip.textContent = 'Пропустить';
     skip.addEventListener('click', onSkip);
-    block.appendChild(skip);
+    return skip;
+  }
 
-    return block;
+  /** Сдержанное празднование финала: галочка в круге (scale-in через CSS). */
+  function buildCelebrate() {
+    const wrap = document.createElement('div');
+    wrap.className = 'ob-popover__celebrate';
+    const circle = document.createElement('div');
+    circle.className = 'ob-popover__check';
+    // Статичная иконка-константа, пользовательских данных нет - innerHTML безопасен.
+    circle.innerHTML = '<svg width="26" height="26" viewBox="0 0 24 24" fill="none"><path d="M5 12.5l4.5 4.5L19 7" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+    wrap.appendChild(circle);
+    return wrap;
+  }
+
+  function buildCtaButton(text, onClick) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'ob-popover__cta';
+    btn.textContent = text;
+    btn.addEventListener('click', onClick);
+    return btn;
   }
 
   /**
@@ -136,7 +159,7 @@ export function useOnboarding() {
    * @param {{ startIndex?: number, onIndexChange?: (globalIndex: number) => void, onDestroyed?: () => void, onBoundaryNext?: () => void }} [options]
    * @returns {import('driver.js').Driver}
    */
-  function createDriver(stepsForSegment, { startIndex = 0, onIndexChange, onDestroyed, onBoundaryNext } = {}) {
+  function createDriver(stepsForSegment, { startIndex = 0, onIndexChange, onDestroyed, onBoundaryNext, onCtaClick } = {}) {
     const store = useOnboardingStore();
     const lastLocal = stepsForSegment.length - 1;
 
@@ -146,7 +169,7 @@ export function useOnboarding() {
       allowClose: true,
       overlayOpacity: 0.7,
       stagePadding: 6,
-      stageRadius: 12,
+      stageRadius: 20,
       popoverClass: 'ob-popover',
       nextBtnText: 'Далее',
       prevBtnText: 'Назад',
@@ -179,15 +202,34 @@ export function useOnboarding() {
         const localIndex = driverObj.getActiveIndex() ?? 0;
         const globalIndex = startIndex + localIndex + 1;
         const total = store.totalSteps;
+        const step = stepsForSegment[localIndex];
         // Подсказка "Далее" сквозная - берём следующий шаг по глобальному
         // индексу, чтобы на границе сегмента показать имя шага со след. страницы.
         const nextStep = store.steps[globalIndex];
         const nextTitle = nextStep ? nextStep.title : '';
 
-        const block = buildProgressBlock(globalIndex, total, nextTitle, () => {
-          driverObj.destroy();
-        });
-        popover.footer.insertBefore(block, popover.footer.firstChild);
+        // Финал: галочка перед заголовком + CTA после описания.
+        if (step?.celebrate) {
+          popover.wrapper.insertBefore(buildCelebrate(), popover.title);
+        }
+        if (step?.cta) {
+          const cta = buildCtaButton(step.cta, () => onCtaClick?.());
+          popover.description.insertAdjacentElement('afterend', cta);
+        }
+
+        // Прогресс сверху футера.
+        popover.footer.insertBefore(
+          buildProgressBlock(globalIndex, total, nextTitle),
+          popover.footer.firstChild,
+        );
+        // "Пропустить" - первым в ряду кнопок (CSS прижимает Назад/Далее вправо).
+        // На финале не показываем: там уже есть "Готово" и CTA.
+        if (!step?.celebrate) {
+          popover.footerButtons.insertBefore(
+            buildSkipButton(() => driverObj.destroy()),
+            popover.footerButtons.firstChild,
+          );
+        }
       },
       onHighlighted() {
         const localIndex = driverObj.getActiveIndex() ?? 0;

--- a/frontend/src/stores/__tests__/onboarding.spec.js
+++ b/frontend/src/stores/__tests__/onboarding.spec.js
@@ -184,4 +184,18 @@ describe('onboarding store', () => {
       expect(store.currentIndex).toBe(0);
     });
   });
+
+  describe('isManual (авто vs ручной запуск)', () => {
+    it('start() без аргумента - авто (isManual=false)', () => {
+      const store = useOnboardingStore();
+      store.start();
+      expect(store.isManual).toBe(false);
+    });
+
+    it('start({ manual: true }) - ручной (флаг для записи completed не ставится)', () => {
+      const store = useOnboardingStore();
+      store.start({ manual: true });
+      expect(store.isManual).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Срез 6/6 (финальный) эпика онбординг-тура (issue #657)

Закрывает эпик: автозапуск, финал-празднование с CTA и вся полировка по замечаниям.

### Автозапуск + флаг
- Тур стартует сам один раз при первом входе на «Обзоре» (любой авторизованный, без гейта по роли). Флаг `onboarding-tour` в localStorage ставится при ЛЮБОМ завершении авто-тура (Готово/Esc/Пропустить/CTA/logout) - значит «один раз» соблюдается строго. Ручной запуск кнопкой «Обучение» флаг не трогает.
- logout снимает overlay тура (App.vue -> store.reset()).

### Финал
- Последний шаг возвращает на «Обзор», подсвечивает кнопку «Обучение» (показывает, откуда перезапустить тур), сдержанная галочка-празднование (scale-in, только transform/opacity) и CTA «Подать первую заявку» -> /new-application.

### Полировка (по замечаниям)
- Поповер: шрифт описания 15px, окно шире (410px); «Пропустить» слева в одном ряду с «Назад»/«Далее» (выровнены), крестик на месте; скругление выделения `stageRadius: 20`.
- Навбар разворачивается СТРОГО на своём шаге (10), не на предыдущем - ре-замер рамки спотлайта через `moveTo` (refresh() оставлял подсветку пустой).
- «Управление данными» без упоминания «Таблиц» (их нет у большинства не-админов).
- Шаг «Объявления» описывает, что объявление может появиться, и подсвечивает его при наличии.
- «Пропустить» скрыт на финале; reduced-motion отключает анимации.

### Проверки
- ESLint 0 ошибок, Vitest 56 passed (автозапуск/isManual/финал-шаг/celebrate-cta).
- Playwright по live-стеку: **104/104** - автозапуск без клика, полный 23-шаговый тур, рельс открывается на шаге 10, «Управление данными» без Таблиц, финал галочка+CTA->/new-application, флаг пишется, повтора автозапуска нет, кнопка перезапускает, Esc/logout закрывают. Скриншоты поповера проверены визуально.
- Ревью-агент: GO, must-fix нет; 3 suggestion внесены (logout метит флаг, скип скрыт на финале, комментарий к innerHTML).