### PR TITLE
feat(onboarding): плавное закрытие тура (#657)

### DIFF
--- a/frontend/src/assets/onboarding.css
+++ b/frontend/src/assets/onboarding.css
@@ -13,6 +13,17 @@
 }
 
 /*
+ * Плавное закрытие тура: driver.js делает только fade-in, на destroy убирает
+ * overlay и поповер мгновенно. Перед удалением DOM хост вешает .ob-fade-out на
+ * .driver-overlay (SVG-затемнение) и .driver-popover - оба плавно затухают.
+ */
+.driver-overlay.ob-fade-out,
+.driver-popover.ob-fade-out {
+  opacity: 0 !important;
+  transition: opacity 0.24s ease !important;
+}
+
+/*
  * driver.css задаёт font-family прямо на потомках (.driver-popover * и
  * font-shorthand на title/description/buttons -> sans-serif), что перебивает
  * Montserrat, унаследованный с контейнера. Форсируем Montserrat на всех

--- a/frontend/src/components/onboarding/OnboardingTour.vue
+++ b/frontend/src/components/onboarding/OnboardingTour.vue
@@ -10,7 +10,28 @@ const store = useOnboardingStore();
 const ui = useUiStore();
 const route = useRoute();
 const router = useRouter();
-const { waitForElement, createDriver } = useOnboarding();
+const { waitForElement, createDriver, prefersReducedMotion } = useOnboarding();
+
+/**
+ * Плавное закрытие тура: driver.js делает только fade-IN, а на destroy убирает
+ * overlay и поповер мгновенно (рывок). Навешиваем класс затухания на оба
+ * элемента и удаляем DOM уже после анимации. Только для ЗАВЕРШЕНИЯ тура
+ * (финал/Esc/крестик/пропуск) - не для переходов между страницами.
+ *
+ * @param {import('driver.js').Driver} driverInstance
+ */
+function fadeAndDestroy(driverInstance) {
+  const els = [
+    document.querySelector('.driver-overlay'),
+    document.querySelector('.driver-popover'),
+  ].filter(Boolean);
+  if (!els.length || prefersReducedMotion()) {
+    driverInstance.destroy();
+    return;
+  }
+  els.forEach((el) => el.classList.add('ob-fade-out'));
+  setTimeout(() => driverInstance.destroy(), 240);
+}
 
 // Первую цель сегмента ждём дольше при cross-page: после router.push страница
 // монтируется и грузит данные (скелетоны), цель появляется не сразу.
@@ -226,10 +247,13 @@ function retreatToSegment(targetIndex, targetRoute) {
 }
 
 function finishTour() {
-  // destroy() синхронно зовёт onDestroyed -> handleDestroyed (pendingSegment=false)
-  // -> markCompleted (если авто) + stop. Без инстанса завершаем напрямую.
+  // Затухаем, затем destroy(): он синхронно зовёт onDestroyed -> handleDestroyed
+  // (pendingSegment=false) -> markCompleted (если авто) + stop. driverObj обнуляем
+  // сразу, чтобы teardown по stop не дёрнул второй destroy. Без инстанса - напрямую.
   if (driverObj) {
-    driverObj.destroy();
+    const d = driverObj;
+    driverObj = null;
+    fadeAndDestroy(d);
   } else {
     restoreRail();
     markIfAuto();
@@ -267,8 +291,11 @@ function teardown() {
     waitController = null;
   }
   if (driverObj) {
-    driverObj.destroy();
+    // Затухаем перед удалением DOM; driverGen уже увеличен - отложенный
+    // onDestroyed обезврежен (gen-гард в handleDestroyed).
+    const d = driverObj;
     driverObj = null;
+    fadeAndDestroy(d);
   }
   store.clearPending();
   restoreRail();


### PR DESCRIPTION
Тур закрывался рывком: driver.js делает только fade-in, а на destroy убирает overlay и поповер мгновенно.

Перед удалением DOM хост вешает класс `.ob-fade-out` на `.driver-overlay` (SVG-затемнение) и `.driver-popover` - оба плавно затухают (`opacity 0` за 0.24s), а сам `destroy()` откладывается на длительность анимации (`fadeAndDestroy` в OnboardingTour). Применяется ко ВСЕМ путям завершения тура (финал «Готово», Esc, крестик, «Пропустить обучение») - они сходятся в `finishTour`/`teardown`. При `prefers-reduced-motion` закрываем мгновенно. Переходы между страницами (advanceToSegment/retreatToSegment) не трогаю - там тур продолжается.

## Проверка
- Юнит: onboarding 37 passed; eslint 0.
- Playwright на живом стеке 15/15: для Esc / Пропустить / крестик / Готово - overlay и поповер получают класс затухания + `transition: opacity 0.24s`, DOM остаётся на месте во время анимации и удаляется после; рестарт тура после закрытия работает (нет утечки состояния).