### PR TITLE
refactor(notifications): admin-компоненты на эталонный notify/ui.confirm

### DIFF
--- a/frontend/src/components/TableConstructorPhotoSection.vue
+++ b/frontend/src/components/TableConstructorPhotoSection.vue
@@ -152,6 +152,7 @@
 <script>
 import { apiRequest } from '@/api/client'
 import { useDeletionsStore } from '@/stores/deletions'
+import { useUiStore } from '@/stores/ui'
 
 export default {
   name: 'TableConstructorPhotoSection',
@@ -210,7 +211,14 @@ export default {
     },
 
     async deletePhoto(photo) {
-      if (!confirm('Удалить фотографию?')) return;
+      const ok = await useUiStore().confirm({
+        title: 'Удалить фотографию?',
+        message: `Фотография «${photo.file_name}» будет удалена без возможности восстановления.`,
+        confirmText: 'Удалить',
+        cancelText: 'Отмена',
+        danger: true,
+      });
+      if (!ok) return;
 
       try {
         const response = await apiRequest(`/system-tables/${this.tableId}/photos/${photo.id}`, {

--- a/frontend/src/components/UserNotificationsInline.vue
+++ b/frontend/src/components/UserNotificationsInline.vue
@@ -124,6 +124,7 @@
 <script>
 import { apiRequest } from '@/api/client'
 import LoaderSpinner from '@/components/ui/LoaderSpinner.vue'
+import { useUiStore } from '@/stores/ui'
 
 export default {
   name: 'UserNotificationsInline',
@@ -205,7 +206,14 @@ export default {
     },
 
     async clearAll() {
-      if (!window.confirm('Вы уверены, что хотите удалить все уведомления?')) return
+      const ok = await useUiStore().confirm({
+        title: 'Очистить уведомления?',
+        message: 'Все уведомления будут удалены.',
+        confirmText: 'Очистить',
+        cancelText: 'Отмена',
+        danger: false,
+      })
+      if (!ok) return
       try {
         const response = await apiRequest('/notifications', { method: 'DELETE' })
         if (response.ok) {

--- a/frontend/src/components/admin/AttachmentTemplateEditor.vue
+++ b/frontend/src/components/admin/AttachmentTemplateEditor.vue
@@ -529,7 +529,7 @@
 </template>
 
 <script>
-import { useUiStore } from '@/stores/ui';
+import { useDeletionsStore } from '@/stores/deletions';
 import {
   getTemplate, uploadTemplate, updateMappings, deleteTemplate,
   getTemplateFields, getTemplateFile, saveBlobAs,
@@ -788,7 +788,7 @@ export default {
         }
       } catch {
         this.enabled = !val;
-        useUiStore().error('Не удалось переключить генерацию бланка');
+        useDeletionsStore().notify({ bold: 'Не удалось переключить генерацию бланка', type: 'error' });
       }
     },
     onFileChange(e) {
@@ -810,12 +810,12 @@ export default {
           listEndRow: this.form.listEndRow,
           maxListRows: this.form.maxListRows,
         });
-        useUiStore().success('Шаблон загружен');
+        useDeletionsStore().notify({ bold: 'Шаблон загружен' });
         this.showUpload = false;
         this.form.file = null;
         await this.loadTemplate();
       } catch (err) {
-        useUiStore().error(err.message || 'Не удалось загрузить шаблон');
+        useDeletionsStore().notify({ prefix: 'Не удалось загрузить шаблон: ', bold: err.message || 'ошибка сервера', type: 'error' });
       } finally {
         this.uploading = false;
       }
@@ -832,11 +832,11 @@ export default {
       this.templateFileBuffer = null;
       try {
         await setActiveTemplate(this.uniqueAttachmentId, tmpl.id);
-        useUiStore().success('Шаблон активирован');
+        useDeletionsStore().notify({ bold: 'Шаблон активирован' });
         this.resetState();
         await Promise.all([this.loadTemplate(), this.loadFields()]);
       } catch {
-        useUiStore().error('Не удалось переключить шаблон');
+        useDeletionsStore().notify({ bold: 'Не удалось переключить шаблон', type: 'error' });
         this.loadingTemplate = false;
         this.loadingFields = false;
       }
@@ -844,23 +844,23 @@ export default {
     async deleteSpecificTemplate(tmpl) {
       try {
         await deleteTemplateByID(this.uniqueAttachmentId, tmpl.id);
-        useUiStore().success('Шаблон удален');
+        useDeletionsStore().notify({ bold: 'Шаблон удалён' });
         if (tmpl.id === this.template?.id) {
           this.templateFileBuffer = null;
         }
         await this.loadTemplate();
       } catch {
-        useUiStore().error('Не удалось удалить шаблон');
+        useDeletionsStore().notify({ bold: 'Не удалось удалить шаблон', type: 'error' });
       }
     },
     async onDeleteTemplate() {
       try {
         await deleteTemplate(this.uniqueAttachmentId);
-        useUiStore().success('Шаблон удален');
+        useDeletionsStore().notify({ bold: 'Шаблон удалён' });
         this.templateFileBuffer = null;
         await this.loadTemplate();
       } catch {
-        useUiStore().error('Не удалось удалить шаблон');
+        useDeletionsStore().notify({ bold: 'Не удалось удалить шаблон', type: 'error' });
       }
     },
     async downloadCurrentTemplate() {
@@ -869,7 +869,7 @@ export default {
         const blob = new Blob([buf], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
         saveBlobAs(blob, this.template.original_file_name || 'template.xlsx');
       } catch {
-        useUiStore().error('Не удалось скачать шаблон');
+        useDeletionsStore().notify({ bold: 'Не удалось скачать шаблон', type: 'error' });
       }
     },
 
@@ -997,10 +997,10 @@ export default {
       try {
         const payload = this.mappings.filter(m => m.cell_ref && m.field_path);
         await updateMappings(this.uniqueAttachmentId, payload, this.concatSeparator);
-        useUiStore().success('Привязки сохранены');
+        useDeletionsStore().notify({ bold: 'Привязки сохранены' });
         await this.loadTemplate();
       } catch (err) {
-        useUiStore().error(err.message || 'Не удалось сохранить');
+        useDeletionsStore().notify({ prefix: 'Не удалось сохранить: ', bold: err.message || 'ошибка сервера', type: 'error' });
       } finally {
         this.savingMappings = false;
       }

--- a/frontend/src/components/admin/RolesGroupsPanel.vue
+++ b/frontend/src/components/admin/RolesGroupsPanel.vue
@@ -164,6 +164,7 @@ import {
 } from '@/api/permissions';
 import { apiRequest } from '@/api/client';
 import { useDeletionsStore } from '@/stores/deletions';
+import { useUiStore } from '@/stores/ui';
 
 /**
  * Контентная панель «Роль и группы» (роль + дополнительные группы + блокировка + merge).
@@ -255,7 +256,14 @@ export default {
       }
     },
     async handleBan() {
-      if (!confirm('Заблокировать пользователя? Все его активные сессии будут завершены.')) return;
+      const ok = await useUiStore().confirm({
+        title: 'Заблокировать пользователя?',
+        message: 'Все активные сессии пользователя будут завершены.',
+        confirmText: 'Заблокировать',
+        cancelText: 'Отмена',
+        danger: true,
+      });
+      if (!ok) return;
       this.actionLoading = true;
       try {
         await banUser(this.user.id);
@@ -270,7 +278,14 @@ export default {
       }
     },
     async handleUnban() {
-      if (!confirm('Снять блокировку?')) return;
+      const ok = await useUiStore().confirm({
+        title: 'Снять блокировку?',
+        message: `Пользователь ${this.user?.username || ''} получит доступ к системе.`,
+        confirmText: 'Разблокировать',
+        cancelText: 'Отмена',
+        danger: false,
+      });
+      if (!ok) return;
       this.actionLoading = true;
       try {
         await unbanUser(this.user.id);

--- a/frontend/src/components/applications/DownloadBlanksModal.vue
+++ b/frontend/src/components/applications/DownloadBlanksModal.vue
@@ -102,7 +102,7 @@
 <script>
 import JSZip from 'jszip';
 import { apiRequest } from '@/api/client';
-import { useUiStore } from '@/stores/ui';
+import { useDeletionsStore } from '@/stores/deletions';
 import { downloadBlank, saveBlobAs } from '@/api/attachment-templates';
 
 const TYPE_LABELS = {
@@ -158,7 +158,7 @@ export default {
         const { blob, filename } = await downloadBlank(this.applicationId, att.id);
         saveBlobAs(blob, filename);
       } catch (err) {
-        useUiStore().error(err.message || 'Не удалось скачать');
+        useDeletionsStore().notify({ prefix: 'Не удалось скачать: ', bold: err.message || 'ошибка сервера', type: 'error' });
       } finally {
         this.downloadingId = null;
       }
@@ -183,7 +183,7 @@ export default {
           const { blob, filename } = await downloadBlank(this.applicationId, id);
           zip.file(filename, blob);
         } catch (err) {
-          useUiStore().error(err.message || 'Не удалось скачать файл');
+          useDeletionsStore().notify({ prefix: 'Не удалось скачать файл: ', bold: err.message || 'ошибка сервера', type: 'error' });
         }
       }
       const content = await zip.generateAsync({ type: 'blob' });
@@ -193,7 +193,7 @@ export default {
       const org = info?.organization_name || '';
       const parts = [num, date, org].filter(Boolean).join('_').replace(/[/\\:*?"<>|]/g, '_');
       saveBlobAs(content, `${parts}.zip`);
-      useUiStore().success(`Скачано: ${ids.length} файлов в ZIP`);
+      useDeletionsStore().notify({ prefix: 'Скачано: ', bold: `${ids.length} файлов в ZIP` });
     },
     async downloadAll() {
       this.selectedIds = this.eligibleAttachments.map(a => a.id);

--- a/frontend/src/views/admin/AccessDenialsLog.vue
+++ b/frontend/src/views/admin/AccessDenialsLog.vue
@@ -191,6 +191,8 @@ import {
   archiveAccessDenials,
 } from '@/api/permissions';
 import RefreshButton from '@/components/RefreshButton.vue';
+import { useDeletionsStore } from '@/stores/deletions';
+import { useUiStore } from '@/stores/ui';
 
 export default {
   name: 'AccessDenialsLog',
@@ -251,25 +253,43 @@ export default {
       }
     },
     async confirmDeleteFiltered() {
-      if (!confirm('Удалить записи активной таблицы по выбранным фильтрам? Архив не затрагивается.')) return;
+      const ok = await useUiStore().confirm({
+        title: 'Очистить записи?',
+        message: 'Записи активной таблицы по выбранным фильтрам будут удалены. Архив не затрагивается.',
+        confirmText: 'Удалить',
+        cancelText: 'Отмена',
+        danger: true,
+      });
+      if (!ok) return;
       try {
         await deleteAccessDenials(this.filters);
         await this.fetch();
+        useDeletionsStore().notify({ bold: 'Записи удалены', suffix: ' по выбранным фильтрам' });
       } catch (e) {
         console.error('Ошибка удаления:', e);
+        useDeletionsStore().notify({ prefix: 'Не удалось удалить ', bold: 'записи журнала', type: 'error' });
       }
     },
     async confirmArchiveAll() {
       const cutoff = this.filters.to || null;
       const msg = cutoff
-        ? `Перенести в архив все записи до ${cutoff}?`
-        : 'Перенести в архив все записи старше 3 месяцев?';
-      if (!confirm(msg)) return;
+        ? `Все записи до ${cutoff} будут перенесены в архив.`
+        : 'Все записи старше 3 месяцев будут перенесены в архив.';
+      const ok = await useUiStore().confirm({
+        title: 'Архивировать записи?',
+        message: msg,
+        confirmText: 'Архивировать',
+        cancelText: 'Отмена',
+        danger: false,
+      });
+      if (!ok) return;
       try {
         await archiveAccessDenials(cutoff);
         await this.fetch();
+        useDeletionsStore().notify({ bold: 'Записи архивированы' });
       } catch (e) {
         console.error('Ошибка архивации:', e);
+        useDeletionsStore().notify({ prefix: 'Не удалось ', bold: 'архивировать записи', type: 'error' });
       }
     },
     formatDateTime(s) {

--- a/frontend/src/views/admin/AdminPermissionGroups.vue
+++ b/frontend/src/views/admin/AdminPermissionGroups.vue
@@ -151,6 +151,8 @@ import {
 import PermissionTreeModal from '@/components/admin/PermissionTreeModal.vue';
 import RefreshButton from '@/components/RefreshButton.vue';
 import { ALL_PERMISSION_KEYS } from '@/constants/permissionKeys';
+import { useDeletionsStore } from '@/stores/deletions';
+import { useUiStore } from '@/stores/ui';
 
 export default {
   name: 'AdminPermissionGroups',
@@ -237,12 +239,21 @@ export default {
       }
     },
     async confirmDelete(group) {
-      if (!confirm(`Удалить группу «${group.name}»? Это действие нельзя отменить.`)) return;
+      const ok = await useUiStore().confirm({
+        title: 'Удалить группу прав?',
+        message: `Группа «${group.name}» будет удалена. Это действие нельзя отменить.`,
+        confirmText: 'Удалить',
+        cancelText: 'Отмена',
+        danger: true,
+      });
+      if (!ok) return;
       try {
         await deletePermissionGroup(group.id);
         await this.fetch();
+        useDeletionsStore().notify({ prefix: 'Группа ', bold: group.name, suffix: ' удалена' });
       } catch (e) {
         console.error('Ошибка удаления:', e);
+        useDeletionsStore().notify({ prefix: 'Не удалось удалить ', bold: group.name, type: 'error' });
       }
     },
   },

--- a/frontend/src/views/admin/AdminRoles.vue
+++ b/frontend/src/views/admin/AdminRoles.vue
@@ -216,6 +216,8 @@ import {
   listPermissionGroups,
 } from '@/api/permissions';
 import RefreshButton from '@/components/RefreshButton.vue';
+import { useDeletionsStore } from '@/stores/deletions';
+import { useUiStore } from '@/stores/ui';
 
 export default {
   name: 'AdminRoles',
@@ -304,12 +306,20 @@ export default {
       }
     },
     async confirmDelete(role) {
-      if (!confirm(`Удалить роль «${role.name}»? Если у неё есть юзеры, удаление будет отклонено бэкендом.`)) return;
+      const ok = await useUiStore().confirm({
+        title: 'Удалить роль?',
+        message: `Роль «${role.name}» будет удалена. Если у неё есть привязанные пользователи, бэкенд откажет.`,
+        confirmText: 'Удалить',
+        cancelText: 'Отмена',
+        danger: true,
+      });
+      if (!ok) return;
       try {
         await deleteRole(role.id);
         await this.fetchAll();
+        useDeletionsStore().notify({ prefix: 'Роль ', bold: role.name, suffix: ' удалена' });
       } catch {
-        alert('Ошибка удаления роли. Возможно, у неё есть привязанные пользователи.');
+        useDeletionsStore().notify({ prefix: 'Не удалось удалить ', bold: role.name, suffix: ': возможно, есть привязанные пользователи', type: 'error' });
       }
     },
   },


### PR DESCRIPTION
Заменил alert()/window.confirm()/useUiStore success-error на эталон в AdminRoles, AdminPermissionGroups, AccessDenialsLog, RolesGroupsPanel, TableConstructorPhotoSection, UserNotificationsInline, AttachmentTemplateEditor, DownloadBlanksModal. 14 конверсий.