### PR TITLE
feat(security): экран "Доступные мне" - список вложений и деталь (#706)

### DIFF
--- a/frontend/src/api/applications.js
+++ b/frontend/src/api/applications.js
@@ -1,4 +1,4 @@
-import { apiRequest } from './client';
+import { apiRequest, apiRequestRaw } from './client';
 
 export async function getApplications(params = {}) {
   const query = new URLSearchParams(params).toString();
@@ -93,4 +93,40 @@ export async function getApplicationDetails(id) {
 export async function getApplicationAttachments(id) {
   const res = await apiRequest(`/applications/${id}/attachments`);
   return res.json();
+}
+
+/**
+ * Список вложений, доступных охраннику/админу во вкладке "Доступные мне" (#706).
+ * Пагинация лежит в envelope.meta рядом с data, а apiRequest снимает только data
+ * и meta теряется - поэтому читаем сырой ответ через apiRequestRaw.
+ * @param {{page?: number, per_page?: number}} params
+ * @returns {Promise<{items: object[], meta: {total: number, page: number, per_page: number}}>}
+ */
+export async function getAccessibleAttachments(params = {}) {
+  const query = new URLSearchParams(params).toString();
+  const res = await apiRequestRaw(`/applications/available-attachments${query ? '?' + query : ''}`);
+  const body = await res.json();
+  if (!res.ok || !body || !body.success) {
+    throw new Error(body?.error || 'Не удалось загрузить доступные вложения');
+  }
+  return {
+    items: body.data || [],
+    meta: body.meta || { total: 0, page: 1, per_page: 20 },
+  };
+}
+
+/**
+ * Деталь доступного вложения (#706): заголовок с инфо заявки + типизированное
+ * содержимое (cars/employees/items). Читаем через apiRequestRaw, чтобы 403 на
+ * чужое вложение пробросился ошибкой, а не отдал полу-распакованный объект.
+ * @param {number} id ID вложения
+ * @returns {Promise<{attachment: object, cars?: object[], employees?: object[], items?: object[]}>}
+ */
+export async function getAccessibleAttachmentDetail(id) {
+  const res = await apiRequestRaw(`/applications/available-attachments/${id}`);
+  const body = await res.json();
+  if (!res.ok || !body || !body.success) {
+    throw new Error(body?.error || 'Не удалось загрузить вложение');
+  }
+  return body.data;
 }

--- a/frontend/src/views/AccessibleAttachmentsView.vue
+++ b/frontend/src/views/AccessibleAttachmentsView.vue
@@ -178,6 +178,8 @@
               </div>
             </div>
 
+            <!-- AvailableAttachment не несёт roof_access/free_parking/custom_values -
+                 эти опц. блоки детали просто не отрисуются (v-if по undefined). -->
             <ApplicationAttachmentDetail
               :attachment="detail.attachment"
               :cars="detail.cars || []"
@@ -222,7 +224,6 @@ const listLoading = ref(false);
 
 const selectedId = ref(null);
 const detail = ref(null);
-const detailLoading = ref(false);
 // Токен последовательности: быстрые клики по карточкам пускают параллельные
 // запросы детали в общий ref, и медленный ответ предыдущего вложения мог бы
 // затереть актуальный (#632). Применяем только ответ последнего запроса.
@@ -296,7 +297,6 @@ function loadMore() {
 async function selectAttachment(id) {
   selectedId.value = id;
   detail.value = null;
-  detailLoading.value = true;
   const seq = ++detailSeq;
   try {
     const data = await getAccessibleAttachmentDetail(id);
@@ -310,8 +310,6 @@ async function selectAttachment(id) {
       bold: 'Не удалось открыть',
       suffix: 'вложение',
     });
-  } finally {
-    if (seq === detailSeq) detailLoading.value = false;
   }
 }
 
@@ -322,7 +320,7 @@ onMounted(() => fetchList({ reset: true }));
 .accessible-attachments {
   background: #fff;
   border: 1px solid #e6e6e6;
-  border-radius: 20px;
+  border-radius: 16px;
   overflow: hidden;
 }
 
@@ -359,7 +357,6 @@ onMounted(() => fetchList({ reset: true }));
   display: flex;
   flex-direction: column;
   background: #fff;
-  transition: width 0.2s ease;
 }
 
 .list-section.with-details {

--- a/frontend/src/views/AccessibleAttachmentsView.vue
+++ b/frontend/src/views/AccessibleAttachmentsView.vue
@@ -1,26 +1,561 @@
 <template>
-  <div class="accessible-attachments">
-    <div class="management-header">
-      <h2 class="management-title">
-        Доступные мне
-      </h2>
+  <AdminPageShell>
+    <div class="accessible-attachments dashboard-card">
+      <div class="management-header">
+        <h3 class="management-title">
+          Доступные мне
+        </h3>
+        <div class="header-controls">
+          <RefreshButton
+            :loading="listLoading"
+            @refresh="refresh"
+          />
+        </div>
+      </div>
+
+      <div class="content-container">
+        <!-- Список вложений -->
+        <div
+          class="list-section"
+          :class="{ 'with-details': selectedId !== null }"
+        >
+          <div
+            v-if="listLoading && !items.length"
+            class="cards-list"
+            data-testid="aa-skeleton"
+          >
+            <SkeletonCard
+              v-for="i in 5"
+              :key="i"
+              :lines="3"
+            />
+          </div>
+
+          <div
+            v-else-if="items.length"
+            class="cards-list"
+            data-testid="aa-list"
+          >
+            <button
+              v-for="a in items"
+              :key="a.attachment_id"
+              type="button"
+              class="attachment-card"
+              :class="{ 'attachment-card--active': a.attachment_id === selectedId }"
+              data-testid="aa-card"
+              @click="selectAttachment(a.attachment_id)"
+            >
+              <div class="attachment-card__top">
+                <Badge
+                  :variant="typeVariant(a.attachment_type)"
+                  size="sm"
+                >
+                  {{ typeLabel(a.attachment_type) }}
+                </Badge>
+                <span class="attachment-card__name">{{ displayName(a) }}</span>
+                <StatusBadge
+                  v-if="statusText(a)"
+                  class="attachment-card__status"
+                  :status="statusText(a)"
+                />
+              </div>
+              <div class="attachment-card__meta">
+                <span
+                  v-if="a.application_number"
+                  class="attachment-card__field"
+                >
+                  <span class="attachment-card__label">Заявка №</span>{{ a.application_number }}
+                </span>
+                <span
+                  v-if="a.organization_name"
+                  class="attachment-card__field"
+                >
+                  <span class="attachment-card__label">Организация:</span>{{ a.organization_name }}
+                </span>
+                <span
+                  v-if="senderName(a)"
+                  class="attachment-card__field"
+                >
+                  <span class="attachment-card__label">Отправитель:</span>{{ senderName(a) }}
+                </span>
+                <span
+                  v-if="dateRange(a)"
+                  class="attachment-card__field"
+                >
+                  <span class="attachment-card__label">Даты:</span>{{ dateRange(a) }}
+                </span>
+                <span
+                  v-if="a.places"
+                  class="attachment-card__field attachment-card__field--places"
+                >
+                  <span class="attachment-card__label">Места:</span>{{ a.places }}
+                </span>
+              </div>
+            </button>
+
+            <button
+              v-if="items.length < total"
+              type="button"
+              class="lk-button lk-button--secondary load-more"
+              :disabled="listLoading"
+              data-testid="aa-load-more"
+              @click="loadMore"
+            >
+              Показать ещё
+            </button>
+          </div>
+
+          <div
+            v-else
+            class="empty-state"
+            data-testid="aa-empty"
+          >
+            <p>Доступных вложений нет</p>
+            <span class="empty-state__hint">
+              Здесь появятся вложения подтверждённых заявок по вашим местам доступа.
+            </span>
+          </div>
+
+          <div class="list-footer">
+            Всего: {{ total }}
+          </div>
+        </div>
+
+        <!-- Деталь вложения -->
+        <div
+          v-if="selectedId !== null"
+          class="detail-section"
+          data-testid="aa-detail"
+        >
+          <template v-if="detail">
+            <div class="application-block">
+              <h4 class="application-block__title">
+                Заявка
+              </h4>
+              <div class="application-block__grid">
+                <div
+                  v-if="detail.attachment.application_number"
+                  class="application-block__row"
+                >
+                  <span class="application-block__label">Номер</span>
+                  <span class="application-block__value">{{ detail.attachment.application_number }}</span>
+                </div>
+                <div
+                  v-if="detail.attachment.organization_name"
+                  class="application-block__row"
+                >
+                  <span class="application-block__label">Организация</span>
+                  <span class="application-block__value">{{ detail.attachment.organization_name }}</span>
+                </div>
+                <div
+                  v-if="detail.attachment.company_name"
+                  class="application-block__row"
+                >
+                  <span class="application-block__label">Компания</span>
+                  <span class="application-block__value">{{ detail.attachment.company_name }}</span>
+                </div>
+                <div
+                  v-if="senderName(detail.attachment)"
+                  class="application-block__row"
+                >
+                  <span class="application-block__label">Отправитель</span>
+                  <span class="application-block__value">{{ senderName(detail.attachment) }}</span>
+                </div>
+                <div
+                  v-if="statusText(detail.attachment)"
+                  class="application-block__row"
+                >
+                  <span class="application-block__label">Статус</span>
+                  <StatusBadge :status="statusText(detail.attachment)" />
+                </div>
+                <div
+                  v-if="detail.attachment.sending_datetime"
+                  class="application-block__row"
+                >
+                  <span class="application-block__label">Отправлена</span>
+                  <span class="application-block__value">{{ formatDateTime(detail.attachment.sending_datetime) }}</span>
+                </div>
+              </div>
+            </div>
+
+            <ApplicationAttachmentDetail
+              :attachment="detail.attachment"
+              :cars="detail.cars || []"
+              :employees="detail.employees || []"
+              :items="detail.items || []"
+            />
+          </template>
+
+          <div
+            v-else
+            class="detail-loading"
+            data-testid="aa-detail-loading"
+          >
+            <SkeletonCard :lines="6" />
+          </div>
+        </div>
+      </div>
     </div>
-    <p class="accessible-attachments__placeholder">
-      Раздел в разработке.
-    </p>
-  </div>
+  </AdminPageShell>
 </template>
 
 <script setup>
-// Заглушка маршрута (FE-S2). Полный список вложений и детали - в FE-S3.
+import { ref, onMounted } from 'vue';
+import AdminPageShell from '@/views/admin/AdminPageShell.vue';
+import RefreshButton from '@/components/RefreshButton.vue';
+import Badge from '@/components/ui/Badge.vue';
+import StatusBadge from '@/components/ui/StatusBadge.vue';
+import SkeletonCard from '@/components/ui/SkeletonCard.vue';
+import ApplicationAttachmentDetail from '@/components/ApplicationDetail/ApplicationAttachmentDetail.vue';
+import { getAccessibleAttachments, getAccessibleAttachmentDetail } from '@/api/applications';
+import { useDeletionsStore } from '@/stores/deletions';
+import { formatDateRu, formatDateTime } from '@/utils/datetime';
+
+const PER_PAGE = 30;
+
+const deletions = useDeletionsStore();
+
+const items = ref([]);
+const total = ref(0);
+const page = ref(1);
+const listLoading = ref(false);
+
+const selectedId = ref(null);
+const detail = ref(null);
+const detailLoading = ref(false);
+// Токен последовательности: быстрые клики по карточкам пускают параллельные
+// запросы детали в общий ref, и медленный ответ предыдущего вложения мог бы
+// затереть актуальный (#632). Применяем только ответ последнего запроса.
+let detailSeq = 0;
+
+const TYPE_LABELS = { cars: 'Автомобили', people: 'Сотрудники', items: 'ТМЦ' };
+const TYPE_VARIANTS = { cars: 'primary', people: 'info', items: 'warning' };
+
+function typeLabel(type) {
+  return TYPE_LABELS[type] || type || 'Вложение';
+}
+
+function typeVariant(type) {
+  return TYPE_VARIANTS[type] || 'neutral';
+}
+
+function displayName(a) {
+  return a.attachment_display_name || a.attachment_name || 'Без названия';
+}
+
+function senderName(a) {
+  return a.sender_full_name || a.sender_name || '';
+}
+
+function statusText(a) {
+  return a.status || a.confirmation || '';
+}
+
+function dateRange(a) {
+  const from = formatDateRu(a.entry_date_from);
+  const to = formatDateRu(a.entry_date_to);
+  if (from && to) return from === to ? from : `${from} - ${to}`;
+  if (from) return `с ${from}`;
+  if (to) return `по ${to}`;
+  return '';
+}
+
+async function fetchList({ reset = true } = {}) {
+  listLoading.value = true;
+  try {
+    if (reset) page.value = 1;
+    const { items: data, meta } = await getAccessibleAttachments({
+      page: page.value,
+      per_page: PER_PAGE,
+    });
+    items.value = reset ? data : [...items.value, ...data];
+    total.value = meta.total || 0;
+  } catch {
+    deletions.notify({
+      type: 'error',
+      bold: 'Не удалось загрузить',
+      suffix: 'список доступных вложений',
+    });
+  } finally {
+    listLoading.value = false;
+  }
+}
+
+function refresh() {
+  selectedId.value = null;
+  detail.value = null;
+  fetchList({ reset: true });
+}
+
+function loadMore() {
+  if (listLoading.value) return;
+  page.value += 1;
+  fetchList({ reset: false });
+}
+
+async function selectAttachment(id) {
+  selectedId.value = id;
+  detail.value = null;
+  detailLoading.value = true;
+  const seq = ++detailSeq;
+  try {
+    const data = await getAccessibleAttachmentDetail(id);
+    if (seq !== detailSeq) return;
+    detail.value = data;
+  } catch {
+    if (seq !== detailSeq) return;
+    selectedId.value = null;
+    deletions.notify({
+      type: 'error',
+      bold: 'Не удалось открыть',
+      suffix: 'вложение',
+    });
+  } finally {
+    if (seq === detailSeq) detailLoading.value = false;
+  }
+}
+
+onMounted(() => fetchList({ reset: true }));
 </script>
 
 <style scoped>
 .accessible-attachments {
-  padding: 20px;
+  background: #fff;
+  border: 1px solid #e6e6e6;
+  border-radius: 20px;
+  overflow: hidden;
 }
 
-.accessible-attachments__placeholder {
-  color: var(--color-text-secondary, #6b7280);
+.management-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 15px 20px;
+  border-bottom: 1px solid #e6e6e6;
+}
+
+.management-title {
+  margin: 0;
+  font-size: 1.2em;
+  font-weight: 600;
+  color: #000;
+}
+
+.header-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.content-container {
+  display: flex;
+  height: 540px;
+  width: 100%;
+  overflow: hidden;
+}
+
+.list-section {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  background: #fff;
+  transition: width 0.2s ease;
+}
+
+.list-section.with-details {
+  width: 40%;
+  border-right: 1px solid #e6e6e6;
+}
+
+.cards-list {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 15px;
+}
+
+.attachment-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  text-align: left;
+  padding: 12px 14px;
+  background: #f9f9f9;
+  border: 1px solid #e6e6e6;
+  border-radius: 15px;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background-color 0.2s ease, transform 0.2s ease;
+  animation: card-in 0.3s ease-out forwards;
+  opacity: 0;
+  transform: translateY(10px);
+}
+
+@keyframes card-in {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.attachment-card:hover {
+  border-color: #4F5BDF;
+  background: #f8f9ff;
+}
+
+.attachment-card--active {
+  border-color: #4F5BDF;
+  background: #f0f2ff;
+}
+
+.attachment-card__top {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.attachment-card__name {
+  font-weight: 600;
+  color: #333;
+  font-size: 15px;
+  flex: 1;
+  min-width: 0;
+}
+
+.attachment-card__status {
+  flex-shrink: 0;
+  min-width: auto;
+}
+
+.attachment-card__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  font-size: 13px;
+  color: #333;
+}
+
+.attachment-card__field {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.attachment-card__field--places {
+  white-space: normal;
+}
+
+.attachment-card__label {
+  color: #a2a2a2;
+  margin-right: 5px;
+}
+
+.load-more {
+  align-self: center;
+  margin-top: 4px;
+}
+
+.empty-state {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 40px 20px;
+  text-align: center;
+}
+
+.empty-state p {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: #333;
+}
+
+.empty-state__hint {
+  font-size: 13px;
+  color: #a2a2a2;
+  max-width: 320px;
+}
+
+.list-footer {
+  flex-shrink: 0;
+  padding: 12px 20px;
+  border-top: 1px solid #e6e6e6;
+  font-size: 14px;
+  color: #666;
+}
+
+.detail-section {
+  width: 60%;
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+  background: #fff;
+  overflow-y: auto;
+  padding: 15px;
+}
+
+.application-block {
+  background: #f9f9f9;
+  border: 1px solid #e6e6e6;
+  border-radius: 20px;
+  padding: 15px;
+}
+
+.application-block__title {
+  margin: 0 0 12px 0;
+  font-size: 16px;
+  font-weight: 700;
+  color: #4F5BDF;
+}
+
+.application-block__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 12px 24px;
+}
+
+.application-block__row {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 14px;
+}
+
+.application-block__label {
+  color: #a2a2a2;
+  font-weight: 400;
+}
+
+.application-block__value {
+  color: #000;
+  font-size: 15px;
+}
+
+.detail-loading {
+  padding: 10px;
+}
+
+@media (max-width: 900px) {
+  .content-container {
+    flex-direction: column;
+    height: auto;
+  }
+
+  .list-section,
+  .list-section.with-details,
+  .detail-section {
+    width: 100%;
+  }
+
+  .list-section.with-details {
+    border-right: none;
+    border-bottom: 1px solid #e6e6e6;
+  }
 }
 </style>

--- a/frontend/src/views/__tests__/AccessibleAttachmentsView.spec.js
+++ b/frontend/src/views/__tests__/AccessibleAttachmentsView.spec.js
@@ -98,6 +98,22 @@ describe('AccessibleAttachmentsView (FE-S3)', () => {
     expect(wrapper.find('[data-testid="aa-empty"]').exists()).toBe(true);
   });
 
+  it('уведомляет и снимает выбор при ошибке загрузки детали', async () => {
+    getAccessibleAttachments.mockResolvedValue({
+      items: [makeItem(1)],
+      meta: { total: 1, page: 1, per_page: 30 },
+    });
+    getAccessibleAttachmentDetail.mockRejectedValue(new Error('boom'));
+
+    wrapper = mountView();
+    await flushPromises();
+    await wrapper.find('[data-testid="aa-card"]').trigger('click');
+    await flushPromises();
+
+    expect(notify).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    expect(wrapper.find('[data-testid="aa-detail"]').exists()).toBe(false);
+  });
+
   it('не даёт устаревшему ответу детали затереть актуальный выбор (#632)', async () => {
     getAccessibleAttachments.mockResolvedValue({
       items: [makeItem(1), makeItem(2)],

--- a/frontend/src/views/__tests__/AccessibleAttachmentsView.spec.js
+++ b/frontend/src/views/__tests__/AccessibleAttachmentsView.spec.js
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+
+// FE-S3 (#706): вкладка "Доступные мне" - список доступных вложений + деталь.
+// Проверяем рендер списка, пустое состояние и защиту детали от гонки (#632):
+// быстрые клики не дают медленному ответу предыдущего вложения затереть актуальное.
+
+vi.mock('@/api/applications', () => ({
+  getAccessibleAttachments: vi.fn(),
+  getAccessibleAttachmentDetail: vi.fn(),
+}));
+
+const notify = vi.fn();
+vi.mock('@/stores/deletions', () => ({
+  useDeletionsStore: () => ({ notify }),
+}));
+
+import AccessibleAttachmentsView from '@/views/AccessibleAttachmentsView.vue';
+import { getAccessibleAttachments, getAccessibleAttachmentDetail } from '@/api/applications';
+
+const stubs = {
+  AdminPageShell: { template: '<div><slot /></div>' },
+  RefreshButton: { template: '<button class="refresh-stub" @click="$emit(\'refresh\')" />' },
+  ApplicationAttachmentDetail: {
+    props: ['attachment', 'cars', 'employees', 'items'],
+    template: '<div class="detail-stub">{{ attachment.attachment_id }}</div>',
+  },
+};
+
+function makeItem(id, over = {}) {
+  return {
+    attachment_id: id,
+    attachment_type: 'cars',
+    attachment_display_name: `Вложение ${id}`,
+    application_number: `A-${id}`,
+    organization_name: 'ООО Ромашка',
+    sender_full_name: 'Иванов И.И.',
+    entry_date_from: '2026-06-01',
+    entry_date_to: '2026-06-02',
+    places: 'Склад 1',
+    status: 'Согласовано',
+    ...over,
+  };
+}
+
+function mountView() {
+  return mount(AccessibleAttachmentsView, { global: { stubs } });
+}
+
+let wrapper;
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  wrapper?.unmount();
+});
+
+describe('AccessibleAttachmentsView (FE-S3)', () => {
+  it('рендерит список карточек вложений и счётчик', async () => {
+    getAccessibleAttachments.mockResolvedValue({
+      items: [makeItem(1), makeItem(2)],
+      meta: { total: 2, page: 1, per_page: 30 },
+    });
+    wrapper = mountView();
+    await flushPromises();
+
+    const cards = wrapper.findAll('[data-testid="aa-card"]');
+    expect(cards).toHaveLength(2);
+    expect(wrapper.text()).toContain('Вложение 1');
+    expect(wrapper.text()).toContain('A-1');
+    expect(wrapper.find('.list-footer').text()).toContain('Всего: 2');
+    expect(wrapper.find('[data-testid="aa-empty"]').exists()).toBe(false);
+  });
+
+  it('показывает пустое состояние без вложений', async () => {
+    getAccessibleAttachments.mockResolvedValue({
+      items: [],
+      meta: { total: 0, page: 1, per_page: 30 },
+    });
+    wrapper = mountView();
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="aa-empty"]').exists()).toBe(true);
+    expect(wrapper.text()).toContain('Доступных вложений нет');
+    expect(wrapper.findAll('[data-testid="aa-card"]')).toHaveLength(0);
+  });
+
+  it('уведомляет об ошибке загрузки списка', async () => {
+    getAccessibleAttachments.mockRejectedValue(new Error('boom'));
+    wrapper = mountView();
+    await flushPromises();
+
+    expect(notify).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    expect(wrapper.find('[data-testid="aa-empty"]').exists()).toBe(true);
+  });
+
+  it('не даёт устаревшему ответу детали затереть актуальный выбор (#632)', async () => {
+    getAccessibleAttachments.mockResolvedValue({
+      items: [makeItem(1), makeItem(2)],
+      meta: { total: 2, page: 1, per_page: 30 },
+    });
+    const resolvers = new Map();
+    getAccessibleAttachmentDetail.mockImplementation(
+      (id) => new Promise((resolve) => resolvers.set(id, resolve)),
+    );
+
+    wrapper = mountView();
+    await flushPromises();
+
+    const cards = wrapper.findAll('[data-testid="aa-card"]');
+    await cards[0].trigger('click'); // выбрали вложение 1 (медленный ответ)
+    await cards[1].trigger('click'); // быстро переключились на вложение 2
+
+    // Резолвим последний выбор первым, затем устаревший первый запрос.
+    resolvers.get(2)({ attachment: makeItem(2), cars: [] });
+    await flushPromises();
+    resolvers.get(1)({ attachment: makeItem(1), cars: [] });
+    await flushPromises();
+
+    // Деталь показывает вложение 2 (актуальный выбор), а не затёртое первым ответом.
+    expect(wrapper.find('.detail-stub').text()).toBe('2');
+  });
+});


### PR DESCRIPTION
## Что
Срез **FE-S3** эпика #706 ("Доступные мне" для охранников ЧОП). Заменил заглушку маршрута `/accessible-attachments` рабочим экраном: master-detail со списком карточек доступных вложений и панелью детали.

## Как
- `views/AccessibleAttachmentsView.vue` (перезаписан с нуля): header-эталон + RefreshButton, слева плоский список карточек (тип/имя/№заявки/организация/отправитель/статус/даты/места), справа деталь через переиспользуемый `ApplicationAttachmentDetail` (read-only) + блок "Заявка". Состояния skeleton/пусто/ошибка через `useDeletionsStore.notify`. Честная пагинация load-more ("Показать ещё"), счётчик "Всего: N".
- `api/applications.js`: `getAccessibleAttachments(params)` (читает пагинацию из `envelope.meta` через `apiRequestRaw` - `apiRequest` снимает только `data` и meta терялась бы) и `getAccessibleAttachmentDetail(id)`.
- Деталь защищена seq-токеном (#632): быстрое переключение карточек не даёт медленному ответу затереть актуальный выбор.

## Тесты
- vitest `views/__tests__/AccessibleAttachmentsView.spec.js`: рендер списка, пустое состояние, ошибка списка, ошибка детали, seq-гонка детали - 5 зелёных.
- eslint новых/изменённых файлов чистый.
- Скриншоты списка и детали сняты локально (Playwright, мок-данные) перед мержем.

## Ревью
Прошёл `code-reviewer`: 2 must-fix исправлены (анимация width -> убрана; border-radius 20px -> 16px под AdminPageShell, как у соседей). Suggestions учтены (убран dead `detailLoading`, добавлен тест ошибки детали, комментарий о деградации опц. блоков детали).

Зависит от FE-S2 (#718) и BE-S4 (#713) - оба смержены.