### PR TITLE
feat(analytics): реальный онлайн пользователей и дневные пики (#632)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -249,6 +249,7 @@ func main() {
 	loginLimiter := mw.LoginRateLimit(cfg.LoginRateLimitMax, time.Duration(cfg.LoginRateLimitWindowSec)*time.Second)
 	maintenanceBlock := mw.MaintenanceBlock(maintenanceService)
 	banCheck := mw.BanCheck(banCheckService)
+	lastSeen := mw.LastSeen(db)
 
 	// Routes
 	router.Setup(e, router.Dependencies{
@@ -297,6 +298,7 @@ func main() {
 		MaintenanceBlock:    maintenanceBlock,
 		BanCheck:            banCheck,
 		LoginLimiter:        loginLimiter,
+		LastSeen:            lastSeen,
 		JWTSecret:           []byte(cfg.JWTSecret),
 	})
 
@@ -320,6 +322,10 @@ func main() {
 	}
 	resetService := services.NewTerritoryResetService(db)
 	go startDailyStatusReset(ctxSig, resetService, resetLoc)
+
+	// Снимок дневного пика онлайна (#632): раз в минуту фиксирует текущий онлайн
+	// как пик за сегодня (peak_count = MAX(...)). Останавливается по ctxSig.
+	go startOnlinePeakSnapshotter(ctxSig, statisticsService, time.Minute)
 
 	// Graceful shutdown
 	go func() {
@@ -413,6 +419,28 @@ func startDailyStatusReset(ctx context.Context, svc services.TerritoryResetServi
 			} else {
 				slog.Info("сброс территориальных статусов выполнен", "employees", emp, "cars", cars)
 			}
+		}
+	}
+}
+
+// startOnlinePeakSnapshotter раз в interval фиксирует текущий онлайн как дневной
+// пик (#632). Останавливается по отмене ctx (graceful shutdown), горутина не течёт.
+func startOnlinePeakSnapshotter(ctx context.Context, svc services.StatisticsService, interval time.Duration) {
+	snapshot := func() {
+		if err := svc.SnapshotOnlinePeak(ctx); err != nil {
+			slog.Error("online peak snapshot failed", "error", err)
+		}
+	}
+	snapshot()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Info("online peak snapshotter stopped")
+			return
+		case <-ticker.C:
+			snapshot()
 		}
 	}
 }

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -158,6 +158,8 @@ func AllModels() []interface{} {
 
 		// Report templates (#632): сохранённые наборы конструктора отчётов
 		&models.ReportTemplate{},
+		// Дневные пики онлайна пользователей (#632): снимок фонового тикера
+		&models.UserOnlinePeak{},
 	}
 }
 

