### PR TITLE
feat(security): поиск и фильтры в "Доступные мне" охранника (#706)

### DIFF
--- a/frontend/src/views/AccessibleAttachmentsView.vue
+++ b/frontend/src/views/AccessibleAttachmentsView.vue
@@ -403,10 +403,8 @@ async function fetchList({ reset = true } = {}) {
   }
 }
 
-// Смена любого фильтра сбрасывает пагинацию (reset: true -> page=1), снимает
-// открытую деталь и переписывает URL, чтобы состояние было шарящимся и переживало
-// перезагрузку (web.md: URL как state). Аккумулирующую страницу load-more в URL не
-// кладём - с "Показать ещё" её число не диплинкается осмысленно.
+// Аккумулирующую страницу load-more в URL не кладём: с "Показать ещё" её число
+// не диплинкается осмысленно. Фильтры и поиск - кладём (syncUrl).
 function applyFilters() {
   selectedId.value = null;
   detail.value = null;
@@ -543,7 +541,9 @@ onBeforeUnmount(() => clearTimeout(searchTimer));
 
 .filters__search {
   position: relative;
-  flex: 1 1 240px;
+  /* Поиск занимает свою строку целиком, дропдауны выстраиваются рядом ниже -
+     иначе растущий инпут отталкивает первый дропдаун к правому краю. */
+  flex: 1 1 100%;
   min-width: 200px;
 }
 
@@ -563,7 +563,7 @@ onBeforeUnmount(() => clearTimeout(searchTimer));
 }
 
 .filters__dropdown {
-  flex: 0 1 200px;
+  flex: 1 1 160px;
   min-width: 160px;
 }
 

--- a/frontend/src/views/AccessibleAttachmentsView.vue
+++ b/frontend/src/views/AccessibleAttachmentsView.vue
@@ -13,6 +13,59 @@
         </div>
       </div>
 
+      <div
+        class="filters"
+        data-testid="aa-filters"
+      >
+        <div class="filters__search">
+          <img
+            class="filters__search-icon"
+            src="@/assets/icons/search.png"
+            alt=""
+          >
+          <input
+            v-model="search"
+            type="text"
+            class="lk-input filters__search-input"
+            placeholder="Поиск по заявке, вложению, отправителю"
+            data-testid="aa-search"
+            @input="onSearchInput"
+          >
+        </div>
+        <BaseDropdown
+          :model-value="typeFilter"
+          :options="typeOptions"
+          class="filters__dropdown"
+          data-testid="aa-filter-type"
+          @update:model-value="setType"
+        />
+        <BaseDropdown
+          :model-value="orgFilter"
+          :options="orgOptions"
+          searchable
+          class="filters__dropdown"
+          data-testid="aa-filter-org"
+          @update:model-value="setOrg"
+        />
+        <BaseDropdown
+          :model-value="companyFilter"
+          :options="companyOptions"
+          searchable
+          class="filters__dropdown"
+          data-testid="aa-filter-company"
+          @update:model-value="setCompany"
+        />
+        <button
+          v-if="hasActiveFilters"
+          type="button"
+          class="lk-button lk-button--secondary filters__reset"
+          data-testid="aa-filter-reset"
+          @click="resetFilters"
+        >
+          Сбросить
+        </button>
+      </div>
+
       <div class="content-container">
         <!-- Список вложений -->
         <div
@@ -110,10 +163,21 @@
             class="empty-state"
             data-testid="aa-empty"
           >
-            <p>Доступных вложений нет</p>
+            <p>{{ hasActiveFilters ? 'Ничего не найдено' : 'Доступных вложений нет' }}</p>
             <span class="empty-state__hint">
-              Здесь появятся вложения подтверждённых заявок по вашим местам доступа.
+              {{ hasActiveFilters
+                ? 'Измените условия поиска или сбросьте фильтры.'
+                : 'Здесь появятся вложения подтверждённых заявок по вашим местам доступа.' }}
             </span>
