### PR TITLE
feat(application-detail): гейт кнопки "Переслать" по роли ответственного (#680)

### DIFF
--- a/frontend/src/components/ApplicationDetail/ApplicationDetail.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationDetail.vue
@@ -30,7 +30,7 @@
             </div>
             <!-- Кнопка пересылки (рядом с датой) -->
             <button
-              v-if="mode === 'center'"
+              v-if="mode === 'center' && canForwardApplication"
               class="forward-btn"
               data-testid="app-detail-button-forward"
               :disabled="updatingConfirmation || processingApplication"
@@ -472,6 +472,13 @@ export default {
         // зеркалит право DELETE /blacklist-overrides на бэке (шире, чем создание override).
         canManageBlacklistOverride() {
             return this.isResponsibleUser || this.isApprover;
+        },
+
+        // Зеркалит BE-проверку canForward (sender OR responsible). Согласующего не включаем
+        // сознательно: isApprover - глобальная роль, видит все заявки, и на чужой forward
+        // вернул бы 403. Отправителя тоже нет - в режиме "Центр" у него нет UI-пути к кнопке.
+        canForwardApplication() {
+            return this.isResponsibleUser;
         },
 
         hasUserVoted() {

--- a/frontend/src/components/ApplicationDetail/__tests__/ApplicationDetailForwardGate.spec.js
+++ b/frontend/src/components/ApplicationDetail/__tests__/ApplicationDetailForwardGate.spec.js
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+
+// #680 срез role-gate: кнопку "Переслать" видит только ответственный по заявке
+// (Принимающий). Согласующий (глобальная роль, видит все заявки) и обычный читатель
+// её не видят - BE-проверка forward пускает только sender||responsible.
+
+vi.mock('@/api/client', () => ({
+  apiRequest: vi.fn().mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue([]) }),
+}));
+vi.mock('@/api/applications', () => ({
+  markAsRead: vi.fn().mockResolvedValue(undefined),
+}));
+
+import ApplicationDetail from '../ApplicationDetail.vue';
+
+const FORWARD = '[data-testid="app-detail-button-forward"]';
+
+async function mountDetail(props = {}, data = {}) {
+  const wrapper = shallowMount(ApplicationDetail, {
+    props: {
+      application: { id: 7, application_number: 'A-7', status: 'Непрочитано' },
+      currentUserId: 1,
+      mode: 'center',
+      ...props,
+    },
+  });
+  await wrapper.setData({ responsibleUsers: [], approvers: [], ...data });
+  return wrapper;
+}
+
+describe('ApplicationDetail - гейт кнопки "Переслать" (#680 role-gate)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('ответственный по заявке видит кнопку', async () => {
+    const wrapper = await mountDetail({}, { responsibleUsers: [{ id: 1, approval_status: 'pending' }] });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find(FORWARD).exists()).toBe(true);
+  });
+
+  it('согласующий (не ответственный) кнопку не видит - forward вернул бы 403', async () => {
+    const wrapper = await mountDetail({}, { responsibleUsers: [{ id: 2 }], approvers: [{ user_id: 1 }] });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.isApprover).toBe(true);
+    expect(wrapper.find(FORWARD).exists()).toBe(false);
+  });
+
+  it('посторонний пользователь кнопку не видит', async () => {
+    const wrapper = await mountDetail({}, { responsibleUsers: [{ id: 2 }] });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find(FORWARD).exists()).toBe(false);
+  });
+
+  it('вне режима "Центр" кнопки нет даже у ответственного', async () => {
+    const wrapper = await mountDetail({ mode: 'my' }, { responsibleUsers: [{ id: 1 }] });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find(FORWARD).exists()).toBe(false);
+  });
+});


### PR DESCRIPTION
Срез 3 (role-gate) эпика #680 (пересыл заявки).

## Что было
Кнопка «Переслать» в `ApplicationDetail.vue` показывалась всем в режиме `mode === 'center'`. При этом BE (`application_approval_service.go` `canForward`) пускает forward только для отправителя или ответственного по заявке.

## Находка по авторизации
Согласующий (`isApprover`) во фронте — это глобальная роль (`/application-approvers` без application_id), и такой пользователь по `applyApplicationAccessFilter` видит ВСЕ заявки. Изначальное решение Q1 «гейт = responsible || approver» наплодило бы битых кнопок: согласующий на чужой заявке увидел бы «Переслать» и получил 403 при клике. По согласованию с пользователем гейт сведён к `isResponsibleUser` (зеркалит BE), approver и отправитель исключены сознательно. BE не трогаем.

## Изменения
- `ApplicationDetail.vue`: computed `canForwardApplication = isResponsibleUser`, кнопка под `v-if="mode === 'center' && canForwardApplication"`.
- Новый юнит-тест `ApplicationDetailForwardGate.spec.js`: 4 смысловых кейса (ответственный видит, согласующий-не-ответственный не видит, посторонний не видит, вне center не видит).

## Проверки
- vitest `ApplicationDetail/__tests__/` — 26/26 зелёные.
- Ревью `code-reviewer`: go, блокеров нет; обе жёлтые правки (await setData, сокращён комментарий) внесены.