### PR TITLE
feat(analytics): шаблоны отчётов - модель, CRUD и системные пресеты (#632)

### DIFF
--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
 
@@ -151,6 +152,9 @@ func AllModels() []interface{} {
 		// Documents (#39)
 		&models.DocumentGroup{},
 		&models.Document{},
+
+		// Report templates (#632): сохранённые наборы конструктора отчётов
+		&models.ReportTemplate{},
 	}
 }
 
@@ -175,7 +179,62 @@ func AutoMigrate(db *gorm.DB) error {
 	if err := backfillSuperAdmin(db); err != nil {
 		return err
 	}
+	if err := SeedReportTemplates(db); err != nil {
+		return err
+	}
 	slog.Info("AutoMigrate completed")
+	return nil
+}
+
+// SeedReportTemplates идемпотентно создаёт системные пресеты конструктора отчётов
+// (#632). Config зеркалит состояние гида и непрозрачен для бэка — его применяет
+// фронт. Создаём только отсутствующие по (name, is_system), существующие не трогаем.
+// Идемпотентность через Count, а не уникальный индекс: личные шаблоны разных
+// пользователей могут совпадать по имени, поэтому DB-level unique на name не ставим.
+func SeedReportTemplates(db *gorm.DB) error {
+	presets := []models.ReportTemplate{
+		{
+			Name:        "Сводка за неделю",
+			Description: "Поданные заявки по дням за последнюю неделю.",
+			Config:      json.RawMessage(`{"mode":"aggregate","metrics":["applications_count"],"dimension":"period","granularity":"day","period_preset":"week"}`),
+		},
+		{
+			Name:        "Проведение работ",
+			Description: "Заявки на работы с деталями: организация, наименование, ответственный, период.",
+			Config:      json.RawMessage(`{"mode":"list","entity":"work_applications"}`),
+		},
+		{
+			Name:        "Машины по местам",
+			Description: "Список машин с организацией, маркой и местом разгрузки.",
+			Config:      json.RawMessage(`{"mode":"list","entity":"cars"}`),
+		},
+		{
+			Name:        "Самые популярные места",
+			Description: "Места разгрузки по числу въездов машин - самые загруженные сверху.",
+			Config:      json.RawMessage(`{"mode":"aggregate","metrics":["car_entries_count"],"dimension":"unload_place"}`),
+		},
+		{
+			Name:        "Проходы людей",
+			Description: "Входы людей по дням за последнюю неделю.",
+			Config:      json.RawMessage(`{"mode":"aggregate","metrics":["people_entries_count"],"dimension":"period","granularity":"day","period_preset":"week"}`),
+		},
+	}
+
+	for i := range presets {
+		presets[i].IsSystem = true
+		var count int64
+		if err := db.Model(&models.ReportTemplate{}).
+			Where("name = ? AND is_system = ?", presets[i].Name, true).
+			Count(&count).Error; err != nil {
+			return fmt.Errorf("check system report template %q: %w", presets[i].Name, err)
+		}
+		if count > 0 {
+			continue
+		}
+		if err := db.Create(&presets[i]).Error; err != nil {
+			return fmt.Errorf("seed system report template %q: %w", presets[i].Name, err)
+		}
+	}
 	return nil
 }
 

