### PR TITLE
feat(security): роут и пункт меню "Доступные мне" для охранника (#706)

### DIFF
--- a/frontend/src/components/NavMenu.vue
+++ b/frontend/src/components/NavMenu.vue
@@ -167,6 +167,20 @@
               />
               <span class="nav-text">Новая заявка</span>
             </div>
+            <div
+              v-show="authStore.canViewAccessibleAttachments && matches('Доступные мне')"
+              class="nav-item"
+              :class="{ active: isActive('/accessible-attachments') }"
+              data-testid="nav-link-accessible-attachments"
+              @click="navigateToAccessibleAttachments"
+            >
+              <NavIcon
+                name="attachment-types"
+                :size="18"
+                class="nav-icon"
+              />
+              <span class="nav-text">Доступные мне</span>
+            </div>
           </div>
 
           <!-- УПРАВЛЕНИЕ ДАННЫМИ -->
@@ -696,7 +710,8 @@ export default {
     sectionVisible() {
       const on = this.searchActive;
       return {
-        requests: !on || this.matches('Центр заявок') || this.matches('Новая заявка'),
+        requests: !on || this.matches('Центр заявок') || this.matches('Новая заявка')
+          || (this.authStore.canViewAccessibleAttachments && this.matches('Доступные мне')),
         data: !on || this.tablesItemVisible || this.matches('Сотрудники') || this.matches('Автомобили'),
         analytics: !on || this.matches('Статистика') || this.matches('Аналитика'),
         admin: !on || this.matches('Администрирование'),
@@ -903,6 +918,10 @@ export default {
 
     navigateToCenter() {
       this.$router.push('/center');
+    },
+    navigateToAccessibleAttachments() {
+      this.$router.push('/accessible-attachments');
+      this.closeMobile();
     },
     navigateToNewApplication() {
       this.$router.push('/new-application');

--- a/frontend/src/components/__tests__/NavMenuAccessibleAttachments.spec.js
+++ b/frontend/src/components/__tests__/NavMenuAccessibleAttachments.spec.js
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import NavMenu from '../NavMenu.vue';
+import { useAuthStore } from '@/stores/auth';
+
+// FE-S2: пункт "Доступные мне" в секции ЗАЯВКИ виден только охраннику
+// (canViewAccessibleAttachments) и супер-админу; обычный пользователь его не видит.
+// Гейтинг идёт через v-show, поэтому проверяем видимость, а не наличие в DOM.
+
+vi.mock('@/stores/auth', () => ({ useAuthStore: vi.fn() }));
+vi.mock('@/api/client', () => ({
+  apiRequest: vi.fn().mockResolvedValue({ ok: false, json: vi.fn().mockResolvedValue([]) }),
+}));
+vi.mock('@/api/applications', () => ({
+  getUnreadCount: vi.fn().mockResolvedValue({ count: 0 }),
+}));
+vi.mock('@/utils/notificationSound', () => ({ playPreset: vi.fn() }));
+
+const TESTID = '[data-testid="nav-link-accessible-attachments"]';
+
+function mountNav() {
+  return mount(NavMenu, {
+    global: {
+      mocks: {
+        $bus: { on: vi.fn(), off: vi.fn(), emit: vi.fn() },
+        $router: { push: vi.fn() },
+        $route: { path: '/news', params: {} },
+      },
+    },
+  });
+}
+
+let wrapper;
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+});
+
+afterEach(() => {
+  wrapper?.unmount();
+});
+
+describe('NavMenu: гейтинг пункта "Доступные мне" (FE-S2)', () => {
+  it('охранник видит пункт', () => {
+    useAuthStore.mockReturnValue({ isSuperAdmin: false, canViewAccessibleAttachments: true });
+    wrapper = mountNav();
+    const item = wrapper.find(TESTID);
+    expect(item.exists()).toBe(true);
+    expect(item.isVisible()).toBe(true);
+  });
+
+  it('супер-админ видит пункт', () => {
+    useAuthStore.mockReturnValue({ isSuperAdmin: true, canViewAccessibleAttachments: true });
+    wrapper = mountNav();
+    expect(wrapper.find(TESTID).isVisible()).toBe(true);
+  });
+
+  it('обычный пользователь не видит пункт', () => {
+    useAuthStore.mockReturnValue({ isSuperAdmin: false, canViewAccessibleAttachments: false });
+    wrapper = mountNav();
+    const item = wrapper.find(TESTID);
+    expect(item.exists()).toBe(true);
+    expect(item.isVisible()).toBe(false);
+  });
+
+  // sectionVisible.requests: при поиске не оставляем осиротевший заголовок ЗАЯВКИ.
+  // Совпадение только по "Доступные мне" поднимает секцию лишь тем, кто пункт видит.
+  it('поиск "Доступные" не показывает секцию ЗАЯВКИ обычному пользователю', async () => {
+    useAuthStore.mockReturnValue({ isSuperAdmin: false, canViewAccessibleAttachments: false });
+    wrapper = mountNav();
+    wrapper.vm.searchQuery = 'Доступные';
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.sectionVisible.requests).toBe(false);
+  });
+
+  it('поиск "Доступные" показывает секцию ЗАЯВКИ охраннику', async () => {
+    useAuthStore.mockReturnValue({ isSuperAdmin: false, canViewAccessibleAttachments: true });
+    wrapper = mountNav();
+    wrapper.vm.searchQuery = 'Доступные';
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.sectionVisible.requests).toBe(true);
+  });
+});

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -65,6 +65,15 @@ const routes = [
     component: ApplicationsCenter,
     meta: { requiresAuth: true }
   },
+  // "Доступные мне": вложения согласованных заявок, совпавших по месту с местами
+  // охранника. Доступ - охранник (user_type code 'security') или супер-админ;
+  // requiresBuro НЕ ставим (охранник не buro). Гейт по коду типа - в beforeEach.
+  {
+    path: '/accessible-attachments',
+    name: 'AccessibleAttachments',
+    component: () => import('./views/AccessibleAttachmentsView.vue'),
+    meta: { requiresAuth: true, requiresSecurityOrAdmin: true }
+  },
   {
     path: '/table-constructor',
     name: 'TableConstructor',
@@ -271,6 +280,18 @@ router.beforeEach(async (to, from, next) => {
   if (to.meta.requiresBuro && !isBuroPropuskov) {
     next('/personal-cabinet');
     return;
+  }
+  // Гейт "Доступные мне": супер-админ проходит сразу; иначе резолвим код типа
+  // пользователя (один раз, лениво) и пускаем только охранника. userTypeCode
+  // приходит из /users/me - на F5 он ещё null, поэтому подгружаем до проверки.
+  if (to.meta.requiresSecurityOrAdmin) {
+    if (!isBuroPropuskov && authStore.userTypeCode === null) {
+      await authStore.loadUserTypeCode();
+    }
+    if (!authStore.canViewAccessibleAttachments) {
+      next('/personal-cabinet');
+      return;
+    }
   }
   if (to.path === '/' && isAuthenticated) {
     next('/news');

--- a/frontend/src/views/AccessibleAttachmentsView.vue
+++ b/frontend/src/views/AccessibleAttachmentsView.vue
@@ -1,0 +1,26 @@
+<template>
+  <div class="accessible-attachments">
+    <div class="management-header">
+      <h2 class="management-title">
+        Доступные мне
+      </h2>
+    </div>
+    <p class="accessible-attachments__placeholder">
+      Раздел в разработке.
+    </p>
+  </div>
+</template>
+
+<script setup>
+// Заглушка маршрута (FE-S2). Полный список вложений и детали - в FE-S3.
+</script>
+
+<style scoped>
+.accessible-attachments {
+  padding: 20px;
+}
+
+.accessible-attachments__placeholder {
+  color: var(--color-text-secondary, #6b7280);
+}
+</style>


### PR DESCRIPTION
Срез FE-S2 эпика «Доступные мне» (#706). Маршрут и пункт навигации для охранников ЧОП, под FE-S1 (#716, смержен).

## Что внутри
- `router.js`: роут `/accessible-attachments` с `meta.requiresSecurityOrAdmin` (без `requiresBuro` - охранник не buro). Ветка в `beforeEach`: супер-админ проходит сразу, иначе при `userTypeCode===null` лениво подгружаем код типа из `/users/me`, пускаем только `canViewAccessibleAttachments`; иначе редирект на `/personal-cabinet`.
- `NavMenu.vue`: пункт «Доступные мне» в секции ЗАЯВКИ, `v-show` под `canViewAccessibleAttachments && matches(...)`, `data-testid="nav-link-accessible-attachments"`, иконка `attachment-types` (переиспользована). `sectionVisible.requests` расширен, чтобы при поиске не оставался осиротевший заголовок секции.
- `AccessibleAttachmentsView.vue`: стаб-страница (полный список вложений и детали - в FE-S3).
- vitest: гейтинг пункта (охранник/супер-админ видят, обычный нет) + видимость секции при поиске.

## Проверка
- `npx eslint` изменённых файлов - чисто.
- `npx vitest run` нового спека - 5/5 зелёных.
- code-reviewer на ветке: вердикт GO, must-fix нет; добавил тесты на видимость секции по его замечанию.

Зависит от FE-S1 (#716). Следующий срез FE-S3 заменит стаб полноценным View.