### PR TITLE
feat(security): сервис фильтра доступных охраннику вложений (#706)

### DIFF
--- a/internal/services/application_service.go
+++ b/internal/services/application_service.go
@@ -179,6 +179,18 @@ type ApplicationService interface {
 
 	// GetApplicationIDByAttachment возвращает ID заявки по ID вложения.
 	GetApplicationIDByAttachment(ctx context.Context, attachmentID int) (int, error)
+
+	// IsSecurityUser сообщает, является ли аккаунт типом security (резолв по user_types.code).
+	IsSecurityUser(ctx context.Context, userID int) (bool, error)
+
+	// GetAvailableAttachmentsForSecurity возвращает страницу вложений подтверждённых заявок,
+	// доступных охраннику по совпадению мест (#706), и общее количество. Супер-админ - без
+	// фильтра по местам.
+	GetAvailableAttachmentsForSecurity(ctx context.Context, userID int, isSuperAdmin bool, page, perPage int) ([]AvailableAttachment, int64, error)
+
+	// CanSecurityViewAttachment сообщает, доступно ли конкретное вложение охраннику по тем же
+	// правилам, что и листинг (#706). Для 403 на чужое вложение в детальном эндпоинте.
+	CanSecurityViewAttachment(ctx context.Context, userID int, isSuperAdmin bool, attachmentID int) (bool, error)
 }
 
 // --- DTO: запросы ---

--- a/internal/services/security_visibility_service.go
+++ b/internal/services/security_visibility_service.go
@@ -1,0 +1,202 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"systemburo/internal/models"
+)
+
+// securityUserTypeCode - код типа аккаунта охранника ЧОП в user_types. Резолвится по code,
+// а не по числовому type_id: id нестабилен между средами (сид может отличаться), code - нет.
+const securityUserTypeCode = "security"
+
+// AvailableAttachment - строка вкладки "Доступные мне" (#706): одно вложение подтверждённой
+// заявки, доступное охраннику по совпадению мест, плюс короткая инфо родительской заявки для
+// карточки. Read-only проекция, без согласований/истории. Places - агрегат имён мест вложения
+// (места разгрузки для cars/items, места прохода сотрудников для people).
+type AvailableAttachment struct {
+	AttachmentID          int        `json:"attachment_id"`
+	AttachmentType        string     `json:"attachment_type"`
+	AttachmentName        *string    `json:"attachment_name"`
+	AttachmentDisplayName *string    `json:"attachment_display_name"`
+	EntryDateFrom         *string    `json:"entry_date_from"`
+	EntryDateTo           *string    `json:"entry_date_to"`
+	EntryTimeFrom         *string    `json:"entry_time_from"`
+	EntryTimeTo           *string    `json:"entry_time_to"`
+	CreatedAt             *time.Time `json:"created_at"`
+	Places                *string    `json:"places"`
+
+	ApplicationID     int        `json:"application_id"`
+	ApplicationNumber *string    `json:"application_number"`
+	Confirmation      *string    `json:"confirmation"`
+	Status            *string    `json:"status"`
+	SendingDatetime   *time.Time `json:"sending_datetime"`
+	OrganizationName  *string    `json:"organization_name"`
+	CompanyName       *string    `json:"company_name"`
+	SenderName        *string    `json:"sender_name"`
+	SenderFullName    *string    `json:"sender_full_name"`
+}
+
+// availableAttachmentSelect - столбцы листинга. Подзапросы places ссылаются на a.id напрямую
+// (без плейсхолдеров), поэтому в args после WHERE идут только LIMIT/OFFSET.
+const availableAttachmentSelect = `
+	a.id as attachment_id,
+	a.attachment_type,
+	a.attachment_name,
+	a.attachment_display_name,
+	a.entry_date_from, a.entry_date_to,
+	a.entry_time_from, a.entry_time_to,
+	a.created_at,
+	app.id as application_id,
+	app.application_number,
+	app.confirmation,
+	app.status,
+	app.sending_datetime,
+	COALESCE(o.name, c.name) as organization_name,
+	c.name as company_name,
+	format_short_name(su.last_name, su.first_name, su.middle_name) as sender_name,
+	format_full_name(su.last_name, su.first_name, su.middle_name) as sender_full_name,
+	CASE WHEN a.attachment_type = 'people' THEN (
+		SELECT string_agg(DISTINCT st.name, ', ')
+		FROM employees e
+		JOIN employee_target_tables ett ON ett.employee_id = e.id
+		JOIN system_tables st ON st.id = ett.table_id
+		WHERE e.attachment_id = a.id
+	) ELSE (
+		SELECT string_agg(DISTINCT up.name, ', ')
+		FROM attachment_unload_places aup
+		JOIN unload_places up ON up.id = aup.unload_place_id
+		WHERE aup.attachment_id = a.id
+	) END as places`
+
+// securityVisibilityWhere строит предикат доступности вложения для вкладки "Доступные мне"
+// (ссылается на алиасы a = attachments, app = applications) и его аргументы. Инвариант (#706):
+// confirmation = 'Согласовано' И пересечение мест вложения с местами охранника непусто. Места:
+// cars/items - attachment_unload_places ∩ security_user_unload_places; people - места прохода
+// сотрудников (employee_target_tables) ∩ security_user_tables. Супер-админ отбрасывает предикат
+// по местам, оставляя только confirmation-гейт. НЕ смотрит is_active/status места (факт назначения
+// = доступ; "обслуживание" места не должно молча скрывать вложение). Не пересекается с
+// forward_attachments (#680) - другой источник видимости.
+func securityVisibilityWhere(userID int, isSuperAdmin bool) (string, []interface{}) {
+	confirm := "app.confirmation = ?"
+	args := []interface{}{models.ConfirmationApproved}
+	if isSuperAdmin {
+		return confirm, args
+	}
+	place := `(
+		(a.attachment_type IN ('cars','items') AND EXISTS (
+			SELECT 1 FROM attachment_unload_places aup
+			JOIN security_user_unload_places suup ON suup.unload_place_id = aup.unload_place_id
+			WHERE aup.attachment_id = a.id AND suup.user_id = ?))
+		OR
+		(a.attachment_type = 'people' AND EXISTS (
+			SELECT 1 FROM employees e
+			JOIN employee_target_tables ett ON ett.employee_id = e.id
+			JOIN security_user_tables sut ON sut.table_id = ett.table_id
+			WHERE e.attachment_id = a.id AND sut.user_id = ?))
+	)`
+	args = append(args, userID, userID)
+	return confirm + " AND " + place, args
+}
+
+// IsSecurityUser сообщает, является ли аккаунт типом security (резолв по user_types.code,
+// образец CheckBuroByUsername). Несуществующий пользователь -> false без ошибки.
+func (s *applicationService) IsSecurityUser(ctx context.Context, userID int) (bool, error) {
+	var row struct{ Code string }
+	err := s.db.WithContext(ctx).
+		Table("users").
+		Select("user_types.code").
+		Joins("JOIN user_types ON user_types.id = users.type_id").
+		Where("users.id = ?", userID).
+		Scan(&row).Error
+	if err != nil {
+		return false, fmt.Errorf("failed to resolve user type: %w", err)
+	}
+	return row.Code == securityUserTypeCode, nil
+}
+
+// securityHasAnyPlace - быстрая проверка, назначено ли охраннику хоть одно место (разгрузки или
+// прохода). Короткое замыкание для GetAvailableAttachmentsForSecurity: без мест список заведомо
+// пуст, основной запрос не нужен.
+func (s *applicationService) securityHasAnyPlace(ctx context.Context, userID int) (bool, error) {
+	var total int64
+	err := s.db.WithContext(ctx).Raw(`
+		SELECT
+			(SELECT COUNT(*) FROM security_user_unload_places WHERE user_id = ?) +
+			(SELECT COUNT(*) FROM security_user_tables WHERE user_id = ?)`,
+		userID, userID).Scan(&total).Error
+	if err != nil {
+		return false, fmt.Errorf("failed to count security places: %w", err)
+	}
+	return total > 0, nil
+}
+
+// GetAvailableAttachmentsForSecurity возвращает страницу вложений подтверждённых заявок, доступных
+// охраннику по совпадению мест (#706), и общее количество. Один плоский SQL без N+1, пагинация по
+// образцу GetApplicationsPaginated (отдельный COUNT + страница). Супер-админ видит все вложения
+// подтверждённых заявок без фильтра по местам. Охранник без назначенных мест -> пустая страница
+// без основного запроса.
+func (s *applicationService) GetAvailableAttachmentsForSecurity(ctx context.Context, userID int, isSuperAdmin bool, page, perPage int) ([]AvailableAttachment, int64, error) {
+	page, perPage = normalizePage(page, perPage)
+
+	if !isSuperAdmin {
+		hasPlaces, err := s.securityHasAnyPlace(ctx, userID)
+		if err != nil {
+			return nil, 0, err
+		}
+		if !hasPlaces {
+			return []AvailableAttachment{}, 0, nil
+		}
+	}
+
+	where, args := securityVisibilityWhere(userID, isSuperAdmin)
+
+	var total int64
+	countSQL := `SELECT COUNT(*) FROM attachments a
+		JOIN applications app ON app.id = a.application_id
+		WHERE ` + where
+	if err := s.db.WithContext(ctx).Raw(countSQL, args...).Scan(&total).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to count available attachments: %w", err)
+	}
+	if total == 0 {
+		return []AvailableAttachment{}, 0, nil
+	}
+
+	offset := (page - 1) * perPage
+	dataSQL := `SELECT ` + availableAttachmentSelect + `
+		FROM attachments a
+		JOIN applications app ON app.id = a.application_id
+		LEFT JOIN organizations o ON o.id = app.organization_id
+		LEFT JOIN companies c ON c.id = app.company_id
+		LEFT JOIN users su ON su.id = app.sender_user_id
+		WHERE ` + where + `
+		ORDER BY app.sending_datetime DESC NULLS LAST, a.id DESC
+		LIMIT ? OFFSET ?`
+	dataArgs := append(append([]interface{}{}, args...), perPage, offset)
+
+	rows := make([]AvailableAttachment, 0)
+	if err := s.db.WithContext(ctx).Raw(dataSQL, dataArgs...).Scan(&rows).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to fetch available attachments: %w", err)
+	}
+	return rows, total, nil
+}
+
+// CanSecurityViewAttachment сообщает, доступно ли конкретное вложение охраннику по тем же правилам,
+// что и листинг (#706). Используется детальным эндпоинтом для 403 на чужое вложение. Супер-админ
+// проходит фильтр по местам, но confirmation-гейт применяется и к нему.
+func (s *applicationService) CanSecurityViewAttachment(ctx context.Context, userID int, isSuperAdmin bool, attachmentID int) (bool, error) {
+	where, args := securityVisibilityWhere(userID, isSuperAdmin)
+	sql := `SELECT EXISTS (
+		SELECT 1 FROM attachments a
+		JOIN applications app ON app.id = a.application_id
+		WHERE a.id = ? AND ` + where + `)`
+	queryArgs := append([]interface{}{attachmentID}, args...)
+
+	var canView bool
+	if err := s.db.WithContext(ctx).Raw(sql, queryArgs...).Scan(&canView).Error; err != nil {
+		return false, fmt.Errorf("failed to check security attachment access: %w", err)
+	}
+	return canView, nil
+}