--- a/internal/handlers/report_template.go
+++ b/internal/handlers/report_template.go
@@ -1,0 +1,114 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+
+	"github.com/labstack/echo/v4"
+)
+
+// ListTemplates godoc
+// @Summary      Список шаблонов отчётов
+// @Description  Системные пресеты + личные шаблоны пользователя + расшаренные
+// @Tags         statistics
+// @Produce      json
+// @Success      200 {object} map[string]interface{}
+// @Security     BearerAuth
+// @Router       /statistics/templates [get]
+func (h *StatisticsHandler) ListTemplates(c echo.Context) error {
+	userID, _ := c.Get("user_id").(int)
+	templates, err := h.service.ListReportTemplates(c.Request().Context(), userID)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, templates)
+}
+
+// CreateTemplate godoc
+// @Summary      Сохранить личный шаблон отчёта
+// @Tags         statistics
+// @Accept       json
+// @Produce      json
+// @Param        body body models.SaveReportTemplateRequest true "Шаблон"
+// @Success      201 {object} models.ReportTemplate
+// @Security     BearerAuth
+// @Router       /statistics/templates [post]
+func (h *StatisticsHandler) CreateTemplate(c echo.Context) error {
+	userID, _ := c.Get("user_id").(int)
+	var req models.SaveReportTemplateRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	tpl, err := h.service.CreateReportTemplate(c.Request().Context(), userID, req)
+	if err != nil {
+		return templateHTTPError(err)
+	}
+	return RespondCreated(c, tpl)
+}
+
+// UpdateTemplate godoc
+// @Summary      Обновить личный шаблон отчёта
+// @Tags         statistics
+// @Accept       json
+// @Produce      json
+// @Param        id path int true "ID шаблона"
+// @Param        body body models.SaveReportTemplateRequest true "Шаблон"
+// @Success      200 {object} models.ReportTemplate
+// @Security     BearerAuth
+// @Router       /statistics/templates/{id} [put]
+func (h *StatisticsHandler) UpdateTemplate(c echo.Context) error {
+	userID, _ := c.Get("user_id").(int)
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	var req models.SaveReportTemplateRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	tpl, err := h.service.UpdateReportTemplate(c.Request().Context(), userID, id, req)
+	if err != nil {
+		return templateHTTPError(err)
+	}
+	return RespondSuccess(c, tpl)
+}
+
+// DeleteTemplate godoc
+// @Summary      Удалить личный шаблон отчёта
+// @Tags         statistics
+// @Produce      json
+// @Param        id path int true "ID шаблона"
+// @Success      200 {object} map[string]interface{}
+// @Security     BearerAuth
+// @Router       /statistics/templates/{id} [delete]
+func (h *StatisticsHandler) DeleteTemplate(c echo.Context) error {
+	userID, _ := c.Get("user_id").(int)
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
+	}
+	if err := h.service.DeleteReportTemplate(c.Request().Context(), userID, id); err != nil {
+		return templateHTTPError(err)
+	}
+	return RespondMessage(c, "Шаблон удалён")
+}
+
+// templateHTTPError переводит доменные ошибки шаблонов в HTTP-статусы.
+func templateHTTPError(err error) error {
+	switch {
+	case errors.Is(err, services.ErrTemplateNotFound):
+		return echo.NewHTTPError(http.StatusNotFound, "Шаблон не найден")
+	case errors.Is(err, services.ErrTemplateForbidden):
+		return echo.NewHTTPError(http.StatusForbidden, "Нет доступа к шаблону")
+	case errors.Is(err, services.ErrTemplateSystem):
+		return echo.NewHTTPError(http.StatusForbidden, "Системный шаблон нельзя изменить")
+	case errors.Is(err, services.ErrTemplateInvalidConfig):
+		return echo.NewHTTPError(http.StatusBadRequest, "Некорректная конфигурация шаблона")
+	default:
+		return err
+	}
+}

