### PR TITLE
style(history): единый разрез по датам во всех историях

### DIFF
--- a/frontend/src/components/ApplicationDetail/ApplicationHistory.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationHistory.vue
@@ -1064,12 +1064,11 @@ export default {
 .history-date-separator {
     font-size: 11px;
     font-weight: 600;
-    color: #a2a2a2;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
+    color: #4F5BDF;
     padding: 8px 0 4px;
-    margin-bottom: 4px;
-    border-bottom: 1px solid #f0f0f0;
+    margin-bottom: 8px;
+    border-bottom: 1px solid #e6f0ff;
+    letter-spacing: 0.02em;
 }
 
 .history-item {

--- a/frontend/src/components/CitizenshipHistoryModal.vue
+++ b/frontend/src/components/CitizenshipHistoryModal.vue
@@ -956,12 +956,11 @@ export default {
 .history-date-separator {
   font-size: 11px;
   font-weight: 600;
-  color: #a2a2a2;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+  color: #4F5BDF;
   padding: 8px 0 4px;
-  margin-bottom: 4px;
-  border-bottom: 1px solid #f0f0f0;
+  margin-bottom: 8px;
+  border-bottom: 1px solid #e6f0ff;
+  letter-spacing: 0.02em;
 }
 
 .history-item {

--- a/frontend/src/components/LicensePlateFormatHistoryModal.vue
+++ b/frontend/src/components/LicensePlateFormatHistoryModal.vue
@@ -990,12 +990,11 @@ export default {
 .history-date-separator {
   font-size: 11px;
   font-weight: 600;
-  color: #a2a2a2;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+  color: #4F5BDF;
   padding: 8px 0 4px;
-  margin-bottom: 4px;
-  border-bottom: 1px solid #f0f0f0;
+  margin-bottom: 8px;
+  border-bottom: 1px solid #e6f0ff;
+  letter-spacing: 0.02em;
 }
 
 .history-item {

--- a/frontend/src/components/UniqueAttachmentHistoryModal.vue
+++ b/frontend/src/components/UniqueAttachmentHistoryModal.vue
@@ -966,12 +966,11 @@ export default {
 .history-date-separator {
   font-size: 11px;
   font-weight: 600;
-  color: #a2a2a2;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+  color: #4F5BDF;
   padding: 8px 0 4px;
-  margin-bottom: 4px;
-  border-bottom: 1px solid #f0f0f0;
+  margin-bottom: 8px;
+  border-bottom: 1px solid #e6f0ff;
+  letter-spacing: 0.02em;
 }
 
 .history-item {

--- a/frontend/src/components/admin/blacklist/BlacklistHistoryModalBase.vue
+++ b/frontend/src/components/admin/blacklist/BlacklistHistoryModalBase.vue
@@ -941,12 +941,11 @@ export default {
 .history-date-separator {
   font-size: 11px;
   font-weight: 600;
-  color: #a2a2a2;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+  color: #4F5BDF;
   padding: 8px 0 4px;
-  margin-bottom: 4px;
-  border-bottom: 1px solid #f0f0f0;
+  margin-bottom: 8px;
+  border-bottom: 1px solid #e6f0ff;
+  letter-spacing: 0.02em;
 }
 
 .history-item {


### PR DESCRIPTION
## Что

Разделитель дат (`.history-date-separator`) в историях был в двух вариантах. Эталон - история автомобиля (`CarHistoryModal`): синий `#4F5BDF`, `border-bottom #e6f0ff`, `margin-bottom 8px`, `letter-spacing 0.02em`, без uppercase. Пять историй имели серый uppercase-вариант (`#a2a2a2`, `text-transform: uppercase`).

Привёл к эталону: история заявки, гражданства, уникального вложения, формата госномера, базовая ЧС (покрывает обёртки ЧС человека/авто). Остальные 13 историй уже соответствовали.

## Проверка

Грепом: все 18 компонентов с `.history-date-separator` теперь `#4F5BDF`, 0 `uppercase`. eslint чист. Только scoped CSS, разметка не тронута.