--- a/internal/handlers/statistics_online_integration_test.go
+++ b/internal/handlers/statistics_online_integration_test.go
@@ -1,0 +1,143 @@
+package handlers_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUsersOnline_CountsByLastSeenWindow проверяет, что users_online считает только
+// пользователей с last_seen внутри окна онлайна, а старые/нулевые не попадают.
+func TestUsersOnline_CountsByLastSeenWindow(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	now := time.Now().UTC()
+	recent := now.Add(-2 * time.Minute) // в окне
+	stale := now.Add(-30 * time.Minute) // вне окна (15 мин)
+	edge := now.Add(-14 * time.Minute)  // на границе - в окне
+
+	mk := func(username string, ls *time.Time) {
+		u := models.User{Username: username, TypeID: 1, IsActive: true}
+		require.NoError(t, db.Create(&u).Error)
+		if ls != nil {
+			require.NoError(t, db.Model(&models.User{}).Where("id = ?", u.ID).
+				Update("last_seen", *ls).Error)
+		}
+	}
+
+	mk("online_recent", &recent)
+	mk("online_edge", &edge)
+	mk("offline_stale", &stale)
+	mk("never_seen", nil)
+
+	svc := services.NewStatisticsService(db)
+	summary, err := svc.GetSummary(context.Background(), now.Add(-24*time.Hour), now)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(2), summary.UsersOnline, "онлайн = recent + edge, без stale и never")
+}
+
+// TestSnapshotOnlinePeak_MaxAndUpsert проверяет: повторные снимки за день не плодят
+// строки (UNIQUE по date) и peak_count монотонно растёт (MAX старого и текущего).
+func TestSnapshotOnlinePeak_MaxAndUpsert(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	now := time.Now().UTC()
+	svc := services.NewStatisticsService(db)
+
+	// Снимок 1: 3 пользователя онлайн.
+	for _, name := range []string{"p1", "p2", "p3"} {
+		u := models.User{Username: name, TypeID: 1, IsActive: true}
+		require.NoError(t, db.Create(&u).Error)
+		require.NoError(t, db.Model(&models.User{}).Where("id = ?", u.ID).
+			Update("last_seen", now).Error)
+	}
+	require.NoError(t, svc.SnapshotOnlinePeak(context.Background()))
+
+	today := now.Format("2006-01-02")
+	var rowCount int64
+	require.NoError(t, db.Table("user_online_peaks").Where("date = ?", today).Count(&rowCount).Error)
+	assert.Equal(t, int64(1), rowCount, "одна строка за дату")
+
+	var peak int
+	require.NoError(t, db.Table("user_online_peaks").Where("date = ?", today).
+		Select("peak_count").Scan(&peak).Error)
+	assert.Equal(t, 3, peak, "пик после первого снимка")
+
+	// Снимок 2: онлайн упал до 1 (двое "ушли") - пик не должен уменьшиться.
+	require.NoError(t, db.Model(&models.User{}).Where("username IN ?", []string{"p2", "p3"}).
+		Update("last_seen", now.Add(-1*time.Hour)).Error)
+	require.NoError(t, svc.SnapshotOnlinePeak(context.Background()))
+
+	require.NoError(t, db.Table("user_online_peaks").Where("date = ?", today).Count(&rowCount).Error)
+	assert.Equal(t, int64(1), rowCount, "upsert не плодит дубли по дате")
+	require.NoError(t, db.Table("user_online_peaks").Where("date = ?", today).
+		Select("peak_count").Scan(&peak).Error)
+	assert.Equal(t, 3, peak, "пик не убывает при снижении онлайна")
+
+	// Снимок 3: онлайн вырос до 5 - пик растёт.
+	for _, name := range []string{"p4", "p5", "p6", "p7"} {
+		u := models.User{Username: name, TypeID: 1, IsActive: true}
+		require.NoError(t, db.Create(&u).Error)
+		require.NoError(t, db.Model(&models.User{}).Where("id = ?", u.ID).
+			Update("last_seen", now).Error)
+	}
+	// p1 ещё онлайн (now), p4..p7 онлайн -> 5.
+	require.NoError(t, svc.SnapshotOnlinePeak(context.Background()))
+	require.NoError(t, db.Table("user_online_peaks").Where("date = ?", today).
+		Select("peak_count").Scan(&peak).Error)
+	assert.Equal(t, 5, peak, "пик вырос до нового максимума")
+
+	// Summary отдаёт пик за сегодня.
+	summary, err := svc.GetSummary(context.Background(), now.Add(-24*time.Hour), now)
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), summary.UsersOnlinePeakToday)
+}
+
+// TestGetOnlinePeaks_Series проверяет серию пиков за период: фильтр по датам и порядок.
+func TestGetOnlinePeaks_Series(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	now := time.Now().UTC()
+	mkPeak := func(date time.Time, peak int) {
+		require.NoError(t, db.Exec(`
+			INSERT INTO user_online_peaks (date, peak_count, created_at, updated_at)
+			VALUES (?, ?, ?, ?)`,
+			date.Format("2006-01-02"), peak, now, now).Error)
+	}
+
+	d2 := now.Add(-48 * time.Hour)
+	d1 := now.Add(-24 * time.Hour)
+	d0 := now
+	old := now.Add(-10 * 24 * time.Hour) // вне периода
+
+	mkPeak(old, 99)
+	mkPeak(d0, 7)
+	mkPeak(d2, 3)
+	mkPeak(d1, 5)
+
+	svc := services.NewStatisticsService(db)
+	points, err := svc.GetOnlinePeaks(context.Background(), now.Add(-3*24*time.Hour), now)
+	require.NoError(t, err)
+
+	require.Len(t, points, 3, "только дни внутри периода")
+	assert.Equal(t, d2.Format("2006-01-02"), points[0].Date, "по возрастанию даты")
+	assert.Equal(t, 3, points[0].Peak)
+	assert.Equal(t, d1.Format("2006-01-02"), points[1].Date)
+	assert.Equal(t, 5, points[1].Peak)
+	assert.Equal(t, d0.Format("2006-01-02"), points[2].Date)
+	assert.Equal(t, 7, points[2].Peak)
+}

