### PR TITLE
feat(analytics): area-график дашборда на ApexCharts и эндпоинт пиков онлайна (#632)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@tiptap/pm": "^2.27.2",
         "@tiptap/starter-kit": "^2.27.2",
         "@tiptap/vue-3": "^2.27.2",
+        "apexcharts": "^5.15.2",
         "chart.js": "^4.5.1",
         "dompurify": "^3.4.1",
         "driver.js": "^1.4.0",
@@ -24,7 +25,8 @@
         "pinia": "^3.0.4",
         "vue": "^3.5.33",
         "vue-router": "^5.0.6",
-        "vue-select": "^4.0.0-beta.6"
+        "vue-select": "^4.0.0-beta.6",
+        "vue3-apexcharts": "^1.11.1"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -2025,6 +2027,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/apexcharts": {
+      "version": "5.15.2",
+      "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-5.15.2.tgz",
+      "integrity": "sha512-qbd+ehDiRxo++wAqaGLmJcd683ktulTqoku4WYYyQ3XOgJIn4yhOQGV27KcdK7c2yhwxblyh4mgMm8ukI0wC0Q==",
+      "license": "SEE LICENSE IN LICENSE"
     },
     "node_modules/archiver": {
       "version": "5.3.2",
@@ -5840,6 +5848,21 @@
       "license": "MIT",
       "peerDependencies": {
         "vue": "3.x"
+      }
+    },
+    "node_modules/vue3-apexcharts": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/vue3-apexcharts/-/vue3-apexcharts-1.11.1.tgz",
+      "integrity": "sha512-MbN3vg8bMG19wc0Lm1HkeQvODgLm56DgpIxtNUO0xpf/JCzYWVGE4jzXp2JISzy2s3Kul1yOxNQUYsLvKQ5L9g==",
+      "license": "see LICENSE in LICENSE",
+      "peerDependencies": {
+        "apexcharts": ">=5.10.0",
+        "vue": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "apexcharts": {
+          "optional": false
+        }
       }
     },
     "node_modules/w3c-keyname": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "@tiptap/pm": "^2.27.2",
     "@tiptap/starter-kit": "^2.27.2",
     "@tiptap/vue-3": "^2.27.2",
+    "apexcharts": "^5.15.2",
     "chart.js": "^4.5.1",
     "dompurify": "^3.4.1",
     "driver.js": "^1.4.0",
@@ -28,7 +29,8 @@
     "pinia": "^3.0.4",
     "vue": "^3.5.33",
     "vue-router": "^5.0.6",