--- a/internal/handlers/report_template_test.go
+++ b/internal/handlers/report_template_test.go
@@ -1,0 +1,154 @@
+package handlers_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"systemburo/internal/database"
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ownedByUser считает личные (не системные) шаблоны, принадлежащие пользователю.
+func ownedByUser(tpls []models.ReportTemplate, userID int) int {
+	n := 0
+	for _, t := range tpls {
+		if !t.IsSystem && t.OwnerUserID != nil && *t.OwnerUserID == userID {
+			n++
+		}
+	}
+	return n
+}
+
+// TestReportTemplates_Scoping: системные пресеты видны всем, личные — только
+// владельцу, расшаренные — всем.
+func TestReportTemplates_Scoping(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	require.NoError(t, database.SeedReportTemplates(db)) // CleanDB чистит report_templates -> пересеваем системные
+
+	svc := services.NewStatisticsService(db)
+	ctx := context.Background()
+	cfg := json.RawMessage(`{"mode":"list","entity":"cars"}`)
+
+	userA := models.User{Username: "tpl_owner_a", TypeID: 1, IsActive: true}
+	require.NoError(t, db.Create(&userA).Error)
+	userB := models.User{Username: "tpl_owner_b", TypeID: 1, IsActive: true}
+	require.NoError(t, db.Create(&userB).Error)
+
+	tplA, err := svc.CreateReportTemplate(ctx, userA.ID, models.SaveReportTemplateRequest{Name: "Личный A", Config: cfg})
+	require.NoError(t, err)
+	assert.False(t, tplA.IsSystem)
+	require.NotNil(t, tplA.OwnerUserID)
+	assert.Equal(t, userA.ID, *tplA.OwnerUserID)
+
+	// A видит системные + свой личный.
+	listA, err := svc.ListReportTemplates(ctx, userA.ID)
+	require.NoError(t, err)
+	systemCount := 0
+	hasWeekly := false
+	for _, tpl := range listA {
+		if tpl.IsSystem {
+			systemCount++
+			if tpl.Name == "Сводка за неделю" {
+				hasWeekly = true
+			}
+		}
+	}
+	assert.GreaterOrEqual(t, systemCount, 5, "не менее 5 системных пресетов засеяно")
+	assert.True(t, hasWeekly, "сидирован пресет 'Сводка за неделю'")
+	assert.Equal(t, 1, ownedByUser(listA, userA.ID))
+
+	// B не видит приватный A.
+	listB, err := svc.ListReportTemplates(ctx, userB.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 0, ownedByUser(listB, userA.ID), "B не видит приватный шаблон A")
+
+	// A расшаривает -> B видит.
+	shared := true
+	_, err = svc.UpdateReportTemplate(ctx, userA.ID, tplA.ID, models.SaveReportTemplateRequest{Name: "Личный A", Config: cfg, IsShared: &shared})
+	require.NoError(t, err)
+	listB2, err := svc.ListReportTemplates(ctx, userB.ID)
+	require.NoError(t, err)
+	found := false
+	for _, tpl := range listB2 {
+		if tpl.ID == tplA.ID {
+			found = true
+		}
+	}
+	assert.True(t, found, "B видит расшаренный шаблон A")
+}
+
+// TestReportTemplates_Protection: системные и чужие шаблоны защищены от правки и
+// удаления; конфиг валидируется.
+func TestReportTemplates_Protection(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	require.NoError(t, database.SeedReportTemplates(db)) // CleanDB чистит report_templates -> пересеваем системные
+
+	svc := services.NewStatisticsService(db)
+	ctx := context.Background()
+	cfg := json.RawMessage(`{"mode":"list","entity":"cars"}`)
+
+	userA := models.User{Username: "tpl_prot_a", TypeID: 1, IsActive: true}
+	require.NoError(t, db.Create(&userA).Error)
+	userB := models.User{Username: "tpl_prot_b", TypeID: 1, IsActive: true}
+	require.NoError(t, db.Create(&userB).Error)
+
+	tplA, err := svc.CreateReportTemplate(ctx, userA.ID, models.SaveReportTemplateRequest{Name: "Защита A", Config: cfg})
+	require.NoError(t, err)
+
+	// Чужой не может править/удалять.
+	_, err = svc.UpdateReportTemplate(ctx, userB.ID, tplA.ID, models.SaveReportTemplateRequest{Name: "Взлом", Config: cfg})
+	assert.ErrorIs(t, err, services.ErrTemplateForbidden)
+	assert.ErrorIs(t, svc.DeleteReportTemplate(ctx, userB.ID, tplA.ID), services.ErrTemplateForbidden)
+
+	// Системный пресет защищён.
+	var sysTpl models.ReportTemplate
+	require.NoError(t, db.Where("is_system = ?", true).First(&sysTpl).Error)
+	_, err = svc.UpdateReportTemplate(ctx, userA.ID, sysTpl.ID, models.SaveReportTemplateRequest{Name: "Подмена", Config: cfg})
+	assert.ErrorIs(t, err, services.ErrTemplateSystem)
+	assert.ErrorIs(t, svc.DeleteReportTemplate(ctx, userA.ID, sysTpl.ID), services.ErrTemplateSystem)
+
+	// Несуществующий.
+	_, err = svc.UpdateReportTemplate(ctx, userA.ID, 999999, models.SaveReportTemplateRequest{Name: "Нет", Config: cfg})
+	assert.ErrorIs(t, err, services.ErrTemplateNotFound)
+
+	// Пустой/невалидный конфиг.
+	_, err = svc.CreateReportTemplate(ctx, userA.ID, models.SaveReportTemplateRequest{Name: "Битый", Config: json.RawMessage(`{не json`)})
+	assert.ErrorIs(t, err, services.ErrTemplateInvalidConfig)
+	_, err = svc.CreateReportTemplate(ctx, userA.ID, models.SaveReportTemplateRequest{Name: "Пустой", Config: nil})
+	assert.ErrorIs(t, err, services.ErrTemplateInvalidConfig)
+	// JSON-null валиден для json.Valid, но не объект -> тоже отклоняем.
+	_, err = svc.CreateReportTemplate(ctx, userA.ID, models.SaveReportTemplateRequest{Name: "Налл", Config: json.RawMessage("null")})
+	assert.ErrorIs(t, err, services.ErrTemplateInvalidConfig)
+
+	// Владелец может удалить свой.
+	require.NoError(t, svc.DeleteReportTemplate(ctx, userA.ID, tplA.ID))
+	_, err = svc.UpdateReportTemplate(ctx, userA.ID, tplA.ID, models.SaveReportTemplateRequest{Name: "После удаления", Config: cfg})
+	assert.ErrorIs(t, err, services.ErrTemplateNotFound)
+}
+
+// TestSeedReportTemplates_Idempotent: повторный сид не дублирует системные пресеты.
+func TestSeedReportTemplates_Idempotent(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	require.NoError(t, database.SeedReportTemplates(db))
+	var first int64
+	require.NoError(t, db.Model(&models.ReportTemplate{}).Where("is_system = ?", true).Count(&first).Error)
+	assert.Equal(t, int64(5), first, "5 системных пресетов после первого сида")
+
+	require.NoError(t, database.SeedReportTemplates(db))
+	var second int64
+	require.NoError(t, db.Model(&models.ReportTemplate{}).Where("is_system = ?", true).Count(&second).Error)
+	assert.Equal(t, int64(5), second, "повторный сид не дублирует")
+}

