### PR TITLE
feat(analytics): выгрузка результата отчёта в Excel (#632)

### DIFF
--- a/frontend/src/components/statistics/ReportResult.vue
+++ b/frontend/src/components/statistics/ReportResult.vue
@@ -97,6 +97,15 @@
             {{ col.label }}
           </button>
         </div>
+        <button
+          type="button"
+          class="lk-button lk-button--ghost rr__export"
+          :disabled="!canExport || exporting"
+          data-testid="rr-export"
+          @click="onExport"
+        >
+          {{ exporting ? 'Готовим…' : 'Excel' }}
+        </button>
       </div>
 
       <ReportChart
@@ -168,6 +177,17 @@
 
     <!-- Выгрузка строк (list) -->
     <template v-else>
+      <div class="rr__toolbar rr__toolbar--end">
+        <button
+          type="button"
+          class="lk-button lk-button--ghost rr__export"
+          :disabled="!canExport || exporting"
+          data-testid="rr-export"
+          @click="onExport"
+        >
+          {{ exporting ? 'Готовим…' : 'Excel' }}
+        </button>
+      </div>
       <div class="rr__table-wrap">
         <table class="rr__table">
           <thead>
@@ -215,12 +235,17 @@
 import { ref, computed, watch } from 'vue';
 import LoaderSpinner from '@/components/ui/LoaderSpinner.vue';
 import ReportChart from './ReportChart.vue';
+import { useReportExport } from '@/composables/useReportExport';
 
 const props = defineProps({
   result: { type: Object, default: null },
   loading: { type: Boolean, default: false },
   error: { type: String, default: '' },
+  // Подпись выгрузки в Excel: { title, period:{from,to}, author }.
+  meta: { type: Object, default: () => ({}) },
 });
+
+const emit = defineEmits(['export-error']);
 
 const view = ref('table'); // 'table' | 'chart'
 const chartType = ref('bar'); // 'bar' | 'pie' | 'line'
@@ -287,6 +312,23 @@ watch(() => props.result, (r) => {
   chartMetric.value = aggColumns.value[0]?.key || '';
 }, { immediate: true });
 
+const { exporting, exportReport } = useReportExport();
+
+// list считаем по его собственным строкам, aggregate — по нормализованным.
+const canExport = computed(() => {
+  const r = props.result;
+  if (!r) return false;
+  return r.mode === 'list' ? (r.rows?.length || 0) > 0 : hasRows.value;
+});
+
+async function onExport() {
+  try {
+    await exportReport(props.result, props.meta);
+  } catch (e) {
+    emit('export-error', e?.message || 'Не удалось выгрузить отчёт');
+  }
+}
+
 function cellValue(row, key) {
   return row?.values?.[key] ?? 0;
 }
@@ -345,6 +387,19 @@ function formatCell(value) {
   align-items: center;
   gap: 10px;
   flex-wrap: wrap;
+}
+
+.rr__toolbar--end {
+  justify-content: flex-end;
+}
+
+/* Кнопка выгрузки (стиль из lk-button--ghost) прижата вправо в панели инструментов. */
+.rr__export {
+  margin-left: auto;
+}
+
+.rr__toolbar--end .rr__export {
+  margin-left: 0;
 }
 
 .rr__seg {

--- a/frontend/src/components/statistics/ReportsTab.vue
+++ b/frontend/src/components/statistics/ReportsTab.vue
@@ -59,6 +59,8 @@
         :result="result"
         :loading="running"
         :error="runError"
+        :meta="exportMeta"
+        @export-error="onExportError"
       />
     </template>
   </div>
@@ -72,6 +74,7 @@ import ReportGallery from './ReportGallery.vue';
 import ReportStepper from './ReportStepper.vue';
 import LoaderSpinner from '@/components/ui/LoaderSpinner.vue';
 import { getReportCatalog, runReport } from '@/api/statistics';
+import { useDeletionsStore } from '@/stores/deletions';
 
 const props = defineProps({
   from: { type: String, default: '' },
@@ -87,6 +90,8 @@ const catalogError = ref('');
 const result = ref(null);
 const running = ref(false);
 const runError = ref('');
+// Подпись для выгрузки в Excel: период берём из последнего построенного запроса.
+const exportMeta = ref({});
 
 // Пресет из галереи: новый объект на каждый клик (даже по той же карточке),
 // чтобы watch в ReportBuilder сработал повторно и перезаполнил конструктор.
@@ -122,6 +127,12 @@ function onBuilderChange(snapshot) {
   builderState.value = snapshot;
 }
 
+// Ошибку выгрузки показываем тостом, не подменяя :error результата (иначе таблица
+// отчёта скрылась бы за текстом ошибки).
+function onExportError(message) {
+  useDeletionsStore().notify({ prefix: 'Не удалось ', bold: 'выгрузить отчёт в Excel', suffix: message ? `: ${message}` : '', type: 'error' });
+}
+
 function onApplyPreset(preset) {
   activePresetId.value = preset.id;
   presetPayload.value = { ...preset.form };
@@ -149,6 +160,9 @@ async function onRun(request) {
     const r = await runReport(request);
     if (seq !== runSeq) return;
     result.value = r;
+    const dr = (request.filters || []).find((f) => f.key === 'date_range');
+    const { from = '', to = '' } = dr || {};
+    exportMeta.value = dr ? { period: { from, to } } : {};
   } catch (e) {
     if (seq !== runSeq) return;
     result.value = null;

--- a/frontend/src/components/statistics/__tests__/ReportResult.spec.js
+++ b/frontend/src/components/statistics/__tests__/ReportResult.spec.js
@@ -1,7 +1,15 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { nextTick } from 'vue';
 import ReportResult from '../ReportResult.vue';
+
+// Экспорт в Excel тянет ExcelJS и пишет файл — в юнит-тесте подменяем composable
+// и проверяем, что клик «Excel» зовёт exportReport с результатом и meta.
+const { exportSpy } = vi.hoisted(() => ({ exportSpy: vi.fn() }));
+vi.mock('@/composables/useReportExport', async () => {
+  const { ref } = await import('vue');
+  return { useReportExport: () => ({ exporting: ref(false), exportReport: exportSpy }) };
+});
 
 // ReportChart лениво тянет chart.js + canvas — в юнит-тесте логики переключателя
 // он не нужен, подменяем стабом и читаем переданные ему props.
@@ -163,6 +171,38 @@ describe('ReportResult — переключатель Таблица/Графи�
     await nextTick();
 
     expect(w.findComponent(chartStub).props('label')).toBe('Количество заявок');
+  });
+
+  it('кнопка «Excel» зовёт экспорт с текущим результатом и meta', async () => {
+    exportSpy.mockClear();
+    const meta = { period: { from: '2026-06-01', to: '2026-06-07' } };
+    const w = mount(ReportResult, {
+      props: { result: aggMulti, meta },
+      global: { stubs: { ReportChart: chartStub } },
+    });
+    await w.find('[data-testid="rr-export"]').trigger('click');
+    expect(exportSpy).toHaveBeenCalledWith(aggMulti, meta);
+  });
+
+  it('кнопка «Excel» недоступна на пустом результате', () => {
+    const w = mountResult({ ...aggStatus, rows: [], total: 0 });
+    expect(w.find('[data-testid="rr-export"]').attributes('disabled')).toBeDefined();
+  });
+
+  it('list-режим тоже отдаёт кнопку выгрузки', () => {
+    const w = mountResult(listRes);
+    expect(w.find('[data-testid="rr-export"]').exists()).toBe(true);
+  });
+
+  it('падение экспорта эмитит export-error с сообщением', async () => {
+    exportSpy.mockRejectedValueOnce(new Error('диск переполнен'));
+    const w = mount(ReportResult, {
+      props: { result: aggMulti },
+      global: { stubs: { ReportChart: chartStub } },
+    });
+    await w.find('[data-testid="rr-export"]').trigger('click');
+    await nextTick();
+    expect(w.emitted('export-error')[0]).toEqual(['диск переполнен']);
   });
 
   it('смена разреза period->status сбрасывает тип графика на столбцы', async () => {

--- a/frontend/src/components/statistics/__tests__/ReportsTab.spec.js
+++ b/frontend/src/components/statistics/__tests__/ReportsTab.spec.js
@@ -20,6 +20,10 @@ vi.mock('@/api/statistics', () => ({
   runReport: () => new Promise((resolve) => { state.deferred.push(resolve); }),
 }));
 
+// Стор уведомлений мокаем: ошибку экспорта показывают тостом, а не подменой :error.
+const { notifySpy } = vi.hoisted(() => ({ notifySpy: vi.fn() }));
+vi.mock('@/stores/deletions', () => ({ useDeletionsStore: () => ({ notify: notifySpy }) }));
+
 import ReportsTab from '../ReportsTab.vue';
 import ReportBuilder from '../ReportBuilder.vue';
 import ReportResult from '../ReportResult.vue';
@@ -74,5 +78,28 @@ describe('ReportsTab', () => {
     await nextTick();
 
     expect(wrapper.findComponent(ReportStepper).props('steps')[3].state).toBe('done');
+  });
+
+  it('ошибку экспорта показывает тостом и не подменяет результат отчёта', async () => {
+    notifySpy.mockClear();
+    state.deferred.length = 0;
+    const wrapper = mount(ReportsTab, { props: { from: '2026-06-01', to: '2026-06-07' } });
+    await flushPromises();
+
+    // Построили отчёт.
+    wrapper.findComponent(ReportBuilder).vm.$emit('run', { mode: 'list', entity: 'cars' });
+    await nextTick();
+    state.deferred[0]({ mode: 'list', columns: [], rows: [{}], total: 1 });
+    await flushPromises();
+
+    // Экспорт упал.
+    wrapper.findComponent(ReportResult).vm.$emit('export-error', 'диск переполнен');
+    await nextTick();
+
+    expect(notifySpy).toHaveBeenCalledTimes(1);
+    expect(notifySpy.mock.calls[0][0]).toMatchObject({ type: 'error' });
+    // Результат на месте, :error не выставлен.
+    expect(wrapper.findComponent(ReportResult).props('result')).not.toBeNull();
+    expect(wrapper.findComponent(ReportResult).props('error')).toBe('');
   });
 });

--- a/frontend/src/composables/__tests__/useReportExport.spec.js
+++ b/frontend/src/composables/__tests__/useReportExport.spec.js
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { reportToTable } from '../useReportExport';
+
+describe('reportToTable', () => {
+  it('мультиметрик aggregate: колонки-метрики, строки значений и строка итогов', () => {
+    const t = reportToTable({
+      mode: 'aggregate',
+      dimension: 'organization',
+      columns: [{ key: 'a', label: 'Заявки', unit: 'шт' }, { key: 'b', label: 'Товары' }],
+      metric_rows: [
+        { label: 'ООО А', values: { a: 10, b: 120 } },
+        { label: 'ООО Б', values: { a: 4, b: 30 } },
+      ],
+      totals: { a: 14, b: 150 },
+    });
+    expect(t.header).toEqual(['Значение разреза', 'Заявки, шт', 'Товары']);
+    expect(t.rows).toEqual([['ООО А', 10, 120], ['ООО Б', 4, 30]]);
+    expect(t.totalsRow).toEqual(['Итого', 14, 150]);
+  });
+
+  it('разрез «без разреза»: заголовок «Итог», без отдельной строки итогов', () => {
+    const t = reportToTable({
+      mode: 'aggregate',
+      dimension: 'none',
+      columns: [{ key: 'a', label: 'Заявки', unit: 'шт' }],
+      metric_rows: [{ label: 'Итого', values: { a: 14 } }],
+      totals: { a: 14 },
+    });
+    expect(t.header[0]).toBe('Итог');
+    expect(t.totalsRow).toBeNull();
+    expect(t.rows).toEqual([['Итого', 14]]);
+  });
+
+  it('одиночная метрика (legacy rows/total/unit) сводится к одной колонке', () => {
+    const t = reportToTable({
+      mode: 'aggregate', dimension: 'status', unit: 'шт',
+      rows: [{ label: 'Завершено', value: 3 }], total: 3,
+    });
+    expect(t.header).toEqual(['Значение разреза', 'Количество, шт']);
+    expect(t.rows).toEqual([['Завершено', 3]]);
+    expect(t.totalsRow).toEqual(['Итого', 3]);
+  });
+
+  it('list: заголовки и строки по колонкам сущности, без итогов', () => {
+    const t = reportToTable({
+      mode: 'list',
+      columns: [{ key: 'number', label: 'Номер' }, { key: 'org', label: 'Организация' }],
+      rows: [{ number: 'A-1', org: 'ООО Ромашка' }, { number: 'A-2', org: '' }],
+      total: 2,
+    });
+    expect(t.header).toEqual(['Номер', 'Организация']);
+    expect(t.rows).toEqual([['A-1', 'ООО Ромашка'], ['A-2', '']]);
+    expect(t.totalsRow).toBeNull();
+  });
+
+  it('пустой результат не падает', () => {
+    expect(reportToTable(null).header).toEqual([]);
+  });
+});

--- a/frontend/src/composables/useReportExport.js
+++ b/frontend/src/composables/useReportExport.js
@@ -1,0 +1,148 @@
+import { ref } from 'vue';
+
+/**
+ * Приводит результат отчёта (aggregate или list) к плоской таблице для выгрузки.
+ * Поддерживает обе формы aggregate-ответа движка: мультиметрик (columns +
+ * metric_rows + totals) и одиночную метрику (rows[{label,value}] + total + unit).
+ *
+ * @param {object} result результат POST /statistics/report
+ * @returns {{ sheetName: string, header: string[], rows: Array<Array<string|number>>,
+ *   totalsRow: Array<string|number>|null }}
+ */
+export function reportToTable(result) {
+  if (!result) return { sheetName: 'Отчёт', header: [], rows: [], totalsRow: null };
+
+  if (result.mode === 'list') {
+    const columns = result.columns || [];
+    return {
+      sheetName: 'Выгрузка',
+      header: columns.map((c) => c.label),
+      rows: (result.rows || []).map((row) => columns.map((c) => cellText(row[c.key]))),
+      totalsRow: null,
+    };
+  }
+
+  const columns = result.columns?.length
+    ? result.columns
+    : [{ key: 'value', label: 'Количество', unit: result.unit || '' }];
+  const metricRows = result.metric_rows
+    || (result.rows || []).map((row) => ({ label: row.label, values: { value: row.value } }));
+  const totals = result.totals || { value: result.total ?? 0 };
+
+  const dimHeader = result.dimension === 'none' ? 'Итог' : 'Значение разреза';
+  const header = [dimHeader, ...columns.map((c) => (c.unit ? `${c.label}, ${c.unit}` : c.label))];
+  const rows = metricRows.map((r) => [r.label, ...columns.map((c) => Number(r.values?.[c.key] ?? 0))]);
+  // «Без разреза» — единственная строка уже итоговая, отдельная строка итогов лишняя.
+  const totalsRow = result.dimension === 'none'
+    ? null
+    : ['Итого', ...columns.map((c) => Number(totals[c.key] ?? 0))];
+
+  return { sheetName: 'Сводка', header, rows, totalsRow };
+}
+
+function cellText(value) {
+  if (value === null || value === undefined || value === '') return '';
+  return value;
+}
+
+const HEADER_FILL = 'FF4F5BDF';
+const ROW_FILL_EVEN = 'FFF0F5FF';
+const ROW_FILL_ODD = 'FFE0E9FF';
+const TOTALS_FILL = 'FFD3DCFF';
+const THIN = { style: 'thin', color: { argb: 'FFE6E6E6' } };
+const THIN_BORDER = { top: THIN, bottom: THIN, left: THIN, right: THIN };
+
+/**
+ * Экспорт результата отчёта в .xlsx в фирменном стиле (заливка шапки primary,
+ * чередование строк, рамка, строка итогов и подпись формирования). ExcelJS тянется
+ * лениво, чтобы не утяжелять основной бандл.
+ */
+export function useReportExport() {
+  const exporting = ref(false);
+
+  /**
+   * @param {object} result результат отчёта
+   * @param {{ title?: string, period?: {from?: string, to?: string}, author?: string }} [opts]
+   */
+  async function exportReport(result, opts = {}) {
+    const table = reportToTable(result);
+    if (!table.header.length) throw new Error('Нет данных для выгрузки');
+
+    exporting.value = true;
+    try {
+      const ExcelJS = (await import('exceljs')).default;
+      const workbook = new ExcelJS.Workbook();
+      const worksheet = workbook.addWorksheet(table.sheetName);
+
+      const headerRow = worksheet.addRow(table.header);
+      headerRow.height = 25;
+      headerRow.eachCell((cell) => {
+        cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: HEADER_FILL } };
+        cell.font = { name: 'Verdana', size: 11, bold: true, color: { argb: 'FFFFFFFF' } };
+        cell.alignment = { vertical: 'middle', horizontal: 'center' };
+        cell.border = THIN_BORDER;
+      });
+
+      table.rows.forEach((cells, index) => {
+        const row = worksheet.addRow(cells);
+        row.height = 20;
+        const fill = index % 2 === 0 ? ROW_FILL_EVEN : ROW_FILL_ODD;
+        row.eachCell((cell) => {
+          cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: fill } };
+          cell.font = { name: 'Verdana', size: 9, color: { argb: 'FF333333' } };
+          cell.alignment = { vertical: 'middle' };
+          cell.border = THIN_BORDER;
+        });
+      });
+
+      if (table.totalsRow) {
+        const row = worksheet.addRow(table.totalsRow);
+        row.height = 22;
+        row.eachCell((cell) => {
+          cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: TOTALS_FILL } };
+          cell.font = { name: 'Verdana', size: 10, bold: true, color: { argb: 'FF1A1A1A' } };
+          cell.alignment = { vertical: 'middle' };
+          cell.border = THIN_BORDER;
+        });
+      }
+
+      worksheet.columns = table.header.map((_, i) => ({ width: i === 0 ? 32 : 22 }));
+
+      worksheet.addRow([]);
+      const period = opts.period?.from || opts.period?.to
+        ? `${opts.period.from || '...'} - ${opts.period.to || '...'}`
+        : 'весь период';
+      const infoRows = [
+        worksheet.addRow(['Отчёт:', opts.title || 'Отчёт по аналитике']),
+        worksheet.addRow(['Период:', period]),
+        worksheet.addRow(['Сформировал:', opts.author || 'Пользователь']),
+        worksheet.addRow(['Дата формирования:', new Date().toLocaleString('ru-RU')]),
+      ];
+      infoRows.forEach((row) => {
+        row.eachCell((cell) => {
+          cell.font = { name: 'Verdana', size: 10, color: { argb: 'FF333333' } };
+          cell.alignment = { vertical: 'middle' };
+        });
+      });
+
+      const buffer = await workbook.xlsx.writeBuffer();
+      const blob = new Blob([buffer], {
+        type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      });
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      const stamp = new Date().toLocaleString('ru-RU').replace(/[.:,\s]/g, '-');
+      a.download = `Отчёт_${(opts.title || 'аналитика').replace(/\s+/g, '_')}_${stamp}.xlsx`;
+      a.href = url;
+      // Без attach в DOM Firefox/Safari не запускают скачивание по click().
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      window.URL.revokeObjectURL(url);
+    } finally {
+      exporting.value = false;
+    }
+  }
+
+  return { exporting, exportReport };
+}