+            <button
+              v-if="hasActiveFilters"
+              type="button"
+              class="lk-button lk-button--secondary"
+              data-testid="aa-empty-reset"
+              @click="resetFilters"
+            >
+              Сбросить фильтры
+            </button>
           </div>
 
           <div class="list-footer">
@@ -202,20 +266,52 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue';
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
 import AdminPageShell from '@/views/admin/AdminPageShell.vue';
 import RefreshButton from '@/components/RefreshButton.vue';
+import BaseDropdown from '@/components/ui/BaseDropdown.vue';
 import Badge from '@/components/ui/Badge.vue';
 import StatusBadge from '@/components/ui/StatusBadge.vue';
 import SkeletonCard from '@/components/ui/SkeletonCard.vue';
 import ApplicationAttachmentDetail from '@/components/ApplicationDetail/ApplicationAttachmentDetail.vue';
 import { getAccessibleAttachments, getAccessibleAttachmentDetail } from '@/api/applications';
+import { getOrganizations, getCompanies } from '@/api/organizations';
 import { useDeletionsStore } from '@/stores/deletions';
 import { formatDateRu, formatDateTime } from '@/utils/datetime';
 
 const PER_PAGE = 30;
+const SEARCH_DEBOUNCE_MS = 300;
+const VALID_TYPES = ['cars', 'people', 'items'];
 
 const deletions = useDeletionsStore();
+const route = useRoute();
+const router = useRouter();
+
+// Фильтры инициализируем из query синхронно (до onMounted), чтобы перезагрузка и
+// диплинк восстановили состояние одним стартовым запросом, без лишнего рефетча.
+// Сентинелы "все": '' для типа, 0 для организации/компании - у BaseDropdown нет
+// очистки (null всегда показывает placeholder), поэтому "все" - явный пункт.
+const search = ref(typeof route.query.search === 'string' ? route.query.search : '');
+const typeFilter = ref(VALID_TYPES.includes(route.query.type) ? route.query.type : '');
+const orgFilter = ref(Number(route.query.organization) || 0);
+const companyFilter = ref(Number(route.query.company) || 0);
+
+const typeOptions = [
+  { id: '', name: 'Все типы' },
+  { id: 'cars', name: 'Автомобили' },
+  { id: 'people', name: 'Сотрудники' },
+  { id: 'items', name: 'ТМЦ' },
+];
+const orgOptions = ref([{ id: 0, name: 'Все организации' }]);
+const companyOptions = ref([{ id: 0, name: 'Все компании' }]);
+
+const hasActiveFilters = computed(
+  () => !!search.value.trim()
+    || !!typeFilter.value
+    || orgFilter.value !== 0
+    || companyFilter.value !== 0,
+);
 
 const items = ref([]);
 const total = ref(0);
@@ -228,6 +324,9 @@ const detail = ref(null);
 // запросы детали в общий ref, и медленный ответ предыдущего вложения мог бы
 // затереть актуальный (#632). Применяем только ответ последнего запроса.
 let detailSeq = 0;
+// Тот же приём для списка: смена фильтра/поиска быстро пускает несколько запросов
+// в общий items/total, медленный предыдущий мог бы затереть актуальный (#632).
+let listSeq = 0;
 
 const TYPE_LABELS = { cars: 'Автомобили', people: 'Сотрудники', items: 'ТМЦ' };
 const TYPE_VARIANTS = { cars: 'primary', people: 'info', items: 'warning' };
@@ -261,25 +360,88 @@ function dateRange(a) {
   return '';
 }
 
