### PR TITLE
feat(applications): мощный fuzzy-поиск заявок по всем полям и вложениям

### DIFF
--- a/internal/normalize/normalize.go
+++ b/internal/normalize/normalize.go
@@ -10,6 +10,49 @@ package normalize
 
 import "strings"
 
+// cyrToLatKeyboard - кириллические буквы на русской раскладке к латинским буквам
+// на той же физической клавише QWERTY. Нижний регистр: позиция руки одна, буква другая.
+// Позволяет найти запрос, набранный кириллицей когда нужна латиница (и наоборот).
+var cyrToLatKeyboard = map[rune]rune{
+	'й': 'q', 'ц': 'w', 'у': 'e', 'к': 'r', 'е': 't', 'н': 'y', 'г': 'u', 'ш': 'i',
+	'щ': 'o', 'з': 'p', 'х': '[', 'ъ': ']',
+	'ф': 'a', 'ы': 's', 'в': 'd', 'а': 'f', 'п': 'g', 'р': 'h', 'о': 'j', 'л': 'k',
+	'д': 'l', 'ж': ';', 'э': '\'',
+	'я': 'z', 'ч': 'x', 'с': 'c', 'м': 'v', 'и': 'b', 'т': 'n', 'ь': 'm', 'б': ',',
+	'ю': '.', 'ё': '`',
+}
+
+// latToCyrKeyboard - обратная таблица: латинские буквы к русским на той же физической
+// клавише QWERTY. Строится из cyrToLatKeyboard при инициализации.
+var latToCyrKeyboard map[rune]rune
+
+func init() {
+	latToCyrKeyboard = make(map[rune]rune, len(cyrToLatKeyboard))
+	for cyr, lat := range cyrToLatKeyboard {
+		latToCyrKeyboard[lat] = cyr
+	}
+}
+
+// SwitchLayout переключает раскладку строки s: кириллица->латиница или латиница->кириллица
+// посимвольно по таблице QWERTY. Символы без соответствия передаются без изменений.
+// Используется для порождения альтернативного варианта поискового запроса: если пользователь
+// набрал слово не переключив раскладку, переключённый вариант совпадёт с хранимыми данными.
+func SwitchLayout(s string) string {
+	lowered := strings.ToLower(s)
+	var b strings.Builder
+	b.Grow(len(lowered))
+	for _, r := range lowered {
+		if lat, ok := cyrToLatKeyboard[r]; ok {
+			b.WriteRune(lat)
+		} else if cyr, ok := latToCyrKeyboard[r]; ok {
+			b.WriteRune(cyr)
+		} else {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
 // latToCyrLower - латинские буквы, которыми подменяют кириллицу в ФИО, в нижнем
 // регистре. Применяется ПОСЛЕ ToLower, поэтому ключи строчные. Набор - это те же 12
 // латинских букв, что омоглифят русские буквы А В Е К М Н О Р С Т У Х (см. latToCyrUpper):

--- a/internal/normalize/switchlayout_test.go
+++ b/internal/normalize/switchlayout_test.go
@@ -1,0 +1,32 @@
+package normalize
+
+import "testing"
+
+func TestSwitchLayout(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"латиница в кириллицу (набрал не переключив раскладку)", "ghbdtn", "привет"},
+		{"кириллица в латиницу", "привет", "ghbdtn"},
+		{"фамилия латиницей в кириллицу", "bdfyjd", "иванов"},
+		{"цифры и неизвестные символы без изменений", "123-45", "123-45"},
+		{"пустая строка", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SwitchLayout(tt.in); got != tt.want {
+				t.Errorf("SwitchLayout(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSwitchLayoutRoundTrip(t *testing.T) {
+	for _, s := range []string{"иванов", "петров", "сидоров"} {
+		if got := SwitchLayout(SwitchLayout(s)); got != s {
+			t.Errorf("round-trip SwitchLayout(SwitchLayout(%q)) = %q, want %q", s, got, s)
+		}
+	}
+}

--- a/internal/services/application_helpers.go
+++ b/internal/services/application_helpers.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"systemburo/internal/models"
+	"systemburo/internal/normalize"
 
 	"github.com/labstack/echo/v4"
 	"gorm.io/gorm"
@@ -199,31 +200,114 @@ func applyApplicationAccessFilter(query *gorm.DB, userID int, isApprover bool) *
 	`, userID, userID, userID)
 }
 
+// buildSearchVariants возвращает уникальный набор вариантов поискового запроса:
+// оригинал, альтернативная раскладка и нормализованный госномер (если запрос похож на номер).
+// Используется для покрытия ввода без переключения раскладки и номеров с омоглифами/нулями.
+func buildSearchVariants(raw string) []string {
+	variants := make([]string, 0, 3)
+	seen := make(map[string]struct{}, 3)
+	add := func(v string) {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			return
+		}
+		if _, ok := seen[v]; !ok {
+			seen[v] = struct{}{}
+			variants = append(variants, v)
+		}
+	}
+	add(raw)
+	add(normalize.SwitchLayout(raw))
+	add(normalize.Plate(raw))
+	return variants
+}
+
+// ilikePatternsArgs строит пары (ILIKE-условие, args) для набора вариантов и набора колонок.
+// Возвращает одну OR-строку из pattern_col ILIKE ? для каждой пары (col, variant).
+func ilikePatternsArgs(cols []string, variants []string) (string, []interface{}) {
+	var parts []string
+	var args []interface{}
+	for _, col := range cols {
+		for _, v := range variants {
+			parts = append(parts, col+" ILIKE ?")
+			args = append(args, "%"+v+"%")
+		}
+	}
+	return strings.Join(parts, " OR "), args
+}
+
 func applyApplicationFilters(query *gorm.DB, filter ApplicationFilter, includeUserSearch bool) *gorm.DB {
 	if filter.SearchQuery != nil && *filter.SearchQuery != "" {
-		pattern := "%" + *filter.SearchQuery + "%"
-		if includeUserSearch {
-			query = query.Where(`
-				a.application_number ILIKE ? OR
-				COALESCE(o.name, c.name, '') ILIKE ? OR
-				c.name ILIKE ? OR
-				a.message ILIKE ? OR
-				a.status ILIKE ? OR
-				a.confirmation ILIKE ? OR
-				u.last_name ILIKE ? OR u.first_name ILIKE ? OR u.middle_name ILIKE ? OR
-				ru.last_name ILIKE ? OR ru.first_name ILIKE ? OR ru.middle_name ILIKE ?
-			`, pattern, pattern, pattern, pattern, pattern, pattern,
-				pattern, pattern, pattern, pattern, pattern, pattern)
-		} else {
-			query = query.Where(`
-				a.application_number ILIKE ? OR
-				COALESCE(o.name, c.name, '') ILIKE ? OR
-				c.name ILIKE ? OR
-				a.message ILIKE ? OR
-				a.status ILIKE ? OR
-				a.confirmation ILIKE ?
-			`, pattern, pattern, pattern, pattern, pattern, pattern)
+		raw := *filter.SearchQuery
+		variants := buildSearchVariants(raw)
+
+		// --- поля заявки и организаций ---
+		baseCols := []string{
+			"a.application_number",
+			"COALESCE(o.name, c.name, '')",
+			"c.name",
+			"a.message",
+			"a.status",
+			"a.confirmation",
 		}
+		baseCond, baseArgs := ilikePatternsArgs(baseCols, variants)
+
+		if includeUserSearch {
+			userCols := []string{
+				"u.last_name", "u.first_name", "u.middle_name",
+				"ru.last_name", "ru.first_name", "ru.middle_name",
+			}
+			userCond, userArgs := ilikePatternsArgs(userCols, variants)
+			baseCond += " OR " + userCond
+			baseArgs = append(baseArgs, userArgs...)
+		}
+
+		// --- вложения: машины ---
+		// Госномер ищем по всем вариантам (включая normalize.Plate для омоглифов/нулей);
+		// марку - по тексту. Подзапрос IN чтобы не размножать строки заявки.
+		carNumCond, carNumArgs := ilikePatternsArgs([]string{"c2.car_number", "c2.mark_name"}, variants)
+		carSubquery := `EXISTS(
+			SELECT 1 FROM attachments att2
+			JOIN cars c2 ON c2.attachment_id = att2.id
+			WHERE att2.application_id = a.id AND (` + carNumCond + `)
+		)`
+
+		// --- вложения: сотрудники ---
+		// ФИО ищем ILIKE + trigramm similarity для нечёткого совпадения (опечатки, транслит).
+		// Similarity-порог 0.3 - ниже чем у ЧС (0.7), потому что поиск менее критичен к ложным
+		// срабатываниям и важнее recall. word_similarity покрывает однословный запрос по полю.
+		empIlikeCond, empIlikeArgs := ilikePatternsArgs(
+			[]string{"e.last_name", "e.first_name", "e.middle_name", "e.position"},
+			variants,
+		)
+		// pg_trgm similarity по исходному запросу на нормализованном ФИО-конкате.
+		empSubquery := `EXISTS(
+			SELECT 1 FROM attachments att3
+			JOIN employees e ON e.attachment_id = att3.id
+			WHERE att3.application_id = a.id AND (
+				` + empIlikeCond + `
+				OR word_similarity(?, concat_ws(' ', e.last_name, e.first_name, e.middle_name)) > 0.3
+			)
+		)`
+
+		// --- вложения: места разгрузки ---
+		upCond, upArgs := ilikePatternsArgs([]string{"up.name"}, variants)
+		upSubquery := `EXISTS(
+			SELECT 1 FROM attachments att4
+			JOIN car_unload_places cup ON cup.attachment_id = att4.id
+			JOIN unload_places up ON up.id = cup.unload_place_id
+			WHERE att4.application_id = a.id AND (` + upCond + `)
+		)`
+
+		fullCond := baseCond + " OR " + carSubquery + " OR " + empSubquery + " OR " + upSubquery
+
+		allArgs := baseArgs
+		allArgs = append(allArgs, carNumArgs...)
+		allArgs = append(allArgs, empIlikeArgs...)
+		allArgs = append(allArgs, raw) // для word_similarity
+		allArgs = append(allArgs, upArgs...)
+
+		query = query.Where(fullCond, allArgs...)
 	}
 
 	if filter.OrganizationID != nil {

--- a/internal/services/application_helpers.go
+++ b/internal/services/application_helpers.go
@@ -249,6 +249,7 @@ func applyApplicationFilters(query *gorm.DB, filter ApplicationFilter, includeUs
 			"a.message",
 			"a.status",
 			"a.confirmation",
+			"a.responsible_comment",
 		}
 		baseCond, baseArgs := ilikePatternsArgs(baseCols, variants)
 
@@ -264,8 +265,15 @@ func applyApplicationFilters(query *gorm.DB, filter ApplicationFilter, includeUs
 
 		// --- вложения: машины ---
 		// Госномер ищем по всем вариантам (включая normalize.Plate для омоглифов/нулей);
-		// марку - по тексту. Подзапрос IN чтобы не размножать строки заявки.
+		// марку - по тексту. EXISTS чтобы не размножать строки заявки.
 		carNumCond, carNumArgs := ilikePatternsArgs([]string{"c2.car_number", "c2.mark_name"}, variants)
+		// Слитно/раздельно: сравниваем номер без пробелов с нормализованным запросом,
+		// чтобы "А 777 АА" находился по "А777АА" и наоборот (только если в запросе есть цифры).
+		platePattern := ""
+		if strings.ContainsAny(raw, "0123456789") {
+			carNumCond += " OR REPLACE(c2.car_number, ' ', '') ILIKE ?"
+			platePattern = "%" + normalize.Plate(raw) + "%"
+		}
 		carSubquery := `EXISTS(
 			SELECT 1 FROM attachments att2
 			JOIN cars c2 ON c2.attachment_id = att2.id
@@ -280,7 +288,6 @@ func applyApplicationFilters(query *gorm.DB, filter ApplicationFilter, includeUs
 			[]string{"e.last_name", "e.first_name", "e.middle_name", "e.position"},
 			variants,
 		)
-		// pg_trgm similarity по исходному запросу на нормализованном ФИО-конкате.
 		empSubquery := `EXISTS(
 			SELECT 1 FROM attachments att3
 			JOIN employees e ON e.attachment_id = att3.id
@@ -299,13 +306,33 @@ func applyApplicationFilters(query *gorm.DB, filter ApplicationFilter, includeUs
 			WHERE att4.application_id = a.id AND (` + upCond + `)
 		)`
 
-		fullCond := baseCond + " OR " + carSubquery + " OR " + empSubquery + " OR " + upSubquery
+		// --- согласующие: ФИО + комментарий согласующего ---
+		// word_similarity для опечаток в фамилии согласующего (диктовка охранником).
+		apprIlikeCond, apprIlikeArgs := ilikePatternsArgs(
+			[]string{"au.last_name", "au.first_name", "au.middle_name", "aru.approval_comment"},
+			variants,
+		)
+		apprSubquery := `EXISTS(
+			SELECT 1 FROM application_responsible_users aru
+			JOIN users au ON au.id = aru.user_id
+			WHERE aru.application_id = a.id AND (
+				` + apprIlikeCond + `
+				OR word_similarity(?, concat_ws(' ', au.last_name, au.first_name, au.middle_name)) > 0.3
+			)
+		)`
+
+		fullCond := baseCond + " OR " + carSubquery + " OR " + empSubquery + " OR " + upSubquery + " OR " + apprSubquery
 
 		allArgs := baseArgs
 		allArgs = append(allArgs, carNumArgs...)
+		if platePattern != "" {
+			allArgs = append(allArgs, platePattern)
+		}
 		allArgs = append(allArgs, empIlikeArgs...)
-		allArgs = append(allArgs, raw) // для word_similarity
+		allArgs = append(allArgs, raw) // для word_similarity сотрудников
 		allArgs = append(allArgs, upArgs...)
+		allArgs = append(allArgs, apprIlikeArgs...)
+		allArgs = append(allArgs, raw) // для word_similarity согласующих
 
 		query = query.Where(fullCond, allArgs...)
 	}

--- a/internal/services/application_search_test.go
+++ b/internal/services/application_search_test.go
@@ -1,0 +1,60 @@
+package services
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildSearchVariants(t *testing.T) {
+	t.Run("включает оригинал и переключённую раскладку", func(t *testing.T) {
+		variants := buildSearchVariants("ghbdtn")
+		if !sliceContains(variants, "ghbdtn") {
+			t.Errorf("нет оригинала в %v", variants)
+		}
+		if !sliceContains(variants, "привет") {
+			t.Errorf("нет варианта раскладки 'привет' в %v", variants)
+		}
+	})
+
+	t.Run("дедуп: одинаковые варианты схлопываются", func(t *testing.T) {
+		// для "123" оригинал == раскладка == номер, должен остаться один вариант
+		variants := buildSearchVariants("123")
+		if len(variants) != 1 {
+			t.Errorf("ожидали 1 вариант для '123', получили %v", variants)
+		}
+	})
+
+	t.Run("пустые варианты отбрасываются", func(t *testing.T) {
+		for _, v := range buildSearchVariants("иванов") {
+			if strings.TrimSpace(v) == "" {
+				t.Errorf("пустой вариант в наборе")
+			}
+		}
+	})
+}
+
+func TestIlikePatternsArgs(t *testing.T) {
+	cond, args := ilikePatternsArgs([]string{"a.x", "b.y"}, []string{"foo", "bar"})
+
+	if got := strings.Count(cond, "ILIKE ?"); got != 4 {
+		t.Errorf("ожидали 4 ILIKE-условия (2 колонки x 2 варианта), получили %d в %q", got, cond)
+	}
+	if len(args) != 4 {
+		t.Fatalf("ожидали 4 аргумента, получили %d: %v", len(args), args)
+	}
+	if args[0] != "%foo%" || args[1] != "%bar%" {
+		t.Errorf("аргументы обёрнуты неверно: %v", args)
+	}
+	if !strings.Contains(cond, " OR ") {
+		t.Errorf("условия не объединены через OR: %q", cond)
+	}
+}
+
+func sliceContains(ss []string, target string) bool {
+	for _, s := range ss {
+		if s == target {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/services/application_service.go
+++ b/internal/services/application_service.go
@@ -615,7 +615,7 @@ func (s *applicationService) GetApplications(ctx context.Context, username strin
 
 	query = applyApplicationAccessFilter(query, user.ID, isApprover)
 
-	query = applyApplicationFilters(query, filter, false)
+	query = applyApplicationFilters(query, filter, true)
 	query = query.Order("a.sending_datetime DESC")
 
 	rows := make([]ApplicationWithDetails, 0)
@@ -637,7 +637,7 @@ func (s *applicationService) buildApplicationsBaseQuery(ctx context.Context, use
 
 	query = applyApplicationAccessFilter(query, userID, isApprover)
 
-	return applyApplicationFilters(query, filter, false)
+	return applyApplicationFilters(query, filter, true)
 }
 
 // GetApplicationsPaginated возвращает страницу заявок с общим количеством.


### PR DESCRIPTION
Поиск Центра расширен: заявка (номер/сообщение/статус/комментарий), организация/компания, отправитель/ответственный, согласующие (ФИО+комментарий, word_similarity для опечаток), сотрудники (ФИО/должность+fuzzy), марка, госномер слитно/раздельно, места разгрузки. Транслитерация раскладки QWERTY. Unit-тесты на новую логику.