### PR TITLE
feat(analytics): ось разворота по типу вложения в конструкторе отчётов (#632)

### DIFF
--- a/frontend/src/components/statistics/ReportBuilder.vue
+++ b/frontend/src/components/statistics/ReportBuilder.vue
@@ -94,6 +94,30 @@
             v-model="form.granularity"
             :tabs="granularityTabs"
           />
+          <template v-if="availablePivots.length">
+            <span class="rb__field-label rb__pivot-label">Развернуть в колонки</span>
+            <div class="rb__pills">
+              <button
+                type="button"
+                class="rb__pill"
+                :class="{ 'rb__pill--on': !form.pivot }"
+                @click="form.pivot = ''"
+              >
+                Без разворота
+              </button>
+              <button
+                v-for="p in availablePivots"
+                :key="p.key"
+                type="button"
+                class="rb__pill"
+                :class="{ 'rb__pill--on': form.pivot === p.key }"
+                @click="form.pivot = p.key"
+              >
+                {{ p.label }}
+              </button>
+            </div>
+            <span class="rb__hint">Каждое значение оси станет отдельным столбцом-счётчиком рядом с периодом.</span>
+          </template>
         </div>
       </div>
     </template>
@@ -202,12 +226,37 @@
       </div>
     </div>
 
-    <!-- Превью «что построим» -->
+    <!-- Превью «что построим»: описание + визуальный скелет колонок результата -->
     <div class="rb__preview">
       <span class="rb__preview-label">Что построим</span>
       <p class="rb__summary">
         {{ summary }}
       </p>
+      <div
+        v-if="previewColumns.length"
+        class="rb__skeleton"
+        aria-hidden="true"
+      >
+        <div
+          v-for="(col, i) in previewColumns"
+          :key="i"
+          class="rb__skel-col"
+          :class="`rb__skel-col--${col.kind}`"
+        >
+          <span class="rb__skel-head">
+            {{ col.label }}<span
+              v-if="col.kind === 'pivot'"
+              class="rb__skel-more"
+            >, …</span>
+          </span>
+          <span
+            v-if="col.sub"
+            class="rb__skel-sub"
+          >{{ col.sub }}</span>
+          <span class="rb__skel-cell" />
+          <span class="rb__skel-cell" />
+        </div>
+      </div>
       <p class="rb__preview-result">
         {{ resultHint }}
       </p>
@@ -243,6 +292,7 @@ import { reactive, ref, computed, watch, nextTick } from 'vue';
 import FilterTabs from '@/components/ui/FilterTabs.vue';
 import BaseDropdown from '@/components/ui/BaseDropdown.vue';
 import { buildReportRequest } from '@/composables/useReportRequest';
+import { formatDateRu } from '@/utils/datetime';
 
 const props = defineProps({
   catalog: { type: Object, required: true },
@@ -267,6 +317,9 @@ const form = reactive({
   metrics: props.catalog.metrics?.[0]?.key ? [props.catalog.metrics[0].key] : [],
   dimension: '',
   granularity: 'day',
+  // Ось cross-tab: значения разворачиваются в колонки. '' -> без разворота.
+  // Применима лишь при dimension='period' и метрике из pivot.metrics (см. availablePivots).
+  pivot: '',
   entity: props.catalog.list_entities?.[0]?.key || '',
   filters: {},
   period: { from: props.period?.from || '', to: props.period?.to || '' },
@@ -329,6 +382,22 @@ const availableDimensions = computed(() => {
   return [dimNoneOption.value, ...realDims];
 });
 
+// Оси cross-tab, применимые к текущему срезу: только при разрезе «период» и когда
+// ось поддерживает КАЖДУЮ выбранную метрику (бэк требует metrics ⊆ pivot.metrics,
+// иначе 400). Пустой набор метрик -> разворачивать нечего.
+const availablePivots = computed(() => {
+  if (form.dimension !== 'period') return [];
+  const sel = selectedMetrics.value;
+  if (!sel.length) return [];
+  return (props.catalog.pivots || []).filter(
+    (p) => sel.every((m) => (p.metrics || []).includes(m.key)),
+  );
+});
+
+const activePivot = computed(
+  () => availablePivots.value.find((p) => p.key === form.pivot) || null,
+);
+
 const selectedEntity = computed(
   () => (props.catalog.list_entities || []).find((e) => e.key === form.entity) || null,
 );
@@ -366,6 +435,12 @@ watch(availableDimensions, (dims) => {
   form.dimension = (firstReal || dims[0]).key;
 }, { immediate: true });
 
+// Ось разворота держим валидной: сменили разрез с «период» или метрику на
+// неподдерживаемую -> сбрасываем pivot, иначе ушлём в движок невалидную ось (400).
+watch(availablePivots, (pivots) => {
+  if (form.pivot && !pivots.some((p) => p.key === form.pivot)) form.pivot = '';
+});
+
 // Смена выгружаемой сущности обнуляет выбранные фильтры — у разных сущностей
 // разный набор применимых фильтров, чужие значения сбивали бы с толку.
 watch(() => form.entity, () => {
@@ -392,9 +467,9 @@ const canRun = computed(() =>
 
 const periodLabel = computed(() => {
   const { from, to } = form.period;
-  if (from && to) return `${from} — ${to}`;
-  if (from) return `с ${from}`;
-  if (to) return `по ${to}`;
+  if (from && to) return `${formatDateRu(from)} — ${formatDateRu(to)}`;
+  if (from) return `с ${formatDateRu(from)}`;
+  if (to) return `по ${formatDateRu(to)}`;
   return 'весь период';
 });
 
@@ -404,7 +479,10 @@ const summary = computed(() => {
   if (form.mode === 'aggregate') {
     const names = selectedMetrics.value.map((m) => m.label).join(', ') || '—';
     const dim = availableDimensions.value.find((d) => d.key === form.dimension)?.label || '—';
-    return `Считаем: ${names}; разрез «${dim}»${periodPart}.`;
+    const pivotPart = activePivot.value
+      ? `, развёрнуто по «${activePivot.value.label}» в колонки`
+      : '';
+    return `Считаем: ${names}; разрез «${dim}»${pivotPart}${periodPart}.`;
   }
   return `Выгрузка строк: «${selectedEntity.value?.label || '—'}»${periodPart}.`;
 });
@@ -412,6 +490,10 @@ const summary = computed(() => {
 const resultHint = computed(() => {
   if (form.mode === 'aggregate') {
     const n = selectedMetrics.value.length;
+    // Cross-tab: период в строках, каждое значение оси -> своя колонка-счётчик.
+    if (activePivot.value) {
+      return `Результат: строки по периоду, отдельная колонка-счётчик на каждое значение «${activePivot.value.label}», с итогами.`;
+    }
     // «Без разреза» -> один итоговый ряд без столбца разреза, поэтому формулировка
     // отличается от разбивки по реальному разрезу.
     if (form.dimension === 'none') {
@@ -429,6 +511,28 @@ const resultHint = computed(() => {
     : 'Результат: таблица строк.';
 });
 
+// Скелет колонок результата для превью «Что построим»: первый столбец — разрез
+// (или «Итог» без разреза), затем по столбцу на метрику, затем ось разворота
+// (pivot) — её значения станут динамическими колонками, поэтому показываем одну
+// «призрачную» колонку-маркер. list -> столбцы выгружаемой сущности.
+const previewColumns = computed(() => {
+  if (form.mode === 'list') {
+    return (selectedEntity.value?.columns || []).map((c) => ({ label: c.label, kind: 'data' }));
+  }
+  const cols = [];
+  const dimLabel = form.dimension === 'none'
+    ? 'Итог'
+    : (availableDimensions.value.find((d) => d.key === form.dimension)?.label || 'Разрез');
+  cols.push({ label: dimLabel, kind: 'dim' });
+  for (const m of selectedMetrics.value) {
+    cols.push({ label: m.label, sub: m.unit || '', kind: 'metric' });
+  }
+  if (activePivot.value) {
+    cols.push({ label: activePivot.value.label, sub: 'колонки по значениям', kind: 'pivot' });
+  }
+  return cols;
+});
+
 // Применить пресет/шаблон и сразу построить отчёт. Галерея-пресеты несут только
 // метрику/разрез; шаблоны (G2) дополнительно несут filters/period/period_preset.
 // Разрез сверяется watch'ем availableDimensions (ключи каталога валидны).
@@ -441,6 +545,9 @@ watch(() => props.preset, (p) => {
     form.metrics = p.metrics ? [...p.metrics] : (p.metric ? [p.metric] : []);
     form.dimension = p.dimension || '';
     form.granularity = p.granularity || 'day';
+    // Ось разворота из шаблона; невалидную (не period / чужая метрика) сбросит
+    // watch availablePivots до построения отчёта.
+    form.pivot = p.pivot || '';
   }
   // Период — синхронно (watch'и его не сбрасывают). Именованный пресет (неделя/
   // месяц/год/весь) пересчитываем на текущую дату; «custom»/произвольный — берём
@@ -526,6 +633,7 @@ const reportConfig = computed(() => ({
   metrics: [...form.metrics],
   dimension: form.dimension,
   granularity: form.granularity,
+  pivot: form.pivot,
   entity: form.entity,
   filters: { ...form.filters },
   period: { from: form.period.from, to: form.period.to },
@@ -890,6 +998,81 @@ function run() {
   margin: 0;
   font-size: 14px;
   color: var(--color-text);
+}
+
+/* Скелет колонок результата: горизонтальный набор «столбцов», каждый — заголовок
+   + пара призрачных ячеек. Даёт почувствовать форму таблицы до построения. */
+.rb__skeleton {
+  display: flex;
+  gap: 8px;
+  margin: 4px 0 2px;
+  padding-bottom: 4px;
+  overflow-x: auto;
+}
+
+.rb__skel-col {
+  flex: 1 1 0;
+  min-width: 96px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 10px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm, 10px);
+  background: #fff;
+}
+
+.rb__skel-col--dim {
+  background: var(--color-bg);
+  border-color: #d7daf0;
+}
+
+.rb__skel-col--metric {
+  border-color: #c9cdf0;
+  background: var(--color-primary-tint);
+}
+
+/* Pivot-колонки динамические (значения оси) -> пунктир + многоточие-маркер. */
+.rb__skel-col--pivot {
+  border-style: dashed;
+  border-color: var(--color-primary);
+  background: #fff;
+}
+
+.rb__skel-head {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.rb__skel-more {
+  color: var(--color-primary);
+  font-weight: 700;
+}
+
+.rb__skel-sub {
+  font-size: 10px;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.rb__skel-cell {
+  height: 7px;
+  border-radius: 4px;
+  background: var(--color-border);
+}
+
+.rb__skel-col--metric .rb__skel-cell {
+  background: #c9cdf0;
+}
+
+.rb__pivot-label {
+  margin-top: 6px;
 }
 
 .rb__preview-result {

--- a/frontend/src/components/statistics/__tests__/ReportBuilder.spec.js
+++ b/frontend/src/components/statistics/__tests__/ReportBuilder.spec.js
@@ -31,6 +31,9 @@ const CATALOG = {
     { key: 'cars', label: 'Машины', columns: [{ key: 'car_number', label: 'Номер' }], filters: ['organization'] },
   ],
   granularities: [{ value: 'day', label: 'По дням' }, { value: 'week', label: 'По неделям' }],
+  pivots: [
+    { key: 'attachment_type', label: 'Тип вложения', metrics: ['applications_count'] },
+  ],
 };
 
 const PERIOD = { from: '2026-06-01', to: '2026-06-07' };
@@ -56,6 +59,21 @@ function metricInputs(wrapper) {
 /** Радио-разрез по его подписи. */
 function dimRadioByLabel(wrapper, label) {
   return wrapper.findAll('.rb__dim').find((d) => d.text().includes(label)).find('.rb__dim-input');
+}
+
+/** Кнопки оси разворота (cross-tab) внутри блока периода. [] если блока нет. */
+function pivotPills(wrapper) {
+  const gran = wrapper.find('.rb__gran');
+  return gran.exists() ? gran.findAll('.rb__pill') : [];
+}
+
+/** Выбрать только метрику «Количество заявок» и разрез «Период (дата)». */
+async function setupAppsPeriod(wrapper) {
+  await metricInputs(wrapper)[1].trigger('change'); // + applications_count
+  await metricInputs(wrapper)[0].trigger('change'); // - car_entries_count
+  await nextTick();
+  await dimRadioByLabel(wrapper, 'Период (дата)').setValue();
+  await nextTick();
 }
 
 describe('ReportBuilder', () => {
@@ -278,5 +296,95 @@ describe('ReportBuilder', () => {
     await wrapper.setProps({ preset: { mode: 'aggregate', metric: 'applications_count', dimension: 'status' } });
     await flushPromises();
     expect(wrapper.emitted('run').length).toBe(firstCount + 1);
+  });
+
+  it('ось разворота доступна при период+метрике из каталога и уходит в запрос как pivot', async () => {
+    const wrapper = mountBuilder();
+    await nextTick();
+    await setupAppsPeriod(wrapper);
+
+    const pills = pivotPills(wrapper);
+    expect(pills.map((p) => p.text())).toEqual(['Без разворота', 'Тип вложения']);
+
+    await pills.find((p) => p.text() === 'Тип вложения').trigger('click');
+    await clickBuild(wrapper);
+
+    const req = lastRun(wrapper);
+    expect(req.metrics).toEqual(['applications_count']);
+    expect(req.dimension).toBe('period');
+    expect(req.pivot).toBe('attachment_type');
+  });
+
+  it('смена разреза с period сбрасывает ось разворота (не уходит в запрос)', async () => {
+    const wrapper = mountBuilder();
+    await nextTick();
+    await setupAppsPeriod(wrapper);
+    await pivotPills(wrapper).find((p) => p.text() === 'Тип вложения').trigger('click');
+
+    // Уходим с period -> ось неприменима, блок исчезает, pivot сбрасывается.
+    await dimRadioByLabel(wrapper, 'Статус заявки').setValue();
+    await nextTick();
+    expect(pivotPills(wrapper)).toEqual([]);
+
+    await clickBuild(wrapper);
+    expect(lastRun(wrapper).pivot).toBeUndefined();
+  });
+
+  it('добавление метрики, не поддерживающей ось, сбрасывает разворот', async () => {
+    const wrapper = mountBuilder();
+    await nextTick();
+    await setupAppsPeriod(wrapper);
+    await pivotPills(wrapper).find((p) => p.text() === 'Тип вложения').trigger('click');
+
+    // Возвращаем car_entries_count: ось attachment_type его не поддерживает.
+    await metricInputs(wrapper)[0].trigger('change');
+    await nextTick();
+    expect(pivotPills(wrapper)).toEqual([]);
+
+    await clickBuild(wrapper);
+    const req = lastRun(wrapper);
+    expect(req.metrics).toEqual(['applications_count', 'car_entries_count']);
+    expect(req.pivot).toBeUndefined();
+  });
+
+  it('скелет «Что построим» отражает разрез, метрику и колонку разворота', async () => {
+    const wrapper = mountBuilder();
+    await nextTick();
+    await setupAppsPeriod(wrapper);
+    await pivotPills(wrapper).find((p) => p.text() === 'Тип вложения').trigger('click');
+    await nextTick();
+
+    const cols = wrapper.findAll('.rb__skel-col');
+    expect(cols.length).toBe(3); // разрез + метрика + ось разворота
+    expect(wrapper.find('.rb__skel-col--metric').text()).toContain('Количество заявок');
+    const pivotCol = wrapper.find('.rb__skel-col--pivot');
+    expect(pivotCol.exists()).toBe(true);
+    expect(pivotCol.text()).toContain('Тип вложения');
+  });
+
+  it('применяет шаблон с осью разворота и шлёт pivot', async () => {
+    const wrapper = mount(ReportBuilder, { props: { catalog: CATALOG, period: PERIOD, preset: null } });
+    await nextTick();
+
+    await wrapper.setProps({
+      preset: {
+        mode: 'aggregate', metrics: ['applications_count'], dimension: 'period',
+        granularity: 'week', pivot: 'attachment_type',
+      },
+    });
+    await flushPromises();
+
+    const req = lastRun(wrapper);
+    expect(req.metrics).toEqual(['applications_count']);
+    expect(req.dimension).toBe('period');
+    expect(req.pivot).toBe('attachment_type');
+  });
+
+  it('период в описании показан как дд.мм.гггг', async () => {
+    const wrapper = mountBuilder();
+    await nextTick();
+    const summary = wrapper.find('.rb__summary').text();
+    expect(summary).toContain('01.06.2026 — 07.06.2026');
+    expect(summary).not.toContain('2026-06-01');
   });
 });

--- a/frontend/src/composables/__tests__/useReportRequest.spec.js
+++ b/frontend/src/composables/__tests__/useReportRequest.spec.js
@@ -66,6 +66,29 @@ describe('buildReportRequest', () => {
       );
       expect(req.filters).toEqual([]);
     });
+
+    it('шлёт pivot (cross-tab ось) только при разрезе period', () => {
+      const period = buildReportRequest(
+        { mode: 'aggregate', metrics: ['applications_count'], dimension: 'period', granularity: 'week', pivot: 'attachment_type' },
+        PERIOD, ['date_range'],
+      );
+      expect(period.pivot).toBe('attachment_type');
+
+      // Вне period ось не имеет смысла -> бэк её не примет, фронт не шлёт.
+      const status = buildReportRequest(
+        { mode: 'aggregate', metrics: ['applications_count'], dimension: 'status', pivot: 'attachment_type' },
+        PERIOD, ['date_range'],
+      );
+      expect(status.pivot).toBeUndefined();
+    });
+
+    it('опускает pivot, когда ось не выбрана', () => {
+      const req = buildReportRequest(
+        { mode: 'aggregate', metrics: ['applications_count'], dimension: 'period', granularity: 'day' },
+        PERIOD, ['date_range'],
+      );
+      expect(req.pivot).toBeUndefined();
+    });
   });
 
   describe('list', () => {

--- a/frontend/src/composables/useReportRequest.js
+++ b/frontend/src/composables/useReportRequest.js
@@ -11,7 +11,7 @@
  * @param {{
  *   mode: 'aggregate'|'list',
  *   metric?: string, metrics?: string[], dimension?: string, granularity?: string,
- *   entity?: string, sort?: string, limit?: number|string|null,
+ *   pivot?: string, entity?: string, sort?: string, limit?: number|string|null,
  *   filters?: Record<string, string[]>
  * }} state
  * @param {{from?: string, to?: string}} [period]
@@ -54,9 +54,11 @@ export function buildReportRequest(state, period = {}, applicableFilters = []) {
   };
   if (metrics.length) req.metrics = metrics;
   else req.metric = state.metric || '';
-  // Гранулярность осмысленна только для временного разреза.
-  if (state.dimension === 'period' && state.granularity) {
-    req.granularity = state.granularity;
+  // Гранулярность и cross-tab-ось осмысленны только для временного разреза. Pivot
+  // разворачивает значения оси в колонки; бэк валидирует ось против метрик.
+  if (state.dimension === 'period') {
+    if (state.granularity) req.granularity = state.granularity;
+    if (state.pivot) req.pivot = state.pivot;
   }
   if (state.sort) req.sort = state.sort;
   return req;


### PR DESCRIPTION
## G5-3 эпика 37-analytics-v2 (issue #632)

Завершает редизайн вкладки «Отчёты»: даёт конструктору cross-tab из движка (G4) и доводит превью.

### Что сделано
- **Ось разворота «Тип вложения» (pivot).** При разрезе по периоду и метрике из каталога (`applications_count`) появляется выбор «Развернуть в колонки» из `catalog.pivots`. Выбранная ось уходит в запрос полем `pivot`.
- **Защита от 400.** Ось валидна только когда `dimension==='period'` И каждая метрика входит в `pivot.metrics` (контракт `resolvePivot`, `report_crosstab.go`). Двойной барьер: `watch(availablePivots)` сбрасывает ось при смене разреза/несовместимой метрике, а `buildReportRequest` независимо шлёт `pivot` только для периода. Невалидную ось бэк не увидит.
- **Превью «Что построим».** К описанию добавлен визуальный скелет колонок результата: разрез + метрики + динамическая колонка-маркер оси (пунктир, значения подставит данные).
- **Даты дд.мм.гггг.** `periodLabel`/`summary` через `formatDateRu` из G5-2 (без `new Date()` — date-only не съезжает на UTC-полночь).
- `pivot` проведён в шаблоны: `reportConfig` (сохранение) и preset-watch (восстановление).

### Проверка
- vitest: ReportBuilder 20/20, useReportRequest 13/13 — pivot в запросе только для периода, сброс при смене разреза и при добавлении несовместимой метрики, скелет отражает разрез/метрику/ось, применение шаблона с pivot, даты дд.мм.гггг.
- eslint 0 errors на изменённых файлах.
- Ревью `code-reviewer`: GO, блокеров нет; находку про тест шаблона с pivot закрыл.

Зависит от G5-2 (#712, merged): утилита дат + рендер pivot/float в ReportResult.