### PR TITLE
fix(e2e): отключил автозапуск тура для seed-юзеров (#657)

### DIFF
--- a/cmd/seed/main.go
+++ b/cmd/seed/main.go
@@ -102,16 +102,23 @@ func seedE2EUsers(db *gorm.DB, orgID, compID, buroTypeID int) {
 	const e2ePassword = "testpass123"
 	hash := hashPassword(e2ePassword)
 
+	// onboardingDoneVersion — заведомо выше любой реальной ONBOARDING_VERSION:
+	// E2E-юзерам тур не нужен, а его автозапуск перекрывает UI оверлеем и валит
+	// клики чужих тестов (shard 3/4 notifications). Берём с запасом, чтобы не
+	// ломаться при росте версии тура.
+	const onboardingDoneVersion = 1000
+
 	// e2e_admin — тот же type_id что buropropuskov (админ).
 	adminResult := db.Exec(`
-		INSERT INTO users (username, password, organization_id, company_id, type_id, last_name, first_name)
-		VALUES ('e2e_admin', ?, ?, ?, ?, 'E2E', 'Admin')
+		INSERT INTO users (username, password, organization_id, company_id, type_id, last_name, first_name, onboarding_completed_version)
+		VALUES ('e2e_admin', ?, ?, ?, ?, 'E2E', 'Admin', ?)
 		ON CONFLICT (username) DO UPDATE SET
 			password = EXCLUDED.password,
 			organization_id = EXCLUDED.organization_id,
 			company_id = EXCLUDED.company_id,
-			type_id = EXCLUDED.type_id
-	`, hash, orgID, compID, buroTypeID)
+			type_id = EXCLUDED.type_id,
+			onboarding_completed_version = EXCLUDED.onboarding_completed_version
+	`, hash, orgID, compID, buroTypeID, onboardingDoneVersion)
 	if adminResult.Error != nil {
 		log.Fatalf("Failed to seed e2e_admin: %v", adminResult.Error)
 	}
@@ -123,16 +130,27 @@ func seedE2EUsers(db *gorm.DB, orgID, compID, buroTypeID int) {
 		userTypeID = 1
 	}
 	userResult := db.Exec(`
-		INSERT INTO users (username, password, organization_id, company_id, type_id, last_name, first_name)
-		VALUES ('e2e_user', ?, ?, ?, ?, 'E2E', 'User')
+		INSERT INTO users (username, password, organization_id, company_id, type_id, last_name, first_name, onboarding_completed_version)
+		VALUES ('e2e_user', ?, ?, ?, ?, 'E2E', 'User', ?)
 		ON CONFLICT (username) DO UPDATE SET
 			password = EXCLUDED.password,
 			organization_id = EXCLUDED.organization_id,
 			company_id = EXCLUDED.company_id,
-			type_id = EXCLUDED.type_id
-	`, hash, orgID, compID, userTypeID)
+			type_id = EXCLUDED.type_id,
+			onboarding_completed_version = EXCLUDED.onboarding_completed_version
+	`, hash, orgID, compID, userTypeID, onboardingDoneVersion)
 	if userResult.Error != nil {
 		log.Fatalf("Failed to seed e2e_user: %v", userResult.Error)
+	}
+
+	// buropropuskov логинится в большинстве E2E-сценариев — ему автозапуск тура
+	// тоже мешает. Помечаем пройденным ТОЛЬКО в E2E (эта ветка по SEED_E2E_USERS),
+	// на staging/prod реальный админ тур увидит.
+	if res := db.Exec(
+		`UPDATE users SET onboarding_completed_version = ? WHERE username = 'buropropuskov'`,
+		onboardingDoneVersion,
+	); res.Error != nil {
+		log.Fatalf("Failed to mark buropropuskov onboarding done: %v", res.Error)
 	}
 
 	fmt.Printf("E2E users seeded: e2e_admin (type_id=%d), e2e_user (type_id=%d), password=%s\n", buroTypeID, userTypeID, e2ePassword)


### PR DESCRIPTION
## Проблема

С момента мержа автозапуска обучающего тура (657-autostart-polish) **E2E-workflow краснеет на всех ветках** — shard 3/4 (тесты панели уведомлений) падает с `locator.click: Test timeout`. Причина: свежий E2E-юзер при входе не имеет отметки о пройденном туре → тур автозапускается → его оверлей перекрывает интерфейс → клики чужих тестов не проходят.

Граница по истории e2e.yml: всё до `657-autostart-polish` — green, всё после — fail (включая мои #632-срезы и онбординг-ветки). Это не регрессия конкретного PR, а pre-existing поломка dev.

## Фикс

E2E-seed (`cmd/seed`, только под `SEED_E2E_USERS`) помечает `e2e_admin`, `e2e_user` и `buropropuskov` пройденным туром (`onboarding_completed_version`), чтобы автозапуск не срабатывал. На staging/prod ветка не выполняется — реальный админ тур увидит.

Версия проставляется с запасом (1000 > любой `ONBOARDING_VERSION`), чтобы не ломаться при росте версии тура. Условие подтверждено в `stores/onboarding.js:116`: автозапуск пропускается при `completedVersion >= ONBOARDING_VERSION`.

## Проверка

- `go build ./cmd/seed` + gofmt чисто.
- Ожидается, что shard 3/4 снова станет зелёным после применения seed.