### PR TITLE
feat(security): модалка "Места доступа" в карточке охранника (#706)

### DIFF
--- a/frontend/src/api/users.js
+++ b/frontend/src/api/users.js
@@ -59,3 +59,29 @@ export async function updateUserCompany(username, companyId) {
 export async function deleteUser(username) {
   return apiRequest(`/users/${username}`, { method: 'DELETE' });
 }
+
+// --- Места доступа охранника (#706, BE-S5) ---
+
+export async function getUserUnloadPlaces(username) {
+  const res = await apiRequest(`/users/${username}/unload-places`);
+  return res.json();
+}
+
+export async function setUserUnloadPlaces(username, unloadPlaceIds) {
+  return apiRequest(`/users/${username}/unload-places`, {
+    method: 'PUT',
+    body: JSON.stringify({ unload_place_ids: unloadPlaceIds }),
+  });
+}
+
+export async function getUserTables(username) {
+  const res = await apiRequest(`/users/${username}/tables`);
+  return res.json();
+}
+
+export async function setUserTables(username, tableIds) {
+  return apiRequest(`/users/${username}/tables`, {
+    method: 'PUT',
+    body: JSON.stringify({ table_ids: tableIds }),
+  });
+}

--- a/frontend/src/components/UserControl.vue
+++ b/frontend/src/components/UserControl.vue
@@ -210,6 +210,14 @@
                   Права доступа
                 </button>
                 <button
+                  v-if="selectedUserIsSecurity"
+                  class="lk-button lk-button--secondary"
+                  data-testid="user-access-places"
+                  @click="openAccessPlaces(selectedUser)"
+                >
+                  Места доступа
+                </button>
+                <button
                   class="lk-button lk-button--secondary"
                   data-testid="user-reset-onboarding"
                   @click="resetOnboarding(selectedUser)"
@@ -649,6 +657,12 @@
       @close="accessUser = null"
       @updated="onAccessUpdated"
     />
+
+    <UserAccessPlacesModal
+      v-if="accessPlacesUser"
+      :user="accessPlacesUser"
+      @close="accessPlacesUser = null"
+    />
   </div>
 </template>
 
@@ -668,6 +682,7 @@ import BaseDropdown from './ui/BaseDropdown.vue';
 import ToggleSwitch from './ui/ToggleSwitch.vue';
 import UserHistoryModal from './UserHistoryModal.vue';
 import UserAccessModal from './admin/UserAccessModal.vue';
+import UserAccessPlacesModal from './admin/UserAccessPlacesModal.vue';
 import { useDeletionsStore } from '@/stores/deletions';
 import { useUiStore } from '@/stores/ui';
 import { resetOnboardingForUser } from '@/api/onboarding';
@@ -681,7 +696,8 @@ export default {
     BaseDropdown,
     ToggleSwitch,
     UserHistoryModal,
-    UserAccessModal
+    UserAccessModal,
+    UserAccessPlacesModal
   },
   props: {
     allUsers: {
@@ -701,6 +717,7 @@ export default {
       selectedUser: null,
       historyForUser: null,
       accessUser: null,
+      accessPlacesUser: null,
       currentUserName: '',
       deleteConfirmUser: null,
       showArchive: false,
@@ -738,6 +755,13 @@ export default {
     },
     companyOptionsWithNone() {
       return [{ id: null, name: 'Не выбрано' }, ...this.companies];
+    },
+    // Места доступа настраиваются только охранникам ЧОП — резолвим по стабильному
+    // user_types.code, не по числовому type_id (нестабилен между средами).
+    selectedUserIsSecurity() {
+      if (!this.selectedUser) return false;
+      const type = this.userTypes.find(t => t.id === this.selectedUser.type_id);
+      return type?.code === 'security';
     },
     filteredUsers() {
       const searchTerm = this.userSearch.toLowerCase();
@@ -918,6 +942,10 @@ export default {
 
     openAccess(user) {
       this.accessUser = user;
+    },
+
+    openAccessPlaces(user) {
+      this.accessPlacesUser = user;
     },
 
     onAccessUpdated() {

--- a/frontend/src/components/admin/UserAccessPlacesModal.vue
+++ b/frontend/src/components/admin/UserAccessPlacesModal.vue
@@ -1,0 +1,481 @@
+<template>
+  <Teleport to="body">
+    <div
+      class="modal-overlay"
+      :class="{ 'modal-leaving': leaving }"
+      data-testid="user-access-places-modal"
+      @mousedown="onOverlayMousedown"
+      @mouseup="onOverlayMouseup"
+    >
+      <div
+        class="access-places-modal"
+        @mousedown.stop
+      >
+        <header class="access-places-modal__header">
+          <h3>Места доступа «{{ user?.username }}»</h3>
+          <button
+            class="close-btn"
+            aria-label="Закрыть"
+            @click="close"
+          >
+            ×
+          </button>
+        </header>
+
+        <div class="access-places-modal__body">
+          <p
+            v-if="loading"
+            class="access-places-modal__loading"
+          >
+            Загрузка...
+          </p>
+
+          <template v-else>
+            <section class="access-block">
+              <label class="block-label">Места разгрузки</label>
+              <div class="places-container">
+                <div
+                  v-if="unloadPlaces.length"
+                  class="places-grid"
+                >
+                  <div
+                    v-for="place in unloadPlaces"
+                    :key="place.id"
+                    class="place-item"
+                    :class="{ selected: selectedUnloadPlaceIds.includes(place.id) }"
+                    @click="toggleUnloadPlace(place.id)"
+                  >
+                    {{ place.name }}
+                  </div>
+                </div>
+                <div
+                  v-else
+                  class="no-places-message"
+                >
+                  <p>Нет доступных мест разгрузки</p>
+                </div>
+              </div>
+            </section>
+
+            <section class="access-block">
+              <label class="block-label">Места прохода</label>
+              <div class="places-container">
+                <div
+                  v-if="tables.length"
+                  class="places-grid"
+                >
+                  <div
+                    v-for="table in tables"
+                    :key="table.id"
+                    class="place-item"
+                    :class="{ selected: selectedTableIds.includes(table.id) }"
+                    @click="toggleTable(table.id)"
+                  >
+                    {{ tableName(table) }}
+                  </div>
+                </div>
+                <div
+                  v-else
+                  class="no-places-message"
+                >
+                  <p>Нет доступных мест прохода</p>
+                </div>
+              </div>
+            </section>
+          </template>
+        </div>
+
+        <footer class="access-places-modal__footer">
+          <button
+            class="lk-button lk-button--ghost"
+            :disabled="saving"
+            @click="close"
+          >
+            Отмена
+          </button>
+          <button
+            class="lk-button lk-button--primary"
+            data-testid="access-places-save"
+            :disabled="saving || loading || !isDirty"
+            @click="save"
+          >
+            {{ saving ? 'Сохранение...' : 'Сохранить' }}
+          </button>
+        </footer>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script>
+import { useOverlayClose } from '@/composables/useOverlayClose';
+import { useDeletionsStore } from '@/stores/deletions';
+import { registerDirtyTracker } from '@/utils/dirtyTracker';
+import { apiRequest } from '@/api/client';
+import {
+  getUserUnloadPlaces,
+  setUserUnloadPlaces,
+  getUserTables,
+  setUserTables,
+} from '@/api/users';
+
+/**
+ * Модалка настройки мест доступа охранника ЧОП (#706): какие места разгрузки и
+ * места прохода видит пользователь во вкладке «Доступные мне». Заменяет привязку
+ * целиком (delete-all-then-recreate на бэке), не добавляет.
+ */
+export default {
+  name: 'UserAccessPlacesModal',
+  props: {
+    user: { type: Object, default: null },
+  },
+  emits: ['close', 'updated'],
+  setup() {
+    const overlay = { close: () => {} };
+    const { onOverlayMousedown, onOverlayMouseup } = useOverlayClose(() => overlay.close());
+    return { onOverlayMousedown, onOverlayMouseup, overlay };
+  },
+  data() {
+    return {
+      leaving: false,
+      loading: true,
+      saving: false,
+      unloadPlaces: [],
+      tables: [],
+      selectedUnloadPlaceIds: [],
+      selectedTableIds: [],
+      originalUnloadPlaceIds: [],
+      originalTableIds: [],
+    };
+  },
+  computed: {
+    isDirty() {
+      return (
+        !this.sameSet(this.selectedUnloadPlaceIds, this.originalUnloadPlaceIds) ||
+        !this.sameSet(this.selectedTableIds, this.originalTableIds)
+      );
+    },
+  },
+  created() {
+    this.overlay.close = () => this.close();
+  },
+  async mounted() {
+    document.addEventListener('keydown', this.onKeydown);
+    this._stopGuard = registerDirtyTracker({
+      isDirty: () => this.isDirty,
+      getChanges: () => ['Изменены места доступа охранника'],
+      save: async () => { await this.save(); },
+    });
+    await this.load();
+  },
+  beforeUnmount() {
+    document.removeEventListener('keydown', this.onKeydown);
+    this._stopGuard?.();
+  },
+  methods: {
+    tableName(table) {
+      return table.display_name || table.name || 'Без названия';
+    },
+
+    sameSet(a, b) {
+      if (a.length !== b.length) return false;
+      const sortedA = [...a].sort((x, y) => x - y);
+      const sortedB = [...b].sort((x, y) => x - y);
+      return sortedA.every((v, i) => v === sortedB[i]);
+    },
+
+    async load() {
+      this.loading = true;
+      const username = this.user?.username;
+      try {
+        const [allPlaces, allTables, userPlaces, userTables] = await Promise.all([
+          this.fetchAllUnloadPlaces(),
+          this.fetchAllTables(),
+          getUserUnloadPlaces(username),
+          getUserTables(username),
+        ]);
+        this.unloadPlaces = allPlaces;
+        this.tables = allTables;
+        // При ошибочном ответе GET .json() отдаёт { message } (truthy объект, не массив) -
+        // Array.isArray отсекает его, иначе .map упал бы TypeError'ом.
+        this.selectedUnloadPlaceIds = Array.isArray(userPlaces) ? userPlaces.map(p => p.id) : [];
+        this.selectedTableIds = Array.isArray(userTables) ? userTables.map(t => t.id) : [];
+        this.originalUnloadPlaceIds = [...this.selectedUnloadPlaceIds];
+        this.originalTableIds = [...this.selectedTableIds];
+      } catch (error) {
+        console.error('Не удалось загрузить места доступа:', error);
+        useDeletionsStore().notify({
+          prefix: 'Не удалось загрузить места доступа: ',
+          bold: 'ошибка сети',
+          type: 'error',
+        });
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    async fetchAllUnloadPlaces() {
+      const response = await apiRequest('/unload-places');
+      if (!response.ok) return [];
+      return response.json();
+    },
+
+    async fetchAllTables() {
+      const response = await apiRequest('/system-tables');
+      if (!response.ok) return [];
+      const data = await response.json();
+      return (data || []).filter(t => t.table_type !== 'cars');
+    },
+
+    toggleUnloadPlace(id) {
+      const i = this.selectedUnloadPlaceIds.indexOf(id);
+      if (i > -1) this.selectedUnloadPlaceIds.splice(i, 1);
+      else this.selectedUnloadPlaceIds.push(id);
+    },
+
+    toggleTable(id) {
+      const i = this.selectedTableIds.indexOf(id);
+      if (i > -1) this.selectedTableIds.splice(i, 1);
+      else this.selectedTableIds.push(id);
+    },
+
+    async save() {
+      if (this.saving || !this.user?.username) return;
+      this.saving = true;
+      const username = this.user.username;
+      try {
+        const [placesRes, tablesRes] = await Promise.all([
+          setUserUnloadPlaces(username, this.selectedUnloadPlaceIds),
+          setUserTables(username, this.selectedTableIds),
+        ]);
+        // PUT идемпотентны (delete-all-then-recreate), поэтому фиксируем original
+        // по каждому набору отдельно: при частичном сбое dirty остаётся только у упавшего.
+        if (placesRes.ok) this.originalUnloadPlaceIds = [...this.selectedUnloadPlaceIds];
+        if (tablesRes.ok) this.originalTableIds = [...this.selectedTableIds];
+
+        if (placesRes.ok && tablesRes.ok) {
+          useDeletionsStore().notify({
+            prefix: 'Места доступа сохранены для ',
+            bold: username,
+            type: 'success',
+          });
+          this.$emit('updated');
+          this.close();
+          return;
+        }
+
+        const failed = [
+          !placesRes.ok && 'места разгрузки',
+          !tablesRes.ok && 'места прохода',
+        ].filter(Boolean).join(' и ');
+        useDeletionsStore().notify({
+          prefix: 'Не удалось сохранить ',
+          bold: failed,
+          type: 'error',
+        });
+      } catch (error) {
+        console.error('Не удалось сохранить места доступа:', error);
+        useDeletionsStore().notify({
+          prefix: 'Не удалось сохранить места доступа: ',
+          bold: 'ошибка сервера',
+          type: 'error',
+        });
+      } finally {
+        this.saving = false;
+      }
+    },
+
+    onKeydown(e) {
+      if (e.key === 'Escape') this.close();
+    },
+
+    close() {
+      if (this.leaving) return;
+      this.leaving = true;
+      setTimeout(() => this.$emit('close'), 250);
+    },
+  },
+};
+</script>
+
+<style scoped>
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 12000;
+  padding: 20px;
+  animation: fadeIn 0.2s ease-out;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.modal-overlay.modal-leaving {
+  animation: fadeOut 0.25s ease-in forwards;
+}
+
+.modal-overlay.modal-leaving .access-places-modal {
+  animation: slideDown 0.25s ease-in forwards;
+}
+
+@keyframes fadeOut {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
+@keyframes slideDown {
+  from { transform: translateY(0); opacity: 1; }
+  to { transform: translateY(20px); opacity: 0; }
+}
+
+.access-places-modal {
+  background: #fff;
+  border-radius: 30px;
+  width: 100%;
+  max-width: 640px;
+  max-height: 88vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+  animation: slideUp 0.2s ease-out;
+}
+
+@keyframes slideUp {
+  from { transform: translateY(20px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}
+
+.access-places-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 24px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.access-places-modal__header h3 {
+  margin: 0;
+  font-size: 1.1em;
+  font-weight: 600;
+  color: #000;
+}
+
+.close-btn {
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+  line-height: 1;
+  color: #999;
+  background: none;
+  border: none;
+  cursor: pointer;
+  border-radius: 50%;
+  transition: all 0.2s;
+}
+
+.close-btn:hover {
+  color: #333;
+  background: #f5f5f5;
+}
+
+.access-places-modal__body {
+  padding: 20px 24px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.access-places-modal__loading {
+  margin: 0;
+  text-align: center;
+  color: var(--color-text-muted);
+}
+
+.access-block {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.block-label {
+  font-size: 0.85em;
+  color: #a2a2a2;
+  font-weight: 400;
+}
+
+.places-container {
+  width: fit-content;
+  background: #fff;
+  border-radius: 15px;
+  border: 1px solid #e6e6e6;
+  padding: 12px;
+}
+
+.places-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 5px;
+  row-gap: 5px;
+}
+
+.place-item {
+  height: 30px;
+  border-radius: 50px;
+  background: #f2f2f2;
+  font-size: 12px;
+  font-weight: 500;
+  color: #a2a2a2;
+  width: 140px;
+  min-width: 80px;
+  padding: 0 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+  user-select: none;
+  text-align: center;
+}
+
+.place-item:hover {
+  background: #e8e8e8;
+}
+
+.place-item.selected {
+  background: #4F5BDF;
+  color: #fff;
+}
+
+.no-places-message {
+  text-align: center;
+  padding: 20px;
+  color: #6b7280;
+  font-style: italic;
+}
+
+.access-places-modal__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 16px 24px;
+  border-top: 1px solid var(--color-border);
+}
+
+@media (max-width: 768px) {
+  .places-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+</style>

--- a/frontend/src/components/admin/__tests__/UserAccessPlacesModal.spec.js
+++ b/frontend/src/components/admin/__tests__/UserAccessPlacesModal.spec.js
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+
+import UserAccessPlacesModal from '../UserAccessPlacesModal.vue';
+import { setUserUnloadPlaces, setUserTables } from '@/api/users';
+
+const UNLOAD_PLACES = [
+  { id: 1, name: 'Склад 1' },
+  { id: 2, name: 'Склад 2' },
+  { id: 3, name: 'Склад 3' },
+];
+
+const SYSTEM_TABLES = [
+  { id: 10, display_name: 'КПП Север', table_type: 'people' },
+  { id: 11, display_name: 'Гараж', table_type: 'cars' },
+  { id: 12, display_name: 'КПП Юг', table_type: 'people' },
+];
+
+const notify = vi.fn();
+
+vi.mock('@/api/client', () => ({
+  apiRequest: vi.fn((path) => {
+    if (path === '/unload-places') {
+      return Promise.resolve({ ok: true, json: async () => UNLOAD_PLACES });
+    }
+    if (path === '/system-tables') {
+      return Promise.resolve({ ok: true, json: async () => SYSTEM_TABLES });
+    }
+    return Promise.resolve({ ok: true, json: async () => [] });
+  }),
+}));
+
+vi.mock('@/api/users', () => ({
+  getUserUnloadPlaces: vi.fn(async () => [{ id: 2, name: 'Склад 2' }]),
+  getUserTables: vi.fn(async () => [{ id: 12, display_name: 'КПП Юг', table_type: 'people' }]),
+  setUserUnloadPlaces: vi.fn(async () => ({ ok: true })),
+  setUserTables: vi.fn(async () => ({ ok: true })),
+}));
+
+vi.mock('@/stores/deletions', () => ({
+  useDeletionsStore: () => ({ notify }),
+}));
+
+async function mountModal() {
+  const wrapper = mount(UserAccessPlacesModal, {
+    props: { user: { username: 'guard1' } },
+    global: { stubs: { teleport: true } },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+describe('UserAccessPlacesModal (#706 FE-S5)', () => {
+  beforeEach(() => {
+    notify.mockClear();
+    setUserUnloadPlaces.mockClear();
+    setUserTables.mockClear();
+  });
+
+  it('грузит пикеры, отфильтровывает cars-таблицы и предвыбирает места пользователя', async () => {
+    const wrapper = await mountModal();
+
+    expect(wrapper.vm.unloadPlaces).toHaveLength(3);
+    // Гараж (cars) исключён - в местах прохода только people-таблицы.
+    expect(wrapper.vm.tables.map(t => t.id)).toEqual([10, 12]);
+    expect(wrapper.vm.selectedUnloadPlaceIds).toEqual([2]);
+    expect(wrapper.vm.selectedTableIds).toEqual([12]);
+
+    const items = wrapper.findAll('.place-item');
+    expect(items).toHaveLength(5);
+    expect(wrapper.findAll('.place-item.selected')).toHaveLength(2);
+  });
+
+  it('Сохранить заблокировано без изменений и разблокируется после toggle', async () => {
+    const wrapper = await mountModal();
+    const sel = '[data-testid="access-places-save"]';
+    expect(wrapper.find(sel).attributes('disabled')).toBeDefined();
+
+    wrapper.vm.toggleUnloadPlace(1);
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.isDirty).toBe(true);
+    expect(wrapper.find(sel).attributes('disabled')).toBeUndefined();
+  });
+
+  it('сохранение шлёт выбранные id в оба эндпоинта, нотифицирует и эмитит updated', async () => {
+    const wrapper = await mountModal();
+
+    wrapper.vm.toggleUnloadPlace(1); // [2,1]
+    wrapper.vm.toggleTable(10); // [12,10]
+    await wrapper.vm.$nextTick();
+
+    await wrapper.find('[data-testid="access-places-save"]').trigger('click');
+    await flushPromises();
+
+    expect(setUserUnloadPlaces).toHaveBeenCalledWith('guard1', [2, 1]);
+    expect(setUserTables).toHaveBeenCalledWith('guard1', [12, 10]);
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({ bold: 'guard1', type: 'success' }),
+    );
+    expect(wrapper.emitted('updated')).toHaveLength(1);
+  });
+
+  it('частичный сбой save: места разгрузки сохранены, места прохода — нет, dirty остаётся у упавшего', async () => {
+    setUserTables.mockResolvedValueOnce({ ok: false });
+    const wrapper = await mountModal();
+
+    wrapper.vm.toggleUnloadPlace(1); // selected [2,1]
+    wrapper.vm.toggleTable(10); // selected [12,10]
+    await wrapper.vm.$nextTick();
+
+    await wrapper.find('[data-testid="access-places-save"]').trigger('click');
+    await flushPromises();
+
+    // Места разгрузки прошли -> их original обновился; места прохода упали -> dirty.
+    expect(wrapper.vm.originalUnloadPlaceIds).toEqual([2, 1]);
+    expect(wrapper.vm.originalTableIds).toEqual([12]);
+    expect(wrapper.vm.isDirty).toBe(true);
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({ bold: 'места прохода', type: 'error' }),
+    );
+    // Модалка не закрылась при ошибке.
+    expect(wrapper.emitted('close')).toBeUndefined();
+  });
+
+  it('toggle снимает уже выбранное место', async () => {
+    const wrapper = await mountModal();
+    wrapper.vm.toggleUnloadPlace(2); // снять предвыбранный
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.selectedUnloadPlaceIds).toEqual([]);
+  });
+});


### PR DESCRIPTION
Срез FE-S5 эпика #706 («Доступные мне»). Админ в карточке пользователя-охранника настраивает места разгрузки и места прохода, которые тот видит во вкладке «Доступные мне».

## Что сделано
- `UserControl.vue`: computed `selectedUserIsSecurity` (резолв по стабильному `user_types.code`, не по числовому type_id), кнопка «Места доступа» в шапке детали - только для активного охранника.
- `components/admin/UserAccessPlacesModal.vue`: модалка по эталону `UserAccessModal` (Teleport, анимация открытия/закрытия, useOverlayClose, Escape, radius 30px). Два блока - места разгрузки + места прохода; гриды `.place-item` скопированы 1:1 из `SelectUnloadPlaces`/`SelectTables`. dirty-tracker, уведомления через `useDeletionsStore().notify()`.
- `api/users.js`: get/set unload-places и tables (эндпоинты BE-S5 #715).

## Ревью (code-reviewer) - исправлено
- must-fix: `load()` падал `.map`, если GET вернёт `{message}` вместо массива -> `Array.isArray`-гард.
- must-fix: частичный сбой `save()` теперь фиксирует `original` по каждому набору отдельно и сообщает, что именно упало («Не удалось сохранить места прохода»), без ложного «всё сохранено».
- Тест на частичный сбой добавлен.

## Проверка
- vitest `UserAccessPlacesModal.spec.js`: 5/5 зелёных (загрузка+фильтр cars, гейт кнопки Сохранить, save шлёт id в оба эндпоинта, partial-failure, toggle снятия).
- `npx eslint` изменённых .vue/.spec.js/.js - чисто.