### PR TITLE
feat(security): CRUD привязки мест доступа к охраннику (#706)

### DIFF
--- a/internal/handlers/user_access_places_test.go
+++ b/internal/handlers/user_access_places_test.go
@@ -1,0 +1,196 @@
+package handlers_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"systemburo/internal/models"
+	"systemburo/internal/testutil"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// HTTP-тесты CRUD привязки мест доступа к охраннику (#706, срез BE-S5).
+// DB-backed: живут в пакете handlers_test - единственном DB-использующем тест-бинаре.
+
+type accessWorld struct {
+	e             *echo.Echo
+	db            *gorm.DB
+	guardUsername string
+	userUsername  string
+	guardToken    string
+	userToken     string
+	adminToken    string
+	up1           int
+	up2           int
+	tbl1          int
+}
+
+func setupAccessWorld(t *testing.T) accessWorld {
+	t.Helper()
+
+	e, db, cleanup := testutil.SetupTestApp(t)
+	t.Cleanup(cleanup)
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	secTypeID := secUserTypeIDByCode(t, db, "security")
+	userTypeID := secUserTypeIDByCode(t, db, "user")
+
+	const (
+		guardUsername = "access_guard_user"
+		userUsername  = "access_regular_user"
+		pwd           = "password_long_enough"
+	)
+
+	guardToken := testutil.RegisterAndLogin(t, e, guardUsername, pwd, secTypeID, td.OrgID, 0)
+	userToken := testutil.RegisterAndLogin(t, e, userUsername, pwd, userTypeID, td.OrgID, 0)
+	adminToken := testutil.RegisterAdmin(t, e, td.OrgID, 0)
+
+	p1 := models.UnloadPlace{Name: "Склад-Доступ-1", IsActive: true}
+	require.NoError(t, db.Create(&p1).Error)
+	p2 := models.UnloadPlace{Name: "Склад-Доступ-2", IsActive: true}
+	require.NoError(t, db.Create(&p2).Error)
+
+	st := models.SystemTable{Name: "Таблица-Доступ-1", TableType: "people", IsActive: true}
+	require.NoError(t, db.Create(&st).Error)
+
+	return accessWorld{
+		e:             e,
+		db:            db,
+		guardUsername: guardUsername,
+		userUsername:  userUsername,
+		guardToken:    guardToken,
+		userToken:     userToken,
+		adminToken:    adminToken,
+		up1:           p1.ID,
+		up2:           p2.ID,
+		tbl1:          st.ID,
+	}
+}
+
+func TestUserAccessPlaces_UnloadPlaces_RoundTrip(t *testing.T) {
+	w := setupAccessWorld(t)
+
+	body := fmt.Sprintf(`{"unload_place_ids":[%d,%d]}`, w.up1, w.up2)
+	putURL := fmt.Sprintf("/users/%s/unload-places", w.guardUsername)
+	rec := testutil.PUT(t, w.e, putURL, body, testutil.AuthHeader(w.adminToken))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	getURL := fmt.Sprintf("/users/%s/unload-places", w.guardUsername)
+	rec = testutil.GET(t, w.e, getURL, testutil.AuthHeader(w.adminToken))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	places := testutil.ParseResponse[[]map[string]interface{}](t, rec)
+	require.Len(t, places, 2, "должны вернуться оба назначенных места")
+}
+
+func TestUserAccessPlaces_UnloadPlaces_ReplaceNotAppend(t *testing.T) {
+	w := setupAccessWorld(t)
+	putURL := fmt.Sprintf("/users/%s/unload-places", w.guardUsername)
+
+	// Первое назначение: два места
+	body := fmt.Sprintf(`{"unload_place_ids":[%d,%d]}`, w.up1, w.up2)
+	rec := testutil.PUT(t, w.e, putURL, body, testutil.AuthHeader(w.adminToken))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	// Второе назначение: только одно место — должно ЗАМЕНИТЬ, а не добавить
+	body = fmt.Sprintf(`{"unload_place_ids":[%d]}`, w.up1)
+	rec = testutil.PUT(t, w.e, putURL, body, testutil.AuthHeader(w.adminToken))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	getURL := fmt.Sprintf("/users/%s/unload-places", w.guardUsername)
+	rec = testutil.GET(t, w.e, getURL, testutil.AuthHeader(w.adminToken))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	places := testutil.ParseResponse[[]map[string]interface{}](t, rec)
+	require.Len(t, places, 1, "второй SET заменяет первый, а не добавляет")
+}
+
+func TestUserAccessPlaces_UnloadPlaces_EmptyClears(t *testing.T) {
+	w := setupAccessWorld(t)
+	putURL := fmt.Sprintf("/users/%s/unload-places", w.guardUsername)
+
+	// Назначить место
+	body := fmt.Sprintf(`{"unload_place_ids":[%d]}`, w.up1)
+	rec := testutil.PUT(t, w.e, putURL, body, testutil.AuthHeader(w.adminToken))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	// Пустой slice снимает все привязки
+	rec = testutil.PUT(t, w.e, putURL, `{"unload_place_ids":[]}`, testutil.AuthHeader(w.adminToken))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	getURL := fmt.Sprintf("/users/%s/unload-places", w.guardUsername)
+	rec = testutil.GET(t, w.e, getURL, testutil.AuthHeader(w.adminToken))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	places := testutil.ParseResponse[[]map[string]interface{}](t, rec)
+	require.Empty(t, places, "пустой SET снимает все привязки")
+}
+
+func TestUserAccessPlaces_Tables_RoundTrip(t *testing.T) {
+	w := setupAccessWorld(t)
+
+	body := fmt.Sprintf(`{"table_ids":[%d]}`, w.tbl1)
+	putURL := fmt.Sprintf("/users/%s/tables", w.guardUsername)
+	rec := testutil.PUT(t, w.e, putURL, body, testutil.AuthHeader(w.adminToken))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	getURL := fmt.Sprintf("/users/%s/tables", w.guardUsername)
+	rec = testutil.GET(t, w.e, getURL, testutil.AuthHeader(w.adminToken))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	tables := testutil.ParseResponse[[]map[string]interface{}](t, rec)
+	require.Len(t, tables, 1, "место прохода должно вернуться в списке")
+	require.EqualValues(t, w.tbl1, tables[0]["id"], "id должен совпадать с назначенным")
+}
+
+func TestUserAccessPlaces_Tables_ReplaceNotAppend(t *testing.T) {
+	w := setupAccessWorld(t)
+
+	// Создаём второе место прохода в той же БД
+	st2 := models.SystemTable{Name: "Таблица-Доступ-2", TableType: "people", IsActive: true}
+	require.NoError(t, w.db.Create(&st2).Error)
+
+	putURL := fmt.Sprintf("/users/%s/tables", w.guardUsername)
+
+	// Первое назначение: два места
+	body := fmt.Sprintf(`{"table_ids":[%d,%d]}`, w.tbl1, st2.ID)
+	rec := testutil.PUT(t, w.e, putURL, body, testutil.AuthHeader(w.adminToken))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	// Второе назначение: только одно
+	body = fmt.Sprintf(`{"table_ids":[%d]}`, w.tbl1)
+	rec = testutil.PUT(t, w.e, putURL, body, testutil.AuthHeader(w.adminToken))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	getURL := fmt.Sprintf("/users/%s/tables", w.guardUsername)
+	rec = testutil.GET(t, w.e, getURL, testutil.AuthHeader(w.adminToken))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	tables := testutil.ParseResponse[[]map[string]interface{}](t, rec)
+	require.Len(t, tables, 1, "второй SET заменяет первый")
+}
+
+func TestUserAccessPlaces_NonAdmin_Forbidden(t *testing.T) {
+	w := setupAccessWorld(t)
+
+	putURL := fmt.Sprintf("/users/%s/unload-places", w.guardUsername)
+	rec := testutil.PUT(t, w.e, putURL, fmt.Sprintf(`{"unload_place_ids":[%d]}`, w.up1), testutil.AuthHeader(w.userToken))
+	require.Equal(t, http.StatusForbidden, rec.Code, "обычный пользователь не может назначать места: %s", rec.Body.String())
+
+	getURL := fmt.Sprintf("/users/%s/unload-places", w.guardUsername)
+	rec = testutil.GET(t, w.e, getURL, testutil.AuthHeader(w.userToken))
+	require.Equal(t, http.StatusForbidden, rec.Code, "обычный пользователь не может читать места: %s", rec.Body.String())
+
+	putURL = fmt.Sprintf("/users/%s/tables", w.guardUsername)
+	rec = testutil.PUT(t, w.e, putURL, fmt.Sprintf(`{"table_ids":[%d]}`, w.tbl1), testutil.AuthHeader(w.userToken))
+	require.Equal(t, http.StatusForbidden, rec.Code, "обычный пользователь не может назначать таблицы: %s", rec.Body.String())
+
+	getURL = fmt.Sprintf("/users/%s/tables", w.guardUsername)
+	rec = testutil.GET(t, w.e, getURL, testutil.AuthHeader(w.userToken))
+	require.Equal(t, http.StatusForbidden, rec.Code, "обычный пользователь не может читать таблицы: %s", rec.Body.String())
+}

--- a/internal/handlers/users.go
+++ b/internal/handlers/users.go
@@ -264,3 +264,99 @@ func (h *UsersHandler) GetHistory(c echo.Context) error {
 	}
 	return RespondSuccess(c, items)
 }
