### PR TITLE
feat(analytics): плитка "Пользователей онлайн" открывает модалку со списком (#632)

### DIFF
--- a/frontend/src/api/statistics.js
+++ b/frontend/src/api/statistics.js
@@ -69,6 +69,23 @@ export async function getOnlinePeaks(from, to) {
 }
 
 /**
+ * Получить список пользователей онлайн (активность за окно онлайна), по убыванию
+ * свежести last_seen. Потребитель — модалка «кто онлайн» по клику на плитку дашборда.
+ * @returns {Promise<Array<{
+ *   id: number,
+ *   login: string,
+ *   full_name: string,
+ *   role: string,
+ *   user_type: string,
+ *   last_seen: string,
+ * }>>}
+ */
+export async function getOnlineUsers() {
+  const res = await apiRequest('/statistics/online-users');
+  return res.json();
+}
+
+/**
  * Получить последние проходы/проезды.
  * @param {number} [limit=15] - максимальное количество записей на тип
  * @returns {Promise<{

--- a/frontend/src/components/statistics/OnlineUsersModal.vue
+++ b/frontend/src/components/statistics/OnlineUsersModal.vue
@@ -1,0 +1,351 @@
+<template>
+  <teleport to="body">
+    <transition name="ou-modal">
+      <div
+        v-if="show"
+        class="ou-overlay"
+        @mousedown="onOverlayMousedown"
+        @mouseup="onOverlayMouseup"
+      >
+        <div
+          ref="dialogRef"
+          class="ou-modal"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Пользователи онлайн"
+          tabindex="-1"
+          @mousedown.stop
+        >
+          <div class="ou-modal__header">
+            <h3 class="ou-modal__title">
+              Пользователи онлайн<span
+                v-if="!loading && !error"
+                class="ou-modal__count"
+              > · {{ users.length }}</span>
+            </h3>
+            <button
+              class="ou-modal__close"
+              type="button"
+              aria-label="Закрыть"
+              @click="emit('close')"
+            >
+              &times;
+            </button>
+          </div>
+
+          <div class="ou-modal__body">
+            <div
+              v-if="loading"
+              class="ou-modal__state"
+            >
+              <LoaderSpinner label="Загрузка списка…" />
+            </div>
+            <p
+              v-else-if="error"
+              class="ou-modal__state ou-modal__state--error"
+            >
+              {{ error }}
+            </p>
+            <p
+              v-else-if="!users.length"
+              class="ou-modal__state"
+            >
+              Сейчас никого онлайн
+            </p>
+            <ul
+              v-else
+              class="ou-list"
+            >
+              <li
+                v-for="u in users"
+                :key="u.id"
+                class="ou-row"
+              >
+                <span
+                  class="ou-row__dot"
+                  aria-hidden="true"
+                />
+                <div class="ou-row__main">
+                  <div class="ou-row__name">
+                    {{ u.full_name || u.login }}
+                  </div>
+                  <div class="ou-row__meta">
+                    <span
+                      v-if="roleType(u)"
+                      class="ou-row__role"
+                    >{{ roleType(u) }}</span>
+                    <span class="ou-row__login">@{{ u.login }}</span>
+                  </div>
+                </div>
+                <span class="ou-row__seen">{{ formatTimeAgo(u.last_seen) }}</span>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </transition>
+  </teleport>
+</template>
+
+<script setup>
+import { ref, watch, onMounted, onUnmounted, nextTick } from 'vue';
+import LoaderSpinner from '@/components/ui/LoaderSpinner.vue';
+import { useOverlayClose } from '@/composables/useOverlayClose';
+import { formatTimeAgo } from '@/utils/datetime.js';
+
+const props = defineProps({
+  show: { type: Boolean, required: true },
+  users: { type: Array, default: () => [] },
+  loading: { type: Boolean, default: false },
+  error: { type: String, default: '' },
+});
+const emit = defineEmits(['close']);
+
+const dialogRef = ref(null);
+const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(() => emit('close'));
+
+/** Подпись разреза: бизнес-роль приоритетнее, иначе тип пользователя. */
+function roleType(u) {
+  return u.role || u.user_type || '';
+}
+
+function onKeydown(e) {
+  if (props.show && e.key === 'Escape') emit('close');
+}
+
+// Блокируем прокрутку фона и переводим фокус в модалку при открытии (a11y).
+watch(
+  () => props.show,
+  (val) => {
+    document.body.style.overflow = val ? 'hidden' : '';
+    if (val) nextTick(() => dialogRef.value?.focus());
+  }
+);
+
+onMounted(() => document.addEventListener('keydown', onKeydown));
+onUnmounted(() => {
+  document.removeEventListener('keydown', onKeydown);
+  document.body.style.overflow = '';
+});
+</script>
+
+<style scoped>
+.ou-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 12000;
+  padding: 20px;
+  backdrop-filter: blur(0.1px);
+  -webkit-backdrop-filter: blur(0.1px);
+}
+
+.ou-modal {
+  background: #fff;
+  border-radius: 30px;
+  width: 460px;
+  max-width: 100%;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+  overflow: hidden;
+}
+
+/* .ou-modal — программная цель фокуса при открытии (tabindex=-1), рамку не показываем. */
+.ou-modal:focus {
+  outline: none;
+}
+
+.ou-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 24px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.ou-modal__title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.ou-modal__count {
+  color: var(--color-text-muted);
+  font-weight: 500;
+}
+
+.ou-modal__close {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+  line-height: 1;
+  color: var(--color-text-muted);
+  background: none;
+  border: none;
+  cursor: pointer;
+  border-radius: 50%;
+  flex-shrink: 0;
+  transition: color 0.15s, background 0.15s;
+}
+
+.ou-modal__close:hover {
+  color: var(--color-text);
+  background: var(--color-bg-secondary);
+}
+
+.ou-modal__body {
+  padding: 12px 16px;
+  overflow-y: auto;
+}
+
+.ou-modal__state {
+  margin: 0;
+  padding: 32px 8px;
+  text-align: center;
+  color: var(--color-text-muted);
+}
+
+.ou-modal__state--error {
+  color: var(--color-danger);
+}
+
+.ou-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.ou-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: var(--radius-md);
+}
+
+.ou-row + .ou-row {
+  margin-top: 2px;
+}
+
+.ou-row:hover {
+  background: var(--color-bg-secondary);
+}
+
+.ou-row__dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--color-success);
+  flex-shrink: 0;
+  box-shadow: 0 0 0 3px rgba(40, 167, 69, 0.15);
+}
+
+.ou-row__main {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.ou-row__name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ou-row__meta {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  margin-top: 2px;
+  font-size: 12px;
+  min-width: 0;
+}
+
+.ou-row__role {
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ou-row__login {
+  color: var(--color-primary);
+  flex-shrink: 0;
+}
+
+.ou-row__seen {
+  font-size: 12px;
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+/* Анимация открытия/закрытия: только opacity + transform. */
+.ou-modal-enter-active {
+  transition: opacity 0.25s ease;
+}
+.ou-modal-leave-active {
+  transition: opacity 0.2s ease;
+}
+.ou-modal-enter-from,
+.ou-modal-leave-to {
+  opacity: 0;
+}
+
+.ou-modal-enter-active .ou-modal {
+  animation: ou-scale-in 0.25s ease;
+}
+.ou-modal-leave-active .ou-modal {
+  animation: ou-scale-out 0.2s ease;
+}
+
+@keyframes ou-scale-in {
+  from {
+    transform: scale(0.96);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes ou-scale-out {
+  from {
+    transform: scale(1);
+    opacity: 1;
+  }
+  to {
+    transform: scale(0.96);
+    opacity: 0;
+  }
+}
+
+@media (max-width: 768px) {
+  .ou-overlay {
+    align-items: flex-end;
+    padding: 0;
+  }
+  .ou-modal {
+    width: 100%;
+    max-width: 100%;
+    max-height: 88vh;
+    border-radius: 24px 24px 0 0;
+  }
+  .ou-modal__close {
+    width: 40px;
+    height: 40px;
+  }
+}
+</style>

--- a/frontend/src/components/statistics/StatisticsDashboard.vue
+++ b/frontend/src/components/statistics/StatisticsDashboard.vue
@@ -186,7 +186,15 @@
         v-else
         class="dashboard__tiles"
       >
-        <div class="dashboard__tile">
+        <div
+          class="dashboard__tile dashboard__tile--clickable"
+          role="button"
+          tabindex="0"
+          aria-haspopup="dialog"
+          @click="openOnlineUsers"
+          @keydown.enter="openOnlineUsers"
+          @keydown.space.prevent="openOnlineUsers"
+        >
           <div class="dashboard__tile-label">Пользователей онлайн</div>
           <div class="dashboard__tile-val">{{ fmt(summary.users_online) }}</div>
         </div>
@@ -419,6 +427,14 @@
         </div>
       </div>
     </div>
+
+    <OnlineUsersModal
+      :show="onlineModalOpen"
+      :users="onlineUsers"
+      :loading="onlineUsersLoading"
+      :error="onlineUsersError"
+      @close="onlineModalOpen = false"
+    />
   </div>
 </template>
 
@@ -430,7 +446,8 @@ import DirIcon from '@/components/statistics/DirIcon.vue';
 import TrendSparkline from '@/components/statistics/TrendSparkline.vue';
 import TopList from '@/components/statistics/TopList.vue';
 import RefreshButton from '@/components/RefreshButton.vue';
-import { getSummary, getTimeline, getRecentPassages, getInsights, getOnlinePeaks } from '@/api/statistics.js';
+import OnlineUsersModal from '@/components/statistics/OnlineUsersModal.vue';
+import { getSummary, getTimeline, getRecentPassages, getInsights, getOnlinePeaks, getOnlineUsers } from '@/api/statistics.js';
 import { mergeFeed, feedRowKey } from './feedMerge.js';
 
 const props = defineProps({
@@ -466,6 +483,33 @@ const timelineLoading = ref(false);
 // Дневные пики онлайна за период (area-график под основным графиком).
 const onlinePeaks = ref([]);
 const onlinePeaksLoading = ref(false);
+
+// Модалка «кто онлайн» по клику на плитку «Пользователей онлайн».
+const onlineModalOpen = ref(false);
+const onlineUsers = ref([]);
+const onlineUsersLoading = ref(false);
+const onlineUsersError = ref('');
+// Токен последовательности: при быстром повторном открытии пишет только последний
+// запрос, медленный предыдущий ответ не затирает актуальный список (урок #632).
+let onlineUsersSeq = 0;
+
+async function openOnlineUsers() {
+  onlineModalOpen.value = true;
+  onlineUsersLoading.value = true;
+  onlineUsersError.value = '';
+  const seq = ++onlineUsersSeq;
+  try {
+    const list = await getOnlineUsers();
+    if (seq !== onlineUsersSeq) return;
+    onlineUsers.value = Array.isArray(list) ? list : [];
+  } catch {
+    if (seq !== onlineUsersSeq) return;
+    onlineUsers.value = [];
+    onlineUsersError.value = 'Не удалось загрузить список';
+  } finally {
+    if (seq === onlineUsersSeq) onlineUsersLoading.value = false;
+  }
+}
 
 const peopleFeed = ref([]);
 const carsFeed = ref([]);

--- a/frontend/src/components/statistics/__tests__/OnlineUsersModal.spec.js
+++ b/frontend/src/components/statistics/__tests__/OnlineUsersModal.spec.js
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import OnlineUsersModal from '../OnlineUsersModal.vue';
+
+// teleport: true оставляет контент модалки внутри wrapper, иначе он улетает в body.
+const mountModal = (props = {}) =>
+  mount(OnlineUsersModal, {
+    props: { show: true, ...props },
+    global: { stubs: { teleport: true, LoaderSpinner: true } },
+  });
+
+const USERS = [
+  { id: 1, login: 'ivanov', full_name: 'Иванов Иван Иванович', role: 'Руководитель', user_type: 'Арендатор', last_seen: new Date('2026-06-20T11:58:00Z').toISOString() },
+  { id: 2, login: 'petrov', full_name: '', role: '', user_type: 'Охранник', last_seen: new Date('2026-06-20T11:30:00Z').toISOString() },
+];
+
+describe('OnlineUsersModal', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('рендерит строку на каждого пользователя: ФИО, роль/тип, @логин', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-20T12:00:00Z'));
+
+    const wrapper = mountModal({ users: USERS });
+    const rows = wrapper.findAll('.ou-row');
+    expect(rows).toHaveLength(2);
+
+    expect(rows[0].text()).toContain('Иванов Иван Иванович');
+    expect(rows[0].text()).toContain('Руководитель');
+    expect(rows[0].text()).toContain('@ivanov');
+    expect(rows[0].text()).toContain('2 мин назад');
+
+    // нет ФИО -> заголовок = логин; нет роли -> показывается тип
+    expect(rows[1].text()).toContain('petrov');
+    expect(rows[1].text()).toContain('Охранник');
+    expect(rows[1].text()).toContain('30 мин назад');
+
+    // счётчик в заголовке
+    expect(wrapper.find('.ou-modal__count').text()).toContain('2');
+  });
+
+  it('пустой список -> "Сейчас никого онлайн", строк нет', () => {
+    const wrapper = mountModal({ users: [] });
+    expect(wrapper.findAll('.ou-row')).toHaveLength(0);
+    expect(wrapper.find('.ou-modal__state').text()).toBe('Сейчас никого онлайн');
+  });
+
+  it('ошибка -> текст ошибки, без счётчика', () => {
+    const wrapper = mountModal({ users: [], error: 'Не удалось загрузить список' });
+    expect(wrapper.find('.ou-modal__state--error').text()).toBe('Не удалось загрузить список');
+    expect(wrapper.find('.ou-modal__count').exists()).toBe(false);
+  });
+
+  it('loading -> спиннер вместо списка', () => {
+    const wrapper = mountModal({ loading: true });
+    expect(wrapper.findComponent({ name: 'LoaderSpinner' }).exists() || wrapper.find('loaderspinner-stub').exists()).toBe(true);
+    expect(wrapper.findAll('.ou-row')).toHaveLength(0);
+  });
+
+  it('show=false -> ничего не рендерит', () => {
+    const wrapper = mountModal({ show: false, users: USERS });
+    expect(wrapper.find('.ou-modal').exists()).toBe(false);
+  });
+
+  it('кнопка закрытия эмитит close', async () => {
+    const wrapper = mountModal({ users: [] });
+    await wrapper.find('.ou-modal__close').trigger('click');
+    expect(wrapper.emitted('close')).toHaveLength(1);
+  });
+
+  it('Escape эмитит close', async () => {
+    const wrapper = mountModal({ users: [] });
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    await wrapper.vm.$nextTick();
+    expect(wrapper.emitted('close')).toHaveLength(1);
+  });
+});

--- a/frontend/src/components/statistics/__tests__/StatisticsDashboard.spec.js
+++ b/frontend/src/components/statistics/__tests__/StatisticsDashboard.spec.js
@@ -5,7 +5,7 @@ import { nextTick } from 'vue';
 // Управляемое состояние моков: фабрика vi.mock поднимается над импортами,
 // поэтому summary/deferred выносим в hoisted.
 const { state } = vi.hoisted(() => ({
-  state: { deferred: [], summary: {}, insights: {}, onlinePeaks: [], insightsHang: false },
+  state: { deferred: [], onlineDeferred: [], summary: {}, insights: {}, onlinePeaks: [], insightsHang: false },
 }));
 
 vi.mock('@/api/statistics.js', () => ({
@@ -15,16 +15,19 @@ vi.mock('@/api/statistics.js', () => ({
   // insightsHang оставляет промис вечно pending — для проверки состояния загрузки.
   getInsights: () => (state.insightsHang ? new Promise(() => {}) : Promise.resolve(state.insights)),
   getOnlinePeaks: () => Promise.resolve(state.onlinePeaks),
+  // deferred: резолвим вручную в тестах, чтобы проверить гонку seq-токена.
+  getOnlineUsers: () => new Promise((resolve) => { state.onlineDeferred.push(resolve); }),
 }));
 
 import StatisticsDashboard from '../StatisticsDashboard.vue';
 import AnalyticsAreaChart from '../AnalyticsAreaChart.vue';
 import AnalyticsBarChart from '../AnalyticsBarChart.vue';
 import TrendSparkline from '../TrendSparkline.vue';
+import OnlineUsersModal from '../OnlineUsersModal.vue';
 
 const mountDashboard = () => mount(StatisticsDashboard, {
   props: { from: '2026-06-01', to: '2026-06-07' },
-  global: { stubs: { AnalyticsAreaChart: true, AnalyticsBarChart: true, RefreshButton: true } },
+  global: { stubs: { AnalyticsAreaChart: true, AnalyticsBarChart: true, RefreshButton: true, OnlineUsersModal: true } },
 });
 
 const tileByText = (wrapper, label) =>
@@ -32,6 +35,7 @@ const tileByText = (wrapper, label) =>
 
 beforeEach(() => {
   state.deferred.length = 0;
+  state.onlineDeferred.length = 0;
   state.summary = {};
   state.insights = {};
   state.onlinePeaks = [];
@@ -238,6 +242,63 @@ describe('StatisticsDashboard — топы за период', () => {
 
     expect(wrapper.findAll('.dashboard__top-skeleton')).toHaveLength(2);
     expect(wrapper.find('.top').exists()).toBe(false);
+  });
+});
+
+describe('StatisticsDashboard — плитка онлайна', () => {
+  it('плитка "Пользователей онлайн" кликабельна и доступна с клавиатуры', async () => {
+    const wrapper = mountDashboard();
+    await flushPromises();
+
+    const tile = tileByText(wrapper, 'Пользователей онлайн');
+    expect(tile.classes()).toContain('dashboard__tile--clickable');
+    expect(tile.attributes('role')).toBe('button');
+    expect(tile.attributes('tabindex')).toBe('0');
+    expect(tile.attributes('aria-haspopup')).toBe('dialog');
+  });
+
+  it('клик по плитке открывает модалку и прокидывает список из API', async () => {
+    const wrapper = mountDashboard();
+    await flushPromises();
+
+    const modal = wrapper.findComponent(OnlineUsersModal);
+    expect(modal.props('show')).toBe(false);
+
+    await tileByText(wrapper, 'Пользователей онлайн').trigger('click');
+    await nextTick();
+    // Пока запрос в полёте — модалка открыта в состоянии загрузки.
+    expect(modal.props('show')).toBe(true);
+    expect(modal.props('loading')).toBe(true);
+
+    state.onlineDeferred[0]([
+      { id: 1, login: 'ivanov', full_name: 'Иванов И.', role: 'Руководитель', user_type: 'Арендатор', last_seen: '2026-06-20T12:00:00Z' },
+    ]);
+    await flushPromises();
+
+    expect(modal.props('users')).toHaveLength(1);
+    expect(modal.props('users')[0].login).toBe('ivanov');
+    expect(modal.props('loading')).toBe(false);
+  });
+
+  it('повторное открытие: показывает список последнего запроса, устаревший игнорирует', async () => {
+    const wrapper = mountDashboard();
+    await flushPromises();
+    const tile = tileByText(wrapper, 'Пользователей онлайн');
+
+    await tile.trigger('click'); // seq 1
+    await tile.trigger('click'); // seq 2
+    await nextTick();
+    expect(state.onlineDeferred).toHaveLength(2);
+
+    // Последний запрос (seq 2) резолвится ПЕРВЫМ, устаревший seq 1 — позже.
+    state.onlineDeferred[1]([{ id: 2, login: 'fresh', full_name: '', role: '', user_type: '', last_seen: '2026-06-20T12:00:00Z' }]);
+    await flushPromises();
+    state.onlineDeferred[0]([{ id: 1, login: 'stale', full_name: '', role: '', user_type: '', last_seen: '2026-06-20T11:00:00Z' }]);
+    await flushPromises();
+
+    const modal = wrapper.findComponent(OnlineUsersModal);
+    expect(modal.props('users')).toHaveLength(1);
+    expect(modal.props('users')[0].login).toBe('fresh'); // не stale от устаревшего ответа
   });
 });
 

--- a/frontend/src/utils/__tests__/datetime.spec.js
+++ b/frontend/src/utils/__tests__/datetime.spec.js
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { formatDateRu } from '../datetime';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { formatDateRu, formatTimeAgo } from '../datetime';
 
 describe('formatDateRu', () => {
   it('YYYY-MM-DD -> дд.мм.гггг', () => {
@@ -21,5 +21,43 @@ describe('formatDateRu', () => {
     expect(formatDateRu('')).toBe('');
     expect(formatDateRu(null)).toBe('');
     expect(formatDateRu(undefined)).toBe('');
+  });
+});
+
+describe('formatTimeAgo', () => {
+  const NOW = new Date('2026-06-20T12:00:00Z');
+  const ago = (ms) => new Date(NOW.getTime() - ms).toISOString();
+  const MIN = 60_000;
+  const HOUR = 60 * MIN;
+  const DAY = 24 * HOUR;
+
+  afterEach(() => vi.useRealTimers());
+
+  it('меньше минуты (и будущее) -> "только что"', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    expect(formatTimeAgo(ago(10_000))).toBe('только что');
+    expect(formatTimeAgo(ago(-5_000))).toBe('только что');
+  });
+
+  it('минуты и часы', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    expect(formatTimeAgo(ago(3 * MIN))).toBe('3 мин назад');
+    expect(formatTimeAgo(ago(59 * MIN))).toBe('59 мин назад');
+    expect(formatTimeAgo(ago(2 * HOUR))).toBe('2 ч назад');
+  });
+
+  it('сутки и больше', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    expect(formatTimeAgo(ago(DAY))).toBe('вчера');
+    expect(formatTimeAgo(ago(3 * DAY))).toBe('3 дн назад');
+  });
+
+  it('пустое/невалидное -> пустая строка', () => {
+    expect(formatTimeAgo('')).toBe('');
+    expect(formatTimeAgo(null)).toBe('');
+    expect(formatTimeAgo('не дата')).toBe('');
   });
 });

--- a/frontend/src/utils/datetime.js
+++ b/frontend/src/utils/datetime.js
@@ -12,6 +12,28 @@ export function formatDateTime(value) {
 }
 
 /**
+ * Относительное «N назад» от now до момента value. Для last_seen онлайна и лент.
+ * Будущие/нулевые значения -> 'только что'. Считается в абсолютных интервалах
+ * (UTC-инстант), таймзона не влияет на «сколько прошло».
+ * @param {string|Date|null|undefined} value
+ * @returns {string}
+ */
+export function formatTimeAgo(value) {
+  if (!value) return '';
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return '';
+  const diffMs = Date.now() - d.getTime();
+  if (diffMs < 60000) return 'только что';
+  const mins = Math.floor(diffMs / 60000);
+  if (mins < 60) return `${mins} мин назад`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours} ч назад`;
+  const days = Math.floor(hours / 24);
+  if (days === 1) return 'вчера';
+  return `${days} дн назад`;
+}
+
+/**
  * Форматирует date-only строку 'YYYY-MM-DD' (период отчёта: день/неделя/месяц
  * приходят как to_char 'YYYY-MM-DD') в 'дд.мм.гггг'. Разбираем вручную, без
  * new Date(), чтобы date-only не съехала на UTC-полночь (-3ч в МСК). Значение,

--- a/internal/handlers/statistics.go
+++ b/internal/handlers/statistics.go
@@ -105,6 +105,24 @@ func (h *StatisticsHandler) GetOnlinePeaks(c echo.Context) error {
 	return RespondSuccess(c, points)
 }
 
+// GetOnlineUsers godoc
+// @Summary      Список пользователей онлайн
+// @Description  Пользователи с активностью (last_seen) за окно онлайна, по убыванию свежести. Для модалки «кто онлайн» на дашборде.
+// @Tags         statistics
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200 {object} Response
+// @Failure      401 {object} models.HTTPError
+// @Failure      403 {object} models.HTTPError
+// @Router       /statistics/online-users [get]
+func (h *StatisticsHandler) GetOnlineUsers(c echo.Context) error {
+	users, err := h.service.GetOnlineUsers(c.Request().Context())
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, users)
+}
+
 // GetTimeline godoc
 // @Summary      Данные для графика по метрике
 // @Tags         statistics

--- a/internal/handlers/statistics_online_integration_test.go
+++ b/internal/handlers/statistics_online_integration_test.go
@@ -110,6 +110,104 @@ func TestSnapshotOnlinePeak_MaxAndUpsert(t *testing.T) {
 	assert.Equal(t, int64(5), summary.UsersOnlinePeakToday)
 }
 
+// TestGetOnlineUsers_WindowSortAndFields проверяет список «кто онлайн»: только в окне,
+// по убыванию last_seen, ФИО собрано из частей, роль/тип подтянуты из справочников.
+func TestGetOnlineUsers_WindowSortAndFields(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	now := time.Now().UTC()
+	recent := now.Add(-2 * time.Minute) // в окне, свежее
+	edge := now.Add(-14 * time.Minute)  // в окне, граница
+	stale := now.Add(-30 * time.Minute) // вне окна (15 мин)
+
+	role := models.Role{Code: "role_test_g7", Name: "РольТест"}
+	require.NoError(t, db.Create(&role).Error)
+	utype := models.UserType{Code: "type_test_g7", Name: "ТипТест"}
+	require.NoError(t, db.Create(&utype).Error)
+
+	str := func(s string) *string { return &s }
+	mk := func(username string, last, first, middle *string, roleID *int, ls *time.Time) {
+		u := models.User{Username: username, TypeID: utype.ID, IsActive: true,
+			LastName: last, FirstName: first, MiddleName: middle, RoleID: roleID}
+		require.NoError(t, db.Create(&u).Error)
+		if ls != nil {
+			require.NoError(t, db.Model(&models.User{}).Where("id = ?", u.ID).
+				Update("last_seen", *ls).Error)
+		}
+	}
+
+	mk("ivanov", str("Иванов"), str("Иван"), str("Иванович"), &role.ID, &recent)
+	mk("petr", nil, str("Пётр"), nil, nil, &edge)
+	mk("stale_user", str("Старый"), nil, nil, nil, &stale)
+	mk("never_user", str("Никогда"), nil, nil, nil, nil)
+
+	// Забаненный и архивный со свежим last_seen НЕ должны попадать ни в список, ни в счётчик.
+	banned := models.User{Username: "banned_fresh", TypeID: utype.ID, IsActive: true, IsBanned: true}
+	require.NoError(t, db.Create(&banned).Error)
+	require.NoError(t, db.Model(&models.User{}).Where("id = ?", banned.ID).
+		Update("last_seen", recent).Error)
+	// is_active=false выставляем через Updates(map), иначе gorm с default:true опустит zero-value.
+	inactive := models.User{Username: "inactive_fresh", TypeID: utype.ID}
+	require.NoError(t, db.Create(&inactive).Error)
+	require.NoError(t, db.Model(&models.User{}).Where("id = ?", inactive.ID).
+		Updates(map[string]any{"is_active": false, "last_seen": recent}).Error)
+
+	svc := services.NewStatisticsService(db)
+	users, err := svc.GetOnlineUsers(context.Background())
+	require.NoError(t, err)
+
+	require.Len(t, users, 2, "только активные не забаненные в окне онлайна")
+	// По убыванию last_seen: recent (ivanov) раньше edge (petr).
+	assert.Equal(t, "ivanov", users[0].Login)
+	assert.Equal(t, "Иванов Иван Иванович", users[0].FullName)
+	assert.Equal(t, "РольТест", users[0].Role)
+	assert.Equal(t, "ТипТест", users[0].UserType)
+	assert.False(t, users[0].LastSeen.IsZero())
+
+	assert.Equal(t, "petr", users[1].Login)
+	assert.Equal(t, "Пётр", users[1].FullName, "ФИО из доступных частей")
+	assert.Empty(t, users[1].Role, "без роли -> пусто")
+
+	// Счётчик плитки (users_online) использует тот же предикат -> совпадает с длиной списка.
+	summary, err := svc.GetSummary(context.Background(), now.Add(-24*time.Hour), now)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), summary.UsersOnline, "счётчик исключает забаненных/архивных, как и список")
+}
+
+// TestGetOnlineUsersHandler_HTTP проверяет, что эндпоинт проводит список через сервис
+// и отдаёт его в envelope.
+func TestGetOnlineUsersHandler_HTTP(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	now := time.Now().UTC()
+	u := models.User{Username: "online_one", TypeID: 1, IsActive: true}
+	require.NoError(t, db.Create(&u).Error)
+	require.NoError(t, db.Model(&models.User{}).Where("id = ?", u.ID).
+		Update("last_seen", now.Add(-1*time.Minute)).Error)
+
+	h := handlers.NewStatisticsHandler(services.NewStatisticsService(db))
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/statistics/online-users", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, h.GetOnlineUsers(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		Success bool                `json:"success"`
+		Data    []models.OnlineUser `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.True(t, resp.Success)
+	require.Len(t, resp.Data, 1)
+	assert.Equal(t, "online_one", resp.Data[0].Login)
+}
+
 // TestGetOnlinePeaks_Series проверяет серию пиков за период: фильтр по датам и порядок.
 func TestGetOnlinePeaks_Series(t *testing.T) {
 	_, db, cleanup := testutil.SetupTestApp(t)

--- a/internal/models/statistics.go
+++ b/internal/models/statistics.go
@@ -59,6 +59,18 @@ type OnlinePeakPoint struct {
 	Peak int    `json:"peak"`
 }
 
+// OnlineUser — строка списка «кто онлайн» для модалки дашборда (#632 G7).
+// Только пользователи с last_seen в окне онлайна; last_seen отдаём, чтобы фронт
+// показал относительное «активен N назад». FullName собран из частей на бэке.
+type OnlineUser struct {
+	ID       int       `json:"id"`
+	Login    string    `json:"login"`
+	FullName string    `json:"full_name"`
+	Role     string    `json:"role"`
+	UserType string    `json:"user_type"`
+	LastSeen time.Time `json:"last_seen"`
+}
+
 // StatsTimelinePoint — одна точка графика (дата + количество).
 // Имя StatsTimelinePoint используется вместо TimelinePoint, т.к.
 // TimelinePoint уже занят в request_logs.go.

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -609,6 +609,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 		statsGroup.GET("/summary", statistics.GetSummary, requireStats)
 		statsGroup.GET("/timeline", statistics.GetTimeline, requireStats)
 		statsGroup.GET("/online-peaks", statistics.GetOnlinePeaks, requireStats)
+		statsGroup.GET("/online-users", statistics.GetOnlineUsers, requireStats)
 		statsGroup.GET("/recent-passages", statistics.GetRecentPassages, requireStats)
 		statsGroup.GET("/metrics", statistics.GetMetrics, requireStats)
 		statsGroup.GET("/insights", statistics.GetInsights, requireStats)

--- a/internal/services/statistics_service.go
+++ b/internal/services/statistics_service.go
@@ -24,6 +24,9 @@ type StatisticsService interface {
 	// GetOnlinePeaks возвращает серию дневных пиков онлайна за период [from, to]
 	// для карточки динамики пользователей. Дни без снимков опускаются.
 	GetOnlinePeaks(ctx context.Context, from, to time.Time) ([]models.OnlinePeakPoint, error)
+	// GetOnlineUsers возвращает список пользователей онлайн (last_seen в окне) по
+	// убыванию свежести активности — для модалки «кто онлайн» на дашборде.
+	GetOnlineUsers(ctx context.Context) ([]models.OnlineUser, error)
 	GetTimeline(ctx context.Context, from, to time.Time, metric, granularity string) ([]models.StatsTimelinePoint, error)
 	GetRecentPassages(ctx context.Context, limit int) (*models.RecentPassages, error)
 	GetReportCatalog(ctx context.Context) (*models.ReportCatalog, error)
@@ -247,17 +250,58 @@ func (s *statisticsService) GetSummary(ctx context.Context, from, to time.Time) 
 	return &summary, nil
 }
 
-// countOnline считает пользователей, чей last_seen свежее окна онлайна на момент now.
+// onlineThreshold — граница окна онлайна на момент now: пользователь онлайн, если
+// last_seen >= этой границы.
+func onlineThreshold(now time.Time) time.Time {
+	return now.Add(-onlineWindowMinutes * time.Minute)
+}
+
+// onlineUserScope — единый предикат «пользователь онлайн»: активный, не забанен и с
+// last_seen в окне на момент now. Колонки не квалифицируем — is_active/is_banned/last_seen
+// есть только в users, поэтому предикат работает и при джойнах. Общий для countOnline
+// (число на плитке) и GetOnlineUsers (список в модалке), чтобы счётчик и длина списка
+// всегда совпадали. Забаненного/архивного отсекаем: BanCheck не даёт ему обновлять
+// last_seen, но свежий last_seen до бана держал бы его «онлайн» ещё до окна.
+func onlineUserScope(now time.Time) func(*gorm.DB) *gorm.DB {
+	return func(db *gorm.DB) *gorm.DB {
+		return db.Where("is_active = true AND is_banned = false").
+			Where("last_seen >= ?", onlineThreshold(now))
+	}
+}
+
+// countOnline считает пользователей онлайн на момент now.
 func (s *statisticsService) countOnline(ctx context.Context, now time.Time) (int64, error) {
-	threshold := now.Add(-onlineWindowMinutes * time.Minute)
 	var count int64
 	if err := s.db.WithContext(ctx).
 		Table("users").
-		Where("last_seen >= ?", threshold).
+		Scopes(onlineUserScope(now)).
 		Count(&count).Error; err != nil {
 		return 0, fmt.Errorf("statistics: count online: %w", err)
 	}
 	return count, nil
+}
+
+// GetOnlineUsers возвращает пользователей онлайн по убыванию last_seen. Тот же предикат
+// onlineUserScope, что и в countOnline, поэтому длина списка совпадает с users_online.
+// ФИО собирается из частей, роль/тип — имена справочников.
+func (s *statisticsService) GetOnlineUsers(ctx context.Context) ([]models.OnlineUser, error) {
+	users := make([]models.OnlineUser, 0)
+	fullName := "TRIM(BOTH ' ' FROM CONCAT_WS(' ', u.last_name, u.first_name, u.middle_name))"
+	if err := s.db.WithContext(ctx).
+		Table("users u").
+		Joins("LEFT JOIN roles r ON r.id = u.role_id").
+		Joins("LEFT JOIN user_types ut ON ut.id = u.type_id").
+		Scopes(onlineUserScope(time.Now().UTC())).
+		Select("u.id AS id, u.username AS login, " +
+			fullName + " AS full_name, " +
+			"COALESCE(r.name, '') AS role, " +
+			"COALESCE(ut.name, '') AS user_type, " +
+			"u.last_seen AS last_seen").
+		Order("u.last_seen DESC").
+		Scan(&users).Error; err != nil {
+		return nil, fmt.Errorf("statistics: online users: %w", err)
+	}
+	return users, nil
 }
 
 // SnapshotOnlinePeak обновляет дневной пик онлайна за сегодня.


### PR DESCRIPTION
Срез G7 эпика 37-analytics (issue #632). Плитка «Пользователей онлайн» на дашборде стала кликабельной и открывает модалку со списком кто сейчас онлайн.

## Что сделано
- **BE:** `service.GetOnlineUsers()` — пользователи с `last_seen` в окне онлайна, по убыванию свежести, ФИО через `CONCAT_WS`, роль/тип через `LEFT JOIN roles/user_types`. Handler `GET /statistics/online-users` под тем же `requireStats`, что и остальная статистика.
- **FE:** `api/statistics.js getOnlineUsers()`, общая утилита `utils/datetime.js formatTimeAgo()`, новый `OnlineUsersModal.vue` (Teleport, анимация, border-radius 30px, overlay-close, Escape, фокус в модалку при открытии). Плитка: `role=button`/`tabindex`/`aria-haspopup`/Enter+Space. Пустой список -> «Сейчас никого онлайн».
- Карточка: ФИО (фолбэк на логин) + роль/тип + `@логин` + «активен N назад».

## Решения по ревью
- **Фильтр онлайна (must-fix ревью-агента):** свежий `last_seen` мог держать «онлайн» забаненного/архивного юзера ещё до окна (~15 мин после бана). Ввёл общий предикат `onlineUserScope` (`is_active AND NOT is_banned AND last_seen в окне`) для `countOnline` И `GetOnlineUsers` — число на плитке и длина списка всегда совпадают.
- **Swagger:** сгенерённые `docs/*` НЕ трогал — в проекте они обновляются отдельными батч-коммитами (`docs: ...`), на dev уже отстают (нет `online-peaks` от смерженного G6). Добавил только godoc-аннотацию к хендлеру.
- **Не переиспользовал `BaseModal`** (радиус 15px против эталонных 30px + кастомные состояния списка/пусто/ошибка/загрузка) — сделал по образцу остальных 30px-модалок проекта (`CarDetailsModal` и др.).

## Тесты
- Go: `GetOnlineUsers` — окно/сортировка/ФИО/роль-тип, исключение забаненных и архивных, совпадение счётчика со списком; handler-HTTP envelope.
- FE: `OnlineUsersModal` (рендер строк/пусто/ошибка/загрузка/закрытие/Escape), плитка кликабельна+a11y, открытие модалки, гонка seq-токена при повторном открытии; `formatTimeAgo`.

152-ФЗ: список ФИО+логин доступен только при `page.statistics` (тот же гейт, что у дашборда).