### PR TITLE
feat(analytics): разворот карточки дашборда в детальные графики (#632)

### DIFF
--- a/frontend/src/components/statistics/AnalyticsBarChart.vue
+++ b/frontend/src/components/statistics/AnalyticsBarChart.vue
@@ -1,18 +1,18 @@
 <template>
   <div
-    class="area-chart"
+    class="bar-chart"
     :style="{ height: height + 'px' }"
   >
     <VueApexCharts
       v-if="hasData"
-      type="area"
+      type="bar"
       :height="height"
       :options="options"
       :series="series"
     />
     <div
       v-else
-      class="area-chart__empty"
+      class="bar-chart__empty"
     >
       Нет данных для отображения
     </div>
@@ -24,23 +24,14 @@ import { computed } from 'vue';
 import VueApexCharts from 'vue3-apexcharts';
 
 const props = defineProps({
-  /** Точки ряда в форме [{ timestamp, count }] — совместимо с timeline дашборда. */
+  /** Столбцы в форме [{ label, value }]; label — подпись оси X (час суток и т.п.). */
   data: {
     type: Array,
     default: () => [],
   },
-  /**
-   * Явные подписи оси X. Нужны рядам без дат (тренд инсайтов — серия по дням
-   * без самих дат: движок отдаёт разреженные бины, восстановить даты нельзя).
-   * null -> подписи берутся из дат timestamp, как у timeline.
-   */
-  categories: {
-    type: Array,
-    default: null,
-  },
   height: {
     type: Number,
-    default: 300,
+    default: 240,
   },
   color: {
     type: String,
@@ -60,23 +51,9 @@ const props = defineProps({
 
 const hasData = computed(() => props.data.length > 0);
 
-// Дата timeline приходит как 'YYYY-MM-DD'. Парсим вручную, без new Date(), чтобы
-// не словить сдвиг таймзоны (date-only -> UTC-полночь -> съезд на -3ч в МСК).
-function dateParts(ts) {
-  const s = String(ts ?? '').slice(0, 10);
-  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s);
-  return m ? { y: m[1], mo: m[2], d: m[3] } : null;
-}
-
-function formatShort(ts) {
-  const p = dateParts(ts);
-  return p ? `${p.d}.${p.mo}` : String(ts ?? '');
-}
-
-function formatFull(ts) {
-  const p = dateParts(ts);
-  return p ? `${p.d}.${p.mo}.${p.y}` : String(ts ?? '');
-}
+const categories = computed(() => props.data.map((d) => String(d.label)));
+const values = computed(() => props.data.map((d) => Number(d.value) || 0));
+const series = computed(() => [{ name: props.seriesName, data: values.value }]);
 
 function pluralize(n) {
   const [one, few, many] = props.unitForms;
@@ -87,19 +64,9 @@ function pluralize(n) {
   return many;
 }
 
-const categories = computed(() =>
-  props.categories ?? props.data.map((d) => formatShort(d.timestamp))
-);
-const fullLabels = computed(() =>
-  props.categories ?? props.data.map((d) => formatFull(d.timestamp))
-);
-const values = computed(() => props.data.map((d) => Number(d.count) || 0));
-
-const series = computed(() => [{ name: props.seriesName, data: values.value }]);
-
 const options = computed(() => ({
   chart: {
-    type: 'area',
+    type: 'bar',
     height: props.height,
     fontFamily: 'inherit',
     toolbar: { show: false },
@@ -108,27 +75,19 @@ const options = computed(() => ({
   },
   colors: [props.color],
   dataLabels: { enabled: false },
-  stroke: { curve: 'smooth', width: 2, lineCap: 'round' },
-  // Мягкий вертикальный градиент в палитре проекта — аналитический стиль без неона.
-  fill: {
-    type: 'gradient',
-    gradient: {
-      shadeIntensity: 1,
-      opacityFrom: 0.32,
-      opacityTo: 0.02,
-      stops: [0, 95],
-    },
+  plotOptions: {
+    bar: { columnWidth: '62%', borderRadius: 4, borderRadiusApplication: 'end' },
   },
+  states: { hover: { filter: { type: 'lighten', value: 0.08 } } },
   grid: {
     borderColor: '#eef0f7',
     strokeDashArray: 0,
     xaxis: { lines: { show: false } },
     padding: { top: 0, right: 8, bottom: 0, left: 8 },
   },
-  markers: { size: 0, strokeWidth: 2, hover: { size: 5 } },
   xaxis: {
     categories: categories.value,
-    tickAmount: Math.min(8, categories.value.length),
+    tickAmount: Math.min(12, categories.value.length),
     labels: {
       rotate: 0,
       hideOverlappingLabels: true,
@@ -149,9 +108,6 @@ const options = computed(() => ({
   legend: { show: false },
   tooltip: {
     theme: 'dark',
-    x: {
-      formatter: (_val, opts) => fullLabels.value[opts?.dataPointIndex] ?? '',
-    },
     y: {
       formatter: (v) => {
         const n = Math.round(Number(v) || 0);
@@ -159,18 +115,17 @@ const options = computed(() => ({
       },
       title: { formatter: () => '' },
     },
-    marker: { show: true },
   },
 }));
 </script>
 
 <style scoped>
-.area-chart {
+.bar-chart {
   position: relative;
   width: 100%;
 }
 
-.area-chart__empty {
+.bar-chart__empty {
   position: absolute;
   inset: 0;
   display: flex;

--- a/frontend/src/components/statistics/StatisticsDashboard.vue
+++ b/frontend/src/components/statistics/StatisticsDashboard.vue
@@ -699,6 +699,9 @@ defineExpose({ refresh });
 
 // ---- реакция на смену периода ----
 watch([() => props.from, () => props.to], () => {
+  // Сворачиваем разворот: иначе под новым периодом мелькает деталь старого,
+  // пока летит ответ инсайтов.
+  expandedMetric.value = null;
   loadSummary();
   loadTimeline();
   loadInsights();

--- a/frontend/src/components/statistics/StatisticsDashboard.vue
+++ b/frontend/src/components/statistics/StatisticsDashboard.vue
@@ -28,8 +28,25 @@
           v-for="tile in dataTiles"
           :key="tile.label"
           class="dashboard__tile"
+          :class="{
+            'dashboard__tile--clickable': tile.expandable,
+            'dashboard__tile--active': tile.expandable && expandedMetric === tile.metric,
+          }"
+          :role="tile.expandable ? 'button' : null"
+          :tabindex="tile.expandable ? 0 : null"
+          :aria-expanded="tile.expandable ? (expandedMetric === tile.metric) : null"
+          @click="tile.expandable && toggleExpand(tile.metric)"
+          @keydown.enter="tile.expandable && toggleExpand(tile.metric)"
+          @keydown.space.prevent="tile.expandable && toggleExpand(tile.metric)"
         >
-          <div class="dashboard__tile-label">{{ tile.label }}</div>
+          <div class="dashboard__tile-label">
+            {{ tile.label }}
+            <span
+              v-if="tile.expandable"
+              class="dashboard__tile-caret"
+              aria-hidden="true"
+            />
+          </div>
           <div class="dashboard__tile-val">{{ fmt(tile.value) }}</div>
           <div
             v-if="tile.comparison || tile.trend"
@@ -52,6 +69,57 @@
           </div>
         </div>
       </div>
+
+      <!-- Детальный разворот карточки: тренд по дням (area) + пик по часам (bar) -->
+      <Transition name="dashboard-detail">
+        <div
+          v-if="expandedDetail"
+          class="dashboard__detail"
+        >
+          <div class="dashboard__detail-head">
+            <h3 class="dashboard__detail-title">{{ expandedDetail.label }} — детально</h3>
+            <button
+              type="button"
+              class="dashboard__detail-close"
+              aria-label="Свернуть"
+              @click="expandedMetric = null"
+            >
+              ×
+            </button>
+          </div>
+          <div class="dashboard__detail-charts">
+            <div class="dashboard__detail-chart">
+              <div class="dashboard__detail-chart-title">Тренд по дням</div>
+              <AnalyticsAreaChart
+                :data="expandedDetail.trendData"
+                :categories="expandedDetail.trendCategories"
+                :height="220"
+                color="#4F5BDF"
+                :series-name="expandedDetail.label"
+                :unit-forms="expandedDetail.unitForms"
+              />
+            </div>
+            <div
+              v-if="expandedDetail.peak"
+              class="dashboard__detail-chart"
+            >
+              <div class="dashboard__detail-chart-title">
+                Пик по часам
+                <span class="dashboard__detail-chart-note">
+                  пик в {{ expandedDetail.peakHourLabel }}
+                </span>
+              </div>
+              <AnalyticsBarChart
+                :data="expandedDetail.peakData"
+                :height="220"
+                color="#4F5BDF"
+                :series-name="expandedDetail.label"
+                :unit-forms="expandedDetail.unitForms"
+              />
+            </div>
+          </div>
+        </div>
+      </Transition>
     </div>
 
     <!-- ===== ГРУППА: ВЛОЖЕНИЯ ===== -->
@@ -184,6 +252,29 @@
       />
     </div>
 
+    <!-- ===== ДИНАМИКА ОНЛАЙНА ===== -->
+    <div class="dashboard__chart-card">
+      <div class="dashboard__chart-head">
+        <div>
+          <h3 class="dashboard__chart-title">Динамика онлайна</h3>
+          <div class="dashboard__chart-sub">пик пользователей онлайн по дням</div>
+        </div>
+      </div>
+
+      <div
+        v-if="onlinePeaksLoading"
+        class="dashboard__chart-skeleton"
+      />
+      <AnalyticsAreaChart
+        v-else
+        :data="onlinePeaksData"
+        :height="240"
+        color="#4F5BDF"
+        series-name="Пик онлайна"
+        :unit-forms="['пользователь', 'пользователя', 'пользователей']"
+      />
+    </div>
+
     <!-- ===== ЖИВЫЕ ЛЕНТЫ ===== -->
     <div class="dashboard__feeds">
 
@@ -298,10 +389,11 @@
 <script setup>
 import { ref, reactive, computed, watch, onMounted, onUnmounted } from 'vue';
 import AnalyticsAreaChart from '@/components/statistics/AnalyticsAreaChart.vue';
+import AnalyticsBarChart from '@/components/statistics/AnalyticsBarChart.vue';
 import DirIcon from '@/components/statistics/DirIcon.vue';
 import TrendSparkline from '@/components/statistics/TrendSparkline.vue';
 import RefreshButton from '@/components/RefreshButton.vue';
-import { getSummary, getTimeline, getRecentPassages, getInsights } from '@/api/statistics.js';
+import { getSummary, getTimeline, getRecentPassages, getInsights, getOnlinePeaks } from '@/api/statistics.js';
 import { mergeFeed, feedRowKey } from './feedMerge.js';
 
 const props = defineProps({
@@ -320,12 +412,21 @@ const summary = ref({});
 const summaryLoading = ref(false);
 
 // Инсайты обогащают карточки группы «Данные»: сравнение с прошлым периодом
-// (дельта/направление) и тренд по дням (спарклайн). Метрики инсайтов покрывают
-// заявки/проезды/проходы — остальные карточки остаются без инсайт-футера.
-const insights = reactive({ comparisons: [], trends: [] });
+// (дельта/направление), тренд по дням (спарклайн) и профиль пика по часам.
+// Метрики инсайтов покрывают заявки/проезды/проходы — остальные карточки без
+// инсайтов. peak_hours есть только у проездов/проходов (у заявок его нет).
+const insights = reactive({ comparisons: [], trends: [], peak_hours: [] });
+
+// Метрика развёрнутой карточки (ключ инсайта) либо null — раскрывает детальные
+// графики под сеткой «Данные». Клик по той же карточке сворачивает.
+const expandedMetric = ref(null);
 
 const timeline = ref([]);
 const timelineLoading = ref(false);
+
+// Дневные пики онлайна за период (area-график под основным графиком).
+const onlinePeaks = ref([]);
+const onlinePeaksLoading = ref(false);
 
 const peopleFeed = ref([]);
 const carsFeed = ref([]);
@@ -372,6 +473,18 @@ const chartData = computed(() =>
   (timeline.value || []).map((d) => ({ timestamp: d.date, count: d.count }))
 );
 
+// Пики онлайна: бэк отдаёт [{date, peak}] -> форма AnalyticsAreaChart.
+const onlinePeaksData = computed(() =>
+  (onlinePeaks.value || []).map((d) => ({ timestamp: d.date, count: d.peak }))
+);
+
+// Формы склонения единицы для тултипов детального разворота, по ключу инсайта.
+const detailUnitForms = {
+  applications_count: ['заявка', 'заявки', 'заявок'],
+  car_entries_count: ['проезд', 'проезда', 'проездов'],
+  people_entries_count: ['проход', 'прохода', 'проходов'],
+};
+
 // ---- вычисляемые из summary ----
 const attachmentBreakdown = computed(() => {
   const list = summary.value.by_attachment_type;
@@ -391,11 +504,32 @@ const dataTiles = computed(() => {
     { label: 'Машин на территории', value: s.cars_on_territory },
     { label: 'Людей на территории', value: s.people_on_territory },
   ];
-  return defs.map((t) => ({
-    ...t,
-    comparison: t.metric ? insights.comparisons.find((c) => c.metric === t.metric) || null : null,
-    trend: t.metric ? insights.trends.find((tr) => tr.metric === t.metric) || null : null,
-  }));
+  return defs.map((t) => {
+    const comparison = t.metric ? insights.comparisons.find((c) => c.metric === t.metric) || null : null;
+    const trend = t.metric ? insights.trends.find((tr) => tr.metric === t.metric) || null : null;
+    const peak = t.metric ? insights.peak_hours.find((p) => p.metric === t.metric) || null : null;
+    return { ...t, comparison, trend, peak, expandable: Boolean(comparison || trend || peak) };
+  });
+});
+
+// Развёрнутая карточка -> данные её детальных графиков. Тренд берём из той же
+// серии, что и мини-спарклайн (визуальная консистентность), пик — из почасового
+// профиля. Серия тренда без дат -> подписи оси X порядковыми позициями дней.
+const expandedDetail = computed(() => {
+  if (!expandedMetric.value) return null;
+  const tile = dataTiles.value.find((t) => t.metric === expandedMetric.value);
+  if (!tile || !tile.expandable) return null;
+  const series = tile.trend?.series || [];
+  const peak = tile.peak;
+  return {
+    label: tile.label,
+    unitForms: detailUnitForms[tile.metric] || ['ед.', 'ед.', 'ед.'],
+    trendData: series.map((v) => ({ count: v })),
+    trendCategories: series.map((_, i) => String(i + 1)),
+    peak,
+    peakData: peak ? hourlyProfile(peak) : [],
+    peakHourLabel: peak ? hourLabel(peak.peak_hour) : '',
+  };
 });
 
 // ---- форматирование ----
@@ -410,6 +544,24 @@ function deltaText(pct) {
   const n = Math.round((Number(pct) || 0) * 10) / 10;
   const sign = n > 0 ? '+' : '';
   return `${sign}${n}%`;
+}
+
+function hourLabel(hour) {
+  return `${String(hour).padStart(2, '0')}:00`;
+}
+
+// Почасовое распределение -> полный профиль суток 0..23 (пустые часы = 0), чтобы
+// столбцы читались как профиль дня, а не разреженный набор.
+function hourlyProfile(peak) {
+  const byHour = new Map((peak.hourly || []).map((b) => [b.hour, b.value]));
+  return Array.from({ length: 24 }, (_, h) => ({
+    label: hourLabel(h),
+    value: byHour.get(h) || 0,
+  }));
+}
+
+function toggleExpand(metric) {
+  expandedMetric.value = expandedMetric.value === metric ? null : metric;
 }
 
 function formatTime(iso) {
@@ -435,6 +587,7 @@ function formatDate(iso) {
 let summarySeq = 0;
 let timelineSeq = 0;
 let insightsSeq = 0;
+let onlinePeaksSeq = 0;
 
 async function loadSummary() {
   const seq = ++summarySeq;
@@ -458,11 +611,29 @@ async function loadInsights() {
     if (seq !== insightsSeq) return;
     insights.comparisons = Array.isArray(data?.comparisons) ? data.comparisons : [];
     insights.trends = Array.isArray(data?.trends) ? data.trends : [];
+    insights.peak_hours = Array.isArray(data?.peak_hours) ? data.peak_hours : [];
   } catch {
     // Сбой инсайтов не должен ронять дашборд — карточки остаются без футера.
     if (seq !== insightsSeq) return;
     insights.comparisons = [];
     insights.trends = [];
+    insights.peak_hours = [];
+  }
+}
+
+async function loadOnlinePeaks() {
+  const seq = ++onlinePeaksSeq;
+  onlinePeaksLoading.value = true;
+  try {
+    const data = await getOnlinePeaks(props.from, props.to);
+    if (seq !== onlinePeaksSeq) return;
+    onlinePeaks.value = Array.isArray(data) ? data : [];
+  } catch {
+    // Сбой пиков онлайна не должен ронять дашборд — блок показывает заглушку.
+    if (seq !== onlinePeaksSeq) return;
+    onlinePeaks.value = [];
+  } finally {
+    if (seq === onlinePeaksSeq) onlinePeaksLoading.value = false;
   }
 }
 
@@ -521,7 +692,7 @@ async function refreshFeeds() {
 
 // ---- публичный метод для обновления из родителя ----
 async function refresh() {
-  await Promise.all([loadSummary(), loadTimeline(), loadInsights(), loadFeed()]);
+  await Promise.all([loadSummary(), loadTimeline(), loadInsights(), loadOnlinePeaks(), loadFeed()]);
 }
 
 defineExpose({ refresh });
@@ -531,6 +702,7 @@ watch([() => props.from, () => props.to], () => {
   loadSummary();
   loadTimeline();
   loadInsights();
+  loadOnlinePeaks();
 });
 
 // ---- реакция на смену настроек графика ----
@@ -545,6 +717,7 @@ onMounted(() => {
   loadSummary();
   loadTimeline();
   loadInsights();
+  loadOnlinePeaks();
   loadFeed({ showSkeleton: true });
   feedInterval = setInterval(() => loadFeed(), 10000);
 });
@@ -697,6 +870,112 @@ onUnmounted(() => {
   background: var(--color-bg);
   color: var(--color-text-muted);
   border: 1px solid var(--color-border);
+}
+
+/* ===== РАЗВОРОТ КАРТОЧКИ ===== */
+.dashboard__tile--clickable {
+  cursor: pointer;
+}
+
+.dashboard__tile--active {
+  border-color: var(--color-primary);
+  box-shadow: var(--shadow-md);
+}
+
+.dashboard__tile-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+}
+
+/* Каретка-подсказка «раскрывается»; поворачивается вверх у активной карточки. */
+.dashboard__tile-caret {
+  width: 7px;
+  height: 7px;
+  border-right: 1.5px solid var(--color-text-muted);
+  border-bottom: 1.5px solid var(--color-text-muted);
+  transform: rotate(45deg);
+  transition: transform 0.2s ease, border-color 0.2s ease;
+  flex-shrink: 0;
+  margin-top: -3px;
+}
+
+.dashboard__tile--active .dashboard__tile-caret {
+  transform: rotate(-135deg);
+  margin-top: 2px;
+  border-color: var(--color-primary);
+}
+
+.dashboard__detail {
+  border: 1px solid var(--color-primary);
+  border-radius: var(--radius-lg);
+  padding: 18px 20px;
+  background: #fff;
+  margin-top: 4px;
+}
+
+.dashboard__detail-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.dashboard__detail-title {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--color-text);
+  margin: 0;
+}
+
+.dashboard__detail-close {
+  border: none;
+  background: transparent;
+  font-size: 22px;
+  line-height: 1;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  padding: 0 4px;
+  border-radius: var(--radius-sm);
+  transition: color 0.18s ease;
+}
+
+.dashboard__detail-close:hover {
+  color: var(--color-text);
+}
+
+.dashboard__detail-charts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 18px;
+}
+
+.dashboard__detail-chart-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text);
+  margin-bottom: 8px;
+}
+
+.dashboard__detail-chart-note {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-primary);
+  margin-left: 6px;
+}
+
+/* Разворот: только transform+opacity (height у Apex считается криво). */
+.dashboard-detail-enter-active,
+.dashboard-detail-leave-active {
+  transition: opacity 0.22s ease, transform 0.22s ease;
+}
+
+.dashboard-detail-enter-from,
+.dashboard-detail-leave-to {
+  opacity: 0;
+  transform: translateY(-8px);
 }
 
 /* ===== ГРАФИК ===== */

--- a/frontend/src/components/statistics/__tests__/AnalyticsBarChart.spec.js
+++ b/frontend/src/components/statistics/__tests__/AnalyticsBarChart.spec.js
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+// apexcharts требует реального SVG/измерений — мокаем vue3-apexcharts стабом,
+// который запоминает последние props, чтобы проверять собранный конфиг (тип,
+// серию, категории, форматтер тултипа), а не рендер в jsdom.
+const { rendered } = vi.hoisted(() => ({ rendered: { last: null } }));
+vi.mock('vue3-apexcharts', () => ({
+  default: {
+    name: 'ApexStub',
+    props: ['type', 'height', 'options', 'series'],
+    render() {
+      rendered.last = { type: this.type, options: this.options, series: this.series };
+      return null;
+    },
+  },
+}));
+
+import AnalyticsBarChart from '../AnalyticsBarChart.vue';
+
+const DATA = [
+  { label: '08:00', value: 3 },
+  { label: '09:00', value: 7 },
+];
+
+describe('AnalyticsBarChart', () => {
+  it('строит bar-серию: значения, категории, палитра проекта', () => {
+    rendered.last = null;
+    mount(AnalyticsBarChart, {
+      props: { data: DATA, color: '#4F5BDF', seriesName: 'Проезды машин' },
+    });
+
+    expect(rendered.last).not.toBeNull();
+    expect(rendered.last.type).toBe('bar');
+    expect(rendered.last.series[0].name).toBe('Проезды машин');
+    expect(rendered.last.series[0].data).toEqual([3, 7]);
+
+    const opts = rendered.last.options;
+    expect(opts.colors).toEqual(['#4F5BDF']);
+    expect(opts.xaxis.categories).toEqual(['08:00', '09:00']);
+    expect(opts.legend.show).toBe(false);
+  });
+
+  it('тултип склоняет единицу по числу', () => {
+    rendered.last = null;
+    mount(AnalyticsBarChart, {
+      props: { data: DATA, unitForms: ['проезд', 'проезда', 'проездов'] },
+    });
+    const tip = rendered.last.options.tooltip;
+    expect(tip.y.formatter(1)).toBe('1 проезд');
+    expect(tip.y.formatter(2)).toBe('2 проезда');
+    expect(tip.y.formatter(5)).toBe('5 проездов');
+  });
+
+  it('пустые данные: показывает заглушку, график не рендерит', () => {
+    rendered.last = null;
+    const wrapper = mount(AnalyticsBarChart, { props: { data: [] } });
+    expect(wrapper.text()).toContain('Нет данных');
+    expect(rendered.last).toBeNull();
+  });
+});

--- a/frontend/src/components/statistics/__tests__/StatisticsDashboard.spec.js
+++ b/frontend/src/components/statistics/__tests__/StatisticsDashboard.spec.js
@@ -174,6 +174,20 @@ describe('StatisticsDashboard — разворот карточки', () => {
     expect(area.props('categories')).toEqual(['1', '2', '3', '4']);
   });
 
+  it('смена периода сворачивает разворот', async () => {
+    withInsights();
+    const wrapper = mountDashboard();
+    await flushPromises();
+
+    await tileByText(wrapper, 'Получено заявок').trigger('click');
+    await nextTick();
+    expect(wrapper.find('.dashboard__detail').exists()).toBe(true);
+
+    await wrapper.setProps({ from: '2026-05-01', to: '2026-05-07' });
+    await nextTick();
+    expect(wrapper.find('.dashboard__detail').exists()).toBe(false);
+  });
+
   it('карточка без инсайтов не кликабельна и не раскрывается', async () => {
     state.summary = { processed: 4 };
     state.insights = {};
@@ -181,6 +195,7 @@ describe('StatisticsDashboard — разворот карточки', () => {
     await flushPromises();
 
     const tile = tileByText(wrapper, 'Обработано');
+    expect(tile).toBeTruthy();
     expect(tile.classes()).not.toContain('dashboard__tile--clickable');
     await tile.trigger('click');
     await nextTick();

--- a/frontend/src/components/statistics/__tests__/StatisticsDashboard.spec.js
+++ b/frontend/src/components/statistics/__tests__/StatisticsDashboard.spec.js
@@ -4,28 +4,36 @@ import { nextTick } from 'vue';
 
 // Управляемое состояние моков: фабрика vi.mock поднимается над импортами,
 // поэтому summary/deferred выносим в hoisted.
-const { state } = vi.hoisted(() => ({ state: { deferred: [], summary: {}, insights: {} } }));
+const { state } = vi.hoisted(() => ({
+  state: { deferred: [], summary: {}, insights: {}, onlinePeaks: [] },
+}));
 
 vi.mock('@/api/statistics.js', () => ({
   getSummary: () => Promise.resolve(state.summary),
   getRecentPassages: () => Promise.resolve({ people: [], cars: [] }),
   getTimeline: () => new Promise((resolve) => { state.deferred.push(resolve); }),
   getInsights: () => Promise.resolve(state.insights),
+  getOnlinePeaks: () => Promise.resolve(state.onlinePeaks),
 }));
 
 import StatisticsDashboard from '../StatisticsDashboard.vue';
 import AnalyticsAreaChart from '../AnalyticsAreaChart.vue';
+import AnalyticsBarChart from '../AnalyticsBarChart.vue';
 import TrendSparkline from '../TrendSparkline.vue';
 
 const mountDashboard = () => mount(StatisticsDashboard, {
   props: { from: '2026-06-01', to: '2026-06-07' },
-  global: { stubs: { AnalyticsAreaChart: true, RefreshButton: true } },
+  global: { stubs: { AnalyticsAreaChart: true, AnalyticsBarChart: true, RefreshButton: true } },
 });
+
+const tileByText = (wrapper, label) =>
+  wrapper.findAll('.dashboard__tile').find((t) => t.text().includes(label));
 
 beforeEach(() => {
   state.deferred.length = 0;
   state.summary = {};
   state.insights = {};
+  state.onlinePeaks = [];
 });
 
 describe('StatisticsDashboard — гонка таймлайна', () => {
@@ -112,5 +120,90 @@ describe('StatisticsDashboard — инсайты карточек', () => {
     await flushPromises();
 
     expect(wrapper.findAll('.dashboard__tile-insight')).toHaveLength(0);
+  });
+});
+
+describe('StatisticsDashboard — разворот карточки', () => {
+  const withInsights = () => {
+    state.summary = { total_applications: 10, cars_entered: 8 };
+    state.insights = {
+      comparisons: [{ metric: 'applications_count', current: 10, previous: 8, delta_pct: 25, direction: 'up' }],
+      trends: [{ metric: 'applications_count', direction: 'up', series: [1, 2, 3, 4] }],
+      peak_hours: [{
+        metric: 'applications_count', label: 'Заявки', peak_hour: 9, peak_value: 5,
+        hourly: [{ hour: 8, value: 2 }, { hour: 9, value: 5 }],
+      }],
+    };
+  };
+
+  it('обогащённая карточка кликабельна, клик раскрывает тренд и пик, повторный — сворачивает', async () => {
+    withInsights();
+    const wrapper = mountDashboard();
+    await flushPromises();
+
+    const tile = tileByText(wrapper, 'Получено заявок');
+    expect(tile.classes()).toContain('dashboard__tile--clickable');
+    expect(wrapper.find('.dashboard__detail').exists()).toBe(false);
+
+    await tile.trigger('click');
+    await nextTick();
+
+    expect(wrapper.find('.dashboard__detail').exists()).toBe(true);
+    expect(wrapper.find('.dashboard__detail').text()).toContain('Получено заявок');
+    // Тренд (area) и пик по часам (bar) — оба графика в детальной панели.
+    const detail = wrapper.find('.dashboard__detail');
+    expect(detail.findComponent(AnalyticsAreaChart).exists()).toBe(true);
+    expect(detail.findComponent(AnalyticsBarChart).exists()).toBe(true);
+    expect(tile.classes()).toContain('dashboard__tile--active');
+
+    await tile.trigger('click');
+    await nextTick();
+    expect(wrapper.find('.dashboard__detail').exists()).toBe(false);
+  });
+
+  it('тренд детали строит ту же серию, что и спарклайн, с порядковыми подписями оси X', async () => {
+    withInsights();
+    const wrapper = mountDashboard();
+    await flushPromises();
+
+    await tileByText(wrapper, 'Получено заявок').trigger('click');
+    await nextTick();
+
+    const area = wrapper.find('.dashboard__detail').findComponent(AnalyticsAreaChart);
+    expect(area.props('data')).toEqual([{ count: 1 }, { count: 2 }, { count: 3 }, { count: 4 }]);
+    expect(area.props('categories')).toEqual(['1', '2', '3', '4']);
+  });
+
+  it('карточка без инсайтов не кликабельна и не раскрывается', async () => {
+    state.summary = { processed: 4 };
+    state.insights = {};
+    const wrapper = mountDashboard();
+    await flushPromises();
+
+    const tile = tileByText(wrapper, 'Обработано');
+    expect(tile.classes()).not.toContain('dashboard__tile--clickable');
+    await tile.trigger('click');
+    await nextTick();
+    expect(wrapper.find('.dashboard__detail').exists()).toBe(false);
+  });
+});
+
+describe('StatisticsDashboard — динамика онлайна', () => {
+  it('рендерит area-график пиков онлайна за период', async () => {
+    state.onlinePeaks = [
+      { date: '2026-06-01', peak: 4 },
+      { date: '2026-06-02', peak: 9 },
+    ];
+    const wrapper = mountDashboard();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Динамика онлайна');
+    const online = wrapper.findAllComponents(AnalyticsAreaChart)
+      .find((c) => c.props('seriesName') === 'Пик онлайна');
+    expect(online).toBeTruthy();
+    expect(online.props('data')).toEqual([
+      { timestamp: '2026-06-01', count: 4 },
+      { timestamp: '2026-06-02', count: 9 },
+    ]);
   });
 });


### PR DESCRIPTION
Срез G3b-2 эпика 37-analytics-v2. Зависит от G3b-1 (#702, merged).

## Что делает
- Клик по обогащённой карточке метрики (Получено заявок / Машин заехало / Людей прошло) раскрывает под сеткой «Данные» детальный блок: **тренд по дням** area-графиком + **пик по часам** столбцами. Повторный клик/крестик сворачивает; смена периода тоже сворачивает.
- Отдельная карточка **«Динамика онлайна»** — area-график дневных пиков онлайна через `getOnlinePeaks` (эндпоинт из G3a).
- Каретка-подсказка на кликабельных карточках, доступность (role/tabindex/aria-expanded/Enter/Space).

## Решения
- **Тренд берётся из той же `insights.trends.series`, что и мини-спарклайн G3b-1** — без нового фетча, ровно «через getInsights» по спеке, и визуально консистентно со спарклайном карточки.
- **Серия тренда без дат:** движок отчётов (`date_trunc` GROUP BY) не заполняет пустые дни, ряд разреженный, восстановить календарные даты нельзя -> ось X идёт порядковыми позициями точек. Реальные даты на разреженном ряду соврали бы. Если владелец захочет даты — это polish-follow-up (отдельный дневной фетч с датами).
- `peak_hours` есть только у проездов/проходов (у заявок нет) -> у «Получено заявок» в развороте только тренд, у машин/людей — тренд + пик.
- Пик по часам разворачивается в полный профиль суток 0..23 (пустые часы = 0).
- Новый `loadOnlinePeaks` под seq-токеном (урок проекта #632: last-resolve-wins при быстрой смене периода).

## Файлы
- `AnalyticsAreaChart.vue` — опциональный prop `categories` (для рядов без дат, обратно совместимо).
- `AnalyticsBarChart.vue` — новый Apex bar-врапер (палитра проекта, ru-тултип со склонением).
- `StatisticsDashboard.vue` — разворот карточки, онлайн-блок, хранение `peak_hours`.
- Спеки на оба чарта + дашборд.

## Проверка
- vitest: 84 статистики-спеки зелёные (16 новых/изменённых: bar-чарт, разворот, онлайн-блок, сворачивание при смене периода).
- eslint на изменённых: 0 errors.
- Ревью `code-reviewer`: GO, без блокеров; Y2 (сворачивать при смене периода) и Y3 (защитный expect в тесте) исправлены, Y1 (префикс «День N») сознательно отклонён — на разреженном ряду подразумевал бы календарный день.
- Визуальная проверка — владелец на staging (OK на скрин-до-мержа дан заранее).