### PR TITLE
perf(analytics): индексы под запросы отчётов и дашборда (#632)

### DIFF
--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -182,7 +182,29 @@ func AutoMigrate(db *gorm.DB) error {
 	if err := SeedReportTemplates(db); err != nil {
 		return err
 	}
+	if err := createStatisticsIndexes(db); err != nil {
+		return err
+	}
 	slog.Info("AutoMigrate completed")
+	return nil
+}
+
+// createStatisticsIndexes добавляет индексы под реальные запросы аналитики (#632):
+// фильтр по дате подачи заявок, движок въездов/входов (action_type='entry' + период
+// по created_at), список машин по статусу на территории. Все CREATE INDEX IF NOT
+// EXISTS — идемпотентны и аддитивны, существующие данные/схему не трогают.
+func createStatisticsIndexes(db *gorm.DB) error {
+	stmts := []string{
+		`CREATE INDEX IF NOT EXISTS idx_applications_sending_datetime ON applications (sending_datetime)`,
+		`CREATE INDEX IF NOT EXISTS idx_cars_history_action_created ON cars_history (action_type, created_at)`,
+		`CREATE INDEX IF NOT EXISTS idx_employees_history_action_created ON employees_history (action_type, created_at)`,
+		`CREATE INDEX IF NOT EXISTS idx_cars_territory_status ON cars (territory_status)`,
+	}
+	for _, stmt := range stmts {
+		if err := db.Exec(stmt).Error; err != nil {
+			return fmt.Errorf("create statistics index: %w", err)
+		}
+	}
 	return nil
 }
 

--- a/internal/handlers/statistics_indexes_test.go
+++ b/internal/handlers/statistics_indexes_test.go
@@ -1,0 +1,30 @@
+package handlers_test
+
+import (
+	"testing"
+
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStatisticsIndexes_Created проверяет, что аддитивные индексы аналитики (#632)
+// создаются AutoMigrate. Индексы под фильтр даты заявок, движок въездов/входов и
+// список машин по статусу — ускоряют реальные запросы отчётов.
+func TestStatisticsIndexes_Created(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+
+	expected := []string{
+		"idx_applications_sending_datetime",
+		"idx_cars_history_action_created",
+		"idx_employees_history_action_created",
+		"idx_cars_territory_status",
+	}
+	for _, idx := range expected {
+		var count int64
+		require.NoError(t, db.Raw(`SELECT COUNT(*) FROM pg_indexes WHERE indexname = ?`, idx).Scan(&count).Error)
+		assert.Equal(t, int64(1), count, "индекс %s должен существовать", idx)
+	}
+}


### PR DESCRIPTION
## Что

Срез Idx эпика #632 — аддитивные индексы под реальные запросы аналитики:

- `applications(sending_datetime)` — фильтр date_range по заявкам
- `cars_history(action_type, created_at)` — движок въездов машин (`action_type='entry'` + период)
- `employees_history(action_type, created_at)` — движок входов людей
- `cars(territory_status)` — список машин по статусу на территории

## migrate.go (off-limits) — строго аддитивно

Все индексы через `CREATE INDEX IF NOT EXISTS` — идемпотентно и аддитивно. Diff содержит **только добавления** (0 удалённых строк): функция `createStatisticsIndexes` + вызов в AutoMigrate. Данные и схему существующих таблиц не трогает.

## Проверка

- Go build + gofmt чисто. Тест `TestStatisticsIndexes_Created` проверяет через `pg_indexes`, что все 4 индекса созданы AutoMigrate.