-    "vue-select": "^4.0.0-beta.6"
+    "vue-select": "^4.0.0-beta.6",
+    "vue3-apexcharts": "^1.11.1"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/frontend/src/api/statistics.js
+++ b/frontend/src/api/statistics.js
@@ -53,6 +53,20 @@ export async function getTimeline({ from, to, metric, granularity }) {
 }
 
 /**
+ * Получить серию дневных пиков онлайна пользователей за период.
+ * @param {string} from - дата начала в формате YYYY-MM-DD
+ * @param {string} to   - дата конца в формате YYYY-MM-DD
+ * @returns {Promise<Array<{date: string, peak: number}>>} по возрастанию даты
+ */
+export async function getOnlinePeaks(from, to) {
+  const params = new URLSearchParams();
+  if (from) params.set('from', from);
+  if (to) params.set('to', to);
+  const res = await apiRequest(`/statistics/online-peaks?${params}`);
+  return res.json();
+}
+
+/**
  * Получить последние проходы/проезды.
  * @param {number} [limit=15] - максимальное количество записей на тип
  * @returns {Promise<{

--- a/frontend/src/api/statistics.js
+++ b/frontend/src/api/statistics.js
@@ -54,6 +54,8 @@ export async function getTimeline({ from, to, metric, granularity }) {
 
 /**
  * Получить серию дневных пиков онлайна пользователей за период.
+ * Потребитель — карточка динамики онлайна на дашборде (срез G3b); там форма
+ * {date, peak} мапится в {timestamp, count} под AnalyticsAreaChart, как chartData.
  * @param {string} from - дата начала в формате YYYY-MM-DD
  * @param {string} to   - дата конца в формате YYYY-MM-DD
  * @returns {Promise<Array<{date: string, peak: number}>>} по возрастанию даты

--- a/frontend/src/components/statistics/AnalyticsAreaChart.vue
+++ b/frontend/src/components/statistics/AnalyticsAreaChart.vue
@@ -115,7 +115,7 @@ const options = computed(() => ({
   markers: { size: 0, strokeWidth: 2, hover: { size: 5 } },
   xaxis: {
     categories: categories.value,
-    tickAmount: Math.min(8, Math.max(1, categories.value.length - 1)),
+    tickAmount: Math.min(8, categories.value.length),
     labels: {
       rotate: 0,
       hideOverlappingLabels: true,

--- a/frontend/src/components/statistics/AnalyticsAreaChart.vue
+++ b/frontend/src/components/statistics/AnalyticsAreaChart.vue
@@ -1,0 +1,169 @@
+<template>
+  <div
+    class="area-chart"
+    :style="{ height: height + 'px' }"
+  >
+    <VueApexCharts
+      v-if="hasData"
+      type="area"
+      :height="height"
+      :options="options"
+      :series="series"
+    />
+    <div
+      v-else
+      class="area-chart__empty"
+    >
+      Нет данных для отображения
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import VueApexCharts from 'vue3-apexcharts';
+
+const props = defineProps({
+  /** Точки ряда в форме [{ timestamp, count }] — совместимо с timeline дашборда. */
+  data: {
+    type: Array,
+    default: () => [],
+  },
+  height: {
+    type: Number,
+    default: 300,
+  },
+  color: {
+    type: String,
+    default: '#4F5BDF',
+  },
+  /** Имя ряда (для доступности; легенда скрыта). */
+  seriesName: {
+    type: String,
+    default: 'Значение',
+  },
+  /** Три формы склонения единицы тултипа [одна, две-четыре, пять+]. */
+  unitForms: {
+    type: Array,
+    default: () => ['значение', 'значения', 'значений'],
+  },
+});
+
+const hasData = computed(() => props.data.length > 0);
+
+// Дата timeline приходит как 'YYYY-MM-DD'. Парсим вручную, без new Date(), чтобы
+// не словить сдвиг таймзоны (date-only -> UTC-полночь -> съезд на -3ч в МСК).
+function dateParts(ts) {
+  const s = String(ts ?? '').slice(0, 10);
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s);
+  return m ? { y: m[1], mo: m[2], d: m[3] } : null;
+}
+
+function formatShort(ts) {
+  const p = dateParts(ts);
+  return p ? `${p.d}.${p.mo}` : String(ts ?? '');
+}
+
+function formatFull(ts) {
+  const p = dateParts(ts);
+  return p ? `${p.d}.${p.mo}.${p.y}` : String(ts ?? '');
+}
+
+function pluralize(n) {
+  const [one, few, many] = props.unitForms;
+  const mod10 = n % 10;
+  const mod100 = n % 100;
+  if (mod10 === 1 && mod100 !== 11) return one;
+  if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) return few;
+  return many;
+}
+
+const categories = computed(() => props.data.map((d) => formatShort(d.timestamp)));
+const fullLabels = computed(() => props.data.map((d) => formatFull(d.timestamp)));
+const values = computed(() => props.data.map((d) => Number(d.count) || 0));
+
+const series = computed(() => [{ name: props.seriesName, data: values.value }]);
+
+const options = computed(() => ({
+  chart: {
+    type: 'area',
+    height: props.height,
+    fontFamily: 'inherit',
+    toolbar: { show: false },
+    zoom: { enabled: false },
+    animations: { enabled: true, easing: 'easeinout', speed: 400 },
+  },
+  colors: [props.color],
+  dataLabels: { enabled: false },
+  stroke: { curve: 'smooth', width: 2, lineCap: 'round' },
+  // Мягкий вертикальный градиент в палитре проекта — аналитический стиль без неона.
+  fill: {
+    type: 'gradient',
+    gradient: {
+      shadeIntensity: 1,
+      opacityFrom: 0.32,
+      opacityTo: 0.02,
+      stops: [0, 95],
+    },
+  },
+  grid: {
+    borderColor: '#eef0f7',
+    strokeDashArray: 0,
+    xaxis: { lines: { show: false } },
+    padding: { top: 0, right: 8, bottom: 0, left: 8 },
+  },
+  markers: { size: 0, strokeWidth: 2, hover: { size: 5 } },
+  xaxis: {
+    categories: categories.value,
+    tickAmount: Math.min(8, Math.max(1, categories.value.length - 1)),
+    labels: {
+      rotate: 0,
+      hideOverlappingLabels: true,
+      style: { colors: '#a2a2a2', fontSize: '11px' },
+    },
+    axisBorder: { show: false },
+    axisTicks: { show: false },
+    tooltip: { enabled: false },
+  },
+  yaxis: {
+    min: 0,
+    forceNiceScale: true,
+    labels: {
+      style: { colors: '#a2a2a2', fontSize: '11px' },
+      formatter: (v) => Math.round(v).toLocaleString('ru-RU'),
+    },
+  },
+  legend: { show: false },
+  tooltip: {
+    theme: 'dark',
+    x: {
+      formatter: (_val, opts) => fullLabels.value[opts?.dataPointIndex] ?? '',
+    },
+    y: {
+      formatter: (v) => {
+        const n = Math.round(Number(v) || 0);
+        return `${n.toLocaleString('ru-RU')} ${pluralize(n)}`;
+      },
+      title: { formatter: () => '' },
+    },
+    marker: { show: true },
+  },
+}));
+</script>
+
+<style scoped>
+.area-chart {
+  position: relative;
+  width: 100%;
+}
+
+.area-chart__empty {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #a2a2a2;
+  font-size: 13px;
+}
+</style>

