### PR TITLE
feat(history): запись в историю о пересылке заявки/вложений

### DIFF
--- a/frontend/src/components/ApplicationDetail/ApplicationHistory.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationHistory.vue
@@ -645,6 +645,7 @@ export default {
                 'restore_to_work': 'dot-info',
                 'assigned_responsible': 'dot-assign',
                 'assigned_viewer': 'dot-view',
+                'forwarded': 'dot-assign',
                 'confirmation_change': 'dot-system',
                 'status_change': 'dot-system',
                 'blacklist_override': 'dot-success',
@@ -665,10 +666,19 @@ export default {
             
             // Новый тип для просматривающих
             if (item.action_type === 'assigned_viewer') {
-                
+
                 return `Получил(-а) доступ к просмотру заявки`;
             }
-            
+
+            // Сводка пересылки: вся заявка или конкретные вложения (#680)
+            if (item.action_type === 'forwarded') {
+                const names = item.metadata?.attachments;
+                if (item.metadata?.whole || !Array.isArray(names) || !names.length) {
+                    return 'Переслал(-а) всю заявку';
+                }
+                return `Переслал(-а) вложения: ${names.join(', ')}`;
+            }
+
             const texts = {
                 'create': 'Создал(-а) заявку',
                 'read': 'Прочитал(-а) заявку',

--- a/internal/handlers/applications_approval_test.go
+++ b/internal/handlers/applications_approval_test.go
@@ -1,6 +1,7 @@
 package handlers_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -329,6 +330,18 @@ func TestForwardAttachments(t *testing.T) {
 		return rows
 	}
 
+	// forwardedMeta читает metadata сводной записи истории action_type='forwarded'.
+	forwardedMeta := func(t *testing.T, appID int) map[string]interface{} {
+		t.Helper()
+		var raw string
+		err := db.Raw("SELECT metadata::text FROM application_history WHERE application_id = ? AND action_type = 'forwarded'", appID).Scan(&raw).Error
+		require.NoError(t, err)
+		require.NotEmpty(t, raw, "должна быть запись истории forwarded")
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(raw), &m))
+		return m
+	}
+
 	t.Run("subset_written_per_recipient", func(t *testing.T) {
 		testutil.CleanDB(t, db)
 		td := testutil.SeedTestData(t, db)
@@ -413,5 +426,48 @@ func TestForwardAttachments(t *testing.T) {
 		}
 		assert.ElementsMatch(t, []int{attID1, attID2}, got[respID])
 		assert.ElementsMatch(t, []int{attID1, attID2}, got[viewerID])
+	})
+
+	t.Run("history_whole_application", func(t *testing.T) {
+		testutil.CleanDB(t, db)
+		td := testutil.SeedTestData(t, db)
+
+		senderToken := testutil.RegisterAndLogin(t, e, "fa_sender5", "pass123", 1, td.OrgID, td.CompanyID)
+		appID, _, _ := createAppWithTwoAttachments(t, senderToken, "fa_cars5")
+
+		testutil.RegisterUser(t, e, "fa_resp5", "pass123", 1, td.OrgID, td.CompanyID)
+		respID := getUserID(t, db, "fa_resp5")
+
+		body := fmt.Sprintf(`{"users":[{"user_id":%d,"required_approval":true,"can_view":false}]}`, respID)
+		rec := testutil.POST(t, e, fmt.Sprintf("/applications/%d/forward", appID), body, testutil.AuthHeader(senderToken))
+		require.Equal(t, http.StatusOK, rec.Code, "forward: %s", rec.Body.String())
+
+		m := forwardedMeta(t, appID)
+		assert.Equal(t, true, m["whole"], "пустой attachment_ids -> переслана вся заявка")
+		if atts, ok := m["attachments"].([]interface{}); ok {
+			assert.Empty(t, atts, "у целой заявки список вложений пуст")
+		}
+	})
+
+	t.Run("history_specific_attachments", func(t *testing.T) {
+		testutil.CleanDB(t, db)
+		td := testutil.SeedTestData(t, db)
+
+		senderToken := testutil.RegisterAndLogin(t, e, "fa_sender6", "pass123", 1, td.OrgID, td.CompanyID)
+		appID, attID1, _ := createAppWithTwoAttachments(t, senderToken, "fa_cars6")
+
+		testutil.RegisterUser(t, e, "fa_resp6", "pass123", 1, td.OrgID, td.CompanyID)
+		respID := getUserID(t, db, "fa_resp6")
+
+		body := fmt.Sprintf(`{"users":[{"user_id":%d,"required_approval":true,"can_view":false}],"attachment_ids":[%d]}`, respID, attID1)
+		rec := testutil.POST(t, e, fmt.Sprintf("/applications/%d/forward", appID), body, testutil.AuthHeader(senderToken))
+		require.Equal(t, http.StatusOK, rec.Code, "forward: %s", rec.Body.String())
+
+		m := forwardedMeta(t, appID)
+		assert.Equal(t, false, m["whole"], "выбран subset -> не вся заявка")
+		atts, ok := m["attachments"].([]interface{})
+		require.True(t, ok, "attachments должен быть списком имён")
+		require.Len(t, atts, 1)
+		assert.Equal(t, "Cars A", atts[0], "имя выбранного вложения попадает в историю")
 	})
 }