### PR DESCRIPTION
## Что

Срез C1 эпика #632 — кнопка «Excel» в результате отчёта (сводка и выгрузка строк).

- **`useReportExport.js`** (новый composable): `reportToTable(result)` приводит все формы результата (мультиметрик columns/metric_rows/totals, legacy rows/total, list) к плоской таблице {header, rows, totalsRow}. `exportReport` рисует .xlsx в фирменном стиле — заливка шапки primary, чередование строк, рамки, строка итогов, подпись (отчёт/период/автор/дата). ExcelJS тянется лениво (`import('exceljs')`).
- Стиль переиспользован из `CarDetailsModal.exportHistory` (оригинал не тронут).
- Кнопка «Excel» (`lk-button--ghost`) в toolbar результата — и для сводки, и для выгрузки строк; disabled при пустом результате/в процессе.
- Период выгрузки берётся из последнего построенного запроса.

## По ревью (code-reviewer, было NO-GO — оба блокера закрыты)

- 🔴 **Firefox/Safari скачивание**: ссылка прикрепляется к DOM (`appendChild` + `remove`) перед `click()`.
- 🔴 **Ошибка не прячет результат**: `export-error` идёт в `useDeletionsStore.notify` (тост), а не в `:error`, который скрывал бы таблицу.
- 🔴 **Reuse кнопки**: `lk-button--ghost` вместо кастомного стиля.
- 🟡 throw на пустых данных вместо тихого return; дефолты `from/to` для date_range; ASCII-дефис в подписи периода.

## Проверка

- `vitest` — 194 теста зелёные. `reportToTable` (мультиметрик/none/legacy/list), клик «Excel» зовёт экспорт с meta, падение → export-error → notify (результат не скрыт).
- ESLint по диффу — 0 ошибок.