### PR TITLE
feat(applications-center): инкрементальное добавление новых заявок наверх со звуком + 10-15 пресетов

### DIFF
--- a/frontend/src/components/NavMenu.vue
+++ b/frontend/src/components/NavMenu.vue
@@ -977,7 +977,10 @@ export default {
         const count = data.count || 0
         // Звук только при РОСТЕ счётчика после первичной загрузки (не на логине) и не чаще
         // кулдауна - пачка заявок в одном опросе даёт +N за раз = один звук.
-        if (this.soundPrimed && count > this.newApplicationsCount && this.soundStore.enabled) {
+        // Звук только вне Центра заявок: когда пользователь на /center,
+        // ApplicationsCenter сам играет звук при prepend новых заявок.
+        if (this.soundPrimed && count > this.newApplicationsCount && this.soundStore.enabled &&
+            this.$route?.path !== '/center') {
           const now = Date.now()
           if (now - this.lastSoundAt > SOUND_COOLDOWN_MS) {
             playPreset(this.soundStore.selectedPreset, this.soundStore.volume)

--- a/frontend/src/utils/notificationSound.js
+++ b/frontend/src/utils/notificationSound.js
@@ -30,7 +30,7 @@ function getAudioContext() {
  * @param {number} startAt - время начала в секундах (ctx.currentTime-базированное)
  * @param {number} duration - длительность тона в секундах
  * @param {number} volume - громкость 0..1
- * @param {'sine'|'triangle'} type - тип волны
+ * @param {'sine'|'triangle'|'square'|'sawtooth'} type - тип волны
  */
 function playTone(ctx, freq, startAt, duration, volume, type = 'sine') {
   const osc = ctx.createOscillator()
@@ -69,11 +69,105 @@ const PRESETS = {
     const t = ctx.currentTime
     playTone(ctx, 1320, t, 0.3, volume, 'triangle')
   },
+
+  /** Три восходящих тона */
+  chime(ctx, volume) {
+    const t = ctx.currentTime
+    playTone(ctx, 523, t, 0.2, volume * 0.8, 'sine')
+    playTone(ctx, 659, t + 0.15, 0.2, volume * 0.9, 'sine')
+    playTone(ctx, 784, t + 0.30, 0.35, volume, 'sine')
+  },
+
+  /** Низкий мягкий удар */
+  thump(ctx, volume) {
+    const t = ctx.currentTime
+    playTone(ctx, 180, t, 0.25, volume, 'sine')
+    playTone(ctx, 90, t + 0.05, 0.3, volume * 0.6, 'sine')
+  },
+
+  /** Быстрые три бипа */
+  triple(ctx, volume) {
+    const t = ctx.currentTime
+    playTone(ctx, 1000, t, 0.1, volume, 'sine')
+    playTone(ctx, 1000, t + 0.14, 0.1, volume, 'sine')
+    playTone(ctx, 1200, t + 0.28, 0.18, volume, 'sine')
+  },
+
+  /** Нежный колокол */
+  bell(ctx, volume) {
+    const t = ctx.currentTime
+    playTone(ctx, 1047, t, 0.6, volume, 'triangle')
+    playTone(ctx, 2093, t, 0.3, volume * 0.3, 'triangle')
+  },
+
+  /** Восходящий свист */
+  rise(ctx, volume) {
+    const t = ctx.currentTime
+    const osc = ctx.createOscillator()
+    const gain = ctx.createGain()
+    osc.connect(gain)
+    gain.connect(ctx.destination)
+    osc.type = 'sine'
+    osc.frequency.setValueAtTime(300, t)
+    osc.frequency.linearRampToValueAtTime(900, t + 0.3)
+    gain.gain.setValueAtTime(0, t)
+    gain.gain.linearRampToValueAtTime(volume, t + 0.05)
+    gain.gain.exponentialRampToValueAtTime(0.001, t + 0.4)
+    osc.start(t)
+    osc.stop(t + 0.45)
+  },
+
+  /** Нисходящий свист */
+  drop(ctx, volume) {
+    const t = ctx.currentTime
+    const osc = ctx.createOscillator()
+    const gain = ctx.createGain()
+    osc.connect(gain)
+    gain.connect(ctx.destination)
+    osc.type = 'sine'
+    osc.frequency.setValueAtTime(900, t)
+    osc.frequency.linearRampToValueAtTime(300, t + 0.3)
+    gain.gain.setValueAtTime(0, t)
+    gain.gain.linearRampToValueAtTime(volume, t + 0.05)
+    gain.gain.exponentialRampToValueAtTime(0.001, t + 0.4)
+    osc.start(t)
+    osc.stop(t + 0.45)
+  },
+
+  /** Пиликание — два тона поочерёдно */
+  ping(ctx, volume) {
+    const t = ctx.currentTime
+    playTone(ctx, 750, t, 0.12, volume, 'sine')
+    playTone(ctx, 1000, t + 0.18, 0.18, volume, 'sine')
+  },
+
+  /** Мягкий треугольник — похож на «кухонный таймер» */
+  timer(ctx, volume) {
+    const t = ctx.currentTime
+    playTone(ctx, 440, t, 0.5, volume, 'triangle')
+    playTone(ctx, 550, t + 0.1, 0.35, volume * 0.5, 'triangle')
+  },
+
+  /** Короткий пульс два раза (квадратная волна) */
+  pulse(ctx, volume) {
+    const t = ctx.currentTime
+    playTone(ctx, 660, t, 0.08, volume * 0.4, 'square')
+    playTone(ctx, 660, t + 0.15, 0.08, volume * 0.4, 'square')
+  },
+
+  /** Фанфара — два восходящих аккорда */
+  fanfare(ctx, volume) {
+    const t = ctx.currentTime
+    playTone(ctx, 523, t, 0.15, volume * 0.9, 'sine')
+    playTone(ctx, 659, t, 0.15, volume * 0.7, 'sine')
+    playTone(ctx, 784, t + 0.18, 0.25, volume, 'sine')
+    playTone(ctx, 1047, t + 0.18, 0.25, volume * 0.6, 'sine')
+  },
 }
 
 /**
  * Воспроизвести пресет.
- * @param {'soft'|'double'|'ding'} preset
+ * @param {string} preset - ключ пресета
  * @param {number} volume - 0..1
  */
 export function playPreset(preset, volume) {
@@ -88,7 +182,17 @@ export function playPreset(preset, volume) {
 }
 
 export const SOUND_PRESETS = [
-  { value: 'soft',   label: 'Мягкий' },
-  { value: 'double', label: 'Двойной' },
-  { value: 'ding',   label: 'Динь' },
+  { value: 'soft',    label: 'Мягкий' },
+  { value: 'double',  label: 'Двойной' },
+  { value: 'ding',    label: 'Динь' },
+  { value: 'chime',   label: 'Перезвон' },
+  { value: 'thump',   label: 'Глухой удар' },
+  { value: 'triple',  label: 'Тройной' },
+  { value: 'bell',    label: 'Колокол' },
+  { value: 'rise',    label: 'Нарастающий' },
+  { value: 'drop',    label: 'Нисходящий' },
+  { value: 'ping',    label: 'Пинг' },
+  { value: 'timer',   label: 'Таймер' },
+  { value: 'pulse',   label: 'Импульс' },
+  { value: 'fanfare', label: 'Фанфара' },
 ]

--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -611,6 +611,10 @@ export default {
             shakeInterval: null,
             applicationsPollInterval: null,
             isInitialLoad: true,
+            // Инкрементальный polling: после первого полного fetch прибавляем только новые
+            // заявки в начало списка без перерисовки всего. pollPrimed=false пока не
+            // завершился первый fetchApplications — чтобы не играть звук при открытии страницы.
+            pollPrimed: false,
             
             // Дата - теперь поддерживаем и одиночную дату, и диапазон
             selectedDate: null,
@@ -813,12 +817,19 @@ export default {
         this.fetchApplications();
         this.getCurrentUser();
 
-        // Динамическое обновление списка заявок - статусы/confirmations
-        // могут меняться из других сессий (согласование, взятие в работу, завершение).
-        // Polling 30s достаточен для UX без overkill.
+        // Polling 30s: инкрементально добавляет новые заявки в начало и
+        // играет звук при появлении; для обновления статусов существующих
+        // раз в 5 минут делается полный reload.
+        let _fullReloadCounter = 0;
         this.applicationsPollInterval = setInterval(() => {
             if (!this.isInitialLoad) {
-                this.fetchApplications();
+                _fullReloadCounter++;
+                if (_fullReloadCounter >= 10) {
+                    _fullReloadCounter = 0;
+                    this.fetchApplications();
+                } else {
+                    this._pollApplicationsIncremental();
+                }
             }
         }, 30000);
 
@@ -1091,6 +1102,76 @@ export default {
         },
 
         // API методы
+
+        /**
+         * Инкрементальный polling: запрашивает список без активных фильтров (только архив),
+         * находит заявки, чей id отсутствует в текущем массиве, и prepend'ит их.
+         * Звук играет в момент добавления, а не при росте unread-счётчика NavMenu —
+         * так пользователь слышит звук именно когда новая строка появляется в таблице.
+         * Не запускается если активны фильтры: новая заявка может просто не попасть
+         * под фильтр, и prepend без полного reload будет некорректен.
+         */
+        async _pollApplicationsIncremental() {
+            // При активных фильтрах инкрементальный prepend некорректен — делаем полный reload.
+            const hasFilters = !!(
+                this.searchQuery ||
+                this.selectedOrganizationId ||
+                this.selectedConfirmations.length ||
+                this.selectedApplicationStatuses.length ||
+                this.selectedDate ||
+                (this.dateRangeStart && this.dateRangeEnd) ||
+                this.activeToday
+            );
+            if (hasFilters) {
+                await this.fetchApplications();
+                return;
+            }
+
+            try {
+                const authStore = useAuthStore();
+                if (!authStore.token) return;
+
+                const params = new URLSearchParams();
+                params.append('archive', this.archiveMode === 'archive' ? 'true' : 'false');
+                const response = await apiRequest(`/applications?${params}`, { method: 'GET' });
+                if (!response.ok) return;
+
+                const fresh = await response.json();
+                if (!Array.isArray(fresh)) return;
+
+                const knownIds = new Set(this.applications.map(a => a.id));
+                const newApps = fresh.filter(a => !knownIds.has(a.id));
+
+                if (newApps.length > 0) {
+                    // Prepend: новые заявки в начало (у них id больше — они свежее)
+                    this.applications = [...newApps, ...this.applications];
+
+                    if (this.pollPrimed && this.soundStore.enabled) {
+                        playPreset(this.soundStore.selectedPreset, this.soundStore.volume);
+                    }
+                }
+
+                // Синхронизируем обновлённые поля существующих (статус/confirmation/is_read),
+                // чтобы не ждать полного reload раз в 5 минут.
+                const freshById = Object.fromEntries(fresh.map(a => [a.id, a]));
+                this.applications = this.applications.map(a => {
+                    const updated = freshById[a.id];
+                    if (!updated) return a;
+                    // Только изменяемые серверные поля, не трогаем локальные (selected и т.п.)
+                    if (
+                        updated.status !== a.status ||
+                        updated.confirmation !== a.confirmation ||
+                        updated.is_read !== a.is_read
+                    ) {
+                        return { ...a, ...updated };
+                    }
+                    return a;
+                });
+            } catch {
+                // сетевой сбой — не критично, следующий poll сам восстановится
+            }
+        },
+
         async fetchApplications() {
             this.refreshing = true;
             try {
@@ -1144,6 +1225,8 @@ export default {
                 if (response.ok) {
                     const data = await response.json();
                     this.applications = data;
+                    // После первого полного fetch включаем инкрементальный polling со звуком.
+                    this.pollPrimed = true;
                 } else {
                     console.error("Ошибка при загрузке заявок:", await response.text());
                 }


### PR DESCRIPTION
Новые заявки prepend'ятся наверх без полного релоада, звук играет в момент добавления (на /center; NavMenu гасит дубль). Полный reload раз в 5 мин для синка статусов. 13 синтез-пресетов звука.