### PR TITLE
fix(analytics): итоги cross-tab и формат дат/времени в отчётах (#632)

### DIFF
--- a/frontend/src/components/statistics/ReportBuilder.vue
+++ b/frontend/src/components/statistics/ReportBuilder.vue
@@ -1043,9 +1043,9 @@ function run() {
   font-size: 12px;
   font-weight: 600;
   color: var(--color-text);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  /* Перенос вместо обрезки: при выгрузке строк колонок много (7+), длинные
+     подписи («Организация/Компания») не должны теряться под многоточием. */
+  overflow-wrap: anywhere;
 }
 
 .rb__skel-more {
@@ -1056,9 +1056,7 @@ function run() {
 .rb__skel-sub {
   font-size: 10px;
   color: var(--color-text-muted);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  overflow-wrap: anywhere;
 }
 
 .rb__skel-cell {

--- a/frontend/src/components/statistics/ReportResult.vue
+++ b/frontend/src/components/statistics/ReportResult.vue
@@ -206,7 +206,7 @@
                 v-for="col in (result.columns || [])"
                 :key="col.key"
               >
-                {{ formatCell(row[col.key]) }}
+                {{ formatCell(row[col.key], col.type) }}
               </td>
             </tr>
             <tr v-if="!result.rows.length">
@@ -234,7 +234,7 @@ import LoaderSpinner from '@/components/ui/LoaderSpinner.vue';
 import AnalyticsAreaChart from './AnalyticsAreaChart.vue';
 import AnalyticsBarChart from './AnalyticsBarChart.vue';
 import { useReportExport } from '@/composables/useReportExport';
-import { formatDateRu } from '@/utils/datetime';
+import { formatDateRu, formatReportCell } from '@/utils/datetime';
 
 const props = defineProps({
   result: { type: Object, default: null },
@@ -366,9 +366,9 @@ function formatNumber(value, float) {
     : n.toLocaleString('ru-RU');
 }
 
-function formatCell(value) {
+function formatCell(value, type) {
   if (value === null || value === undefined || value === '') return '—';
-  return value;
+  return formatReportCell(value, type);
 }
 </script>
 

--- a/frontend/src/components/statistics/__tests__/ReportResult.spec.js
+++ b/frontend/src/components/statistics/__tests__/ReportResult.spec.js
@@ -92,6 +92,23 @@ describe('ReportResult — переключатель Таблица/Графи�
     expect(w.find('.rr__table').exists()).toBe(true);
   });
 
+  it('list-режим: колонки date/time форматируются, текст с датой — нет', () => {
+    const w = mountResult({
+      mode: 'list',
+      columns: [
+        { key: 'period', label: 'Период работ', type: 'date' },
+        { key: 'time', label: 'Время работ', type: 'time' },
+        { key: 'name', label: 'Наименование работ' }, // без типа — свободный текст
+      ],
+      rows: [{ period: '2026-06-20 - 2026-06-21', time: '00:01:00 - 23:59:00', name: 'Ремонт 2026-06-15' }],
+      total: 1,
+    });
+    const cells = w.findAll('.rr__table tbody tr')[0].findAll('td').map((td) => td.text());
+    expect(cells[0]).toBe('20.06.2026 - 21.06.2026');
+    expect(cells[1]).toBe('00:01 - 23:59');
+    expect(cells[2]).toBe('Ремонт 2026-06-15'); // дата в тексте не тронута
+  });
+
   it('aggregate: переключатель есть, по умолчанию таблица', () => {
     const w = mountResult(aggStatus);
     expect(w.find('[data-testid="rr-view-chart"]').exists()).toBe(true);

--- a/frontend/src/composables/useReportExport.js
+++ b/frontend/src/composables/useReportExport.js
@@ -1,5 +1,5 @@
 import { ref } from 'vue';
-import { formatDateRu } from '@/utils/datetime';
+import { formatDateRu, formatReportCell } from '@/utils/datetime';
 
 // Значение колонки строки/итогов: дробные метрики (float) лежат в float_values/
 // float_totals, целочисленные (счётчики, суммы, pivot cross-tab) — в values/totals.
@@ -27,7 +27,7 @@ export function reportToTable(result) {
     return {
       sheetName: 'Выгрузка',
       header: columns.map((c) => c.label),
-      rows: (result.rows || []).map((row) => columns.map((c) => cellText(row[c.key]))),
+      rows: (result.rows || []).map((row) => columns.map((c) => cellText(row[c.key], c.type))),
       totalsRow: null,
     };
   }
@@ -55,9 +55,9 @@ export function reportToTable(result) {
   return { sheetName: 'Сводка', header, rows, totalsRow };
 }
 
-function cellText(value) {
+function cellText(value, type) {
   if (value === null || value === undefined || value === '') return '';
-  return value;
+  return formatReportCell(value, type);
 }
 
 const HEADER_FILL = 'FF4F5BDF';

--- a/frontend/src/utils/__tests__/datetime.spec.js
+++ b/frontend/src/utils/__tests__/datetime.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { formatDateRu, formatTimeAgo } from '../datetime';
+import { formatDateRu, formatTimeAgo, formatReportCell } from '../datetime';
 
 describe('formatDateRu', () => {
   it('YYYY-MM-DD -> дд.мм.гггг', () => {
@@ -21,6 +21,34 @@ describe('formatDateRu', () => {
     expect(formatDateRu('')).toBe('');
     expect(formatDateRu(null)).toBe('');
     expect(formatDateRu(undefined)).toBe('');
+  });
+});
+
+describe('formatReportCell', () => {
+  it('type=date: ISO-даты -> дд.мм.гггг (в т.ч. диапазон)', () => {
+    expect(formatReportCell('2026-06-20', 'date')).toBe('20.06.2026');
+    expect(formatReportCell('2026-06-20 - 2026-06-21', 'date')).toBe('20.06.2026 - 21.06.2026');
+  });
+
+  it('type=time: убирает секунды', () => {
+    expect(formatReportCell('00:01:00 - 23:59:00', 'time')).toBe('00:01 - 23:59');
+  });
+
+  it('type=datetime: дата + время без секунд', () => {
+    expect(formatReportCell('2026-06-20 14:30:45', 'datetime')).toBe('20.06.2026 14:30');
+  });
+
+  it('без типа НЕ форматирует — свободный текст не портится', () => {
+    // Ключевая защита: в "Наименовании работ" может быть дата — её нельзя трогать.
+    expect(formatReportCell('Ремонт 2026-06-15', undefined)).toBe('Ремонт 2026-06-15');
+    expect(formatReportCell('Смена 00:01:00', '')).toBe('Смена 00:01:00');
+    expect(formatReportCell('№ 20260619/001', 'text')).toBe('№ 20260619/001');
+  });
+
+  it('пустое -> пустая строка', () => {
+    expect(formatReportCell('', 'date')).toBe('');
+    expect(formatReportCell(null, 'date')).toBe('');
+    expect(formatReportCell(undefined, 'date')).toBe('');
   });
 });
 

--- a/frontend/src/utils/datetime.js
+++ b/frontend/src/utils/datetime.js
@@ -47,3 +47,26 @@ export function formatDateRu(value) {
   const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s);
   return m ? `${m[3]}.${m[2]}.${m[1]}` : String(value);
 }
+
+/**
+ * Форматирует ячейку отчёта-выгрузки (mode=list) ПО ТИПУ колонки (column.type с
+ * бэка): 'date'/'datetime' -> ISO-даты 'ГГГГ-ММ-ДД' в 'дд.мм.гггг'; 'time'/'datetime'
+ * -> убрать секунды 'ЧЧ:ММ:СС' -> 'ЧЧ:ММ' (секунды в отчётах не нужны). Бэк отдаёт
+ * склеенные строки-диапазоны ('2026-06-20 - 2026-06-21', '00:01:00 - 23:59:00'),
+ * поэтому правим все подстроки. Колонки без типа (номер, ФИО, организация,
+ * произвольный текст) возвращаем как есть — иначе дата внутри текста была бы испорчена.
+ * @param {string|number|null|undefined} value
+ * @param {string} [type] — тип колонки: 'date' | 'time' | 'datetime' | прочее
+ * @returns {string}
+ */
+export function formatReportCell(value, type) {
+  if (value == null || value === '') return '';
+  let s = String(value);
+  if (type === 'date' || type === 'datetime') {
+    s = s.replace(/(\d{4})-(\d{2})-(\d{2})/g, '$3.$2.$1');
+  }
+  if (type === 'time' || type === 'datetime') {
+    s = s.replace(/(\d{1,2}:\d{2}):\d{2}/g, '$1');
+  }
+  return s;
+}

--- a/internal/models/report_catalog.go
+++ b/internal/models/report_catalog.go
@@ -52,10 +52,13 @@ type ReportFilterInfo struct {
 	Options []ReportOption  `json:"options,omitempty"`
 }
 
-// ReportColumnInfo — столбец list-режима (выгрузки строк).
+// ReportColumnInfo — столбец list-режима (выгрузки строк). Type (опц.) подсказывает
+// фронту формат значения: "date"/"time"/"datetime" -> дд.мм.гггг и время без секунд.
+// Пусто -> произвольный текст (номер, ФИО, организация), не форматируется.
 type ReportColumnInfo struct {
 	Key   string `json:"key"`
 	Label string `json:"label"`
+	Type  string `json:"type,omitempty"`
 }
 
 // ReportListEntityInfo — сущность list-режима: какие столбцы и фильтры доступны.

--- a/internal/services/report_catalog.go
+++ b/internal/services/report_catalog.go
@@ -58,6 +58,8 @@ type filterDef struct {
 type listColumnDef struct {
 	key   string
 	label string
+	// format подсказывает фронту тип значения: "date"/"time"/"datetime". Пусто -> текст.
+	format string
 }
 
 // listEntityDef — сущность list-режима: набор столбцов и применимых фильтров.
@@ -198,8 +200,8 @@ var reportListEntityRegistry = map[string]listEntityDef{
 			{key: "org_or_company", label: "Организация/Компания"},
 			{key: "work_name", label: "Наименование работ"},
 			{key: "responsible", label: "Ответственный"},
-			{key: "work_period", label: "Период работ"},
-			{key: "work_time", label: "Время работ"},
+			{key: "work_period", label: "Период работ", format: "date"},
+			{key: "work_time", label: "Время работ", format: "time"},
 			{key: "people_count", label: "Кол-во людей"},
 		},
 		filters: []string{"date_range", "organization", "status"},
@@ -211,7 +213,7 @@ var reportListEntityRegistry = map[string]listEntityDef{
 			{key: "status", label: "Статус"},
 			{key: "organization", label: "Организация"},
 			{key: "company", label: "Компания"},
-			{key: "sending_datetime", label: "Дата подачи"},
+			{key: "sending_datetime", label: "Дата подачи", format: "datetime"},
 			{key: "attachments_count", label: "Вложений"},
 		},
 		filters: []string{"date_range", "status", "organization", "company"},
@@ -360,7 +362,7 @@ func buildReportCatalog(dyn dynamicReportOptions) models.ReportCatalog {
 		def := reportListEntityRegistry[key]
 		cols := make([]models.ReportColumnInfo, 0, len(def.columns))
 		for _, c := range def.columns {
-			cols = append(cols, models.ReportColumnInfo{Key: c.key, Label: c.label})
+			cols = append(cols, models.ReportColumnInfo{Key: c.key, Label: c.label, Type: c.format})
 		}
 		cat.ListEntities = append(cat.ListEntities, models.ReportListEntityInfo{
 			Key:     key,

--- a/internal/services/report_crosstab.go
+++ b/internal/services/report_crosstab.go
@@ -130,11 +130,12 @@ func buildPivotPlan(metric, pivotKey, granularity string, filters []models.Repor
 }
 
 // applyPivotCells вписывает cross-tab ячейки в уже собранные построчные данные и
-// возвращает добавочные pivot-колонки. Чистая функция. Колонки строятся по всем
-// встреченным значениям оси (детерминированный порядок — по убыванию суммы, затем
-// по имени), их ключи — pivotColumnPrefix+значение. Бины, которых нет среди rows
-// (отфильтрованы лимитом), игнорируются — cross-tab не добавляет новых строк.
-func applyPivotCells(rows []models.ReportMetricRow, cells []pivotCell, axisLabel string) []models.ReportMetricColumn {
+// возвращает добавочные pivot-колонки + их итоги (ключ колонки -> сумма по видимым
+// строкам, для строки «Итого»). Чистая функция. Колонки строятся по всем встреченным
+// значениям оси (детерминированный порядок — по убыванию суммы, затем по имени), их
+// ключи — pivotColumnPrefix+значение. Бины, которых нет среди rows (отфильтрованы
+// лимитом), игнорируются — cross-tab не добавляет новых строк, и в итоги не входят.
+func applyPivotCells(rows []models.ReportMetricRow, cells []pivotCell, axisLabel string) ([]models.ReportMetricColumn, map[string]int64) {
 	rowByLabel := make(map[string]int, len(rows))
 	for i, r := range rows {
 		rowByLabel[r.Label] = i
@@ -166,13 +167,16 @@ func applyPivotCells(rows []models.ReportMetricRow, cells []pivotCell, axisLabel
 	})
 
 	cols := make([]models.ReportMetricColumn, 0, len(pivots))
+	colTotals := make(map[string]int64, len(pivots))
 	for _, p := range pivots {
+		key := pivotColumnPrefix + p
 		cols = append(cols, models.ReportMetricColumn{
-			Key:   pivotColumnPrefix + p,
+			Key:   key,
 			Label: axisLabel + ": " + p,
 			Unit:  "шт",
 			Kind:  models.ReportColumnPivot,
 		})
+		colTotals[key] = pivotTotals[p]
 	}
 	// Строки без значения по колонке должны давать 0 (явный нуль для FE-таблицы).
 	for ri := range rows {
@@ -186,7 +190,7 @@ func applyPivotCells(rows []models.ReportMetricRow, cells []pivotCell, axisLabel
 			}
 		}
 	}
-	return cols
+	return cols, colTotals
 }
 
 // avgMetrics — метрики-средние: значение бина = счётчик / число календарных дней

--- a/internal/services/report_crosstab_test.go
+++ b/internal/services/report_crosstab_test.go
@@ -114,7 +114,7 @@ func TestApplyPivotCells_BuildsColumnsAndFillsRows(t *testing.T) {
 		{Period: "2026-06-08", Pivot: "Машины", Count: 3}, // в этом бине только машины
 		{Period: "2026-07-01", Pivot: "Люди", Count: 9},   // бин вне видимых строк -> игнор
 	}
-	cols := applyPivotCells(rows, cells, "Вложения")
+	cols, colTotals := applyPivotCells(rows, cells, "Вложения")
 
 	// Колонки: Машины (итог 6) перед Люди (итог 2) — по убыванию суммы.
 	if len(cols) != 2 {
@@ -125,6 +125,15 @@ func TestApplyPivotCells_BuildsColumnsAndFillsRows(t *testing.T) {
 	}
 	if cols[0].Label != "Вложения: Машины" || cols[0].Kind != models.ReportColumnPivot {
 		t.Errorf("ожидался label/kind pivot-колонки, got %q/%q", cols[0].Label, cols[0].Kind)
+	}
+
+	// Итоги pivot-колонок (для строки «Итого») = суммы по видимым строкам, по ключу
+	// колонки. Бин 2026-07-01 (вне видимых строк) в итоги не входит: Машины 3+3=6, Люди 2.
+	if colTotals[pivotColumnPrefix+"Машины"] != 6 {
+		t.Errorf("итог Машины: ожидалось 6, got %d", colTotals[pivotColumnPrefix+"Машины"])
+	}
+	if colTotals[pivotColumnPrefix+"Люди"] != 2 {
+		t.Errorf("итог Люди: ожидалось 2, got %d", colTotals[pivotColumnPrefix+"Люди"])
 	}
 
 	// Метрика осталась нетронутой, pivot-значения вписаны, отсутствующие -> 0.

--- a/internal/services/report_list_engine.go
+++ b/internal/services/report_list_engine.go
@@ -194,7 +194,7 @@ func buildListPlan(req models.ReportRequest) (*listPlan, error) {
 		}
 		selects = append(selects, def.expr+" AS "+c.key)
 		plan.selectArgs = append(plan.selectArgs, def.args...)
-		cols = append(cols, models.ReportColumnInfo{Key: c.key, Label: c.label})
+		cols = append(cols, models.ReportColumnInfo{Key: c.key, Label: c.label, Type: c.format})
 	}
 	plan.selectStr = strings.Join(selects, ", ")
 	plan.columns = cols

--- a/internal/services/report_list_engine_test.go
+++ b/internal/services/report_list_engine_test.go
@@ -27,6 +27,10 @@ func TestListEngine_CoversCatalogEntities(t *testing.T) {
 			if plan.columns[i].Key != c.key {
 				t.Errorf("сущность %q: столбец #%d ключ %q != каталог %q", entity, i, plan.columns[i].Key, c.key)
 			}
+			// Тип форматирования (date/time/datetime) пробрасывается фронту как есть.
+			if plan.columns[i].Type != c.format {
+				t.Errorf("сущность %q: столбец %q тип %q != каталог %q", entity, c.key, plan.columns[i].Type, c.format)
+			}
 			// каждый столбец каталога должен попасть в SELECT под своим алиасом
 			if !strings.Contains(plan.selectStr, " AS "+c.key) {
 				t.Errorf("сущность %q: столбец %q отсутствует в select %q", entity, c.key, plan.selectStr)

--- a/internal/services/statistics_service.go
+++ b/internal/services/statistics_service.go
@@ -587,11 +587,17 @@ func (s *statisticsService) RunReport(ctx context.Context, req models.ReportRequ
 		return nil, perr
 	}
 	if pivotOn {
-		pivotCols, cerr := s.collectPivotColumns(ctx, metrics, axis, req, metricRows)
+		pivotCols, pivotTotals, cerr := s.collectPivotColumns(ctx, metrics, axis, req, metricRows)
 		if cerr != nil {
 			return nil, cerr
 		}
 		columns = append(columns, pivotCols...)
+		// Итоги pivot-колонок: mergeMetricRows считает totals только по метрикам, а
+		// cross-tab-колонки добавляются после. Без этого строка «Итого» показывает 0
+		// по колонкам оси (баг: суммы есть в ячейках, но не в итогах).
+		for k, v := range pivotTotals {
+			totals[k] = v
+		}
 	}
 
 	// Метрики-средние (avg_*): целые счётчики бинов делятся на число дней бина в Go
@@ -635,23 +641,25 @@ func (s *statisticsService) RunReport(ctx context.Context, req models.ReportRequ
 }
 
 // collectPivotColumns исполняет cross-tab запрос по каждой метрике оси и вписывает
-// ячейки в уже упорядоченные строки, возвращая добавочные pivot-колонки. Несколько
-// метрик с одной осью дают один общий набор pivot-колонок (счётчики складываются —
-// все метрики оси считают заявки по тому же выражению).
-func (s *statisticsService) collectPivotColumns(ctx context.Context, metrics []string, axis models.ReportPivotInfo, req models.ReportRequest, metricRows []models.ReportMetricRow) ([]models.ReportMetricColumn, error) {
+// ячейки в уже упорядоченные строки, возвращая добавочные pivot-колонки и их итоги
+// (ключ колонки -> сумма по видимым строкам). Несколько метрик с одной осью дают
+// один общий набор pivot-колонок (счётчики складываются — все метрики оси считают
+// заявки по тому же выражению).
+func (s *statisticsService) collectPivotColumns(ctx context.Context, metrics []string, axis models.ReportPivotInfo, req models.ReportRequest, metricRows []models.ReportMetricRow) ([]models.ReportMetricColumn, map[string]int64, error) {
 	var cells []pivotCell
 	for _, m := range metrics {
 		plan, perr := buildPivotPlan(m, axis.Key, req.Granularity, req.Filters)
 		if perr != nil {
-			return nil, perr
+			return nil, nil, perr
 		}
 		mcells, eerr := s.execPivotPlan(ctx, plan)
 		if eerr != nil {
-			return nil, eerr
+			return nil, nil, eerr
 		}
 		cells = append(cells, mcells...)
 	}
-	return applyPivotCells(metricRows, cells, axis.Label), nil
+	cols, totals := applyPivotCells(metricRows, cells, axis.Label)
+	return cols, totals, nil
 }
 
 // execPivotPlan исполняет cross-tab запрос: GROUP BY (период-бин, ось pivot) ->


### PR DESCRIPTION
## Что чинит

Три бага, пойманные при тестировании вкладки «Отчёты» на staging.

**1. Итого по cross-tab всегда 0.** Бэкенд считал суммы по pivot-колонкам (`applyPivotCells`), но отбрасывал их - в `totals` попадали только базовые метрики, а развёрнутые столбцы («Тип вложения: Автозаявка» и т.п.) в строке «Итого» показывали 0. Теперь `applyPivotCells`/`collectPivotColumns` возвращают карту итогов по pivot-столбцам, и `RunReport` вливает их в общий `totals`.

**2. Даты в ISO и лишние секунды.** Колонки-списки (`work_period`, `work_time`, `sending_datetime`) рендерились сырой строкой из БД: `2026-06-20`, `00:01:00`. Бэкенд теперь помечает тип колонки (`date`/`time`/`datetime`) в `ReportColumnInfo.Type`, фронт форматирует ТОЛЬКО типизированные колонки (`formatReportCell`): дату в `дд.мм.гггг`, время обрезает до `чч:мм`. Свободный текст (`work_name` и пр.) проходит сырым - нетипизированные ячейки не трогаются.

**3. Обрезанные заголовки в «Что построим».** Скелет колонок в превью конструктора резал длинные заголовки через `text-overflow:ellipsis`; заменено на `overflow-wrap:anywhere` - заголовок переносится целиком.

## Почему важна типизация колонок

Первый подход форматировал ВСЕ ячейки списка глобальным regex - это испортило бы свободный текст вида «Ремонт 2026-06-15» -> «Ремонт 15.06.2026». Поэтому формат завязан на явный тип колонки от бэка; есть регресс-тест, что нетипизированная ячейка с датой внутри текста не меняется.

## Проверка

- Go `go test ./...` (полный скоуп, как CI) - зелёно.
- FE vitest (`datetime.spec.js`, `ReportResult.spec.js`) - 34 теста зелёно.
- eslint изменённых файлов - чисто.
- code-review пройден (GO).