### PR TITLE
feat(security): фильтры на эндпоинте "Доступные мне" охранника (#706)

### DIFF
--- a/internal/handlers/security_attachments.go
+++ b/internal/handlers/security_attachments.go
@@ -44,8 +44,12 @@ func (h *ApplicationHandler) requireSecurityOrAdmin(c echo.Context) (int, bool, 
 // @Tags         applications
 // @Produce      json
 // @Security     BearerAuth
-// @Param        page     query int false "Номер страницы"
-// @Param        per_page query int false "Размер страницы"
+// @Param        page            query int    false "Номер страницы"
+// @Param        per_page        query int    false "Размер страницы"
+// @Param        search          query string false "Поиск по номеру заявки, имени вложения и ФИО отправителя"
+// @Param        attachment_type query string false "Тип вложения: cars/people/items"
+// @Param        organization_id query int    false "ID организации"
+// @Param        company_id      query int    false "ID компании"
 // @Success      200 {array}  services.AvailableAttachment
 // @Failure      401 {object} models.HTTPError
 // @Failure      403 {object} models.HTTPError
@@ -57,6 +61,11 @@ func (h *ApplicationHandler) GetAvailableAttachments(c echo.Context) error {
 		return err
 	}
 
+	var filter services.AvailableAttachmentFilters
+	if err := c.Bind(&filter); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
+	}
+
 	var params models.PaginationParams
 	if err := c.Bind(&params); err != nil {
 		params = models.PaginationParams{}
@@ -64,7 +73,7 @@ func (h *ApplicationHandler) GetAvailableAttachments(c echo.Context) error {
 	params.Normalize()
 
 	data, total, err := h.service.GetAvailableAttachmentsForSecurity(
-		c.Request().Context(), userID, isSuperAdmin, params.Page, params.PerPage,
+		c.Request().Context(), userID, isSuperAdmin, filter, params.Page, params.PerPage,
 	)
 	if err != nil {
 		return err

--- a/internal/handlers/security_filters_test.go
+++ b/internal/handlers/security_filters_test.go
@@ -1,0 +1,284 @@
+package handlers_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Тесты опциональных фильтров вкладки "Доступные мне" (#706, срез BE-S6). DB-backed, пакет
+// handlers_test (единственный DB-бинарь, см. security_visibility_test.go). Переиспользуют secWorld
+// и хелперы из security_visibility_test.go; ниже - только доп. фабрики для org/company/sender и
+// именованных вложений. Главный инвариант: фильтры сужают выдачу ПОВЕРХ гейта мест, не вместо него.
+
+func secPtrStr(s string) *string { return &s }
+
+func (w secWorld) newOrg(t *testing.T, name string) int {
+	t.Helper()
+	o := models.Organization{Name: name, IsActive: true}
+	require.NoError(t, w.db.Create(&o).Error)
+	return o.ID
+}
+
+func (w secWorld) newCompany(t *testing.T, name string) int {
+	t.Helper()
+	c := models.Company{Name: name, IsActive: true}
+	require.NoError(t, w.db.Create(&c).Error)
+	return c.ID
+}
+
+func (w secWorld) newSenderNamed(t *testing.T, username, last, first, middle string) int {
+	t.Helper()
+	userTypeID := secUserTypeIDByCode(t, w.db, "user")
+	u := models.User{
+		Username: username, Password: "x", TypeID: userTypeID,
+		LastName: &last, FirstName: &first, MiddleName: &middle,
+	}
+	require.NoError(t, w.db.Create(&u).Error)
+	return u.ID
+}
+
+// newAppWith создаёт согласованную заявку с заданными организацией/компанией/отправителем.
+func (w secWorld) newAppWith(t *testing.T, orgID int, companyID *int, senderID int) int {
+	t.Helper()
+	now := time.Now()
+	conf := models.ConfirmationApproved
+	app := models.Application{
+		OrganizationID:  orgID,
+		CompanyID:       companyID,
+		SenderUserID:    senderID,
+		Confirmation:    &conf,
+		SendingDatetime: &now,
+	}
+	require.NoError(t, w.db.Create(&app).Error)
+	return app.ID
+}
+
+func (w secWorld) newAppOrg(t *testing.T, orgID int) int {
+	t.Helper()
+	return w.newAppWith(t, orgID, nil, w.senderID)
+}
+
+func (w secWorld) newAttachmentNamed(t *testing.T, appID int, atype, name string) int {
+	t.Helper()
+	att := models.Attachment{ApplicationID: appID, AttachmentType: atype, AttachmentName: &name}
+	require.NoError(t, w.db.Create(&att).Error)
+	return att.ID
+}
+
+func (w secWorld) setAttachmentDisplayName(t *testing.T, attID int, name string) {
+	t.Helper()
+	require.NoError(t, w.db.Model(&models.Attachment{}).Where("id = ?", attID).
+		Update("attachment_display_name", name).Error)
+}
+
+func (w secWorld) setAppNumber(t *testing.T, appID int, number string) {
+	t.Helper()
+	require.NoError(t, w.db.Model(&models.Application{}).Where("id = ?", appID).
+		Update("application_number", number).Error)
+}
+
+func (w secWorld) listFiltered(t *testing.T, ctx context.Context, f services.AvailableAttachmentFilters) ([]services.AvailableAttachment, int64) {
+	t.Helper()
+	rows, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, false, f, 1, 50)
+	require.NoError(t, err)
+	return rows, total
+}
+
+func TestAvailableAttachments_FilterByType(t *testing.T) {
+	w := setupSecurityWorld(t)
+	ctx := context.Background()
+
+	place := w.newUnloadPlace(t, "Склад А", true)
+	w.assignUnloadPlace(t, place)
+
+	app := w.newApp(t, models.ConfirmationApproved)
+	carsAtt := w.newAttachment(t, app, "cars")
+	w.attachPlace(t, carsAtt, place)
+	itemsAtt := w.newAttachment(t, app, "items")
+	w.attachPlace(t, itemsAtt, place)
+
+	rows, total := w.listFiltered(t, ctx, services.AvailableAttachmentFilters{AttachmentType: secPtrStr("cars")})
+	require.EqualValues(t, 1, total)
+	require.True(t, secContainsAttachment(rows, carsAtt))
+	require.False(t, secContainsAttachment(rows, itemsAtt))
+
+	rows, total = w.listFiltered(t, ctx, services.AvailableAttachmentFilters{AttachmentType: secPtrStr("items")})
+	require.EqualValues(t, 1, total)
+	require.True(t, secContainsAttachment(rows, itemsAtt))
+
+	// Невалидный тип игнорируется (не сужает) - возвращаются оба вложения.
+	_, total = w.listFiltered(t, ctx, services.AvailableAttachmentFilters{AttachmentType: secPtrStr("bogus")})
+	require.EqualValues(t, 2, total, "невалидный attachment_type не должен сужать выдачу")
+}
+
+func TestAvailableAttachments_FilterByOrganization(t *testing.T) {
+	w := setupSecurityWorld(t)
+	ctx := context.Background()
+
+	place := w.newUnloadPlace(t, "Склад А", true)
+	w.assignUnloadPlace(t, place)
+	org2 := w.newOrg(t, "Орг 2")
+
+	app1 := w.newApp(t, models.ConfirmationApproved) // org = w.orgID
+	att1 := w.newAttachment(t, app1, "cars")
+	w.attachPlace(t, att1, place)
+	app2 := w.newAppOrg(t, org2)
+	att2 := w.newAttachment(t, app2, "cars")
+	w.attachPlace(t, att2, place)
+
+	rows, total := w.listFiltered(t, ctx, services.AvailableAttachmentFilters{OrganizationID: secPtrInt(w.orgID)})
+	require.EqualValues(t, 1, total)
+	require.True(t, secContainsAttachment(rows, att1))
+	require.False(t, secContainsAttachment(rows, att2), "фильтр по организации скрывает чужую")
+}
+
+func TestAvailableAttachments_FilterByCompany(t *testing.T) {
+	w := setupSecurityWorld(t)
+	ctx := context.Background()
+
+	place := w.newUnloadPlace(t, "Склад А", true)
+	w.assignUnloadPlace(t, place)
+	comp1 := w.newCompany(t, "Компания 1")
+	comp2 := w.newCompany(t, "Компания 2")
+
+	app1 := w.newAppWith(t, w.orgID, secPtrInt(comp1), w.senderID)
+	att1 := w.newAttachment(t, app1, "cars")
+	w.attachPlace(t, att1, place)
+	app2 := w.newAppWith(t, w.orgID, secPtrInt(comp2), w.senderID)
+	att2 := w.newAttachment(t, app2, "cars")
+	w.attachPlace(t, att2, place)
+
+	rows, total := w.listFiltered(t, ctx, services.AvailableAttachmentFilters{CompanyID: secPtrInt(comp1)})
+	require.EqualValues(t, 1, total)
+	require.True(t, secContainsAttachment(rows, att1))
+	require.False(t, secContainsAttachment(rows, att2), "фильтр по компании скрывает чужую")
+}
+
+func TestAvailableAttachments_FilterBySearch(t *testing.T) {
+	w := setupSecurityWorld(t)
+	ctx := context.Background()
+
+	place := w.newUnloadPlace(t, "Склад А", true)
+	w.assignUnloadPlace(t, place)
+	ivanov := w.newSenderNamed(t, "ivanov", "Иванов", "Иван", "Иванович")
+
+	appA := w.newAppWith(t, w.orgID, nil, ivanov)
+	w.setAppNumber(t, appA, "APP-777")
+	attA := w.newAttachmentNamed(t, appA, "cars", "Volvo Truck") // латиница для проверки ILIKE-регистра
+	w.attachPlace(t, attA, place)
+
+	appB := w.newAppWith(t, w.orgID, nil, w.senderID) // sender1 без ФИО
+	w.setAppNumber(t, appB, "APP-100")
+	attB := w.newAttachmentNamed(t, appB, "cars", "Lada")
+	w.setAttachmentDisplayName(t, attB, "Рефрижератор")
+	w.attachPlace(t, attB, place)
+
+	// По номеру заявки.
+	rows, total := w.listFiltered(t, ctx, services.AvailableAttachmentFilters{Search: secPtrStr("777")})
+	require.EqualValues(t, 1, total)
+	require.True(t, secContainsAttachment(rows, attA))
+	require.False(t, secContainsAttachment(rows, attB))
+
+	// По имени вложения, регистронезависимо (ILIKE).
+	rows, total = w.listFiltered(t, ctx, services.AvailableAttachmentFilters{Search: secPtrStr("volvo")})
+	require.EqualValues(t, 1, total)
+	require.True(t, secContainsAttachment(rows, attA))
+
+	// По отображаемому имени вложения (attachment_display_name).
+	rows, total = w.listFiltered(t, ctx, services.AvailableAttachmentFilters{Search: secPtrStr("Рефрижератор")})
+	require.EqualValues(t, 1, total)
+	require.True(t, secContainsAttachment(rows, attB))
+	require.False(t, secContainsAttachment(rows, attA))
+
+	// По ФИО отправителя.
+	rows, total = w.listFiltered(t, ctx, services.AvailableAttachmentFilters{Search: secPtrStr("Иванов")})
+	require.EqualValues(t, 1, total)
+	require.True(t, secContainsAttachment(rows, attA))
+	require.False(t, secContainsAttachment(rows, attB), "поиск по ФИО не цепляет отправителя без имени")
+
+	// Несуществующая подстрока - пусто.
+	_, total = w.listFiltered(t, ctx, services.AvailableAttachmentFilters{Search: secPtrStr("несуществует")})
+	require.EqualValues(t, 0, total)
+}
+
+func TestAvailableAttachments_EmptyFilterMatchesBaseline(t *testing.T) {
+	w := setupSecurityWorld(t)
+	ctx := context.Background()
+
+	place := w.newUnloadPlace(t, "Склад А", true)
+	w.assignUnloadPlace(t, place)
+	app := w.newApp(t, models.ConfirmationApproved)
+	for i := 0; i < 3; i++ {
+		att := w.newAttachment(t, app, "cars")
+		w.attachPlace(t, att, place)
+	}
+
+	// nil-поля фильтра = поведение до BE-S6: все совпавшие по месту вложения.
+	_, total := w.listFiltered(t, ctx, services.AvailableAttachmentFilters{})
+	require.EqualValues(t, 3, total, "пустой фильтр возвращает всю доступную выдачу")
+}
+
+func TestAvailableAttachments_FiltersApplyForSuperAdmin(t *testing.T) {
+	w := setupSecurityWorld(t)
+	ctx := context.Background()
+
+	// Супер-админ видит все согласованные вложения без гейта мест - места никому не назначаем.
+	org2 := w.newOrg(t, "Орг 2")
+	app1 := w.newApp(t, models.ConfirmationApproved) // org = w.orgID
+	att1 := w.newAttachment(t, app1, "cars")
+	app2 := w.newAppOrg(t, org2)
+	att2 := w.newAttachment(t, app2, "items")
+
+	// Без фильтра супер-админ видит оба.
+	_, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, true, services.AvailableAttachmentFilters{}, 1, 50)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, total)
+
+	// Фильтр по организации сужает и на пути супер-админа.
+	rows, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, true, services.AvailableAttachmentFilters{OrganizationID: secPtrInt(org2)}, 1, 50)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, total)
+	require.True(t, secContainsAttachment(rows, att2))
+	require.False(t, secContainsAttachment(rows, att1))
+
+	// Фильтр по типу так же действует для супер-админа.
+	rows, total, err = w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, true, services.AvailableAttachmentFilters{AttachmentType: secPtrStr("cars")}, 1, 50)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, total)
+	require.True(t, secContainsAttachment(rows, att1))
+}
+
+func TestAvailableAttachments_FilterDoesNotBypassPlaceGate(t *testing.T) {
+	w := setupSecurityWorld(t)
+	ctx := context.Background()
+
+	myPlace := w.newUnloadPlace(t, "Мой склад", true)
+	otherPlace := w.newUnloadPlace(t, "Чужой склад", true)
+	w.assignUnloadPlace(t, myPlace)
+	org2 := w.newOrg(t, "Орг 2")
+
+	app1 := w.newApp(t, models.ConfirmationApproved) // org = w.orgID
+	mineCars := w.newAttachment(t, app1, "cars")
+	w.attachPlace(t, mineCars, myPlace)
+
+	app2 := w.newAppOrg(t, org2)
+	foreignCars := w.newAttachment(t, app2, "cars")
+	w.attachPlace(t, foreignCars, otherPlace)
+
+	// Фильтр по типу совпадает с обоими, но чужое место остаётся скрытым.
+	rows, total := w.listFiltered(t, ctx, services.AvailableAttachmentFilters{AttachmentType: secPtrStr("cars")})
+	require.EqualValues(t, 1, total, "фильтр не обходит гейт мест")
+	require.True(t, secContainsAttachment(rows, mineCars))
+	require.False(t, secContainsAttachment(rows, foreignCars), "чужое место скрыто несмотря на совпадение типа")
+
+	// Фильтр по организации чужого вложения не раскрывает его - оно вне мест охранника.
+	rows, total = w.listFiltered(t, ctx, services.AvailableAttachmentFilters{OrganizationID: secPtrInt(org2)})
+	require.EqualValues(t, 0, total, "фильтр по чужой организации не раскрывает вложение вне мест охранника")
+	require.False(t, secContainsAttachment(rows, foreignCars))
+}