--- a/internal/models/report_template.go
+++ b/internal/models/report_template.go
@@ -1,0 +1,35 @@
+package models
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// ReportTemplate — сохранённый набор параметров конструктора отчётов (#632).
+// Config — непрозрачный для бэка снимок состояния гида (mode/metrics/dimension/
+// filters/period preset); сервер его не интерпретирует, только хранит и отдаёт.
+// Системные пресеты (IsSystem) сидируются и защищены от правки/удаления. Личные
+// привязаны к OwnerUserID; IsShared делает личный шаблон видимым всем.
+type ReportTemplate struct {
+	ID          int             `json:"id"`
+	Name        string          `gorm:"size:200;index" json:"name"`
+	Description string          `gorm:"type:text" json:"description,omitempty"`
+	Config      json.RawMessage `gorm:"type:jsonb" json:"config" swaggerignore:"true"`
+	IsSystem    bool            `gorm:"default:false;index" json:"is_system"`
+	IsShared    bool            `gorm:"default:false" json:"is_shared"`
+	OwnerUserID *int            `gorm:"index" json:"owner_user_id,omitempty"`
+	// Owner с FK OnDelete:CASCADE — личные шаблоны уходят вместе с пользователем,
+	// чтобы не оставлять осиротевшие записи. Системные пресеты имеют OwnerUserID=nil.
+	Owner     *User     `gorm:"foreignKey:OwnerUserID;constraint:OnDelete:CASCADE" json:"-"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// SaveReportTemplateRequest — тело создания/обновления личного шаблона. Config
+// валидируется на непустой JSON в сервисе (validator не умеет json.RawMessage).
+type SaveReportTemplateRequest struct {
+	Name        string          `json:"name" validate:"required,min=1,max=200"`
+	Description string          `json:"description" validate:"max=1000"`
+	Config      json.RawMessage `json:"config" swaggerignore:"true"`
+	IsShared    *bool           `json:"is_shared"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -590,5 +590,9 @@ func Setup(e *echo.Echo, d Dependencies) {
 		statsGroup.GET("/recent-passages", statistics.GetRecentPassages, requireStats)
 		statsGroup.GET("/metrics", statistics.GetMetrics, requireStats)
 		statsGroup.POST("/report", statistics.RunReport, requireStats)
+		statsGroup.GET("/templates", statistics.ListTemplates, requireStats)
+		statsGroup.POST("/templates", statistics.CreateTemplate, requireStats)
+		statsGroup.PUT("/templates/:id", statistics.UpdateTemplate, requireStats)
+		statsGroup.DELETE("/templates/:id", statistics.DeleteTemplate, requireStats)
 	}
 }

