### PR TITLE
feat(security): схема привязки мест к охраннику и место разгрузки вложения (#706)

### DIFF
--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -87,6 +87,12 @@ func AllModels() []interface{} {
 		// Forward attachments (#680: пер-вложенный пересыл; depends on Application, User, Attachment)
 		&models.ForwardAttachment{},
 
+		// Доступные мне (#706): привязка мест к охраннику + место разгрузки на уровне вложения
+		// (depends on User, UnloadPlace, SystemTable, Attachment)
+		&models.SecurityUserUnloadPlace{},
+		&models.SecurityUserTable{},
+		&models.AttachmentUnloadPlace{},
+
 		// Attachment templates (#183: Excel-бланки)
 		&models.AttachmentTemplate{},
 		&models.AttachmentTemplateMapping{},

--- a/internal/models/security_place.go
+++ b/internal/models/security_place.go
@@ -1,0 +1,46 @@
+package models
+
+import "time"
+
+// SecurityUserUnloadPlace - прямая привязка аккаунта охранника (тип security) к месту
+// разгрузки (#706). Используется фильтром вкладки "Доступные мне": вложение типа cars/items
+// доступно охраннику, если место разгрузки вложения пересекается с назначенными ему местами.
+// Уникальный индекс (user_id, unload_place_id) делает повторное назначение идемпотентным;
+// его левый префикс обслуживает выборку мест охранника, индекс на unload_place_id -
+// обратное направление (какие охранники видят место).
+type SecurityUserUnloadPlace struct {
+	ID            int         `json:"id"`
+	UserID        int         `gorm:"uniqueIndex:idx_sec_user_unload,priority:1" json:"user_id"`
+	User          User        `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"-"`
+	UnloadPlaceID int         `gorm:"uniqueIndex:idx_sec_user_unload,priority:2;index" json:"unload_place_id"`
+	UnloadPlace   UnloadPlace `gorm:"constraint:OnDelete:CASCADE" json:"-"`
+	CreatedAt     time.Time   `json:"created_at"`
+	CreatedBy     *int        `json:"created_by"`
+}
+
+// SecurityUserTable - прямая привязка аккаунта охранника к месту прохода (#706). Место прохода
+// это строка system_tables с table_type='people'. Вложение типа people доступно охраннику,
+// если место прохода сотрудника (employee_target_tables) пересекается с назначенными местами.
+type SecurityUserTable struct {
+	ID        int         `json:"id"`
+	UserID    int         `gorm:"uniqueIndex:idx_sec_user_table,priority:1" json:"user_id"`
+	User      User        `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"-"`
+	TableID   int         `gorm:"uniqueIndex:idx_sec_user_table,priority:2;index" json:"table_id"`
+	Table     SystemTable `gorm:"foreignKey:TableID;constraint:OnDelete:CASCADE" json:"-"`
+	CreatedAt time.Time   `json:"created_at"`
+	CreatedBy *int        `json:"created_by"`
+}
+
+// AttachmentUnloadPlace - место разгрузки на уровне ВЛОЖЕНИЯ (#706). Единый источник места для
+// фильтра "Доступные мне": для items это единственная привязка места, для cars дублирует
+// дедуп-union мест всех машин вложения (per-машина car_unload_places остаётся для read-side
+// и истории). Уникальный индекс (attachment_id, unload_place_id) идемпотентен при пересохранении.
+type AttachmentUnloadPlace struct {
+	ID            int         `json:"id"`
+	AttachmentID  int         `gorm:"uniqueIndex:idx_att_unload,priority:1" json:"attachment_id"`
+	Attachment    Attachment  `gorm:"constraint:OnDelete:CASCADE" json:"-"`
+	UnloadPlaceID int         `gorm:"uniqueIndex:idx_att_unload,priority:2;index" json:"unload_place_id"`
+	UnloadPlace   UnloadPlace `gorm:"constraint:OnDelete:CASCADE" json:"-"`
+	OrderIndex    *int        `json:"order_index"`
+	CreatedAt     time.Time   `json:"created_at"`
+}


### PR DESCRIPTION
Срез BE-S1 эпика #706 («Доступные мне» для охранников ЧОП).

## Что
Три GORM junction-модели + регистрация в `AllModels()`:
- `security_user_unload_places` (user↔места разгрузки) — прямая привязка охранника.
- `security_user_tables` (user↔места прохода, system_tables people).
- `attachment_unload_places` (вложение↔место разгрузки) — единый attachment-level источник места для фильтра (для items новое, для cars дублирует дедуп-union; per-машина `car_unload_places` остаётся).

## Зачем
Фундамент под фильтр доступности вложений охраннику по совпадению мест + перенос места разгрузки на уровень вложения. Остальные срезы (сервис фильтра, endpoints, write-path, CRUD, FE) зависят от этой схемы.

## Проверка
- `go build ./...` — ок.
- AutoMigrate на тест-PG — таблицы созданы; вручную (`psql \d`) сверены composite-unique индексы, индексы обратного направления и FK `ON DELETE CASCADE` на users/unload_places/system_tables/attachments.
- Существующие handler-тесты зелёные.

## Заметки ревью
`code-reviewer`: GO, блокеров нет. Применено: явный `foreignKey:UserID` на User-ассоциациях; убран дублирующий `index` на `attachment_id` (покрыт левым префиксом composite-unique). Индексы на `unload_place_id`/`table_id` оставлены намеренно — правая часть composite, нужны для производительности `ON DELETE CASCADE`.

Аддитивная схема, `dev` остаётся рабочим. Правка off-limits `migrate.go` согласована.