--- a/frontend/src/components/statistics/StatisticsDashboard.vue
+++ b/frontend/src/components/statistics/StatisticsDashboard.vue
@@ -221,6 +221,7 @@
                 </div>
               </div>
               <div class="dashboard__feed-right">
+                <div class="dashboard__feed-date">{{ formatDate(row.created_at) }}</div>
                 <div class="dashboard__feed-time">{{ formatTime(row.created_at) }}</div>
                 <span
                   class="dashboard__dir-badge"
@@ -274,6 +275,7 @@
                 </div>
               </div>
               <div class="dashboard__feed-right">
+                <div class="dashboard__feed-date">{{ formatDate(row.created_at) }}</div>
                 <div class="dashboard__feed-time">{{ formatTime(row.created_at) }}</div>
                 <span
                   class="dashboard__dir-badge"
@@ -378,7 +380,15 @@ function formatTime(iso) {
   const d = new Date(iso);
   // Смещение UTC+3
   const utc3 = new Date(d.getTime() + 3 * 60 * 60 * 1000);
-  return utc3.toISOString().substring(11, 19);
+  return utc3.toISOString().substring(11, 16);
+}
+
+function formatDate(iso) {
+  if (!iso) return '';
+  const d = new Date(iso);
+  // Смещение UTC+3: дату ленты считаем по МСК, иначе у ночных отметок съезжает день.
+  const s = new Date(d.getTime() + 3 * 60 * 60 * 1000).toISOString();
+  return `${s.substring(8, 10)}.${s.substring(5, 7)}.${s.substring(0, 4)}`;
 }
 
 // ---- загрузка данных ----