--- a/internal/handlers/security_visibility_test.go
+++ b/internal/handlers/security_visibility_test.go
@@ -155,7 +155,7 @@ func TestGetAvailableAttachments_MatchByUnloadPlace(t *testing.T) {
 	foreignAtt := w.newAttachment(t, app, "cars")
 	w.attachPlace(t, foreignAtt, otherPlace)
 
-	rows, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, false, 1, 50)
+	rows, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, false, services.AvailableAttachmentFilters{}, 1, 50)
 	require.NoError(t, err)
 	require.EqualValues(t, 2, total)
 	require.True(t, secContainsAttachment(rows, carsAtt), "cars at guard place visible")
@@ -177,7 +177,7 @@ func TestGetAvailableAttachments_PeopleMatchByTable(t *testing.T) {
 	foreignAtt := w.newAttachment(t, app, "people")
 	w.attachEmployeeWithTable(t, foreignAtt, otherTable)
 
-	rows, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, false, 1, 50)
+	rows, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, false, services.AvailableAttachmentFilters{}, 1, 50)
 	require.NoError(t, err)
 	require.EqualValues(t, 1, total)
 	require.True(t, secContainsAttachment(rows, peopleAtt), "people at guard passage visible")
@@ -199,7 +199,7 @@ func TestGetAvailableAttachments_ApprovedGate(t *testing.T) {
 	pendingAtt := w.newAttachment(t, pendingApp, "cars")
 	w.attachPlace(t, pendingAtt, myPlace)
 
-	rows, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, false, 1, 50)
+	rows, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, false, services.AvailableAttachmentFilters{}, 1, 50)
 	require.NoError(t, err)
 	require.EqualValues(t, 1, total)
 	require.True(t, secContainsAttachment(rows, approvedAtt))
