### PR TITLE
feat(analytics): cross-tab вложений и среднее машин в день в отчётах (#632)

### DIFF
--- a/internal/handlers/statistics_report_crosstab_integration_test.go
+++ b/internal/handlers/statistics_report_crosstab_integration_test.go
@@ -1,0 +1,258 @@
+package handlers_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunReport_CrossTabAttachmentType проверяет реальный GORM-путь cross-tab (G4):
+// разрез period/week + pivot=attachment_type разворачивает типы вложений в колонки.
+// Значения по бинам и pivot-колонки корректны; обычная метрика остаётся колонкой.
+func TestRunReport_CrossTabAttachmentType(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	org := models.Organization{Name: "Орг-Кросс", IsActive: true}
+	require.NoError(t, db.Create(&org).Error)
+	user := models.User{Username: "ct_sender", TypeID: 1, IsActive: true}
+	require.NoError(t, db.Create(&user).Error)
+
+	status := models.StatusCompleted
+	// ISO-неделя: понедельник 2026-06-08 .. воскресенье 2026-06-14.
+	week1 := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)  // вторник той же недели
+	week1b := time.Date(2026, 6, 10, 9, 0, 0, 0, time.UTC) // среда той же недели
+	week2 := time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC) // следующая неделя
+
+	// Хелпер создания заявки с одним вложением заданного display_name.
+	mk := func(number string, sent time.Time, display string) {
+		n := number
+		s := status
+		app := models.Application{ApplicationNumber: &n, OrganizationID: org.ID,
+			SenderUserID: user.ID, Status: &s, SendingDatetime: &sent}
+		require.NoError(t, db.Create(&app).Error)
+		dn := display
+		att := models.Attachment{ApplicationID: app.ID, AttachmentType: "cars", AttachmentDisplayName: &dn}
+		require.NoError(t, db.Create(&att).Error)
+	}
+
+	// Неделя 1: 2 заявки "Машины" + 1 "Люди". Неделя 2: 1 "Машины".
+	mk("CT/1", week1, "Машины")
+	mk("CT/2", week1b, "Машины")
+	mk("CT/3", week1, "Люди")
+	mk("CT/4", week2, "Машины")
+
+	svc := services.NewStatisticsService(db)
+	res, err := svc.RunReport(context.Background(), models.ReportRequest{
+		Mode:        "aggregate",
+		Metrics:     []string{"applications_count"},
+		Dimension:   "period",
+		Granularity: "week",
+		Pivot:       "attachment_type",
+		Filters: []models.ReportFilterValue{
+			{Key: "date_range", From: "2026-06-08", To: "2026-06-21"},
+		},
+	})
+	require.NoError(t, err)
+
+	// Колонки: обычная метрика + 2 pivot-колонки (Машины, Люди).
+	var hasMetric, hasMachines, hasPeople bool
+	for _, c := range res.Columns {
+		switch {
+		case c.Key == "applications_count" && c.Kind == "":
+			hasMetric = true
+		case c.Key == "pivot:Машины" && c.Kind == models.ReportColumnPivot:
+			hasMachines = true
+			assert.Equal(t, "Тип вложения: Машины", c.Label)
+		case c.Key == "pivot:Люди" && c.Kind == models.ReportColumnPivot:
+			hasPeople = true
+		}
+	}
+	assert.True(t, hasMetric, "колонка метрики applications_count")
+	assert.True(t, hasMachines, "pivot-колонка Машины")
+	assert.True(t, hasPeople, "pivot-колонка Люди")
+
+	// Две строки-бина (две недели), хронологически.
+	require.Len(t, res.MetricRows, 2)
+	w1 := res.MetricRows[0]
+	w2 := res.MetricRows[1]
+	assert.Less(t, w1.Label, w2.Label, "бины хронологически")
+
+	// Неделя 1: всего 3 заявки, 2 машины, 1 человек.
+	assert.Equal(t, int64(3), w1.Values["applications_count"])
+	assert.Equal(t, int64(2), w1.Values["pivot:Машины"])
+	assert.Equal(t, int64(1), w1.Values["pivot:Люди"])
+	// Неделя 2: 1 заявка, 1 машина, 0 людей (явный нуль).
+	assert.Equal(t, int64(1), w2.Values["applications_count"])
+	assert.Equal(t, int64(1), w2.Values["pivot:Машины"])
+	assert.Equal(t, int64(0), w2.Values["pivot:Люди"])
+}
+
+// TestRunReport_NoPivotUnchanged — regression: при пустом pivot ответ совпадает со
+// старым поведением (никаких pivot-колонок, только метрика).
+func TestRunReport_NoPivotUnchanged(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	org := models.Organization{Name: "Орг-NoPivot", IsActive: true}
+	require.NoError(t, db.Create(&org).Error)
+	user := models.User{Username: "np_sender", TypeID: 1, IsActive: true}
+	require.NoError(t, db.Create(&user).Error)
+
+	status := models.StatusCompleted
+	sent := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+	n := "NP/1"
+	app := models.Application{ApplicationNumber: &n, OrganizationID: org.ID,
+		SenderUserID: user.ID, Status: &status, SendingDatetime: &sent}
+	require.NoError(t, db.Create(&app).Error)
+	dn := "Машины"
+	require.NoError(t, db.Create(&models.Attachment{ApplicationID: app.ID, AttachmentType: "cars", AttachmentDisplayName: &dn}).Error)
+
+	svc := services.NewStatisticsService(db)
+	res, err := svc.RunReport(context.Background(), models.ReportRequest{
+		Mode:        "aggregate",
+		Metrics:     []string{"applications_count"},
+		Dimension:   "period",
+		Granularity: "week",
+		// Pivot пуст — обычный отчёт.
+		Filters: []models.ReportFilterValue{
+			{Key: "date_range", From: "2026-06-08", To: "2026-06-14"},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, res.Columns, 1, "только колонка метрики")
+	assert.Equal(t, "applications_count", res.Columns[0].Key)
+	assert.Equal(t, models.ReportColumnKind(""), res.Columns[0].Kind)
+	require.Len(t, res.MetricRows, 1)
+	assert.Equal(t, int64(1), res.MetricRows[0].Values["applications_count"])
+	// Никаких pivot-ключей в строке.
+	for k := range res.MetricRows[0].Values {
+		assert.NotContains(t, k, "pivot:", "не должно быть pivot-ключей")
+	}
+}
+
+// TestRunReport_AvgCarsPerDayWeekly проверяет реальный GORM-путь метрики-среднего:
+// въезды машин по неделям делятся на число дней бина (крайний неполный бин — на
+// фактическое пересечение с окном). Значения дробные -> FloatValues, колонка Float.
+func TestRunReport_AvgCarsPerDayWeekly(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	// Машина с вложением (cars_history.car_id -> cars).
+	org := models.Organization{Name: "Орг-Avg", IsActive: true}
+	require.NoError(t, db.Create(&org).Error)
+	user := models.User{Username: "avg_sender", TypeID: 1, IsActive: true}
+	require.NoError(t, db.Create(&user).Error)
+	status := models.StatusCompleted
+	sent := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+	n := "AVG/1"
+	app := models.Application{ApplicationNumber: &n, OrganizationID: org.ID,
+		SenderUserID: user.ID, Status: &status, SendingDatetime: &sent}
+	require.NoError(t, db.Create(&app).Error)
+	att := models.Attachment{ApplicationID: app.ID, AttachmentType: "cars"}
+	require.NoError(t, db.Create(&att).Error)
+	num := "А001АА"
+	car := models.Car{AttachmentID: att.ID, CarNumber: &num}
+	require.NoError(t, db.Create(&car).Error)
+
+	// Въезды: неделя 06-08..06-14 (понедельник..воскресенье) — 14 въездов -> 2/день.
+	// Окно запроса 06-08..06-14 (полная неделя).
+	week1Days := []int{8, 9, 10, 11, 12, 13, 14}
+	for _, d := range week1Days {
+		for i := 0; i < 2; i++ { // по 2 въезда в день -> 14 за неделю
+			h := models.CarHistory{CarID: car.ID, ActionType: "entry",
+				CreatedAt: time.Date(2026, 6, d, 10+i, 0, 0, 0, time.UTC)}
+			require.NoError(t, db.Create(&h).Error)
+		}
+	}
+
+	svc := services.NewStatisticsService(db)
+	res, err := svc.RunReport(context.Background(), models.ReportRequest{
+		Mode:        "aggregate",
+		Metrics:     []string{"avg_cars_per_day"},
+		Dimension:   "period",
+		Granularity: "week",
+		Filters: []models.ReportFilterValue{
+			{Key: "date_range", From: "2026-06-08", To: "2026-06-14"},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, res.Columns, 1)
+	assert.Equal(t, "avg_cars_per_day", res.Columns[0].Key)
+	assert.True(t, res.Columns[0].Float, "колонка среднего помечена Float")
+
+	require.Len(t, res.MetricRows, 1, "одна неделя в окне")
+	row := res.MetricRows[0]
+	// 14 въездов / 7 дней = 2.0; значение дробное -> FloatValues, не Values.
+	require.NotNil(t, row.FloatValues)
+	assert.Equal(t, 2.0, row.FloatValues["avg_cars_per_day"])
+	_, intPresent := row.Values["avg_cars_per_day"]
+	assert.False(t, intPresent, "среднее не должно лежать в целочисленных Values")
+
+	// Итог-среднее: 14 въездов / 7 дней окна = 2.0.
+	assert.Equal(t, 2.0, res.FloatTotals["avg_cars_per_day"])
+}
+
+// TestRunReport_AvgCarsPartialBin проверяет крайний неполный бин: окно начинается
+// в среду, ведущая неделя делится на фактическое число дней пересечения, не на 7.
+func TestRunReport_AvgCarsPartialBin(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	org := models.Organization{Name: "Орг-AvgP", IsActive: true}
+	require.NoError(t, db.Create(&org).Error)
+	user := models.User{Username: "avgp_sender", TypeID: 1, IsActive: true}
+	require.NoError(t, db.Create(&user).Error)
+	status := models.StatusCompleted
+	sent := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	n := "AVGP/1"
+	app := models.Application{ApplicationNumber: &n, OrganizationID: org.ID,
+		SenderUserID: user.ID, Status: &status, SendingDatetime: &sent}
+	require.NoError(t, db.Create(&app).Error)
+	att := models.Attachment{ApplicationID: app.ID, AttachmentType: "cars"}
+	require.NoError(t, db.Create(&att).Error)
+	num := "В002ВВ"
+	car := models.Car{AttachmentID: att.ID, CarNumber: &num}
+	require.NoError(t, db.Create(&car).Error)
+
+	// Окно 06-10 (среда) .. 06-14 (воскресенье) = ведущий неполный бин недели
+	// 06-08..06-14, пересечение 06-10..06-14 = 5 дней. 10 въездов -> 10/5 = 2.0.
+	for _, d := range []int{10, 11, 12, 13, 14} {
+		for i := 0; i < 2; i++ {
+			h := models.CarHistory{CarID: car.ID, ActionType: "entry",
+				CreatedAt: time.Date(2026, 6, d, 10+i, 0, 0, 0, time.UTC)}
+			require.NoError(t, db.Create(&h).Error)
+		}
+	}
+
+	svc := services.NewStatisticsService(db)
+	res, err := svc.RunReport(context.Background(), models.ReportRequest{
+		Mode:        "aggregate",
+		Metrics:     []string{"avg_cars_per_day"},
+		Dimension:   "period",
+		Granularity: "week",
+		Filters: []models.ReportFilterValue{
+			{Key: "date_range", From: "2026-06-10", To: "2026-06-14"},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, res.MetricRows, 1)
+	// 10 въездов / 5 дней (фактическое пересечение неполного бина) = 2.0.
+	assert.Equal(t, 2.0, res.MetricRows[0].FloatValues["avg_cars_per_day"])
+	// Итог: 10 / 5 дней окна = 2.0.
+	assert.Equal(t, 2.0, res.FloatTotals["avg_cars_per_day"])
+}

--- a/internal/models/report.go
+++ b/internal/models/report.go
@@ -14,13 +14,16 @@ type ReportFilterValue struct {
 // Metrics имеет приоритет; если он пуст — берётся Metric (обратная совместимость с
 // одиночным конструктором). Каждая метрика становится колонкой результата.
 // Dimension="none" — без разреза (один итоговый ряд).
-// Mode=list: выгрузка строк сущности (Entity).
+// Pivot (опц.) — cross-tab: при Dimension="period" каждое значение оси Pivot
+// (например "attachment_type") разворачивается в отдельную колонку-счётчик рядом с
+// метриками. Пустой Pivot -> обычный отчёт. Mode=list: выгрузка строк сущности (Entity).
 type ReportRequest struct {
 	Mode        string              `json:"mode"`
 	Metric      string              `json:"metric"`
 	Metrics     []string            `json:"metrics,omitempty"`
 	Dimension   string              `json:"dimension"`
 	Granularity string              `json:"granularity"`
+	Pivot       string              `json:"pivot,omitempty"`
 	Entity      string              `json:"entity"`
 	Filters     []ReportFilterValue `json:"filters"`
 	Sort        string              `json:"sort"`
@@ -33,18 +36,35 @@ type ReportAggregateRow struct {
 	Value int64  `json:"value"`
 }
 
-// ReportMetricColumn — колонка-метрика мультиметричного отчёта (ключ, подпись, единица).
+// ReportColumnKind различает тип колонки результата: обычная метрика или
+// pivot-колонка cross-tab (значение оси Pivot, развёрнутое в столбец).
+type ReportColumnKind string
+
+const (
+	ReportColumnMetric ReportColumnKind = "metric" // обычная метрика (Values)
+	ReportColumnPivot  ReportColumnKind = "pivot"  // cross-tab колонка (Values)
+)
+
+// ReportMetricColumn — колонка мультиметричного/cross-tab отчёта (ключ, подпись, единица).
+// Kind пуст для обычных метрик (обратная совместимость) либо "pivot" для cross-tab
+// колонок. Float=true -> значение колонки лежит в ReportMetricRow.FloatValues
+// (дробные метрики вроде среднего), иначе — в Values (целые счётчики).
 type ReportMetricColumn struct {
-	Key   string `json:"key"`
-	Label string `json:"label"`
-	Unit  string `json:"unit,omitempty"`
+	Key   string           `json:"key"`
+	Label string           `json:"label"`
+	Unit  string           `json:"unit,omitempty"`
+	Kind  ReportColumnKind `json:"kind,omitempty"`
+	Float bool             `json:"float,omitempty"`
 }
 
-// ReportMetricRow — строка мультиметрик: подпись разреза + значение каждой метрики
-// (по её ключу). Метрики без значения в этом бакете -> 0.
+// ReportMetricRow — строка мультиметрик: подпись разреза + значение каждой колонки
+// (по её ключу). Целочисленные колонки (счётчики, суммы, pivot) -> Values; дробные
+// (средние) -> FloatValues. Колонки без значения в этом бакете -> 0. FloatValues
+// заполняется только при наличии дробных метрик (omitempty -> старый ответ не меняется).
 type ReportMetricRow struct {
-	Label  string           `json:"label"`
-	Values map[string]int64 `json:"values"`
+	Label       string             `json:"label"`
+	Values      map[string]int64   `json:"values"`
+	FloatValues map[string]float64 `json:"float_values,omitempty"`
 }
 
 // ReportResponse — результат агрегатного отчёта.
@@ -60,9 +80,10 @@ type ReportResponse struct {
 	Rows      []ReportAggregateRow `json:"rows"`
 	Total     int64                `json:"total"`
 
-	Columns    []ReportMetricColumn `json:"columns,omitempty"`
-	MetricRows []ReportMetricRow    `json:"metric_rows,omitempty"`
-	Totals     map[string]int64     `json:"totals,omitempty"`
+	Columns     []ReportMetricColumn `json:"columns,omitempty"`
+	MetricRows  []ReportMetricRow    `json:"metric_rows,omitempty"`
+	Totals      map[string]int64     `json:"totals,omitempty"`
+	FloatTotals map[string]float64   `json:"float_totals,omitempty"`
 }
 
 // ReportListResponse — результат list-отчёта (mode=list): выгрузка строк сущности.

--- a/internal/models/report_catalog.go
+++ b/internal/models/report_catalog.go
@@ -35,6 +35,15 @@ type ReportDimensionInfo struct {
 	Label string `json:"label"`
 }
 
+// ReportPivotInfo — ось cross-tab: значения этой оси разворачиваются в колонки при
+// Dimension="period". Metrics — метрики, для которых pivot применим (фронт прячет
+// опцию для прочих). Пока единственная ось — тип вложения для applications_count.
+type ReportPivotInfo struct {
+	Key     string   `json:"key"`
+	Label   string   `json:"label"`
+	Metrics []string `json:"metrics"`
+}
+
 // ReportFilterInfo — поле фильтра. Для enum/dict Options заполнены значениями.
 type ReportFilterInfo struct {
 	Key     string          `json:"key"`
@@ -66,4 +75,5 @@ type ReportCatalog struct {
 	Filters       []ReportFilterInfo     `json:"filters"`
 	ListEntities  []ReportListEntityInfo `json:"list_entities"`
 	Granularities []ReportOption         `json:"granularities"`
+	Pivots        []ReportPivotInfo      `json:"pivots,omitempty"`
 }

--- a/internal/services/report_catalog.go
+++ b/internal/services/report_catalog.go
@@ -74,6 +74,7 @@ var reportMetricOrder = []string{
 	"applications_count",
 	"car_entries_count",
 	"people_entries_count",
+	"avg_cars_per_day",
 	"items_sum",
 }
 
@@ -103,6 +104,17 @@ var reportMetricRegistry = map[string]metricDef{
 		aggExpr:    "COUNT(*)",
 		baseFilter: "action_type = 'entry'",
 		dimensions: []string{"period", "hour_of_day", "organization"},
+	},
+	"avg_cars_per_day": {
+		label:      "Среднее машин в день",
+		unit:       "шт/день",
+		group:      metricGroupCars,
+		baseTable:  "cars_history",
+		aggExpr:    "COUNT(*)",
+		baseFilter: "action_type = 'entry'",
+		// Только period (среднее в день имеет смысл только по времени) и none
+		// (общее среднее за весь период) — последний валидируется универсально.
+		dimensions: []string{"period"},
 	},
 	"items_sum": {
 		label:      "Количество товаров",
@@ -140,6 +152,15 @@ var reportDimensionRegistry = map[string]dimensionDef{
 	"unload_place":    {label: "Место разгрузки"},
 	"period":          {label: "Период (дата)"},
 	"hour_of_day":     {label: "Час суток"},
+}
+
+// pivotAttachmentType — ключ cross-tab оси "тип вложения" (значения -> колонки).
+const pivotAttachmentType = "attachment_type"
+
+// reportPivotRegistry — whitelist осей cross-tab. Каждая ось знает, для каких
+// метрик она применима (движок разворачивает её в колонки счётчиков заявок).
+var reportPivotRegistry = []models.ReportPivotInfo{
+	{Key: pivotAttachmentType, Label: "Тип вложения", Metrics: []string{"applications_count"}},
 }
 
 var reportFilterOrder = []string{
@@ -303,6 +324,7 @@ func buildReportCatalog(dyn dynamicReportOptions) models.ReportCatalog {
 		Filters:       make([]models.ReportFilterInfo, 0, len(reportFilterOrder)),
 		ListEntities:  make([]models.ReportListEntityInfo, 0, len(reportListEntityOrder)),
 		Granularities: reportGranularities,
+		Pivots:        reportPivotRegistry,
 	}
 
 	for _, key := range reportMetricOrder {

--- a/internal/services/report_crosstab.go
+++ b/internal/services/report_crosstab.go
@@ -1,0 +1,314 @@
+package services
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"systemburo/internal/models"
+)
+
+// Cross-tab (G4): при разрезе period значения оси pivot (тип вложения)
+// разворачиваются в отдельные колонки-счётчики рядом с обычными метриками.
+// Pivot-колонки динамические (зависят от данных). Реализовано отдельной веткой,
+// не трогая mergeMetricRows: pivot активируется только при заданном req.Pivot и
+// Dimension="period"; иначе путь движка не меняется (обратная совместимость).
+
+// pivotColumnPrefix — префикс ключа pivot-колонки в Values/Columns. Отделяет
+// cross-tab колонки от ключей метрик (метрики берут ключи из реестра).
+const pivotColumnPrefix = "pivot:"
+
+// pivotPlan — план cross-tab запроса: period-бин + значение оси pivot -> счётчик.
+// SQL-выражения — только whitelist (period по tsColumn метрики, pivotExpr из схемы).
+type pivotPlan struct {
+	table      string
+	periodExpr string // GROUP BY-выражение периода-бина
+	labelExpr  string // подпись бина (совпадает с label обычных period-строк)
+	pivotExpr  string // GROUP BY-выражение оси pivot (значение -> колонка)
+	aggExpr    string
+	joins      []string
+	wheres     []whereClause
+}
+
+// pivotCell — одна ячейка cross-tab: период-бин, значение оси, счётчик.
+type pivotCell struct {
+	Period string `json:"period"`
+	Pivot  string `json:"pivot"`
+	Count  int64  `json:"count"`
+}
+
+// resolvePivot проверяет ось pivot против whitelist и применимость к метрикам
+// запроса. Возвращает (axis, true) только когда pivot задан, ось известна и
+// применима ко ВСЕМ метрикам запроса при Dimension="period". Иначе (false) —
+// обычный путь без cross-tab.
+func resolvePivot(pivot, dimension string, metrics []string) (models.ReportPivotInfo, bool, error) {
+	if pivot == "" {
+		return models.ReportPivotInfo{}, false, nil
+	}
+	if dimension != "period" {
+		return models.ReportPivotInfo{}, false, errInvalidReport("pivot")
+	}
+	var axis models.ReportPivotInfo
+	found := false
+	for _, p := range reportPivotRegistry {
+		if p.Key == pivot {
+			axis = p
+			found = true
+			break
+		}
+	}
+	if !found {
+		return models.ReportPivotInfo{}, false, errInvalidReport("pivot")
+	}
+	for _, m := range metrics {
+		if !contains(axis.Metrics, m) {
+			return models.ReportPivotInfo{}, false, errInvalidReport("pivot")
+		}
+	}
+	return axis, true, nil
+}
+
+// buildPivotPlan собирает план cross-tab запроса из whitelist-схемы метрики и оси.
+// Чистая функция (без БД) — тестируется напрямую. period строится по tsColumn
+// метрики (как обычный разрез period), pivot — по выражению из схемы метрики dims.
+// Фильтры запроса применяются тем же резолвером, что и в обычном плане.
+func buildPivotPlan(metric, pivotKey, granularity string, filters []models.ReportFilterValue) (*pivotPlan, error) {
+	schema, ok := aggMetricRegistry[metric]
+	if !ok {
+		return nil, errInvalidReport("metric")
+	}
+	pivotCol, ok := schema.dims[pivotKey]
+	if !ok {
+		return nil, errInvalidReport("pivot")
+	}
+
+	unit := "day"
+	if granularity != "" {
+		u, gok := aggGranularity[granularity]
+		if !gok {
+			return nil, errInvalidReport("granularity")
+		}
+		unit = u
+	}
+	periodExpr := fmt.Sprintf("date_trunc('%s', %s)", unit, schema.tsColumn)
+	labelExpr := fmt.Sprintf("to_char(%s, 'YYYY-MM-DD')", periodExpr)
+
+	plan := &pivotPlan{
+		table:      schema.base,
+		periodExpr: periodExpr,
+		labelExpr:  labelExpr,
+		pivotExpr:  pivotCol.expr,
+		aggExpr:    schema.aggExpr,
+	}
+	if schema.baseWhere != "" {
+		plan.wheres = append(plan.wheres, whereClause{expr: schema.baseWhere})
+	}
+
+	var needChain, needAttach bool
+	addJoinNeed(schema.tsJoin, &needChain, &needAttach)
+	addJoinNeed(pivotCol.join, &needChain, &needAttach)
+
+	for _, f := range filters {
+		wc, fjoin, ferr := resolveAggFilter(schema, f)
+		if ferr != nil {
+			return nil, ferr
+		}
+		if wc == nil {
+			continue
+		}
+		plan.wheres = append(plan.wheres, *wc)
+		addJoinNeed(fjoin, &needChain, &needAttach)
+	}
+
+	if needChain {
+		plan.joins = append(plan.joins, schema.joinBlock...)
+	}
+	if needAttach {
+		plan.joins = append(plan.joins, schema.attachJoin...)
+	}
+	return plan, nil
+}
+
+// applyPivotCells вписывает cross-tab ячейки в уже собранные построчные данные и
+// возвращает добавочные pivot-колонки. Чистая функция. Колонки строятся по всем
+// встреченным значениям оси (детерминированный порядок — по убыванию суммы, затем
+// по имени), их ключи — pivotColumnPrefix+значение. Бины, которых нет среди rows
+// (отфильтрованы лимитом), игнорируются — cross-tab не добавляет новых строк.
+func applyPivotCells(rows []models.ReportMetricRow, cells []pivotCell, axisLabel string) []models.ReportMetricColumn {
+	rowByLabel := make(map[string]int, len(rows))
+	for i, r := range rows {
+		rowByLabel[r.Label] = i
+	}
+
+	pivotTotals := make(map[string]int64)
+	for _, c := range cells {
+		ri, ok := rowByLabel[c.Period]
+		if !ok {
+			continue // бин вне видимых строк (лимит) — не разворачиваем
+		}
+		key := pivotColumnPrefix + c.Pivot
+		if rows[ri].Values == nil {
+			rows[ri].Values = map[string]int64{}
+		}
+		rows[ri].Values[key] += c.Count
+		pivotTotals[c.Pivot] += c.Count
+	}
+
+	pivots := make([]string, 0, len(pivotTotals))
+	for p := range pivotTotals {
+		pivots = append(pivots, p)
+	}
+	sort.SliceStable(pivots, func(i, j int) bool {
+		if pivotTotals[pivots[i]] != pivotTotals[pivots[j]] {
+			return pivotTotals[pivots[i]] > pivotTotals[pivots[j]]
+		}
+		return pivots[i] < pivots[j]
+	})
+
+	cols := make([]models.ReportMetricColumn, 0, len(pivots))
+	for _, p := range pivots {
+		cols = append(cols, models.ReportMetricColumn{
+			Key:   pivotColumnPrefix + p,
+			Label: axisLabel + ": " + p,
+			Unit:  "шт",
+			Kind:  models.ReportColumnPivot,
+		})
+	}
+	// Строки без значения по колонке должны давать 0 (явный нуль для FE-таблицы).
+	for ri := range rows {
+		if rows[ri].Values == nil {
+			rows[ri].Values = map[string]int64{}
+		}
+		for _, p := range pivots {
+			key := pivotColumnPrefix + p
+			if _, ok := rows[ri].Values[key]; !ok {
+				rows[ri].Values[key] = 0
+			}
+		}
+	}
+	return cols
+}
+
+// avgMetrics — метрики-средние: значение бина = счётчик / число календарных дней
+// бина. Обрабатываются постпроцессом RunReport (значение дробное -> FloatValues).
+var avgMetrics = map[string]bool{
+	"avg_cars_per_day": true,
+}
+
+// reportDateBounds извлекает границы периода [from, to] из date_range-фильтра запроса
+// (UTC, без МСК-логики — как везде в движке). Нужны для деления крайних неполных
+// бинов на фактическое число дней пересечения с периодом.
+func reportDateBounds(filters []models.ReportFilterValue) (from, to time.Time, hasFrom, hasTo bool) {
+	for _, f := range filters {
+		if f.Key != "date_range" {
+			continue
+		}
+		if t, ok := parseReportDate(f.From, false); ok {
+			from, hasFrom = t, true
+		}
+		if t, ok := parseReportDate(f.To, true); ok {
+			to, hasTo = t, true
+		}
+	}
+	return from, to, hasFrom, hasTo
+}
+
+// binDays возвращает число календарных дней в периоде-бине гранулярности unit,
+// начинающемся в binStart, с поправкой на пересечение с запрошенным окном [from,to]:
+// крайний неполный бин делится на фактическое число дней внутри окна (а не на полную
+// длину бина). Если границы окна не заданы — берётся полная длина бина (day=1,
+// week=7, month=число дней месяца).
+func binDays(binStart time.Time, unit string, from, to time.Time, hasFrom, hasTo bool) float64 {
+	binEnd := nextBinStart(binStart, unit) // эксклюзивный конец бина
+	lo := binStart
+	if hasFrom && from.After(lo) {
+		lo = from
+	}
+	hi := binEnd
+	if hasTo {
+		// to — конец дня (23:59:59); эксклюзивная граница окна = начало след. суток.
+		toExcl := time.Date(to.Year(), to.Month(), to.Day(), 0, 0, 0, 0, time.UTC).AddDate(0, 0, 1)
+		if toExcl.Before(hi) {
+			hi = toExcl
+		}
+	}
+	days := hi.Sub(lo).Hours() / 24
+	if days < 1 {
+		days = 1 // защита от деления на ноль/отрицательного пересечения
+	}
+	return days
+}
+
+// nextBinStart возвращает начало следующего бина гранулярности unit. week —
+// ISO-неделя (date_trunc('week') начинает с понедельника), поэтому +7 дней.
+func nextBinStart(binStart time.Time, unit string) time.Time {
+	switch unit {
+	case "week":
+		return binStart.AddDate(0, 0, 7)
+	case "month":
+		return binStart.AddDate(0, 1, 0)
+	default: // day
+		return binStart.AddDate(0, 0, 1)
+	}
+}
+
+// applyAvgPerDay превращает целые счётчики метрики-среднего в дробные средние в день.
+// Чистая функция. Для разреза period каждое значение бина делится на число дней бина
+// (binDays, с поправкой на крайние неполные бины). Для разреза none знаменатель —
+// число дней всего окна [from,to] (общее среднее). Значения переносятся из Values в
+// FloatValues и удаляются из Values (метрика дробная). Округление до 1 знака.
+func applyAvgPerDay(rows []models.ReportMetricRow, metric, dimension, granularity string, filters []models.ReportFilterValue) float64 {
+	from, to, hasFrom, hasTo := reportDateBounds(filters)
+	unit := "day"
+	if granularity != "" {
+		if u, ok := aggGranularity[granularity]; ok {
+			unit = u
+		}
+	}
+
+	var sumCount int64
+	for i := range rows {
+		raw := rows[i].Values[metric]
+		sumCount += raw
+		delete(rows[i].Values, metric)
+		if rows[i].FloatValues == nil {
+			rows[i].FloatValues = map[string]float64{}
+		}
+		var days float64
+		if dimension == "period" {
+			if binStart, ok := parseReportDate(rows[i].Label, false); ok {
+				days = binDays(binStart, unit, from, to, hasFrom, hasTo)
+			} else {
+				days = 1
+			}
+		} else {
+			days = windowDays(from, to, hasFrom, hasTo)
+		}
+		rows[i].FloatValues[metric] = round1(float64(raw) / days)
+	}
+
+	// Итог метрики-среднего: общий счётчик / число дней окна (а не сумма средних
+	// бинов — последняя не имеет смысла как "среднее за период").
+	return round1(float64(sumCount) / windowDays(from, to, hasFrom, hasTo))
+}
+
+// windowDays — число календарных дней в окне [from,to] включительно; без заданных
+// границ -> 1 (нет периода — среднее вырождается в сам счётчик). Считается по датам
+// (to нормализуется к началу своих суток), чтобы не зависеть от 23:59:59-хвоста.
+func windowDays(from, to time.Time, hasFrom, hasTo bool) float64 {
+	if !hasFrom || !hasTo {
+		return 1
+	}
+	fromDay := time.Date(from.Year(), from.Month(), from.Day(), 0, 0, 0, 0, time.UTC)
+	toDay := time.Date(to.Year(), to.Month(), to.Day(), 0, 0, 0, 0, time.UTC)
+	days := int(toDay.Sub(fromDay).Hours()/24) + 1
+	if days < 1 {
+		days = 1
+	}
+	return float64(days)
+}
+
+// round1 округляет до одного знака после запятой.
+func round1(v float64) float64 {
+	return float64(int(v*10+0.5)) / 10
+}

--- a/internal/services/report_crosstab_test.go
+++ b/internal/services/report_crosstab_test.go
@@ -1,0 +1,243 @@
+package services
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"systemburo/internal/models"
+)
+
+func TestResolvePivot(t *testing.T) {
+	cases := []struct {
+		name    string
+		pivot   string
+		dim     string
+		metrics []string
+		wantOn  bool
+		wantErr bool
+	}{
+		{"empty pivot -> off, no error", "", "period", []string{"applications_count"}, false, false},
+		{"valid attachment_type on period", pivotAttachmentType, "period", []string{"applications_count"}, true, false},
+		{"pivot with non-period dimension -> error", pivotAttachmentType, "organization", []string{"applications_count"}, false, true},
+		{"unknown pivot axis -> error", "nope", "period", []string{"applications_count"}, false, true},
+		{"pivot not applicable to metric -> error", pivotAttachmentType, "period", []string{"car_entries_count"}, false, true},
+		{"pivot applicable to all metrics required", pivotAttachmentType, "period", []string{"applications_count", "items_sum"}, false, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, on, err := resolvePivot(tc.pivot, tc.dim, tc.metrics)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ожидалась ошибка валидации")
+				}
+				if !errors.Is(err, ErrInvalidReportRequest) {
+					t.Errorf("ожидался ErrInvalidReportRequest, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("неожиданная ошибка: %v", err)
+			}
+			if on != tc.wantOn {
+				t.Errorf("pivotOn: got %v, want %v", on, tc.wantOn)
+			}
+		})
+	}
+}
+
+func TestBuildPivotPlan_PeriodAndAttachJoin(t *testing.T) {
+	plan, err := buildPivotPlan("applications_count", pivotAttachmentType, "week",
+		[]models.ReportFilterValue{{Key: "date_range", From: "2026-06-01", To: "2026-06-17"}})
+	if err != nil {
+		t.Fatalf("неожиданная ошибка: %v", err)
+	}
+	if !strings.Contains(plan.periodExpr, "date_trunc('week', app.sending_datetime)") {
+		t.Errorf("ожидался period week, got %q", plan.periodExpr)
+	}
+	if !strings.Contains(plan.pivotExpr, "att.attachment_display_name") {
+		t.Errorf("ожидалось выражение типа вложения, got %q", plan.pivotExpr)
+	}
+	// attach-join обязателен (выражение оси лежит за вложениями).
+	joined := strings.Join(plan.joins, " ")
+	if !strings.Contains(joined, "attachments att") || !strings.Contains(joined, "unique_attachments ua") {
+		t.Errorf("ожидался attach-join, got %v", plan.joins)
+	}
+	if !strings.Contains(plan.aggExpr, "COUNT(DISTINCT app.id)") {
+		t.Errorf("ожидался COUNT(DISTINCT app.id), got %q", plan.aggExpr)
+	}
+	// date_range -> WHERE по sending_datetime.
+	var hasFrom bool
+	for _, w := range plan.wheres {
+		if strings.Contains(w.expr, "app.sending_datetime >= ?") {
+			hasFrom = true
+		}
+	}
+	if !hasFrom {
+		t.Errorf("date_range не попал в where: %+v", plan.wheres)
+	}
+}
+
+func TestBuildPivotPlan_RejectsBadAxisOrGranularity(t *testing.T) {
+	cases := []struct {
+		name        string
+		metric      string
+		pivot       string
+		granularity string
+	}{
+		{"unknown metric", "nope", pivotAttachmentType, "week"},
+		{"axis not a dim of metric", "items_sum", pivotAttachmentType, "week"},
+		{"bad granularity", "applications_count", pivotAttachmentType, "year"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := buildPivotPlan(tc.metric, tc.pivot, tc.granularity, nil)
+			if err == nil {
+				t.Fatalf("ожидалась ошибка")
+			}
+			if !errors.Is(err, ErrInvalidReportRequest) {
+				t.Errorf("ожидался ErrInvalidReportRequest, got %v", err)
+			}
+		})
+	}
+}
+
+func TestApplyPivotCells_BuildsColumnsAndFillsRows(t *testing.T) {
+	rows := []models.ReportMetricRow{
+		{Label: "2026-06-01", Values: map[string]int64{"applications_count": 5}},
+		{Label: "2026-06-08", Values: map[string]int64{"applications_count": 3}},
+	}
+	cells := []pivotCell{
+		{Period: "2026-06-01", Pivot: "Люди", Count: 2},
+		{Period: "2026-06-01", Pivot: "Машины", Count: 3},
+		{Period: "2026-06-08", Pivot: "Машины", Count: 3}, // в этом бине только машины
+		{Period: "2026-07-01", Pivot: "Люди", Count: 9},   // бин вне видимых строк -> игнор
+	}
+	cols := applyPivotCells(rows, cells, "Вложения")
+
+	// Колонки: Машины (итог 6) перед Люди (итог 2) — по убыванию суммы.
+	if len(cols) != 2 {
+		t.Fatalf("ожидалось 2 pivot-колонки, got %d (%+v)", len(cols), cols)
+	}
+	if cols[0].Key != pivotColumnPrefix+"Машины" || cols[1].Key != pivotColumnPrefix+"Люди" {
+		t.Errorf("порядок колонок по убыванию суммы нарушен: %q,%q", cols[0].Key, cols[1].Key)
+	}
+	if cols[0].Label != "Вложения: Машины" || cols[0].Kind != models.ReportColumnPivot {
+		t.Errorf("ожидался label/kind pivot-колонки, got %q/%q", cols[0].Label, cols[0].Kind)
+	}
+
+	// Метрика осталась нетронутой, pivot-значения вписаны, отсутствующие -> 0.
+	r0 := rows[0]
+	if r0.Values["applications_count"] != 5 {
+		t.Errorf("метрика не должна меняться, got %d", r0.Values["applications_count"])
+	}
+	if r0.Values[pivotColumnPrefix+"Люди"] != 2 || r0.Values[pivotColumnPrefix+"Машины"] != 3 {
+		t.Errorf("ячейки бина 06-01: %+v", r0.Values)
+	}
+	r1 := rows[1]
+	if r1.Values[pivotColumnPrefix+"Машины"] != 3 {
+		t.Errorf("бин 06-08 машины: got %d", r1.Values[pivotColumnPrefix+"Машины"])
+	}
+	if v, ok := r1.Values[pivotColumnPrefix+"Люди"]; !ok || v != 0 {
+		t.Errorf("отсутствующая pivot-колонка должна давать явный 0, got %v ok=%v", v, ok)
+	}
+}
+
+func TestWindowDays(t *testing.T) {
+	cases := []struct {
+		name     string
+		from, to string
+		want     float64
+	}{
+		{"single day", "2026-06-01", "2026-06-01", 1},
+		{"seventeen days inclusive", "2026-06-01", "2026-06-17", 17},
+		{"full week", "2026-06-01", "2026-06-07", 7},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			from, _ := parseReportDate(tc.from, false)
+			to, _ := parseReportDate(tc.to, true)
+			if got := windowDays(from, to, true, true); got != tc.want {
+				t.Errorf("windowDays = %v, want %v", got, tc.want)
+			}
+		})
+	}
+	if got := windowDays(time.Time{}, time.Time{}, false, false); got != 1 {
+		t.Errorf("без границ окна windowDays должен быть 1, got %v", got)
+	}
+}
+
+func TestBinDays_FullAndPartial(t *testing.T) {
+	from, _ := parseReportDate("2026-06-03", false) // среда
+	to, _ := parseReportDate("2026-06-17", true)
+
+	cases := []struct {
+		name     string
+		binStart string
+		unit     string
+		want     float64
+	}{
+		// Неделя ISO начинается с понедельника. Бин 06-01..06-07, окно с 06-03 ->
+		// пересечение 06-03..06-07 = 5 дней (крайний неполный бин).
+		{"partial leading week", "2026-06-01", "week", 5},
+		// Полная средняя неделя 06-08..06-14 целиком в окне -> 7.
+		{"full middle week", "2026-06-08", "week", 7},
+		// Бин 06-15..06-21, окно до 06-17 включительно -> 06-15..06-17 = 3 дня.
+		{"partial trailing week", "2026-06-15", "week", 3},
+		// Гранулярность day -> всегда 1.
+		{"day bin", "2026-06-10", "day", 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			binStart, _ := parseReportDate(tc.binStart, false)
+			if got := binDays(binStart, tc.unit, from, to, true, true); got != tc.want {
+				t.Errorf("binDays(%s,%s) = %v, want %v", tc.binStart, tc.unit, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestApplyAvgPerDay_PeriodWeekly(t *testing.T) {
+	// entries по неделям, окно 2026-06-03..2026-06-17.
+	rows := []models.ReportMetricRow{
+		{Label: "2026-06-01", Values: map[string]int64{"avg_cars_per_day": 10}}, // 5 дней пересечения -> 2.0
+		{Label: "2026-06-08", Values: map[string]int64{"avg_cars_per_day": 14}}, // 7 дней -> 2.0
+		{Label: "2026-06-15", Values: map[string]int64{"avg_cars_per_day": 9}},  // 3 дня -> 3.0
+	}
+	filters := []models.ReportFilterValue{{Key: "date_range", From: "2026-06-03", To: "2026-06-17"}}
+
+	total := applyAvgPerDay(rows, "avg_cars_per_day", "period", "week", filters)
+
+	wantFloat := []float64{2.0, 2.0, 3.0}
+	for i, w := range wantFloat {
+		if rows[i].FloatValues["avg_cars_per_day"] != w {
+			t.Errorf("row[%d] float: got %v, want %v", i, rows[i].FloatValues["avg_cars_per_day"], w)
+		}
+		// целое значение метрики убрано из Values (метрика дробная).
+		if _, ok := rows[i].Values["avg_cars_per_day"]; ok {
+			t.Errorf("row[%d]: целое значение должно быть удалено из Values", i)
+		}
+	}
+	// Итог = суммарный счётчик (10+14+9=33) / число дней окна (15) = 2.2.
+	if total != 2.2 {
+		t.Errorf("total avg: got %v, want 2.2", total)
+	}
+}
+
+func TestApplyAvgPerDay_NoneWholeWindow(t *testing.T) {
+	rows := []models.ReportMetricRow{
+		{Label: "Итого", Values: map[string]int64{"avg_cars_per_day": 30}},
+	}
+	filters := []models.ReportFilterValue{{Key: "date_range", From: "2026-06-01", To: "2026-06-10"}}
+
+	total := applyAvgPerDay(rows, "avg_cars_per_day", dimNone, "", filters)
+
+	// 30 entries / 10 дней = 3.0.
+	if rows[0].FloatValues["avg_cars_per_day"] != 3.0 {
+		t.Errorf("none avg: got %v, want 3.0", rows[0].FloatValues["avg_cars_per_day"])
+	}
+	if total != 3.0 {
+		t.Errorf("none total: got %v, want 3.0", total)
+	}
+}

--- a/internal/services/report_engine.go
+++ b/internal/services/report_engine.go
@@ -151,6 +151,33 @@ var aggMetricRegistry = map[string]aggMetricSchema{
 			"citizenship":     {expr: "cz.name", join: jChain},
 		},
 	},
+	// avg_cars_per_day считает COUNT(entry) по бинам так же, как car_entries_count;
+	// деление на число календарных дней бина выполняет RunReport (postprocess),
+	// поэтому aggExpr тут — счётчик, а не среднее. Доступные разрезы: period/none.
+	"avg_cars_per_day": {
+		base:      "cars_history ch",
+		aggExpr:   "COUNT(*)",
+		baseWhere: "ch.action_type = 'entry'",
+		tsColumn:  "ch.created_at",
+		tsJoin:    jNone,
+		unit:      "шт/день",
+		joinBlock: []string{
+			"JOIN cars c ON c.id = ch.car_id",
+			"LEFT JOIN attachments att ON att.id = c.attachment_id",
+			"LEFT JOIN applications app ON app.id = att.application_id",
+			"LEFT JOIN organizations org ON org.id = app.organization_id",
+			"LEFT JOIN companies comp ON comp.id = app.company_id",
+			"LEFT JOIN unique_attachments ua ON ua.id = att.unique_attachment_id",
+		},
+		dims: map[string]aggColumn{},
+		filters: map[string]aggColumn{
+			"organization":    {expr: "org.name", join: jChain},
+			"company":         {expr: "comp.name", join: jChain},
+			"status":          {expr: "app.status", join: jChain},
+			"attachment_type": {expr: "COALESCE(ua.display_name, att.attachment_display_name, att.attachment_type)", join: jChain},
+			"unload_place":    {expr: "c.unload_place", join: jChain},
+		},
+	},
 	"items_sum": {
 		base:     "items",
 		aggExpr:  "COALESCE(SUM(items.count), 0)",

--- a/internal/services/statistics_service.go
+++ b/internal/services/statistics_service.go
@@ -454,6 +454,37 @@ func (s *statisticsService) RunReport(ctx context.Context, req models.ReportRequ
 
 	metricRows, totals := mergeMetricRows(metrics, perMetric, req.Dimension, req.Sort, clampLimit(req.Limit))
 
+	// Cross-tab (G4): при заданном req.Pivot и разрезе period — развернуть значения
+	// оси pivot в добавочные колонки-счётчики (отдельной веткой движка). Невалидный
+	// pivot (неизвестная ось / неприменима к метрикам / не period) -> 400.
+	axis, pivotOn, perr := resolvePivot(req.Pivot, req.Dimension, metrics)
+	if perr != nil {
+		return nil, perr
+	}
+	if pivotOn {
+		pivotCols, cerr := s.collectPivotColumns(ctx, metrics, axis, req, metricRows)
+		if cerr != nil {
+			return nil, cerr
+		}
+		columns = append(columns, pivotCols...)
+	}
+
+	// Метрики-средние (avg_*): целые счётчики бинов делятся на число дней бина в Go
+	// (постпроцесс), значения переходят в FloatValues. Колонка помечается Float.
+	var floatTotals map[string]float64
+	for i, m := range metrics {
+		if !avgMetrics[m] {
+			continue
+		}
+		total := applyAvgPerDay(metricRows, m, req.Dimension, req.Granularity, req.Filters)
+		columns[i].Float = true
+		if floatTotals == nil {
+			floatTotals = map[string]float64{}
+		}
+		floatTotals[m] = total
+		delete(totals, m)
+	}
+
 	// Legacy-поля одиночной метрики (текущий FE читает Rows/Total/Unit): первая
 	// метрика как label/value по уже упорядоченным строкам. Unit берём из той же
 	// колонки (единый источник — план метрики), чтобы columns[].unit и legacy unit
@@ -465,16 +496,59 @@ func (s *statisticsService) RunReport(ctx context.Context, req models.ReportRequ
 	}
 
 	return &models.ReportResponse{
-		Mode:       "aggregate",
-		Metric:     first,
-		Dimension:  req.Dimension,
-		Unit:       columns[0].Unit,
-		Rows:       legacyRows,
-		Total:      totals[first],
-		Columns:    columns,
-		MetricRows: metricRows,
-		Totals:     totals,
+		Mode:        "aggregate",
+		Metric:      first,
+		Dimension:   req.Dimension,
+		Unit:        columns[0].Unit,
+		Rows:        legacyRows,
+		Total:       totals[first],
+		Columns:     columns,
+		MetricRows:  metricRows,
+		Totals:      totals,
+		FloatTotals: floatTotals,
 	}, nil
+}
+
+// collectPivotColumns исполняет cross-tab запрос по каждой метрике оси и вписывает
+// ячейки в уже упорядоченные строки, возвращая добавочные pivot-колонки. Несколько
+// метрик с одной осью дают один общий набор pivot-колонок (счётчики складываются —
+// все метрики оси считают заявки по тому же выражению).
+func (s *statisticsService) collectPivotColumns(ctx context.Context, metrics []string, axis models.ReportPivotInfo, req models.ReportRequest, metricRows []models.ReportMetricRow) ([]models.ReportMetricColumn, error) {
+	var cells []pivotCell
+	for _, m := range metrics {
+		plan, perr := buildPivotPlan(m, axis.Key, req.Granularity, req.Filters)
+		if perr != nil {
+			return nil, perr
+		}
+		mcells, eerr := s.execPivotPlan(ctx, plan)
+		if eerr != nil {
+			return nil, eerr
+		}
+		cells = append(cells, mcells...)
+	}
+	return applyPivotCells(metricRows, cells, axis.Label), nil
+}
+
+// execPivotPlan исполняет cross-tab запрос: GROUP BY (период-бин, ось pivot) ->
+// счётчик. period-подпись совпадает с label обычных period-строк (для слияния).
+func (s *statisticsService) execPivotPlan(ctx context.Context, plan *pivotPlan) ([]pivotCell, error) {
+	selectStr := fmt.Sprintf("%s AS period, %s AS pivot, %s AS count",
+		plan.labelExpr, plan.pivotExpr, plan.aggExpr)
+	tx := s.db.WithContext(ctx).Table(plan.table).Select(selectStr)
+	for _, j := range plan.joins {
+		tx = tx.Joins(j)
+	}
+	for _, w := range plan.wheres {
+		tx = tx.Where(w.expr, w.args...)
+	}
+
+	cells := make([]pivotCell, 0)
+	if err := tx.
+		Group(plan.periodExpr + ", " + plan.pivotExpr).
+		Scan(&cells).Error; err != nil {
+		return nil, fmt.Errorf("statistics: run report pivot: %w", err)
+	}
+	return cells, nil
 }
 
 // execAggregatePlan исполняет один резолвленный план агрегата и возвращает строки


### PR DESCRIPTION
## Что и зачем
Движок отчётов (группа G4 эпика #632) — под отчёт «за неделю со столбцами вложений по типам + среднее машин/день».

### Cross-tab по типу вложения
- новое поле `pivot` в `ReportRequest`: при `dimension=period` каждое значение оси (тип вложения) разворачивается в отдельную колонку-счётчик рядом с метриками
- ось валидируется по whitelist (`reportPivotRegistry`, пока `attachment_type` -> `applications_count`), неприменимая/не-period -> 400
- pivot-колонки динамические (ключ `pivot:<имя>`), отсутствующие значения -> явный 0
- пустой `pivot` -> старый путь байт-в-байт

### Метрика «среднее машин в день»
- `avg_cars_per_day`: COUNT(entry) по бинам, деление на число календарных дней бина делает Go-постпроцесс с поправкой на крайние неполные бины (фактическое пересечение с `[from,to]`)
- дробное значение -> `FloatValues`, колонка помечается `float:true`, итог в `float_totals`

### Обратная совместимость
- новые поля ответа (`FloatValues`, `FloatTotals`, `Kind`, `Float`, `Pivot`, `Pivots`) — все `omitempty`; существующие отчёты не меняются

## Тесты
- unit (чистые): `resolvePivot`, `buildPivotPlan` (x2), `applyPivotCells`, `windowDays`, `binDays` (full/partial), `applyAvgPerDay` (period/none) — зелёные локально
- integration через `RunReport` (cross-tab по неделям, regression «pivot пуст», avg 14/7=2.0, неполный бин 10/5=2.0) — зелёные у автора
- build/vet OK

## Заметки для ревью
- `FloatValues` — параллельное поле вместо смены типа `Values` на float (обратная совместимость с FE); дробные метрики читать через `float`-флаг колонки
- pivot `totals` не заполняются (строка «Итого» по типам — YAGNI, добавлю если нужно)