--- a/internal/middleware/last_seen.go
+++ b/internal/middleware/last_seen.go
@@ -1,0 +1,86 @@
+package middleware
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"systemburo/internal/models"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+// lastSeenThrottleWindow - минимальный интервал между записями last_seen одного
+// пользователя в БД. Защищает горячий путь: без троттлинга каждый authenticated
+// запрос делал бы UPDATE users, что недопустимо под нагрузкой.
+const lastSeenThrottleWindow = 60 * time.Second
+
+// seenThrottle решает, пора ли снова писать last_seen в БД для пользователя.
+// In-memory, по процессу: при рестарте сбрасывается (тогда первый запрос юзера
+// после рестарта снова запишет - это безвредно). Потокобезопасен.
+type seenThrottle struct {
+	mu     sync.Mutex
+	last   map[int]time.Time
+	window time.Duration
+}
+
+func newSeenThrottle(window time.Duration) *seenThrottle {
+	return &seenThrottle{
+		last:   make(map[int]time.Time),
+		window: window,
+	}
+}
+
+// shouldWrite возвращает true, если с последней записи для userID прошло не
+// меньше window. При true атомарно фиксирует now как момент последней записи,
+// поэтому два конкурентных запроса одного юзера дают ровно одну запись.
+func (t *seenThrottle) shouldWrite(userID int, now time.Time) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	last, ok := t.last[userID]
+	if ok && now.Sub(last) < t.window {
+		return false
+	}
+	t.last[userID] = now
+	return true
+}
+
+// LastSeen обновляет users.last_seen=now для аутентифицированного пользователя
+// с троттлингом (не чаще раза в lastSeenThrottleWindow на юзера).
+//
+// Ставится ПОСЛЕ JWTAuth (нужен user_id в context). Запись в БД выполняется
+// асинхронно в отдельной горутине, чтобы не добавлять латентность ответа на
+// горячем пути; метка времени фиксируется в троттле синхронно до запуска
+// горутины, поэтому всплеск запросов одного юзера не плодит конкурентные UPDATE.
+func LastSeen(db *gorm.DB) echo.MiddlewareFunc {
+	throttle := newSeenThrottle(lastSeenThrottleWindow)
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			userID, _ := c.Get("user_id").(int)
+			if userID == 0 {
+				return next(c)
+			}
+			now := time.Now().UTC()
+			if throttle.shouldWrite(userID, now) {
+				go writeLastSeen(db, userID, now)
+			}
+			return next(c)
+		}
+	}
+}
+
+// writeLastSeen пишет last_seen в БД вне жизненного цикла запроса.
+// Собственный таймаут-контекст: ctx запроса к этому моменту может быть уже
+// отменён (ответ отправлен), а апдейт всё равно нужно довести.
+func writeLastSeen(db *gorm.DB, userID int, now time.Time) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := db.WithContext(ctx).
+		Model(&models.User{}).
+		Where("id = ?", userID).
+		Update("last_seen", now).Error; err != nil {
+		slog.Warn("last_seen: update failed", "user_id", userID, "error", err)
+	}
+}