@@ -221,7 +221,7 @@ func TestGetAvailableAttachments_SuperAdminSeesAllApproved(t *testing.T) {
 	pendingAtt := w.newAttachment(t, pendingApp, "cars")
 	w.attachPlace(t, pendingAtt, place)
 
-	rows, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, true, 1, 50)
+	rows, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, true, services.AvailableAttachmentFilters{}, 1, 50)
 	require.NoError(t, err)
 	require.EqualValues(t, 1, total, "super-admin sees approved regardless of place, still approved-gated")
 	require.True(t, secContainsAttachment(rows, approvedAtt))
@@ -238,7 +238,7 @@ func TestGetAvailableAttachments_NoPlacesEmpty(t *testing.T) {
 	att := w.newAttachment(t, app, "cars")
 	w.attachPlace(t, att, place)
 
-	rows, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, false, 1, 50)
+	rows, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, false, services.AvailableAttachmentFilters{}, 1, 50)
 	require.NoError(t, err)
 	require.EqualValues(t, 0, total)
 	require.Empty(t, rows)
@@ -256,7 +256,7 @@ func TestGetAvailableAttachments_AttachmentWithoutPlacesHidden(t *testing.T) {
 	app := w.newApp(t, models.ConfirmationApproved)
 	att := w.newAttachment(t, app, "cars")
 
-	rows, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, false, 1, 50)
+	rows, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, false, services.AvailableAttachmentFilters{}, 1, 50)
 	require.NoError(t, err)
 	require.EqualValues(t, 0, total)
 	require.False(t, secContainsAttachment(rows, att), "attachment without places must not leak")