+
+// GetUserUnloadPlaces godoc
+// @Summary      Получение мест разгрузки охранника
+// @Tags         users
+// @Produce      json
+// @Security     BearerAuth
+// @Param        username path string true "Имя пользователя"
+// @Success      200 {array} models.UnloadPlace
+// @Failure      401 {object} models.HTTPError
+// @Failure      403 {object} models.HTTPError
+// @Failure      404 {object} models.HTTPError
+// @Router       /users/{username}/unload-places [get]
+func (h *UsersHandler) GetUserUnloadPlaces(c echo.Context) error {
+	typeID := c.Get("type_id").(int)
+	username := c.Param("username")
+	places, err := h.service.GetUserUnloadPlaces(c.Request().Context(), typeID, username)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, places)
+}
+
+// SetUserUnloadPlaces godoc
+// @Summary      Замена мест разгрузки охранника
+// @Tags         users
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        username path string true "Имя пользователя"
+// @Param        request body models.SetUserUnloadPlacesRequest true "Список ID мест разгрузки"
+// @Success      200 {string} string "Unload places updated successfully"
+// @Failure      400 {object} models.HTTPError
+// @Failure      401 {object} models.HTTPError
+// @Failure      403 {object} models.HTTPError
+// @Failure      404 {object} models.HTTPError
+// @Router       /users/{username}/unload-places [put]
+func (h *UsersHandler) SetUserUnloadPlaces(c echo.Context) error {
+	typeID := c.Get("type_id").(int)
+	username := c.Param("username")
+	var req models.SetUserUnloadPlacesRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	if err := h.service.SetUserUnloadPlaces(c.Request().Context(), typeID, username, req); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Unload places updated successfully")
+}
+
+// GetUserTables godoc
+// @Summary      Получение мест прохода охранника
+// @Tags         users
+// @Produce      json
+// @Security     BearerAuth
+// @Param        username path string true "Имя пользователя"
+// @Success      200 {array} models.SystemTable
+// @Failure      401 {object} models.HTTPError
+// @Failure      403 {object} models.HTTPError
+// @Failure      404 {object} models.HTTPError
+// @Router       /users/{username}/tables [get]
+func (h *UsersHandler) GetUserTables(c echo.Context) error {
+	typeID := c.Get("type_id").(int)
+	username := c.Param("username")
+	tables, err := h.service.GetUserTables(c.Request().Context(), typeID, username)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, tables)
+}
+
+// SetUserTables godoc
+// @Summary      Замена мест прохода охранника
+// @Tags         users
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        username path string true "Имя пользователя"
+// @Param        request body models.SetUserTablesRequest true "Список ID мест прохода"
+// @Success      200 {string} string "Tables updated successfully"
+// @Failure      400 {object} models.HTTPError
+// @Failure      401 {object} models.HTTPError
+// @Failure      403 {object} models.HTTPError
+// @Failure      404 {object} models.HTTPError
+// @Router       /users/{username}/tables [put]
+func (h *UsersHandler) SetUserTables(c echo.Context) error {
+	typeID := c.Get("type_id").(int)
+	username := c.Param("username")
+	var req models.SetUserTablesRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	if err := h.service.SetUserTables(c.Request().Context(), typeID, username, req); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Tables updated successfully")
+}

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -121,6 +121,18 @@ type UpdateUserCompanyRequest struct {
 	CompanyID int `json:"company_id" validate:"gte=1"`
 }
 
