### PR TITLE
feat(onboarding): статус тура per-user через API (#657)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -146,6 +146,7 @@ func main() {
 	companyService := services.NewCompanyService(db)
 	notificationServiceEarly := services.NewNotificationService(db)
 	userService := services.NewUserService(db, notificationServiceEarly)
+	onboardingService := services.NewOnboardingService(db)
 	unloadPlaceService := services.NewUnloadPlaceService(db)
 	carService := services.NewCarService(db)
 	employeeService := services.NewEmployeeService(db)
@@ -199,6 +200,7 @@ func main() {
 	organizationHandler := handlers.NewOrganizationHandler(organizationService, db)
 	companyHandler := handlers.NewCompanyHandler(companyService)
 	usersHandler := handlers.NewUsersHandler(userService)
+	onboardingHandler := handlers.NewOnboardingHandler(onboardingService)
 	unloadPlaceHandler := handlers.NewUnloadPlaceHandler(unloadPlaceService, cfg.UploadMaxFileSize, cfg.UploadPath)
 	carHandler := handlers.NewCarHandler(carService)
 	employeeHandler := handlers.NewEmployeeHandler(employeeService)
@@ -289,6 +291,7 @@ func main() {
 		DocumentGroups:      documentGroupHandler,
 		Documents:           documentHandler,
 		Statistics:          statisticsHandler,
+		Onboarding:          onboardingHandler,
 		PermResolver:        permissionResolver,
 		DenialLog:           accessDenialService,
 		MaintenanceBlock:    maintenanceBlock,

--- a/frontend/src/api/onboarding.js
+++ b/frontend/src/api/onboarding.js
@@ -1,0 +1,36 @@
+import { apiRequest } from './client';
+
+/**
+ * API статуса онбординг-тура (per-user, #657). Источник правды - бэкенд:
+ * хранит версию тура, которую прошёл юзер, чтобы статус переживал смену
+ * браузера/устройства, а подъём ONBOARDING_VERSION показывал тур заново.
+ *
+ * apiRequest разворачивает envelope: на успехе res.json() отдаёт data,
+ * на ошибке - { message }. res.ok проверяем явно и бросаем Error.
+ */
+
+async function unwrap(res, fallback) {
+  const body = await res.json();
+  if (!res.ok) throw new Error(body?.message || fallback);
+  return body;
+}
+
+/**
+ * @returns {Promise<{ completed_version: number | null }>}
+ */
+export async function getOnboardingStatus() {
+  const res = await apiRequest('/onboarding');
+  return unwrap(res, 'Не удалось загрузить статус обучения');
+}
+
+/**
+ * @param {number} version версия пройденного тура (>= 1)
+ * @returns {Promise<{ message: string }>}
+ */
+export async function markOnboardingComplete(version) {
+  const res = await apiRequest('/onboarding/complete', {
+    method: 'POST',
+    body: JSON.stringify({ version }),
+  });
+  return unwrap(res, 'Не удалось сохранить статус обучения');
+}

--- a/frontend/src/components/onboarding/OnboardingTour.vue
+++ b/frontend/src/components/onboarding/OnboardingTour.vue
@@ -102,6 +102,11 @@ async function startSegment() {
     },
     onBoundaryNext: handleBoundaryNext,
     onCtaClick: finishAndCreateApp,
+    // Esc/оверлей/крестик/Пропустить -> просто останавливаем тур. teardown
+    // (через watch isActive) снимет overlay и пометит авто-тур пройденным -
+    // надёжно, даже если шаг закрыли во время entry-анимации (когда driver
+    // не зовёт onDestroyed).
+    onCloseRequest: () => store.stop(),
     onDestroyed: () => handleDestroyed(myGen),
   });
   driverObj.drive(0);
@@ -222,13 +227,18 @@ const removeAfterEach = router.afterEach((to) => {
 
 /**
  * Автозапуск один раз для любого первого входа: на «Обзоре», если юзер
- * авторизован и тур ещё не пройден (localStorage-флаг). Повторно не сработает -
- * флаг ставится при любом завершении авто-тура (см. markIfAuto).
+ * авторизован и тур ещё не пройден. Статус per-user тянется с бэкенда
+ * (loadStatus) - на ошибке сети не автозапускаем (statusLoaded остаётся false).
+ * Повторно не сработает: completedVersion ставится при любом завершении
+ * авто-тура (см. markIfAuto), а на бэкенде - per-user, сброс только админом.
  */
-function maybeAutostart() {
+async function maybeAutostart() {
   if (store.isActive) return;
   if (route.path !== '/news') return;
   if (!store.canShowTour) return;
+  if (!store.statusLoaded) await store.loadStatus();
+  // Перепроверяем после await: статус мог не загрузиться, юзер мог уйти/стартовать.
+  if (!store.statusLoaded || store.isActive || route.path !== '/news') return;
   if (store.hasCompleted()) return;
   store.start({ manual: false });
 }

--- a/frontend/src/composables/useOnboarding.js
+++ b/frontend/src/composables/useOnboarding.js
@@ -156,10 +156,10 @@ export function useOnboarding() {
    * с общим route).
    *
    * @param {Array<object>} stepsForSegment
-   * @param {{ startIndex?: number, onIndexChange?: (globalIndex: number) => void, onDestroyed?: () => void, onBoundaryNext?: () => void }} [options]
+   * @param {{ startIndex?: number, onIndexChange?: (globalIndex: number) => void, onDestroyed?: () => void, onBoundaryNext?: () => void, onCtaClick?: () => void, onCloseRequest?: () => void }} [options]
    * @returns {import('driver.js').Driver}
    */
-  function createDriver(stepsForSegment, { startIndex = 0, onIndexChange, onDestroyed, onBoundaryNext, onCtaClick } = {}) {
+  function createDriver(stepsForSegment, { startIndex = 0, onIndexChange, onDestroyed, onBoundaryNext, onCtaClick, onCloseRequest } = {}) {
     const store = useOnboardingStore();
     const lastLocal = stepsForSegment.length - 1;
 
@@ -226,10 +226,18 @@ export function useOnboarding() {
         // На финале не показываем: там уже есть "Готово" и CTA.
         if (!step?.celebrate) {
           popover.footerButtons.insertBefore(
-            buildSkipButton(() => driverObj.destroy()),
+            buildSkipButton(() => (onCloseRequest ? onCloseRequest() : driverObj.destroy())),
             popover.footerButtons.firstChild,
           );
         }
+      },
+      // Esc / клик по оверлею / крестик идут сюда (g(true)) ДО гейта на
+      // __activeStep - в отличие от onDestroyed это надёжно срабатывает, даже
+      // если шаг закрыт во время entry-анимации. Отдаём закрытие хосту; он
+      // остановит тур (-> teardown снимет overlay и пометит авто-тур).
+      onDestroyStarted() {
+        if (onCloseRequest) onCloseRequest();
+        else driverObj.destroy();
       },
       onHighlighted() {
         const localIndex = driverObj.getActiveIndex() ?? 0;

--- a/frontend/src/stores/__tests__/onboarding.spec.js
+++ b/frontend/src/stores/__tests__/onboarding.spec.js
@@ -3,8 +3,12 @@ import { setActivePinia, createPinia } from 'pinia';
 import { useOnboardingStore } from '../onboarding';
 import { useAuthStore } from '../auth';
 import { onboardingSteps, ONBOARDING_VERSION } from '@/components/onboarding/onboardingSteps';
+import { getOnboardingStatus, markOnboardingComplete } from '@/api/onboarding';
 
-const STORAGE_KEY = 'onboarding-tour';
+vi.mock('@/api/onboarding', () => ({
+  getOnboardingStatus: vi.fn(),
+  markOnboardingComplete: vi.fn(),
+}));
 
 function createMockJWT(payload, expiresInSeconds = 3600) {
   const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
@@ -18,7 +22,9 @@ function createMockJWT(payload, expiresInSeconds = 3600) {
 describe('onboarding store', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
-    localStorage.clear();
+    getOnboardingStatus.mockReset();
+    markOnboardingComplete.mockReset();
+    markOnboardingComplete.mockResolvedValue({ message: 'ok' });
   });
 
   afterEach(() => {
@@ -73,14 +79,17 @@ describe('onboarding store', () => {
       expect(store.currentStep).toBe(onboardingSteps[2]);
     });
 
-    it('reset сбрасывает активность и индекс', () => {
+    it('reset сбрасывает активность, индекс и per-user статус', () => {
       const store = useOnboardingStore();
       store.start();
       store.setIndex(2);
+      store.markCompleted();
       store.reset();
 
       expect(store.isActive).toBe(false);
       expect(store.currentIndex).toBe(0);
+      expect(store.completedVersion).toBe(null);
+      expect(store.statusLoaded).toBe(false);
     });
   });
 
@@ -91,45 +100,76 @@ describe('onboarding store', () => {
     });
   });
 
-  describe('markCompleted / hasCompleted', () => {
-    it('markCompleted пишет корректный JSON-флаг в localStorage', () => {
+  describe('loadStatus / hasCompleted (per-user через API)', () => {
+    it('loadStatus тянет статус и ставит completedVersion + statusLoaded', async () => {
+      getOnboardingStatus.mockResolvedValue({ completed_version: ONBOARDING_VERSION });
       const store = useOnboardingStore();
-      store.markCompleted();
+      await store.loadStatus();
 
-      const raw = localStorage.getItem(STORAGE_KEY);
-      expect(JSON.parse(raw)).toEqual({ completed: true, version: ONBOARDING_VERSION });
+      expect(getOnboardingStatus).toHaveBeenCalledOnce();
+      expect(store.completedVersion).toBe(ONBOARDING_VERSION);
+      expect(store.statusLoaded).toBe(true);
     });
 
-    it('hasCompleted true после markCompleted', () => {
+    it('конкурентные loadStatus шлют один GET (guard от гонки)', async () => {
+      let resolve;
+      getOnboardingStatus.mockReturnValue(new Promise((r) => { resolve = r; }));
       const store = useOnboardingStore();
-      store.markCompleted();
+      const p1 = store.loadStatus();
+      const p2 = store.loadStatus();
+      resolve({ completed_version: null });
+      await Promise.all([p1, p2]);
+
+      expect(getOnboardingStatus).toHaveBeenCalledOnce();
+    });
+
+    it('loadStatus с completed_version=null -> не пройден', async () => {
+      getOnboardingStatus.mockResolvedValue({ completed_version: null });
+      const store = useOnboardingStore();
+      await store.loadStatus();
+
+      expect(store.statusLoaded).toBe(true);
+      expect(store.hasCompleted()).toBe(false);
+    });
+
+    it('loadStatus при ошибке сети оставляет statusLoaded=false (fail-safe)', async () => {
+      getOnboardingStatus.mockRejectedValue(new Error('network'));
+      const store = useOnboardingStore();
+      await store.loadStatus();
+
+      expect(store.statusLoaded).toBe(false);
+      expect(store.hasCompleted()).toBe(false);
+    });
+
+    it('hasCompleted true когда пройдена версия >= текущей', async () => {
+      getOnboardingStatus.mockResolvedValue({ completed_version: ONBOARDING_VERSION });
+      const store = useOnboardingStore();
+      await store.loadStatus();
       expect(store.hasCompleted()).toBe(true);
     });
 
-    it('hasCompleted false когда флага нет', () => {
+    it('hasCompleted false когда пройдена старая версия (тур обновился)', async () => {
+      getOnboardingStatus.mockResolvedValue({ completed_version: ONBOARDING_VERSION - 1 });
       const store = useOnboardingStore();
+      await store.loadStatus();
       expect(store.hasCompleted()).toBe(false);
     });
 
-    it('hasCompleted false при чужой версии флага', () => {
+    it('markCompleted ставит версию локально сразу и шлёт на бэкенд', () => {
       const store = useOnboardingStore();
-      localStorage.setItem(STORAGE_KEY, JSON.stringify({ completed: true, version: 0 }));
-      expect(store.hasCompleted()).toBe(false);
+      store.markCompleted();
+
+      expect(store.completedVersion).toBe(ONBOARDING_VERSION);
+      expect(store.hasCompleted()).toBe(true);
+      expect(markOnboardingComplete).toHaveBeenCalledWith(ONBOARDING_VERSION);
     });
 
-    it('hasCompleted false при битом JSON', () => {
+    it('markCompleted не падает при ошибке записи на бэкенд (fire-and-forget)', () => {
+      markOnboardingComplete.mockRejectedValue(new Error('network'));
       const store = useOnboardingStore();
-      localStorage.setItem(STORAGE_KEY, 'not-json');
-      expect(store.hasCompleted()).toBe(false);
-    });
-
-    it('markCompleted не падает когда localStorage.setItem кидает', () => {
-      const store = useOnboardingStore();
-      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
-        throw new Error('storage disabled');
-      });
-
       expect(() => store.markCompleted()).not.toThrow();
+      // локально статус всё равно проставлен
+      expect(store.hasCompleted()).toBe(true);
     });
   });
 

--- a/frontend/src/stores/onboarding.js
+++ b/frontend/src/stores/onboarding.js
@@ -2,23 +2,33 @@ import { defineStore } from 'pinia';
 import { ref, computed } from 'vue';
 import { useAuthStore } from '@/stores/auth';
 import { onboardingSteps, ONBOARDING_VERSION } from '@/components/onboarding/onboardingSteps';
-
-const STORAGE_KEY = 'onboarding-tour';
+import { getOnboardingStatus, markOnboardingComplete } from '@/api/onboarding';
 
 /**
  * Стор онбординг-тура. Держит ГЛОБАЛЬНЫЙ индекс активного шага по всему
  * массиву onboardingSteps; хост-компонент режет массив на сегменты по route
  * и водит driver.js внутри текущего сегмента.
+ *
+ * Статус «пройден» хранится per-user на бэкенде (а не в localStorage), чтобы
+ * переживал смену браузера/устройства и сбрасывался админом. completedVersion -
+ * версия тура, которую прошёл юзер (null = не проходил).
  */
 export const useOnboardingStore = defineStore('onboarding', () => {
   const isActive = ref(false);
   const currentIndex = ref(0);
-  // Авто-запуск (срез 6) ставит флаг завершения даже при пропуске, ручной — нет.
+  // Авто-запуск ставит флаг завершения даже при пропуске, ручной — нет.
   const isManual = ref(false);
   // Тур переходит между страницами: на границе сегмента driver уничтожается,
   // выполняется router.push, и pendingSegment сигналит хосту подхватить
   // следующий сегмент после навигации (router.afterEach).
   const pendingSegment = ref(false);
+
+  // Per-user статус с бэкенда: версия пройденного тура и флаг загрузки.
+  const completedVersion = ref(null);
+  const statusLoaded = ref(false);
+  // In-flight промис загрузки статуса - чтобы конкурентные maybeAutostart
+  // (onMounted + watch route) не слали два GET (урок про гонки авто-fetch).
+  let loadStatusPromise = null;
 
   const steps = computed(() => onboardingSteps);
   const totalSteps = computed(() => steps.value.length);
@@ -30,21 +40,34 @@ export const useOnboardingStore = defineStore('onboarding', () => {
   });
 
   /**
-   * Тур пройден только если сохранённый флаг помечен completed И его версия
-   * совпадает с текущей. Чтение в try/catch: приватный режим / отключённый
-   * storage кидают при доступе.
+   * Подтянуть per-user статус с бэкенда (один раз за сессию). На ошибке сети
+   * statusLoaded остаётся false - хост тогда не автозапускает тур (fail-safe),
+   * кнопка «Обучение» по-прежнему работает.
+   */
+  async function loadStatus() {
+    if (loadStatusPromise) return loadStatusPromise;
+    loadStatusPromise = (async () => {
+      try {
+        const data = await getOnboardingStatus();
+        completedVersion.value = data?.completed_version ?? null;
+        statusLoaded.value = true;
+      } catch {
+        statusLoaded.value = false;
+      } finally {
+        loadStatusPromise = null;
+      }
+    })();
+    return loadStatusPromise;
+  }
+
+  /**
+   * Тур пройден, если юзер прошёл версию не ниже текущей. Подъём
+   * ONBOARDING_VERSION делает тур «непройденным» и показывает заново.
    *
    * @returns {boolean}
    */
   function hasCompleted() {
-    try {
-      const raw = localStorage.getItem(STORAGE_KEY);
-      if (!raw) return false;
-      const parsed = JSON.parse(raw);
-      return parsed.completed === true && parsed.version === ONBOARDING_VERSION;
-    } catch {
-      return false;
-    }
+    return completedVersion.value !== null && completedVersion.value >= ONBOARDING_VERSION;
   }
 
   /**
@@ -81,22 +104,30 @@ export const useOnboardingStore = defineStore('onboarding', () => {
     pendingSegment.value = false;
   }
 
+  /**
+   * Пометить тур пройденным для текущего юзера. Локально обновляем
+   * completedVersion сразу (чтобы автозапуск не сработал повторно в этой
+   * сессии), запись на бэкенд - fire-and-forget: сбой сети не должен ломать
+   * завершение тура (в худшем случае переиграется при следующем входе).
+   */
   function markCompleted() {
-    try {
-      localStorage.setItem(
-        STORAGE_KEY,
-        JSON.stringify({ completed: true, version: ONBOARDING_VERSION }),
-      );
-    } catch {
-      // storage недоступен (приватный режим / квота) - тур всё равно отработал,
-      // просто переиграется при следующем авто-запуске. Не критично.
-    }
+    // Идемпотентно: разные пути закрытия (Esc/Готово/CTA) могут позвать дважды -
+    // версию ставим и POST шлём только если ещё не помечено.
+    if (completedVersion.value !== null && completedVersion.value >= ONBOARDING_VERSION) return;
+    completedVersion.value = ONBOARDING_VERSION;
+    statusLoaded.value = true;
+    markOnboardingComplete(ONBOARDING_VERSION).catch(() => {
+      // best-effort: статус локально уже стоит, бэкенд догонит при следующем разе
+    });
   }
 
   function reset() {
     isActive.value = false;
     currentIndex.value = 0;
     pendingSegment.value = false;
+    // Сброс статуса при logout - следующий юзер на этом устройстве подтянет свой.
+    completedVersion.value = null;
+    statusLoaded.value = false;
   }
 
   return {
@@ -108,6 +139,9 @@ export const useOnboardingStore = defineStore('onboarding', () => {
     canShowTour,
     isManual,
     pendingSegment,
+    completedVersion,
+    statusLoaded,
+    loadStatus,
     hasCompleted,
     start,
     stop,

--- a/internal/handlers/onboarding.go
+++ b/internal/handlers/onboarding.go
@@ -1,0 +1,68 @@
+package handlers
+
+import (
+	"systemburo/internal/services"
+
+	"github.com/labstack/echo/v4"
+)
+
+// OnboardingHandler — self-service эндпоинты per-user статуса онбординг-тура.
+// Каждый авторизованный пользователь читает и помечает прохождение ДЛЯ СЕБЯ
+// (userID берётся из JWT-контекста, а не из path/body).
+type OnboardingHandler struct {
+	service *services.OnboardingService
+}
+
+// NewOnboardingHandler создаёт новый экземпляр обработчика онбординга.
+func NewOnboardingHandler(service *services.OnboardingService) *OnboardingHandler {
+	return &OnboardingHandler{service: service}
+}
+
+// markCompleteRequest — тело POST /onboarding/complete.
+type markCompleteRequest struct {
+	Version int `json:"version" validate:"gte=1"`
+}
+
+// GetStatus godoc
+// @Summary      Статус онбординг-тура текущего пользователя
+// @Description  Возвращает версию тура, которую прошёл пользователь. null — не проходил.
+// @Tags         onboarding
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200 {object} map[string]interface{} "completed_version: int|null"
+// @Failure      401 {object} models.HTTPError
+// @Failure      500 {object} models.HTTPError
+// @Router       /onboarding [get]
+func (h *OnboardingHandler) GetStatus(c echo.Context) error {
+	userID, _ := c.Get("user_id").(int)
+	version, err := h.service.GetCompletedVersion(c.Request().Context(), userID)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, map[string]any{"completed_version": version})
+}
+
+// MarkComplete godoc
+// @Summary      Отметить прохождение онбординг-тура
+// @Description  Сохраняет версию тура, которую прошёл текущий пользователь.
+// @Tags         onboarding
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        request body handlers.markCompleteRequest true "Версия пройденного тура (>=1)"
+// @Success      200 {object} map[string]interface{} "success + message"
+// @Failure      400 {object} models.HTTPError
+// @Failure      401 {object} models.HTTPError
+// @Failure      500 {object} models.HTTPError
+// @Router       /onboarding/complete [post]
+func (h *OnboardingHandler) MarkComplete(c echo.Context) error {
+	userID, _ := c.Get("user_id").(int)
+	var req markCompleteRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	if err := h.service.SetCompleted(c.Request().Context(), userID, req.Version); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Onboarding marked as completed")
+}

--- a/internal/handlers/onboarding_test.go
+++ b/internal/handlers/onboarding_test.go
@@ -1,0 +1,107 @@
+package handlers_test
+
+import (
+	"net/http"
+	"testing"
+
+	"systemburo/internal/models"
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOnboarding_GetStatus_NewUserIsNull(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	rec := testutil.GET(t, e, "/onboarding", testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	resp := testutil.ParseMap(t, rec)
+	// JSON null десериализуется в nil; ключ присутствует.
+	val, ok := resp["completed_version"]
+	assert.True(t, ok, "completed_version key must be present")
+	assert.Nil(t, val, "new user must have null completed_version")
+
+	var u models.User
+	require.NoError(t, db.Where("username = ?", "testadmin").First(&u).Error)
+	assert.Nil(t, u.OnboardingCompletedVersion, "DB column must be null for new user")
+}
+
+func TestOnboarding_MarkComplete_ThenGetReturnsVersion(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	rec := testutil.POST(t, e, "/onboarding/complete", `{"version":1}`, testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+	assert.Equal(t, "Onboarding marked as completed", testutil.ParseMessage(t, rec))
+
+	// Значение записалось в БД.
+	var u models.User
+	require.NoError(t, db.Where("username = ?", "testadmin").First(&u).Error)
+	require.NotNil(t, u.OnboardingCompletedVersion)
+	assert.Equal(t, 1, *u.OnboardingCompletedVersion)
+
+	// И отдаётся через GET.
+	recGet := testutil.GET(t, e, "/onboarding", testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, recGet.Code, "body: %s", recGet.Body.String())
+	resp := testutil.ParseMap(t, recGet)
+	// JSON-число приходит как float64.
+	assert.Equal(t, float64(1), resp["completed_version"])
+}
+
+func TestOnboarding_MarkComplete_UpdatesToNewVersion(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	require.Equal(t, http.StatusOK,
+		testutil.POST(t, e, "/onboarding/complete", `{"version":1}`, testutil.AuthHeader(token)).Code)
+	require.Equal(t, http.StatusOK,
+		testutil.POST(t, e, "/onboarding/complete", `{"version":3}`, testutil.AuthHeader(token)).Code)
+
+	var u models.User
+	require.NoError(t, db.Where("username = ?", "testadmin").First(&u).Error)
+	require.NotNil(t, u.OnboardingCompletedVersion)
+	assert.Equal(t, 3, *u.OnboardingCompletedVersion, "later version must overwrite earlier")
+}
+
+func TestOnboarding_MarkComplete_RejectsVersionBelowOne(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	rec := testutil.POST(t, e, "/onboarding/complete", `{"version":0}`, testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "version<1 must be rejected")
+
+	// Поле не должно было записаться.
+	var u models.User
+	require.NoError(t, db.Where("username = ?", "testadmin").First(&u).Error)
+	assert.Nil(t, u.OnboardingCompletedVersion, "rejected request must not write the column")
+}
+
+func TestOnboarding_Unauthorized(t *testing.T) {
+	e, _, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+
+	rec := testutil.GET(t, e, "/onboarding", nil)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	rec = testutil.POST(t, e, "/onboarding/complete", `{"version":1}`, nil)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -29,6 +29,10 @@ type User struct {
 	LastLoginAt      *time.Time   `json:"last_login_at,omitempty"`
 	FailedLoginCount int          `gorm:"default:0" json:"-"`
 	LockedUntil      *time.Time   `json:"-"`
+	// OnboardingCompletedVersion - версия онбординг-тура, которую прошёл юзер.
+	// null = не проходил. Хранится per-user (а не per-browser), чтобы тур не
+	// сбрасывался при смене устройства; при подъёме версии шагов тур показывается заново.
+	OnboardingCompletedVersion *int `json:"onboarding_completed_version,omitempty"`
 }
 
 type Organization struct {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -23,6 +23,7 @@ type Dependencies struct {
 	Organization        *handlers.OrganizationHandler
 	Company             *handlers.CompanyHandler
 	Users               *handlers.UsersHandler
+	Onboarding          *handlers.OnboardingHandler
 	UnloadPlace         *handlers.UnloadPlaceHandler
 	Cars                *handlers.CarHandler
 	Employees           *handlers.EmployeeHandler
@@ -78,6 +79,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	org := d.Organization
 	comp := d.Company
 	users := d.Users
+	onboarding := d.Onboarding
 	up := d.UnloadPlace
 	cars := d.Cars
 	employees := d.Employees
@@ -156,6 +158,11 @@ func Setup(e *echo.Echo, d Dependencies) {
 	protected.GET("/user-data", auth.GetUserData)
 	protected.GET("/users/me", auth.GetCurrentUser)
 	protected.GET("/users/current", auth.GetCurrentUser)
+
+	// Онбординг-тур (#657) - self-service статус: любой авторизованный читает и
+	// помечает прохождение ДЛЯ СЕБЯ (userID из JWT). Не admin-only.
+	protected.GET("/onboarding", onboarding.GetStatus)
+	protected.POST("/onboarding/complete", onboarding.MarkComplete)
 
 	// Шаблоны вложений (unique_attachments)
 	att := protected.Group("/attachments")

--- a/internal/services/onboarding_service.go
+++ b/internal/services/onboarding_service.go
@@ -1,0 +1,51 @@
+package services
+
+import (
+	"context"
+	"fmt"
+
+	"systemburo/internal/models"
+
+	"gorm.io/gorm"
+)
+
+// OnboardingService управляет per-user статусом онбординг-тура.
+// Хранит версию тура, которую юзер прошёл (null = не проходил), чтобы при
+// подъёме версии шагов показать тур заново и не сбрасывать его при смене браузера.
+type OnboardingService struct {
+	db *gorm.DB
+}
+
+// NewOnboardingService конструирует сервис.
+func NewOnboardingService(db *gorm.DB) *OnboardingService {
+	return &OnboardingService{db: db}
+}
+
+// GetCompletedVersion возвращает версию тура, которую прошёл юзер.
+// nil-значение означает "не проходил". Если юзера нет - возвращает ошибку,
+// чтобы handler не выдавал "не проходил" для несуществующего id.
+func (s *OnboardingService) GetCompletedVersion(ctx context.Context, userID int) (*int, error) {
+	var user models.User
+	if err := s.db.WithContext(ctx).
+		Select("id", "onboarding_completed_version").
+		Where("id = ?", userID).
+		First(&user).Error; err != nil {
+		return nil, fmt.Errorf("failed to get onboarding version for user %d: %w", userID, err)
+	}
+	return user.OnboardingCompletedVersion, nil
+}
+
+// SetCompleted помечает прохождение тура указанной версии для юзера.
+func (s *OnboardingService) SetCompleted(ctx context.Context, userID int, version int) error {
+	res := s.db.WithContext(ctx).
+		Model(&models.User{}).
+		Where("id = ?", userID).
+		Update("onboarding_completed_version", version)
+	if res.Error != nil {
+		return fmt.Errorf("failed to set onboarding version for user %d: %w", userID, res.Error)
+	}
+	if res.RowsAffected == 0 {
+		return fmt.Errorf("failed to set onboarding version: user %d not found: %w", userID, gorm.ErrRecordNotFound)
+	}
+	return nil
+}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -106,6 +106,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	companyService := services.NewCompanyService(db)
 	notificationServiceEarly := services.NewNotificationService(db)
 	userService := services.NewUserService(db, notificationServiceEarly)
+	onboardingService := services.NewOnboardingService(db)
 	unloadPlaceService := services.NewUnloadPlaceService(db)
 	carService := services.NewCarService(db)
 	employeeService := services.NewEmployeeService(db)
@@ -158,6 +159,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	organizationHandler := handlers.NewOrganizationHandler(organizationService, db)
 	companyHandler := handlers.NewCompanyHandler(companyService)
 	usersHandler := handlers.NewUsersHandler(userService)
+	onboardingHandler := handlers.NewOnboardingHandler(onboardingService)
 	unloadPlaceHandler := handlers.NewUnloadPlaceHandler(unloadPlaceService, 10*1024*1024, "./uploads")
 	carHandler := handlers.NewCarHandler(carService)
 	employeeHandler := handlers.NewEmployeeHandler(employeeService)
@@ -208,6 +210,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 		Organization:        organizationHandler,
 		Company:             companyHandler,
 		Users:               usersHandler,
+		Onboarding:          onboardingHandler,
 		UnloadPlace:         unloadPlaceHandler,
 		Cars:                carHandler,
 		Employees:           employeeHandler,


### PR DESCRIPTION
## Per-user статус онбординг-тура (issue #657)

Прохождение тура теперь хранится **на пользователе**, а не в localStorage браузера - переживает смену браузера/устройства (по просьбе). Готовит почву для админ-сброса (отдельный PR).

### Бэкенд (без off-limits)
- `User.OnboardingCompletedVersion *int` - аддитивное поле (GORM AutoMigrate сам добавит колонку, `migrate.go` не трогаю). `omitempty`.
- `services/onboarding_service.go`: GetCompletedVersion / SetCompleted.
- `handlers/onboarding.go`: self-эндпоинты `GET /api/onboarding`, `POST /api/onboarding/complete` - userID ТОЛЬКО из JWT (`c.Get("user_id")`), нельзя читать/писать чужой статус.
- Проводка в main.go/router.go. Go-тесты (5) + testutil.

### Фронт
- `api/onboarding.js`; стор: `hasCompleted`/`markCompleted`/`loadStatus` через API вместо localStorage (`completedVersion`/`statusLoaded`); guard от конкурентного loadStatus.
- Хост: `maybeAutostart` грузит статус с бэка и решает автозапуск; на ошибке сети не автозапускает (fail-safe), кнопка работает.

### Заодно починен латентный баг
Закрытие тура во время entry-анимации шага не помечало прохождение (driver не звал `onDestroyed`, пока не выставлен `__activeStep`). Теперь закрытие (Esc/оверлей/крестик/Пропустить) ловится через `onDestroyStarted` -> `onCloseRequest` -> надёжный teardown + пометка.

### Проверки
- Go build + тесты (5 PASS, граничные: null/запись/upgrade/version<1/401). ESLint 0. Vitest 57.
- Playwright по live-стеку (ворктри-бэкенд против той же БД): **per-user 7/7** - статус переживает НОВЫЙ контекст браузера (не localStorage!), сброс в БД снова включает автозапуск; **полный проход 104/104** - автозапуск, 23 шага, CTA пишет статус в БД, повтор кнопкой, Esc.
- Ревью-агент: GO, must-fix нет.

Примечание: добавляет колонку в `users` через AutoMigrate на деплое (аддитивно, безопасно).