+function buildParams() {
+  const params = { page: page.value, per_page: PER_PAGE };
+  const s = search.value.trim();
+  if (s) params.search = s;
+  if (typeFilter.value) params.attachment_type = typeFilter.value;
+  if (orgFilter.value) params.organization_id = orgFilter.value;
+  if (companyFilter.value) params.company_id = companyFilter.value;
+  return params;
+}
+
+function syncUrl() {
+  const query = {};
+  const s = search.value.trim();
+  if (s) query.search = s;
+  if (typeFilter.value) query.type = typeFilter.value;
+  if (orgFilter.value) query.organization = String(orgFilter.value);
+  if (companyFilter.value) query.company = String(companyFilter.value);
+  // catch гасит navigation-cancel при быстрой смене фильтров: vue-router отклоняет
+  // отменённую replace - это не ошибка приложения, а нормальная гонка ввода.
+  router.replace({ query }).catch(() => {});
+}
+
 async function fetchList({ reset = true } = {}) {
+  if (reset) page.value = 1;
   listLoading.value = true;
+  const seq = ++listSeq;
   try {
-    if (reset) page.value = 1;
-    const { items: data, meta } = await getAccessibleAttachments({
-      page: page.value,
-      per_page: PER_PAGE,
-    });
+    const { items: data, meta } = await getAccessibleAttachments(buildParams());
+    if (seq !== listSeq) return;
     items.value = reset ? data : [...items.value, ...data];
     total.value = meta.total || 0;
   } catch {
+    if (seq !== listSeq) return;
     deletions.notify({
       type: 'error',
       bold: 'Не удалось загрузить',
       suffix: 'список доступных вложений',
     });
   } finally {
-    listLoading.value = false;
+    if (seq === listSeq) listLoading.value = false;
   }
+}
+
+// Смена любого фильтра сбрасывает пагинацию (reset: true -> page=1), снимает
+// открытую деталь и переписывает URL, чтобы состояние было шарящимся и переживало
+// перезагрузку (web.md: URL как state). Аккумулирующую страницу load-more в URL не
+// кладём - с "Показать ещё" её число не диплинкается осмысленно.
+function applyFilters() {
+  selectedId.value = null;
+  detail.value = null;
+  syncUrl();
+  fetchList({ reset: true });
+}
+
+let searchTimer = null;
+function onSearchInput() {
+  clearTimeout(searchTimer);
+  searchTimer = setTimeout(applyFilters, SEARCH_DEBOUNCE_MS);
+}
+
+function setType(value) {
+  typeFilter.value = value;
+  applyFilters();
+}
+
+function setOrg(value) {
+  orgFilter.value = value;
+  applyFilters();
+}
+
+function setCompany(value) {
+  companyFilter.value = value;
+  applyFilters();
+}
+
+function resetFilters() {
+  clearTimeout(searchTimer);
+  search.value = '';
+  typeFilter.value = '';
+  orgFilter.value = 0;
+  companyFilter.value = 0;
+  applyFilters();
 }
 
 function refresh() {
@@ -292,6 +454,26 @@ function loadMore() {
   if (listLoading.value) return;
   page.value += 1;
   fetchList({ reset: false });
+}
+
+// Пикеры орг/компаний - вспомогательные: без них поиск и фильтр по типу всё равно
+// работают, дропдауны просто остаются с одним пунктом "Все". Список не блокируем.
+async function loadFilterOptions() {
+  try {
+    const [orgs, companies] = await Promise.all([getOrganizations(), getCompanies()]);
+    if (Array.isArray(orgs)) {
+      orgOptions.value = [{ id: 0, name: 'Все организации' }, ...orgs];
+    }
+    if (Array.isArray(companies)) {
+      companyOptions.value = [{ id: 0, name: 'Все компании' }, ...companies];
+    }
+  } catch {
+    deletions.notify({
+      type: 'error',
+      bold: 'Не удалось загрузить',
+      suffix: 'списки для фильтров',
+    });
+  }
 }
 
 async function selectAttachment(id) {
@@ -313,7 +495,12 @@ async function selectAttachment(id) {
   }
 }
 
-onMounted(() => fetchList({ reset: true }));
+onMounted(() => {
+  loadFilterOptions();
+  fetchList({ reset: true });
+});
+
+onBeforeUnmount(() => clearTimeout(searchTimer));
 </script>
 
 <style scoped>
@@ -343,6 +530,45 @@ onMounted(() => fetchList({ reset: true }));
   display: flex;
   align-items: center;
   gap: 12px;
+}
+
+.filters {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+  padding: 12px 20px;
+  border-bottom: 1px solid #e6e6e6;
+}
+
+.filters__search {
+  position: relative;
+  flex: 1 1 240px;
+  min-width: 200px;
+}
+
+.filters__search-icon {
+  position: absolute;
+  left: 14px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 16px;
+  height: 16px;
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.filters__search-input {
+  padding-left: 38px;
+}
+
+.filters__dropdown {
+  flex: 0 1 200px;
+  min-width: 160px;
+}
+
+.filters__reset {
+  flex-shrink: 0;
 }
 
 .content-container {

--- a/frontend/src/views/__tests__/AccessibleAttachmentsView.spec.js
+++ b/frontend/src/views/__tests__/AccessibleAttachmentsView.spec.js
@@ -223,21 +223,27 @@ describe('AccessibleAttachmentsView (FE-S6) фильтры', () => {
   });
 
   it('поиск применяется после debounce и шлёт search', async () => {
-    getAccessibleAttachments.mockResolvedValue({ items: [], meta: { total: 0 } });
-    wrapper = mountView();
-    await flushPromises();
-    getAccessibleAttachments.mockClear();
+    vi.useFakeTimers();
+    try {
+      getAccessibleAttachments.mockResolvedValue({ items: [], meta: { total: 0 } });
+      wrapper = mountView();
+      // advanceTimersByTimeAsync прокручивает микротаски между таймерами - так
+      // под фейковыми таймерами дорешиваются промисы onMounted-запросов.
+      await vi.advanceTimersByTimeAsync(0);
+      getAccessibleAttachments.mockClear();
 
-    await wrapper.find('[data-testid="aa-search"]').setValue('ромашка');
-    // До истечения debounce запроса нет.
-    expect(getAccessibleAttachments).not.toHaveBeenCalled();
+      await wrapper.find('[data-testid="aa-search"]').setValue('ромашка');
+      // До истечения debounce (300мс) запроса нет.
+      expect(getAccessibleAttachments).not.toHaveBeenCalled();
 
-    await new Promise((resolve) => setTimeout(resolve, 350));
-    await flushPromises();
+      await vi.advanceTimersByTimeAsync(300);
 
-    expect(getAccessibleAttachments).toHaveBeenCalledWith(
-      expect.objectContaining({ search: 'ромашка', page: 1 }),
-    );
+      expect(getAccessibleAttachments).toHaveBeenCalledWith(
+        expect.objectContaining({ search: 'ромашка', page: 1 }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('сброс фильтров очищает query-параметры и URL', async () => {

--- a/frontend/src/views/__tests__/AccessibleAttachmentsView.spec.js
+++ b/frontend/src/views/__tests__/AccessibleAttachmentsView.spec.js
@@ -3,12 +3,18 @@ import { mount, flushPromises } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 
 // FE-S3 (#706): вкладка "Доступные мне" - список доступных вложений + деталь.
-// Проверяем рендер списка, пустое состояние и защиту детали от гонки (#632):
-// быстрые клики не дают медленному ответу предыдущего вложения затереть актуальное.
+// FE-S6 (#706): панель поиска и фильтров (тип/организация/компания) + URL-как-state.
+// Проверяем рендер списка, пустое состояние, защиту детали от гонки (#632),
+// формирование query-параметров фильтрами и сброс пагинации при смене фильтра.
 
 vi.mock('@/api/applications', () => ({
   getAccessibleAttachments: vi.fn(),
   getAccessibleAttachmentDetail: vi.fn(),
+}));
+
+vi.mock('@/api/organizations', () => ({
+  getOrganizations: vi.fn(),
+  getCompanies: vi.fn(),
 }));
 
 const notify = vi.fn();
@@ -16,8 +22,21 @@ vi.mock('@/stores/deletions', () => ({
   useDeletionsStore: () => ({ notify }),
 }));
 
+// Роутер мокаем, чтобы тестировать URL-как-state без поднятия реального роутера:
+// route.query - источник стартовых фильтров, router.replace - запись фильтров в URL.
+const { routeState, replace } = vi.hoisted(() => ({
+  routeState: { query: {} },
+  replace: vi.fn(() => Promise.resolve()),
+}));
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: routeState.query }),
+  useRouter: () => ({ replace }),
+}));
+
 import AccessibleAttachmentsView from '@/views/AccessibleAttachmentsView.vue';
+import BaseDropdown from '@/components/ui/BaseDropdown.vue';
 import { getAccessibleAttachments, getAccessibleAttachmentDetail } from '@/api/applications';
+import { getOrganizations, getCompanies } from '@/api/organizations';
 
 const stubs = {
   AdminPageShell: { template: '<div><slot /></div>' },
@@ -44,7 +63,8 @@ function makeItem(id, over = {}) {
   };
 }
 
-function mountView() {
+function mountView(query = {}) {
+  routeState.query = query;
   return mount(AccessibleAttachmentsView, { global: { stubs } });
 }
 
@@ -53,6 +73,9 @@ let wrapper;
 beforeEach(() => {
   setActivePinia(createPinia());
   vi.clearAllMocks();
+  routeState.query = {};
+  getOrganizations.mockResolvedValue([]);
+  getCompanies.mockResolvedValue([]);
 });
 
 afterEach(() => {
@@ -139,5 +162,97 @@ describe('AccessibleAttachmentsView (FE-S3)', () => {
 
     // Деталь показывает вложение 2 (актуальный выбор), а не затёртое первым ответом.
     expect(wrapper.find('.detail-stub').text()).toBe('2');
+  });
+});
+
+describe('AccessibleAttachmentsView (FE-S6) фильтры', () => {
+  it('восстанавливает фильтры из query при загрузке (URL-как-state)', async () => {
+    getAccessibleAttachments.mockResolvedValue({ items: [], meta: { total: 0 } });
+    wrapper = mountView({ type: 'cars', search: 'абв', organization: '7' });
+    await flushPromises();
+
+    expect(getAccessibleAttachments).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attachment_type: 'cars',
+        search: 'абв',
+        organization_id: 7,
+        page: 1,
+        per_page: 30,
+      }),
+    );
+  });
+
+  it('смена типа шлёт attachment_type, пишет URL и сбрасывает страницу на 1', async () => {
+    getAccessibleAttachments.mockResolvedValue({
+      items: [makeItem(1)],
+      meta: { total: 60, page: 1, per_page: 30 },
+    });
+    wrapper = mountView();
+    await flushPromises();
+
+    // Подгружаем вторую страницу через "Показать ещё" - страница становится 2.
+    await wrapper.find('[data-testid="aa-load-more"]').trigger('click');
+    await flushPromises();
+    getAccessibleAttachments.mockClear();
+
+    const dropdowns = wrapper.findAllComponents(BaseDropdown);
+    dropdowns[0].vm.$emit('update:modelValue', 'cars'); // тип вложения
+    await flushPromises();
+
+    expect(getAccessibleAttachments).toHaveBeenCalledWith(
+      expect.objectContaining({ attachment_type: 'cars', page: 1 }),
+    );
+    expect(replace).toHaveBeenLastCalledWith({ query: { type: 'cars' } });
+  });
+
+  it('смена организации шлёт organization_id числом и пишет URL', async () => {
+    getAccessibleAttachments.mockResolvedValue({ items: [], meta: { total: 0 } });
+    getOrganizations.mockResolvedValue([{ id: 7, name: 'ООО Ромашка' }]);
+    wrapper = mountView();
+    await flushPromises();
+    getAccessibleAttachments.mockClear();
+
+    const dropdowns = wrapper.findAllComponents(BaseDropdown);
+    dropdowns[1].vm.$emit('update:modelValue', 7); // организация
+    await flushPromises();
+
+    expect(getAccessibleAttachments).toHaveBeenCalledWith(
+      expect.objectContaining({ organization_id: 7, page: 1 }),
+    );
+    expect(replace).toHaveBeenLastCalledWith({ query: { organization: '7' } });
+  });
+
+  it('поиск применяется после debounce и шлёт search', async () => {
+    getAccessibleAttachments.mockResolvedValue({ items: [], meta: { total: 0 } });
+    wrapper = mountView();
+    await flushPromises();
+    getAccessibleAttachments.mockClear();
+
+    await wrapper.find('[data-testid="aa-search"]').setValue('ромашка');
+    // До истечения debounce запроса нет.
+    expect(getAccessibleAttachments).not.toHaveBeenCalled();
+
+    await new Promise((resolve) => setTimeout(resolve, 350));
+    await flushPromises();
+
+    expect(getAccessibleAttachments).toHaveBeenCalledWith(
+      expect.objectContaining({ search: 'ромашка', page: 1 }),
+    );
+  });
+
+  it('сброс фильтров очищает query-параметры и URL', async () => {
+    getAccessibleAttachments.mockResolvedValue({ items: [], meta: { total: 0 } });
+    wrapper = mountView({ type: 'cars', search: 'абв' });
+    await flushPromises();
+    getAccessibleAttachments.mockClear();
+
+    await wrapper.find('[data-testid="aa-filter-reset"]').trigger('click');
+    await flushPromises();
+
+    const lastArg = getAccessibleAttachments.mock.calls.at(-1)[0];
+    expect(lastArg).not.toHaveProperty('attachment_type');
+    expect(lastArg).not.toHaveProperty('search');
+    expect(lastArg).toMatchObject({ page: 1, per_page: 30 });
+    expect(replace).toHaveBeenLastCalledWith({ query: {} });
   });
 });


### PR DESCRIPTION
## Что это
Финальный срез FE-S6 эпика #706 («Доступные мне» — вложения охранникам ЧОП). В экран `AccessibleAttachmentsView.vue` добавлена панель поиска и фильтров, как в Центре заявок.

## Изменения
- **Поиск** по номеру заявки / имени вложения / ФИО отправителя (input с debounce 300мс, иконка-лупа).
- **Фильтры** через `ui/BaseDropdown`: тип вложения (Автомобили/Сотрудники/ТМЦ), организация, компания. Org/company-пикеры — реюз `getOrganizations()`/`getCompanies()` (JWT-only эндпоинты, охранник имеет доступ). «Все ...» — явный сентинел-пункт ('' / 0), т.к. у BaseDropdown нет очистки (null всегда показывает placeholder).
- **URL-как-state** (web.md): фильтры и поиск пишутся в query-параметры роута через `router.replace` — диплинк и переживают перезагрузку; на старте состояние восстанавливается из query синхронно, без лишнего рефетча.
- **Сброс пагинации** на 1-ю страницу при смене любого фильтра; кнопка «Сбросить» при активном фильтре; пустое состояние с подсказкой «Ничего не найдено».
- **seq-токен на рефетч списка** (#632) — медленный предыдущий ответ не затирает актуальный (симметрично уже существующему seq на детали).
- Бэкенд BE-S6 (#724) уже принимает `search`/`attachment_type`/`organization_id`/`company_id` поверх инварианта видимости охранника; пустые/сентинел-значения в запрос не протекают (`if (value)` в `buildParams`).

## Проверки
- vitest `AccessibleAttachmentsView.spec.js` — 10 зелёных (рендер, пусто, гонка детали #632, восстановление фильтров из URL, формирование query-параметров, сброс страницы при смене фильтра, debounce, сброс фильтров).
- eslint по изменённым .vue/.spec.js — чисто.
- `code-reviewer` — GO; два жёлтых закрыты (debounce-тест переведён на `vi.useFakeTimers`, убран What-комментарий).
- Раскладка панели одобрена пользователем по скриншоту ДО мержа (поиск на своей строке, три дропдауна ровным рядом ниже).
- Живой путь со списком — `/ship-check` на staging после мержа (локальный go-backend устарел на 5 дней, до BE-S4-роута; роут+фильтры покрыты 8 зелёными хендлер-тестами BE-S6).