--- a/internal/services/application_approval_service.go
+++ b/internal/services/application_approval_service.go
@@ -175,6 +175,31 @@ func (s *applicationService) ForwardApplication(ctx context.Context, username st
 		`, applicationID, viewerID, string(meta), historyTime)
 	}
 
+	// Сводная запись о пересылке: всю заявку или конкретные вложения (#680).
+	// Пишем один раз на действие и только если кому-то реально переслали. Имена
+	// вложений кладём в metadata, текст собирает фронт (как у assigned_*).
+	if len(addedResponsibleUsers) > 0 || len(addedViewers) > 0 {
+		var attNames []string
+		if len(req.AttachmentIDs) > 0 {
+			tx.Raw(`
+				SELECT COALESCE(attachment_display_name, attachment_name, '')
+				FROM attachments
+				WHERE application_id = ? AND id IN ?
+				ORDER BY COALESCE(attachment_display_name, attachment_name, '')
+			`, applicationID, req.AttachmentIDs).Scan(&attNames)
+		}
+		historyTime = historyTime.Add(time.Millisecond)
+		meta, _ := json.Marshal(map[string]interface{}{
+			"forwarded_by": currentUserName,
+			"whole":        len(attNames) == 0,
+			"attachments":  attNames,
+		})
+		tx.Exec(`
+			INSERT INTO application_history (application_id, user_id, action_type, metadata, created_at)
+			VALUES (?, ?, 'forwarded', ?, ?)
+		`, applicationID, user.ID, string(meta), historyTime)
+	}
+
 	// Обновляем confirmation если были добавлены ответственные
 	if len(addedResponsibleUsers) > 0 {
 		if err := s.updateConfirmationBasedOnApprovals(tx, applicationID); err != nil {


### PR DESCRIPTION
## Зачем
В истории заявки при пересылке не было видно, переслали её целиком или только часть вложений. Пользователь просил писать конкретно: либо вся заявка, либо список вложений.

## Что сделано
В транзакцию пересылки (`ForwardApplication`) добавлена сводная запись `action_type=forwarded`:
- в `metadata` кладётся `whole` (флаг целой заявки) и `attachments` (имена выбранных вложений, COALESCE display_name/name);
- пишется один раз на действие и только если кому-то реально переслали (есть добавленные ответственные/просматривающие);
- `user_id` = форвардер (inner JOIN users в чтении истории это требует).

Фронт `ApplicationHistory.vue` рендерит метку из metadata: "Переслал(-а) всю заявку" либо "Переслал(-а) вложения: A, B" (как уже делают assigned_*). Текст собирается на фронте, имена - из metadata.

## Тесты
`TestForwardAttachments/history_whole_application` (пустой attachment_ids -> whole=true) и `/history_specific_attachments` (subset -> whole=false, имя в metadata). Пакет handlers зелёный.