@@ -278,7 +278,7 @@ func TestGetAvailableAttachments_InactivePlaceStillMatches(t *testing.T) {
 	att := w.newAttachment(t, app, "items")
 	w.attachPlace(t, att, inactivePlace)
 
-	rows, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, false, 1, 50)
+	rows, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, false, services.AvailableAttachmentFilters{}, 1, 50)
 	require.NoError(t, err)
 	require.EqualValues(t, 1, total)
 	require.True(t, secContainsAttachment(rows, att), "inactive place still grants visibility")
@@ -305,7 +305,7 @@ func TestGetAvailableAttachments_IndependentFromForwardAttachments(t *testing.T)
 		AttachmentID:    attB,
 	}).Error)
 
-	rows, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, false, 1, 50)
+	rows, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, false, services.AvailableAttachmentFilters{}, 1, 50)
 	require.NoError(t, err)
 	require.EqualValues(t, 2, total, "forward_attachments must not restrict security visibility")
 	require.True(t, secContainsAttachment(rows, attA))
@@ -325,12 +325,12 @@ func TestGetAvailableAttachments_Pagination(t *testing.T) {
 		w.attachPlace(t, att, myPlace)
 	}
 
-	page1, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, false, 1, 2)
+	page1, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, false, services.AvailableAttachmentFilters{}, 1, 2)
 	require.NoError(t, err)
 	require.EqualValues(t, 5, total, "total counts all matches, not page size")
 	require.Len(t, page1, 2)
 
