### PR TITLE
fix(history): таблица въезда/выезда в истории авто и сотрудника

### DIFF
--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -935,7 +935,7 @@ export default {
         let territory_status = type === 'entry' ? 1 : 2;
         const response = await apiRequest(`/cars/${item.id}/territory-status`, {
           method: "PUT",
-          body: JSON.stringify({ territory_status, user_id: this.currentUserId })
+          body: JSON.stringify({ territory_status, user_id: this.currentUserId, table_id: this.tableId })
         });
         if (response.ok) {
           const index = this.itemsData.findIndex(i => i.id === item.id);

--- a/frontend/src/components/FactTable.vue
+++ b/frontend/src/components/FactTable.vue
@@ -773,7 +773,7 @@ export default {
         let territory_status = type === 'entry' ? 1 : 2;
         const response = await apiRequest(`/cars/${item.id}/territory-status`, {
           method: "PUT",
-          body: JSON.stringify({ territory_status, user_id: this.currentUserId })
+          body: JSON.stringify({ territory_status, user_id: this.currentUserId, table_id: this.tableId })
         });
         if (response.ok) {
           const index = this.factData.findIndex(i => i.id === item.id);

--- a/internal/handlers/cars_status_test.go
+++ b/internal/handlers/cars_status_test.go
@@ -61,6 +61,41 @@ func TestCarTerritoryStatus_EntryThenExitWithHistory(t *testing.T) {
 	assert.Contains(t, actionTypes, "exit", "history should contain exit record")
 }
 
+// TestCarTerritoryStatus_RecordsTableInHistory фиксирует регрессию: въезд/выезд
+// должны сохранять table_id таблицы (КПП), из которой отмечены, и история должна
+// отдавать table_name. Раньше table_id не писался и read-запрос не джойнил system_tables.
+func TestCarTerritoryStatus_RecordsTableInHistory(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "carentrytbl1", "pass123", 1, td.OrgID, td.CompanyID)
+	appID, _, carID := seedCarViaCompleteApp(t, e, db, token, "Test Organization")
+	activateCarViaApp(t, e, db, appID, td)
+	tableID := seedSystemTable(t, db)
+
+	rec := testutil.PUT(t, e, fmt.Sprintf("/cars/%d/territory-status", carID),
+		fmt.Sprintf(`{"territory_status": 1, "table_id": %d}`, tableID), testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = testutil.GET(t, e, fmt.Sprintf("/cars/%d/history", carID), testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+	history := testutil.ParseSlice(t, rec)
+
+	var entry map[string]interface{}
+	for _, h := range history {
+		if h["action_type"] == "entry" {
+			entry = h
+			break
+		}
+	}
+	require.NotNil(t, entry, "history should contain entry record")
+	require.NotNil(t, entry["table_id"], "entry record should carry table_id")
+	assert.Equal(t, float64(tableID), entry["table_id"])
+	assert.Equal(t, "Test Table", entry["table_name"], "entry record should resolve table_name from system_tables")
+}
+
 func TestCarTerritoryStatus_DeactivateSetsDateRemoved(t *testing.T) {
 	e, db, cleanup := testutil.SetupTestApp(t)
 	defer cleanup()

--- a/internal/handlers/employees_history_actions_test.go
+++ b/internal/handlers/employees_history_actions_test.go
@@ -305,3 +305,40 @@ func TestEmployeesHistoryActions_Unauthorized(t *testing.T) {
 		})
 	}
 }
+
+// TestEmployeeTerritoryStatus_RecordsTableInHistory фиксирует регрессию: вход/выход
+// сотрудника должны сохранять table_id таблицы (КПП) и история должна отдавать table_name.
+// Фронт уже слал table_id, но UpdateTerritoryStatusRequest не имел поля и запись его теряла.
+func TestEmployeeTerritoryStatus_RecordsTableInHistory(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "empentrytbl1", "pass123", 1, td.OrgID, td.CompanyID)
+	_, _, empID := seedEmployeeViaCompleteApp(t, e, db, token, "Test Organization")
+
+	// seedEmployeeViaCompleteApp уже создал system_table "test_table" (display_name "Test Table").
+	var st models.SystemTable
+	require.NoError(t, db.Where("name = ?", "test_table").First(&st).Error)
+
+	rec := testutil.PUT(t, e, fmt.Sprintf("/employees/%d/territory-status", empID),
+		fmt.Sprintf(`{"territory_status": 1, "table_id": %d}`, st.ID), testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = testutil.GET(t, e, fmt.Sprintf("/employees/%d/history", empID), testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+	history := testutil.ParseSlice(t, rec)
+
+	var entry map[string]interface{}
+	for _, h := range history {
+		if h["action_type"] == "entry" {
+			entry = h
+			break
+		}
+	}
+	require.NotNil(t, entry, "history should contain entry record")
+	require.NotNil(t, entry["table_id"], "entry record should carry table_id")
+	assert.Equal(t, float64(st.ID), entry["table_id"])
+	assert.Equal(t, "Test Table", entry["table_name"], "entry record should resolve table_name from system_tables")
+}

--- a/internal/services/car_history_service.go
+++ b/internal/services/car_history_service.go
@@ -33,6 +33,8 @@ type carHistoryRow struct {
 	CarBrand      *string
 	Organization  *string
 	Company       *string
+	TableID       *int
+	TableName     *string
 }
 
 // GetCarHistory возвращает историю конкретного автомобиля.
@@ -58,6 +60,8 @@ func (s *carService) GetCarHistory(ctx context.Context, carID int) ([]CarHistory
 			h.comment,
 			h.created_at,
 			h.metadata::text AS metadata,
+			h.table_id,
+			st.display_name AS table_name,
 			app.id AS application_id
 		FROM cars_history h
 		LEFT JOIN users u ON h.user_id = u.id
@@ -66,6 +70,7 @@ func (s *carService) GetCarHistory(ctx context.Context, carID int) ([]CarHistory
 		LEFT JOIN cars c ON h.car_id = c.id
 		LEFT JOIN attachments a ON c.attachment_id = a.id
 		LEFT JOIN applications app ON a.application_id = app.id
+		LEFT JOIN system_tables st ON h.table_id = st.id
 		WHERE h.car_id = ?
 		ORDER BY h.created_at DESC
 	`, carID).Scan(&rows).Error
@@ -116,6 +121,8 @@ func (s *carService) GetAllCarsHistory(ctx context.Context) ([]AllCarsHistoryIte
 		CarBrand     *string
 		Organization *string
 		Company      *string
+		TableID      *int
+		TableName    *string
 	}
 
 	rows := make([]allHistRow, 0)
@@ -135,7 +142,9 @@ func (s *carService) GetAllCarsHistory(ctx context.Context) ([]AllCarsHistoryIte
 			c.car_number,
 			c.car_brand,
 			COALESCE(o.name, '') AS organization,
-			COALESCE(c2.name, '') AS company
+			COALESCE(c2.name, '') AS company,
+			h.table_id,
+			st.display_name AS table_name
 		FROM cars_history h
 		LEFT JOIN users u ON h.user_id = u.id
 		JOIN cars c ON h.car_id = c.id
@@ -143,6 +152,7 @@ func (s *carService) GetAllCarsHistory(ctx context.Context) ([]AllCarsHistoryIte
 		LEFT JOIN applications app ON a.application_id = app.id
 		LEFT JOIN organizations o ON app.organization_id = o.id
 		LEFT JOIN companies c2 ON app.company_id = c2.id
+		LEFT JOIN system_tables st ON h.table_id = st.id
 		WHERE h.action_type IN ('entry', 'exit')
 		ORDER BY h.created_at DESC
 	`).Scan(&rows).Error
@@ -168,6 +178,8 @@ func (s *carService) GetAllCarsHistory(ctx context.Context) ([]AllCarsHistoryIte
 			CarBrand:     r.CarBrand,
 			Organization: r.Organization,
 			Company:      r.Company,
+			TableID:      r.TableID,
+			TableName:    r.TableName,
 		})
 	}
 	return items, nil
@@ -236,6 +248,8 @@ func (s *carService) GetUnifiedCarHistory(ctx context.Context, req UnifiedCarHis
 			c.car_brand,
 			COALESCE(o.name, '') AS organization,
 			COALESCE(c2.name, '') AS company,
+			h.table_id,
+			st.display_name AS table_name,
 			app.id AS application_id
 		FROM cars_history h
 		LEFT JOIN users u ON h.user_id = u.id
@@ -244,6 +258,7 @@ func (s *carService) GetUnifiedCarHistory(ctx context.Context, req UnifiedCarHis
 		LEFT JOIN applications app ON a.application_id = app.id
 		LEFT JOIN organizations o ON app.organization_id = o.id
 		LEFT JOIN companies c2 ON app.company_id = c2.id
+		LEFT JOIN system_tables st ON h.table_id = st.id
 		WHERE h.car_id IN ?
 		ORDER BY h.created_at DESC
 	`, ids).Scan(&rows).Error
@@ -285,6 +300,8 @@ func (s *carService) mapHistoryRows(rows []carHistoryRow, includeCarInfo bool) [
 			Comment:       r.Comment,
 			CreatedAt:     FormatUTC(r.CreatedAt),
 			Metadata:      metadata,
+			TableID:       r.TableID,
+			TableName:     r.TableName,
 		}
 		if includeCarInfo {
 			item.CarNumber = r.CarNumber

--- a/internal/services/car_service.go
+++ b/internal/services/car_service.go
@@ -106,6 +106,9 @@ type AddCarHistoryRequest struct {
 type UpdateTerritoryStatusRequest struct {
 	TerritoryStatus int  `json:"territory_status"`
 	UserID          *int `json:"user_id"`
+	// TableID -- таблица (КПП), из которой отмечен въезд/выезд; пишется в историю,
+	// чтобы в карточке истории было видно, где произошло событие.
+	TableID *int `json:"table_id"`
 }
 
 // DeactivateCarRequest -- тело запроса деактивации автомобиля.
@@ -184,6 +187,8 @@ type CarHistoryItemResponse struct {
 	CarBrand      *string          `json:"car_brand"`
 	Organization  *string          `json:"organization"`
 	Company       *string          `json:"company"`
+	TableID       *int             `json:"table_id"`
+	TableName     *string          `json:"table_name"`
 }
 
 // AllCarsHistoryItem -- элемент общей истории (только entry/exit).
@@ -199,6 +204,8 @@ type AllCarsHistoryItem struct {
 	CarBrand     *string `json:"car_brand"`
 	Organization *string `json:"organization"`
 	Company      *string `json:"company"`
+	TableID      *int    `json:"table_id"`
+	TableName    *string `json:"table_name"`
 }
 
 // CarCurrentStatus -- текущий территориальный статус автомобиля.

--- a/internal/services/car_status_service.go
+++ b/internal/services/car_status_service.go
@@ -107,6 +107,7 @@ func (s *carService) UpdateCarTerritoryStatus(ctx context.Context, carID int, re
 			ActionType: actionType,
 			Comment:    &comment,
 			CreatedAt:  now,
+			TableID:    req.TableID,
 		}
 		if err := tx.Create(&history).Error; err != nil {
 			slog.Error("не удалось добавить запись в историю автомобиля", "car_id", carID, "action_type", actionType, "error", err)

--- a/internal/services/employee_service.go
+++ b/internal/services/employee_service.go
@@ -325,6 +325,7 @@ func (s *employeeService) UpdateEmployeeTerritoryStatus(ctx context.Context, emp
 			ActionType: actionType,
 			Comment:    &comment,
 			CreatedAt:  now,
+			TableID:    req.TableID,
 		}
 		if err := tx.Create(&history).Error; err != nil {
 			slog.Error("не удалось добавить запись в историю сотрудника", "employee_id", employeeID, "action_type", actionType, "error", err)


### PR DESCRIPTION
## Что ломалось
В истории автомобиля и сотрудника пропало указание, в какой таблице (КПП) был отмечен въезд/выезд (авто) и вход/выход (человек). Раньше показывалось.

## Причина
Для entry/exit `table_id` нигде не сохранялся:
- фронт `/territory-status` слал `{territory_status, user_id}` без `table_id`, хотя `tableId`/`currentTableId` в скоупе (delete-путь его уже слал);
- `UpdateTerritoryStatusRequest` не имел поля `TableID`, обе записи истории (`UpdateCarTerritoryStatus`/`UpdateEmployeeTerritoryStatus`) теряли таблицу -> `table_id = NULL`;
- чтение истории авто (`GetCarHistory`/`GetUnifiedCarHistory`/`GetAllCarsHistory`) не джойнило `system_tables`, поэтому `table_name` был пуст даже там, где `table_id` мог бы быть. У сотрудника read-джойн уже был.

Фронт рендерит `item.table_name` (блок `.place-name`) с порта - данные просто не доходили.

## Фикс
Протянул `table_id` сквозь: тело запроса (CarsTable/FactTable; PeopleTable уже слал) -> `UpdateTerritoryStatusRequest.TableID` -> запись истории обоих сущностей -> чтение истории авто с `LEFT JOIN system_tables` и полями `table_id`/`table_name` в ответе. Колонки `table_id` в обеих history-таблицах уже существуют - миграция не нужна.

## Тесты
Добавил регресс-тесты `TestCarTerritoryStatus_RecordsTableInHistory` и `TestEmployeeTerritoryStatus_RecordsTableInHistory`: PUT territory-status с table_id -> история отдаёт корректные `table_id`/`table_name`. Пакет handlers зелёный.