### PR TITLE
feat(create-application): место разгрузки на уровне заявки (#706)

### DIFF
--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -234,10 +234,12 @@
               :user-company="company"
               :user-company-id="companyId"
               :existing-vehicles="vehicles"
+              :application-unload-places="applicationUnloadPlaces"
               @vehicle-added="handleVehicleAdded"
               @vehicles-added="handleVehiclesAdded"
               @vehicle-updated="handleVehicleUpdated"
               @edit-cancelled="handleVehicleEditCancelled"
+              @update:unload-places="onApplicationUnloadPlacesChange"
             />
             <VehiclesList 
               :vehicles="sortedVehicles"
@@ -283,10 +285,14 @@
               :key="itemsFormKey"
               ref="itemsForm"
               :field-config="currentFieldConfig"              :existing-items="items"
+              :show-unload-places="showItemsUnloadPlaces"
+              :all-unloading-places="allUnloadingPlaces"
+              :selected-unload-places="applicationUnloadPlaces"
               @item-added="handleItemAdded"
               @items-added="handleItemsAdded"
               @item-updated="handleItemUpdated"
               @edit-cancelled="handleItemEditCancelled"
+              @update:unload-places="onApplicationUnloadPlacesChange"
             />
             <ItemsList
               :items="sortedItems"
@@ -384,6 +390,11 @@ export default {
 
             allUnloadingPlaces: [],
 
+            // Места разгрузки на уровне заявки (#706): единый выбор, синхронизируется
+            // во все cars-вложения и уходит в items-вложения. Для items-без-машин это
+            // единственный источник; для cars - дубль дедуп-union мест всех машин.
+            applicationUnloadPlaces: [],
+
             organizationId: null,
             companyId: null,
             
@@ -469,6 +480,25 @@ export default {
             return this.itemsByAttachment[this.attachmentKey(this.selectedAttachment)] || [];
         },
 
+        hasCars() {
+            return this.attachments.some(a => a.attachment_type === 'cars');
+        },
+
+        hasItems() {
+            return this.attachments.some(a => a.attachment_type === 'items');
+        },
+
+        // Выбор мест разгрузки в форме ТМЦ показываем только когда машин нет:
+        // при наличии машин единый выбор живёт в форме авто (#706).
+        showItemsUnloadPlaces() {
+            return !this.hasCars && this.hasItems;
+        },
+
+        // Для ТМЦ-без-машин место разгрузки обязательно: без него охранник не увидит вложение.
+        itemsUnloadRequired() {
+            return this.showItemsUnloadPlaces;
+        },
+
         currentCustomFields() {
             if (!this.selectedAttachment) return [];
             const uaId = this.selectedAttachment.template_id || this.selectedAttachment.id;
@@ -533,6 +563,9 @@ export default {
                     case 'items':
                         hasAttachmentData = (this.itemsByAttachment[key] || []).length > 0;
                         if (!hasAttachmentData) reasons.push(`"${label}": добавьте хотя бы одну позицию`);
+                        if (this.itemsUnloadRequired && this.applicationUnloadPlaces.length === 0) {
+                            reasons.push(`"${label}": выберите место разгрузки`);
+                        }
                         break;
                 }
 
@@ -590,6 +623,10 @@ export default {
                 if (type === 'cars' && items.length === 0) errors.push('Не добавлено ни одного автомобиля');
                 else if (type === 'people' && items.length === 0) errors.push('Не добавлено ни одного сотрудника');
                 else if (type === 'items' && items.length === 0) errors.push('Не добавлено ни одной позиции');
+
+                if (type === 'items' && this.itemsUnloadRequired && this.applicationUnloadPlaces.length === 0) {
+                    errors.push('Не выбрано место разгрузки');
+                }
 
                 const dateData = this.attachmentDatesByAttachment[key];
                 if (dateData) {
@@ -831,6 +868,41 @@ export default {
             } catch (error) {
                 console.error("Ошибка при загрузке мест разгрузки:", error);
             }
+        },
+
+        // Единый обработчик изменения мест разгрузки заявки (#706): источник -
+        // форма авто или форма ТМЦ. Пишем app-level выбор и раскатываем его во все
+        // машины cars-вложений, чтобы дедуп-union на бэке совпал с выбором.
+        onApplicationUnloadPlacesChange(placeIds) {
+            this.applicationUnloadPlaces = Array.isArray(placeIds) ? [...placeIds] : [];
+            this.syncUnloadPlacesToCars();
+            this.saveToLocalStorage();
+        },
+
+        syncUnloadPlacesToCars() {
+            const ids = this.applicationUnloadPlaces;
+            const formatted = this.formatUnloadPlacesDisplay(ids);
+            this.attachments.forEach(attachment => {
+                if (attachment.attachment_type !== 'cars') return;
+                const vehicles = this.vehiclesByAttachment[this.attachmentKey(attachment)];
+                if (!vehicles) return;
+                vehicles.forEach(vehicle => {
+                    vehicle.unloadPlaces = [...ids];
+                    vehicle.unloadingPlace = formatted;
+                });
+            });
+        },
+
+        formatUnloadPlacesDisplay(ids) {
+            if (!ids || ids.length === 0) return '';
+            const names = ids
+                .map(id => {
+                    const place = this.allUnloadingPlaces.find(p => p.id === id);
+                    return place ? place.name : '';
+                })
+                .filter(Boolean);
+            if (names.length === 0) return '';
+            return names.length > 1 ? `${names[0]} и др.` : names[0];
         },
         
         getDefaultDateData() {
@@ -1797,6 +1869,9 @@ export default {
                     entry_time_to: dateData.endTime + ":00",
                     roof_access: dateData.roofAccess,
                     free_parking: dateData.freeParking,
+                    // Место разгрузки на уровне вложения (#706): для items - единственный
+                    // источник; для cars бэк берёт дедуп-union мест машин, поле дублирует.
+                    unload_places: [...this.applicationUnloadPlaces],
                     data: {}
                 };
 
@@ -2075,6 +2150,8 @@ export default {
                     employeesByAttachment: hasAttachments ? this.employeesByAttachment : {},
                     itemsByAttachment: hasAttachments ? this.itemsByAttachment : {},
 
+                    applicationUnloadPlaces: hasAttachments ? this.applicationUnloadPlaces : [],
+
                     attachmentDatesByAttachment: hasAttachments ? this.attachmentDatesByAttachment : {},
                     customFieldsByAttachment: hasAttachments ? this.customFieldsByAttachment : {},
 
@@ -2110,6 +2187,8 @@ export default {
                     this.vehiclesByAttachment = parsedData.vehiclesByAttachment || {};
                     this.employeesByAttachment = parsedData.employeesByAttachment || {};
                     this.itemsByAttachment = parsedData.itemsByAttachment || {};
+
+                    this.applicationUnloadPlaces = parsedData.applicationUnloadPlaces || [];
 
                     this.attachmentDatesByAttachment = parsedData.attachmentDatesByAttachment || {};
                     this.customFieldsByAttachment = parsedData.customFieldsByAttachment || {};

--- a/frontend/src/components/CreateApplication/ItemsForm.vue
+++ b/frontend/src/components/CreateApplication/ItemsForm.vue
@@ -816,7 +816,7 @@ export default {
     font-size: 12px;
     font-weight: 500;
     cursor: pointer;
-    transition: all 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s;
     padding: 0 10px;
     text-align: center;
     border: 1px solid transparent;

--- a/frontend/src/components/CreateApplication/ItemsForm.vue
+++ b/frontend/src/components/CreateApplication/ItemsForm.vue
@@ -127,6 +127,51 @@
         </div>
       </div>
     </div>
+
+    <!-- Места разгрузки (#706): для ТМЦ-без-машин - единственный источник мест.
+         Грид 1:1 повторяет форму авто (completion__unloading). -->
+    <div
+      v-if="showUnloadPlaces"
+      class="completion__unloading"
+    >
+      <label class="input__label">Места разгрузки (выбор) <span class="required">*</span></label>
+      <div
+        v-if="allUnloadingPlaces.length > 0"
+        class="unloading__grid"
+      >
+        <div
+          v-for="place in allUnloadingPlaces"
+          :key="place.id"
+          class="unloading__item"
+          :class="{
+            'unloading__item--active': selectedUnloadPlaces.includes(place.id) && place.status === 'active',
+            'unloading__item--inactive': place.status !== 'active'
+          }"
+          @click="togglePlace(place)"
+          @mouseenter="showInactiveTooltip(place, $event)"
+          @mouseleave="hideInactiveTooltip"
+        >
+          {{ place.name }}
+        </div>
+      </div>
+      <div
+        v-else
+        class="no-places-message"
+      >
+        Нет доступных мест разгрузки
+      </div>
+    </div>
+
+    <!-- Tooltip для неактивных мест -->
+    <div
+      v-if="inactiveTooltip.visible"
+      class="inactive-tooltip"
+      :style="{ top: inactiveTooltip.y + 'px', left: inactiveTooltip.x + 'px' }"
+    >
+      <div class="inactive-tooltip-content">
+        {{ inactiveTooltip.text }}
+      </div>
+    </div>
   </div>
 </template>
 
@@ -150,9 +195,23 @@ export default {
         disabled: {
             type: Boolean,
             default: false
+        },
+        // Место разгрузки на уровне заявки (#706): для ТМЦ-без-машин это единственный
+        // источник мест. Показываем грид только когда машин в заявке нет.
+        showUnloadPlaces: {
+            type: Boolean,
+            default: false
+        },
+        allUnloadingPlaces: {
+            type: Array,
+            default: () => []
+        },
+        selectedUnloadPlaces: {
+            type: Array,
+            default: () => []
         }
     },
-    emits: ['edit-cancelled', 'item-added', 'item-updated', 'items-added'],
+    emits: ['edit-cancelled', 'item-added', 'item-updated', 'items-added', 'update:unload-places'],
     setup(props) {
         return useFieldConfig(() => props.fieldConfig);
     },
@@ -169,7 +228,13 @@ export default {
             showTooltip: false,
             submitted: false,
             tempItemsBackup: null,
-            isAddingRow: false
+            isAddingRow: false,
+            inactiveTooltip: {
+                visible: false,
+                text: '',
+                x: 0,
+                y: 0
+            }
         }
     },
     computed: {
@@ -342,6 +407,36 @@ export default {
             
             // Эмитируем событие отмены
             this.$emit('edit-cancelled');
+        },
+
+        togglePlace(place) {
+            if (place.status !== 'active') {
+                return;
+            }
+            const current = this.selectedUnloadPlaces || [];
+            const next = current.includes(place.id)
+                ? current.filter(id => id !== place.id)
+                : [...current, place.id];
+            this.$emit('update:unload-places', next);
+        },
+
+        showInactiveTooltip(place, event) {
+            if (place.status !== 'active') {
+                this.inactiveTooltip.text = place.status_comment
+                    ? `Недоступно: ${place.status_comment}`
+                    : 'Недоступно';
+                this.inactiveTooltip.visible = true;
+
+                this.$nextTick(() => {
+                    const rect = event.target.getBoundingClientRect();
+                    this.inactiveTooltip.x = rect.left + rect.width / 2;
+                    this.inactiveTooltip.y = rect.top - 10;
+                });
+            }
+        },
+
+        hideInactiveTooltip() {
+            this.inactiveTooltip.visible = false;
         }
     }
 }
@@ -693,5 +788,96 @@ export default {
     right: 40px;
     border: 5px solid transparent;
     border-bottom-color: #333;
+}
+
+/* Места разгрузки (#706): грид 1:1 из VehicleForm (completion__unloading). */
+.completion__unloading {
+    margin-top: 15px;
+}
+
+.unloading__grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 10px;
+    row-gap: 5px;
+    max-width: 425px;
+    margin-top: 5px;
+    position: relative;
+}
+
+.unloading__item {
+    height: 30px;
+    background: #F2F2F2;
+    color: #a2a2a2;
+    border-radius: 50px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s;
+    padding: 0 10px;
+    text-align: center;
+    border: 1px solid transparent;
+    position: relative;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.unloading__item:hover:not(.unloading__item--active):not(.unloading__item--inactive) {
+    background: #e8e8e8;
+}
+
+.unloading__item--active {
+    background: #4F5BDF;
+    color: #fff;
+    border-color: #4F5BDF;
+}
+
+.unloading__item--inactive {
+    background: #ffe6e6;
+    color: #ff6b6b;
+    border-color: #ffcccc;
+    cursor: not-allowed;
+    opacity: 0.7;
+}
+
+.no-places-message {
+    font-size: 12px;
+    color: #ff6b6b;
+    text-align: center;
+    padding: 20px;
+    background: #fff5f5;
+    border-radius: 8px;
+    margin-top: 10px;
+}
+
+.inactive-tooltip {
+    position: fixed;
+    transform: translateX(-50%) translateY(-100%);
+    z-index: 10000;
+    pointer-events: none;
+}
+
+.inactive-tooltip-content {
+    background: #333;
+    color: white;
+    padding: 8px 12px;
+    border-radius: 8px;
+    font-size: 12px;
+    max-width: 300px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+}
+
+.inactive-tooltip-content::before {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 5px solid transparent;
+    border-top-color: #333;
 }
 </style>

--- a/frontend/src/components/CreateApplication/VehicleForm.vue
+++ b/frontend/src/components/CreateApplication/VehicleForm.vue
@@ -393,6 +393,12 @@ export default {
             type: Array,
             default: () => []
         },
+        // Места разгрузки на уровне заявки (#706): приоритетный источник начального
+        // выбора. Пусто - падаем на автоподстановку по организации/компании.
+        applicationUnloadPlaces: {
+            type: Array,
+            default: () => []
+        },
         // Настройка полей шаблона (#529): { [fieldKey]: { visible, required, locked, requirable } }.
         // Раздаётся из CreateApplication; потребление (скрытие/обязательность полей машин) - срез H-7.
         fieldConfig: {
@@ -405,7 +411,7 @@ export default {
             default: false
         }
     },
-    emits: ['edit-cancelled', 'vehicle-added', 'vehicle-updated', 'vehicles-added'],
+    emits: ['edit-cancelled', 'vehicle-added', 'vehicle-updated', 'vehicles-added', 'update:unload-places'],
     setup(props) {
         const instance = getCurrentInstance()
         const toast = useToast()
@@ -644,31 +650,43 @@ export default {
                     this.allUnloadingPlaces = await allPlacesResponse.json();
                 }
 
-                if (this.userOrganizationId) {
-                    const orgPlacesResponse = await apiRequest(`/organizations/${this.userOrganizationId}/unload-places`, {
-                        method: "GET"});
+                if (this.applicationUnloadPlaces.length > 0) {
+                    // Приоритет - единый выбор мест заявки (#706): предзаполняем новое
+                    // cars-вложение уже сделанным выбором, минуя автоподстановку.
+                    this.selectedUnloadingPlaces = [...this.applicationUnloadPlaces];
+                } else {
+                    if (this.userOrganizationId) {
+                        const orgPlacesResponse = await apiRequest(`/organizations/${this.userOrganizationId}/unload-places`, {
+                            method: "GET"});
 
-                    if (orgPlacesResponse.ok) {
-                        this.attachedUnloadingPlaces = await orgPlacesResponse.json();
-                        const activeAttachedPlaces = this.attachedUnloadingPlaces.filter(place => place.status === 'active');
-                        this.selectedUnloadingPlaces = activeAttachedPlaces.map(place => place.id);
-                        if (this.selectedUnloadingPlaces.length > 0) {
-                            this.toast.success('Место разгрузки выбрано автоматически для вашей организации');
+                        if (orgPlacesResponse.ok) {
+                            this.attachedUnloadingPlaces = await orgPlacesResponse.json();
+                            const activeAttachedPlaces = this.attachedUnloadingPlaces.filter(place => place.status === 'active');
+                            this.selectedUnloadingPlaces = activeAttachedPlaces.map(place => place.id);
+                            if (this.selectedUnloadingPlaces.length > 0) {
+                                this.toast.success('Место разгрузки выбрано автоматически для вашей организации');
+                            }
                         }
                     }
-                }
 
-                if (this.attachedUnloadingPlaces.length === 0 && this.userCompanyId) {
-                    const companyPlacesResponse = await apiRequest(`/companies/${this.userCompanyId}/unload-places`, {
-                        method: "GET"});
+                    if (this.attachedUnloadingPlaces.length === 0 && this.userCompanyId) {
+                        const companyPlacesResponse = await apiRequest(`/companies/${this.userCompanyId}/unload-places`, {
+                            method: "GET"});
 
-                    if (companyPlacesResponse.ok) {
-                        this.attachedUnloadingPlaces = await companyPlacesResponse.json();
-                        const activeAttachedPlaces = this.attachedUnloadingPlaces.filter(place => place.status === 'active');
-                        this.selectedUnloadingPlaces = activeAttachedPlaces.map(place => place.id);
-                        if (this.selectedUnloadingPlaces.length > 0) {
-                            this.toast.success('Место разгрузки выбрано автоматически для вашей компании');
+                        if (companyPlacesResponse.ok) {
+                            this.attachedUnloadingPlaces = await companyPlacesResponse.json();
+                            const activeAttachedPlaces = this.attachedUnloadingPlaces.filter(place => place.status === 'active');
+                            this.selectedUnloadingPlaces = activeAttachedPlaces.map(place => place.id);
+                            if (this.selectedUnloadingPlaces.length > 0) {
+                                this.toast.success('Место разгрузки выбрано автоматически для вашей компании');
+                            }
                         }
+                    }
+
+                    // Поднимаем автоподставленный выбор на уровень заявки, чтобы он
+                    // пережил удаление последнего cars-вложения и ушёл в items (#706).
+                    if (this.selectedUnloadingPlaces.length > 0) {
+                        this.$emit('update:unload-places', [...this.selectedUnloadingPlaces]);
                     }
                 }
 
@@ -779,6 +797,8 @@ export default {
             } else {
                 this.selectedUnloadingPlaces.push(place.id);
             }
+            // Единый выбор на заявку (#706): синхронизируем во все cars-вложения и items.
+            this.$emit('update:unload-places', [...this.selectedUnloadingPlaces]);
         },
         
         validateUnloadingPlaces() {

--- a/frontend/src/components/CreateApplication/__tests__/ApplicationUnloadPlaces.spec.js
+++ b/frontend/src/components/CreateApplication/__tests__/ApplicationUnloadPlaces.spec.js
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { shallowMount, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import CreateApplication from '../CreateApplication.vue';
+
+// FE-S4 (#706): место разгрузки на уровне заявки. Единый выбор синхронизируется
+// во все cars-вложения, уходит в items-DTO; для items-без-машин обязателен.
+
+vi.mock('@/api/client', () => ({
+  apiRequest: vi.fn().mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue([]) }),
+}));
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: vi.fn().mockReturnValue({ token: 'test-token' }),
+}));
+vi.mock('@/composables/useToast', () => ({
+  useToast: vi.fn().mockReturnValue({ success: vi.fn(), error: vi.fn() }),
+}));
+
+const PLACES = [
+  { id: 1, name: 'Ворота 1', status: 'active' },
+  { id: 2, name: 'Ворота 2', status: 'active' },
+  { id: 3, name: 'Док 3', status: 'inactive' },
+];
+
+async function mountApp() {
+  const w = shallowMount(CreateApplication);
+  await flushPromises();
+  w.vm.allUnloadingPlaces = PLACES;
+  return w;
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  localStorage.clear();
+});
+
+describe('CreateApplication - место разгрузки на уровне заявки (#706)', () => {
+  it('onApplicationUnloadPlacesChange раскатывает выбор во все машины cars-вложений', async () => {
+    const w = await mountApp();
+    w.vm.attachments = [{ local_id: 'a1', attachment_type: 'cars' }];
+    w.vm.vehiclesByAttachment = {
+      a1: [
+        { id: 1, unloadPlaces: [], unloadingPlace: '' },
+        { id: 2, unloadPlaces: [], unloadingPlace: '' },
+      ],
+    };
+
+    w.vm.onApplicationUnloadPlacesChange([1, 2]);
+
+    expect(w.vm.applicationUnloadPlaces).toEqual([1, 2]);
+    expect(w.vm.vehiclesByAttachment.a1[0].unloadPlaces).toEqual([1, 2]);
+    expect(w.vm.vehiclesByAttachment.a1[1].unloadPlaces).toEqual([1, 2]);
+    // Отображаемая строка машины - первое место + "и др." при нескольких.
+    expect(w.vm.vehiclesByAttachment.a1[0].unloadingPlace).toBe('Ворота 1 и др.');
+  });
+
+  it('одно место - строка без "и др."', async () => {
+    const w = await mountApp();
+    w.vm.attachments = [{ local_id: 'a1', attachment_type: 'cars' }];
+    w.vm.vehiclesByAttachment = { a1: [{ id: 1, unloadPlaces: [], unloadingPlace: '' }] };
+
+    w.vm.onApplicationUnloadPlacesChange([2]);
+
+    expect(w.vm.vehiclesByAttachment.a1[0].unloadingPlace).toBe('Ворота 2');
+  });
+
+  it('showItemsUnloadPlaces/itemsUnloadRequired: только items без машин', async () => {
+    const w = await mountApp();
+
+    w.vm.attachments = [{ local_id: 'i1', attachment_type: 'items' }];
+    expect(w.vm.showItemsUnloadPlaces).toBe(true);
+    expect(w.vm.itemsUnloadRequired).toBe(true);
+
+    // Появилась машина - выбор мест переезжает в форму авто.
+    w.vm.attachments = [
+      { local_id: 'i1', attachment_type: 'items' },
+      { local_id: 'c1', attachment_type: 'cars' },
+    ];
+    expect(w.vm.showItemsUnloadPlaces).toBe(false);
+    expect(w.vm.itemsUnloadRequired).toBe(false);
+  });
+
+  it('#529: items-без-машин без места блокирует отправку (submitValidation + tooltipSections)', async () => {
+    const w = await mountApp();
+    w.vm.attachments = [{ local_id: 'i1', attachment_type: 'items', attachment_display_name: 'Разовый пропуск' }];
+    w.vm.itemsByAttachment = { i1: [{ id: 1, itemName: 'Ящик', quantity: 1 }] };
+
+    expect(w.vm.submitValidation.some(r => r.includes('место разгрузки'))).toBe(true);
+    const itemsSection = w.vm.tooltipSections.find(s => s.attachmentType === 'items');
+    expect(itemsSection.messages).toContain('Не выбрано место разгрузки');
+
+    w.vm.onApplicationUnloadPlacesChange([1]);
+
+    expect(w.vm.submitValidation.some(r => r.includes('место разгрузки'))).toBe(false);
+    const itemsSectionAfter = w.vm.tooltipSections.find(s => s.attachmentType === 'items');
+    expect(itemsSectionAfter ? itemsSectionAfter.messages : []).not.toContain('Не выбрано место разгрузки');
+  });
+
+  it('место не обязательно для items, когда в заявке есть машины', async () => {
+    const w = await mountApp();
+    w.vm.attachments = [
+      { local_id: 'i1', attachment_type: 'items', attachment_display_name: 'ТМЦ' },
+      { local_id: 'c1', attachment_type: 'cars', attachment_display_name: 'Авто' },
+    ];
+    w.vm.itemsByAttachment = { i1: [{ id: 1, itemName: 'Ящик', quantity: 1 }] };
+
+    expect(w.vm.submitValidation.some(r => r.includes('место разгрузки'))).toBe(false);
+  });
+
+  it('applicationUnloadPlaces переживает save/restore localStorage', async () => {
+    const w = await mountApp();
+    w.vm.attachments = [{ local_id: 'i1', attachment_type: 'items' }];
+    w.vm.applicationUnloadPlaces = [1, 2];
+    w.vm.saveToLocalStorage();
+
+    // Свежий монтаж: mounted() вызывает restoreFromLocalStorage.
+    const w2 = await mountApp();
+    expect(w2.vm.applicationUnloadPlaces).toEqual([1, 2]);
+  });
+});


### PR DESCRIPTION
## Что

FE-S4 эпика #706 «Доступные мне». Место разгрузки переезжает с уровня машины на уровень **заявки** — единый выбор, общий для всех вложений.

- `applicationUnloadPlaces[]` в `CreateApplication` — единый источник. Меняется из формы авто или формы ТМЦ, синхронизируется во все cars-вложения (каждая машина получает один и тот же набор) и уходит в items-вложения.
- `VehicleForm`: prop `applicationUnloadPlaces` (приоритетный начальный выбор; пусто — fallback на места организации/компании, как раньше, + поднимаем выбор наверх). Toggle эмитит `update:unload-places`.
- `ItemsForm`: для ТМЦ-**без машин** показывает грид мест (`showUnloadPlaces = !hasCars && hasItems`), грид скопирован из `VehicleForm` 1:1 (#481). При наличии машин выбор живёт в форме авто.
- DTO: `unload_places` на уровне вложения (для items — единственный источник; бэк BE-S2 #714 читает его; для cars бэк берёт дедуп-union мест машин).
- **#529**: для ТМЦ-без-машин место **обязательно** (решение пользователя) — проведено в `submitValidation`, `tooltipSections` и DTO. При наличии машин не блокирует.
- Выбор переживает удаление последнего cars-вложения и save/restore `localStorage`.

## Проверка

- vitest: 6 новых тестов синхронизации (`ApplicationUnloadPlaces.spec.js`) + регрессия field-config/gate — 38 зелёных.
- eslint изменённых файлов: 0 errors.
- `code-reviewer`: вердикт GO, 0 функциональных блокеров; yellow по `transition: all` поправлен (скоупнут на цвета, визуально идентично).

Зависит от BE-S2 (#714, merged).