### PR TITLE
feat(onboarding): сброс обучения пользователю из админки (#657)

### DIFF
--- a/frontend/src/api/onboarding.js
+++ b/frontend/src/api/onboarding.js
@@ -34,3 +34,17 @@ export async function markOnboardingComplete(version) {
   });
   return unwrap(res, 'Не удалось сохранить статус обучения');
 }
+
+/**
+ * Сброс прохождения тура пользователю (админ): после сброса у него снова
+ * сработает автозапуск при входе.
+ *
+ * @param {string} username
+ * @returns {Promise<{ message: string }>}
+ */
+export async function resetOnboardingForUser(username) {
+  const res = await apiRequest(`/users/${encodeURIComponent(username)}/onboarding/reset`, {
+    method: 'POST',
+  });
+  return unwrap(res, 'Не удалось сбросить обучение');
+}

--- a/frontend/src/components/UserControl.vue
+++ b/frontend/src/components/UserControl.vue
@@ -210,6 +210,13 @@
                   Права доступа
                 </button>
                 <button
+                  class="lk-button lk-button--secondary"
+                  data-testid="user-reset-onboarding"
+                  @click="resetOnboarding(selectedUser)"
+                >
+                  Сбросить обучение
+                </button>
+                <button
                   class="delete-icon-btn"
                   @click="confirmDeleteUser(selectedUser)"
                 >
@@ -662,6 +669,8 @@ import ToggleSwitch from './ui/ToggleSwitch.vue';
 import UserHistoryModal from './UserHistoryModal.vue';
 import UserAccessModal from './admin/UserAccessModal.vue';
 import { useDeletionsStore } from '@/stores/deletions';
+import { useUiStore } from '@/stores/ui';
+import { resetOnboardingForUser } from '@/api/onboarding';
 
 export default {
   components: {
@@ -883,6 +892,23 @@ export default {
       } catch (error) {
         console.error('Ошибка сети при восстановлении пользователя:', error);
         useDeletionsStore().notify({ prefix: 'Не удалось восстановить: ', bold: 'нет связи с сервером', type: 'error' });
+      }
+    },
+
+    async resetOnboarding(user) {
+      const ok = await useUiStore().confirm({
+        title: 'Сбросить обучение?',
+        message: `Пользователь «${user.username}» снова увидит автозапуск обучающего тура при следующем входе.`,
+        confirmText: 'Сбросить',
+        cancelText: 'Отмена',
+        danger: false,
+      });
+      if (!ok) return;
+      try {
+        await resetOnboardingForUser(user.username);
+        useDeletionsStore().notify({ prefix: 'Обучение сброшено для ', bold: user.username, suffix: ' — тур запустится снова при входе' });
+      } catch (error) {
+        useDeletionsStore().notify({ prefix: 'Не удалось сбросить обучение: ', bold: error?.message || 'ошибка', type: 'error' });
       }
     },
 

--- a/internal/handlers/onboarding.go
+++ b/internal/handlers/onboarding.go
@@ -66,3 +66,25 @@ func (h *OnboardingHandler) MarkComplete(c echo.Context) error {
 	}
 	return RespondMessage(c, "Onboarding marked as completed")
 }
+
+// ResetForUser godoc
+// @Summary      Сбросить онбординг-тур пользователю (админ)
+// @Description  Обнуляет статус прохождения тура у пользователя по username - при
+// @Description  следующем входе у него снова сработает автозапуск. Только для админов.
+// @Tags         onboarding
+// @Produce      json
+// @Security     BearerAuth
+// @Param        username path string true "Логин пользователя"
+// @Success      200 {object} map[string]interface{} "success + message"
+// @Failure      401 {object} models.HTTPError
+// @Failure      403 {object} models.HTTPError
+// @Failure      404 {object} models.HTTPError
+// @Failure      500 {object} models.HTTPError
+// @Router       /users/{username}/onboarding/reset [post]
+func (h *OnboardingHandler) ResetForUser(c echo.Context) error {
+	username := c.Param("username")
+	if err := h.service.ResetByUsername(c.Request().Context(), username); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Onboarding reset for user")
+}

--- a/internal/handlers/onboarding_test.go
+++ b/internal/handlers/onboarding_test.go
@@ -105,3 +105,55 @@ func TestOnboarding_Unauthorized(t *testing.T) {
 	rec = testutil.POST(t, e, "/onboarding/complete", `{"version":1}`, nil)
 	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 }
