### PR TITLE
feat(security): auth-гейт security в сторе (#706)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -91,11 +91,12 @@ export default {
   },
   created() {
     // tryRestoreSession вызывается в main.js ДО mount - auth уже hydrated.
-    // Здесь остаётся только загрузить permissions если юзер залогинен.
+    // Здесь остаётся только загрузить permissions и userTypeCode если юзер залогинен.
     const authStore = useAuthStore()
     if (authStore.token) {
       const permissionsStore = usePermissionsStore()
       permissionsStore.fetchPermissions()
+      authStore.loadUserTypeCode()
     }
   },
   methods: {
@@ -104,6 +105,7 @@ export default {
       authStore.setTokens(tokenData.token)
       const permissionsStore = usePermissionsStore()
       permissionsStore.fetchPermissions()
+      authStore.loadUserTypeCode()
     },
 
     async logout() {

--- a/frontend/src/stores/__tests__/auth.spec.js
+++ b/frontend/src/stores/__tests__/auth.spec.js
@@ -1,6 +1,10 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
 import { useAuthStore } from '../auth';
+
+vi.mock('@/api/auth', () => ({
+  getMe: vi.fn(),
+}));
 
 function createMockJWT(payload, expiresInSeconds = 3600) {
   const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
@@ -35,6 +39,14 @@ describe('auth store', () => {
       store.clearTokens();
 
       expect(store.token).toBeNull();
+    });
+
+    it('сбрасывает userTypeCode в null', () => {
+      const store = useAuthStore();
+      store.userTypeCode = 'security';
+      store.clearTokens();
+
+      expect(store.userTypeCode).toBeNull();
     });
   });
 
@@ -101,6 +113,70 @@ describe('auth store', () => {
       const store = useAuthStore();
       store.setTokens(createMockJWT({ username: 'testuser' }));
       expect(store.username).toBe('testuser');
+    });
+  });
+
+  describe('isSecurity', () => {
+    it('возвращает true когда userTypeCode равен security', () => {
+      const store = useAuthStore();
+      store.userTypeCode = 'security';
+      expect(store.isSecurity).toBe(true);
+    });
+
+    it('возвращает false для другого кода типа', () => {
+      const store = useAuthStore();
+      store.userTypeCode = 'admin';
+      expect(store.isSecurity).toBe(false);
+    });
+
+    it('возвращает false когда userTypeCode не загружен', () => {
+      const store = useAuthStore();
+      expect(store.isSecurity).toBe(false);
+    });
+  });
+
+  describe('canViewAccessibleAttachments', () => {
+    it('возвращает true для охранника', () => {
+      const store = useAuthStore();
+      store.userTypeCode = 'security';
+      expect(store.canViewAccessibleAttachments).toBe(true);
+    });
+
+    it('возвращает true для супер-админа', () => {
+      const store = useAuthStore();
+      store.setTokens(createMockJWT({ is_super_admin: true }));
+      expect(store.canViewAccessibleAttachments).toBe(true);
+    });
+
+    it('возвращает false для обычного пользователя', () => {
+      const store = useAuthStore();
+      store.setTokens(createMockJWT({ type_id: 2 }));
+      store.userTypeCode = 'user';
+      expect(store.canViewAccessibleAttachments).toBe(false);
+    });
+  });
+
+  describe('loadUserTypeCode', () => {
+    it('загружает и сохраняет user_type_code из getMe', async () => {
+      const { getMe } = await import('@/api/auth');
+      getMe.mockResolvedValue({
+        json: async () => ({ user_type_code: 'security' }),
+      });
+
+      const store = useAuthStore();
+      await store.loadUserTypeCode();
+
+      expect(store.userTypeCode).toBe('security');
+    });
+
+    it('оставляет null при ошибке сети', async () => {
+      const { getMe } = await import('@/api/auth');
+      getMe.mockRejectedValue(new Error('network error'));
+
+      const store = useAuthStore();
+      await store.loadUserTypeCode();
+
+      expect(store.userTypeCode).toBeNull();
     });
   });
 });