--- a/internal/services/report_template_service.go
+++ b/internal/services/report_template_service.go
@@ -1,0 +1,122 @@
+package services
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"systemburo/internal/models"
+
+	"gorm.io/gorm"
+)
+
+// validTemplateConfig — config должен быть непустым JSON-объектом (снимок формы
+// конструктора). json.Valid пропускает скаляры (`null`, числа, строки), поэтому
+// дополнительно требуем ведущую `{` — иначе фронт получит не-объект и сломает гид.
+func validTemplateConfig(c json.RawMessage) bool {
+	t := bytes.TrimSpace(c)
+	return len(t) > 0 && json.Valid(t) && t[0] == '{'
+}
+
+// Ошибки управления шаблонами отчётов (#632).
+var (
+	// ErrTemplateNotFound — шаблон не существует.
+	ErrTemplateNotFound = errors.New("report template not found")
+	// ErrTemplateForbidden — шаблон принадлежит другому пользователю.
+	ErrTemplateForbidden = errors.New("report template belongs to another user")
+	// ErrTemplateSystem — системный пресет нельзя менять или удалять.
+	ErrTemplateSystem = errors.New("system report template is read-only")
+	// ErrTemplateInvalidConfig — пустой или невалидный JSON конфигурации.
+	ErrTemplateInvalidConfig = errors.New("report template config must be valid non-empty JSON")
+)
+
+// ListReportTemplates возвращает доступные пользователю шаблоны: системные пресеты,
+// собственные личные и расшаренные чужие. Системные идут первыми, затем по имени.
+// owner_user_id расшаренных чужих шаблонов отдаётся намеренно — фронт по нему
+// понимает, что шаблон не свой (только применить, без правки/удаления).
+func (s *statisticsService) ListReportTemplates(ctx context.Context, userID int) ([]models.ReportTemplate, error) {
+	var templates []models.ReportTemplate
+	err := s.db.WithContext(ctx).
+		Where("is_system = ? OR owner_user_id = ? OR is_shared = ?", true, userID, true).
+		Order("is_system DESC, name ASC").
+		Find(&templates).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to list report templates: %w", err)
+	}
+	return templates, nil
+}
+
+// CreateReportTemplate сохраняет личный шаблон текущего пользователя.
+func (s *statisticsService) CreateReportTemplate(ctx context.Context, userID int, req models.SaveReportTemplateRequest) (*models.ReportTemplate, error) {
+	if !validTemplateConfig(req.Config) {
+		return nil, ErrTemplateInvalidConfig
+	}
+	tpl := models.ReportTemplate{
+		Name:        req.Name,
+		Description: req.Description,
+		Config:      req.Config,
+		IsShared:    req.IsShared != nil && *req.IsShared,
+		OwnerUserID: &userID,
+	}
+	if err := s.db.WithContext(ctx).Create(&tpl).Error; err != nil {
+		return nil, fmt.Errorf("failed to create report template: %w", err)
+	}
+	return &tpl, nil
+}
+
+// UpdateReportTemplate обновляет личный шаблон владельца. Системные пресеты и чужие
+// шаблоны защищены.
+func (s *statisticsService) UpdateReportTemplate(ctx context.Context, userID, id int, req models.SaveReportTemplateRequest) (*models.ReportTemplate, error) {
+	if !validTemplateConfig(req.Config) {
+		return nil, ErrTemplateInvalidConfig
+	}
+	tpl, err := s.loadOwnedTemplate(ctx, userID, id)
+	if err != nil {
+		return nil, err
+	}
+	tpl.Name = req.Name
+	tpl.Description = req.Description
+	tpl.Config = req.Config
+	if req.IsShared != nil {
+		tpl.IsShared = *req.IsShared
+	}
+	if err := s.db.WithContext(ctx).Save(tpl).Error; err != nil {
+		return nil, fmt.Errorf("failed to update report template: %w", err)
+	}
+	return tpl, nil
+}
+
+// DeleteReportTemplate удаляет личный шаблон владельца. Системные пресеты и чужие
+// шаблоны защищены.
+func (s *statisticsService) DeleteReportTemplate(ctx context.Context, userID, id int) error {
+	tpl, err := s.loadOwnedTemplate(ctx, userID, id)
+	if err != nil {
+		return err
+	}
+	if err := s.db.WithContext(ctx).Delete(tpl).Error; err != nil {
+		return fmt.Errorf("failed to delete report template: %w", err)
+	}
+	return nil
+}
+
+// loadOwnedTemplate загружает шаблон и проверяет, что текущий пользователь вправе
+// его менять: существует, не системный, принадлежит ему.
+func (s *statisticsService) loadOwnedTemplate(ctx context.Context, userID, id int) (*models.ReportTemplate, error) {
+	var tpl models.ReportTemplate
+	err := s.db.WithContext(ctx).First(&tpl, id).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, ErrTemplateNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to load report template: %w", err)
+	}
+	if tpl.IsSystem {
+		return nil, ErrTemplateSystem
+	}
+	if tpl.OwnerUserID == nil || *tpl.OwnerUserID != userID {
+		return nil, ErrTemplateForbidden
+	}
+	return &tpl, nil
+}