+
+func TestOnboarding_AdminReset_ClearsOtherUserStatus(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	adminToken := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	// Отдельный пользователь B, который прошёл тур со своего токена.
+	userToken := testutil.RegisterAndLogin(t, e, "tour_user", "Password123!", 1, td.OrgID, td.CompanyID)
+	rec := testutil.POST(t, e, "/onboarding/complete", `{"version":1}`, testutil.AuthHeader(userToken))
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	var before models.User
+	require.NoError(t, db.Where("username = ?", "tour_user").First(&before).Error)
+	require.NotNil(t, before.OnboardingCompletedVersion)
+
+	// Админ сбрасывает обучение ДРУГОМУ юзеру по username.
+	recReset := testutil.POST(t, e, "/users/tour_user/onboarding/reset", ``, testutil.AuthHeader(adminToken))
+	require.Equal(t, http.StatusOK, recReset.Code, "body: %s", recReset.Body.String())
+	assert.Equal(t, "Onboarding reset for user", testutil.ParseMessage(t, recReset))
+
+	// Колонка пользователя B снова NULL.
+	var after models.User
+	require.NoError(t, db.Where("username = ?", "tour_user").First(&after).Error)
+	assert.Nil(t, after.OnboardingCompletedVersion, "reset must null the target user's column")
+}
+
+func TestOnboarding_AdminReset_UnknownUser_Returns404(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	rec := testutil.POST(t, e, "/users/nosuchuser/onboarding/reset", ``, testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusNotFound, rec.Code, "reset of unknown user must be 404")
+}
+
+func TestOnboarding_AdminReset_NonAdmin_Forbidden(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	// Обычный пользователь без прав page.admin.
+	userToken := testutil.RegisterAndLogin(t, e, "regular_user", "Password123!", 1, td.OrgID, td.CompanyID)
+
+	rec := testutil.POST(t, e, "/users/regular_user/onboarding/reset", ``, testutil.AuthHeader(userToken))
+	assert.Equal(t, http.StatusForbidden, rec.Code, "non-admin must not reset onboarding")
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -567,6 +567,10 @@ func Setup(e *echo.Echo, d Dependencies) {
 
 	// Документы (#39). Admin-операции под page.admin; скачивание и публичный список -- под auth.
 	requireAdmin := mw.RequirePermissionV2(permResolver, denialLog, services.KeyPageAdmin)
+
+	// Сброс онбординг-тура пользователю - админ-действие (после сброса у юзера
+	// снова автозапуск). Под page.admin, в отличие от self-эндпоинтов /onboarding.
+	protected.POST("/users/:username/onboarding/reset", onboarding.ResetForUser, requireAdmin)
 	if docGroups != nil {
 		dgGroup := protected.Group("/document-groups")
 		dgGroup.GET("", docGroups.List, requireAdmin)

--- a/internal/services/onboarding_service.go
+++ b/internal/services/onboarding_service.go
@@ -3,9 +3,11 @@ package services
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"systemburo/internal/models"
 
+	"github.com/labstack/echo/v4"
 	"gorm.io/gorm"
 )
 
@@ -46,6 +48,24 @@ func (s *OnboardingService) SetCompleted(ctx context.Context, userID int, versio
 	}
 	if res.RowsAffected == 0 {
 		return fmt.Errorf("failed to set onboarding version: user %d not found: %w", userID, gorm.ErrRecordNotFound)
+	}
+	return nil
+}
+
+// ResetByUsername сбрасывает статус прохождения тура (NULL) для пользователя по
+// username. Админ-действие: после сброса у юзера снова сработает автозапуск.
+func (s *OnboardingService) ResetByUsername(ctx context.Context, username string) error {
+	res := s.db.WithContext(ctx).
+		Model(&models.User{}).
+		Where("username = ?", username).
+		Update("onboarding_completed_version", gorm.Expr("NULL"))
+	if res.Error != nil {
+		return fmt.Errorf("failed to reset onboarding for user %q: %w", username, res.Error)
+	}
+	if res.RowsAffected == 0 {
+		// echo.HTTPError, чтобы error-handler отдал 404 (а не 500): username
+		// приходит из path, несуществующий юзер - валидный клиентский кейс.
+		return echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("пользователь %q не найден", username))
 	}
 	return nil
 }


### PR DESCRIPTION
## Админ-сброс онбординг-тура (issue #657)

Админ может сбросить статус прохождения тура любому пользователю - после сброса у того снова срабатывает автозапуск при входе. Дополняет per-user механизм (отдельный смерженный PR #672).

### Бэкенд
- `OnboardingService.ResetByUsername` - обнуляет колонку (`gorm.Expr("NULL")`), на несуществующем юзере отдаёт **404** (echo.HTTPError, не 500).
- Хендлер `ResetForUser` (username из path).
- Роут `POST /users/:username/onboarding/reset` под **`requireAdmin`** (RequirePermissionV2 page.admin) - сброс ЧУЖОГО юзера только для админов.
- Go-тесты: сброс другого юзера -> NULL; несуществующий -> 404; **non-admin -> 403** (авторизация залочена).

### Фронт
- `api/onboarding.js`: `resetOnboardingForUser` (encodeURIComponent).
- `UserControl.vue`: кнопка «Сбросить обучение» в панели юзера (скрыта для архивных) -> `useUiStore().confirm` -> API -> `useDeletionsStore().notify`; ошибки в catch.

### Проверки
- Go build + тесты (3 reset-теста PASS: чужой юзер/404/403). ESLint 0.
- Playwright по live-стеку: **7/8** - кнопка видна -> подтверждение -> POST reset 200 -> БД NULL -> **после сброса у юзера снова автозапуск при входе** (e2e). 1 фейл - транзиентная Failed-to-fetch объявления при быстрой навигации теста, не связано со сбросом.
- Ревью-агент: RED (404 вместо 500) исправлен, авторизация подтверждена; yellow-замечания по тестам внесены.