--- a/internal/services/security_visibility_service.go
+++ b/internal/services/security_visibility_service.go
@@ -104,6 +104,8 @@ func securityVisibilityWhere(userID int, isSuperAdmin bool) (string, []interface
 // IsSecurityUser сообщает, является ли аккаунт типом security (резолв по user_types.code,
 // образец CheckBuroByUsername). Несуществующий пользователь -> false без ошибки.
 func (s *applicationService) IsSecurityUser(ctx context.Context, userID int) (bool, error) {
+	// GORM Scan не возвращает ошибку на 0 строк (в отличие от First): для несуществующего
+	// userID Code остаётся пустой строкой -> false.
 	var row struct{ Code string }
 	err := s.db.WithContext(ctx).
 		Table("users").

--- a/internal/services/security_visibility_service_test.go
+++ b/internal/services/security_visibility_service_test.go
@@ -242,6 +242,28 @@ func TestGetAvailableAttachments_NoPlacesEmpty(t *testing.T) {
 	require.Empty(t, rows)
 }
 
+func TestGetAvailableAttachments_AttachmentWithoutPlacesHidden(t *testing.T) {
+	w := setupSecurityWorld(t)
+	ctx := context.Background()
+
+	// У охранника есть место, но у согласованного cars-вложения нет ни одной строки
+	// attachment_unload_places - пересечение пусто, вложение не видно.
+	myPlace := w.newUnloadPlace(t, "Склад А", true)
+	w.assignUnloadPlace(t, myPlace)
+
+	app := w.newApp(t, models.ConfirmationApproved)
+	att := w.newAttachment(t, app, "cars")
+
+	rows, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, false, 1, 50)
+	require.NoError(t, err)
+	require.EqualValues(t, 0, total)
+	require.False(t, containsAttachment(rows, att), "attachment without places must not leak")
+
+	can, err := w.svc.CanSecurityViewAttachment(ctx, w.guardID, false, att)
+	require.NoError(t, err)
+	require.False(t, can)
+}
+
 func TestGetAvailableAttachments_InactivePlaceStillMatches(t *testing.T) {
 	w := setupSecurityWorld(t)
 	ctx := context.Background()

--- a/internal/services/security_visibility_service_test.go
+++ b/internal/services/security_visibility_service_test.go
@@ -1,0 +1,352 @@
+package services_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// Тесты фильтра "Доступные мне" (#706, срез BE-S3). DB-backed: реальный Postgres через testutil,
+// сервис конструируется напрямую (методы фильтра используют только db, прочие зависимости nil).
+// Каждый тест изолируется CleanDB; параллелизма нет - общий cachedDB.
+
+func ptrInt(i int) *int { return &i }
+
+type svcWorld struct {
+	db       *gorm.DB
+	svc      services.ApplicationService
+	orgID    int
+	senderID int
+	guardID  int
+}
+
+func setupSecurityWorld(t *testing.T) svcWorld {
+	t.Helper()
+	_, db, cleanup := testutil.SetupTestApp(t)
+	t.Cleanup(cleanup)
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	secTypeID := userTypeIDByCode(t, db, "security")
+	userTypeID := userTypeIDByCode(t, db, "user")
+
+	guard := models.User{Username: "guard1", Password: "x", TypeID: secTypeID, OrganizationID: ptrInt(td.OrgID)}
+	require.NoError(t, db.Create(&guard).Error)
+	sender := models.User{Username: "sender1", Password: "x", TypeID: userTypeID, OrganizationID: ptrInt(td.OrgID)}
+	require.NoError(t, db.Create(&sender).Error)
+
+	svc := services.NewApplicationService(db, nil, nil, nil, nil)
+	return svcWorld{db: db, svc: svc, orgID: td.OrgID, senderID: sender.ID, guardID: guard.ID}
+}
+
+func userTypeIDByCode(t *testing.T, db *gorm.DB, code string) int {
+	t.Helper()
+	var id int
+	require.NoError(t, db.Table("user_types").Where("code = ?", code).Select("id").Scan(&id).Error)
+	require.NotZero(t, id, "user_type %q not seeded", code)
+	return id
+}
+
+func (w svcWorld) newApp(t *testing.T, confirmation string) int {
+	t.Helper()
+	now := time.Now()
+	conf := confirmation
+	app := models.Application{
+		OrganizationID:  w.orgID,
+		SenderUserID:    w.senderID,
+		Confirmation:    &conf,
+		SendingDatetime: &now,
+	}
+	require.NoError(t, w.db.Create(&app).Error)
+	return app.ID
+}
+
+func (w svcWorld) newAttachment(t *testing.T, appID int, atype string) int {
+	t.Helper()
+	att := models.Attachment{ApplicationID: appID, AttachmentType: atype}
+	require.NoError(t, w.db.Create(&att).Error)
+	return att.ID
+}
+
+func (w svcWorld) newUnloadPlace(t *testing.T, name string, active bool) int {
+	t.Helper()
+	p := models.UnloadPlace{Name: name, IsActive: active}
+	require.NoError(t, w.db.Create(&p).Error)
+	return p.ID
+}
+
+func (w svcWorld) newPeopleTable(t *testing.T, name string) int {
+	t.Helper()
+	st := models.SystemTable{Name: name, TableType: "people", IsActive: true}
+	require.NoError(t, w.db.Create(&st).Error)
+	return st.ID
+}
+
+func (w svcWorld) attachPlace(t *testing.T, attID, placeID int) {
+	t.Helper()
+	require.NoError(t, w.db.Create(&models.AttachmentUnloadPlace{AttachmentID: attID, UnloadPlaceID: placeID}).Error)
+}
+
+func (w svcWorld) attachEmployeeWithTable(t *testing.T, attID, tableID int) {
+	t.Helper()
+	emp := models.Employee{AttachmentID: ptrInt(attID)}
+	require.NoError(t, w.db.Create(&emp).Error)
+	require.NoError(t, w.db.Create(&models.EmployeeTargetTable{EmployeeID: emp.ID, TableID: tableID}).Error)
+}
+
+func (w svcWorld) assignUnloadPlace(t *testing.T, placeID int) {
+	t.Helper()
+	require.NoError(t, w.db.Create(&models.SecurityUserUnloadPlace{UserID: w.guardID, UnloadPlaceID: placeID}).Error)
+}
+
+func (w svcWorld) assignTable(t *testing.T, tableID int) {
+	t.Helper()
+	require.NoError(t, w.db.Create(&models.SecurityUserTable{UserID: w.guardID, TableID: tableID}).Error)
+}
+
+func containsAttachment(rows []services.AvailableAttachment, attID int) bool {
+	for _, r := range rows {
+		if r.AttachmentID == attID {
+			return true
+		}
+	}
+	return false
+}
+
+func TestIsSecurityUser(t *testing.T) {
+	w := setupSecurityWorld(t)
+	ctx := context.Background()
+
+	isSec, err := w.svc.IsSecurityUser(ctx, w.guardID)
+	require.NoError(t, err)
+	require.True(t, isSec, "guard must be recognised as security")
+
+	isSec, err = w.svc.IsSecurityUser(ctx, w.senderID)
+	require.NoError(t, err)
+	require.False(t, isSec, "regular user must not be security")
+
+	isSec, err = w.svc.IsSecurityUser(ctx, 999999)
+	require.NoError(t, err)
+	require.False(t, isSec, "non-existent user must not be security")
+}
+
+func TestGetAvailableAttachments_MatchByUnloadPlace(t *testing.T) {
+	w := setupSecurityWorld(t)
+	ctx := context.Background()
+
+	myPlace := w.newUnloadPlace(t, "Склад А", true)
+	otherPlace := w.newUnloadPlace(t, "Склад Б", true)
+	w.assignUnloadPlace(t, myPlace)
+
+	app := w.newApp(t, models.ConfirmationApproved)
+	carsAtt := w.newAttachment(t, app, "cars")
+	w.attachPlace(t, carsAtt, myPlace)
+	itemsAtt := w.newAttachment(t, app, "items")
+	w.attachPlace(t, itemsAtt, myPlace)
+	foreignAtt := w.newAttachment(t, app, "cars")
+	w.attachPlace(t, foreignAtt, otherPlace)
+
+	rows, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, false, 1, 50)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, total)
+	require.True(t, containsAttachment(rows, carsAtt), "cars at guard place visible")
+	require.True(t, containsAttachment(rows, itemsAtt), "items at guard place visible")
+	require.False(t, containsAttachment(rows, foreignAtt), "attachment at foreign place hidden")
+}
+
+func TestGetAvailableAttachments_PeopleMatchByTable(t *testing.T) {
+	w := setupSecurityWorld(t)
+	ctx := context.Background()
+
+	myTable := w.newPeopleTable(t, "Проходная 1")
+	otherTable := w.newPeopleTable(t, "Проходная 2")
+	w.assignTable(t, myTable)
+
+	app := w.newApp(t, models.ConfirmationApproved)
+	peopleAtt := w.newAttachment(t, app, "people")
+	w.attachEmployeeWithTable(t, peopleAtt, myTable)
+	foreignAtt := w.newAttachment(t, app, "people")
+	w.attachEmployeeWithTable(t, foreignAtt, otherTable)
+
+	rows, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, false, 1, 50)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, total)
+	require.True(t, containsAttachment(rows, peopleAtt), "people at guard passage visible")
+	require.False(t, containsAttachment(rows, foreignAtt), "people at foreign passage hidden")
+}
+
+func TestGetAvailableAttachments_ApprovedGate(t *testing.T) {
+	w := setupSecurityWorld(t)
+	ctx := context.Background()
+
+	myPlace := w.newUnloadPlace(t, "Склад А", true)
+	w.assignUnloadPlace(t, myPlace)
+
+	approvedApp := w.newApp(t, models.ConfirmationApproved)
+	approvedAtt := w.newAttachment(t, approvedApp, "cars")
+	w.attachPlace(t, approvedAtt, myPlace)
+
+	pendingApp := w.newApp(t, "Согласование")
+	pendingAtt := w.newAttachment(t, pendingApp, "cars")
+	w.attachPlace(t, pendingAtt, myPlace)
+
+	rows, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, false, 1, 50)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, total)
+	require.True(t, containsAttachment(rows, approvedAtt))
+	require.False(t, containsAttachment(rows, pendingAtt), "non-approved application hidden")
+}
+
+func TestGetAvailableAttachments_SuperAdminSeesAllApproved(t *testing.T) {
+	w := setupSecurityWorld(t)
+	ctx := context.Background()
+
+	// Место никому не назначено - охранник бы не увидел, супер-админ видит.
+	place := w.newUnloadPlace(t, "Склад без назначения", true)
+
+	approvedApp := w.newApp(t, models.ConfirmationApproved)
+	approvedAtt := w.newAttachment(t, approvedApp, "cars")
+	w.attachPlace(t, approvedAtt, place)
+
+	pendingApp := w.newApp(t, "Согласование")
+	pendingAtt := w.newAttachment(t, pendingApp, "cars")
+	w.attachPlace(t, pendingAtt, place)
+
+	rows, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, true, 1, 50)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, total, "super-admin sees approved regardless of place, still approved-gated")
+	require.True(t, containsAttachment(rows, approvedAtt))
+	require.False(t, containsAttachment(rows, pendingAtt), "approved-gate applies to super-admin too")
+}
+
+func TestGetAvailableAttachments_NoPlacesEmpty(t *testing.T) {
+	w := setupSecurityWorld(t)
+	ctx := context.Background()
+
+	// Охраннику не назначено ни одного места, но согласованное вложение существует.
+	place := w.newUnloadPlace(t, "Склад А", true)
+	app := w.newApp(t, models.ConfirmationApproved)
+	att := w.newAttachment(t, app, "cars")
+	w.attachPlace(t, att, place)
+
+	rows, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, false, 1, 50)
+	require.NoError(t, err)
+	require.EqualValues(t, 0, total)
+	require.Empty(t, rows)
+}
+
+func TestGetAvailableAttachments_InactivePlaceStillMatches(t *testing.T) {
+	w := setupSecurityWorld(t)
+	ctx := context.Background()
+
+	// is_active=false не должно скрывать вложение: доступ = факт назначения места.
+	inactivePlace := w.newUnloadPlace(t, "Склад на обслуживании", false)
+	w.assignUnloadPlace(t, inactivePlace)
+
+	app := w.newApp(t, models.ConfirmationApproved)
+	att := w.newAttachment(t, app, "items")
+	w.attachPlace(t, att, inactivePlace)
+
+	rows, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, false, 1, 50)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, total)
+	require.True(t, containsAttachment(rows, att), "inactive place still grants visibility")
+}
+
+func TestGetAvailableAttachments_IndependentFromForwardAttachments(t *testing.T) {
+	w := setupSecurityWorld(t)
+	ctx := context.Background()
+
+	myPlace := w.newUnloadPlace(t, "Склад А", true)
+	w.assignUnloadPlace(t, myPlace)
+
+	app := w.newApp(t, models.ConfirmationApproved)
+	attA := w.newAttachment(t, app, "cars")
+	w.attachPlace(t, attA, myPlace)
+	attB := w.newAttachment(t, app, "cars")
+	w.attachPlace(t, attB, myPlace)
+
+	// Пересыл ограничил бы охранника только attB, если бы фильтр звал forward-логику.
+	// Security-фильтр её игнорирует - оба вложения по месту видимы.
+	require.NoError(t, w.db.Create(&models.ForwardAttachment{
+		ApplicationID:   app,
+		RecipientUserID: w.guardID,
+		AttachmentID:    attB,
+	}).Error)
+
+	rows, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, false, 1, 50)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, total, "forward_attachments must not restrict security visibility")
+	require.True(t, containsAttachment(rows, attA))
+	require.True(t, containsAttachment(rows, attB))
+}
+
+func TestGetAvailableAttachments_Pagination(t *testing.T) {
+	w := setupSecurityWorld(t)
+	ctx := context.Background()
+
+	myPlace := w.newUnloadPlace(t, "Склад А", true)
+	w.assignUnloadPlace(t, myPlace)
+
+	app := w.newApp(t, models.ConfirmationApproved)
+	for i := 0; i < 5; i++ {
+		att := w.newAttachment(t, app, "cars")
+		w.attachPlace(t, att, myPlace)
+	}
+
+	page1, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, false, 1, 2)
+	require.NoError(t, err)
+	require.EqualValues(t, 5, total, "total counts all matches, not page size")
+	require.Len(t, page1, 2)
+
+	page3, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, false, 3, 2)
+	require.NoError(t, err)
+	require.EqualValues(t, 5, total)
+	require.Len(t, page3, 1, "last page holds the remainder")
+}
+
+func TestCanSecurityViewAttachment(t *testing.T) {
+	w := setupSecurityWorld(t)
+	ctx := context.Background()
+
+	myPlace := w.newUnloadPlace(t, "Склад А", true)
+	otherPlace := w.newUnloadPlace(t, "Склад Б", true)
+	w.assignUnloadPlace(t, myPlace)
+
+	app := w.newApp(t, models.ConfirmationApproved)
+	ownAtt := w.newAttachment(t, app, "cars")
+	w.attachPlace(t, ownAtt, myPlace)
+	foreignAtt := w.newAttachment(t, app, "cars")
+	w.attachPlace(t, foreignAtt, otherPlace)
+
+	pendingApp := w.newApp(t, "Согласование")
+	pendingAtt := w.newAttachment(t, pendingApp, "cars")
+	w.attachPlace(t, pendingAtt, myPlace)
+
+	can, err := w.svc.CanSecurityViewAttachment(ctx, w.guardID, false, ownAtt)
+	require.NoError(t, err)
+	require.True(t, can, "own place attachment viewable")
+
+	can, err = w.svc.CanSecurityViewAttachment(ctx, w.guardID, false, foreignAtt)
+	require.NoError(t, err)
+	require.False(t, can, "foreign place attachment not viewable")
+
+	can, err = w.svc.CanSecurityViewAttachment(ctx, w.guardID, false, pendingAtt)
+	require.NoError(t, err)
+	require.False(t, can, "non-approved attachment not viewable")
+
+	can, err = w.svc.CanSecurityViewAttachment(ctx, w.guardID, true, foreignAtt)
+	require.NoError(t, err)
+	require.True(t, can, "super-admin views attachment regardless of place")
+
+	can, err = w.svc.CanSecurityViewAttachment(ctx, w.guardID, true, pendingAtt)
+	require.NoError(t, err)
+	require.False(t, can, "approved-gate applies to super-admin")
+}