--- a/internal/services/statistics_service.go
+++ b/internal/services/statistics_service.go
@@ -18,6 +18,11 @@ type StatisticsService interface {
 	GetReportCatalog(ctx context.Context) (*models.ReportCatalog, error)
 	RunReport(ctx context.Context, req models.ReportRequest) (*models.ReportResponse, error)
 	RunReportList(ctx context.Context, req models.ReportRequest) (*models.ReportListResponse, error)
+
+	ListReportTemplates(ctx context.Context, userID int) ([]models.ReportTemplate, error)
+	CreateReportTemplate(ctx context.Context, userID int, req models.SaveReportTemplateRequest) (*models.ReportTemplate, error)
+	UpdateReportTemplate(ctx context.Context, userID, id int, req models.SaveReportTemplateRequest) (*models.ReportTemplate, error)
+	DeleteReportTemplate(ctx context.Context, userID, id int) error
 }
 
 type statisticsService struct {

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -36,6 +36,7 @@ const (
 // tables lists all tables in FK-safe deletion order (dependents first).
 var tables = []string{
 	"system_settings",
+	"report_templates",
 	"pd_audit_logs", "pd_consents",
 	"access_denials", "access_denial_archives",
 	"user_permission_overrides", "user_groups", "permission_group_grants",


### PR DESCRIPTION
## Что

Срез G1 эпика #632 — backend шаблонов конструктора отчётов.

- **Модель `ReportTemplate`** (`report_templates`): Config (jsonb, непрозрачный снимок гида), IsSystem, IsShared, OwnerUserID (+FK на users, `OnDelete:CASCADE`).
- **CRUD-сервис**: List (системные + свои + расшаренные), Create (личный), Update/Delete (только владелец, не системный). Права проверяет `loadOwnedTemplate` — чужой/системный защищены (IDOR закрыт). Доменные ошибки → HTTP-статусы.
- **Роуты** под `page.statistics`: `GET/POST /statistics/templates`, `PUT/DELETE /statistics/templates/:id`.
- **Сид 5 системных пресетов** (Сводка за неделю, Проведение работ, Машины по местам, Самые популярные места, Проходы людей) — идемпотентный.

## migrate.go (off-limits) — строго аддитивно

Diff содержит **только добавления** (0 удалённых строк): новая таблица в AllModels + FK на новую таблицу + идемпотентный сид через Count. **Никаких ALTER/DROP/изменения существующих таблиц.** AutoMigrate новой таблицы безопасен на заполненной БД. Тесты реально прогоняют AutoMigrate на чистой БД (зелёные).

## По ревью (code-reviewer, было NO-GO — оба блокера закрыты)

- 🔴 Изоляция тестов: `report_templates` добавлен в `CleanDB`, системные пресеты пересеваются явным `SeedReportTemplates` (экспортирован); добавлен тест идемпотентности сида.
- 🔴 Валидация config: `validTemplateConfig` требует JSON-**объект** (json.Valid пропускал `null`/скаляры) — тест на null.
- 🟡 FK `OnDelete:CASCADE` на owner (не осиротевшие шаблоны); комментарии про Count vs unique и про owner_user_id в shared.

## Проверка

- Go: build + vet + gofmt чисто. Тесты scoping/protection/idempotent — зелёные (реальный GORM-путь, проверяют права и данные).
- Зависимый срез: G2 (FE-панель шаблонов) разблокирован.