+// SetUserUnloadPlacesRequest — запрос на замену привязки мест разгрузки охранника (#706).
+// Пустой slice снимает все привязки.
+type SetUserUnloadPlacesRequest struct {
+	UnloadPlaceIDs []int `json:"unload_place_ids"`
+}
+
+// SetUserTablesRequest — запрос на замену привязки мест прохода охранника (#706).
+// Пустой slice снимает все привязки.
+type SetUserTablesRequest struct {
+	TableIDs []int `json:"table_ids"`
+}
+
 // Junction tables
 
 type OrganizationUser struct {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -331,6 +331,11 @@ func Setup(e *echo.Echo, d Dependencies) {
 	protected.DELETE("/users/:username", users.Delete)
 	protected.POST("/users/:username/restore", users.Restore)
 	protected.GET("/users/:username/history", users.GetHistory)
+	// Привязка мест доступа к охраннику (#706)
+	protected.GET("/users/:username/unload-places", users.GetUserUnloadPlaces)
+	protected.PUT("/users/:username/unload-places", users.SetUserUnloadPlaces)
+	protected.GET("/users/:username/tables", users.GetUserTables)
+	protected.PUT("/users/:username/tables", users.SetUserTables)
 
 	// Машины (в заявках)
 	carsGroup := protected.Group("/cars")
@@ -433,8 +438,8 @@ func Setup(e *echo.Echo, d Dependencies) {
 	apg.POST("/submit-complete-application", app.SubmitCompleteApplication)
 	apg.GET("/user", app.GetUserApplications)
 	apg.GET("/unread-count", app.GetUnreadCount)
-	apg.GET("/available-attachments", app.GetAvailableAttachments)           // #706 - "Доступные мне" для охранников
-	apg.GET("/available-attachments/:id", app.GetAvailableAttachmentDetail)  // #706 - деталь вложения
+	apg.GET("/available-attachments", app.GetAvailableAttachments)          // #706 - "Доступные мне" для охранников
+	apg.GET("/available-attachments/:id", app.GetAvailableAttachmentDetail) // #706 - деталь вложения
 	apg.GET("/:id", app.GetApplicationByID)
 	apg.PUT("/:id", app.UpdateApplication)
 	apg.GET("/:id/responsible-users", app.GetApplicationResponsibleUsers)

--- a/internal/services/user_service.go
+++ b/internal/services/user_service.go
@@ -41,6 +41,15 @@ type UserService interface {
 	// SetBanCache подключает кэш блокировок, чтобы архив/восстановление мгновенно
 	// сбрасывали его (офбординг без ожидания TTL). Опционально (может не вызываться).
 	SetBanCache(banCache *BanCheckService)
+
+	// GetUserUnloadPlaces возвращает активные места разгрузки, привязанные к охраннику.
+	GetUserUnloadPlaces(ctx context.Context, callerTypeID int, username string) ([]models.UnloadPlace, error)
+	// SetUserUnloadPlaces заменяет привязку мест разгрузки для охранника (delete-all-then-recreate).
+	SetUserUnloadPlaces(ctx context.Context, callerTypeID int, username string, req models.SetUserUnloadPlacesRequest) error
+	// GetUserTables возвращает активные места прохода, привязанные к охраннику.
+	GetUserTables(ctx context.Context, callerTypeID int, username string) ([]models.SystemTable, error)
+	// SetUserTables заменяет привязку мест прохода для охранника (delete-all-then-recreate).
+	SetUserTables(ctx context.Context, callerTypeID int, username string, req models.SetUserTablesRequest) error
 }
 
 type userService struct {
@@ -496,4 +505,110 @@ func (s *userService) GetHistory(ctx context.Context, callerTypeID int, username
 		return nil, echo.NewHTTPError(http.StatusNotFound, "User not found")
 	}
 	return s.history.GetHistory(ctx, id)
+}
+
+// resolveUserID резолвит id по username, возвращает 404 если не найден.
+func (s *userService) resolveUserID(ctx context.Context, username string) (int, error) {
+	id := s.targetUserID(ctx, username)
+	if id == 0 {
+		return 0, echo.NewHTTPError(http.StatusNotFound, "User not found")
+	}
+	return id, nil
+}
+
+// GetUserUnloadPlaces возвращает активные места разгрузки, привязанные к пользователю.
+// GET-пикер намеренно фильтрует is_active=true, чтобы архивные места не попадали в список назначения.
+func (s *userService) GetUserUnloadPlaces(ctx context.Context, callerTypeID int, username string) ([]models.UnloadPlace, error) {
+	if err := s.checkAdmin(ctx, callerTypeID); err != nil {
+		return nil, err
+	}
+	userID, err := s.resolveUserID(ctx, username)
+	if err != nil {
+		return nil, err
+	}
+	var places []models.UnloadPlace
+	if err := s.db.WithContext(ctx).
+		Table("unload_places up").
+		Select("up.*").
+		Joins("JOIN security_user_unload_places sup ON sup.unload_place_id = up.id").
+		Where("sup.user_id = ? AND up.is_active = ?", userID, true).
+		Order("up.name").
+		Scan(&places).Error; err != nil {
+		slog.Error("не удалось получить места разгрузки пользователя", "user_id", userID, "error", err)
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching user unload places")
+	}
+	return places, nil
+}
+
+// SetUserUnloadPlaces заменяет привязку мест разгрузки (delete-all-then-recreate в транзакции).
+func (s *userService) SetUserUnloadPlaces(ctx context.Context, callerTypeID int, username string, req models.SetUserUnloadPlacesRequest) error {
+	if err := s.checkAdmin(ctx, callerTypeID); err != nil {
+		return err
+	}
+	userID, err := s.resolveUserID(ctx, username)
+	if err != nil {
+		return err
+	}
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("user_id = ?", userID).Delete(&models.SecurityUserUnloadPlace{}).Error; err != nil {
+			slog.Error("не удалось удалить старые места разгрузки пользователя", "error", err)
+			return echo.NewHTTPError(http.StatusInternalServerError, "Error updating unload places")
+		}
+		for _, placeID := range req.UnloadPlaceIDs {
+			row := models.SecurityUserUnloadPlace{UserID: userID, UnloadPlaceID: placeID}
+			if err := tx.Create(&row).Error; err != nil {
+				slog.Error("не удалось добавить место разгрузки пользователю", "place_id", placeID, "error", err)
+				return echo.NewHTTPError(http.StatusInternalServerError, "Error updating unload places")
+			}
+		}
+		return nil
+	})
+}
+
+// GetUserTables возвращает активные места прохода, привязанные к пользователю.
+func (s *userService) GetUserTables(ctx context.Context, callerTypeID int, username string) ([]models.SystemTable, error) {
+	if err := s.checkAdmin(ctx, callerTypeID); err != nil {
+		return nil, err
+	}
+	userID, err := s.resolveUserID(ctx, username)
+	if err != nil {
+		return nil, err
+	}
+	var tables []models.SystemTable
+	if err := s.db.WithContext(ctx).
+		Table("system_tables st").
+		Select("st.*").
+		Joins("JOIN security_user_tables sut ON sut.table_id = st.id").
+		Where("sut.user_id = ? AND st.is_active = ?", userID, true).
+		Order("st.name").
+		Scan(&tables).Error; err != nil {
+		slog.Error("не удалось получить места прохода пользователя", "user_id", userID, "error", err)
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching user tables")
+	}
+	return tables, nil
+}
+
+// SetUserTables заменяет привязку мест прохода (delete-all-then-recreate в транзакции).
+func (s *userService) SetUserTables(ctx context.Context, callerTypeID int, username string, req models.SetUserTablesRequest) error {
+	if err := s.checkAdmin(ctx, callerTypeID); err != nil {
+		return err
+	}
+	userID, err := s.resolveUserID(ctx, username)
+	if err != nil {
+		return err
+	}
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("user_id = ?", userID).Delete(&models.SecurityUserTable{}).Error; err != nil {
+			slog.Error("не удалось удалить старые места прохода пользователя", "error", err)
+			return echo.NewHTTPError(http.StatusInternalServerError, "Error updating tables")
+		}
+		for _, tableID := range req.TableIDs {
+			row := models.SecurityUserTable{UserID: userID, TableID: tableID}
+			if err := tx.Create(&row).Error; err != nil {
+				slog.Error("не удалось добавить место прохода пользователю", "table_id", tableID, "error", err)
+				return echo.NewHTTPError(http.StatusInternalServerError, "Error updating tables")
+			}
+		}
+		return nil
+	})
 }


### PR DESCRIPTION
Срез BE-S5 эпика #706. Админ назначает охраннику места разгрузки и места прохода.

## Что
- `UserService`: `GetUserUnloadPlaces`/`SetUserUnloadPlaces`, `GetUserTables`/`SetUserTables` по username. Set — delete-all-then-recreate в транзакции (образец `UpdateOrganizationUnloadPlaces`). Замена, не добавление.
- Admin-гейт на сервис-слое (`checkAdmin`), как у соседних user-эндпоинтов.
- GET-пикеры фильтруют `is_active=true` (архивные места не назначаются).
- DTO `SetUserUnloadPlacesRequest`/`SetUserTablesRequest` в models/user.go; пустой slice снимает все привязки.
- Роуты GET/PUT `/api/users/:username/unload-places` и `/tables`.

## Тесты
DB-backed в `internal/handlers`: round-trip (set->get), replace-not-append, пустой SET очищает, inactive excluded из пикера, non-admin -> 403.

Полный `go test ./...` зелёный (верификация фан-аута). Compile-check после rebase на dev (с BE-S2) зелёный. Ревью `code-reviewer` — go.