### PR TITLE
feat(forward): фильтрация чтения вложений по получателю пересылки (#680)

### DIFF
--- a/internal/handlers/application_reads_test.go
+++ b/internal/handlers/application_reads_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"systemburo/internal/models"
+	"systemburo/internal/services"
 	"systemburo/internal/testutil"
 
 	"github.com/stretchr/testify/assert"
@@ -350,6 +351,187 @@ func TestTakeToWork_ArchivedReturns403(t *testing.T) {
 	body := fmt.Sprintf(`{"user_id":%d,"action":"accept"}`, adminID)
 	rec := testutil.POST(t, e, fmt.Sprintf("/applications/%d/take-to-work", appID), body, testutil.AuthHeader(token))
 	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+// TestForwardAttachmentsRead проверяет фильтрацию чтения вложений по получателю пересылки
+// (#680): получатель видит только пересланные ему вложения и их теги, отправитель и
+// получатель без ограничений - все.
+func TestForwardAttachmentsRead(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+
+	// createAppWithTwoCars создаёт заявку с двумя cars-вложениями, возвращает их ID.
+	createAppWithTwoCars := func(t *testing.T, token, prefix string) (appID, attID1, attID2 int) {
+		t.Helper()
+		uaID1 := seedUniqueAttachment(t, db, "cars", prefix+"_a", prefix+" A")
+		uaID2 := seedUniqueAttachment(t, db, "cars", prefix+"_b", prefix+" B")
+		body := fmt.Sprintf(`{
+			"message": "read filter test",
+			"organization": "Test Organization",
+			"responsible_person": "Test Person",
+			"contact_phone": "+79001234567",
+			"data_approval": true,
+			"attachments": [
+				{"attachment_type":"cars","attachment_name":"cars_a","attachment_display_name":"Cars A",
+				 "unique_attachment_id":%d,"entry_date_from":"2026-04-01","entry_date_to":"2099-12-31",
+				 "entry_time_from":"08:00","entry_time_to":"18:00",
+				 "data":{"vehicles":[{"car_number":"B001BB777","car_brand":"Honda"}]}},
+				{"attachment_type":"cars","attachment_name":"cars_b","attachment_display_name":"Cars B",
+				 "unique_attachment_id":%d,"entry_date_from":"2026-04-01","entry_date_to":"2099-12-31",
+				 "entry_time_from":"08:00","entry_time_to":"18:00",
+				 "data":{"vehicles":[{"car_number":"C001CC777","car_brand":"Mazda"}]}}
+			]
+		}`, uaID1, uaID2)
+		rec := testutil.POST(t, e, "/applications/submit-complete-application", body, testutil.AuthHeader(token))
+		require.Equal(t, http.StatusOK, rec.Code, "create: %s", rec.Body.String())
+		resp := testutil.ParseResponse[services.CompleteApplicationResponse](t, rec)
+
+		rec = testutil.GET(t, e, fmt.Sprintf("/applications/%d/attachments", resp.ApplicationID), testutil.AuthHeader(token))
+		require.Equal(t, http.StatusOK, rec.Code)
+		atts := testutil.ParseSlice(t, rec)
+		require.Len(t, atts, 2)
+		return resp.ApplicationID, int(atts[0]["id"].(float64)), int(atts[1]["id"].(float64))
+	}
+
+	attachmentIDs := func(t *testing.T, token string, appID int) []int {
+		t.Helper()
+		rec := testutil.GET(t, e, fmt.Sprintf("/applications/%d/attachments", appID), testutil.AuthHeader(token))
+		require.Equal(t, http.StatusOK, rec.Code)
+		out := make([]int, 0)
+		for _, a := range testutil.ParseSlice(t, rec) {
+			out = append(out, int(a["id"].(float64)))
+		}
+		return out
+	}
+
+	findApp := func(apps []map[string]interface{}, id int) map[string]interface{} {
+		for _, a := range apps {
+			if int(a["id"].(float64)) == id {
+				return a
+			}
+		}
+		return nil
+	}
+
+	t.Run("recipient_sees_only_forwarded_attachments", func(t *testing.T) {
+		testutil.CleanDB(t, db)
+		td := testutil.SeedTestData(t, db)
+
+		senderToken := testutil.RegisterAndLogin(t, e, "fr_sender1", "pass123", 1, td.OrgID, td.CompanyID)
+		appID, attID1, attID2 := createAppWithTwoCars(t, senderToken, "fr_cars1")
+
+		respToken := testutil.RegisterAndLogin(t, e, "fr_resp1", "pass123", 1, td.OrgID, td.CompanyID)
+		respID := getUserID(t, db, "fr_resp1")
+
+		body := fmt.Sprintf(`{"users":[{"user_id":%d,"required_approval":true,"can_view":false}],"attachment_ids":[%d]}`, respID, attID1)
+		rec := testutil.POST(t, e, fmt.Sprintf("/applications/%d/forward", appID), body, testutil.AuthHeader(senderToken))
+		require.Equal(t, http.StatusOK, rec.Code, "forward: %s", rec.Body.String())
+
+		assert.Equal(t, []int{attID1}, attachmentIDs(t, respToken, appID), "получатель видит только пересланное вложение")
+		assert.ElementsMatch(t, []int{attID1, attID2}, attachmentIDs(t, senderToken, appID), "отправитель видит все")
+	})
+
+	t.Run("recipient_without_subset_sees_all", func(t *testing.T) {
+		testutil.CleanDB(t, db)
+		td := testutil.SeedTestData(t, db)
+
+		senderToken := testutil.RegisterAndLogin(t, e, "fr_sender2", "pass123", 1, td.OrgID, td.CompanyID)
+		appID, attID1, attID2 := createAppWithTwoCars(t, senderToken, "fr_cars2")
+
+		respToken := testutil.RegisterAndLogin(t, e, "fr_resp2", "pass123", 1, td.OrgID, td.CompanyID)
+		respID := getUserID(t, db, "fr_resp2")
+
+		// Пересыл без attachment_ids -> строк нет -> получатель видит все (обратная совместимость).
+		body := fmt.Sprintf(`{"users":[{"user_id":%d,"required_approval":true,"can_view":false}]}`, respID)
+		rec := testutil.POST(t, e, fmt.Sprintf("/applications/%d/forward", appID), body, testutil.AuthHeader(senderToken))
+		require.Equal(t, http.StatusOK, rec.Code, "forward: %s", rec.Body.String())
+
+		assert.ElementsMatch(t, []int{attID1, attID2}, attachmentIDs(t, respToken, appID))
+	})
+
+	t.Run("detail_endpoints_403_for_hidden_attachment", func(t *testing.T) {
+		testutil.CleanDB(t, db)
+		td := testutil.SeedTestData(t, db)
+
+		senderToken := testutil.RegisterAndLogin(t, e, "fr_sender3", "pass123", 1, td.OrgID, td.CompanyID)
+		appID, attID1, attID2 := createAppWithTwoCars(t, senderToken, "fr_cars3")
+
+		respToken := testutil.RegisterAndLogin(t, e, "fr_resp3", "pass123", 1, td.OrgID, td.CompanyID)
+		respID := getUserID(t, db, "fr_resp3")
+
+		body := fmt.Sprintf(`{"users":[{"user_id":%d,"required_approval":true,"can_view":false}],"attachment_ids":[%d]}`, respID, attID1)
+		rec := testutil.POST(t, e, fmt.Sprintf("/applications/%d/forward", appID), body, testutil.AuthHeader(senderToken))
+		require.Equal(t, http.StatusOK, rec.Code, "forward: %s", rec.Body.String())
+
+		recHidden := testutil.GET(t, e, fmt.Sprintf("/attachments/%d/cars", attID2), testutil.AuthHeader(respToken))
+		assert.Equal(t, http.StatusForbidden, recHidden.Code, "скрытое вложение -> 403")
+
+		recVisible := testutil.GET(t, e, fmt.Sprintf("/attachments/%d/cars", attID1), testutil.AuthHeader(respToken))
+		assert.Equal(t, http.StatusOK, recVisible.Code, "пересланное вложение доступно")
+
+		recSender := testutil.GET(t, e, fmt.Sprintf("/attachments/%d/cars", attID2), testutil.AuthHeader(senderToken))
+		assert.Equal(t, http.StatusOK, recSender.Code, "отправитель видит любое вложение")
+	})
+
+	t.Run("tags_reflect_only_visible_attachments", func(t *testing.T) {
+		testutil.CleanDB(t, db)
+		td := testutil.SeedTestData(t, db)
+
+		senderToken := testutil.RegisterAndLogin(t, e, "fr_sender4", "pass123", 1, td.OrgID, td.CompanyID)
+		appID, attID1, attID2 := createAppWithTwoCars(t, senderToken, "fr_cars4")
+
+		// Теги только на СКРЫТОМ вложении: получатель не должен их увидеть.
+		require.NoError(t, db.Model(&models.Attachment{}).Where("id = ?", attID2).
+			Updates(map[string]interface{}{"roof_access": true, "free_parking": true}).Error)
+
+		respToken := testutil.RegisterAndLogin(t, e, "fr_resp4", "pass123", 1, td.OrgID, td.CompanyID)
+		respID := getUserID(t, db, "fr_resp4")
+
+		body := fmt.Sprintf(`{"users":[{"user_id":%d,"required_approval":true,"can_view":false}],"attachment_ids":[%d]}`, respID, attID1)
+		rec := testutil.POST(t, e, fmt.Sprintf("/applications/%d/forward", appID), body, testutil.AuthHeader(senderToken))
+		require.Equal(t, http.StatusOK, rec.Code, "forward: %s", rec.Body.String())
+
+		recResp := testutil.GET(t, e, "/applications", testutil.AuthHeader(respToken))
+		require.Equal(t, http.StatusOK, recResp.Code)
+		respApp := findApp(testutil.ParseSlice(t, recResp), appID)
+		require.NotNil(t, respApp, "получатель видит заявку в Центре")
+		assert.Equal(t, false, respApp["has_roof_access"], "тег скрытого вложения не виден получателю")
+		assert.Equal(t, false, respApp["has_free_parking"], "тег скрытого вложения не виден получателю")
+
+		recSender := testutil.GET(t, e, "/applications", testutil.AuthHeader(senderToken))
+		require.Equal(t, http.StatusOK, recSender.Code)
+		senderApp := findApp(testutil.ParseSlice(t, recSender), appID)
+		require.NotNil(t, senderApp)
+		assert.Equal(t, true, senderApp["has_roof_access"], "отправитель видит тег")
+		assert.Equal(t, true, senderApp["has_free_parking"], "отправитель видит тег")
+	})
+
+	t.Run("superadmin_recipient_sees_all_tags", func(t *testing.T) {
+		testutil.CleanDB(t, db)
+		td := testutil.SeedTestData(t, db)
+
+		senderToken := testutil.RegisterAndLogin(t, e, "fr_sender5", "pass123", 1, td.OrgID, td.CompanyID)
+		appID, attID1, attID2 := createAppWithTwoCars(t, senderToken, "fr_cars5")
+
+		require.NoError(t, db.Model(&models.Attachment{}).Where("id = ?", attID2).
+			Updates(map[string]interface{}{"roof_access": true, "free_parking": true}).Error)
+
+		// Получатель с ограниченным набором, но он же супер-админ -> видит все теги (bypass).
+		superToken := testutil.RegisterAndLogin(t, e, "fr_super5", "pass123", 1, td.OrgID, td.CompanyID)
+		superID := getUserID(t, db, "fr_super5")
+		require.NoError(t, db.Model(&models.User{}).Where("id = ?", superID).Update("is_super_admin", true).Error)
+
+		body := fmt.Sprintf(`{"users":[{"user_id":%d,"required_approval":true,"can_view":false}],"attachment_ids":[%d]}`, superID, attID1)
+		rec := testutil.POST(t, e, fmt.Sprintf("/applications/%d/forward", appID), body, testutil.AuthHeader(senderToken))
+		require.Equal(t, http.StatusOK, rec.Code, "forward: %s", rec.Body.String())
+
+		recSuper := testutil.GET(t, e, "/applications", testutil.AuthHeader(superToken))
+		require.Equal(t, http.StatusOK, recSuper.Code)
+		superApp := findApp(testutil.ParseSlice(t, recSuper), appID)
+		require.NotNil(t, superApp, "супер-админ видит заявку")
+		assert.Equal(t, true, superApp["has_roof_access"], "супер-админ не ограничивается пересылом - видит все теги")
+		assert.Equal(t, true, superApp["has_free_parking"], "супер-админ не ограничивается пересылом - видит все теги")
+	})
 }
 
 // --- Unauthorized tests for new endpoints ---

--- a/internal/handlers/applications_reads.go
+++ b/internal/handlers/applications_reads.go
@@ -151,7 +151,7 @@ func (h *ApplicationHandler) GetApplicationAttachments(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusForbidden, "Access denied")
 	}
 
-	attachments, err := h.service.GetApplicationAttachments(c.Request().Context(), id)
+	attachments, err := h.service.GetApplicationAttachments(c.Request().Context(), id, viewerUserID(c))
 	if err != nil {
 		return err
 	}
@@ -181,6 +181,14 @@ func (h *ApplicationHandler) GetAttachmentCars(c echo.Context) error {
 	}
 	username := c.Get("username").(string)
 	if !h.service.CanAccessApplication(c.Request().Context(), appID, username, IsSuperAdmin(c)) {
+		return echo.NewHTTPError(http.StatusForbidden, "Access denied")
+	}
+
+	canView, err := h.service.CanViewAttachment(c.Request().Context(), appID, id, viewerUserID(c))
+	if err != nil {
+		return err
+	}
+	if !canView {
 		return echo.NewHTTPError(http.StatusForbidden, "Access denied")
 	}
 
@@ -217,6 +225,14 @@ func (h *ApplicationHandler) GetAttachmentEmployees(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusForbidden, "Access denied")
 	}
 
