### PR TITLE
fix(analytics): время аналитики в МСК и подпись динамики по метрике (#632)

### DIFF
--- a/frontend/src/components/RealTimeChart.vue
+++ b/frontend/src/components/RealTimeChart.vue
@@ -55,6 +55,13 @@ export default {
     intervalLabel: {
       type: String,
       default: 'мин'
+    },
+    // Три формы склонения единицы для тултипа [одна, две-четыре, пять+].
+    // Дефолт — «запрос» (лента запросов в RequestsView); дашборд аналитики
+    // передаёт форму по метрике (заявки/проходы/проезды).
+    unitForms: {
+      type: Array,
+      default: () => ['запрос', 'запроса', 'запросов']
     }
   },
   data() {
@@ -86,11 +93,12 @@ export default {
   },
   methods: {
     pluralize(n) {
+      const [one, few, many] = this.unitForms;
       const mod10 = n % 10;
       const mod100 = n % 100;
-      if (mod10 === 1 && mod100 !== 11) return 'запрос';
-      if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) return 'запроса';
-      return 'запросов';
+      if (mod10 === 1 && mod100 !== 11) return one;
+      if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) return few;
+      return many;
     },
 
     draw() {

--- a/frontend/src/components/statistics/StatisticsDashboard.vue
+++ b/frontend/src/components/statistics/StatisticsDashboard.vue
@@ -177,6 +177,7 @@
         :height="300"
         color="#4F5BDF"
         interval-label="ед."
+        :unit-forms="chartUnit"
       />
     </div>
 
@@ -340,6 +341,14 @@ const chartTitles = {
 };
 
 const chartTitle = computed(() => chartTitles[activeMetric.value] ?? '');
+
+// Формы склонения единицы тултипа по метрике [одна, две-четыре, пять+].
+const chartUnitForms = {
+  applications: ['заявка', 'заявки', 'заявок'],
+  people_entries: ['проход', 'прохода', 'проходов'],
+  car_entries: ['проезд', 'проезда', 'проездов'],
+};
+const chartUnit = computed(() => chartUnitForms[activeMetric.value] ?? ['ед.', 'ед.', 'ед.']);
 const chartSubtitle = computed(() => {
   const labels = { day: 'по дням', week: 'по неделям', month: 'по месяцам' };
   const period = [props.from, props.to].filter(Boolean).join(' — ');

--- a/internal/handlers/statistics.go
+++ b/internal/handlers/statistics.go
@@ -23,11 +23,15 @@ func NewStatisticsHandler(service services.StatisticsService) *StatisticsHandler
 }
 
 // parseDateRange парсит from/to из query-параметров (формат YYYY-MM-DD).
-// По умолчанию — последние 7 дней. from -> начало дня, to -> конец дня (23:59:59).
+// По умолчанию — последние 7 дней. Границы считаются в московских сутках (как и
+// бакетинг аналитики), иначе "сегодня"/"неделя" съезжают на 3 часа: from -> начало
+// дня 00:00 МСК, to -> конец дня 23:59:59 МСК. Инстанты сравниваются с timestamptz
+// корректно вне зависимости от хранения в UTC.
 func parseDateRange(c echo.Context) (from, to time.Time) {
-	now := time.Now().UTC()
-	toDefault := time.Date(now.Year(), now.Month(), now.Day(), 23, 59, 59, 0, time.UTC)
-	fromDefault := toDefault.AddDate(0, 0, -6).Truncate(24 * time.Hour)
+	loc := services.AnalyticsLocation()
+	now := time.Now().In(loc)
+	toDefault := time.Date(now.Year(), now.Month(), now.Day(), 23, 59, 59, 0, loc)
+	fromDefault := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, loc).AddDate(0, 0, -6)
 
 	fromStr := c.QueryParam("from")
 	toStr := c.QueryParam("to")
@@ -40,13 +44,13 @@ func parseDateRange(c echo.Context) (from, to time.Time) {
 	to = toDefault
 
 	if fromStr != "" {
-		if t, err := time.ParseInLocation("2006-01-02", fromStr, time.UTC); err == nil {
-			from = t // уже начало дня (00:00:00) в UTC
+		if t, err := time.ParseInLocation("2006-01-02", fromStr, loc); err == nil {
+			from = t // начало дня (00:00:00) в МСК
 		}
 	}
 	if toStr != "" {
-		if t, err := time.ParseInLocation("2006-01-02", toStr, time.UTC); err == nil {
-			to = time.Date(t.Year(), t.Month(), t.Day(), 23, 59, 59, 0, time.UTC)
+		if t, err := time.ParseInLocation("2006-01-02", toStr, loc); err == nil {
+			to = time.Date(t.Year(), t.Month(), t.Day(), 23, 59, 59, 0, loc)
 		}
 	}
 

--- a/internal/services/analytics_tz.go
+++ b/internal/services/analytics_tz.go
@@ -1,0 +1,37 @@
+package services
+
+import (
+	"fmt"
+	"time"
+)
+
+// analyticsTimeZone — бизнес-таймзона аналитики (МСК). Бакетинг по времени
+// (date_trunc/EXTRACT) и границы периода считаются в ней, иначе сутки режутся по
+// UTC-полуночи (= 03:00 МСК) и точки графика «съезжают» на 3 часа. Колонки времени
+// хранятся как timestamptz, поэтому `ts AT TIME ZONE 'Europe/Moscow'` переводит
+// UTC-инстант в московское настенное время для группировки.
+const analyticsTimeZone = "Europe/Moscow"
+
+// analyticsLocation — та же зона для разбора входных дат периода (YYYY-MM-DD ->
+// инстант начала/конца московских суток). При сбое загрузки падаем на UTC.
+var analyticsLocation = func() *time.Location {
+	loc, err := time.LoadLocation(analyticsTimeZone)
+	if err != nil {
+		return time.UTC
+	}
+	return loc
+}()
+
+// AnalyticsLocation возвращает бизнес-таймзону аналитики для разбора дат периода
+// на уровне хендлеров (границы периода считаются в МСК, как и бакетинг).
+func AnalyticsLocation() *time.Location {
+	return analyticsLocation
+}
+
+// tzColumn оборачивает timestamptz-колонку переводом в московское настенное время.
+// Подставляется в date_trunc/EXTRACT, чтобы бакеты резались по локальным суткам.
+// Имя колонки — только из whitelist (не пользовательский ввод), литерал зоны
+// константный, поэтому подстановка в SQL безопасна.
+func tzColumn(col string) string {
+	return fmt.Sprintf("(%s AT TIME ZONE '%s')", col, analyticsTimeZone)
+}

--- a/internal/services/analytics_tz_test.go
+++ b/internal/services/analytics_tz_test.go
@@ -1,0 +1,57 @@
+package services
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAnalyticsLocation(t *testing.T) {
+	loc := AnalyticsLocation()
+	if loc == nil {
+		t.Fatal("AnalyticsLocation вернул nil")
+	}
+	if loc.String() != "Europe/Moscow" {
+		t.Fatalf("ожидали Europe/Moscow, получили %q", loc.String())
+	}
+}
+
+func TestTzColumn(t *testing.T) {
+	got := tzColumn("sending_datetime")
+	want := "(sending_datetime AT TIME ZONE 'Europe/Moscow')"
+	if got != want {
+		t.Fatalf("tzColumn: ожидали %q, получили %q", want, got)
+	}
+}
+
+// parseReportDate должен трактовать YYYY-MM-DD как границу московских суток, а не
+// UTC: 00:00 МСК (= 21:00 UTC предыдущих суток), конец дня — 23:59:59 МСК.
+func TestParseReportDate_MoscowBoundaries(t *testing.T) {
+	loc := AnalyticsLocation()
+	tests := []struct {
+		name     string
+		in       string
+		endOfDay bool
+		want     time.Time
+	}{
+		{"начало суток МСК", "2026-06-15", false, time.Date(2026, 6, 15, 0, 0, 0, 0, loc)},
+		{"конец суток МСК", "2026-06-15", true, time.Date(2026, 6, 15, 23, 59, 59, 0, loc)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseReportDate(tt.in, tt.endOfDay)
+			if !ok {
+				t.Fatal("parseReportDate вернул ok=false")
+			}
+			if !got.Equal(tt.want) {
+				t.Fatalf("ожидали %v, получили %v", tt.want, got)
+			}
+			// Начало московских суток в UTC — это 21:00 предыдущего дня.
+			if !tt.endOfDay {
+				utc := got.UTC()
+				if utc.Hour() != 21 {
+					t.Fatalf("00:00 МСК в UTC должно быть 21:00, получили %02d:00", utc.Hour())
+				}
+			}
+		})
+	}
+}

--- a/internal/services/report_crosstab.go
+++ b/internal/services/report_crosstab.go
@@ -196,7 +196,7 @@ var avgMetrics = map[string]bool{
 }
 
 // reportDateBounds извлекает границы периода [from, to] из date_range-фильтра запроса
-// (UTC, без МСК-логики — как везде в движке). Нужны для деления крайних неполных
+// (в МСК, как и бакетинг — parseReportDate). Нужны для деления крайних неполных
 // бинов на фактическое число дней пересечения с периодом.
 func reportDateBounds(filters []models.ReportFilterValue) (from, to time.Time, hasFrom, hasTo bool) {
 	for _, f := range filters {
@@ -226,8 +226,9 @@ func binDays(binStart time.Time, unit string, from, to time.Time, hasFrom, hasTo
 	}
 	hi := binEnd
 	if hasTo {
-		// to — конец дня (23:59:59); эксклюзивная граница окна = начало след. суток.
-		toExcl := time.Date(to.Year(), to.Month(), to.Day(), 0, 0, 0, 0, time.UTC).AddDate(0, 0, 1)
+		// to — конец дня (23:59:59) МСК; эксклюзивная граница окна = начало след. суток
+		// в той же зоне (иначе смешение с MSK-бинами даёт дробные дни).
+		toExcl := time.Date(to.Year(), to.Month(), to.Day(), 0, 0, 0, 0, analyticsLocation).AddDate(0, 0, 1)
 		if toExcl.Before(hi) {
 			hi = toExcl
 		}
@@ -299,8 +300,8 @@ func windowDays(from, to time.Time, hasFrom, hasTo bool) float64 {
 	if !hasFrom || !hasTo {
 		return 1
 	}
-	fromDay := time.Date(from.Year(), from.Month(), from.Day(), 0, 0, 0, 0, time.UTC)
-	toDay := time.Date(to.Year(), to.Month(), to.Day(), 0, 0, 0, 0, time.UTC)
+	fromDay := time.Date(from.Year(), from.Month(), from.Day(), 0, 0, 0, 0, analyticsLocation)
+	toDay := time.Date(to.Year(), to.Month(), to.Day(), 0, 0, 0, 0, analyticsLocation)
 	days := int(toDay.Sub(fromDay).Hours()/24) + 1
 	if days < 1 {
 		days = 1

--- a/internal/services/report_engine.go
+++ b/internal/services/report_engine.go
@@ -313,11 +313,11 @@ func resolveAggDimension(s aggMetricSchema, dim, granularity string) (group, lab
 			}
 			unit = u
 		}
-		group = fmt.Sprintf("date_trunc('%s', %s)", unit, s.tsColumn)
+		group = fmt.Sprintf("date_trunc('%s', %s)", unit, tzColumn(s.tsColumn))
 		label = fmt.Sprintf("to_char(%s, 'YYYY-MM-DD')", group)
 		return group, label, s.tsJoin, nil
 	case "hour_of_day":
-		group = fmt.Sprintf("(EXTRACT(HOUR FROM %s))::int", s.tsColumn)
+		group = fmt.Sprintf("(EXTRACT(HOUR FROM %s))::int", tzColumn(s.tsColumn))
 		label = group + "::text"
 		return group, label, s.tsJoin, nil
 	default:
@@ -391,17 +391,19 @@ func clampLimit(limit int) int {
 	return limit
 }
 
-// parseReportDate парсит YYYY-MM-DD в UTC. endOfDay=true -> 23:59:59 (для верхней границы).
+// parseReportDate парсит YYYY-MM-DD как границу московских суток (бакетинг тоже в
+// МСК). endOfDay=true -> 23:59:59 МСК (для верхней границы). Инстант сравнивается
+// с timestamptz-колонками корректно вне зависимости от их хранения в UTC.
 func parseReportDate(s string, endOfDay bool) (time.Time, bool) {
 	if s == "" {
 		return time.Time{}, false
 	}
-	t, err := time.ParseInLocation("2006-01-02", s, time.UTC)
+	t, err := time.ParseInLocation("2006-01-02", s, analyticsLocation)
 	if err != nil {
 		return time.Time{}, false
 	}
 	if endOfDay {
-		return time.Date(t.Year(), t.Month(), t.Day(), 23, 59, 59, 0, time.UTC), true
+		return time.Date(t.Year(), t.Month(), t.Day(), 23, 59, 59, 0, analyticsLocation), true
 	}
 	return t, true
 }

--- a/internal/services/statistics_service.go
+++ b/internal/services/statistics_service.go
@@ -346,12 +346,14 @@ func (s *statisticsService) GetTimeline(ctx context.Context, from, to time.Time,
 	}
 
 	// table, tsColumn и unit берутся только из whitelist-карт — безопасно подставлять в SQL.
-	// from, to и значения filter передаются через ? плейсхолдеры.
+	// from, to и значения filter передаются через ? плейсхолдеры. Бакетинг — в МСК
+	// (tzColumn), иначе сутки режутся по UTC-полуночи и точки «съезжают» на 3 часа.
+	tsBucket := tzColumn(src.tsColumn)
 	selectExpr := fmt.Sprintf(
 		"to_char(date_trunc('%s', %s), 'YYYY-MM-DD') AS date, COUNT(*) AS count",
-		unit, src.tsColumn,
+		unit, tsBucket,
 	)
-	groupExpr := fmt.Sprintf("date_trunc('%s', %s)", unit, src.tsColumn)
+	groupExpr := fmt.Sprintf("date_trunc('%s', %s)", unit, tsBucket)
 
 	tx := s.db.WithContext(ctx).
 		Table(src.table).


### PR DESCRIPTION
## Что ломалось
- График «Динамика заявок» строил бакеты `date_trunc('day', ts)` в **UTC** -> сутки резались по UTC-полуночи (= 03:00 МСК), все точки «съезжали» на 03:00 и попадали не в тот локальный день
- Тултип `RealTimeChart` хардкодил слово «запрос/запроса/запросов» независимо от метрики -> «6 запросов» вместо «6 заявок»

## Что сделано
- Новый хелпер `internal/services/analytics_tz.go`: константа зоны `Europe/Moscow`, `tzColumn()` (оборачивает timestamptz-колонку в `AT TIME ZONE`), `AnalyticsLocation()` для разбора дат
- Бакетинг в МСК: `GetTimeline` (timeline дашборда), period-разрез движка отчётов, `hour_of_day` (пик по часам инсайтов) — все через `tzColumn`
- Границы периода в МСК: `parseDateRange` (хендлер) и `parseReportDate` (движок) парсят `YYYY-MM-DD` как московские сутки (00:00 / 23:59:59 МСК)
- `report_crosstab.go` (среднее машин/день): `binDays`/`windowDays` приведены к той же зоне, чтобы дни бинов оставались целыми
- FE: `RealTimeChart` получил проп `unitForms` (дефолт «запрос…» — `RequestsView` не меняется); дашборд передаёт форму по метрике (заявки/проходы/проезды)

## Тесты
- Go (чистые): `AnalyticsLocation`, `tzColumn`, `parseReportDate` (границы МСК = 21:00 UTC); регрессия cross-tab/avg зелёная (`binDays`/`windowDays`)
- FE: `StatisticsDashboard.spec` 3/3; eslint 0 errors
- build/vet OK

## Заметка
- Колонки времени — `timestamptz`, поэтому `ts AT TIME ZONE 'Europe/Moscow'` корректно переводит UTC-инстант в московское настенное время; интеграционная проверка бакетинга — на CI и ship-check staging (точки на корректных датах)