### PR TITLE
feat(forward): таблица forward_attachments и запись при пересылке (#680)

### DIFF
--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -84,6 +84,9 @@ func AllModels() []interface{} {
 		// Attachments (depends on Application, UniqueAttachment)
 		&models.Attachment{},
 
+		// Forward attachments (#680: пер-вложенный пересыл; depends on Application, User, Attachment)
+		&models.ForwardAttachment{},
+
 		// Attachment templates (#183: Excel-бланки)
 		&models.AttachmentTemplate{},
 		&models.AttachmentTemplateMapping{},

--- a/internal/handlers/applications_approval_test.go
+++ b/internal/handlers/applications_approval_test.go
@@ -275,3 +275,143 @@ func TestApprovalWorkflow(t *testing.T) {
 		t.Run(tt.name, tt.run)
 	}
 }
+
+// TestForwardAttachments проверяет запись строк forward_attachments при пересылке (#680):
+// общий список вложений разворачивается построчно на каждого получателя, чужие ID
+// отбрасываются, пустой список не пишет строк (обратная совместимость).
+func TestForwardAttachments(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+
+	// createAppWithTwoAttachments создаёт заявку с двумя cars-вложениями и возвращает их ID.
+	createAppWithTwoAttachments := func(t *testing.T, token, prefix string) (appID, attID1, attID2 int) {
+		t.Helper()
+		uaID1 := seedUniqueAttachment(t, db, "cars", prefix+"_a", prefix+" A")
+		uaID2 := seedUniqueAttachment(t, db, "cars", prefix+"_b", prefix+" B")
+		body := fmt.Sprintf(`{
+			"message": "forward attachments test",
+			"organization": "Test Organization",
+			"responsible_person": "Test Person",
+			"contact_phone": "+79001234567",
+			"data_approval": true,
+			"attachments": [
+				{"attachment_type":"cars","attachment_name":"cars_a","attachment_display_name":"Cars A",
+				 "unique_attachment_id":%d,"entry_date_from":"2026-04-01","entry_date_to":"2099-12-31",
+				 "entry_time_from":"08:00","entry_time_to":"18:00",
+				 "data":{"vehicles":[{"car_number":"B001BB777","car_brand":"Honda"}]}},
+				{"attachment_type":"cars","attachment_name":"cars_b","attachment_display_name":"Cars B",
+				 "unique_attachment_id":%d,"entry_date_from":"2026-04-01","entry_date_to":"2099-12-31",
+				 "entry_time_from":"08:00","entry_time_to":"18:00",
+				 "data":{"vehicles":[{"car_number":"C001CC777","car_brand":"Mazda"}]}}
+			]
+		}`, uaID1, uaID2)
+		rec := testutil.POST(t, e, "/applications/submit-complete-application", body, testutil.AuthHeader(token))
+		require.Equal(t, http.StatusOK, rec.Code, "create: %s", rec.Body.String())
+		resp := testutil.ParseResponse[services.CompleteApplicationResponse](t, rec)
+		appID = resp.ApplicationID
+
+		rec = testutil.GET(t, e, fmt.Sprintf("/applications/%d/attachments", appID), testutil.AuthHeader(token))
+		require.Equal(t, http.StatusOK, rec.Code)
+		attachments := testutil.ParseSlice(t, rec)
+		require.Len(t, attachments, 2)
+		return appID, int(attachments[0]["id"].(float64)), int(attachments[1]["id"].(float64))
+	}
+
+	type faRow struct {
+		RecipientUserID int `gorm:"column:recipient_user_id"`
+		AttachmentID    int `gorm:"column:attachment_id"`
+	}
+	forwardRows := func(t *testing.T, appID int) []faRow {
+		t.Helper()
+		var rows []faRow
+		err := db.Raw("SELECT recipient_user_id, attachment_id FROM forward_attachments WHERE application_id = ? ORDER BY recipient_user_id, attachment_id", appID).Scan(&rows).Error
+		require.NoError(t, err)
+		return rows
+	}
+
+	t.Run("subset_written_per_recipient", func(t *testing.T) {
+		testutil.CleanDB(t, db)
+		td := testutil.SeedTestData(t, db)
+
+		senderToken := testutil.RegisterAndLogin(t, e, "fa_sender1", "pass123", 1, td.OrgID, td.CompanyID)
+		appID, attID1, _ := createAppWithTwoAttachments(t, senderToken, "fa_cars1")
+
+		testutil.RegisterUser(t, e, "fa_resp1", "pass123", 1, td.OrgID, td.CompanyID)
+		respID := getUserID(t, db, "fa_resp1")
+
+		body := fmt.Sprintf(`{"users":[{"user_id":%d,"required_approval":true,"can_view":false}],"attachment_ids":[%d]}`, respID, attID1)
+		rec := testutil.POST(t, e, fmt.Sprintf("/applications/%d/forward", appID), body, testutil.AuthHeader(senderToken))
+		require.Equal(t, http.StatusOK, rec.Code, "forward: %s", rec.Body.String())
+
+		rows := forwardRows(t, appID)
+		require.Len(t, rows, 1, "ровно одна строка на (получатель, выбранное вложение)")
+		assert.Equal(t, respID, rows[0].RecipientUserID)
+		assert.Equal(t, attID1, rows[0].AttachmentID)
+	})
+
+	t.Run("empty_list_writes_nothing", func(t *testing.T) {
+		testutil.CleanDB(t, db)
+		td := testutil.SeedTestData(t, db)
+
+		senderToken := testutil.RegisterAndLogin(t, e, "fa_sender2", "pass123", 1, td.OrgID, td.CompanyID)
+		appID, _, _ := createAppWithTwoAttachments(t, senderToken, "fa_cars2")
+
+		testutil.RegisterUser(t, e, "fa_resp2", "pass123", 1, td.OrgID, td.CompanyID)
+		respID := getUserID(t, db, "fa_resp2")
+
+		body := fmt.Sprintf(`{"users":[{"user_id":%d,"required_approval":true,"can_view":false}]}`, respID)
+		rec := testutil.POST(t, e, fmt.Sprintf("/applications/%d/forward", appID), body, testutil.AuthHeader(senderToken))
+		require.Equal(t, http.StatusOK, rec.Code, "forward: %s", rec.Body.String())
+
+		assert.Empty(t, forwardRows(t, appID), "без attachment_ids строк быть не должно (видит все)")
+	})
+
+	t.Run("all_foreign_ids_writes_nothing", func(t *testing.T) {
+		testutil.CleanDB(t, db)
+		td := testutil.SeedTestData(t, db)
+
+		senderToken := testutil.RegisterAndLogin(t, e, "fa_sender4", "pass123", 1, td.OrgID, td.CompanyID)
+		appID, _, _ := createAppWithTwoAttachments(t, senderToken, "fa_cars4")
+
+		testutil.RegisterUser(t, e, "fa_resp4", "pass123", 1, td.OrgID, td.CompanyID)
+		respID := getUserID(t, db, "fa_resp4")
+
+		// Все ID чужие (не из этой заявки) - все отброшены, строк нет. Важно для чтения:
+		// получатель остаётся в режиме "видит все" (нет строк), а не "видит ничего".
+		body := fmt.Sprintf(`{"users":[{"user_id":%d,"required_approval":true,"can_view":false}],"attachment_ids":[999998,999999]}`, respID)
+		rec := testutil.POST(t, e, fmt.Sprintf("/applications/%d/forward", appID), body, testutil.AuthHeader(senderToken))
+		require.Equal(t, http.StatusOK, rec.Code, "forward: %s", rec.Body.String())
+
+		assert.Empty(t, forwardRows(t, appID), "чужие attachment_ids отброшены -> строк нет")
+	})
+
+	t.Run("fanout_to_recipients_filters_foreign_ids", func(t *testing.T) {
+		testutil.CleanDB(t, db)
+		td := testutil.SeedTestData(t, db)
+
+		senderToken := testutil.RegisterAndLogin(t, e, "fa_sender3", "pass123", 1, td.OrgID, td.CompanyID)
+		appID, attID1, attID2 := createAppWithTwoAttachments(t, senderToken, "fa_cars3")
+
+		testutil.RegisterUser(t, e, "fa_resp3", "pass123", 1, td.OrgID, td.CompanyID)
+		respID := getUserID(t, db, "fa_resp3")
+		testutil.RegisterUser(t, e, "fa_view3", "pass123", 1, td.OrgID, td.CompanyID)
+		viewerID := getUserID(t, db, "fa_view3")
+
+		// Чужой attachment_id 999999 должен быть отброшен фильтром по application_id.
+		body := fmt.Sprintf(`{"users":[
+			{"user_id":%d,"required_approval":true,"can_view":false},
+			{"user_id":%d,"required_approval":false,"can_view":true}
+		],"attachment_ids":[%d,%d,999999]}`, respID, viewerID, attID1, attID2)
+		rec := testutil.POST(t, e, fmt.Sprintf("/applications/%d/forward", appID), body, testutil.AuthHeader(senderToken))
+		require.Equal(t, http.StatusOK, rec.Code, "forward: %s", rec.Body.String())
+
+		rows := forwardRows(t, appID)
+		require.Len(t, rows, 4, "2 получателя x 2 валидных вложения, чужой ID отброшен")
+		got := map[int][]int{}
+		for _, r := range rows {
+			got[r.RecipientUserID] = append(got[r.RecipientUserID], r.AttachmentID)
+		}
+		assert.ElementsMatch(t, []int{attID1, attID2}, got[respID])
+		assert.ElementsMatch(t, []int{attID1, attID2}, got[viewerID])
+	})
+}

--- a/internal/models/forward_attachment.go
+++ b/internal/models/forward_attachment.go
@@ -1,0 +1,20 @@
+package models
+
+import "time"
+
+// ForwardAttachment связывает получателя пересылки с конкретным вложением заявки (#680).
+// Семантика чтения (срез be-read): есть строки для пары (заявка, получатель) - получатель
+// видит только перечисленные вложения; нет строк - видит все (обратная совместимость).
+// Уникальный индекс по (application_id, recipient_user_id, attachment_id) делает повторную
+// пересылку тех же вложений идемпотентной; его левый префикс обслуживает фильтр чтения.
+type ForwardAttachment struct {
+	ID              int         `json:"id"`
+	ApplicationID   int         `gorm:"uniqueIndex:idx_forward_att,priority:1" json:"application_id"`
+	Application     Application `gorm:"constraint:OnDelete:CASCADE" json:"-"`
+	RecipientUserID int         `gorm:"uniqueIndex:idx_forward_att,priority:2" json:"recipient_user_id"`
+	RecipientUser   User        `gorm:"foreignKey:RecipientUserID;constraint:OnDelete:CASCADE" json:"-"`
+	AttachmentID    int         `gorm:"uniqueIndex:idx_forward_att,priority:3" json:"attachment_id"`
+	Attachment      Attachment  `gorm:"constraint:OnDelete:CASCADE" json:"-"`
+	CreatedAt       time.Time   `json:"created_at"`
+	CreatedBy       *int        `json:"created_by"`
+}

--- a/internal/services/application_approval_service.go
+++ b/internal/services/application_approval_service.go
@@ -117,6 +117,36 @@ func (s *applicationService) ForwardApplication(ctx context.Context, username st
 		}
 	}
 