+	canView, err := h.service.CanViewAttachment(c.Request().Context(), appID, id, viewerUserID(c))
+	if err != nil {
+		return err
+	}
+	if !canView {
+		return echo.NewHTTPError(http.StatusForbidden, "Access denied")
+	}
+
 	employees, err := h.service.GetAttachmentEmployees(c.Request().Context(), id)
 	if err != nil {
 		return err
@@ -247,6 +263,14 @@ func (h *ApplicationHandler) GetAttachmentItems(c echo.Context) error {
 	}
 	username := c.Get("username").(string)
 	if !h.service.CanAccessApplication(c.Request().Context(), appID, username, IsSuperAdmin(c)) {
+		return echo.NewHTTPError(http.StatusForbidden, "Access denied")
+	}
+
+	canView, err := h.service.CanViewAttachment(c.Request().Context(), appID, id, viewerUserID(c))
+	if err != nil {
+		return err
+	}
+	if !canView {
 		return echo.NewHTTPError(http.StatusForbidden, "Access denied")
 	}
 

--- a/internal/handlers/helpers.go
+++ b/internal/handlers/helpers.go
@@ -59,3 +59,13 @@ func IsSuperAdmin(c echo.Context) bool {
 	v, _ := c.Get("is_super_admin").(bool)
 	return v
 }
+
+// viewerUserID возвращает id просматривающего для фильтра пер-вложенного пересыла (#680):
+// реальный user_id, либо 0 для супер-админа (без фильтра - видит все вложения).
+func viewerUserID(c echo.Context) int {
+	if IsSuperAdmin(c) {
+		return 0
+	}
+	id, _ := c.Get("user_id").(int)
+	return id
+}

--- a/internal/services/application_attachment_service.go
+++ b/internal/services/application_attachment_service.go
@@ -38,8 +38,66 @@ func (s *applicationService) GetApplicationViewers(ctx context.Context, applicat
 	return viewers, nil
 }
 
+// resolveForwardFilter определяет, ограничен ли просматривающий пер-вложенным пересылом
+// (#680), и какие вложения ему доступны. restricted=false означает «видит все вложения
+// заявки»: супер-админ (viewerUserID==0), отправитель заявки или пользователь без строк
+// forward_attachments для этой заявки (обратная совместимость). restricted=true -> allowed
+// содержит только перечисленные при пересылке вложения.
+func (s *applicationService) resolveForwardFilter(ctx context.Context, applicationID, viewerUserID int) (allowed map[int]bool, restricted bool, err error) {
+	if viewerUserID == 0 {
+		return nil, false, nil
+	}
+
+	var ids []int
+	if e := s.db.WithContext(ctx).Raw(
+		"SELECT attachment_id FROM forward_attachments WHERE application_id = ? AND recipient_user_id = ?",
+		applicationID, viewerUserID,
+	).Scan(&ids).Error; e != nil {
+		slog.Error("Ошибка чтения forward_attachments", "application_id", applicationID, "user_id", viewerUserID, "error", e)
+		return nil, false, echo.NewHTTPError(http.StatusInternalServerError, "Database error")
+	}
+	if len(ids) == 0 {
+		return nil, false, nil
+	}
+
+	// Отправитель видит все вложения независимо от строк (напр. пересылка ему же).
+	var isSender bool
+	if e := s.db.WithContext(ctx).Raw(
+		"SELECT EXISTS(SELECT 1 FROM applications WHERE id = ? AND sender_user_id = ?)",
+		applicationID, viewerUserID,
+	).Scan(&isSender).Error; e != nil {
+		slog.Error("Ошибка проверки отправителя", "application_id", applicationID, "user_id", viewerUserID, "error", e)
+		return nil, false, echo.NewHTTPError(http.StatusInternalServerError, "Database error")
+	}
+	if isSender {
+		return nil, false, nil
+	}
+
+	allowed = make(map[int]bool, len(ids))
+	for _, id := range ids {
+		allowed[id] = true
+	}
+	return allowed, true, nil
+}
+
+// CanViewAttachment сообщает, доступно ли конкретное вложение просматривающему с учётом
+// пер-вложенного пересыла (#680). viewerUserID==0 (супер-админ) и отправитель видят любое
+// вложение заявки; получатель с ограничением - только перечисленные.
+func (s *applicationService) CanViewAttachment(ctx context.Context, applicationID, attachmentID, viewerUserID int) (bool, error) {
+	allowed, restricted, err := s.resolveForwardFilter(ctx, applicationID, viewerUserID)
+	if err != nil {
+		return false, err
+	}
+	if !restricted {
+		return true, nil
+	}
+	return allowed[attachmentID], nil
+}
+
 // GetApplicationAttachments возвращает вложения заявки с информацией о шаблонах.
-func (s *applicationService) GetApplicationAttachments(ctx context.Context, applicationID int) ([]AttachmentInfo, error) {
+// viewerUserID ограничивает выдачу вложениями, доступными получателю пересылки (#680);
+// 0 - супер-админ, фильтр не применяется.
+func (s *applicationService) GetApplicationAttachments(ctx context.Context, applicationID, viewerUserID int) ([]AttachmentInfo, error) {
 	attachments := make([]AttachmentInfo, 0)
 	err := s.db.WithContext(ctx).Raw(`
 		SELECT
@@ -67,6 +125,20 @@ func (s *applicationService) GetApplicationAttachments(ctx context.Context, appl
 	if err != nil {
 		slog.Error("Ошибка получения вложений", "application_id", applicationID, "error", err)
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching attachments")
+	}
+
+	allowed, restricted, err := s.resolveForwardFilter(ctx, applicationID, viewerUserID)
+	if err != nil {
+		return nil, err
+	}
+	if restricted {
+		visible := make([]AttachmentInfo, 0, len(allowed))
+		for _, a := range attachments {
+			if allowed[a.ID] {
+				visible = append(visible, a)
+			}
+		}
+		attachments = visible
 	}
 
 	if len(attachments) > 0 {

--- a/internal/services/application_service.go
+++ b/internal/services/application_service.go
@@ -26,6 +26,57 @@ var allowedConfirmations = map[string]bool{
 	"Согласование": true, "Согласовано": true, "Не согласовано": true,
 }
 
+// forwardAttachmentVisible ограничивает агрегаты-теги заявки вложениями, видимыми
+// просматривающему с учётом пер-вложенного пересыла (#680): отправитель и пользователь
+// без строк forward_attachments видят все вложения, получатель со строками - только
+// перечисленные. Три плейсхолдера связываются с id просматривающего; ссылается на att.id
+// (вложение тег-подзапроса) и a (заявка внешнего запроса).
+const forwardAttachmentVisible = `(
+		a.sender_user_id = ?
+		OR NOT EXISTS (SELECT 1 FROM forward_attachments fa WHERE fa.application_id = a.id AND fa.recipient_user_id = ?)
+		OR EXISTS (SELECT 1 FROM forward_attachments fav WHERE fav.application_id = a.id AND fav.recipient_user_id = ? AND fav.attachment_id = att.id)
+	)`
+
+// applicationsListSelect - общий список столбцов для листингов заявок (Центр, пагинация,
+// заявки пользователя). Теги has_roof_access/has_free_parking учитывают видимость пересыла
+// (forwardAttachmentVisible). Плейсхолдеры (?) связываются через applicationsListSelectArgs.
+const applicationsListSelect = `
+		a.*,
+		COALESCE(o.name, c.name) as organization_name,
+		c.name as company_name,
+		format_full_name(u.last_name, u.first_name, u.middle_name) as sender_full_name,
+		format_short_name(u.last_name, u.first_name, u.middle_name) as sender_name,
+		u.is_important as sender_is_important,
+		format_full_name(ru.last_name, ru.first_name, ru.middle_name) as responsible_full_name,
+		format_short_name(ru.last_name, ru.first_name, ru.middle_name) as responsible_name,
+		EXISTS (SELECT 1 FROM attachments att JOIN attachment_templates at2 ON at2.unique_attachment_id = att.unique_attachment_id AND at2.is_active = true WHERE att.application_id = a.id) as has_blank_template,
+		EXISTS (SELECT 1 FROM application_reads ar WHERE ar.application_id = a.id AND ar.user_id = ?) as is_read,
+		EXISTS (SELECT 1 FROM attachments att WHERE att.application_id = a.id AND att.roof_access = true AND ` + forwardAttachmentVisible + `) as has_roof_access,
+		EXISTS (SELECT 1 FROM attachments att WHERE att.application_id = a.id AND att.free_parking = true AND ` + forwardAttachmentVisible + `) as has_free_parking,
+		(SELECT COUNT(*) FROM application_blacklist_flags f WHERE f.application_id = a.id AND NOT EXISTS (SELECT 1 FROM application_blacklist_overrides o WHERE o.flag_id = f.id)) as blacklist_flags_count
+	`
+
+// applicationsListSelectArgs связывает плейсхолдеры applicationsListSelect: is_read (1)
+// всегда по реальному id просматривающего; теги видимости (по три на каждый из двух) -
+// по forwardViewerID, который равен 0 для супер-админа (bypass фильтра пересыла, видит
+// все теги - симметрично resolveForwardFilter в detail-пути).
+func applicationsListSelectArgs(readUserID, forwardViewerID int) []interface{} {
+	return []interface{}{
+		readUserID,
+		forwardViewerID, forwardViewerID, forwardViewerID,
+		forwardViewerID, forwardViewerID, forwardViewerID,
+	}
+}
+
+// forwardViewerID возвращает id для фильтра видимости тегов: 0 (bypass) для супер-админа,
+// иначе реальный id - супер-админ видит все теги независимо от пересыла.
+func forwardViewerID(user *models.User) int {
+	if user.IsSuperAdmin {
+		return 0
+	}
+	return user.ID
+}
+
 // ApplicationService определяет интерфейс бизнес-логики для работы с заявками.
 type ApplicationService interface {
 	// GetApplications возвращает список заявок для Центра заявок с фильтрацией.
@@ -92,8 +143,12 @@ type ApplicationService interface {
 	// GetApplicationViewers возвращает просматривающих заявки.
 	GetApplicationViewers(ctx context.Context, applicationID int) ([]ViewerWithUser, error)
 
-	// GetApplicationAttachments возвращает вложения заявки.
-	GetApplicationAttachments(ctx context.Context, applicationID int) ([]AttachmentInfo, error)
+	// GetApplicationAttachments возвращает вложения заявки, видимые получателю пересылки
+	// (viewerUserID; 0 - супер-админ, без фильтра).
+	GetApplicationAttachments(ctx context.Context, applicationID, viewerUserID int) ([]AttachmentInfo, error)
+
+	// CanViewAttachment сообщает, доступно ли вложение просматривающему с учётом пересыла.
+	CanViewAttachment(ctx context.Context, applicationID, attachmentID, viewerUserID int) (bool, error)
 
 	// GetAttachmentCars возвращает автомобили вложения.
 	GetAttachmentCars(ctx context.Context, attachmentID int) ([]CarWithPlaces, error)
@@ -532,21 +587,7 @@ func (s *applicationService) GetApplications(ctx context.Context, username strin
 	}
 
 	query := s.db.WithContext(ctx).Table("applications a").
-		Select(`
-			a.*,
-			COALESCE(o.name, c.name) as organization_name,
-			c.name as company_name,
-			format_full_name(u.last_name, u.first_name, u.middle_name) as sender_full_name,
-			format_short_name(u.last_name, u.first_name, u.middle_name) as sender_name,
-			u.is_important as sender_is_important,
-			format_full_name(ru.last_name, ru.first_name, ru.middle_name) as responsible_full_name,
-			format_short_name(ru.last_name, ru.first_name, ru.middle_name) as responsible_name,
-			EXISTS (SELECT 1 FROM attachments att JOIN attachment_templates at2 ON at2.unique_attachment_id = att.unique_attachment_id AND at2.is_active = true WHERE att.application_id = a.id) as has_blank_template,
-			EXISTS (SELECT 1 FROM application_reads ar WHERE ar.application_id = a.id AND ar.user_id = ?) as is_read,
-			EXISTS (SELECT 1 FROM attachments att WHERE att.application_id = a.id AND att.roof_access = true) as has_roof_access,
-			EXISTS (SELECT 1 FROM attachments att WHERE att.application_id = a.id AND att.free_parking = true) as has_free_parking,
-			(SELECT COUNT(*) FROM application_blacklist_flags f WHERE f.application_id = a.id AND NOT EXISTS (SELECT 1 FROM application_blacklist_overrides o WHERE o.flag_id = f.id)) as blacklist_flags_count
-		`, user.ID).
+		Select(applicationsListSelect, applicationsListSelectArgs(user.ID, forwardViewerID(user))...).
 		Joins("LEFT JOIN organizations o ON a.organization_id = o.id").
 		Joins("LEFT JOIN companies c ON a.company_id = c.id").
 		Joins("LEFT JOIN users u ON a.sender_user_id = u.id").
@@ -600,21 +641,7 @@ func (s *applicationService) GetApplicationsPaginated(ctx context.Context, usern
 	offset := (page - 1) * perPage
 	dataQuery := s.buildApplicationsBaseQuery(ctx, user.ID, isApprover, filter)
 	dataQuery = dataQuery.
-		Select(`
-			a.*,
-			COALESCE(o.name, c.name) as organization_name,
-			c.name as company_name,
-			format_full_name(u.last_name, u.first_name, u.middle_name) as sender_full_name,
-			format_short_name(u.last_name, u.first_name, u.middle_name) as sender_name,
-			u.is_important as sender_is_important,
-			format_full_name(ru.last_name, ru.first_name, ru.middle_name) as responsible_full_name,
-			format_short_name(ru.last_name, ru.first_name, ru.middle_name) as responsible_name,
-			EXISTS (SELECT 1 FROM attachments att JOIN attachment_templates at2 ON at2.unique_attachment_id = att.unique_attachment_id AND at2.is_active = true WHERE att.application_id = a.id) as has_blank_template,
-			EXISTS (SELECT 1 FROM application_reads ar WHERE ar.application_id = a.id AND ar.user_id = ?) as is_read,
-			EXISTS (SELECT 1 FROM attachments att WHERE att.application_id = a.id AND att.roof_access = true) as has_roof_access,
-			EXISTS (SELECT 1 FROM attachments att WHERE att.application_id = a.id AND att.free_parking = true) as has_free_parking,
-			(SELECT COUNT(*) FROM application_blacklist_flags f WHERE f.application_id = a.id AND NOT EXISTS (SELECT 1 FROM application_blacklist_overrides o WHERE o.flag_id = f.id)) as blacklist_flags_count
-		`, user.ID).
+		Select(applicationsListSelect, applicationsListSelectArgs(user.ID, forwardViewerID(user))...).
 		Order("a.sending_datetime DESC").
 		Offset(offset).
 		Limit(perPage)
@@ -636,21 +663,7 @@ func (s *applicationService) GetUserApplications(ctx context.Context, username s
 	}
 
 	query := s.db.WithContext(ctx).Table("applications a").
-		Select(`
-			a.*,
-			COALESCE(o.name, c.name) as organization_name,
-			c.name as company_name,
-			format_full_name(u.last_name, u.first_name, u.middle_name) as sender_full_name,
-			format_short_name(u.last_name, u.first_name, u.middle_name) as sender_name,
-			u.is_important as sender_is_important,
-			format_full_name(ru.last_name, ru.first_name, ru.middle_name) as responsible_full_name,
-			format_short_name(ru.last_name, ru.first_name, ru.middle_name) as responsible_name,
-			EXISTS (SELECT 1 FROM attachments att JOIN attachment_templates at2 ON at2.unique_attachment_id = att.unique_attachment_id AND at2.is_active = true WHERE att.application_id = a.id) as has_blank_template,
-			EXISTS (SELECT 1 FROM application_reads ar WHERE ar.application_id = a.id AND ar.user_id = ?) as is_read,
-			EXISTS (SELECT 1 FROM attachments att WHERE att.application_id = a.id AND att.roof_access = true) as has_roof_access,
-			EXISTS (SELECT 1 FROM attachments att WHERE att.application_id = a.id AND att.free_parking = true) as has_free_parking,
-			(SELECT COUNT(*) FROM application_blacklist_flags f WHERE f.application_id = a.id AND NOT EXISTS (SELECT 1 FROM application_blacklist_overrides o WHERE o.flag_id = f.id)) as blacklist_flags_count
-		`, user.ID).
+		Select(applicationsListSelect, applicationsListSelectArgs(user.ID, forwardViewerID(user))...).
 		Joins("LEFT JOIN organizations o ON a.organization_id = o.id").
 		Joins("LEFT JOIN companies c ON a.company_id = c.id").
 		Joins("LEFT JOIN users u ON a.sender_user_id = u.id").


### PR DESCRIPTION
## Что и зачем
Срез 5 (be-read) эпика пересыла заявки (#680). Срез be-schema (#690) уже пишет строки `forward_attachments` при пересылке с выбранным подмножеством вложений, но чтение их игнорировало - получатель видел все вложения заявки независимо от пересланного. Этот срез включает фильтрацию чтения.

## Правило доступа (резолв Q4)
Получатель видит ТОЛЬКО перечисленные ему вложения, если у него есть строки `forward_attachments` для заявки И он не отправитель И не супер-админ. Иначе (нет строк / отправитель / супер-админ) - видит все. Реализация - единый helper `resolveForwardFilter` (id просматривающего `0` = супер-админ, bypass).

## Изменения
- `application_attachment_service.go`: `resolveForwardFilter` + `CanViewAttachment`; пост-фильтр списка в `GetApplicationAttachments(... viewerUserID)`.
- `applications_reads.go`: прокинут `viewerUserID(c)` в список; гейт `403` на скрытое вложение в detail-эндпоинтах cars/employees/items.
- `application_service.go`: фильтр тегов `has_roof_access`/`has_free_parking` в 3 листингах (Центр, пагинация, заявки пользователя) через SQL-предикат `forwardAttachmentVisible`; общий `applicationsListSelect` (убрана тройная дупликация select).
- `helpers.go`: `viewerUserID(c)` (0 для супер-админа).

## Сознательное отклонение от гипотезы Q4
Approver («Принимающий») отдельно НЕ выделяется: чистый approver и так получает 403 на attachment-эндпоинтах (`CanAccessApplication` его не пускает), а в листинге approver без forward-строк естественно видит все теги. Approver, которому переслали ограниченный набор как responsible/viewer, честно ограничивается (defense-in-depth).

## Тесты
`internal/handlers/application_reads_test.go` (`TestForwardAttachmentsRead`): получатель видит только пересланное; отправитель/получатель-без-подмножества видят все; detail-эндпоинты 403 на скрытое и 200 на доступное; теги отражают только видимые вложения; супер-админ не ограничивается пересылом.

## Ревью
`code-reviewer` нашёл расхождение bypass супер-админа между detail-путём (id=0) и SQL-листингом (реальный id) - супер-админу с ограниченной пересылкой теги занижались. Исправлено: листинги берут `forwardViewerID(user)` (0 для `user.IsSuperAdmin`), `is_read` остаётся на реальном id; добавлен покрывающий тест.

## Верификация
Go-тесты зелёные изолированно: `ok services`, `ok handlers` (`TestForwardAttachmentsRead` + ранее затронутые). Падения полного локального прогона - кросс-сессионный контеншн общей тест-БД (duplicate index при параллельном AutoMigrate), не логика; CI гоняет на свежей изолированной БД.