-	page3, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, false, 3, 2)
+	page3, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, false, services.AvailableAttachmentFilters{}, 3, 2)
 	require.NoError(t, err)
 	require.EqualValues(t, 5, total)
 	require.Len(t, page3, 1, "last page holds the remainder")

--- a/internal/services/application_service.go
+++ b/internal/services/application_service.go
@@ -185,8 +185,8 @@ type ApplicationService interface {
 
 	// GetAvailableAttachmentsForSecurity возвращает страницу вложений подтверждённых заявок,
 	// доступных охраннику по совпадению мест (#706), и общее количество. Супер-админ - без
-	// фильтра по местам.
-	GetAvailableAttachmentsForSecurity(ctx context.Context, userID int, isSuperAdmin bool, page, perPage int) ([]AvailableAttachment, int64, error)
+	// фильтра по местам. filter (BE-S6) опционально сужает выдачу поверх гейта видимости.
+	GetAvailableAttachmentsForSecurity(ctx context.Context, userID int, isSuperAdmin bool, filter AvailableAttachmentFilters, page, perPage int) ([]AvailableAttachment, int64, error)
 
 	// CanSecurityViewAttachment сообщает, доступно ли конкретное вложение охраннику по тем же
 	// правилам, что и листинг (#706). Для 403 на чужое вложение в детальном эндпоинте.

--- a/internal/services/security_visibility_service.go
+++ b/internal/services/security_visibility_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"systemburo/internal/models"
@@ -39,8 +40,31 @@ type AvailableAttachment struct {
 	SenderFullName    *string    `json:"sender_full_name"`
 }
 
+// availableAttachmentFilters - опциональные пользовательские фильтры вкладки "Доступные мне"
+// (BE-S6). Сужают листинг ПОВЕРХ инварианта видимости (места ∩ + confirmation='Согласовано'), не
+// ослабляя его. Все поля опциональны: nil/пусто = фильтр не применяется, выдача как до BE-S6.
+// query-теги повторяют стиль ApplicationFilter - биндятся echo c.Bind из query-строки.
+type AvailableAttachmentFilters struct {
+	Search         *string `query:"search"`
+	AttachmentType *string `query:"attachment_type"`
+	OrganizationID *int    `query:"organization_id"`
+	CompanyID      *int    `query:"company_id"`
+}
+
+// availableAttachmentFrom - общий FROM листинга и счётчика "Доступные мне". LEFT JOIN'ы
+// organizations/companies/users держат отношение 1:1 к вложению (все по PK), поэтому НЕ меняют
+// COUNT(*) и могут стоять в обоих запросах; благодаря им и подзапросы select, и фильтры BE-S6
+// (поиск по ФИО отправителя через su) видят алиасы o/c/su. attachments x applications - INNER
+// (вложение всегда принадлежит заявке).
+const availableAttachmentFrom = `
+	FROM attachments a
+	JOIN applications app ON app.id = a.application_id
+	LEFT JOIN organizations o ON o.id = app.organization_id
+	LEFT JOIN companies c ON c.id = app.company_id
+	LEFT JOIN users su ON su.id = app.sender_user_id`
+
 // availableAttachmentSelect - столбцы листинга. Подзапросы places ссылаются на a.id напрямую
-// (без плейсхолдеров), поэтому в args после WHERE идут только LIMIT/OFFSET.
+// (без плейсхолдеров); аргументы в порядке: видимость -> фильтры BE-S6 -> LIMIT/OFFSET.
 const availableAttachmentSelect = `
 	a.id as attachment_id,
 	a.attachment_type,
@@ -101,6 +125,50 @@ func securityVisibilityWhere(userID int, isSuperAdmin bool) (string, []interface
 	return confirm + " AND " + place, args
 }
 
+// availableAttachmentFilterWhere добавляет к предикату видимости опциональные пользовательские
+// фильтры (BE-S6) и их аргументы. Поверх инварианта, не вместо: возвращает фрагмент с ведущим
+// " AND ", приклеиваемый к результату securityVisibilityWhere - гейт мест/confirmation остаётся.
+// Пустые/nil-поля игнорируются; attachment_type вне cars/people/items отбрасывается (не сужает).
+// Search ищет по номеру заявки, имени и отображаемому имени вложения, ФИО отправителя (ILIKE,
+// регистронезависимо). Требует алиасы a/app/su (есть в availableAttachmentFrom).
+func availableAttachmentFilterWhere(f AvailableAttachmentFilters) (string, []interface{}) {
+	var clauses []string
+	var args []interface{}
+
+	if f.AttachmentType != nil {
+		switch t := *f.AttachmentType; t {
+		case "cars", "people", "items":
+			clauses = append(clauses, "a.attachment_type = ?")
+			args = append(args, t)
+		}
+	}
+	if f.OrganizationID != nil {
+		clauses = append(clauses, "app.organization_id = ?")
+		args = append(args, *f.OrganizationID)
+	}
+	if f.CompanyID != nil {
+		clauses = append(clauses, "app.company_id = ?")
+		args = append(args, *f.CompanyID)
+	}
+	if f.Search != nil {
+		if s := strings.TrimSpace(*f.Search); s != "" {
+			like := "%" + s + "%"
+			clauses = append(clauses, `(
+				app.application_number ILIKE ?
+				OR a.attachment_name ILIKE ?
+				OR a.attachment_display_name ILIKE ?
+				OR format_full_name(su.last_name, su.first_name, su.middle_name) ILIKE ?
+			)`)
+			args = append(args, like, like, like, like)
+		}
+	}
+
+	if len(clauses) == 0 {
+		return "", nil
+	}
+	return " AND " + strings.Join(clauses, " AND "), args
+}
+
 // IsSecurityUser сообщает, является ли аккаунт типом security (резолв по user_types.code,
 // образец CheckBuroByUsername). Несуществующий пользователь -> false без ошибки.
 func (s *applicationService) IsSecurityUser(ctx context.Context, userID int) (bool, error) {
@@ -140,7 +208,7 @@ func (s *applicationService) securityHasAnyPlace(ctx context.Context, userID int
 // образцу GetApplicationsPaginated (отдельный COUNT + страница). Супер-админ видит все вложения
 // подтверждённых заявок без фильтра по местам. Охранник без назначенных мест -> пустая страница
 // без основного запроса.
-func (s *applicationService) GetAvailableAttachmentsForSecurity(ctx context.Context, userID int, isSuperAdmin bool, page, perPage int) ([]AvailableAttachment, int64, error) {
+func (s *applicationService) GetAvailableAttachmentsForSecurity(ctx context.Context, userID int, isSuperAdmin bool, filter AvailableAttachmentFilters, page, perPage int) ([]AvailableAttachment, int64, error) {
 	page, perPage = normalizePage(page, perPage)
 
 	if !isSuperAdmin {
@@ -154,10 +222,13 @@ func (s *applicationService) GetAvailableAttachmentsForSecurity(ctx context.Cont
 	}
 
 	where, args := securityVisibilityWhere(userID, isSuperAdmin)
+	if filterWhere, filterArgs := availableAttachmentFilterWhere(filter); filterWhere != "" {
+		where += filterWhere
+		args = append(args, filterArgs...)
+	}
 
 	var total int64
-	countSQL := `SELECT COUNT(*) FROM attachments a
-		JOIN applications app ON app.id = a.application_id
+	countSQL := `SELECT COUNT(*) ` + availableAttachmentFrom + `
 		WHERE ` + where
 	if err := s.db.WithContext(ctx).Raw(countSQL, args...).Scan(&total).Error; err != nil {
 		return nil, 0, fmt.Errorf("failed to count available attachments: %w", err)
@@ -167,12 +238,7 @@ func (s *applicationService) GetAvailableAttachmentsForSecurity(ctx context.Cont
 	}
 
 	offset := (page - 1) * perPage
-	dataSQL := `SELECT ` + availableAttachmentSelect + `
-		FROM attachments a
-		JOIN applications app ON app.id = a.application_id
-		LEFT JOIN organizations o ON o.id = app.organization_id
-		LEFT JOIN companies c ON c.id = app.company_id
-		LEFT JOIN users su ON su.id = app.sender_user_id
+	dataSQL := `SELECT ` + availableAttachmentSelect + availableAttachmentFrom + `
 		WHERE ` + where + `
 		ORDER BY app.sending_datetime DESC NULLS LAST, a.id DESC
 		LIMIT ? OFFSET ?`
@@ -209,12 +275,7 @@ func (s *applicationService) CanSecurityViewAttachment(ctx context.Context, user
 // через CanSecurityViewAttachment. nil без ошибки означает "вложение не найдено" (явный сигнал
 // для 404, реальные ошибки БД пробрасываются).
 func (s *applicationService) GetAvailableAttachmentByID(ctx context.Context, attachmentID int) (*AvailableAttachment, error) {
-	sql := `SELECT ` + availableAttachmentSelect + `
-		FROM attachments a
-		JOIN applications app ON app.id = a.application_id
-		LEFT JOIN organizations o ON o.id = app.organization_id
-		LEFT JOIN companies c ON c.id = app.company_id
-		LEFT JOIN users su ON su.id = app.sender_user_id
+	sql := `SELECT ` + availableAttachmentSelect + availableAttachmentFrom + `
 		WHERE a.id = ?`
 
 	var row AvailableAttachment


### PR DESCRIPTION
Срез BE-S6 эпика «Доступные мне» (#706). Добавляет фильтр-параметры на эндпоинт доступных охраннику вложений.

## Что
`GET /api/applications/available-attachments` теперь принимает опциональные query-фильтры:
- `search` — ILIKE по номеру заявки, имени и отображаемому имени вложения, ФИО отправителя;
- `attachment_type` — cars/people/items (невалидное значение игнорируется, не сужает);
- `organization_id`, `company_id`.

Все значения идут через `?`-плейсхолдеры GORM Raw (не конкатенация). Фильтры приклеиваются поверх предиката видимости через AND — гейт мест (`места вложения ∩ места охранника ≠ ∅`) и `confirmation=Согласовано` остаются в силе.

## Как
- `AvailableAttachmentFilters` + билдер `availableAttachmentFilterWhere` (security_visibility_service.go).
- FROM листинга и счётчика вынесен в общую константу `availableAttachmentFrom` — LEFT JOIN orgs/companies/users по PK (1:1, COUNT не меняют), благодаря им оба запроса видят алиасы под фильтры и поиск по ФИО. Заодно переиспользован в `GetAvailableAttachmentByID`.
- Handler биндит фильтры через `c.Bind` (как в Центре заявок), пагинация meta без изменений; swagger `@Param` дописаны.

## Тесты (internal/handlers, DB-backed)
Фильтр по типу/организации/компании/поиску сужает выдачу; поиск по номеру/имени/display_name/ФИО; пустой фильтр = baseline; фильтры действуют и на пути супер-админа; **ключевой инвариант — фильтр НЕ обходит гейт мест** (чужое место скрыто несмотря на совпадение типа/организации). Полный `go test ./...` зелёный.

## Ревью
`code-reviewer` — GO, блокеров нет. Два жёлтых (покрытие поиска по `display_name` и фильтров на пути супер-админа) закрыты добавленными тестами в этом же PR.