### PR TITLE
feat(security): endpoints "Доступные мне" для охранников (#706)

### DIFF
--- a/internal/handlers/security_attachments.go
+++ b/internal/handlers/security_attachments.go
@@ -1,0 +1,132 @@
+package handlers
+
+import (
+	"net/http"
+
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+
+	"github.com/labstack/echo/v4"
+)
+
+// availableAttachmentDetail - ответ детального эндпоинта вкладки "Доступные мне" (#706):
+// заголовок вложения с краткой инфо родительской заявки плюс типизированное содержимое.
+// Заполняется только релевантный тип (cars/people/items), остальные опускаются.
+type availableAttachmentDetail struct {
+	Attachment services.AvailableAttachment  `json:"attachment"`
+	Cars       []services.CarWithPlaces      `json:"cars,omitempty"`
+	Employees  []services.EmployeeWithTables `json:"employees,omitempty"`
+	Items      []services.ItemInfo           `json:"items,omitempty"`
+}
+
+// requireSecurityOrAdmin - ролевой гейт вкладки "Доступные мне" (#706): доступ только охраннику
+// (user_types.code='security') или супер-админу. Возвращает (userID, isSuperAdmin) для проброса
+// в сервис фильтрации, либо 403 для прочих типов аккаунтов.
+func (h *ApplicationHandler) requireSecurityOrAdmin(c echo.Context) (int, bool, error) {
+	userID := GetUserID(c)
+	isSuperAdmin := IsSuperAdmin(c)
+	if isSuperAdmin {
+		return userID, true, nil
+	}
+	isSecurity, err := h.service.IsSecurityUser(c.Request().Context(), userID)
+	if err != nil {
+		return 0, false, err
+	}
+	if !isSecurity {
+		return 0, false, echo.NewHTTPError(http.StatusForbidden, "Access denied")
+	}
+	return userID, false, nil
+}
+
+// GetAvailableAttachments godoc
+// @Summary      Доступные мне вложения
+// @Description  Плоский список вложений подтверждённых заявок, доступных охраннику по совпадению мест разгрузки/прохода. Супер-админ видит все подтверждённые вложения. Прочим типам - 403.
+// @Tags         applications
+// @Produce      json
+// @Security     BearerAuth
+// @Param        page     query int false "Номер страницы"
+// @Param        per_page query int false "Размер страницы"
+// @Success      200 {array}  services.AvailableAttachment
+// @Failure      401 {object} models.HTTPError
+// @Failure      403 {object} models.HTTPError
+// @Failure      500 {object} models.HTTPError
+// @Router       /applications/available-attachments [get]
+func (h *ApplicationHandler) GetAvailableAttachments(c echo.Context) error {
+	userID, isSuperAdmin, err := h.requireSecurityOrAdmin(c)
+	if err != nil {
+		return err
+	}
+
+	var params models.PaginationParams
+	if err := c.Bind(&params); err != nil {
+		params = models.PaginationParams{}
+	}
+	params.Normalize()
+
+	data, total, err := h.service.GetAvailableAttachmentsForSecurity(
+		c.Request().Context(), userID, isSuperAdmin, params.Page, params.PerPage,
+	)
+	if err != nil {
+		return err
+	}
+	return RespondPaginated(c, data, models.PaginationMeta{
+		Total: total, Page: params.Page, PerPage: params.PerPage,
+	})
+}
+
+// GetAvailableAttachmentDetail godoc
+// @Summary      Деталь доступного вложения
+// @Description  Заголовок вложения с инфо заявки и типизированное содержимое (автомобили/сотрудники/ТМЦ). Доступ только охраннику с совпавшим местом или супер-админу, иначе 403.
+// @Tags         applications
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path int true "ID вложения"
+// @Success      200 {object} handlers.availableAttachmentDetail
+// @Failure      400 {object} models.HTTPError
+// @Failure      401 {object} models.HTTPError
+// @Failure      403 {object} models.HTTPError
+// @Failure      404 {object} models.HTTPError
+// @Failure      500 {object} models.HTTPError
+// @Router       /applications/available-attachments/{id} [get]
+func (h *ApplicationHandler) GetAvailableAttachmentDetail(c echo.Context) error {
+	userID, isSuperAdmin, err := h.requireSecurityOrAdmin(c)
+	if err != nil {
+		return err
+	}
+
+	id, err := ParseID(c, "id")
+	if err != nil {
+		return err
+	}
+
+	ctx := c.Request().Context()
+	canView, err := h.service.CanSecurityViewAttachment(ctx, userID, isSuperAdmin, id)
+	if err != nil {
+		return err
+	}
+	if !canView {
+		return echo.NewHTTPError(http.StatusForbidden, "Access denied")
+	}
+
+	header, err := h.service.GetAvailableAttachmentByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	if header == nil {
+		return echo.NewHTTPError(http.StatusNotFound, "Attachment not found")
+	}
+
+	detail := availableAttachmentDetail{Attachment: *header}
+	switch header.AttachmentType {
+	case "cars":
+		detail.Cars, err = h.service.GetAttachmentCars(ctx, id)
+	case "people":
+		detail.Employees, err = h.service.GetAttachmentEmployees(ctx, id)
+	case "items":
+		detail.Items, err = h.service.GetAttachmentItems(ctx, id)
+	}
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, detail)
+}