--- a/internal/middleware/last_seen_test.go
+++ b/internal/middleware/last_seen_test.go
@@ -1,0 +1,114 @@
+package middleware
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestSeenThrottle_ShouldWrite(t *testing.T) {
+	base := time.Date(2026, 6, 19, 12, 0, 0, 0, time.UTC)
+	window := 60 * time.Second
+
+	tests := []struct {
+		name string
+		// steps: каждый шаг - запрос пользователя в момент base+offset; want - ожидаемое shouldWrite.
+		steps []struct {
+			userID int
+			offset time.Duration
+			want   bool
+		}
+	}{
+		{
+			name: "первый запрос юзера всегда пишет",
+			steps: []struct {
+				userID int
+				offset time.Duration
+				want   bool
+			}{
+				{1, 0, true},
+			},
+		},
+		{
+			name: "два быстрых запроса в окне - одна запись",
+			steps: []struct {
+				userID int
+				offset time.Duration
+				want   bool
+			}{
+				{1, 0, true},
+				{1, 5 * time.Second, false},
+				{1, 59 * time.Second, false},
+			},
+		},
+		{
+			name: "запрос за окном - вторая запись",
+			steps: []struct {
+				userID int
+				offset time.Duration
+				want   bool
+			}{
+				{1, 0, true},
+				{1, 30 * time.Second, false},
+				{1, 60 * time.Second, true},
+				{1, 90 * time.Second, false},
+				{1, 120 * time.Second, true},
+			},
+		},
+		{
+			name: "разные юзеры не мешают друг другу",
+			steps: []struct {
+				userID int
+				offset time.Duration
+				want   bool
+			}{
+				{1, 0, true},
+				{2, 1 * time.Second, true},
+				{1, 2 * time.Second, false},
+				{2, 3 * time.Second, false},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			th := newSeenThrottle(window)
+			for i, s := range tc.steps {
+				got := th.shouldWrite(s.userID, base.Add(s.offset))
+				if got != s.want {
+					t.Errorf("step %d (user=%d offset=%s): shouldWrite=%v, want %v",
+						i, s.userID, s.offset, got, s.want)
+				}
+			}
+		})
+	}
+}
+
+// TestSeenThrottle_Concurrent проверяет, что всплеск конкурентных запросов одного
+// юзера в одном окне приводит ровно к одной записи (защита горячего пути от гонки).
+func TestSeenThrottle_Concurrent(t *testing.T) {
+	th := newSeenThrottle(60 * time.Second)
+	now := time.Date(2026, 6, 19, 12, 0, 0, 0, time.UTC)
+
+	const goroutines = 100
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	writes := 0
+
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			if th.shouldWrite(7, now) {
+				mu.Lock()
+				writes++
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if writes != 1 {
+		t.Errorf("конкурентный всплеск дал %d записей, ожидалась 1", writes)
+	}
+}

--- a/internal/models/statistics.go
+++ b/internal/models/statistics.go
@@ -17,28 +17,46 @@ type StatusCount struct {
 // StatsSummary — сводная статистика дашборда за период.
 type StatsSummary struct {
 	// Данные (заявки, въезды, товары)
-	TotalApplications   int64                 `json:"total_applications"`
-	ByAttachmentType    []AttachmentTypeCount  `json:"by_attachment_type"`
-	ByStatus            []StatusCount          `json:"by_status"`
-	Processed           int64                 `json:"processed"`
-	InWork              int64                 `json:"in_work"`
-	CarsEntered         int64                 `json:"cars_entered"`
-	PeopleEntered       int64                 `json:"people_entered"`
-	AvgCarsPerDay       float64               `json:"avg_cars_per_day"`
-	ItemsSum            int64                 `json:"items_sum"`
-	CarsOnTerritory     int64                 `json:"cars_on_territory"`
-	PeopleOnTerritory   int64                 `json:"people_on_territory"`
+	TotalApplications int64                 `json:"total_applications"`
+	ByAttachmentType  []AttachmentTypeCount `json:"by_attachment_type"`
+	ByStatus          []StatusCount         `json:"by_status"`
+	Processed         int64                 `json:"processed"`
+	InWork            int64                 `json:"in_work"`
+	CarsEntered       int64                 `json:"cars_entered"`
+	PeopleEntered     int64                 `json:"people_entered"`
+	AvgCarsPerDay     float64               `json:"avg_cars_per_day"`
+	ItemsSum          int64                 `json:"items_sum"`
+	CarsOnTerritory   int64                 `json:"cars_on_territory"`
+	PeopleOnTerritory int64                 `json:"people_on_territory"`
 
 	// Система (пользователи, справочники)
-	UsersOnline        int64 `json:"users_online"`
-	ActiveUsers        int64 `json:"active_users"`
-	BannedUsers        int64 `json:"banned_users"`
-	OpenFeedback       int64 `json:"open_feedback"`
-	ActiveUnloadPlaces int64 `json:"active_unload_places"`
-	BlacklistCars      int64 `json:"blacklist_cars"`
-	BlacklistPeople    int64 `json:"blacklist_people"`
-	UniqueCars         int64 `json:"unique_cars"`
-	UniquePeople       int64 `json:"unique_people"`
+	UsersOnline          int64 `json:"users_online"`
+	UsersOnlinePeakToday int64 `json:"users_online_peak_today"`
+	ActiveUsers          int64 `json:"active_users"`
+	BannedUsers          int64 `json:"banned_users"`
+	OpenFeedback         int64 `json:"open_feedback"`
+	ActiveUnloadPlaces   int64 `json:"active_unload_places"`
+	BlacklistCars        int64 `json:"blacklist_cars"`
+	BlacklistPeople      int64 `json:"blacklist_people"`
+	UniqueCars           int64 `json:"unique_cars"`
+	UniquePeople         int64 `json:"unique_people"`
+}
+
+// UserOnlinePeak — дневной пик одновременного онлайна пользователей (#632).
+// Снимок пишет фоновый тикер раз в ~1-2 мин: peak_count = MAX(peak_count, текущий
+// онлайн). Одна строка на дату (UNIQUE по date), upsert по date.
+type UserOnlinePeak struct {
+	ID        int       `gorm:"primaryKey" json:"id"`
+	Date      time.Time `gorm:"type:date;uniqueIndex;not null" json:"date"`
+	PeakCount int       `gorm:"not null;default:0" json:"peak_count"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// OnlinePeakPoint — пик онлайна за один день для серии динамики (#632).
+type OnlinePeakPoint struct {
+	Date string `json:"date"`
+	Peak int    `json:"peak"`
 }
 
 // StatsTimelinePoint — одна точка графика (дата + количество).
@@ -55,10 +73,10 @@ type StatsTimelinePoint struct {
 type RecentPassage struct {
 	ActionType   string    `json:"action_type"`
 	CreatedAt    time.Time `json:"created_at"`
-	Subject      string    `json:"subject"`         // ФИО (люди) или гос. номер (машины)
-	Mark         string    `json:"mark,omitempty"`  // марка машины
+	Subject      string    `json:"subject"`        // ФИО (люди) или гос. номер (машины)
+	Mark         string    `json:"mark,omitempty"` // марка машины
 	Organization string    `json:"organization"`
-	Place        string    `json:"place"`           // таблица системы, где отметка
+	Place        string    `json:"place"` // таблица системы, где отметка
 }
 
 // RecentPassages — последние проходы людей и проезды машин для живых лент.

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -3,32 +3,36 @@ package models
 import "time"
 
 type User struct {
-	ID               int          `json:"id"`
-	Username         string       `gorm:"uniqueIndex;size:100" json:"username"`
-	Password         string       `gorm:"size:255" json:"-"`
-	OrganizationID   *int         `json:"organization_id"`
-	Organization     Organization `json:"organization,omitempty"`
-	CompanyID        *int         `json:"company_id"`
-	Company          Company      `json:"company,omitempty"`
-	TypeID           int          `gorm:"default:1" json:"type_id"`
-	UserType         UserType     `gorm:"foreignKey:TypeID" json:"user_type,omitempty"`
-	RoleID           *int         `json:"role_id"`
-	Role             *Role        `gorm:"foreignKey:RoleID" json:"role,omitempty"`
-	IsSuperAdmin     bool         `gorm:"default:false;index" json:"is_super_admin"`
-	IsActive         bool         `gorm:"default:true;index" json:"is_active"`
-	IsBanned         bool         `gorm:"default:false;index" json:"is_banned"`
-	IsImportant      bool         `gorm:"default:false" json:"is_important"`
-	BannedAt         *time.Time   `json:"banned_at,omitempty"`
-	BannedBy         *int         `json:"banned_by,omitempty"`
-	LastName         *string      `gorm:"size:100" json:"last_name"`
-	FirstName        *string      `gorm:"size:100" json:"first_name"`
-	MiddleName       *string      `gorm:"size:100" json:"middle_name"`
-	Position         *string      `gorm:"size:100;column:position" json:"position"`
-	Email            *string      `gorm:"size:100" json:"email"`
-	Phone            *string      `gorm:"size:20" json:"phone"`
-	LastLoginAt      *time.Time   `json:"last_login_at,omitempty"`
-	FailedLoginCount int          `gorm:"default:0" json:"-"`
-	LockedUntil      *time.Time   `json:"-"`
+	ID             int          `json:"id"`
+	Username       string       `gorm:"uniqueIndex;size:100" json:"username"`
+	Password       string       `gorm:"size:255" json:"-"`
+	OrganizationID *int         `json:"organization_id"`
+	Organization   Organization `json:"organization,omitempty"`
+	CompanyID      *int         `json:"company_id"`
+	Company        Company      `json:"company,omitempty"`
+	TypeID         int          `gorm:"default:1" json:"type_id"`
+	UserType       UserType     `gorm:"foreignKey:TypeID" json:"user_type,omitempty"`
+	RoleID         *int         `json:"role_id"`
+	Role           *Role        `gorm:"foreignKey:RoleID" json:"role,omitempty"`
+	IsSuperAdmin   bool         `gorm:"default:false;index" json:"is_super_admin"`
+	IsActive       bool         `gorm:"default:true;index" json:"is_active"`
+	IsBanned       bool         `gorm:"default:false;index" json:"is_banned"`
+	IsImportant    bool         `gorm:"default:false" json:"is_important"`
+	BannedAt       *time.Time   `json:"banned_at,omitempty"`
+	BannedBy       *int         `json:"banned_by,omitempty"`
+	LastName       *string      `gorm:"size:100" json:"last_name"`
+	FirstName      *string      `gorm:"size:100" json:"first_name"`
+	MiddleName     *string      `gorm:"size:100" json:"middle_name"`
+	Position       *string      `gorm:"size:100;column:position" json:"position"`
+	Email          *string      `gorm:"size:100" json:"email"`
+	Phone          *string      `gorm:"size:20" json:"phone"`
+	LastLoginAt    *time.Time   `json:"last_login_at,omitempty"`
+	// LastSeen - момент последней активности (любой authenticated-запрос),
+	// обновляется middleware с троттлингом. В отличие от LastLoginAt отражает
+	// присутствие "онлайн" между логинами; по нему считается users_online (#632).
+	LastSeen         *time.Time `gorm:"index" json:"last_seen,omitempty"`
+	FailedLoginCount int        `gorm:"default:0" json:"-"`
+	LockedUntil      *time.Time `json:"-"`
 	// OnboardingCompletedVersion - версия онбординг-тура, которую прошёл юзер.
 	// null = не проходил. Хранится per-user (а не per-browser), чтобы тур не
 	// сбрасывался при смене устройства; при подъёме версии шагов тур показывается заново.

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -64,6 +64,7 @@ type Dependencies struct {
 	MaintenanceBlock echo.MiddlewareFunc
 	BanCheck         echo.MiddlewareFunc
 	LoginLimiter     echo.MiddlewareFunc
+	LastSeen         echo.MiddlewareFunc
 
 	// Misc
 	JWTSecret []byte
@@ -116,6 +117,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	maintenanceBlock := d.MaintenanceBlock
 	banCheck := d.BanCheck
 	loginLimiter := d.LoginLimiter
+	lastSeen := d.LastSeen
 	jwtSecret := d.JWTSecret
 	// Health check — вне /api, для мониторинга и readiness-проб.
 	e.GET("/health", func(c echo.Context) error {
@@ -151,6 +153,12 @@ func Setup(e *echo.Echo, d Dependencies) {
 	// Ban/Unban из UserBanService. nil в тестах чтобы не требовать service.
 	if banCheck != nil {
 		protected.Use(banCheck)
+	}
+	// LastSeen - после JWTAuth (нужен user_id). Обновляет users.last_seen для
+	// учёта онлайна (#632), с in-memory троттлингом и асинхронной записью.
+	// nil в тестах, где БД-запись не нужна.
+	if lastSeen != nil {
+		protected.Use(lastSeen)
 	}
 
 	protected.POST("/logout", auth.Logout)

--- a/internal/services/statistics_service.go
+++ b/internal/services/statistics_service.go
@@ -10,9 +10,20 @@ import (
 	"gorm.io/gorm"
 )
 
+// onlineWindowMinutes — окно "онлайн": пользователь считается онлайн, если его
+// last_seen обновлялся за последние N минут. Должно быть >= троттл-окна записи
+// last_seen в middleware (60с), с запасом на простой между запросами.
+const onlineWindowMinutes = 15
+
 // StatisticsService — интерфейс бизнес-логики статистики дашборда.
 type StatisticsService interface {
 	GetSummary(ctx context.Context, from, to time.Time) (*models.StatsSummary, error)
+	// SnapshotOnlinePeak фиксирует текущий онлайн как дневной пик за сегодня
+	// (upsert по date, peak_count = MAX(старый, текущий)). Зовётся фоновым тикером.
+	SnapshotOnlinePeak(ctx context.Context) error
+	// GetOnlinePeaks возвращает серию дневных пиков онлайна за период [from, to]
+	// для карточки динамики пользователей. Дни без снимков опускаются.
+	GetOnlinePeaks(ctx context.Context, from, to time.Time) ([]models.OnlinePeakPoint, error)
 	GetTimeline(ctx context.Context, from, to time.Time, metric, granularity string) ([]models.StatsTimelinePoint, error)
 	GetRecentPassages(ctx context.Context, limit int) (*models.RecentPassages, error)
 	GetReportCatalog(ctx context.Context) (*models.ReportCatalog, error)
@@ -155,13 +166,20 @@ func (s *statisticsService) GetSummary(ctx context.Context, from, to time.Time) 
 		return nil, fmt.Errorf("statistics: people_on_territory: %w", err)
 	}
 
-	// users_online: онлайн = вход за последние 15 минут, прокси без сессий.
-	onlineThreshold := time.Now().UTC().Add(-15 * time.Minute)
-	if err := s.db.WithContext(ctx).
-		Table("users").
-		Where("last_login_at >= ?", onlineThreshold).
-		Count(&summary.UsersOnline).Error; err != nil {
+	// users_online: онлайн = активность (last_seen) за последние onlineWindowMinutes.
+	online, err := s.countOnline(ctx, time.Now().UTC())
+	if err != nil {
 		return nil, fmt.Errorf("statistics: users_online: %w", err)
+	}
+	summary.UsersOnline = online
+
+	// users_online_peak_today: пик одновременного онлайна за сегодня из снимков тикера.
+	if err := s.db.WithContext(ctx).
+		Table("user_online_peaks").
+		Where("date = ?", time.Now().UTC().Format("2006-01-02")).
+		Select("COALESCE(MAX(peak_count), 0)").
+		Scan(&summary.UsersOnlinePeakToday).Error; err != nil {
+		return nil, fmt.Errorf("statistics: users_online_peak_today: %w", err)
 	}
 
 	// active_users
@@ -227,6 +245,64 @@ func (s *statisticsService) GetSummary(ctx context.Context, from, to time.Time) 
 	}
 
 	return &summary, nil
+}
+
+// countOnline считает пользователей, чей last_seen свежее окна онлайна на момент now.
+func (s *statisticsService) countOnline(ctx context.Context, now time.Time) (int64, error) {
+	threshold := now.Add(-onlineWindowMinutes * time.Minute)
+	var count int64
+	if err := s.db.WithContext(ctx).
+		Table("users").
+		Where("last_seen >= ?", threshold).
+		Count(&count).Error; err != nil {
+		return 0, fmt.Errorf("statistics: count online: %w", err)
+	}
+	return count, nil
+}
+
+// SnapshotOnlinePeak обновляет дневной пик онлайна за сегодня.
+// Upsert по date: при конфликте берём MAX(существующий peak_count, текущий онлайн),
+// поэтому повторные вызовы за день не плодят строки и пик только растёт.
+func (s *statisticsService) SnapshotOnlinePeak(ctx context.Context) error {
+	now := time.Now().UTC()
+	current, err := s.countOnline(ctx, now)
+	if err != nil {
+		return err
+	}
+	today := now.Format("2006-01-02")
+	// ON CONFLICT (date) гарантирует одну строку на дату; peak_count монотонно
+	// не убывает за день. GREATEST на стороне БД исключает гонку чтение-запись.
+	if err := s.db.WithContext(ctx).Exec(`
+		INSERT INTO user_online_peaks (date, peak_count, created_at, updated_at)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT (date) DO UPDATE
+		SET peak_count = GREATEST(user_online_peaks.peak_count, EXCLUDED.peak_count),
+		    updated_at = EXCLUDED.updated_at`,
+		today, current, now, now).Error; err != nil {
+		return fmt.Errorf("statistics: snapshot online peak: %w", err)
+	}
+	return nil
+}
+
+// GetOnlinePeaks возвращает дневные пики онлайна за период [from, to], по возрастанию даты.
+func (s *statisticsService) GetOnlinePeaks(ctx context.Context, from, to time.Time) ([]models.OnlinePeakPoint, error) {
+	points := make([]models.OnlinePeakPoint, 0)
+	rows := []struct {
+		Date string
+		Peak int
+	}{}
+	if err := s.db.WithContext(ctx).
+		Table("user_online_peaks").
+		Where("date BETWEEN ? AND ?", from.Format("2006-01-02"), to.Format("2006-01-02")).
+		Select("to_char(date, 'YYYY-MM-DD') AS date, peak_count AS peak").
+		Order("date ASC").
+		Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf("statistics: online peaks: %w", err)
+	}
+	for _, r := range rows {
+		points = append(points, models.OnlinePeakPoint{Date: r.Date, Peak: r.Peak})
+	}
+	return points, nil
 }
 
 // timelineSource описывает источник данных для GetTimeline.

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -36,6 +36,7 @@ const (
 // tables lists all tables in FK-safe deletion order (dependents first).
 var tables = []string{
 	"system_settings",
+	"user_online_peaks",
 	"report_templates",
 	"pd_audit_logs", "pd_consents",
 	"access_denials", "access_denial_archives",


### PR DESCRIPTION
## Что и зачем
Честный онлайн вместо заглушки (группа G6 эпика #632). Раньше `users_online` считался по `last_login_at` (пишется только при вводе пароля) -> почти всегда 0.

### last_seen
- `User.LastSeen *time.Time` (колонка `last_seen`, индекс)
- новый middleware `LastSeen` после JWTAuth: обновляет `last_seen=now` с **троттлингом** (не чаще раза в 60с на юзера, in-memory mutex+map, атомарный check-and-set) и **асинхронной** записью (своя горутина + 5s-контекст, не добавляет латентность ответу, fail-open через slog.Warn)
- `users_online` = COUNT по `last_seen >= now - 15м` (константа `onlineWindowMinutes`)

### Дневные пики
- таблица `user_online_peaks` (date уникальный, peak_count)
- фоновый тикер раз в минуту фиксирует текущий онлайн как пик за сегодня (`ON CONFLICT (date) DO UPDATE SET peak_count = GREATEST(...)` — атомарно, без read-modify-write), останавливается по graceful shutdown ctx
- `StatsSummary.UsersOnlinePeakToday`; метод `GetOnlinePeaks(from,to)` для серии (HTTP-эндпоинт под карточку динамики добавлю в G3)

## Off-limits (одобрено владельцем)
- `migrate.go`: +2 строки — `&models.UserOnlinePeak{}` в `AllModels()` (аддитивно, как `ReportTemplate`)
- `internal/auth/**`, `jwt.go`, `permission*` НЕ тронуты — отдельный новый middleware
- `router.go`/`main.go`: подключение middleware + тикер (nil-guard в тестах, graceful-остановка)

## Тесты
- middleware: троттл (первый запрос/окно/разные юзеры/граница) + конкурентный (100 горутин -> одна запись) — зелёные локально
- integration: `users_online` по окну, snapshot (MAX+upsert без дублей), `GetOnlinePeaks` (фильтр/порядок) — зелёные у автора
- build/vet OK после ребейза на dev (G1+G4)

## Заметка
- map троттла не чистится (растёт по уникальным userID за жизнь процесса) — для бюро пропусков незначимо, очистка YAGNI