### PR TITLE
feat(analytics): движок инсайтов поверх агрегатов (#632)

### DIFF
--- a/internal/handlers/insights.go
+++ b/internal/handlers/insights.go
@@ -1,0 +1,31 @@
+package handlers
+
+import (
+	"github.com/labstack/echo/v4"
+)
+
+// GetInsights godoc
+// @Summary      Инсайты аналитики
+// @Description  Готовые инсайты за период: пик по часам, сравнение с прошлым периодом, топ мест/организаций, тренды
+// @Tags         statistics
+// @Produce      json
+// @Param        from query string false "Дата начала YYYY-MM-DD"
+// @Param        to query string false "Дата конца YYYY-MM-DD"
+// @Success      200 {object} models.InsightsResponse
+// @Failure      400 {object} models.HTTPError
+// @Failure      401 {object} models.HTTPError
+// @Failure      403 {object} models.HTTPError
+// @Security     BearerAuth
+// @Router       /statistics/insights [get]
+func (h *StatisticsHandler) GetInsights(c echo.Context) error {
+	from, to := parseDateRange(c)
+	res, err := h.service.GetInsights(
+		c.Request().Context(),
+		from.Format("2006-01-02"),
+		to.Format("2006-01-02"),
+	)
+	if err != nil {
+		return mapReportError(err)
+	}
+	return RespondSuccess(c, res)
+}

--- a/internal/handlers/insights_integration_test.go
+++ b/internal/handlers/insights_integration_test.go
@@ -1,0 +1,70 @@
+package handlers_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetInsights_Structure проверяет реальный путь движка: все 4 блока инсайтов
+// собираются вызовами RunReport (разрезы hour_of_day/none/unload_place/organization/
+// period исполняются на postgres), структура согласована, заявка попадает в
+// сравнение и топ организаций.
+func TestGetInsights_Structure(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	org := models.Organization{Name: "Орг-Инсайт", IsActive: true}
+	require.NoError(t, db.Create(&org).Error)
+	user := models.User{Username: "ins_sender", TypeID: 1, IsActive: true}
+	require.NoError(t, db.Create(&user).Error)
+
+	status := models.StatusCompleted
+	number := "INS/001"
+	// applications_count фильтрует период по sending_datetime — ставим дату в окне.
+	sent := time.Date(2026, 6, 15, 10, 0, 0, 0, time.UTC)
+	app := models.Application{
+		ApplicationNumber: &number, OrganizationID: org.ID,
+		SenderUserID: user.ID, Status: &status, SendingDatetime: &sent,
+	}
+	require.NoError(t, db.Create(&app).Error)
+
+	svc := services.NewStatisticsService(db)
+	res, err := svc.GetInsights(context.Background(), "2026-06-01", "2026-06-30")
+	require.NoError(t, err)
+
+	// Сравнения и тренды — по 3 ключевым метрикам.
+	require.Len(t, res.Comparisons, 3)
+	require.Len(t, res.Trends, 3)
+
+	// applications_count есть среди сравнений, направление заполнено.
+	var apps *models.ComparisonInsight
+	for i := range res.Comparisons {
+		if res.Comparisons[i].Metric == "applications_count" {
+			apps = &res.Comparisons[i]
+		}
+		assert.Contains(t, []string{"up", "down", "flat"}, res.Comparisons[i].Direction)
+	}
+	require.NotNil(t, apps)
+	assert.Equal(t, int64(1), apps.Current, "одна заявка в текущем периоде")
+
+	// Тренды несут направление.
+	for _, tr := range res.Trends {
+		assert.Contains(t, []string{"up", "down", "flat"}, tr.Direction)
+	}
+
+	// Срезы исполнились (не nil-слайсы), заявка дала топ организацию.
+	assert.NotNil(t, res.PeakHours)
+	assert.NotNil(t, res.TopPlaces)
+	require.NotEmpty(t, res.TopOrgs)
+	assert.Equal(t, "Орг-Инсайт", res.TopOrgs[0].Label)
+	assert.Equal(t, int64(1), res.TopOrgs[0].Value)
+}

--- a/internal/models/insights.go
+++ b/internal/models/insights.go
@@ -1,0 +1,55 @@
+package models
+
+// Инсайты аналитики (#632, E1) — эвристики поверх агрегатов движка отчётов.
+// Считаются вызовами RunReport с разными запросами, без нового SQL.
+
+// InsightsResponse — сводка готовых инсайтов за период.
+type InsightsResponse struct {
+	PeakHours   []PeakHoursInsight  `json:"peak_hours"`
+	Comparisons []ComparisonInsight `json:"comparisons"`
+	TopPlaces   []TopItemInsight    `json:"top_places"`
+	TopOrgs     []TopItemInsight    `json:"top_orgs"`
+	Trends      []TrendInsight      `json:"trends"`
+}
+
+// HourBucket — значение метрики в конкретный час суток (0-23).
+type HourBucket struct {
+	Hour  int   `json:"hour"`
+	Value int64 `json:"value"`
+}
+
+// PeakHoursInsight — распределение метрики по часам суток с выделенным пиком.
+type PeakHoursInsight struct {
+	Metric    string       `json:"metric"`
+	Label     string       `json:"label"`
+	Unit      string       `json:"unit,omitempty"`
+	PeakHour  int          `json:"peak_hour"`
+	PeakValue int64        `json:"peak_value"`
+	Hourly    []HourBucket `json:"hourly"`
+}
+
+// ComparisonInsight — метрика за текущий период против предыдущего равной длины.
+type ComparisonInsight struct {
+	Metric    string  `json:"metric"`
+	Label     string  `json:"label"`
+	Unit      string  `json:"unit,omitempty"`
+	Current   int64   `json:"current"`
+	Previous  int64   `json:"previous"`
+	DeltaPct  float64 `json:"delta_pct"`
+	Direction string  `json:"direction"` // up | down | flat
+}
+
+// TopItemInsight — позиция рейтинга (место разгрузки или организация).
+type TopItemInsight struct {
+	Metric string `json:"metric"`
+	Label  string `json:"label"`
+	Value  int64  `json:"value"`
+}
+
+// TrendInsight — динамика метрики по дням периода с направлением тренда.
+type TrendInsight struct {
+	Metric    string  `json:"metric"`
+	Label     string  `json:"label"`
+	Direction string  `json:"direction"` // up | down | flat
+	Series    []int64 `json:"series"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -600,6 +600,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 		statsGroup.GET("/timeline", statistics.GetTimeline, requireStats)
 		statsGroup.GET("/recent-passages", statistics.GetRecentPassages, requireStats)
 		statsGroup.GET("/metrics", statistics.GetMetrics, requireStats)
+		statsGroup.GET("/insights", statistics.GetInsights, requireStats)
 		statsGroup.POST("/report", statistics.RunReport, requireStats)
 		statsGroup.GET("/templates", statistics.ListTemplates, requireStats)
 		statsGroup.POST("/templates", statistics.CreateTemplate, requireStats)

--- a/internal/services/insights_service.go
+++ b/internal/services/insights_service.go
@@ -1,0 +1,250 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strconv"
+	"time"
+
+	"systemburo/internal/models"
+)
+
+// Метрики, на которых строятся инсайты (#632, E1).
+const (
+	insightApps   = "applications_count"
+	insightCars   = "car_entries_count"
+	insightPeople = "people_entries_count"
+)
+
+// insightDeltaThreshold — порог в %, ниже которого изменение считаем «без
+// динамики» (flat), чтобы шум не выглядел трендом.
+const insightDeltaThreshold = 5.0
+
+// GetInsights собирает готовые инсайты за период: пик нагрузки по часам, сравнение
+// с предыдущим периодом, топ мест и организаций, тренды. Всё считается вызовами
+// RunReport (движок отчётов), нового SQL нет.
+//
+// MVP: ~13 последовательных запросов на вызов. Если станет узким местом — блок
+// comparison (6 запросов) сворачивается в один запрос с двумя CTE по периодам.
+func (s *statisticsService) GetInsights(ctx context.Context, from, to string) (*models.InsightsResponse, error) {
+	resp := &models.InsightsResponse{
+		PeakHours:   []models.PeakHoursInsight{},
+		Comparisons: []models.ComparisonInsight{},
+		TopPlaces:   []models.TopItemInsight{},
+		TopOrgs:     []models.TopItemInsight{},
+		Trends:      []models.TrendInsight{},
+	}
+
+	// Пик по часам — для въездов машин и проходов людей.
+	for _, metric := range []string{insightCars, insightPeople} {
+		r, err := s.runInsightAgg(ctx, metric, "hour_of_day", from, to, "", 0)
+		if err != nil {
+			return nil, fmt.Errorf("insight peak hours %s: %w", metric, err)
+		}
+		if ph := buildPeakHours(metric, r); ph != nil {
+			resp.PeakHours = append(resp.PeakHours, *ph)
+		}
+	}
+
+	// Сравнение с предыдущим периодом равной длины.
+	prevFrom, prevTo := prevPeriod(from, to)
+	for _, metric := range []string{insightApps, insightCars, insightPeople} {
+		cur, err := s.runInsightAgg(ctx, metric, "none", from, to, "", 0)
+		if err != nil {
+			return nil, fmt.Errorf("insight comparison current %s: %w", metric, err)
+		}
+		prev, err := s.runInsightAgg(ctx, metric, "none", prevFrom, prevTo, "", 0)
+		if err != nil {
+			return nil, fmt.Errorf("insight comparison previous %s: %w", metric, err)
+		}
+		resp.Comparisons = append(resp.Comparisons, buildComparison(metric, cur.Total, prev.Total))
+	}
+
+	// Топ мест разгрузки по въездам машин.
+	places, err := s.runInsightAgg(ctx, insightCars, "unload_place", from, to, "", 5)
+	if err != nil {
+		return nil, fmt.Errorf("insight top places: %w", err)
+	}
+	resp.TopPlaces = topItems(insightCars, places, 5)
+
+	// Топ организаций по числу заявок.
+	orgs, err := s.runInsightAgg(ctx, insightApps, "organization", from, to, "", 5)
+	if err != nil {
+		return nil, fmt.Errorf("insight top orgs: %w", err)
+	}
+	resp.TopOrgs = topItems(insightApps, orgs, 5)
+
+	// Тренды по дням.
+	for _, metric := range []string{insightApps, insightCars, insightPeople} {
+		r, err := s.runInsightAgg(ctx, metric, "period", from, to, "day", 0)
+		if err != nil {
+			return nil, fmt.Errorf("insight trend %s: %w", metric, err)
+		}
+		resp.Trends = append(resp.Trends, buildTrend(metric, r))
+	}
+
+	return resp, nil
+}
+
+// runInsightAgg — вызов агрегатного движка с фильтром периода.
+func (s *statisticsService) runInsightAgg(ctx context.Context, metric, dimension, from, to, granularity string, limit int) (*models.ReportResponse, error) {
+	req := models.ReportRequest{
+		Mode:        "aggregate",
+		Metric:      metric,
+		Dimension:   dimension,
+		Granularity: granularity,
+		Limit:       limit,
+		Filters:     []models.ReportFilterValue{{Key: "date_range", From: from, To: to}},
+	}
+	return s.RunReport(ctx, req)
+}
+
+// metricMeta достаёт человекочитаемые подпись и единицу метрики из реестра.
+func metricMeta(key string) (string, string) {
+	if d, ok := reportMetricRegistry[key]; ok {
+		return d.label, d.unit
+	}
+	return key, ""
+}
+
+// buildPeakHours переводит почасовое распределение в инсайт с выделенным пиком.
+// Возвращает nil, если данных за период нет.
+func buildPeakHours(metric string, r *models.ReportResponse) *models.PeakHoursInsight {
+	if r == nil || r.Total == 0 {
+		return nil
+	}
+	label, unit := metricMeta(metric)
+	buckets := make([]models.HourBucket, 0, len(r.Rows))
+	peakHour, peakValue := 0, int64(-1)
+	for _, row := range r.Rows {
+		hour, err := strconv.Atoi(row.Label)
+		if err != nil {
+			continue
+		}
+		buckets = append(buckets, models.HourBucket{Hour: hour, Value: row.Value})
+		if row.Value > peakValue {
+			peakValue = row.Value
+			peakHour = hour
+		}
+	}
+	if len(buckets) == 0 {
+		return nil
+	}
+	return &models.PeakHoursInsight{
+		Metric:    metric,
+		Label:     label,
+		Unit:      unit,
+		PeakHour:  peakHour,
+		PeakValue: peakValue,
+		Hourly:    buckets,
+	}
+}
+
+// buildComparison считает дельту текущего периода к предыдущему.
+func buildComparison(metric string, current, previous int64) models.ComparisonInsight {
+	label, unit := metricMeta(metric)
+	delta := 0.0
+	if previous != 0 {
+		delta = float64(current-previous) / float64(previous) * 100
+	} else if current > 0 {
+		delta = 100
+	}
+	return models.ComparisonInsight{
+		Metric:    metric,
+		Label:     label,
+		Unit:      unit,
+		Current:   current,
+		Previous:  previous,
+		DeltaPct:  roundOne(delta),
+		Direction: classifyDelta(delta),
+	}
+}
+
+// topItems превращает строки агрегата в рейтинг (движок уже отсортировал по
+// убыванию значения для категориального разреза).
+func topItems(metric string, r *models.ReportResponse, limit int) []models.TopItemInsight {
+	out := []models.TopItemInsight{}
+	if r == nil {
+		return out
+	}
+	for i, row := range r.Rows {
+		if i >= limit {
+			break
+		}
+		out = append(out, models.TopItemInsight{Metric: metric, Label: row.Label, Value: row.Value})
+	}
+	return out
+}
+
+// buildTrend строит ряд по дням и определяет направление (сравнение средних
+// первой и второй половины периода).
+func buildTrend(metric string, r *models.ReportResponse) models.TrendInsight {
+	label, _ := metricMeta(metric)
+	series := make([]int64, 0, len(r.Rows))
+	for _, row := range r.Rows {
+		series = append(series, row.Value)
+	}
+	return models.TrendInsight{
+		Metric:    metric,
+		Label:     label,
+		Direction: trendDirection(series),
+		Series:    series,
+	}
+}
+
+// prevPeriod возвращает предыдущий период той же длины, заканчивающийся за день до
+// начала текущего. Невалидные даты возвращает как есть.
+func prevPeriod(from, to string) (string, string) {
+	const layout = "2006-01-02"
+	f, errF := time.Parse(layout, from)
+	t, errT := time.Parse(layout, to)
+	if errF != nil || errT != nil || t.Before(f) {
+		return from, to
+	}
+	days := int(t.Sub(f).Hours()/24) + 1
+	prevTo := f.AddDate(0, 0, -1)
+	prevFrom := prevTo.AddDate(0, 0, -(days - 1))
+	return prevFrom.Format(layout), prevTo.Format(layout)
+}
+
+// classifyDelta — направление по проценту изменения с порогом.
+func classifyDelta(delta float64) string {
+	if delta > insightDeltaThreshold {
+		return "up"
+	}
+	if delta < -insightDeltaThreshold {
+		return "down"
+	}
+	return "flat"
+}
+
+// trendDirection сравнивает средние первой и второй половин ряда.
+func trendDirection(series []int64) string {
+	n := len(series)
+	if n < 2 {
+		return "flat"
+	}
+	mid := n / 2
+	var firstSum, secondSum int64
+	for i := 0; i < mid; i++ {
+		firstSum += series[i]
+	}
+	for i := mid; i < n; i++ {
+		secondSum += series[i]
+	}
+	firstAvg := float64(firstSum) / float64(mid)
+	secondAvg := float64(secondSum) / float64(n-mid)
+	if firstAvg == 0 {
+		if secondAvg > 0 {
+			return "up"
+		}
+		return "flat"
+	}
+	return classifyDelta((secondAvg - firstAvg) / firstAvg * 100)
+}
+
+// roundOne округляет до одного знака после запятой.
+func roundOne(v float64) float64 {
+	return math.Round(v*10) / 10
+}

--- a/internal/services/insights_service_test.go
+++ b/internal/services/insights_service_test.go
@@ -1,0 +1,102 @@
+package services
+
+import (
+	"testing"
+
+	"systemburo/internal/models"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrevPeriod(t *testing.T) {
+	// 7-дневный период -> предыдущие 7 дней, заканчивающиеся за день до начала.
+	from, to := prevPeriod("2026-06-08", "2026-06-14")
+	assert.Equal(t, "2026-06-01", from)
+	assert.Equal(t, "2026-06-07", to)
+
+	// Один день -> предыдущий день.
+	from, to = prevPeriod("2026-06-10", "2026-06-10")
+	assert.Equal(t, "2026-06-09", from)
+	assert.Equal(t, "2026-06-09", to)
+
+	// Невалидные даты возвращаются как есть.
+	from, to = prevPeriod("xx", "yy")
+	assert.Equal(t, "xx", from)
+	assert.Equal(t, "yy", to)
+}
+
+func TestRoundOne(t *testing.T) {
+	assert.Equal(t, 18.0, roundOne(18.0))
+	assert.Equal(t, 0.0, roundOne(0.0))
+	// дробь без .5-границы (float-устойчиво): 100/3 = 33.333..., -200/3 = -66.666...
+	assert.Equal(t, 33.3, roundOne(100.0/3.0))
+	assert.Equal(t, -66.7, roundOne(-200.0/3.0))
+}
+
+func TestClassifyDelta(t *testing.T) {
+	assert.Equal(t, "up", classifyDelta(18))
+	assert.Equal(t, "down", classifyDelta(-12))
+	assert.Equal(t, "flat", classifyDelta(3))
+	assert.Equal(t, "flat", classifyDelta(-4))
+}
+
+func TestTrendDirection(t *testing.T) {
+	assert.Equal(t, "up", trendDirection([]int64{1, 1, 5, 5}))
+	assert.Equal(t, "down", trendDirection([]int64{5, 5, 1, 1}))
+	assert.Equal(t, "flat", trendDirection([]int64{3, 3, 3, 3}))
+	assert.Equal(t, "flat", trendDirection([]int64{7}))
+	assert.Equal(t, "up", trendDirection([]int64{0, 0, 4, 4}))
+}
+
+func TestBuildComparison(t *testing.T) {
+	c := buildComparison("applications_count", 118, 100)
+	assert.Equal(t, int64(118), c.Current)
+	assert.Equal(t, int64(100), c.Previous)
+	assert.Equal(t, 18.0, c.DeltaPct)
+	assert.Equal(t, "up", c.Direction)
+	assert.NotEmpty(t, c.Label)
+
+	// previous = 0, current > 0 -> 100% рост.
+	z := buildComparison("car_entries_count", 5, 0)
+	assert.Equal(t, 100.0, z.DeltaPct)
+	assert.Equal(t, "up", z.Direction)
+
+	// оба ноля -> flat.
+	zz := buildComparison("car_entries_count", 0, 0)
+	assert.Equal(t, 0.0, zz.DeltaPct)
+	assert.Equal(t, "flat", zz.Direction)
+}
+
+func TestBuildPeakHours(t *testing.T) {
+	r := &models.ReportResponse{
+		Total: 10,
+		Rows: []models.ReportAggregateRow{
+			{Label: "9", Value: 2},
+			{Label: "10", Value: 5},
+			{Label: "11", Value: 3},
+		},
+	}
+	ph := buildPeakHours("car_entries_count", r)
+	if assert.NotNil(t, ph) {
+		assert.Equal(t, 10, ph.PeakHour)
+		assert.Equal(t, int64(5), ph.PeakValue)
+		assert.Len(t, ph.Hourly, 3)
+	}
+
+	// Нет данных -> nil.
+	assert.Nil(t, buildPeakHours("car_entries_count", &models.ReportResponse{Total: 0}))
+}
+
+func TestTopItems(t *testing.T) {
+	r := &models.ReportResponse{
+		Rows: []models.ReportAggregateRow{
+			{Label: "Дебаркадер №1", Value: 12},
+			{Label: "Склад A", Value: 7},
+			{Label: "Склад B", Value: 3},
+		},
+	}
+	top := topItems("car_entries_count", r, 2)
+	assert.Len(t, top, 2)
+	assert.Equal(t, "Дебаркадер №1", top[0].Label)
+	assert.Equal(t, int64(12), top[0].Value)
+}

--- a/internal/services/statistics_service.go
+++ b/internal/services/statistics_service.go
@@ -19,6 +19,8 @@ type StatisticsService interface {
 	RunReport(ctx context.Context, req models.ReportRequest) (*models.ReportResponse, error)
 	RunReportList(ctx context.Context, req models.ReportRequest) (*models.ReportListResponse, error)
 
+	GetInsights(ctx context.Context, from, to string) (*models.InsightsResponse, error)
+
 	ListReportTemplates(ctx context.Context, userID int) ([]models.ReportTemplate, error)
 	CreateReportTemplate(ctx context.Context, userID int, req models.SaveReportTemplateRequest) (*models.ReportTemplate, error)
 	UpdateReportTemplate(ctx context.Context, userID, id int, req models.SaveReportTemplateRequest) (*models.ReportTemplate, error)


### PR DESCRIPTION
## Что

BE-движок инсайтов аналитики (E1, первая часть). `GET /statistics/insights?from=&to=` отдаёт 4 блока:

- **Пик по часам** — распределение въездов машин / проходов людей по часам суток с выделенным пиком.
- **Сравнение с прошлым периодом** — заявки/въезды/проходы текущего периода против предыдущего равной длины, дельта в %.
- **Топ мест и организаций** — рейтинг мест разгрузки по въездам и организаций по заявкам.
- **Тренды** — динамика по дням с направлением (рост/падение/стабильно).

Всё считается **вызовами движка отчётов `RunReport`** с разными запросами — нового SQL нет, логика поверх уже протестированных whitelist-агрегатов.

## По ревью (code-reviewer, было no-go — блокер закрыт)

- 🔴 Хендлер прогоняет ошибку через `mapReportError` (400 вместо 500 при рассинхроне с каталогом), как соседние statistics-хендлеры.
- 🟡 swagger `@Failure 401/403`; `roundOne` через `math.Round` (убрана лишняя `sign`); TODO про сворачивание comparison в CTE; прямой тест `roundOne`.

## Проверка

- Go build + vet + gofmt чисто.
- Unit-тесты логики: prevPeriod (граничные/невалидные даты), classifyDelta, trendDirection (деление на ноль), buildComparison (previous=0), buildPeakHours, topItems, roundOne.
- Integration: GetInsights на реальной БД — все разрезы (hour_of_day/none/unload_place/organization/period) исполняются, заявка попадает в сравнение и топ организаций.

## Дальше

FE-вкладка «Инсайты» с кнопками-инсайтами — следующий срез (потребляет этот эндпоинт).