--- a/internal/handlers/security_attachments.go
+++ b/internal/handlers/security_attachments.go
@@ -9,10 +9,10 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// availableAttachmentDetail - ответ детального эндпоинта вкладки "Доступные мне" (#706):
+// AvailableAttachmentDetail - ответ детального эндпоинта вкладки "Доступные мне" (#706):
 // заголовок вложения с краткой инфо родительской заявки плюс типизированное содержимое.
 // Заполняется только релевантный тип (cars/people/items), остальные опускаются.
-type availableAttachmentDetail struct {
+type AvailableAttachmentDetail struct {
 	Attachment services.AvailableAttachment  `json:"attachment"`
 	Cars       []services.CarWithPlaces      `json:"cars,omitempty"`
 	Employees  []services.EmployeeWithTables `json:"employees,omitempty"`
@@ -81,7 +81,7 @@ func (h *ApplicationHandler) GetAvailableAttachments(c echo.Context) error {
 // @Produce      json
 // @Security     BearerAuth
 // @Param        id path int true "ID вложения"
-// @Success      200 {object} handlers.availableAttachmentDetail
+// @Success      200 {object} handlers.AvailableAttachmentDetail
 // @Failure      400 {object} models.HTTPError
 // @Failure      401 {object} models.HTTPError
 // @Failure      403 {object} models.HTTPError
@@ -116,7 +116,7 @@ func (h *ApplicationHandler) GetAvailableAttachmentDetail(c echo.Context) error 
 		return echo.NewHTTPError(http.StatusNotFound, "Attachment not found")
 	}
 
-	detail := availableAttachmentDetail{Attachment: *header}
+	detail := AvailableAttachmentDetail{Attachment: *header}
 	switch header.AttachmentType {
 	case "cars":
 		detail.Cars, err = h.service.GetAttachmentCars(ctx, id)
@@ -124,6 +124,8 @@ func (h *ApplicationHandler) GetAvailableAttachmentDetail(c echo.Context) error 
 		detail.Employees, err = h.service.GetAttachmentEmployees(ctx, id)
 	case "items":
 		detail.Items, err = h.service.GetAttachmentItems(ctx, id)
+	default:
+		return echo.NewHTTPError(http.StatusInternalServerError, "Unknown attachment type")
 	}
 	if err != nil {
 		return err

--- a/internal/handlers/security_attachments_test.go
+++ b/internal/handlers/security_attachments_test.go
@@ -1,0 +1,193 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+	"systemburo/internal/testutil"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// HTTP-тесты эндпоинтов "Доступные мне" (#706, срез BE-S4). Реюз DB-хелперов secWorld из
+// security_visibility_test.go (тот же пакет handlers_test, единственный DB-тест-бинарь проекта).
+
+const secHTTPPassword = "guardpass_long_enough_for_login"
+
+// secHTTPWorld - поднятый echo + БД + secWorld (DB-хелперы) + логинабельные токены трёх ролей.
+type secHTTPWorld struct {
+	e          *echo.Echo
+	w          secWorld
+	guardToken string
+	userToken  string
+	adminToken string
+}
+
+func setupSecurityHTTP(t *testing.T) secHTTPWorld {
+	t.Helper()
+	e, db, cleanup := testutil.SetupTestApp(t)
+	t.Cleanup(cleanup)
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	secTypeID := secUserTypeIDByCode(t, db, "security")
+	userTypeID := secUserTypeIDByCode(t, db, "user")
+
+	guardToken := testutil.RegisterAndLogin(t, e, "guardhttp", secHTTPPassword, secTypeID, td.OrgID, 0)
+	userToken := testutil.RegisterAndLogin(t, e, "userhttp", secHTTPPassword, userTypeID, td.OrgID, 0)
+	adminToken := testutil.RegisterAdmin(t, e, td.OrgID, 0)
+
+	guardID := secUserIDByUsername(t, db, "guardhttp")
+	senderID := secUserIDByUsername(t, db, "userhttp")
+
+	svc := services.NewApplicationService(db, nil, nil, nil, nil)
+	w := secWorld{db: db, svc: svc, orgID: td.OrgID, senderID: senderID, guardID: guardID}
+	return secHTTPWorld{e: e, w: w, guardToken: guardToken, userToken: userToken, adminToken: adminToken}
+}
+
+func secUserIDByUsername(t *testing.T, db *gorm.DB, username string) int {
+	t.Helper()
+	var id int
+	require.NoError(t, db.Table("users").Where("username = ?", username).Select("id").Scan(&id).Error)
+	require.NotZero(t, id, "user %q not found", username)
+	return id
+}
+
+// secMetaEnvelope читает meta-блок пагинированного ответа (testutil.ParseResponse даёт только data).
+type secMetaEnvelope struct {
+	Success bool `json:"success"`
+	Meta    struct {
+		Total   int64 `json:"total"`
+		Page    int   `json:"page"`
+		PerPage int   `json:"per_page"`
+	} `json:"meta"`
+}
+
+// secDetailResponse зеркалит handlers.availableAttachmentDetail (тип хендлера неэкспортируемый).
+type secDetailResponse struct {
+	Attachment services.AvailableAttachment  `json:"attachment"`
+	Cars       []services.CarWithPlaces      `json:"cars"`
+	Employees  []services.EmployeeWithTables `json:"employees"`
+	Items      []services.ItemInfo           `json:"items"`
+}
+
+func secGetDetail(t *testing.T, h secHTTPWorld, attID int, token string) secDetailResponse {
+	t.Helper()
+	rec := testutil.GET(t, h.e, fmt.Sprintf("/applications/available-attachments/%d", attID), testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	return testutil.ParseResponse[secDetailResponse](t, rec)
+}
+
+func TestAvailableAttachments_RoleGate(t *testing.T) {
+	h := setupSecurityHTTP(t)
+
+	rec := testutil.GET(t, h.e, "/applications/available-attachments", testutil.AuthHeader(h.userToken))
+	require.Equal(t, http.StatusForbidden, rec.Code, "обычный пользователь не имеет доступа: %s", rec.Body.String())
+
+	rec = testutil.GET(t, h.e, "/applications/available-attachments", testutil.AuthHeader(h.guardToken))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	rows := testutil.ParseResponse[[]services.AvailableAttachment](t, rec)
+	require.Empty(t, rows, "у охранника нет назначенных мест - список пуст")
+
+	rec = testutil.GET(t, h.e, "/applications/available-attachments", testutil.AuthHeader(h.adminToken))
+	require.Equal(t, http.StatusOK, rec.Code, "супер-админ имеет доступ: %s", rec.Body.String())
+}
+
+func TestAvailableAttachments_PaginationMeta(t *testing.T) {
+	h := setupSecurityHTTP(t)
+	w := h.w
+
+	place := w.newUnloadPlace(t, "Склад А", true)
+	w.assignUnloadPlace(t, place)
+	app := w.newApp(t, models.ConfirmationApproved)
+	for i := 0; i < 5; i++ {
+		att := w.newAttachment(t, app, "cars")
+		w.attachPlace(t, att, place)
+	}
+
+	rec := testutil.GET(t, h.e, "/applications/available-attachments?page=1&per_page=2", testutil.AuthHeader(h.guardToken))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	rows := testutil.ParseResponse[[]services.AvailableAttachment](t, rec)
+	require.Len(t, rows, 2, "страница ограничена per_page")
+
+	var env secMetaEnvelope
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &env), rec.Body.String())
+	require.EqualValues(t, 5, env.Meta.Total, "total считает все совпадения, не размер страницы")
+	require.Equal(t, 1, env.Meta.Page)
+	require.Equal(t, 2, env.Meta.PerPage)
+}
+
+func TestAvailableAttachmentDetail_Access(t *testing.T) {
+	h := setupSecurityHTTP(t)
+	w := h.w
+
+	myPlace := w.newUnloadPlace(t, "Склад А", true)
+	otherPlace := w.newUnloadPlace(t, "Склад Б", true)
+	w.assignUnloadPlace(t, myPlace)
+
+	app := w.newApp(t, models.ConfirmationApproved)
+	ownAtt := w.newAttachment(t, app, "cars")
+	w.attachPlace(t, ownAtt, myPlace)
+	foreignAtt := w.newAttachment(t, app, "cars")
+	w.attachPlace(t, foreignAtt, otherPlace)
+
+	detail := secGetDetail(t, h, ownAtt, h.guardToken)
+	require.Equal(t, ownAtt, detail.Attachment.AttachmentID)
+	require.Equal(t, "cars", detail.Attachment.AttachmentType)
+	require.Equal(t, app, detail.Attachment.ApplicationID, "деталь несёт инфо родительской заявки")
+
+	rec := testutil.GET(t, h.e, fmt.Sprintf("/applications/available-attachments/%d", foreignAtt), testutil.AuthHeader(h.guardToken))
+	require.Equal(t, http.StatusForbidden, rec.Code, "вложение на чужом месте недоступно охраннику")
+
+	rec = testutil.GET(t, h.e, fmt.Sprintf("/applications/available-attachments/%d", ownAtt), testutil.AuthHeader(h.userToken))
+	require.Equal(t, http.StatusForbidden, rec.Code, "обычный пользователь не имеет доступа к детали")
+
+	rec = testutil.GET(t, h.e, fmt.Sprintf("/applications/available-attachments/%d", foreignAtt), testutil.AuthHeader(h.adminToken))
+	require.Equal(t, http.StatusOK, rec.Code, "супер-админ видит любое подтверждённое вложение: %s", rec.Body.String())
+}
+
+func TestAvailableAttachmentDetail_ContentByType(t *testing.T) {
+	h := setupSecurityHTTP(t)
+	w := h.w
+
+	place := w.newUnloadPlace(t, "Склад А", true)
+	table := w.newPeopleTable(t, "Проходная 1")
+	w.assignUnloadPlace(t, place)
+	w.assignTable(t, table)
+
+	app := w.newApp(t, models.ConfirmationApproved)
+
+	carsAtt := w.newAttachment(t, app, "cars")
+	w.attachPlace(t, carsAtt, place)
+	num := "А123ВС777"
+	require.NoError(t, w.db.Create(&models.Car{AttachmentID: carsAtt, CarNumber: &num}).Error)
+
+	itemsAtt := w.newAttachment(t, app, "items")
+	w.attachPlace(t, itemsAtt, place)
+	iname := "Ноутбук"
+	icount := 2
+	require.NoError(t, w.db.Create(&models.Item{AttachmentID: itemsAtt, Name: &iname, Count: &icount}).Error)
+
+	peopleAtt := w.newAttachment(t, app, "people")
+	w.attachEmployeeWithTable(t, peopleAtt, table)
+
+	carsDetail := secGetDetail(t, h, carsAtt, h.guardToken)
+	require.Len(t, carsDetail.Cars, 1, "cars-вложение возвращает автомобили")
+	require.Empty(t, carsDetail.Employees)
+	require.Empty(t, carsDetail.Items)
+
+	itemsDetail := secGetDetail(t, h, itemsAtt, h.guardToken)
+	require.Len(t, itemsDetail.Items, 1, "items-вложение возвращает ТМЦ")
+	require.Empty(t, itemsDetail.Cars)
+
+	peopleDetail := secGetDetail(t, h, peopleAtt, h.guardToken)
+	require.Len(t, peopleDetail.Employees, 1, "people-вложение возвращает сотрудников")
+	require.Empty(t, peopleDetail.Cars)
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -433,6 +433,8 @@ func Setup(e *echo.Echo, d Dependencies) {
 	apg.POST("/submit-complete-application", app.SubmitCompleteApplication)
 	apg.GET("/user", app.GetUserApplications)
 	apg.GET("/unread-count", app.GetUnreadCount)
+	apg.GET("/available-attachments", app.GetAvailableAttachments)           // #706 - "Доступные мне" для охранников
+	apg.GET("/available-attachments/:id", app.GetAvailableAttachmentDetail)  // #706 - деталь вложения
 	apg.GET("/:id", app.GetApplicationByID)
 	apg.PUT("/:id", app.UpdateApplication)
 	apg.GET("/:id/responsible-users", app.GetApplicationResponsibleUsers)

--- a/internal/services/application_service.go
+++ b/internal/services/application_service.go
@@ -191,6 +191,11 @@ type ApplicationService interface {
 	// CanSecurityViewAttachment сообщает, доступно ли конкретное вложение охраннику по тем же
 	// правилам, что и листинг (#706). Для 403 на чужое вложение в детальном эндпоинте.
 	CanSecurityViewAttachment(ctx context.Context, userID int, isSuperAdmin bool, attachmentID int) (bool, error)
+
+	// GetAvailableAttachmentByID возвращает заголовок вложения с инфо заявки для детали
+	// "Доступные мне" (#706). nil без ошибки - вложение не найдено. Без проверки доступа,
+	// вызывать после CanSecurityViewAttachment.
+	GetAvailableAttachmentByID(ctx context.Context, attachmentID int) (*AvailableAttachment, error)
 }
 
 // --- DTO: запросы ---

--- a/internal/services/security_visibility_service.go
+++ b/internal/services/security_visibility_service.go
@@ -202,3 +202,27 @@ func (s *applicationService) CanSecurityViewAttachment(ctx context.Context, user
 	}
 	return canView, nil
 }
+
+// GetAvailableAttachmentByID возвращает заголовок одного вложения с краткой инфо родительской
+// заявки для детального экрана "Доступные мне" (#706). Проекция совпадает с листингом
+// (availableAttachmentSelect), без предиката доступа: вызывающий хендлер уже проверил видимость
+// через CanSecurityViewAttachment. nil без ошибки означает "вложение не найдено" (явный сигнал
+// для 404, реальные ошибки БД пробрасываются).
+func (s *applicationService) GetAvailableAttachmentByID(ctx context.Context, attachmentID int) (*AvailableAttachment, error) {
+	sql := `SELECT ` + availableAttachmentSelect + `
+		FROM attachments a
+		JOIN applications app ON app.id = a.application_id
+		LEFT JOIN organizations o ON o.id = app.organization_id
+		LEFT JOIN companies c ON c.id = app.company_id
+		LEFT JOIN users su ON su.id = app.sender_user_id
+		WHERE a.id = ?`
+
+	var row AvailableAttachment
+	if err := s.db.WithContext(ctx).Raw(sql, attachmentID).Scan(&row).Error; err != nil {
+		return nil, fmt.Errorf("failed to fetch available attachment: %w", err)
+	}
+	if row.AttachmentID == 0 {
+		return nil, nil
+	}
+	return &row, nil
+}


### PR DESCRIPTION
Срез BE-S4 эпика #706. Охранники ЧОП и супер-админ получают список доступных вложений и деталь вложения.

## Что добавлено
- `GET /api/applications/available-attachments` - пагинированный список вложений подтверждённых заявок, совпавших по месту. Ролевой гейт: только `security` (по `user_types.code`) или супер-админ, прочим типам 403. Отдаётся через `RespondPaginated`.
- `GET /api/applications/available-attachments/:id` - деталь вложения: заголовок заявки плюс автомобили/сотрудников/ТМЦ по типу. Чужое вложение закрывается через `CanSecurityViewAttachment` (403). Порядок: ролевой гейт -> доступ к объекту -> fetch.
- Тонкий сервис-метод `GetAvailableAttachmentByID` (заголовок для детали, та же проекция, что и листинг) + запись в интерфейс `ApplicationService`.
- Роуты в `internal/router/router.go` зарегистрированы до `/:id`, статический сегмент не перехватывается wildcard'ом.

Логика фильтрации (BE-S3, инвариант пересечения мест + confirmation) уже смержена и переиспользуется.

## Тесты
HTTP-тесты в `internal/handlers` (единственный DB-тест-бинарь, урок #706/#710): ролевой гейт (обычный user -> 403, охранник/админ -> 200), пагинация meta (total/page/per_page), доступ к детали (своё 200, чужое 403, обычный user 403, супер-админ видит любое подтверждённое), контент по типу (cars/people/items).

Прогон полного `go test ./...` зелёный.

## Ревью
Прошёл `code-reviewer`, вердикт go без блокеров. Закрыты два замечания отдельным коммитом: default-ветка в switch по типу вложения (устойчивость к новому типу) и экспорт DTO ответа детали для корректной swagger-схемы.