### PR TITLE
feat(analytics): причесал дашборд аналитики (#632)

### DIFF
--- a/frontend/src/components/statistics/StatisticsDashboard.vue
+++ b/frontend/src/components/statistics/StatisticsDashboard.vue
@@ -14,7 +14,7 @@
         class="dashboard__tiles"
       >
         <div
-          v-for="n in 9"
+          v-for="n in 6"
           :key="n"
           class="dashboard__tile dashboard__tile--skeleton"
         />
@@ -25,30 +25,12 @@
         class="dashboard__tiles"
       >
         <div class="dashboard__tile">
-          <div class="dashboard__tile-label">Всего заявок</div>
+          <div class="dashboard__tile-label">Получено заявок</div>
           <div class="dashboard__tile-val">{{ fmt(summary.total_applications) }}</div>
-        </div>
-        <div class="dashboard__tile">
-          <div class="dashboard__tile-label">Вложения (всего)</div>
-          <div class="dashboard__tile-val">{{ fmt(attachmentsTotal) }}</div>
-          <div
-            v-if="attachmentBreakdown.length"
-            class="dashboard__tile-breakdown"
-          >
-            <span
-              v-for="item in attachmentBreakdown"
-              :key="item.label"
-              class="dashboard__breakdown-item"
-            >{{ item.label }}: {{ item.count }}</span>
-          </div>
         </div>
         <div class="dashboard__tile">
           <div class="dashboard__tile-label">Обработано</div>
           <div class="dashboard__tile-val">{{ fmt(summary.processed) }}</div>
-        </div>
-        <div class="dashboard__tile">
-          <div class="dashboard__tile-label">В работе</div>
-          <div class="dashboard__tile-val">{{ fmt(summary.in_work) }}</div>
         </div>
         <div class="dashboard__tile">
           <div class="dashboard__tile-label">Машин заехало</div>
@@ -59,16 +41,53 @@
           <div class="dashboard__tile-val">{{ fmt(summary.people_entered) }}</div>
         </div>
         <div class="dashboard__tile">
-          <div class="dashboard__tile-label">Сумма товаров</div>
-          <div class="dashboard__tile-val">{{ fmt(summary.items_sum) }}</div>
-        </div>
-        <div class="dashboard__tile">
           <div class="dashboard__tile-label">Машин на территории</div>
           <div class="dashboard__tile-val">{{ fmt(summary.cars_on_territory) }}</div>
         </div>
         <div class="dashboard__tile">
           <div class="dashboard__tile-label">Людей на территории</div>
           <div class="dashboard__tile-val">{{ fmt(summary.people_on_territory) }}</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ===== ГРУППА: ВЛОЖЕНИЯ ===== -->
+    <div class="dashboard__group">
+      <div class="dashboard__group-head">
+        <h2 class="dashboard__group-title">Вложения</h2>
+        <span class="dashboard__group-chip">по типам за период</span>
+        <span class="dashboard__group-rule" />
+      </div>
+
+      <div
+        v-if="summaryLoading"
+        class="dashboard__tiles"
+      >
+        <div
+          v-for="n in 6"
+          :key="n"
+          class="dashboard__tile dashboard__tile--skeleton"
+        />
+      </div>
+
+      <div
+        v-else-if="attachmentBreakdown.length === 0"
+        class="dashboard__feed-empty"
+      >
+        В системе нет настроенных типов вложений
+      </div>
+
+      <div
+        v-else
+        class="dashboard__tiles"
+      >
+        <div
+          v-for="item in attachmentBreakdown"
+          :key="item.label"
+          class="dashboard__tile"
+        >
+          <div class="dashboard__tile-label">{{ item.label }}</div>
+          <div class="dashboard__tile-val">{{ fmt(item.count) }}</div>
         </div>
       </div>
     </div>
@@ -101,7 +120,7 @@
           <div class="dashboard__tile-val">{{ fmt(summary.users_online) }}</div>
         </div>
         <div class="dashboard__tile">
-          <div class="dashboard__tile-label">Активных пользователей</div>
+          <div class="dashboard__tile-label">Пользователи</div>
           <div class="dashboard__tile-val">{{ fmt(summary.active_users) }}</div>
         </div>
         <div class="dashboard__tile">
@@ -171,7 +190,10 @@
             <span class="dashboard__live-dot" />
             Проход людей
           </h3>
-          <span class="dashboard__feed-meta">обновление каждые 10 сек · UTC+3</span>
+          <RefreshButton
+            :loading="feedRefreshing"
+            @refresh="refreshFeeds"
+          />
         </div>
 
         <div class="dashboard__feed-list">
@@ -187,8 +209,8 @@
           </template>
           <template v-else>
             <div
-              v-for="(row, idx) in peopleFeed"
-              :key="idx"
+              v-for="row in peopleFeed"
+              :key="feedRowKey(row)"
               class="dashboard__feed-row"
             >
               <div class="dashboard__feed-main">
@@ -218,7 +240,10 @@
             <span class="dashboard__live-dot" />
             Проезд машин
           </h3>
-          <span class="dashboard__feed-meta">обновление каждые 10 сек · UTC+3</span>
+          <RefreshButton
+            :loading="feedRefreshing"
+            @refresh="refreshFeeds"
+          />
         </div>
 
         <div class="dashboard__feed-list">
@@ -234,8 +259,8 @@
           </template>
           <template v-else>
             <div
-              v-for="(row, idx) in carsFeed"
-              :key="idx"
+              v-for="row in carsFeed"
+              :key="feedRowKey(row)"
               class="dashboard__feed-row"
             >
               <div class="dashboard__plate">{{ row.subject }}</div>
@@ -267,7 +292,9 @@
 <script setup>
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue';
 import RealTimeChart from '@/components/RealTimeChart.vue';
+import RefreshButton from '@/components/RefreshButton.vue';
 import { getSummary, getTimeline, getRecentPassages } from '@/api/statistics.js';
+import { mergeFeed, feedRowKey } from './feedMerge.js';
 
 const props = defineProps({
   from: {
@@ -290,6 +317,7 @@ const timelineLoading = ref(false);
 const peopleFeed = ref([]);
 const carsFeed = ref([]);
 const feedLoading = ref(false);
+const feedRefreshing = ref(false);
 
 // ---- переключатели графика ----
 const metricOptions = [
@@ -324,12 +352,6 @@ const chartData = computed(() =>
 );
 
 // ---- вычисляемые из summary ----
-const attachmentsTotal = computed(() => {
-  const list = summary.value.by_attachment_type;
-  if (!Array.isArray(list)) return 0;
-  return list.reduce((s, item) => s + (item?.count || 0), 0);
-});
-
 const attachmentBreakdown = computed(() => {
   const list = summary.value.by_attachment_type;
   if (!Array.isArray(list)) return [];
@@ -392,17 +414,36 @@ async function loadTimeline() {
   }
 }
 
-async function loadFeed() {
-  feedLoading.value = true;
+// showSkeleton: только первичная загрузка показывает скелетоны. Фоновые тики и
+// ручное обновление доливают новые записи сверху через mergeFeed — без мигания
+// всего блока и без перерисовки уже показанных строк.
+async function loadFeed({ showSkeleton = false } = {}) {
+  if (showSkeleton) feedLoading.value = true;
   try {
     const data = await getRecentPassages(15);
-    peopleFeed.value = Array.isArray(data?.people) ? data.people : [];
-    carsFeed.value = Array.isArray(data?.cars) ? data.cars : [];
+    const people = Array.isArray(data?.people) ? data.people : [];
+    const cars = Array.isArray(data?.cars) ? data.cars : [];
+    peopleFeed.value = mergeFeed(peopleFeed.value, people);
+    carsFeed.value = mergeFeed(carsFeed.value, cars);
   } catch {
-    peopleFeed.value = [];
-    carsFeed.value = [];
+    // Фоновый сбой не должен очищать уже показанные ленты — чистим только при
+    // первичной загрузке, где показать пустоту корректнее, чем скелетон навсегда.
+    if (showSkeleton) {
+      peopleFeed.value = [];
+      carsFeed.value = [];
+    }
   } finally {
-    feedLoading.value = false;
+    if (showSkeleton) feedLoading.value = false;
+  }
+}
+
+// Ручное обновление лент — крутит RefreshButton, не показывает скелетон.
+async function refreshFeeds() {
+  feedRefreshing.value = true;
+  try {
+    await loadFeed();
+  } finally {
+    feedRefreshing.value = false;
   }
 }
 
@@ -430,8 +471,8 @@ let feedInterval = null;
 onMounted(() => {
   loadSummary();
   loadTimeline();
-  loadFeed();
-  feedInterval = setInterval(loadFeed, 10000);
+  loadFeed({ showSkeleton: true });
+  feedInterval = setInterval(() => loadFeed(), 10000);
 });
 
 onUnmounted(() => {
@@ -540,22 +581,6 @@ onUnmounted(() => {
   line-height: 1;
 }
 
-.dashboard__tile-breakdown {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
-  margin-top: 6px;
-}
-
-.dashboard__breakdown-item {
-  font-size: 10px;
-  color: var(--color-text-muted);
-  background: var(--color-bg);
-  border-radius: var(--radius-pill);
-  padding: 2px 7px;
-  border: 1px solid var(--color-border);
-}
-
 /* ===== ГРАФИК ===== */
 .dashboard__chart-card {
   border: 1px solid var(--color-border);
@@ -623,6 +648,11 @@ onUnmounted(() => {
   color: #fff;
 }
 
+/* На активной сегмент-кнопке hover не должен перекрашивать текст в синий. */
+.dashboard__seg-btn--active:hover {
+  color: #fff;
+}
+
 .dashboard__chart-skeleton {
   height: 300px;
   background: var(--color-skeleton);
@@ -686,12 +716,6 @@ onUnmounted(() => {
   0%   { box-shadow: 0 0 0 0 rgba(40, 167, 69, 0.55); }
   70%  { box-shadow: 0 0 0 8px rgba(40, 167, 69, 0); }
   100% { box-shadow: 0 0 0 0 rgba(40, 167, 69, 0); }
-}
-
-.dashboard__feed-meta {
-  font-size: 11px;
-  color: var(--color-text-muted);
-  white-space: nowrap;
 }
 
 .dashboard__feed-list {

--- a/frontend/src/components/statistics/__tests__/StatisticsDashboard.spec.js
+++ b/frontend/src/components/statistics/__tests__/StatisticsDashboard.spec.js
@@ -1,13 +1,13 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mount, flushPromises } from '@vue/test-utils';
 import { nextTick } from 'vue';
 
-// Управляемые промисы getTimeline: фабрика vi.mock поднимается над импортами,
-// поэтому состояние выносим в hoisted.
-const { state } = vi.hoisted(() => ({ state: { deferred: [] } }));
+// Управляемое состояние моков: фабрика vi.mock поднимается над импортами,
+// поэтому summary/deferred выносим в hoisted.
+const { state } = vi.hoisted(() => ({ state: { deferred: [], summary: {} } }));
 
 vi.mock('@/api/statistics.js', () => ({
-  getSummary: () => Promise.resolve({}),
+  getSummary: () => Promise.resolve(state.summary),
   getRecentPassages: () => Promise.resolve({ people: [], cars: [] }),
   getTimeline: () => new Promise((resolve) => { state.deferred.push(resolve); }),
 }));
@@ -15,13 +15,19 @@ vi.mock('@/api/statistics.js', () => ({
 import StatisticsDashboard from '../StatisticsDashboard.vue';
 import RealTimeChart from '@/components/RealTimeChart.vue';
 
+const mountDashboard = () => mount(StatisticsDashboard, {
+  props: { from: '2026-06-01', to: '2026-06-07' },
+  global: { stubs: { RealTimeChart: true, RefreshButton: true } },
+});
+
+beforeEach(() => {
+  state.deferred.length = 0;
+  state.summary = {};
+});
+
 describe('StatisticsDashboard — гонка таймлайна', () => {
   it('при быстрой смене метрики рисует данные последнего запроса, медленный предыдущий игнорирует', async () => {
-    state.deferred.length = 0;
-    const wrapper = mount(StatisticsDashboard, {
-      props: { from: '2026-06-01', to: '2026-06-07' },
-      global: { stubs: { RealTimeChart: true, RefreshButton: true } },
-    });
+    const wrapper = mountDashboard();
     await nextTick(); // onMounted -> loadTimeline (seq 1, deferred)
 
     // Быстрое переключение метрики -> второй loadTimeline (seq 2).
@@ -40,5 +46,37 @@ describe('StatisticsDashboard — гонка таймлайна', () => {
     const data = chart.props('data');
     expect(data).toHaveLength(1);
     expect(data[0].count).toBe(222); // не 111 от устаревшего ответа
+  });
+});
+
+describe('StatisticsDashboard — плитки', () => {
+  it('показывает переименованные метрики и убирает снятые плитки', async () => {
+    state.summary = { total_applications: 5, processed: 2, active_users: 7 };
+    const wrapper = mountDashboard();
+    await flushPromises();
+
+    const text = wrapper.text();
+    expect(text).toContain('Получено заявок');
+    expect(text).toContain('Пользователи');
+    expect(text).not.toContain('Всего заявок');
+    expect(text).not.toContain('В работе');
+    expect(text).not.toContain('Сумма товаров');
+    expect(text).not.toContain('Вложения (всего)');
+  });
+
+  it('раздел Вложения рендерит блок на каждый активный тип системы', async () => {
+    state.summary = {
+      by_attachment_type: [
+        { name: 'Паспорт', count: 3 },
+        { name: 'Виза', count: 0 },
+      ],
+    };
+    const wrapper = mountDashboard();
+    await flushPromises();
+
+    const text = wrapper.text();
+    expect(text).toContain('Вложения');
+    expect(text).toContain('Паспорт');
+    expect(text).toContain('Виза');
   });
 });

--- a/frontend/src/components/statistics/__tests__/feedMerge.spec.js
+++ b/frontend/src/components/statistics/__tests__/feedMerge.spec.js
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { mergeFeed, feedRowKey } from '../feedMerge.js';
+
+const row = (created_at, subject, action_type = 'entry') => ({ created_at, subject, action_type });
+
+describe('mergeFeed', () => {
+  it('на первой загрузке возвращает входящие записи', () => {
+    const incoming = [row('2026-06-19T10:00:00Z', 'Иванов'), row('2026-06-19T09:00:00Z', 'Петров')];
+    expect(mergeFeed([], incoming)).toEqual(incoming);
+  });
+
+  it('новые записи добавляет сверху, существующие оставляет на месте', () => {
+    const current = [row('2026-06-19T10:00:00Z', 'Иванов'), row('2026-06-19T09:00:00Z', 'Петров')];
+    const incoming = [row('2026-06-19T11:00:00Z', 'Сидоров'), ...current];
+
+    const merged = mergeFeed(current, incoming);
+
+    expect(merged).toHaveLength(3);
+    expect(merged[0].subject).toBe('Сидоров');
+    // старые строки — те же объекты (Vue не перемонтирует их по стабильному ключу)
+    expect(merged[1]).toBe(current[0]);
+    expect(merged[2]).toBe(current[1]);
+  });
+
+  it('при отсутствии новых возвращает тот же массив (ссылочная стабильность)', () => {
+    const current = [row('2026-06-19T10:00:00Z', 'Иванов')];
+    const incoming = [row('2026-06-19T10:00:00Z', 'Иванов')];
+    expect(mergeFeed(current, incoming)).toBe(current);
+  });
+
+  it('различает запись по направлению при одинаковом времени и субъекте', () => {
+    const current = [row('2026-06-19T10:00:00Z', 'Иванов', 'entry')];
+    const incoming = [row('2026-06-19T10:00:00Z', 'Иванов', 'exit'), ...current];
+
+    const merged = mergeFeed(current, incoming);
+
+    expect(merged).toHaveLength(2);
+    expect(merged[0].action_type).toBe('exit');
+  });
+
+  it('ограничивает размер ленты параметром max', () => {
+    const current = Array.from({ length: 50 }, (_, i) => row(`t${i}`, `s${i}`));
+    const incoming = [row('new', 'newcomer'), ...current];
+
+    const merged = mergeFeed(current, incoming, 50);
+
+    expect(merged).toHaveLength(50);
+    expect(merged[0].subject).toBe('newcomer');
+  });
+
+  it('feedRowKey собирает ключ из времени, субъекта и направления', () => {
+    expect(feedRowKey(row('2026-06-19T10:00:00Z', 'Иванов', 'entry')))
+      .toBe('2026-06-19T10:00:00Z|Иванов|entry');
+  });
+});

--- a/frontend/src/components/statistics/feedMerge.js
+++ b/frontend/src/components/statistics/feedMerge.js
@@ -1,0 +1,25 @@
+/**
+ * Стабильный ключ записи живой ленты. У бэка нет id для проходов/проездов,
+ * поэтому ключ собираем из времени, субъекта и направления.
+ * @param {{ created_at: string, subject: string, action_type: string }} row
+ * @returns {string}
+ */
+export function feedRowKey(row) {
+  return `${row.created_at}|${row.subject}|${row.action_type}`;
+}
+
+/**
+ * Слить входящие записи ленты с текущими: новые (по ключу) добавляются сверху,
+ * существующие остаются на месте. Стабильный порядок -> Vue не перерисовывает
+ * старые строки на каждом тике, анимация появления играет только на новых.
+ * @param {Array} current  текущие записи (новые сверху)
+ * @param {Array} incoming входящие, отсортированы по времени по убыванию
+ * @param {number} [max=50] ограничение размера ленты
+ * @returns {Array} тот же массив current, если новых нет (ссылочная стабильность)
+ */
+export function mergeFeed(current, incoming, max = 50) {
+  const existing = new Set(current.map(feedRowKey));
+  const fresh = incoming.filter((row) => !existing.has(feedRowKey(row)));
+  if (fresh.length === 0) return current;
+  return [...fresh, ...current].slice(0, max);
+}

--- a/frontend/src/views/StatisticsView.vue
+++ b/frontend/src/views/StatisticsView.vue
@@ -284,6 +284,11 @@ function onRefresh() {
   color: #fff;
 }
 
+/* На активной кнопке hover не должен перекрашивать текст в синий — он сливается с фоном. */
+.period-preset--active:hover {
+  color: #fff;
+}
+
 /* Кнопка «Инструкция» в стиле проекта */
 .lk-button {
   display: inline-flex;

--- a/internal/services/statistics_service.go
+++ b/internal/services/statistics_service.go
@@ -48,16 +48,19 @@ func (s *statisticsService) GetSummary(ctx context.Context, from, to time.Time) 
 		return nil, fmt.Errorf("statistics: count applications: %w", err)
 	}
 
-	// by_attachment_type
+	// by_attachment_type: все активные типы из справочника (включая нулевые за
+	// период) — раздел дашборда показывает блок на каждый тип системы, поэтому
+	// идём от unique_attachments, а не от фактических вложений.
 	summary.ByAttachmentType = make([]models.AttachmentTypeCount, 0)
+	attachmentName := "COALESCE(ua.display_name, ua.name, ua.title, ua.attachment_type)"
 	if err := s.db.WithContext(ctx).
-		Table("attachments a").
-		Joins("JOIN applications app ON app.id = a.application_id").
-		Joins("LEFT JOIN unique_attachments ua ON ua.id = a.unique_attachment_id").
-		Where("app.sending_datetime BETWEEN ? AND ?", from, to).
-		Select("COALESCE(ua.display_name, a.attachment_display_name, a.attachment_type) AS name, COUNT(*) AS count").
-		Group("COALESCE(ua.display_name, a.attachment_display_name, a.attachment_type)").
-		Order("count DESC").
+		Table("unique_attachments ua").
+		Joins("LEFT JOIN attachments a ON a.unique_attachment_id = ua.id").
+		Joins("LEFT JOIN applications app ON app.id = a.application_id AND app.sending_datetime BETWEEN ? AND ?", from, to).
+		Where("ua.is_active = true").
+		Select(attachmentName + " AS name, COUNT(app.id) AS count").
+		Group(attachmentName).
+		Order("count DESC, name ASC").
 		Scan(&summary.ByAttachmentType).Error; err != nil {
 		return nil, fmt.Errorf("statistics: by_attachment_type: %w", err)
 	}


### PR DESCRIPTION
## Что и зачем
Правки дашборда аналитики по фидбэку владельца (группа G1 эпика #632).

### Плитки
- `Всего заявок` -> `Получено заявок`, `Активных пользователей` -> `Пользователи`
- убраны плитки `В работе`, `Сумма товаров`, `Вложения (всего)`

### Раздел «Вложения»
- новая группа с блоком на каждый **активный** тип справочника `unique_attachments`, включая нулевые за период
- BE: `by_attachment_type` теперь идёт от `unique_attachments` через LEFT JOIN (раньше — от фактических вложений, нулевые типы не показывались)

### Живые ленты
- больше не мигают скелетоном на 10-секундном тике: новые проходы доливаются сверху через `mergeFeed` (стабильный ключ строки -> старые узлы не перерисовываются, анимация играет только на новых)
- кнопка «Обновить» (`RefreshButton`) в шапке каждой ленты, убрана подпись «обновление каждые 10 сек · UTC+3»

### Прочее
- починен синий текст активной кнопки периода при наведении (`.period-preset--active:hover`), то же для сегмент-кнопок графика

## Тесты
- FE: `feedMerge.spec.js` (6) + `StatisticsDashboard.spec.js` (лейблы/раздел/гонка) — 9/9 зелёные
- Go: build/vet OK, `TestResolveTimelineSource` зелёный
- eslint `src/` — 0 errors

## Заметки для ревью
- `by_attachment_type` сменил семантику: считает вложения по активным типам справочника, привязанные к заявкам периода (`COUNT(app.id)`); legacy-вложения без `unique_attachment_id` в раздел не попадают — это осознанно (раздел показывает типы системы).