+	// Пер-вложенный пересыл (#680): фиксируем, какие вложения видит каждый получатель.
+	// Список общий на действие, разворачиваем построчно (получатель x вложение). Пустой
+	// список не пишет строк -> получатели видят все вложения (обратная совместимость).
+	// Семантика аддитивная: повторная пересылка с другим набором ДОБАВЛЯет строки
+	// (ON CONFLICT DO NOTHING), а не заменяет; сужение видимости здесь не предусмотрено.
+	if len(req.AttachmentIDs) > 0 {
+		recipients := make([]int, 0, len(addedResponsibleUsers)+len(addedViewers))
+		for _, resp := range addedResponsibleUsers {
+			recipients = append(recipients, resp.UserID)
+		}
+		recipients = append(recipients, addedViewers...)
+
+		if len(recipients) > 0 {
+			// Только вложения самой заявки - чужие ID отбрасываем, чтобы строка не ссылалась
+			// на чужое вложение и фильтр чтения не прятал всё подряд.
+			var validAttIDs []int
+			tx.Raw("SELECT id FROM attachments WHERE application_id = ? AND id IN ?", applicationID, req.AttachmentIDs).Scan(&validAttIDs)
+
+			for _, recipientID := range recipients {
+				for _, attID := range validAttIDs {
+					tx.Exec(`
+						INSERT INTO forward_attachments (application_id, recipient_user_id, attachment_id, created_at, created_by)
+						VALUES (?, ?, ?, ?, ?)
+						ON CONFLICT (application_id, recipient_user_id, attachment_id) DO NOTHING
+					`, applicationID, recipientID, attID, baseTime, user.ID)
+				}
+			}
+		}
+	}
+
 	// Записываем историю назначений ответственных
 	for _, resp := range addedResponsibleUsers {
 		historyTime = historyTime.Add(time.Millisecond)

--- a/internal/services/application_service.go
+++ b/internal/services/application_service.go
@@ -227,8 +227,12 @@ type ApplicationUpdateRequest struct {
 }
 
 // ForwardApplicationRequest тело запроса на пересылку заявки.
+// AttachmentIDs - общий для всех получателей список вложений (#680): пустой -> получатели
+// видят все вложения заявки; непустой -> в forward_attachments пишется строка на каждого
+// получателя x каждое вложение, и при чтении получатель видит только перечисленные.
 type ForwardApplicationRequest struct {
-	Users []ForwardUser `json:"users"`
+	Users         []ForwardUser `json:"users"`
+	AttachmentIDs []int         `json:"attachment_ids"`
 }
 
 // ForwardUser пользователь для пересылки. required_approval и can_view не могут быть оба true.


### PR DESCRIPTION
## Срез be-schema эпика «пересыл заявки» (#680, п.42 эпика 46-edits)

Бэкенд-фундамент пер-вложенного пересыла: схема + запись. Чтение/фильтрация по этим строкам — следующий срез (be-read), здесь его нет.

### Что сделано
- Модель `internal/models/forward_attachment.go` — таблица `forward_attachments` (application_id, recipient_user_id, attachment_id). Составной уникальный индекс по трём полям; его левый префикс `(application_id, recipient_user_id)` готов под фильтр чтения be-read. FK `OnDelete:CASCADE` на Application/User/Attachment.
- В payload `ForwardApplicationRequest` добавлен общий список `attachment_ids []int` (один на действие пересылки).
- В `ForwardApplication` строки пишутся fan-out: каждый добавленный получатель (responsible + viewer) × каждое валидное вложение. Чужие `attachment_id` (не из этой заявки) отбрасываются через `WHERE application_id=? AND id IN ?`. Пустой список строк не пишет — получатель видит все вложения (обратная совместимость). Запись внутри той же транзакции, `ON CONFLICT DO NOTHING` для идемпотентности повторной пересылки.
- Go-тест `TestForwardAttachments`: подмножество на получателя, пустой список = 0 строк, все-чужие ID = 0 строк, fan-out на 2 получателей + отброс чужого ID.

### Решения
- **Q2 (вариант A):** список вложений общий на всех получателей, в БД разворачивается построчно per-recipient.
- **Q3 — OFF-LIMITS `migrate.go`:** добавлена строка `&models.ForwardAttachment{}` в `AllModels()`. На правку этого файла получен явный OK человека; таблицу создаёт GORM AutoMigrate.
- Семантика повторной пересылки **аддитивная** (добавляет строки, не сужает) — задокументировано комментарием рядом с кодом, важно для be-read.

### Заметки по ревью (code-reviewer)
- Swagger-определение `attachment_ids` не дописано вручную — генерируется `swag init` на деплое (swaggo читает экспортированные поля), generated-файлы руками не правлю.
- Ошибки `tx.Raw` не проверяются точечно — консистентно с окружающим кодом ForwardApplication; накопленный `tx.Error` ловит `tx.Commit()` (фейл → 500), молчаливого проглатывания нет.

### Проверки
- `go test ./internal/handlers/... ./internal/services/... ./internal/models/... ./internal/database/...` — зелёные (включая создание таблицы через AutoMigrate в SetupTestApp).
- gofmt чистый, `go build ./...` OK.