--- a/frontend/src/stores/__tests__/auth.spec.js
+++ b/frontend/src/stores/__tests__/auth.spec.js
@@ -159,9 +159,9 @@ describe('auth store', () => {
   describe('loadUserTypeCode', () => {
     it('загружает и сохраняет user_type_code из getMe', async () => {
       const { getMe } = await import('@/api/auth');
-      getMe.mockResolvedValue({
-        json: async () => ({ user_type_code: 'security' }),
-      });
+      // getMe уже возвращает распарсенные данные (envelope снят в client.js),
+      // мок отдаёт plain-объект, а не Response-like - иначе тест зелёный на сломанном коде.
+      getMe.mockResolvedValue({ user_type_code: 'security' });
 
       const store = useAuthStore();
       await store.loadUserTypeCode();

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -64,8 +64,9 @@ export const useAuthStore = defineStore('auth', {
     },
     async loadUserTypeCode() {
       try {
-        const res = await getMe();
-        const data = await res.json();
+        // getMe() уже снимает envelope и возвращает данные (как getMyPermissions);
+        // повторный .json() здесь дал бы TypeError и userTypeCode остался бы null.
+        const data = await getMe();
         this.userTypeCode = data?.user_type_code ?? null;
       } catch {
         // сеть упала или токен протух - оставляем null, не блокируем рендер

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia';
+import { getMe } from '@/api/auth';
 
 function decodeToken(token) {
   try {
@@ -14,6 +15,9 @@ function decodeToken(token) {
 export const useAuthStore = defineStore('auth', {
   state: () => ({
     token: null,
+    // Код типа пользователя из /users/me (стабильный, не type_id).
+    // null до первой загрузки.
+    userTypeCode: null,
   }),
 
   getters: {
@@ -42,6 +46,12 @@ export const useAuthStore = defineStore('auth', {
     username() {
       return this.userPayload?.username || null;
     },
+    isSecurity() {
+      return this.userTypeCode === 'security';
+    },
+    canViewAccessibleAttachments() {
+      return this.isSecurity || this.isSuperAdmin;
+    },
   },
 
   actions: {
@@ -50,6 +60,16 @@ export const useAuthStore = defineStore('auth', {
     },
     clearTokens() {
       this.token = null;
+      this.userTypeCode = null;
+    },
+    async loadUserTypeCode() {
+      try {
+        const res = await getMe();
+        const data = await res.json();
+        this.userTypeCode = data?.user_type_code ?? null;
+      } catch {
+        // сеть упала или токен протух - оставляем null, не блокируем рендер
+      }
     },
   },
 });


### PR DESCRIPTION
Срез FE-S1 эпика #706. Фронтовый гейт для вкладки "Доступные мне".

## Что
- `stores/auth.js`: state `userTypeCode` (стабильный код типа из `/users/me`, не type_id), action `loadUserTypeCode()`, геттеры `isSecurity` (code==='security') и `canViewAccessibleAttachments` (isSecurity || isSuperAdmin), сброс в `clearTokens`.
- `App.vue`: гидрация `loadUserTypeCode()` в created и handleSuccessfulLogin (fire-and-forget, рядом с fetchPermissions).
- vitest: isSecurity, canViewAccessibleAttachments (security + super-admin), clearTokens, loadUserTypeCode (успех/ошибка сети).

## Ревью
Фан-аут вернул no-go: `loadUserTypeCode` делал двойной `.json()` (getMe уже отдаёт распарсенные данные, как getMyPermissions) -> TypeError -> userTypeCode навсегда null; тест мокал getMe как Response-объект и был зелёным на сломанном коде. Поправил отдельным коммитом: убрал второй `.json()`, мок переведён на plain-объект под реальный контракт. Пустой catch оставлен осознанно - идиома соседнего fetchPermissions (fire-and-forget hydration).

vitest 21/21, eslint чистый.