### PR TITLE
fix(analytics): телепорт календаря DateFilter в body против обрезки (#632)

### DIFF
--- a/frontend/src/components/DateFilter.vue
+++ b/frontend/src/components/DateFilter.vue
@@ -406,6 +406,7 @@ export default {
         showCalendar(open) {
             if (open) {
                 this.$nextTick(() => {
+                    if (!this.showCalendar) return; // успели закрыть до тика - не вешаем слушатели
                     this.updatePosition();
                     window.addEventListener('scroll', this.updatePosition, true);
                     window.addEventListener('resize', this.updatePosition);
@@ -894,11 +895,11 @@ export default {
 }
 
 .calendar-modal {
-    position: absolute;
-    top: calc(100% + 5px);
-    left: 0;
-    z-index: 1001;
-    width: 500px; /* Увеличили ширину для горизонтального расположения */
+    /* Телепортирован в body: top/left задаёт inline-стиль из updatePosition.
+       width нужен здесь, чтобы offsetHeight измерялся до применения inline-стиля. */
+    position: fixed;
+    z-index: 9999;
+    width: 500px;
 }
 
 .calendar-container {
@@ -1281,7 +1282,7 @@ export default {
         transform: translate(-50%, -50%);
         width: 90vw;
         max-width: 320px;
-        z-index: 1002;
+        z-index: 9999;
     }
     
     .calendar-body {

--- a/frontend/src/components/DateFilter.vue
+++ b/frontend/src/components/DateFilter.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="date-filter">
     <div
+      ref="trigger"
       class="date-field"
       @click="toggleCalendar"
     >
@@ -37,235 +38,239 @@
         </svg>
       </div>
             
-      <transition name="calendar-slide">
-        <div
-          v-if="showCalendar"
-          class="calendar-modal"
-          @click.stop
-        >
-          <div class="calendar-container">
-            <!-- Header -->
-            <div class="calendar-header">
-              <div class="header-actions">
-                <button
-                  class="nav-btn prev-btn"
-                  @click="prevMonth"
-                >
-                  <svg
-                    width="12"
-                    height="12"
-                    viewBox="0 0 24 24"
-                    fill="none"
+      <Teleport to="body">
+        <transition name="calendar-slide">
+          <div
+            v-if="showCalendar"
+            ref="calendar"
+            class="calendar-modal"
+            :style="calendarStyle"
+            @click.stop
+          >
+            <div class="calendar-container">
+              <!-- Header -->
+              <div class="calendar-header">
+                <div class="header-actions">
+                  <button
+                    class="nav-btn prev-btn"
+                    @click="prevMonth"
                   >
-                    <path
-                      d="M15 18L9 12L15 6"
-                      stroke="#4F5BDF"
-                      stroke-width="2"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                  </svg>
-                </button>
-                <div class="date-display">
-                  <span class="current-month-year">{{ capitalizeFirstLetter(currentMonthYear) }}</span>
+                    <svg
+                      width="12"
+                      height="12"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                    >
+                      <path
+                        d="M15 18L9 12L15 6"
+                        stroke="#4F5BDF"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                  </button>
+                  <div class="date-display">
+                    <span class="current-month-year">{{ capitalizeFirstLetter(currentMonthYear) }}</span>
+                  </div>
+                  <button
+                    class="nav-btn next-btn"
+                    @click="nextMonth"
+                  >
+                    <svg
+                      width="12"
+                      height="12"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                    >
+                      <path
+                        d="M9 18L15 12L9 6"
+                        stroke="#4F5BDF"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                  </button>
                 </div>
-                <button
-                  class="nav-btn next-btn"
-                  @click="nextMonth"
-                >
-                  <svg
-                    width="12"
-                    height="12"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                  >
-                    <path
-                      d="M9 18L15 12L9 6"
-                      stroke="#4F5BDF"
-                      stroke-width="2"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                  </svg>
-                </button>
               </div>
-            </div>
                         
-            <div class="calendar-body">
-              <!-- Quick selection слева -->
-              <div class="quick-selection">
-                <div class="quick-buttons-list">
-                  <button
-                    class="quick-btn"
-                    :class="{ 'active': isQuickActive('today') }"
-                    @click="setQuickDate('today')"
-                  >
-                    Сегодня
-                  </button>
-                  <button
-                    class="quick-btn"
-                    :class="{ 'active': isQuickActive('yesterday') }"
-                    @click="setQuickDate('yesterday')"
-                  >
-                    Вчера
-                  </button>
-                  <button
-                    class="quick-btn"
-                    :class="{ 'active': isQuickActive('tomorrow') }"
-                    @click="setQuickDate('tomorrow')"
-                  >
-                    Завтра
-                  </button>
-                  <button
-                    class="quick-btn"
-                    :class="{ 'active': isQuickActive('dayBeforeYesterday') }"
-                    @click="setQuickDate('dayBeforeYesterday')"
-                  >
-                    Позавчера
-                  </button>
-                  <button
-                    class="quick-btn"
-                    :class="{ 'active': isQuickActive('dayAfterTomorrow') }"
-                    @click="setQuickDate('dayAfterTomorrow')"
-                  >
-                    Послезавтра
-                  </button>
-                  <button
-                    class="quick-btn"
-                    :class="{ 'active': isQuickActive('thisWeek') }"
-                    @click="setQuickDate('thisWeek')"
-                  >
-                    Эта неделя
-                  </button>
-                  <button
-                    class="quick-btn"
-                    :class="{ 'active': isQuickActive('lastWeek') }"
-                    @click="setQuickDate('lastWeek')"
-                  >
-                    Прошлая неделя
-                  </button>
-                  <button
-                    class="quick-btn"
-                    :class="{ 'active': isQuickActive('nextWeek') }"
-                    @click="setQuickDate('nextWeek')"
-                  >
-                    Следующая неделя
-                  </button>
-                  <button
-                    class="quick-btn"
-                    :class="{ 'active': isQuickActive('thisMonth') }"
-                    @click="setQuickDate('thisMonth')"
-                  >
-                    Этот месяц
-                  </button>
-                  <button
-                    class="quick-btn"
-                    :class="{ 'active': isQuickActive('lastMonth') }"
-                    @click="setQuickDate('lastMonth')"
-                  >
-                    Прошлый месяц
-                  </button>
-                  <button
-                    class="quick-btn"
-                    :class="{ 'active': isQuickActive('nextMonth') }"
-                    @click="setQuickDate('nextMonth')"
-                  >
-                    Следующий месяц
-                  </button>
-                  <button
-                    class="quick-btn"
-                    :class="{ 'active': isQuickActive('thisYear') }"
-                    @click="setQuickDate('thisYear')"
-                  >
-                    Этот год
-                  </button>
-                  <button
-                    class="quick-btn"
-                    :class="{ 'active': isQuickActive('lastYear') }"
-                    @click="setQuickDate('lastYear')"
-                  >
-                    Прошлый год
-                  </button>
+              <div class="calendar-body">
+                <!-- Quick selection слева -->
+                <div class="quick-selection">
+                  <div class="quick-buttons-list">
+                    <button
+                      class="quick-btn"
+                      :class="{ 'active': isQuickActive('today') }"
+                      @click="setQuickDate('today')"
+                    >
+                      Сегодня
+                    </button>
+                    <button
+                      class="quick-btn"
+                      :class="{ 'active': isQuickActive('yesterday') }"
+                      @click="setQuickDate('yesterday')"
+                    >
+                      Вчера
+                    </button>
+                    <button
+                      class="quick-btn"
+                      :class="{ 'active': isQuickActive('tomorrow') }"
+                      @click="setQuickDate('tomorrow')"
+                    >
+                      Завтра
+                    </button>
+                    <button
+                      class="quick-btn"
+                      :class="{ 'active': isQuickActive('dayBeforeYesterday') }"
+                      @click="setQuickDate('dayBeforeYesterday')"
+                    >
+                      Позавчера
+                    </button>
+                    <button
+                      class="quick-btn"
+                      :class="{ 'active': isQuickActive('dayAfterTomorrow') }"
+                      @click="setQuickDate('dayAfterTomorrow')"
+                    >
+                      Послезавтра
+                    </button>
+                    <button
+                      class="quick-btn"
+                      :class="{ 'active': isQuickActive('thisWeek') }"
+                      @click="setQuickDate('thisWeek')"
+                    >
+                      Эта неделя
+                    </button>
+                    <button
+                      class="quick-btn"
+                      :class="{ 'active': isQuickActive('lastWeek') }"
+                      @click="setQuickDate('lastWeek')"
+                    >
+                      Прошлая неделя
+                    </button>
+                    <button
+                      class="quick-btn"
+                      :class="{ 'active': isQuickActive('nextWeek') }"
+                      @click="setQuickDate('nextWeek')"
+                    >
+                      Следующая неделя
+                    </button>
+                    <button
+                      class="quick-btn"
+                      :class="{ 'active': isQuickActive('thisMonth') }"
+                      @click="setQuickDate('thisMonth')"
+                    >
+                      Этот месяц
+                    </button>
+                    <button
+                      class="quick-btn"
+                      :class="{ 'active': isQuickActive('lastMonth') }"
+                      @click="setQuickDate('lastMonth')"
+                    >
+                      Прошлый месяц
+                    </button>
+                    <button
+                      class="quick-btn"
+                      :class="{ 'active': isQuickActive('nextMonth') }"
+                      @click="setQuickDate('nextMonth')"
+                    >
+                      Следующий месяц
+                    </button>
+                    <button
+                      class="quick-btn"
+                      :class="{ 'active': isQuickActive('thisYear') }"
+                      @click="setQuickDate('thisYear')"
+                    >
+                      Этот год
+                    </button>
+                    <button
+                      class="quick-btn"
+                      :class="{ 'active': isQuickActive('lastYear') }"
+                      @click="setQuickDate('lastYear')"
+                    >
+                      Прошлый год
+                    </button>
+                  </div>
                 </div>
-              </div>
                             
-              <!-- Calendar справа -->
-              <div class="calendar-main">
-                <div class="calendar-mode-switch">
-                  <button 
-                    class="mode-btn" 
-                    :class="{ 'active': !selectingRange }"
-                    @click="setMode('single')"
-                  >
-                    Один день
-                  </button>
-                  <button 
-                    class="mode-btn" 
-                    :class="{ 'active': selectingRange }"
-                    @click="setMode('range')"
-                  >
-                    Период
-                  </button>
-                </div>
-                                
-                <div class="weekdays">
-                  <div
-                    v-for="day in weekdays"
-                    :key="day"
-                    class="weekday"
-                  >
-                    {{ day }}
+                <!-- Calendar справа -->
+                <div class="calendar-main">
+                  <div class="calendar-mode-switch">
+                    <button 
+                      class="mode-btn" 
+                      :class="{ 'active': !selectingRange }"
+                      @click="setMode('single')"
+                    >
+                      Один день
+                    </button>
+                    <button 
+                      class="mode-btn" 
+                      :class="{ 'active': selectingRange }"
+                      @click="setMode('range')"
+                    >
+                      Период
+                    </button>
                   </div>
-                </div>
                                 
-                <div class="days-grid">
-                  <div 
-                    v-for="day in daysInMonth" 
-                    :key="day.date ? day.date.getTime() : `empty-${day.index}`"
-                    class="day"
-                    :class="getDayClass(day)"
-                    @click="selectDay(day)"
-                  >
-                    <span class="day-number">{{ day.number }}</span>
+                  <div class="weekdays">
+                    <div
+                      v-for="day in weekdays"
+                      :key="day"
+                      class="weekday"
+                    >
+                      {{ day }}
+                    </div>
                   </div>
-                </div>
                                 
-                <!-- Selected range display - всегда отображается -->
-                <div class="selected-range">
-                  <div class="range-display">
-                    <template v-if="!selectingRange">
-                      <span class="range-label">Отобразить дату:</span>
-                      <span class="range-date">{{ formatDateForDisplay(internalSelectedDate) || '...' }}</span>
-                    </template>
-                    <template v-else>
-                      <span class="range-label">Отобразить с</span>
-                      <span class="range-date">{{ formatDateForDisplay(internalRangeStart) || '...' }}</span>
-                      <span class="range-label">по</span>
-                      <span class="range-date">{{ formatDateForDisplay(internalRangeEnd) || '...' }}</span>
-                    </template>
+                  <div class="days-grid">
+                    <div 
+                      v-for="day in daysInMonth" 
+                      :key="day.date ? day.date.getTime() : `empty-${day.index}`"
+                      class="day"
+                      :class="getDayClass(day)"
+                      @click="selectDay(day)"
+                    >
+                      <span class="day-number">{{ day.number }}</span>
+                    </div>
+                  </div>
+                                
+                  <!-- Selected range display - всегда отображается -->
+                  <div class="selected-range">
+                    <div class="range-display">
+                      <template v-if="!selectingRange">
+                        <span class="range-label">Отобразить дату:</span>
+                        <span class="range-date">{{ formatDateForDisplay(internalSelectedDate) || '...' }}</span>
+                      </template>
+                      <template v-else>
+                        <span class="range-label">Отобразить с</span>
+                        <span class="range-date">{{ formatDateForDisplay(internalRangeStart) || '...' }}</span>
+                        <span class="range-label">по</span>
+                        <span class="range-date">{{ formatDateForDisplay(internalRangeEnd) || '...' }}</span>
+                      </template>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
                         
-            <!-- Actions -->
-            <div class="calendar-actions">
-              <button
-                class="action-btn action-btn--clear"
-                @click="clearSelection"
-              >
-                Очистить
-              </button>
-              <button
-                class="action-btn action-btn--apply"
-                @click="applySelection"
-              >
-                Применить
-              </button>
+              <!-- Actions -->
+              <div class="calendar-actions">
+                <button
+                  class="action-btn action-btn--clear"
+                  @click="clearSelection"
+                >
+                  Очистить
+                </button>
+                <button
+                  class="action-btn action-btn--apply"
+                  @click="applySelection"
+                >
+                  Применить
+                </button>
+              </div>
             </div>
           </div>
-        </div>
-      </transition>
+        </transition>
+      </Teleport>
     </div>
   </div>
 </template>
@@ -302,6 +307,7 @@ export default {
             selectingRange: this.mode === 'range', // true для периода, false для одного дня
             activeQuickDate: null,
             weekdays: ['Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб', 'Вс'],
+            calendarStyle: {},
         };
     },
     computed: {
@@ -397,6 +403,18 @@ export default {
                 this.selectingRange = newVal === 'range';
             }
         },
+        showCalendar(open) {
+            if (open) {
+                this.$nextTick(() => {
+                    this.updatePosition();
+                    window.addEventListener('scroll', this.updatePosition, true);
+                    window.addEventListener('resize', this.updatePosition);
+                });
+            } else {
+                window.removeEventListener('scroll', this.updatePosition, true);
+                window.removeEventListener('resize', this.updatePosition);
+            }
+        },
     },
     mounted() {
         document.addEventListener('click', this.handleClickOutside);
@@ -405,6 +423,8 @@ export default {
     },
     beforeUnmount() {
         document.removeEventListener('click', this.handleClickOutside);
+        window.removeEventListener('scroll', this.updatePosition, true);
+        window.removeEventListener('resize', this.updatePosition);
     },
     methods: {
         capitalizeFirstLetter(string) {
@@ -431,8 +451,45 @@ export default {
             }
         },
         
+        updatePosition() {
+            if (!this.showCalendar) return;
+            const trigger = this.$refs.trigger;
+            if (!trigger) return;
+            // На мобильных вёрстка центрирует попап через @media - не навязываем inline-позицию.
+            if (window.innerWidth <= 768) {
+                this.calendarStyle = {};
+                return;
+            }
+            const rect = trigger.getBoundingClientRect();
+            const width = 500;
+            const margin = 8;
+            let left = rect.left;
+            if (left + width > window.innerWidth - margin) {
+                left = Math.max(margin, window.innerWidth - width - margin);
+            }
+            let top = rect.bottom + 5;
+            const height = this.$refs.calendar ? this.$refs.calendar.offsetHeight : 0;
+            // Не влезает снизу - открываем вверх, если там есть место.
+            if (height && top + height > window.innerHeight - margin) {
+                const above = rect.top - height - 5;
+                top = above >= margin ? above : Math.max(margin, window.innerHeight - height - margin);
+            }
+            this.calendarStyle = {
+                position: 'fixed',
+                top: `${top}px`,
+                left: `${left}px`,
+                width: `${width}px`,
+            };
+        },
+
         handleClickOutside(event) {
-            if (this.showCalendar && !this.$el.contains(event.target)) {
+            if (!this.showCalendar) return;
+            // Календарь телепортирован в body, поэтому this.$el его не содержит -
+            // проверяем и триггер, и сам попап через отдельный ref.
+            const inTrigger = this.$el.contains(event.target);
+            const calendarEl = this.$refs.calendar;
+            const inCalendar = calendarEl && calendarEl.contains(event.target);
+            if (!inTrigger && !inCalendar) {
                 this.showCalendar = false;
                 // Сбрасываем режим выбора периода при закрытии
                 if (this.selectingRange && !this.internalRangeEnd) {
@@ -826,7 +883,8 @@ export default {
 /* Calendar modal */
 .calendar-slide-enter-active,
 .calendar-slide-leave-active {
-    transition: all 0.3s ease;
+    /* Только opacity/transform: top/left пересчитываются на скролле и не должны анимироваться. */
+    transition: opacity 0.3s ease, transform 0.3s ease;
 }
 
 .calendar-slide-enter-from,


### PR DESCRIPTION
## Что чинит

Выпадающий календарь общего `DateFilter` (`.calendar-modal`, 500px) обрезался контейнером Аналитики: `.statistics { overflow:hidden; border-radius:35px }` резал absolute-позиционированный попап. Срез `fix-calendar-overflow` эпика #632.

## Решение (выбор владельца)

Teleport попапа календаря в `<body>` - уводит его из-под любого `overflow:hidden` контейнера. Координаты считаются `position:fixed` от `getBoundingClientRect()` триггера в `updatePosition()`, с пересчётом на `scroll`/`resize` и клампингом по правому/нижнему краю viewport. На мобиле inline-позиция не навязывается - центрирование остаётся за `@media`.

Поскольку `this.$el` больше не содержит телепортированный календарь, `handleClickOutside` теперь проверяет и триггер (`this.$el`), и сам попап через отдельный `ref`.

## Где используется (проверено во всех 4)

`DateFilter` общий для ApplicationsCenter, TablesComponent, TrashView, StatisticsView. Прогнал headless-браузером (логин супер-админом, реальный бэкенд) открытие календаря в каждом:

| View | parent | position | z-index | clippedBy | в пределах viewport |
|------|--------|----------|---------|-----------|---------------------|
| /analytics | body | fixed | 9999 | нет | да |
| /center | body | fixed | 9999 | нет | да |
| /table/kpp_4 | body | fixed | 9999 | нет | да (правый край, clamp сработал) |
| /table/kpp_4/trash | body | fixed | 9999 | нет | да |

## По ревью (code-reviewer)

- Статический `.calendar-modal` остался `position:absolute; top:calc(100%+5px)` - после Teleport считается от body, мёртвый/опасный CSS. Заменил на `position:fixed` без координат (их даёт inline-стиль). `width:500px` оставлен в CSS осознанно: `offsetHeight` меряется до применения inline-стиля.
- Guard в `$nextTick`: если попап закрыли до тика, слушатели scroll/resize не вешаются.
- z-index попапа поднят 1001 -> 9999 (общий компонент, был риск перекрытия чужими стэками).