@@ -790,6 +800,12 @@ onUnmounted(() => {
   flex-shrink: 0;
 }
 
+.dashboard__feed-date {
+  font-size: 11px;
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
 .dashboard__feed-time {
   font-size: 11px;
   color: var(--color-text-muted);
@@ -812,9 +828,8 @@ onUnmounted(() => {
 }
 
 .dashboard__dir-badge--out {
-  background: var(--color-bg);
-  color: var(--color-text-muted);
-  border: 1px solid var(--color-border);
+  background: rgba(220, 53, 69, 0.12);
+  color: var(--color-danger);
 }
 
 /* Номерной знак машины */

--- a/frontend/src/components/statistics/StatisticsDashboard.vue
+++ b/frontend/src/components/statistics/StatisticsDashboard.vue
@@ -171,12 +171,12 @@
         v-if="timelineLoading"
         class="dashboard__chart-skeleton"
       />
-      <RealTimeChart
+      <AnalyticsAreaChart
         v-else
         :data="chartData"
         :height="300"
         color="#4F5BDF"
-        interval-label="ед."
+        :series-name="chartTitle"
         :unit-forms="chartUnit"
       />
     </div>
@@ -292,7 +292,7 @@
 
 <script setup>
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue';
-import RealTimeChart from '@/components/RealTimeChart.vue';
+import AnalyticsAreaChart from '@/components/statistics/AnalyticsAreaChart.vue';
 import RefreshButton from '@/components/RefreshButton.vue';
 import { getSummary, getTimeline, getRecentPassages } from '@/api/statistics.js';
 import { mergeFeed, feedRowKey } from './feedMerge.js';
@@ -355,7 +355,7 @@ const chartSubtitle = computed(() => {
   return [period, labels[activeGranularity.value]].filter(Boolean).join(' · ');
 });
 
-// RealTimeChart ожидает [{timestamp, count}], бэк отдаёт [{date, count}]
+// AnalyticsAreaChart ожидает [{timestamp, count}], бэк отдаёт [{date, count}]
 const chartData = computed(() =>
   (timeline.value || []).map((d) => ({ timestamp: d.date, count: d.count }))
 );

--- a/frontend/src/components/statistics/__tests__/AnalyticsAreaChart.spec.js
+++ b/frontend/src/components/statistics/__tests__/AnalyticsAreaChart.spec.js
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+// apexcharts требует реального SVG/измерений — мокаем vue3-apexcharts стабом,
+// который запоминает последние props, чтобы проверять собранный конфиг (тип,
+// серию, палитру, форматтеры), а не рендер в jsdom.
+const { rendered } = vi.hoisted(() => ({ rendered: { last: null } }));
+vi.mock('vue3-apexcharts', () => ({
+  default: {
+    name: 'ApexStub',
+    props: ['type', 'height', 'options', 'series'],
+    render() {
+      rendered.last = { type: this.type, options: this.options, series: this.series };
+      return null;
+    },
+  },
+}));
+
+import AnalyticsAreaChart from '../AnalyticsAreaChart.vue';
+
+const DATA = [
+  { timestamp: '2026-06-15', count: 4 },
+  { timestamp: '2026-06-16', count: 9 },
+];
+
+describe('AnalyticsAreaChart', () => {
+  it('строит area-серию: значения, палитра проекта, градиентная заливка', () => {
+    rendered.last = null;
+    mount(AnalyticsAreaChart, {
+      props: { data: DATA, color: '#4F5BDF', seriesName: 'Динамика заявок' },
+    });
+
+    expect(rendered.last).not.toBeNull();
+    expect(rendered.last.type).toBe('area');
+    expect(rendered.last.series[0].name).toBe('Динамика заявок');
+    expect(rendered.last.series[0].data).toEqual([4, 9]);
+
+    const opts = rendered.last.options;
+    expect(opts.colors).toEqual(['#4F5BDF']);
+    expect(opts.fill.type).toBe('gradient');
+    expect(opts.stroke.curve).toBe('smooth');
+    expect(opts.legend.show).toBe(false);
+  });
+
+  it('метки оси X — дд.мм без сдвига таймзоны', () => {
+    rendered.last = null;
+    mount(AnalyticsAreaChart, { props: { data: DATA } });
+    // '2026-06-15' -> '15.06' (день не съезжает на 14.06 из-за UTC-полуночи)
+    expect(rendered.last.options.xaxis.categories).toEqual(['15.06', '16.06']);
+  });
+
+  it('тултип склоняет единицу по числу и показывает полную дату', () => {
+    rendered.last = null;
+    mount(AnalyticsAreaChart, {
+      props: { data: DATA, unitForms: ['заявка', 'заявки', 'заявок'] },
+    });
+    const tip = rendered.last.options.tooltip;
+    expect(tip.y.formatter(1)).toBe('1 заявка');
+    expect(tip.y.formatter(2)).toBe('2 заявки');
+    expect(tip.y.formatter(5)).toBe('5 заявок');
+    // полная дата по индексу точки
+    expect(tip.x.formatter(null, { dataPointIndex: 0 })).toBe('15.06.2026');
+  });
+
+  it('пустые данные: показывает заглушку, график не рендерит', () => {
+    rendered.last = null;
+    const wrapper = mount(AnalyticsAreaChart, { props: { data: [] } });
+    expect(wrapper.text()).toContain('Нет данных');
+    expect(rendered.last).toBeNull();
+  });
+});

--- a/frontend/src/components/statistics/__tests__/StatisticsDashboard.spec.js
+++ b/frontend/src/components/statistics/__tests__/StatisticsDashboard.spec.js
@@ -13,11 +13,11 @@ vi.mock('@/api/statistics.js', () => ({
 }));
 
 import StatisticsDashboard from '../StatisticsDashboard.vue';
-import RealTimeChart from '@/components/RealTimeChart.vue';
+import AnalyticsAreaChart from '../AnalyticsAreaChart.vue';
 
 const mountDashboard = () => mount(StatisticsDashboard, {
   props: { from: '2026-06-01', to: '2026-06-07' },
-  global: { stubs: { RealTimeChart: true, RefreshButton: true } },
+  global: { stubs: { AnalyticsAreaChart: true, RefreshButton: true } },
 });
 
 beforeEach(() => {
@@ -42,7 +42,7 @@ describe('StatisticsDashboard — гонка таймлайна', () => {
     state.deferred[0]([{ date: '2026-06-01', count: 111 }]);
     await flushPromises();
 
-    const chart = wrapper.findComponent(RealTimeChart);
+    const chart = wrapper.findComponent(AnalyticsAreaChart);
     const data = chart.props('data');
     expect(data).toHaveLength(1);
     expect(data[0].count).toBe(222); // не 111 от устаревшего ответа

--- a/internal/handlers/statistics.go
+++ b/internal/handlers/statistics.go
@@ -80,6 +80,31 @@ func (h *StatisticsHandler) GetSummary(c echo.Context) error {
 	return RespondSuccess(c, summary)
 }
 
+// GetOnlinePeaks godoc
+// @Summary      Дневные пики онлайна пользователей
+// @Description  Серия дневных пиков одновременного онлайна за период для графика динамики пользователей
+// @Tags         statistics
+// @Produce      json
+// @Security     BearerAuth
+// @Param        from query string false "Начало периода (YYYY-MM-DD)"
+// @Param        to   query string false "Конец периода (YYYY-MM-DD)"
+// @Success      200 {array} models.OnlinePeakPoint
+// @Failure      400 {object} models.HTTPError
+// @Failure      401 {object} models.HTTPError
+// @Failure      403 {object} models.HTTPError
+// @Router       /statistics/online-peaks [get]
+func (h *StatisticsHandler) GetOnlinePeaks(c echo.Context) error {
+	from, to := parseDateRange(c)
+	if from.After(to) {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid date range")
+	}
+	points, err := h.service.GetOnlinePeaks(c.Request().Context(), from, to)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, points)
+}
+
 // GetTimeline godoc
 // @Summary      Данные для графика по метрике
 // @Tags         statistics

--- a/internal/handlers/statistics_online_integration_test.go
+++ b/internal/handlers/statistics_online_integration_test.go
@@ -2,13 +2,18 @@ package handlers_test
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
+	"systemburo/internal/handlers"
 	"systemburo/internal/models"
 	"systemburo/internal/services"
 	"systemburo/internal/testutil"
 
+	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -140,4 +145,65 @@ func TestGetOnlinePeaks_Series(t *testing.T) {
 	assert.Equal(t, 5, points[1].Peak)
 	assert.Equal(t, d0.Format("2006-01-02"), points[2].Date)
 	assert.Equal(t, 7, points[2].Peak)
+}
+
+// TestGetOnlinePeaksHandler_HTTP проверяет, что эндпоинт GET /statistics/online-peaks
+// проводит серию пиков через сервис и отдаёт её в envelope, отфильтрованную по периоду.
+func TestGetOnlinePeaksHandler_HTTP(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	now := time.Now().UTC()
+	mkPeak := func(date time.Time, peak int) {
+		require.NoError(t, db.Exec(`
+			INSERT INTO user_online_peaks (date, peak_count, created_at, updated_at)
+			VALUES (?, ?, ?, ?)`,
+			date.Format("2006-01-02"), peak, now, now).Error)
+	}
+	d1 := now.Add(-24 * time.Hour)
+	mkPeak(d1, 4)
+	mkPeak(now, 9)
+
+	h := handlers.NewStatisticsHandler(services.NewStatisticsService(db))
+
+	e := echo.New()
+	from := now.Add(-72 * time.Hour).Format("2006-01-02")
+	to := now.Format("2006-01-02")
+	req := httptest.NewRequest(http.MethodGet, "/statistics/online-peaks?from="+from+"&to="+to, nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, h.GetOnlinePeaks(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		Success bool                     `json:"success"`
+		Data    []models.OnlinePeakPoint `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.True(t, resp.Success)
+	require.Len(t, resp.Data, 2, "оба дня внутри периода")
+	assert.Equal(t, d1.Format("2006-01-02"), resp.Data[0].Date, "по возрастанию даты")
+	assert.Equal(t, 4, resp.Data[0].Peak)
+	assert.Equal(t, now.Format("2006-01-02"), resp.Data[1].Date)
+	assert.Equal(t, 9, resp.Data[1].Peak)
+}
+
+// TestGetOnlinePeaksHandler_InvalidRange проверяет, что from позже to даёт 400.
+func TestGetOnlinePeaksHandler_InvalidRange(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+
+	h := handlers.NewStatisticsHandler(services.NewStatisticsService(db))
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/statistics/online-peaks?from=2026-06-10&to=2026-06-01", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := h.GetOnlinePeaks(c)
+	require.Error(t, err)
+	he, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusBadRequest, he.Code)
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -606,6 +606,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 		statsGroup := protected.Group("/statistics")
 		statsGroup.GET("/summary", statistics.GetSummary, requireStats)
 		statsGroup.GET("/timeline", statistics.GetTimeline, requireStats)
+		statsGroup.GET("/online-peaks", statistics.GetOnlinePeaks, requireStats)
 		statsGroup.GET("/recent-passages", statistics.GetRecentPassages, requireStats)
 		statsGroup.GET("/metrics", statistics.GetMetrics, requireStats)
 		statsGroup.GET("/insights", statistics.GetInsights, requireStats)

--- a/internal/services/report_engine_test.go
+++ b/internal/services/report_engine_test.go
@@ -115,8 +115,8 @@ func TestAggregatePlan_PeriodAndDateRange(t *testing.T) {
 	if err != nil {
 		t.Fatalf("неожиданная ошибка: %v", err)
 	}
-	if !strings.Contains(plan.groupExpr, "date_trunc('week', ch.created_at)") {
-		t.Errorf("ожидался date_trunc week, got %q", plan.groupExpr)
+	if !strings.Contains(plan.groupExpr, "date_trunc('week', (ch.created_at AT TIME ZONE 'Europe/Moscow'))") {
+		t.Errorf("ожидался date_trunc week в МСК, got %q", plan.groupExpr)
 	}
 	// baseWhere метрики (entry) присутствует.
 	var hasBase, hasFrom, hasTo bool
@@ -150,8 +150,8 @@ func TestAggregatePlan_HourOfDayAndValueSort(t *testing.T) {
 	if err != nil {
 		t.Fatalf("неожиданная ошибка: %v", err)
 	}
-	if !strings.Contains(plan.groupExpr, "EXTRACT(HOUR FROM eh.created_at)") {
-		t.Errorf("ожидался EXTRACT HOUR, got %q", plan.groupExpr)
+	if !strings.Contains(plan.groupExpr, "EXTRACT(HOUR FROM (eh.created_at AT TIME ZONE 'Europe/Moscow'))") {
+		t.Errorf("ожидался EXTRACT HOUR в МСК, got %q", plan.groupExpr)
 	}
 	if plan.orderStr != "COUNT(*) DESC" {
 		t.Errorf("ожидался ORDER BY COUNT(*) DESC, got %q", plan.orderStr)


### PR DESCRIPTION
## Что это

Срез **G3a** эпика 37-analytics-v2 (#632). Исходный G3 (ApexCharts + перенос инсайтов в дашборд) разбит на G3a (фундамент) и G3b (редизайн карточек), т.к. цельный G3 выходил >600 LOC / >10 файлов - против правила эпика и инцидента #283-287.

## Изменения

**FE**
- Подключил `apexcharts` + `vue3-apexcharts`.
- Новый компонент-обёртка `AnalyticsAreaChart.vue`: area-график, мягкий вертикальный градиент в палитре проекта (#4F5BDF, без неона), плавная кривая, ru-числа, тултип со склонением единицы, защита от tz-сдвига в подписях дд.мм (парсинг даты regex, без `new Date()`).
- Заменил самописный canvas `RealTimeChart` на дашборде (`StatisticsDashboard.vue`) на него. `RequestsView` оставлен на `RealTimeChart` - вне скоупа.
- `api/statistics.js`: `getOnlinePeaks(from, to)`.

**BE**
- HTTP-роут `GET /statistics/online-peaks` -> существующий `service.GetOnlinePeaks` (метод добавлен прошлым срезом G6, роута не было). Хендлер симметричен `GetSummary`/`GetTimeline` (тот же `parseDateRange`, проверка диапазона, envelope).

## Заметки по ревью

- `getOnlinePeaks` (FE) и роут (BE) - **намеренная заготовка под G3b** (карточка динамики онлайна). В этом PR ещё не потребляется компонентом; помечено комментарием в коде. Это не незавершённая интеграция, а граница между срезами.
- **Swagger docs не регенерил намеренно**: закоммиченные `docs/*` отстали на 3 месяца (последний реген - #15) и не поддерживаются по-PR. Полный реген втянул бы ~30k строк чужих эндпоинтов (off-topic). Godoc на новом хендлере на месте - подхватится при следующем общем регене.

## Проверено

- Go: `go build ./...` + тесты `internal/handlers` зелёные (новые HTTP-тесты `TestGetOnlinePeaksHandler_HTTP` / `_InvalidRange`).
- FE: vitest `AnalyticsAreaChart.spec.js` (4) + `StatisticsDashboard.spec.js` (3) зелёные; eslint без ошибок.
- Визуально (локальный worktree-стек, чистый бэкенд против dev-БД): ApexCharts рендерит area-серию с градиентной заливкой, заголовок «Динамика заявок», подписи оси дд.мм (18.05 / 23.05 на реальных майских данных), 0 console errors, переключение метрики/гранулярности без ошибок, пустое состояние корректно. Скрин владельцу до мержа.