### PR DESCRIPTION
Срез **BE-S3** эпика #706 «Доступные мне» (вложения для охранников ЧОП). Зависит от BE-S1 (#708, смержен) — использует модели security_user_unload_places / security_user_tables / attachment_unload_places.

## Что добавлено
`internal/services/security_visibility_service.go` — методы на `*applicationService`:
- `GetAvailableAttachmentsForSecurity(ctx, userID, isSuperAdmin, page, perPage)` — страница вложений подтверждённых заявок, доступных охраннику по пересечению мест. Один плоский SQL без N+1, пагинация по образцу `GetApplicationsPaginated` (отдельный COUNT + страница), короткое замыкание: охранник без мест -> пустая страница без основного запроса.
- `CanSecurityViewAttachment(...)` — гейт детали (для 403 на чужое в BE-S4).
- `IsSecurityUser(ctx, userID)` — резолв типа по `user_types.code='security'` (не хардкод id).
- DTO `AvailableAttachment` (вложение + инфо заявки + агрегат мест).

Три метода добавлены в интерфейс `ApplicationService`.

## Инвариант доступа
`confirmation = 'Согласовано'` И пересечение мест вложения с местами охранника:
- cars/items: `attachment_unload_places` ∩ `security_user_unload_places`;
- people: `employee_target_tables` ∩ `security_user_tables`.

Супер-админ отбрасывает предикат по местам, **confirmation-гейт остаётся для всех**. Фильтр НЕ смотрит `is_active`/`status` места (доступ = факт назначения) и НЕ пересекается с `forward_attachments` (#680) — это другой источник видимости.

## Тесты
`security_visibility_service_test.go` (DB-backed, реальный Postgres через testutil): матч по месту разгрузки (cars+items), матч по месту прохода (people), approved-гейт, супер-админ видит всё согласованное без фильтра мест, охранник без мест -> пусто, вложение без мест не протекает, неактивное место всё равно матчится, независимость от forward_attachments, пагинация (total vs страница), `CanSecurityViewAttachment` (своё/чужое/несогласованное/супер-админ), `IsSecurityUser`.

`go test ./internal/services/ -count=1` -> ok. Ревью code-reviewer: GO, блокеров нет.

## Дальше по эпику
BE-S4 (endpoints списка/детали) использует эти методы.