### PR TITLE
fix(tables): убрал лимит 255 у подсказки таблицы по факту

### DIFF
--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -178,6 +178,9 @@ func AutoMigrate(db *gorm.DB) error {
 	if err := relaxApplicationOrgNotNull(db); err != nil {
 		return err
 	}
+	if err := widenFactTableHint(db); err != nil {
+		return err
+	}
 	if err := installSQLFunctions(db); err != nil {
 		return err
 	}
@@ -293,6 +296,18 @@ func backfillSuperAdmin(db *gorm.DB) error {
 func relaxApplicationOrgNotNull(db *gorm.DB) error {
 	if err := db.Exec(`ALTER TABLE applications ALTER COLUMN organization_id DROP NOT NULL`).Error; err != nil {
 		return fmt.Errorf("relax applications.organization_id NOT NULL: %w", err)
+	}
+	return nil
+}
+
+// widenFactTableHint расширяет system_tables.fact_table_hint с varchar(255) до text.
+// Поле редактируется тем же rich-text TextConstructor, что и instruction, - HTML
+// форматирования легко переваливает за 255 символов, и запись падает с "value too
+// long". AutoMigrate существующие колонки не расширяет, поэтому ALTER явно. Идемпотентен
+// (на уже text-колонке - noop).
+func widenFactTableHint(db *gorm.DB) error {
+	if err := db.Exec(`ALTER TABLE system_tables ALTER COLUMN fact_table_hint TYPE text`).Error; err != nil {
+		return fmt.Errorf("widen system_tables.fact_table_hint to text: %w", err)
 	}
 	return nil
 }

--- a/internal/handlers/system_tables_test.go
+++ b/internal/handlers/system_tables_test.go
@@ -1,8 +1,10 @@
 package handlers_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"systemburo/internal/testutil"
@@ -732,4 +734,35 @@ func TestSystemTables_FactFields_DefaultVisibilityFromCatalog(t *testing.T) {
 	assert.False(t, visByName["status"], "status скрыт (каталог)")
 	assert.False(t, visByName["company"], "company скрыт (каталог)")
 	assert.False(t, visByName["application_id"], "application_id скрыт (каталог)")
+}
+
+// fact_table_hint редактируется тем же rich-text TextConstructor, что и instruction:
+// HTML-обёртки форматирования легко переваливают за старый лимит varchar(255), и запись
+// падала с "value too long" (юзер ловил это на "привет -" - длина пересекала границу).
+// После перевода колонки в text длинная форматированная подсказка должна сохраняться.
+func TestSystemTables_FactTableHint_LongFormattedHTML(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	rec := testutil.POST(t, e, "/system-tables",
+		`{"name":"fact_hint_long","display_name":"FH","table_type":"cars","show_fact_table":true}`, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	tableID := int(testutil.ParseMap(t, rec)["id"].(float64))
+
+	hint := `<span class="font-size-16">` + strings.Repeat("привет - ", 50) + `</span>`
+	require.Greater(t, len(hint), 255, "подсказка должна быть длиннее старого лимита")
+	body, err := json.Marshal(map[string]string{"fact_table_hint": hint})
+	require.NoError(t, err)
+
+	rec = testutil.PUT(t, e, fmt.Sprintf("/system-tables/%d", tableID), string(body), h)
+	require.Equal(t, http.StatusOK, rec.Code, "длинная форматированная подсказка должна сохраняться")
+
+	rec = testutil.GET(t, e, fmt.Sprintf("/system-tables/%d", tableID), h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	table := testutil.ParseMap(t, rec)["table"].(map[string]interface{})
+	assert.Equal(t, hint, table["fact_table_hint"], "подсказка round-trip без обрезки")
 }

--- a/internal/models/system_table.go
+++ b/internal/models/system_table.go
@@ -8,7 +8,7 @@ type SystemTable struct {
 	DisplayName         *string   `gorm:"size:200" json:"display_name"`
 	TableType           string    `gorm:"size:20;default:'cars'" json:"table_type"` // cars, people
 	ShowFactTable       bool      `gorm:"default:false" json:"show_fact_table"`
-	FactTableHint       *string   `gorm:"size:255" json:"fact_table_hint"`
+	FactTableHint       *string   `gorm:"type:text" json:"fact_table_hint"` // форматированный HTML из TextConstructor - длина не лезет в varchar(255)
 	IsActive            bool      `gorm:"default:true;index" json:"is_active"`
 	CreatedAt           time.Time `json:"created_at"`
 	UpdatedAt           time.Time `json:"updated_at"`


### PR DESCRIPTION
## Проблема
Сохранение форматированной «инструкции к таблице по факту» (`fact_table_hint`) периодически падало с `{"success":false,"error":"Error updating system table"}`. Пользователь изолировал триггер: «привет» и «привет-» сохраняются, «привет -» и лишний перенос строки - ошибка.

## Причина
`fact_table_hint` объявлена как `varchar(255)` (`gorm:"size:255"`), но редактируется тем же rich-text `TextConstructor`, что и `instruction` (`text`). HTML-обёртки форматирования (`<span class="font-size-16">...`) раздувают длину, и при пересечении 255 символов Postgres отклоняет запись:

```
ERROR: value too long for type character varying(255) (SQLSTATE 22001)
```

GORM отдаёт это как `result.Error`, сервис заворачивает в дженерик `Error updating system table`. «Иногда» и зависимость от одного символа - это граница 255: контент уже был ~247-248 символов, каждый лишний символ опрокидывал запись.

## Фикс
- `fact_table_hint` -> `type:text` (как у `instruction`), лимит снят.
- Идемпотентная миграция `widenFactTableHint` расширяет колонку на существующих БД (staging/prod уже с `varchar(255)`); расширение `varchar->text` неразрушающее.
- Характеризационный тест: PUT `fact_table_hint` с HTML >255 символов даёт 200 и round-trip. На исходном коде тест краснеет ровно с `value too long ... (SQLSTATE 22001)` -> 500.

## Проверка
`go vet` чист, весь набор `TestSystemTables` зелёный.