### PR TITLE
refactor(application-detail): ForwardModal к общему стилю на BaseModal (#680)

### DIFF
--- a/frontend/src/components/ApplicationDetail/ApplicationDetail.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationDetail.vue
@@ -6,7 +6,7 @@
   >
     <!-- Модальное окно пересылки -->
     <ForwardModal
-      v-if="showForwardModal"
+      :show="showForwardModal"
       :all-users="allUsers"
       :responsible-users="responsibleUsers"
       :existing-approvers="approvers"  

--- a/frontend/src/components/ApplicationDetail/ForwardModal.vue
+++ b/frontend/src/components/ApplicationDetail/ForwardModal.vue
@@ -380,8 +380,7 @@ export default {
     background: #fff;
     border: 1px solid var(--color-border);
     border-radius: var(--radius-lg);
-    max-height: 382px;
-    overflow-y: auto;
+    overflow: hidden;
     z-index: 1000;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
     margin-top: 5px;
@@ -644,9 +643,15 @@ export default {
 </style>
 
 <!-- не scoped: контент BaseModal телепортится в body и несёт data-v самого BaseModal,
-     поэтому радиус задаём глобально двойным классом (бьёт scoped .base-modal BaseModal). -->
+     поэтому радиус и overflow задаём глобально двойным классом (бьёт scoped .base-modal BaseModal).
+     overflow: visible нужен, чтобы выпадающий список поиска не обрезался скроллом модалки. -->
 <style>
 .base-modal.forward-modal {
     border-radius: 30px;
+    overflow: visible;
+}
+
+.base-modal.forward-modal .base-modal__body {
+    overflow: visible;
 }
 </style>

--- a/frontend/src/components/ApplicationDetail/ForwardModal.vue
+++ b/frontend/src/components/ApplicationDetail/ForwardModal.vue
@@ -1,175 +1,181 @@
 <!-- ForwardModal.vue -->
 <template>
-  <Teleport to="body">
-    <div
-      class="modal-overlay"
-      @click.self="close"
-    >
-      <div class="modal">
-        <div class="modal-header">
-          <h3>Переслать заявку</h3>
-          <button
-            class="modal-close"
-            @click="close"
-          >
-            ×
-          </button>
-        </div>
-        <div class="modal-content">
-          <div class="user-search-section">
-            <input
-              ref="searchInput"
-              v-model="searchQuery"
-              class="forward-search-input"
-              placeholder="Поиск пользователей..."
-              type="text"
-              @input="searchUsers"
-              @focus="onSearchFocus"
-              @blur="onSearchBlur"
-            >
+  <BaseModal
+    :show="show"
+    title="Переслать заявку"
+    width="600px"
+    :z-index="20000"
+    content-class="forward-modal"
+    @close="close"
+  >
+    <div class="forward-body">
+      <div class="user-search-section">
+        <input
+          ref="searchInput"
+          v-model="searchQuery"
+          class="lk-input"
+          data-testid="forward-modal-search"
+          placeholder="Поиск пользователей..."
+          type="text"
+          @input="searchUsers"
+          @focus="onSearchFocus"
+          @blur="onSearchBlur"
+        >
+        <div
+          v-if="showDropdown && filteredUsers.length > 0"
+          class="forward-user-dropdown"
+        >
+          <div class="forward-user-dropdown-content">
             <div
-              v-if="showDropdown && filteredUsers.length > 0"
-              class="forward-user-dropdown"
+              v-for="user in filteredUsers"
+              :key="user.username"
+              class="forward-user-item"
+              data-testid="forward-modal-user-option"
+              @mousedown.prevent="addUser(user)"
             >
-              <div class="forward-user-dropdown-content">
-                <div 
-                  v-for="user in filteredUsers" 
-                  :key="user.username"
-                  class="forward-user-item"
-                  @mousedown.prevent="addUser(user)"
-                >
-                  <div class="forward-user-info">
-                    <div class="forward-user-main">
-                      <span class="forward-user-name">{{ getUserDisplayName(user) }}</span>
-                      <span class="forward-user-username">@{{ user.username }}</span>
-                    </div>
-                    <div class="forward-user-details">
-                      <span
-                        v-if="user.position"
-                        class="forward-user-position"
-                      >{{ user.position }}</span>
-                      <span
-                        v-if="user.organization"
-                        class="forward-user-organization"
-                      >{{ user.organization }}</span>
-                    </div>
-                  </div>
+              <div class="forward-user-info">
+                <div class="forward-user-main">
+                  <span class="forward-user-name">{{ getUserDisplayName(user) }}</span>
+                  <span class="forward-user-username">@{{ user.username }}</span>
+                </div>
+                <div class="forward-user-details">
+                  <span
+                    v-if="user.position"
+                    class="forward-user-position"
+                  >{{ user.position }}</span>
+                  <span
+                    v-if="user.organization"
+                    class="forward-user-organization"
+                  >{{ user.organization }}</span>
                 </div>
               </div>
             </div>
-            <div
-              v-else-if="showDropdown && filteredUsers.length === 0"
-              class="forward-user-dropdown no-results"
-            >
-              <div class="forward-user-dropdown-content">
-                <div class="no-results-message">
-                  Пользователи не найдены
-                </div>
-              </div>
-            </div>
-          </div>
-                
-          <div
-            v-if="selectedUsers.length > 0"
-            class="selected-forward-users"
-          >
-            <h4>Выбранные пользователи ({{ selectedUsers.length }})</h4>
-            <div class="forward-users-list-container">
-              <div class="forward-users-list">
-                <div 
-                  v-for="user in selectedUsers" 
-                  :key="user.username"
-                  class="forward-selected-user"
-                >
-                  <div class="forward-selected-user-info">
-                    <div class="forward-selected-user-main">
-                      <span class="forward-selected-user-name">{{ getUserDisplayName(user) }}</span>
-                      <span class="forward-selected-user-username">@{{ user.username }}</span>
-                    </div>
-                    <div class="forward-selected-user-details">
-                      <span
-                        v-if="user.position"
-                        class="forward-selected-user-position"
-                      >{{ user.position }}</span>
-                      <span
-                        v-if="user.organization"
-                        class="forward-selected-user-organization"
-                      >{{ user.organization }}</span>
-                    </div>
-                                    
-                    <!-- Настройки доступа -->
-                    <div class="forward-selected-user-settings">
-                      <!-- Тумблер "Требуется согласование" -->
-                      <label class="setting-toggle">
-                        <input 
-                          v-model="user.requires_approval" 
-                          type="checkbox"
-                          class="setting-checkbox"
-                          @change="onApprovalToggle(user)"
-                        >
-                        <span class="toggle-slider" />
-                        <span class="toggle-text">Требуется согласование</span>
-                      </label>
-
-                      <!-- Тумблер "Согласование обязательно" (активен только если requires_approval = true) -->
-                      <label
-                        class="setting-toggle"
-                        :class="{ 'toggle-disabled': !user.requires_approval }"
-                      >
-                        <input 
-                          v-model="user.required_approval" 
-                          type="checkbox"
-                          :disabled="!user.requires_approval"
-                          class="setting-checkbox"
-                        >
-                        <span class="toggle-slider" />
-                        <span class="toggle-text">Согласование обязательно</span>
-                      </label>
-                    </div>
-                  </div>
-                  <button 
-                    class="remove-forward-user-btn"
-                    title="Удалить"
-                    @click="removeUser(user)"
-                  >
-                    ×
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-                
-          <div
-            v-else
-            class="no-forward-users"
-          >
-            <p>Выберите пользователей для пересылки заявки</p>
           </div>
         </div>
-        <div class="modal-footer">
-          <button 
-            class="modal-cancel-btn"
-            @click="close"
-          >
-            Отмена
-          </button>
-          <button 
-            class="modal-send-btn"
-            :disabled="selectedUsers.length === 0 || isSending"
-            @click="send"
-          >
-            {{ isSending ? 'Отправка...' : 'Отправить' }}
-          </button>
+        <div
+          v-else-if="showDropdown && filteredUsers.length === 0"
+          class="forward-user-dropdown no-results"
+        >
+          <div class="forward-user-dropdown-content">
+            <div class="no-results-message">
+              Пользователи не найдены
+            </div>
+          </div>
         </div>
       </div>
+
+      <div
+        v-if="selectedUsers.length > 0"
+        class="selected-forward-users"
+      >
+        <h4>Выбранные пользователи ({{ selectedUsers.length }})</h4>
+        <div class="forward-users-list-container">
+          <div class="forward-users-list">
+            <div
+              v-for="user in selectedUsers"
+              :key="user.username"
+              class="forward-selected-user"
+            >
+              <div class="forward-selected-user-info">
+                <div class="forward-selected-user-main">
+                  <span class="forward-selected-user-name">{{ getUserDisplayName(user) }}</span>
+                  <span class="forward-selected-user-username">@{{ user.username }}</span>
+                </div>
+                <div class="forward-selected-user-details">
+                  <span
+                    v-if="user.position"
+                    class="forward-selected-user-position"
+                  >{{ user.position }}</span>
+                  <span
+                    v-if="user.organization"
+                    class="forward-selected-user-organization"
+                  >{{ user.organization }}</span>
+                </div>
+
+                <!-- Настройки доступа -->
+                <div class="forward-selected-user-settings">
+                  <!-- Тумблер "Требуется согласование" -->
+                  <label class="setting-toggle">
+                    <input
+                      v-model="user.requires_approval"
+                      type="checkbox"
+                      class="setting-checkbox"
+                      @change="onApprovalToggle(user)"
+                    >
+                    <span class="toggle-slider" />
+                    <span class="toggle-text">Требуется согласование</span>
+                  </label>
+
+                  <!-- Тумблер "Согласование обязательно" (активен только если requires_approval = true) -->
+                  <label
+                    class="setting-toggle"
+                    :class="{ 'toggle-disabled': !user.requires_approval }"
+                  >
+                    <input
+                      v-model="user.required_approval"
+                      type="checkbox"
+                      :disabled="!user.requires_approval"
+                      class="setting-checkbox"
+                    >
+                    <span class="toggle-slider" />
+                    <span class="toggle-text">Согласование обязательно</span>
+                  </label>
+                </div>
+              </div>
+              <button
+                class="remove-forward-user-btn"
+                data-testid="forward-modal-remove-user"
+                title="Удалить"
+                @click="removeUser(user)"
+              >
+                ×
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div
+        v-else
+        class="no-forward-users"
+      >
+        <p>Выберите пользователей для пересылки заявки</p>
+      </div>
     </div>
-  </Teleport>
+
+    <template #actions>
+      <button
+        type="button"
+        class="lk-button lk-button--ghost"
+        data-testid="forward-modal-button-cancel"
+        @click="close"
+      >
+        Отмена
+      </button>
+      <button
+        type="button"
+        class="lk-button lk-button--primary"
+        data-testid="forward-modal-button-send"
+        :disabled="selectedUsers.length === 0 || isSending"
+        @click="send"
+      >
+        {{ isSending ? 'Отправка...' : 'Отправить' }}
+      </button>
+    </template>
+  </BaseModal>
 </template>
 
 <script>
+import BaseModal from '@/components/ui/BaseModal.vue'
+
 export default {
     name: 'ForwardModal',
+    components: { BaseModal },
     props: {
+        show: {
+            type: Boolean,
+            required: true
+        },
         allUsers: {
             type: Array,
             required: true
@@ -224,28 +230,22 @@ export default {
 
         // Сортированный список всех пользователей, исключая тех, у кого уже есть доступ
         sortedAllUsers() {
-            console.log('All users:', this.allUsers.length);
-            console.log('Existing user IDs:', this.existingUserIds);
-            
-            const filteredUsers = [...this.allUsers]
-                .filter(user => !this.existingUserIds.includes(user.id));
-            
-            console.log('Filtered users:', filteredUsers.length);
-            
-            return filteredUsers.sort((a, b) => {
-                const nameA = this.getUserDisplayName(a).toLowerCase();
-                const nameB = this.getUserDisplayName(b).toLowerCase();
-                return nameA.localeCompare(nameB);
-            });
+            return [...this.allUsers]
+                .filter(user => !this.existingUserIds.includes(user.id))
+                .sort((a, b) => {
+                    const nameA = this.getUserDisplayName(a).toLowerCase();
+                    const nameB = this.getUserDisplayName(b).toLowerCase();
+                    return nameA.localeCompare(nameB);
+                });
         },
-        
+
         // Отфильтрованные пользователи для отображения
         filteredUsers() {
             // Исключаем уже выбранных пользователей
-            let availableUsers = this.sortedAllUsers.filter(user => 
+            let availableUsers = this.sortedAllUsers.filter(user =>
                 !this.selectedUsers.some(selected => selected.username === user.username)
             );
-            
+
             // Если есть поисковый запрос, фильтруем по нему
             if (this.searchQuery.trim()) {
                 const query = this.searchQuery.toLowerCase();
@@ -254,15 +254,27 @@ export default {
                     const username = user.username.toLowerCase();
                     const position = (user.position || '').toLowerCase();
                     const organization = (user.organization || '').toLowerCase();
-                    
+
                     return fullName.includes(query) ||
                            username.includes(query) ||
                            position.includes(query) ||
                            organization.includes(query);
                 });
             }
-            
+
             return availableUsers.slice(0, 15);
+        }
+    },
+    watch: {
+        // Модалка теперь всегда смонтирована (паттерн :show), поэтому чистим состояние
+        // при открытии и переводим фокус на поиск.
+        show(visible) {
+            if (visible) {
+                this.reset();
+                this.$nextTick(() => {
+                    this.$refs.searchInput?.focus();
+                });
+            }
         }
     },
     methods: {
@@ -280,7 +292,6 @@ export default {
         },
 
         addUser(user) {
-            console.log('Adding user:', user);
             const userWithSettings = {
                 ...user,
                 requires_approval: false,  // По умолчанию только просмотр
@@ -288,28 +299,24 @@ export default {
             };
             this.selectedUsers.push(userWithSettings);
             this.searchQuery = '';
-            
+
             this.showDropdown = false;
             this.searchResults = [];
             this.$refs.searchInput.blur();
-            
+
             this.$emit('update:selected-users', this.selectedUsers);
-            console.log('Selected users after add:', this.selectedUsers);
         },
 
         onApprovalToggle(user) {
-            console.log('Toggle changed for user:', user.username, 'requires_approval:', user.requires_approval);
             // Если выключили "Требуется согласование", сбрасываем "Согласование обязательно"
             if (!user.requires_approval) {
                 user.required_approval = false;
             }
-            console.log('User after toggle:', user);
         },
 
         removeUser(user) {
             this.selectedUsers = this.selectedUsers.filter(u => u.username !== user.username);
             this.$emit('update:selected-users', this.selectedUsers);
-            console.log('Selected users after remove:', this.selectedUsers);
         },
 
         onSearchBlur() {
@@ -323,8 +330,6 @@ export default {
         },
 
         send() {
-            console.log('Sending selected users:', this.selectedUsers);
-            
             // Преобразуем данные для отправки на сервер
             const usersToSend = this.selectedUsers.map(user => {
                 // Если требуется согласование - отправляем как ответственного
@@ -334,7 +339,7 @@ export default {
                         required_approval: user.required_approval || false,
                         can_view: false  // Не может быть только просматривающим, если требуется согласование
                     };
-                } 
+                }
                 // Если не требуется согласование - отправляем как просматривающего
                 else {
                     return {
@@ -344,8 +349,7 @@ export default {
                     };
                 }
             });
-            
-            console.log('Users to send to server:', usersToSend);
+
             this.$emit('send', usersToSend);
         },
 
@@ -359,115 +363,13 @@ export default {
 </script>
 
 <style scoped>
-.modal-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0, 0, 0, 0.5);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    z-index: 20000;
-    backdrop-filter: blur(0.1px);
-    -webkit-backdrop-filter: blur(0.1px);
-    animation: fadeIn 0.3s ease-out;
-}
-
-@keyframes fadeIn {
-    from { opacity: 0; }
-    to { opacity: 1; }
-}
-
-.modal {
-    background: white;
-    border-radius: 20px;
-    width: 600px;
-    max-width: 90%;
-    height: 85vh;
-    max-height: 85vh;
-    display: flex;
-    flex-direction: column;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.25);
-    animation: scaleIn 0.3s ease-out;
-    overflow: hidden;
-}
-
-@keyframes scaleIn {
-    from {
-        opacity: 0;
-        transform: scale(0.95);
-    }
-    to {
-        opacity: 1;
-        transform: scale(1);
-    }
-}
-
-.modal-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+.forward-body {
     padding: 20px;
-    border-bottom: 1px solid #e6e6e6;
-    flex-shrink: 0;
-    background: white;
-}
-
-.modal-header h3 {
-    font-size: 18px;
-    font-weight: 700;
-    color: #333;
-    margin: 0;
-}
-
-.modal-close {
-    background: none;
-    border: none;
-    font-size: 24px;
-    color: #a2a2a2;
-    cursor: pointer;
-    width: 24px;
-    height: 24px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 50%;
-    transition: all 0.2s ease;
-}
-
-.modal-close:hover {
-    background: #f0f0f0;
-    color: #333;
-}
-
-.modal-content {
-    flex: 1;
-    padding: 20px;
-    min-height: 0;
-    display: flex;
-    flex-direction: column;
 }
 
 .user-search-section {
     position: relative;
     margin-bottom: 20px;
-    flex-shrink: 0;
-}
-
-.forward-search-input {
-    width: 100%;
-    padding: 12px 15px;
-    border: 1px solid #e6e6e6;
-    border-radius: 10px;
-    font-size: 14px;
-    transition: border-color 0.2s ease;
-}
-
-.forward-search-input:focus {
-    border-color: #4F5BDF;
-    outline: none;
 }
 
 .forward-user-dropdown {
@@ -475,9 +377,9 @@ export default {
     top: 100%;
     left: 0;
     right: 0;
-    background: white;
-    border: 1px solid #e6e6e6;
-    border-radius: 20px;
+    background: #fff;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
     max-height: 382px;
     overflow-y: auto;
     z-index: 1000;
@@ -547,25 +449,20 @@ export default {
 }
 
 .selected-forward-users {
-    margin-top: 20px;
     display: flex;
     flex-direction: column;
-    min-height: 0;
-    flex: 1;
 }
 
 .selected-forward-users h4 {
     font-size: 16px;
-    color: #333;
+    color: var(--color-text);
     margin-bottom: 10px;
     font-weight: 600;
-    flex-shrink: 0;
 }
 
 .forward-users-list-container {
-    flex: 1;
+    max-height: 320px;
     overflow-y: auto;
-    min-height: 0;
     padding-right: 5px;
 }
 
@@ -580,15 +477,15 @@ export default {
     justify-content: space-between;
     align-items: flex-start;
     padding: 12px;
-    background: #f9f9f9;
+    background: var(--color-bg-secondary);
     border-radius: 12px;
-    border: 1px solid #e6e6e6;
+    border: 1px solid var(--color-border);
     transition: all 0.2s ease;
 }
 
 .forward-selected-user:hover {
-    border-color: #4F5BDF;
-    background: #f8f9ff;
+    border-color: var(--color-primary);
+    background: var(--color-bg);
 }
 
 .forward-selected-user-info {
@@ -680,7 +577,7 @@ export default {
 }
 
 .setting-checkbox:checked + .toggle-slider {
-    background-color: #4F5BDF;
+    background-color: var(--color-primary);
 }
 
 .setting-checkbox:checked + .toggle-slider:before {
@@ -694,13 +591,13 @@ export default {
 
 .toggle-text {
     font-size: 13px;
-    color: #333;
+    color: var(--color-text);
 }
 
 .remove-forward-user-btn {
     background: none;
     border: none;
-    color: #ef4444;
+    color: var(--color-danger);
     font-size: 20px;
     cursor: pointer;
     padding: 6px 10px;
@@ -718,60 +615,9 @@ export default {
     padding: 40px;
     color: #6b7280;
     font-size: 15px;
-    border: 1px dashed #e6e6e6;
+    border: 1px dashed var(--color-border);
     border-radius: 12px;
     background: #fafafa;
-    flex: 1;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-.modal-footer {
-    display: flex;
-    justify-content: flex-end;
-    gap: 12px;
-    padding: 20px;
-    border-top: 1px solid #e6e6e6;
-    flex-shrink: 0;
-    background: white;
-}
-
-.modal-cancel-btn {
-    padding: 10px 24px;
-    background: #f0f0f0;
-    color: #333;
-    border: none;
-    border-radius: 10px;
-    font-size: 15px;
-    font-weight: 600;
-    cursor: pointer;
-    transition: all 0.2s ease;
-}
-
-.modal-cancel-btn:hover {
-    background: #e0e0e0;
-}
-
-.modal-send-btn {
-    padding: 10px 24px;
-    background: #4F5BDF;
-    color: white;
-    border: none;
-    border-radius: 10px;
-    font-size: 15px;
-    font-weight: 600;
-    cursor: pointer;
-    transition: all 0.2s ease;
-}
-
-.modal-send-btn:hover:not(:disabled) {
-    background: #3a45c0;
-}
-
-.modal-send-btn:disabled {
-    background: #9ca3af;
-    cursor: not-allowed;
 }
 
 .forward-user-dropdown-content::-webkit-scrollbar,
@@ -794,5 +640,13 @@ export default {
 .forward-user-dropdown-content::-webkit-scrollbar-thumb:hover,
 .forward-users-list-container::-webkit-scrollbar-thumb:hover {
     background: #a8a8a8;
+}
+</style>
+
+<!-- не scoped: контент BaseModal телепортится в body и несёт data-v самого BaseModal,
+     поэтому радиус задаём глобально двойным классом (бьёт scoped .base-modal BaseModal). -->
+<style>
+.base-modal.forward-modal {
+    border-radius: 30px;
 }
 </style>


### PR DESCRIPTION
Срез 2 эпика пересыла заявки (#680, п.42 эпика 46-edits). Приводит модалку пересыла к общему стилю проекта.

## Что сделано
- `ForwardModal.vue` переведён с собственного оверлея на общий `BaseModal` (как `BlacklistOverrideModal`): radius 30px, анимация transform+opacity, Escape, закрытие по overlay с защитой от drag-out, блокировка скролла body, focus-trap, `role/aria`.
- Кнопки футера → `.lk-button` (ghost/primary), поиск → `.lk-input` (radius 15px), хардкод-цвета → design-токены (`--color-primary` и пр.).
- Удалены 10 `console.log`, добавлены `data-testid` (search, user-option, remove-user, cancel, send) под будущий e2e среза 6.
- Родитель `ApplicationDetail.vue` рендерит модалку через `:show` вместо `v-if`, иначе BaseModal не отыграет leave-анимацию.

## Поведение сохранено
Поиск/дропдаун, выбор и удаление получателей, тумблеры «Требуется согласование»/«Согласование обязательно», payload `send` (user_id/required_approval/can_view), эмиты close/send. Состояние чистится через `watch(show)` при открытии (модалка теперь всегда смонтирована).

## Ревью (code-reviewer)
- Поправлено: выпадающий список поиска обрезался `overflow-y:auto` базовой модалки — снят overflow с модалки и тела, дропдаун со своим скроллом (отдельный коммит).
- Поправлено: двойной scrollbar на дропдауне.
- Отклонено как ложное: «глобальный `<style>` небезопасен» — это паттерн эталона `BlacklistOverrideModal`, класс `forward-modal` уникален.
- Вне скоупа: двойная трансформация payload в родителе — pre-existing, относится к срезу 6 (AttachmentIDs).

## Проверка
vitest `src/components/ApplicationDetail` — 22/22 зелёные; ESLint чист. Визуальная проверка модалки — батчем в конце эпика 46-edits (по согласованному флоу: мерж по зелёному CI, юзер проверяет пункты разом).