### PR TITLE
feat(analytics): панель личных шаблонов отчётов (#632)

### DIFF
--- a/frontend/src/api/statistics.js
+++ b/frontend/src/api/statistics.js
@@ -101,3 +101,53 @@ export async function runReport(request) {
   if (!res.ok) throw new Error(data?.message || 'Не удалось построить отчёт');
   return data;
 }
+
+/**
+ * @typedef {object} ReportTemplate
+ * @property {number} id
+ * @property {string} name
+ * @property {string} [description]
+ * @property {object} config   снимок состояния конструктора
+ * @property {boolean} is_system
+ * @property {boolean} is_shared
+ * @property {number} [owner_user_id]
+ */
+
+/**
+ * Список доступных шаблонов отчётов: системные пресеты + личные + расшаренные.
+ * @returns {Promise<ReportTemplate[]>}
+ */
+export async function getReportTemplates() {
+  const res = await apiRequest('/statistics/templates');
+  const data = await res.json();
+  if (!res.ok) throw new Error(data?.message || 'Не удалось загрузить шаблоны');
+  return data;
+}
+
+/**
+ * Сохранить личный шаблон отчёта.
+ * @param {{ name: string, description?: string, config: object, is_shared?: boolean }} payload
+ * @returns {Promise<ReportTemplate>}
+ */
+export async function saveReportTemplate(payload) {
+  const res = await apiRequest('/statistics/templates', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  const data = await res.json();
+  if (!res.ok) throw new Error(data?.message || 'Не удалось сохранить шаблон');
+  return data;
+}
+
+/**
+ * Удалить личный шаблон отчёта.
+ * @param {number} id
+ * @returns {Promise<void>}
+ */
+export async function deleteReportTemplate(id) {
+  const res = await apiRequest(`/statistics/templates/${id}`, { method: 'DELETE' });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(data?.message || 'Не удалось удалить шаблон');
+  }
+}

--- a/frontend/src/components/statistics/ReportBuilder.vue
+++ b/frontend/src/components/statistics/ReportBuilder.vue
@@ -429,8 +429,9 @@ const resultHint = computed(() => {
     : 'Результат: таблица строк.';
 });
 
-// Применить пресет из галереи и сразу построить отчёт. Разрез сверяется watch'ем
-// availableDimensions (пресеты используют валидные ключи каталога).
+// Применить пресет/шаблон и сразу построить отчёт. Галерея-пресеты несут только
+// метрику/разрез; шаблоны (G2) дополнительно несут filters/period/period_preset.
+// Разрез сверяется watch'ем availableDimensions (ключи каталога валидны).
 watch(() => props.preset, (p) => {
   if (!p) return;
   form.mode = p.mode || 'aggregate';
@@ -441,9 +442,23 @@ watch(() => props.preset, (p) => {
     form.dimension = p.dimension || '';
     form.granularity = p.granularity || 'day';
   }
-  // Пресеты не несут значений фильтров; watch entity их и так обнулит.
-  form.filters = {};
-  nextTick(run);
+  // Период — синхронно (watch'и его не сбрасывают). Именованный пресет (неделя/
+  // месяц/год/весь) пересчитываем на текущую дату; «custom»/произвольный — берём
+  // явные даты шаблона, иначе computePeriod стёр бы их.
+  const namedPreset = ['week', 'month', 'year', 'all'].includes(p.period_preset);
+  if (namedPreset) {
+    applyPeriodPreset(p.period_preset);
+  } else if (p.period) {
+    form.period.from = p.period.from || '';
+    form.period.to = p.period.to || '';
+    activePeriodPreset.value = 'custom';
+  }
+  // Фильтры применяем в nextTick: watch entity/metrics успевает синхронно сбросить
+  // form.filters, иначе он затёр бы значения шаблона. Затем строим отчёт.
+  nextTick(() => {
+    form.filters = p.filters ? { ...p.filters } : {};
+    nextTick(run);
+  });
 });
 
 function isMetricOn(key) {
@@ -502,6 +517,21 @@ function applyPeriodPreset(kind) {
 const filterCount = computed(
   () => Object.values(form.filters).reduce((n, vals) => n + (vals?.length || 0), 0),
 );
+
+// Полный снимок состояния гида для сохранения в шаблон. Тот же формат принимает
+// preset-watch при применении шаблона. period_preset сохраняем, чтобы при
+// восстановлении подсветить ту же кнопку периода. Бэк хранит config как непрозрачный.
+const reportConfig = computed(() => ({
+  mode: form.mode,
+  metrics: [...form.metrics],
+  dimension: form.dimension,
+  granularity: form.granularity,
+  entity: form.entity,
+  filters: { ...form.filters },
+  period: { from: form.period.from, to: form.period.to },
+  period_preset: activePeriodPreset.value,
+}));
+
 watch(
   () => ({
     mode: form.mode,
@@ -511,6 +541,7 @@ watch(
     filterCount: filterCount.value,
     periodApplicable: periodApplicable.value,
     periodFilled: Boolean(form.period.from && form.period.to),
+    config: reportConfig.value,
   }),
   (snapshot) => emit('change', snapshot),
   { immediate: true, deep: true },

--- a/frontend/src/components/statistics/ReportsTab.vue
+++ b/frontend/src/components/statistics/ReportsTab.vue
@@ -33,9 +33,90 @@
           <h3 class="col-heading col-heading--mt">
             Мои шаблоны
           </h3>
-          <div class="template-placeholder">
-            Сохранённые наборы появятся здесь. Соберите отчёт в мастере и сохраните его как шаблон.
+
+          <!-- Сохранить текущий набор как шаблон -->
+          <div
+            v-if="savingMode"
+            class="tpl-save-form"
+          >
+            <input
+              v-model="newTemplateName"
+              class="lk-input"
+              placeholder="Название шаблона"
+              maxlength="200"
+              @keyup.enter="confirmSaveTemplate"
+            >
+            <div class="tpl-save-actions">
+              <button
+                type="button"
+                class="lk-button lk-button--primary"
+                :disabled="!newTemplateName.trim() || savingTemplate"
+                @click="confirmSaveTemplate"
+              >
+                {{ savingTemplate ? 'Сохраняем…' : 'Сохранить' }}
+              </button>
+              <button
+                type="button"
+                class="lk-button lk-button--ghost"
+                @click="savingMode = false"
+              >
+                Отмена
+              </button>
+            </div>
           </div>
+          <button
+            v-else
+            type="button"
+            class="lk-button lk-button--ghost tpl-save-btn"
+            :disabled="!canSaveTemplate"
+            @click="startSaveTemplate"
+          >
+            + Сохранить текущий
+          </button>
+
+          <div
+            v-if="templatesLoading"
+            class="template-placeholder"
+          >
+            Загрузка шаблонов…
+          </div>
+          <div
+            v-else-if="!myTemplates.length"
+            class="template-placeholder"
+          >
+            Сохранённых наборов пока нет. Соберите отчёт в мастере и нажмите «Сохранить текущий».
+          </div>
+          <ul
+            v-else
+            class="tpl-list"
+          >
+            <li
+              v-for="tpl in myTemplates"
+              :key="tpl.id"
+              class="tpl-item"
+            >
+              <button
+                type="button"
+                class="tpl-apply"
+                @click="applyTemplate(tpl)"
+              >
+                <span class="tpl-name">{{ tpl.name }}</span>
+                <span
+                  v-if="tpl.description"
+                  class="tpl-desc"
+                >{{ tpl.description }}</span>
+              </button>
+              <button
+                type="button"
+                class="tpl-del"
+                :title="`Удалить шаблон ${tpl.name}`"
+                :aria-label="`Удалить шаблон ${tpl.name}`"
+                @click="removeTemplate(tpl)"
+              >
+                ×
+              </button>
+            </li>
+          </ul>
         </aside>
 
         <!-- Мастер -->
@@ -73,8 +154,12 @@ import ReportResult from './ReportResult.vue';
 import ReportGallery from './ReportGallery.vue';
 import ReportStepper from './ReportStepper.vue';
 import LoaderSpinner from '@/components/ui/LoaderSpinner.vue';
-import { getReportCatalog, runReport } from '@/api/statistics';
+import {
+  getReportCatalog, runReport,
+  getReportTemplates, saveReportTemplate, deleteReportTemplate,
+} from '@/api/statistics';
 import { useDeletionsStore } from '@/stores/deletions';
+import { useUiStore } from '@/stores/ui';
 
 const props = defineProps({
   from: { type: String, default: '' },
@@ -99,7 +184,78 @@ const presetPayload = ref(null);
 const activePresetId = ref('');
 
 // Снимок состояния мастера для индикатора шагов.
-const builderState = ref({ mode: 'aggregate', metric: '', dimension: '', entity: '', filterCount: 0, periodApplicable: true, periodFilled: false });
+const builderState = ref({ mode: 'aggregate', metric: '', dimension: '', entity: '', filterCount: 0, periodApplicable: true, periodFilled: false, config: null });
+
+// Личные шаблоны пользователя (G2). Системные пресеты остаются в галерее «Готовые
+// наборы» (reportPresets), здесь — только сохранённые наборы пользователя.
+const myTemplates = ref([]);
+const templatesLoading = ref(true);
+const savingMode = ref(false);
+const savingTemplate = ref(false);
+const newTemplateName = ref('');
+
+const canSaveTemplate = computed(() => {
+  const s = builderState.value;
+  return s.mode === 'list' ? Boolean(s.entity) : Boolean(s.metric);
+});
+
+async function loadTemplates() {
+  templatesLoading.value = true;
+  try {
+    const all = await getReportTemplates();
+    // Только свои личные. Системные пресеты живут в галерее; чужие расшаренные
+    // (is_shared) сюда не берём — прав на их удаление нет, кнопка × дала бы 403.
+    myTemplates.value = (all || []).filter((t) => !t.is_system && !t.is_shared);
+  } catch (e) {
+    useDeletionsStore().notify({ prefix: 'Не удалось ', bold: 'загрузить шаблоны', suffix: e?.message ? `: ${e.message}` : '', type: 'error' });
+  } finally {
+    templatesLoading.value = false;
+  }
+}
+
+function startSaveTemplate() {
+  newTemplateName.value = '';
+  savingMode.value = true;
+}
+
+async function confirmSaveTemplate() {
+  const name = newTemplateName.value.trim();
+  if (!name || !builderState.value.config) return;
+  savingTemplate.value = true;
+  try {
+    await saveReportTemplate({ name, config: builderState.value.config });
+    savingMode.value = false;
+    await loadTemplates();
+    useDeletionsStore().notify({ prefix: 'Шаблон ', bold: name, suffix: ' сохранён', type: 'success' });
+  } catch (e) {
+    useDeletionsStore().notify({ prefix: 'Не удалось ', bold: 'сохранить шаблон', suffix: e?.message ? `: ${e.message}` : '', type: 'error' });
+  } finally {
+    savingTemplate.value = false;
+  }
+}
+
+function applyTemplate(tpl) {
+  activePresetId.value = `tpl-${tpl.id}`;
+  presetPayload.value = { ...tpl.config };
+}
+
+async function removeTemplate(tpl) {
+  const ok = await useUiStore().confirm({
+    title: 'Удалить шаблон?',
+    message: `Шаблон «${tpl.name}» будет удалён без возможности восстановить.`,
+    confirmText: 'Удалить',
+    cancelText: 'Отмена',
+    danger: true,
+  });
+  if (!ok) return;
+  try {
+    await deleteReportTemplate(tpl.id);
+    await loadTemplates();
+    useDeletionsStore().notify({ prefix: 'Шаблон ', bold: tpl.name, suffix: ' удалён', type: 'success' });
+  } catch (e) {
+    useDeletionsStore().notify({ prefix: 'Не удалось ', bold: 'удалить шаблон', suffix: e?.message ? `: ${e.message}` : '', type: 'error' });
+  }
+}
 
 const STEP_LABELS = ['1 · Что считаем', '2 · По чему разбиваем', '3 · Фильтры', '4 · Период'];
 
@@ -139,6 +295,7 @@ function onApplyPreset(preset) {
 }
 
 onMounted(async () => {
+  loadTemplates();
   try {
     catalog.value = await getReportCatalog();
   } catch (e) {
@@ -229,6 +386,99 @@ async function onRun(request) {
   font-weight: 500;
   line-height: 1.45;
   color: var(--color-text-muted);
+}
+
+/* Шаблоны (G2) */
+.tpl-save-btn {
+  width: 100%;
+  justify-content: center;
+}
+
+.tpl-save-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.tpl-save-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.tpl-save-actions .lk-button {
+  flex: 1;
+  justify-content: center;
+}
+
+.tpl-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 8px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.tpl-item {
+  display: flex;
+  align-items: stretch;
+  gap: 4px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  transition: border-color 0.18s ease;
+}
+
+.tpl-item:hover {
+  border-color: var(--color-primary);
+}
+
+.tpl-apply {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 9px 11px;
+  border: none;
+  background: transparent;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.tpl-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tpl-desc {
+  font-size: 11px;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tpl-del {
+  flex-shrink: 0;
+  width: 32px;
+  border: none;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 0.18s ease, color 0.18s ease;
+}
+
+.tpl-del:hover {
+  background: var(--color-danger);
+  color: #fff;
 }
 
 .wizard {

--- a/frontend/src/components/statistics/__tests__/ReportBuilder.spec.js
+++ b/frontend/src/components/statistics/__tests__/ReportBuilder.spec.js
@@ -177,6 +177,26 @@ describe('ReportBuilder', () => {
     expect(req.filters).toContainEqual({ key: 'date_range', from: '2026-06-01', to: '2026-06-07' });
   });
 
+  it('применяет шаблон с фильтрами и собственным периодом', async () => {
+    const wrapper = mount(ReportBuilder, { props: { catalog: CATALOG, period: PERIOD, preset: null } });
+    await nextTick();
+
+    await wrapper.setProps({
+      preset: {
+        mode: 'aggregate', metrics: ['applications_count'], dimension: 'status',
+        filters: { organization: ['ООО А'] }, period: { from: '2026-01-01', to: '2026-03-31' },
+      },
+    });
+    await flushPromises();
+
+    const req = lastRun(wrapper);
+    expect(req.metrics).toEqual(['applications_count']);
+    expect(req.dimension).toBe('status');
+    // Фильтры и период из шаблона, а не из шапки.
+    expect(req.filters).toContainEqual({ key: 'organization', values: ['ООО А'] });
+    expect(req.filters).toContainEqual({ key: 'date_range', from: '2026-01-01', to: '2026-03-31' });
+  });
+
   it('применяет list-пресет и сразу строит отчёт', async () => {
     const wrapper = mount(ReportBuilder, { props: { catalog: CATALOG, period: PERIOD, preset: null } });
     await nextTick();

--- a/frontend/src/components/statistics/__tests__/ReportsTab.spec.js
+++ b/frontend/src/components/statistics/__tests__/ReportsTab.spec.js
@@ -5,7 +5,7 @@ import { nextTick } from 'vue';
 // Каталог и управляемые промисы runReport вынесены в hoisted — vi.mock поднимается
 // над импортами, его фабрика не видит обычные переменные модуля.
 const { state, CATALOG } = vi.hoisted(() => ({
-  state: { deferred: [] },
+  state: { deferred: [], templates: [], saved: [], deleted: [] },
   CATALOG: {
     metrics: [{ key: 'applications_count', label: 'Заявки', unit: 'шт', dimensions: ['status'] }],
     dimensions: [{ key: 'status', label: 'Статус заявки' }],
@@ -18,11 +18,15 @@ const { state, CATALOG } = vi.hoisted(() => ({
 vi.mock('@/api/statistics', () => ({
   getReportCatalog: () => Promise.resolve(CATALOG),
   runReport: () => new Promise((resolve) => { state.deferred.push(resolve); }),
+  getReportTemplates: () => Promise.resolve(state.templates),
+  saveReportTemplate: (payload) => { state.saved.push(payload); return Promise.resolve({ id: 99, ...payload, is_system: false }); },
+  deleteReportTemplate: (id) => { state.deleted.push(id); return Promise.resolve(); },
 }));
 
 // Стор уведомлений мокаем: ошибку экспорта показывают тостом, а не подменой :error.
-const { notifySpy } = vi.hoisted(() => ({ notifySpy: vi.fn() }));
+const { notifySpy, confirmSpy } = vi.hoisted(() => ({ notifySpy: vi.fn(), confirmSpy: vi.fn(() => Promise.resolve(true)) }));
 vi.mock('@/stores/deletions', () => ({ useDeletionsStore: () => ({ notify: notifySpy }) }));
+vi.mock('@/stores/ui', () => ({ useUiStore: () => ({ confirm: confirmSpy }) }));
 
 import ReportsTab from '../ReportsTab.vue';
 import ReportBuilder from '../ReportBuilder.vue';
@@ -101,5 +105,82 @@ describe('ReportsTab', () => {
     // Результат на месте, :error не выставлен.
     expect(wrapper.findComponent(ReportResult).props('result')).not.toBeNull();
     expect(wrapper.findComponent(ReportResult).props('error')).toBe('');
+  });
+
+  it('грузит личные шаблоны, системные пресеты в «Мои шаблоны» не попадают', async () => {
+    state.templates = [
+      { id: 1, name: 'Личный набор', config: { mode: 'list', entity: 'cars' }, is_system: false },
+      { id: 2, name: 'Системный', config: {}, is_system: true },
+    ];
+    const wrapper = mount(ReportsTab, { props: { from: '', to: '' } });
+    await flushPromises();
+
+    const items = wrapper.findAll('.tpl-item');
+    expect(items).toHaveLength(1);
+    expect(items[0].text()).toContain('Личный набор');
+  });
+
+  it('применение шаблона прокидывает его config в ReportBuilder', async () => {
+    state.templates = [{ id: 5, name: 'Мой', config: { mode: 'list', entity: 'cars' }, is_system: false }];
+    const wrapper = mount(ReportsTab, { props: { from: '', to: '' } });
+    await flushPromises();
+
+    await wrapper.find('.tpl-apply').trigger('click');
+    await nextTick();
+    expect(wrapper.findComponent(ReportBuilder).props('preset')).toMatchObject({ mode: 'list', entity: 'cars' });
+  });
+
+  it('сохранение шаблона шлёт имя и текущий config мастера', async () => {
+    state.templates = [];
+    state.saved.length = 0;
+    const wrapper = mount(ReportsTab, { props: { from: '', to: '' } });
+    await flushPromises();
+
+    // Снимок мастера с полным config.
+    wrapper.findComponent(ReportBuilder).vm.$emit('change', {
+      mode: 'aggregate', metric: 'applications_count', dimension: 'status', entity: '',
+      filterCount: 0, periodApplicable: true, periodFilled: false,
+      config: { mode: 'aggregate', metrics: ['applications_count'], dimension: 'status', granularity: 'day', entity: '', filters: {}, period: { from: '', to: '' } },
+    });
+    await nextTick();
+
+    await wrapper.find('.tpl-save-btn').trigger('click');
+    await nextTick();
+    await wrapper.find('.tpl-save-form input').setValue('Новый набор');
+    await wrapper.find('.tpl-save-actions .lk-button--primary').trigger('click');
+    await flushPromises();
+
+    expect(state.saved).toHaveLength(1);
+    expect(state.saved[0]).toMatchObject({
+      name: 'Новый набор',
+      config: { mode: 'aggregate', metrics: ['applications_count'], dimension: 'status' },
+    });
+  });
+
+  it('удаление шаблона требует подтверждения и дёргает API по id', async () => {
+    state.templates = [{ id: 7, name: 'Удалить меня', config: { mode: 'list', entity: 'cars' }, is_system: false }];
+    state.deleted.length = 0;
+    confirmSpy.mockClear();
+    confirmSpy.mockResolvedValueOnce(true);
+    const wrapper = mount(ReportsTab, { props: { from: '', to: '' } });
+    await flushPromises();
+
+    await wrapper.find('.tpl-del').trigger('click');
+    await flushPromises();
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(state.deleted).toContain(7);
+  });
+
+  it('отмена подтверждения не удаляет шаблон', async () => {
+    state.templates = [{ id: 8, name: 'Оставить', config: { mode: 'list', entity: 'cars' }, is_system: false }];
+    state.deleted.length = 0;
+    confirmSpy.mockClear();
+    confirmSpy.mockResolvedValueOnce(false);
+    const wrapper = mount(ReportsTab, { props: { from: '', to: '' } });
+    await flushPromises();
+
+    await wrapper.find('.tpl-del').trigger('click');
+    await flushPromises();
+    expect(state.deleted).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Что

Срез G2 эпика #632 — FE-панель шаблонов отчётов (поверх backend G1).

- **«Мои шаблоны»** в сайдбаре Отчётов: список личных наборов, применить (config → конструктор), удалить (с подтверждением).
- **«Сохранить текущий»** — инлайн-форма имени, сохраняет полный снимок состояния гида (mode/metrics/dimension/granularity/entity/filters/period/period_preset).
- Применение шаблона восстанавливает всё состояние, включая фильтры и период (preset-watch расширен).
- Системные пресеты остаются в галерее «Готовые наборы»; здесь — только свои личные.
- `api/statistics.js`: getReportTemplates / saveReportTemplate / deleteReportTemplate.

## По ревью (code-reviewer, было NO-GO — блокер закрыт)

- 🔴 Чужие расшаренные шаблоны больше не попадают в «Мои шаблоны» (`!is_system && !is_shared`) — на них нет прав удаления, кнопка × давала бы 403.
- 🟡 Удаление через `useUiStore().confirm` (необратимая операция); `period_preset` сохраняется в config (подсветка кнопки при restore); `buildConfig` → computed; убрана неиспользуемая `updateReportTemplate`; aria-label на кнопке удаления.

## Проверка

- `vitest` statistics — 53 теста зелёные (загрузка/применение/сохранение/удаление шаблонов, отмена подтверждения, применение config с фильтрами и периодом).
- ESLint по диффу — 0 ошибок.