### PR TITLE
feat(admin): перенёс управление новостями и объявлениями в Администрирование

### DIFF
--- a/frontend/src/components/NavMenu.vue
+++ b/frontend/src/components/NavMenu.vue
@@ -621,6 +621,7 @@ export default {
             { label: 'Типы пользователей', icon: 'user-types', path: '/admin/user-types' },
             { label: 'Принимающие', icon: 'approvers', path: '/admin/approvers' },
             { label: 'Документы', icon: 'documents', path: '/admin/documents' },
+            { label: 'Новости и объявления', icon: 'news', path: '/admin/news' },
           ],
         },
         {

--- a/frontend/src/components/NewsManagement.vue
+++ b/frontend/src/components/NewsManagement.vue
@@ -1,0 +1,1120 @@
+<template>
+  <div class="news-management">
+    <!-- Шапка -->
+    <div class="management-header">
+      <h2 class="management-title">
+        Новости и объявления
+      </h2>
+      <div class="management-header__actions">
+        <div class="tab-group">
+          <button
+            class="tab-btn"
+            :class="{ active: activeTab === 'news' }"
+            @click="switchTab('news')"
+          >
+            Новости
+          </button>
+          <button
+            class="tab-btn"
+            :class="{ active: activeTab === 'announcements' }"
+            @click="switchTab('announcements')"
+          >
+            Объявления
+          </button>
+        </div>
+        <button
+          class="lk-button lk-button--primary"
+          @click="openCreateModal"
+        >
+          + {{ activeTab === 'news' ? 'Добавить новость' : 'Добавить объявление' }}
+        </button>
+        <RefreshButton
+          :loading="loading"
+          @refresh="fetchAll"
+        />
+      </div>
+    </div>
+
+    <!-- Контент -->
+    <div class="management-body">
+      <!-- Список новостей -->
+      <div
+        v-if="activeTab === 'news'"
+        class="items-list"
+      >
+        <div
+          v-if="loading"
+          class="empty-state"
+        >
+          Загрузка…
+        </div>
+        <div
+          v-else-if="newsItems.length === 0"
+          class="empty-state"
+        >
+          Нет новостей
+        </div>
+        <div
+          v-for="item in newsItems"
+          v-else
+          :key="item.id"
+          class="manage-item"
+          :class="{ selected: selectedItem?.id === item.id }"
+          @click="selectItem(item)"
+        >
+          <div class="item-main">
+            <div class="item-title">
+              {{ item.title }}
+              <span
+                v-if="!item.is_active"
+                class="badge badge--archive"
+              >(скрыта)</span>
+            </div>
+            <div class="item-meta">
+              <span>{{ formatDate(item.created_at) }}</span>
+              <span>{{ item.created_by_name || 'Система' }}</span>
+              <span
+                class="status-chip"
+                :class="item.is_active ? 'status-chip--active' : 'status-chip--hidden'"
+              >{{ item.is_active ? 'Активна' : 'Скрыта' }}</span>
+            </div>
+          </div>
+        </div>
+        <div class="items-footer">
+          Всего: {{ newsItems.length }}
+        </div>
+      </div>
+
+      <!-- Список объявлений -->
+      <div
+        v-if="activeTab === 'announcements'"
+        class="items-list"
+      >
+        <div
+          v-if="loading"
+          class="empty-state"
+        >
+          Загрузка…
+        </div>
+        <div
+          v-else-if="announcementsItems.length === 0"
+          class="empty-state"
+        >
+          Нет объявлений
+        </div>
+        <div
+          v-if="activeTab === 'announcements'"
+          class="info-note"
+        >
+          Активно может быть только одно объявление
+        </div>
+        <div
+          v-for="item in announcementsItems"
+          v-else
+          :key="item.id"
+          class="manage-item"
+          :class="{ selected: selectedItem?.id === item.id }"
+          @click="selectItem(item)"
+        >
+          <div class="item-main">
+            <div class="item-title">
+              {{ item.title }}
+              <span
+                v-if="item.is_important"
+                class="badge badge--important"
+              >Важное</span>
+              <span
+                v-if="item.is_active"
+                class="badge badge--active"
+              >Активно</span>
+            </div>
+            <div class="item-meta">
+              <span>{{ formatDate(item.created_at) }}</span>
+              <span>{{ item.created_by_name || 'Система' }}</span>
+              <span v-if="item.activated_by_name">Активировал: {{ item.activated_by_name }}</span>
+            </div>
+          </div>
+        </div>
+        <div class="items-footer">
+          Всего: {{ announcementsItems.length }}
+        </div>
+      </div>
+
+      <!-- Панель деталей -->
+      <div
+        v-if="selectedItem"
+        class="detail-panel"
+      >
+        <div class="detail-header">
+          <h3 class="detail-title">
+            {{ selectedItem.title }}
+          </h3>
+          <div class="detail-actions">
+            <button
+              class="lk-button lk-button--secondary"
+              @click="openEditModal"
+            >
+              Редактировать
+            </button>
+            <template v-if="activeTab === 'news'">
+              <button
+                class="lk-button lk-button--secondary"
+                @click="toggleNewsActive(selectedItem)"
+              >
+                {{ selectedItem.is_active ? 'Скрыть' : 'Показать' }}
+              </button>
+            </template>
+            <template v-else>
+              <button
+                v-if="!selectedItem.is_active"
+                class="lk-button lk-button--secondary"
+                @click="setActiveAnnouncement(selectedItem.id)"
+              >
+                Показать
+              </button>
+              <button
+                v-if="selectedItem.is_active"
+                class="lk-button lk-button--secondary"
+                @click="deactivateAnnouncement(selectedItem.id)"
+              >
+                Скрыть
+              </button>
+            </template>
+            <button
+              class="lk-button lk-button--danger"
+              @click="deleteItem(selectedItem)"
+            >
+              Удалить
+            </button>
+          </div>
+        </div>
+        <div class="detail-body">
+          <div class="detail-meta">
+            <span>{{ formatDate(selectedItem.created_at) }}</span>
+            <span v-if="selectedItem.created_by_name">{{ selectedItem.created_by_name }}</span>
+          </div>
+          <p class="detail-description">
+            {{ selectedItem.description }}
+          </p>
+          <div
+            v-if="selectedItem.full_text"
+            class="detail-full-text news-body-html"
+            v-html="sanitizeHtml(selectedItem.full_text)"
+          />
+        </div>
+      </div>
+      <div
+        v-else
+        class="detail-panel detail-panel--empty"
+      >
+        <span>Выберите элемент из списка</span>
+      </div>
+    </div>
+
+    <!-- Модалка создания/редактирования новости -->
+    <Teleport to="body">
+      <transition name="modal-fade">
+        <div
+          v-if="showNewsModal"
+          class="modal-overlay"
+          @click.self="closeNewsModal"
+        >
+          <div class="modal-content">
+            <div class="modal-header">
+              <h3 class="modal-title">
+                {{ editingItem ? 'Редактировать новость' : 'Создать новость' }}
+              </h3>
+              <button
+                class="modal-close"
+                @click="closeNewsModal"
+              >
+                <svg
+                  width="10"
+                  height="10"
+                  viewBox="0 0 14 14"
+                  fill="none"
+                ><path
+                  d="M13 1L1 13M1 1L13 13"
+                  stroke="#666"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                /></svg>
+              </button>
+            </div>
+            <div class="modal-body">
+              <div class="form-group">
+                <label class="form-label">Заголовок</label>
+                <input
+                  v-model="newsForm.title"
+                  type="text"
+                  class="lk-input"
+                  placeholder="Введите заголовок"
+                >
+              </div>
+              <div class="form-group">
+                <label class="form-label">Краткое описание</label>
+                <textarea
+                  v-model="newsForm.description"
+                  class="lk-textarea"
+                  placeholder="Введите краткое описание"
+                  rows="3"
+                />
+              </div>
+              <div class="form-group">
+                <label class="form-label">Полный текст</label>
+                <TextConstructor v-model="newsForm.fullText" />
+              </div>
+            </div>
+            <div class="modal-footer">
+              <button
+                class="lk-button lk-button--secondary"
+                @click="closeNewsModal"
+              >
+                Отмена
+              </button>
+              <button
+                class="lk-button lk-button--primary"
+                @click="submitNews"
+              >
+                Сохранить
+              </button>
+            </div>
+          </div>
+        </div>
+      </transition>
+    </Teleport>
+
+    <!-- Модалка создания/редактирования объявления -->
+    <Teleport to="body">
+      <transition name="modal-fade">
+        <div
+          v-if="showAnnouncementModal"
+          class="modal-overlay"
+          @click.self="closeAnnouncementModal"
+        >
+          <div class="modal-content">
+            <div class="modal-header">
+              <h3 class="modal-title">
+                {{ editingItem ? 'Редактировать объявление' : 'Создать объявление' }}
+              </h3>
+              <button
+                class="modal-close"
+                @click="closeAnnouncementModal"
+              >
+                <svg
+                  width="10"
+                  height="10"
+                  viewBox="0 0 14 14"
+                  fill="none"
+                ><path
+                  d="M13 1L1 13M1 1L13 13"
+                  stroke="#666"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                /></svg>
+              </button>
+            </div>
+            <div class="modal-body">
+              <div class="form-group">
+                <label class="form-label">Заголовок</label>
+                <input
+                  v-model="announcementForm.title"
+                  type="text"
+                  class="lk-input"
+                  placeholder="Введите заголовок"
+                >
+              </div>
+              <div class="form-group">
+                <label class="form-label">Краткое описание</label>
+                <textarea
+                  v-model="announcementForm.description"
+                  class="lk-textarea"
+                  placeholder="Введите краткое описание"
+                  rows="3"
+                />
+              </div>
+              <div class="form-group">
+                <label class="form-label">Полный текст</label>
+                <TextConstructor v-model="announcementForm.fullText" />
+              </div>
+              <div class="form-group">
+                <label class="checkbox-label">
+                  <input
+                    v-model="announcementForm.isImportant"
+                    type="checkbox"
+                  >
+                  <span>Важное объявление</span>
+                </label>
+              </div>
+            </div>
+            <div class="modal-footer">
+              <button
+                class="lk-button lk-button--secondary"
+                @click="closeAnnouncementModal"
+              >
+                Отмена
+              </button>
+              <button
+                class="lk-button lk-button--primary"
+                @click="submitAnnouncement"
+              >
+                Сохранить
+              </button>
+            </div>
+          </div>
+        </div>
+      </transition>
+    </Teleport>
+  </div>
+</template>
+
+<script>
+import { apiRequest } from '@/api/client';
+import RefreshButton from '@/components/RefreshButton.vue';
+import TextConstructor from '@/components/TextConstructor.vue';
+import { useDeletionsStore } from '@/stores/deletions';
+import { useUiStore } from '@/stores/ui';
+import { sanitizeHtml } from '@/utils/sanitize.js';
+
+export default {
+  name: 'NewsManagement',
+  components: { RefreshButton, TextConstructor },
+  data() {
+    return {
+      loading: false,
+      activeTab: 'news',
+      selectedItem: null,
+      newsItems: [],
+      announcementsItems: [],
+      showNewsModal: false,
+      showAnnouncementModal: false,
+      editingItem: null,
+      newsForm: { title: '', description: '', fullText: '' },
+      announcementForm: { title: '', description: '', fullText: '', isImportant: false },
+    };
+  },
+  mounted() {
+    this.fetchAll();
+  },
+  methods: {
+    sanitizeHtml,
+    formatDate(dateString) {
+      if (!dateString) return '';
+      const date = new Date(dateString);
+      const mskDate = new Date(date.getTime() + 3 * 60 * 60 * 1000);
+      return mskDate.toLocaleDateString('ru-RU', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      }).replace(',', '');
+    },
+
+    switchTab(tab) {
+      this.activeTab = tab;
+      this.selectedItem = null;
+    },
+
+    async fetchAll() {
+      this.loading = true;
+      try {
+        await Promise.all([this.fetchNews(), this.fetchAnnouncements()]);
+      } finally {
+        this.loading = false;
+      }
+    },
+    async fetchNews() {
+      try {
+        const res = await apiRequest('/news/all');
+        if (res.ok) this.newsItems = await res.json();
+      } catch (e) {
+        console.error('Ошибка загрузки новостей:', e);
+      }
+    },
+    async fetchAnnouncements() {
+      try {
+        const res = await apiRequest('/announcements/all');
+        if (res.ok) this.announcementsItems = await res.json();
+      } catch (e) {
+        console.error('Ошибка загрузки объявлений:', e);
+      }
+    },
+
+    selectItem(item) {
+      this.selectedItem = item;
+    },
+
+    // --- Новости ---
+    openCreateModal() {
+      if (this.activeTab === 'news') {
+        this.editingItem = null;
+        this.newsForm = { title: '', description: '', fullText: '' };
+        this.showNewsModal = true;
+      } else {
+        this.editingItem = null;
+        this.announcementForm = { title: '', description: '', fullText: '', isImportant: false };
+        this.showAnnouncementModal = true;
+      }
+    },
+    openEditModal() {
+      if (this.activeTab === 'news') {
+        this.editingItem = this.selectedItem;
+        this.newsForm = {
+          title: this.selectedItem.title,
+          description: this.selectedItem.description,
+          fullText: this.selectedItem.full_text || '',
+        };
+        this.showNewsModal = true;
+      } else {
+        this.editingItem = this.selectedItem;
+        this.announcementForm = {
+          title: this.selectedItem.title,
+          description: this.selectedItem.description,
+          fullText: this.selectedItem.full_text || '',
+          isImportant: this.selectedItem.is_important,
+        };
+        this.showAnnouncementModal = true;
+      }
+    },
+    closeNewsModal() {
+      this.showNewsModal = false;
+      this.editingItem = null;
+    },
+    closeAnnouncementModal() {
+      this.showAnnouncementModal = false;
+      this.editingItem = null;
+    },
+    async submitNews() {
+      if (!this.newsForm.title || !this.newsForm.description) {
+        useDeletionsStore().notify({ bold: 'Заполните заголовок и описание', type: 'error' });
+        return;
+      }
+      const payload = {
+        title: this.newsForm.title,
+        description: this.newsForm.description,
+        full_text: this.newsForm.fullText,
+      };
+      try {
+        let res;
+        if (this.editingItem) {
+          res = await apiRequest(`/news/${this.editingItem.id}`, {
+            method: 'PUT',
+            body: JSON.stringify(payload),
+          });
+        } else {
+          res = await apiRequest('/news', { method: 'POST', body: JSON.stringify(payload) });
+        }
+        if (res.ok) {
+          this.closeNewsModal();
+          await this.fetchNews();
+          useDeletionsStore().notify({
+            prefix: this.editingItem ? 'Новость обновлена' : 'Новость создана',
+          });
+        } else {
+          useDeletionsStore().notify({
+            bold: this.editingItem ? 'Ошибка обновления новости' : 'Ошибка создания новости',
+            type: 'error',
+          });
+        }
+      } catch (e) {
+        console.error('Ошибка сохранения новости:', e);
+      }
+    },
+    async toggleNewsActive(item) {
+      try {
+        const res = await apiRequest(`/news/${item.id}`, {
+          method: 'PUT',
+          body: JSON.stringify({ is_active: !item.is_active }),
+        });
+        if (res.ok) {
+          await this.fetchNews();
+          this.selectedItem = this.newsItems.find((n) => n.id === item.id) || null;
+          useDeletionsStore().notify({
+            prefix: item.is_active ? 'Новость скрыта' : 'Новость показана',
+          });
+        } else {
+          useDeletionsStore().notify({ bold: 'Ошибка изменения статуса', type: 'error' });
+        }
+      } catch (e) {
+        console.error('Ошибка изменения статуса новости:', e);
+      }
+    },
+
+    // --- Объявления ---
+    async submitAnnouncement() {
+      if (!this.announcementForm.title || !this.announcementForm.description) {
+        useDeletionsStore().notify({ bold: 'Заполните заголовок и описание', type: 'error' });
+        return;
+      }
+      const payload = {
+        title: this.announcementForm.title,
+        description: this.announcementForm.description,
+        full_text: this.announcementForm.fullText,
+        is_important: this.announcementForm.isImportant,
+      };
+      try {
+        let res;
+        if (this.editingItem) {
+          res = await apiRequest(`/announcements/${this.editingItem.id}`, {
+            method: 'PUT',
+            body: JSON.stringify(payload),
+          });
+        } else {
+          res = await apiRequest('/announcements', { method: 'POST', body: JSON.stringify(payload) });
+        }
+        if (res.ok) {
+          this.closeAnnouncementModal();
+          await this.fetchAnnouncements();
+          useDeletionsStore().notify({
+            prefix: this.editingItem ? 'Объявление обновлено' : 'Объявление создано',
+          });
+        } else {
+          useDeletionsStore().notify({
+            bold: this.editingItem ? 'Ошибка обновления объявления' : 'Ошибка создания объявления',
+            type: 'error',
+          });
+        }
+      } catch (e) {
+        console.error('Ошибка сохранения объявления:', e);
+      }
+    },
+    async setActiveAnnouncement(id) {
+      const ok = await useUiStore().confirm({
+        title: 'Показать объявление',
+        message: 'Активировать это объявление? Текущее активное будет скрыто.',
+        confirmText: 'Показать',
+        danger: false,
+      });
+      if (!ok) return;
+      try {
+        const res = await apiRequest('/announcements/set-active', {
+          method: 'POST',
+          body: JSON.stringify({ announcement_id: id }),
+        });
+        if (res.ok) {
+          await this.fetchAnnouncements();
+          this.selectedItem = this.announcementsItems.find((a) => a.id === id) || null;
+          useDeletionsStore().notify({ prefix: 'Объявление активировано' });
+        } else {
+          useDeletionsStore().notify({ bold: 'Ошибка активации объявления', type: 'error' });
+        }
+      } catch (e) {
+        console.error('Ошибка активации объявления:', e);
+      }
+    },
+    async deactivateAnnouncement(id) {
+      const ok = await useUiStore().confirm({
+        title: 'Скрыть объявление',
+        message: 'Скрыть активное объявление?',
+        confirmText: 'Скрыть',
+        danger: false,
+      });
+      if (!ok) return;
+      try {
+        const res = await apiRequest(`/announcements/${id}/hide`, { method: 'POST' });
+        if (res.ok) {
+          await this.fetchAnnouncements();
+          this.selectedItem = this.announcementsItems.find((a) => a.id === id) || null;
+          useDeletionsStore().notify({ prefix: 'Объявление скрыто' });
+        } else {
+          useDeletionsStore().notify({ bold: 'Ошибка скрытия объявления', type: 'error' });
+        }
+      } catch (e) {
+        console.error('Ошибка скрытия объявления:', e);
+      }
+    },
+
+    async deleteItem(item) {
+      const label = this.activeTab === 'news' ? 'новость' : 'объявление';
+      const ok = await useUiStore().confirm({
+        title: `Удалить ${label}`,
+        message: `Удалить "${item.title}"? Это действие необратимо.`,
+        confirmText: 'Удалить',
+        danger: true,
+      });
+      if (!ok) return;
+
+      const endpoint = this.activeTab === 'news'
+        ? `/news/${item.id}`
+        : `/announcements/${item.id}`;
+
+      const deletedTitle = item.title;
+      try {
+        const res = await apiRequest(endpoint, { method: 'DELETE' });
+        if (res.ok) {
+          if (this.activeTab === 'news') {
+            await this.fetchNews();
+          } else {
+            await this.fetchAnnouncements();
+          }
+          this.selectedItem = null;
+          useDeletionsStore().notify({
+            prefix: this.activeTab === 'news' ? 'Новость удалена: ' : 'Объявление удалено: ',
+            bold: deletedTitle,
+          });
+        } else {
+          useDeletionsStore().notify({ bold: `Ошибка удаления: ${deletedTitle}`, type: 'error' });
+        }
+      } catch (e) {
+        console.error('Ошибка удаления:', e);
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.news-management {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  font-family: 'Montserrat', sans-serif;
+  background: #fff;
+  border: 1px solid #e6e6e6;
+  border-radius: 35px;
+  overflow: hidden;
+}
+
+/* Шапка */
+.management-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 24px;
+  height: 50px;
+  border-bottom: 1px solid #e6e6e6;
+  flex-shrink: 0;
+}
+
+.management-title {
+  margin: 0;
+  font-size: 1.2em;
+  font-weight: 600;
+  color: #000;
+}
+
+.management-header__actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+/* Табы */
+.tab-group {
+  display: flex;
+  gap: 4px;
+  background: #f5f5f5;
+  border-radius: 20px;
+  padding: 3px;
+}
+
+.tab-btn {
+  background: none;
+  border: none;
+  padding: 5px 16px;
+  font-family: 'Montserrat', sans-serif;
+  font-size: 13px;
+  font-weight: 500;
+  color: #a2a2a2;
+  cursor: pointer;
+  border-radius: 17px;
+  transition: all 0.2s ease;
+}
+
+.tab-btn:hover {
+  color: #4F5BDF;
+}
+
+.tab-btn.active {
+  background: #fff;
+  color: #4F5BDF;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+/* Тело: список + детали */
+.management-body {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+/* Левый список */
+.items-list {
+  width: 360px;
+  flex-shrink: 0;
+  border-right: 1px solid #e6e6e6;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.items-list::-webkit-scrollbar {
+  width: 4px;
+}
+
+.items-list::-webkit-scrollbar-thumb {
+  background: #D9E2FF;
+  border-radius: 4px;
+}
+
+.empty-state {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 20px;
+  color: #a2a2a2;
+  font-size: 13px;
+}
+
+.info-note {
+  margin: 10px 12px 0;
+  padding: 8px 12px;
+  background: #f0f4ff;
+  border-radius: 10px;
+  font-size: 12px;
+  color: #4F5BDF;
+}
+
+.manage-item {
+  padding: 14px 16px;
+  border-bottom: 1px solid #f0f0f0;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.manage-item:hover {
+  background: #fafafa;
+}
+
+.manage-item.selected {
+  background: #f0f4ff;
+}
+
+.item-title {
+  font-weight: 500;
+  font-size: 13px;
+  color: #333;
+  margin-bottom: 4px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.item-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 11px;
+  color: #a2a2a2;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 7px;
+  border-radius: 10px;
+  font-size: 10px;
+  font-weight: 500;
+}
+
+.badge--archive {
+  background: #f5f5f5;
+  color: #999;
+}
+
+.badge--active {
+  background: #4F5BDF;
+  color: #fff;
+}
+
+.badge--important {
+  background: #ff9800;
+  color: #fff;
+}
+
+.status-chip {
+  padding: 1px 7px;
+  border-radius: 10px;
+  font-size: 10px;
+  font-weight: 500;
+}
+
+.status-chip--active {
+  background: #e8f5e9;
+  color: #2e7d32;
+}
+
+.status-chip--hidden {
+  background: #f5f5f5;
+  color: #999;
+}
+
+.items-footer {
+  padding: 10px 16px;
+  font-size: 12px;
+  color: #a2a2a2;
+  border-top: 1px solid #f0f0f0;
+  margin-top: auto;
+}
+
+/* Правая панель деталей */
+.detail-panel {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px 24px;
+}
+
+.detail-panel--empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #a2a2a2;
+  font-size: 13px;
+}
+
+.detail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 16px;
+  gap: 12px;
+}
+
+.detail-title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+  color: #1a1a1a;
+  flex: 1;
+}
+
+.detail-actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
+.detail-meta {
+  display: flex;
+  gap: 16px;
+  font-size: 12px;
+  color: #a2a2a2;
+  margin-bottom: 12px;
+}
+
+.detail-description {
+  font-size: 14px;
+  line-height: 1.5;
+  color: #333;
+  margin: 0 0 16px;
+}
+
+.detail-full-text {
+  font-size: 14px;
+  line-height: 1.6;
+  color: #666;
+  padding-top: 16px;
+  border-top: 1px solid #f0f0f0;
+}
+
+/* Кнопки */
+.lk-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 18px;
+  border-radius: 30px;
+  font-family: 'Montserrat', sans-serif;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+}
+
+.lk-button--primary {
+  background: #4F5BDF;
+  color: #fff;
+  border-color: #4F5BDF;
+}
+
+.lk-button--primary:hover {
+  background: #3a45c0;
+  border-color: #3a45c0;
+}
+
+.lk-button--secondary {
+  background: #fff;
+  color: #333;
+  border-color: #e6e6e6;
+}
+
+.lk-button--secondary:hover {
+  background: #f5f5f5;
+}
+
+.lk-button--danger {
+  background: #fff;
+  color: #dc2626;
+  border-color: #fca5a5;
+}
+
+.lk-button--danger:hover {
+  background: #ffebee;
+}
+
+/* Инпуты */
+.lk-input,
+.lk-textarea {
+  width: 100%;
+  padding: 10px 14px;
+  border: 1px solid #e6e6e6;
+  border-radius: var(--radius-md, 15px);
+  font-family: 'Montserrat', sans-serif;
+  font-size: 13px;
+  box-sizing: border-box;
+  transition: border-color 0.2s ease;
+  resize: vertical;
+}
+
+.lk-input:focus,
+.lk-textarea:focus {
+  outline: none;
+  border-color: #4F5BDF;
+}
+
+/* Модалки */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1100;
+  backdrop-filter: blur(0.1px);
+}
+
+.modal-fade-enter-active,
+.modal-fade-leave-active {
+  transition: all 0.25s ease;
+}
+
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+  opacity: 0;
+}
+
+.modal-fade-enter-from .modal-content,
+.modal-fade-leave-to .modal-content {
+  opacity: 0;
+  transform: scale(0.92) translateY(-16px);
+}
+
+.modal-content {
+  background: #fff;
+  border-radius: 30px;
+  width: 560px;
+  max-width: 92vw;
+  max-height: 82vh;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.25);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 28px 0;
+  flex-shrink: 0;
+}
+
+.modal-title {
+  margin: 0;
+  font-size: 17px;
+  font-weight: 600;
+  color: #1a1a1a;
+}
+
+.modal-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 6px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s ease;
+}
+
+.modal-close:hover {
+  background-color: #f5f5f5;
+}
+
+.modal-body {
+  padding: 20px 28px;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.modal-footer {
+  padding: 14px 28px 22px;
+  border-top: 1px solid #f0f0f0;
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.form-group {
+  margin-bottom: 18px;
+}
+
+.form-label {
+  display: block;
+  font-size: 13px;
+  font-weight: 500;
+  color: #333;
+  margin-bottom: 6px;
+}
+
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-size: 13px;
+  color: #333;
+}
+
+.checkbox-label input {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+  accent-color: #4F5BDF;
+}
+
+/* news-body-html от NewsAndReview */
+.news-body-html { line-height: 1.6; }
+.news-body-html :deep(*) { overflow-wrap: break-word; }
+.news-body-html :deep(h1),
+.news-body-html :deep(h2),
+.news-body-html :deep(h3) { font-weight: 600; margin: 0.75em 0 0.4em; }
+.news-body-html :deep(p) { margin: 0.5em 0; }
+.news-body-html :deep(ul),
+.news-body-html :deep(ol) { padding-left: 1.5em; margin: 0.5em 0; }
+.news-body-html :deep(img) { max-width: 100%; border-radius: 8px; }
+.news-body-html :deep(img:not([height])) { height: auto; }
+.news-body-html :deep(.constructor-image.img-align-left) { float: left; margin: 0 14px 10px 0; }
+.news-body-html :deep(.constructor-image.img-align-right) { float: right; margin: 0 0 10px 14px; }
+.news-body-html :deep(.constructor-image.img-align-center) { display: block; margin: 10px auto; float: none; }
+.news-body-html::after { content: ''; display: block; clear: both; }
+</style>

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -206,6 +206,12 @@ const routes = [
     meta: { requiresAuth: true, requiresBuro: true, permission: 'page.admin' }
   },
   {
+    path: '/admin/news',
+    name: 'AdminNews',
+    component: () => import('./views/admin/NewsManagement.vue'),
+    meta: { requiresAuth: true, requiresBuro: true }
+  },
+  {
     path: '/analytics',
     name: 'analytics',
     component: () => import('./views/StatisticsView.vue'),

--- a/frontend/src/views/NewsAndReview.vue
+++ b/frontend/src/views/NewsAndReview.vue
@@ -13,12 +13,6 @@
             </h2>
             <div class="header-actions">
               <OnboardingButton />
-              <button
-                class="manage-btn"
-                @click="openManageModal"
-              >
-                Управление
-              </button>
               <RefreshButton @refresh="fetchAllData" />
             </div>
           </div>
@@ -111,7 +105,7 @@
                         width="64"
                         height="64"
                         preserveAspectRatio="none"
-                        xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAACXBIWXMAAAHYAAAB2AH6XKZyAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAwxJREFUeJzt209oHkUcxvGPMQlqBAk9WCoBJZdoDuLJQyMtlBZSKv4Be6m3QpRcKmoN9RQPpVCCUA+e9FRPCqWlHixeVGwPUpFCrNhi0ItQJH+MQpU2TQ+7L+8SeHl3N7OZTbJfWN7Z3fnNPPMw876zs/PSsL15oGRcP17AM3gknJyg/IwvQxfajynMY3UTHM+HbPwgvqtBo4ocr3drVG/OxvfiC0m3bzGHS1jOWcZaxrA7TV/G94FiDmG0pKaOvKHt6grexYPrLHM6U+Z0wJizKugBxzPpDzCTM6729OTI8zSG0/QiTlcnZ+PJY8BwJn0F/1WkJQp5DHgsk16qSkgs8hiQnSytViUkFnkM2NI0BsQWEJvGgNgCOjCDf2zAhKuOBkzhHTyafr5XZWV1M+AgTq65dgovV1VhnQx4Dp9rP2TdTT978Fl6Pzh1MWAnLmAgPf8dz+K39HxAsrrzROiK62LABIbS9DJexHVJ12+tN+zC0dAV18WA1nR7RfIMP5uez+Kw9nAou4bZkboY0OJtXFxz7ZJkAaYS6mTAp/iow70z+LiKSmMakH20/hpvdsl/LM3XYjGEiLxLYlXwCZ5EH97XHueduIvXJPOC/9P4dRPTgH/xVsGYvzEZUkSdvgOi0BgQW0BsGgNiC4hNY0BsAbFpDIgtIDaNAbEFxKYxILaA2DQGxBYQm8aA2AJis+0NKLskNoZXJRsSd4STE4SnimQuasAQvsGegnGxWOmWoagBm6XhJMvuV7plKjsE/pK8qLiMhZJlVM2cHO8OyhjwE8Zxq0Rs7Sj6K3Abr9gijad4DziHP9L0wziBkaCKwnAPV/Fhml4XR7S3n2f360yq5k8OIY8D3RqXZwhkX2I+lEn/mSM2JityDNU8Gw5G8Eua/hZ7M/d2S3Zu1JEbuBaqsJva3Wo8VKGbiQltA5bwUlw54ci756YXX2Ff5tqPkn+RLeBOYF0h+BXnQxY4KHkOiP3NXuQY69aoIhOhReyX/BTOF4irNWW3nfVJ3B3F4+l5nbiHHwQeAg1bkfsR5B+/y7yHCAAAAABJRU5ErkJggg=="
+                        xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAACXBIWXMAAAHYAAAB2AH6XKZyAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAwxJREFUeJzt209oHkUcxvGPMQlqBAk9WCoBJZdoDuLJQyMtlBZSKv4Be6m3QpRcKmoN9RQPpVCCUA+e9FRPCqWlHixeVGwPUpFCrNhi0ItQJH+MQpU2TQ+7L+8SeHl3N7OZTbJfWN7Z3fnNPPMw876zs/PSsL15oGRcP17AM3gknJyg/IwvQxfajynMY3UTHM+HbPwgvqtBo4ocr3drVG/OxvfiC0m3bzGHS1jOWcZaxrA7TV/G94FiDmG0pKaOvKHt6grexYPrLHM6U+Z0wJizKugBxzPpDzCTM6729OTI8zSG0/QiTlcnZ+PJY8BwJn0F/1WkJQp5DHgsk16qSkgs8hiQnSytViUkFnkM2NI0BsQWEJvGgNgCOjCDf2zAhKuOBkzhHTyafr5XZWV1M+AgTq65dgovV1VhnQx4Dp9rP2TdTT978Fl6Pzh1MWAnLmAgPf8dz+K39HxAsrrzROiK62LABIbS9DJexHVJ12+tN+zC0dAV18WA1nR7RfIMP5uez+Kw9nAou4bZkboY0OJtXFxz7ZJkAaYS6mTAp/iow70z+LiKSmMakH20/hpvdsl/LM3XYjGEiLxLYlXwCZ5EH97XHueduIvXJPOC/9P4dRPTgH/xVsGYvzEZUkSdvgOi0BgQW0BsGgNiC4hNY0BsAbFpDIgtIDaNAbEFxKYxILaA2DQGxBYQm8aA2AJis+0NKLskNoZXJRsSd4STE4SniWQuasAQvsGegnGxWOmWoagBm6XhJMvuV7plKjsE/pK8qLiMhZJlVM2cHO8OyhjwE8Zxq0Rs7Sj6K3Abr9gijad4DziHP9L0wziBkaCKwnAPV/Fhml4XR7S3n2f360yq5k8OIY8D3RqXZwhkX2I+lEn/mSM2JityDNU8Gw5G8Eua/hZ7M/d2S3Zu1JEbuBaqsJva3Wo8VKGbiQltA5bwUlw54ci756YXX2Ff5tqPkn+RLeBOYF0h+BXnQxY4KHkOiP3NXuQY69aoIhOhReyX/BTOF4irNWW3nfVJ3B3F4+l5nbiHHwQeAg1bkfsR5B+/y7yHCAAAAABJRU5ErkJggg=="
                       />
                     </defs>
                   </svg>
@@ -157,360 +151,6 @@
         <DocumentsBlock />
       </div>
     </div>
-
-    <!-- Модальное окно управления -->
-    <Teleport to="body">
-      <transition name="modal-fade">
-        <div
-          v-if="showManageModal"
-          class="modal-overlay"
-          @click.self="closeManageModal"
-        >
-          <div class="modal-content manage-modal">
-            <div class="modal-header">
-              <h3 class="modal-title">
-                Управление контентом
-              </h3>
-              <button
-                class="modal-close"
-                @click="closeManageModal"
-              >
-                <svg
-                  width="10"
-                  height="10"
-                  viewBox="0 0 14 14"
-                  fill="none"
-                ><path
-                  d="M13 1L1 13M1 1L13 13"
-                  stroke="#666"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                /></svg>
-              </button>
-            </div>
-
-            <div class="modal-body">
-              <div class="manage-tabs">
-                <button
-                  class="tab-btn"
-                  :class="{ active: activeTab === 'news' }"
-                  @click="activeTab = 'news'"
-                >
-                  Новости
-                </button>
-                <button
-                  class="tab-btn"
-                  :class="{ active: activeTab === 'announcements' }"
-                  @click="activeTab = 'announcements'"
-                >
-                  Объявления
-                </button>
-              </div>
-
-              <!-- Новости -->
-              <div
-                v-if="activeTab === 'news'"
-                class="manage-section"
-              >
-                <div class="section-header">
-                  <div class="section-title">
-                    Список новостей
-                  </div>
-                  <button
-                    class="add-btn"
-                    @click="openCreateNewsModal"
-                  >
-                    + Добавить новость
-                  </button>
-                </div>
-                <div class="items-list">
-                  <div
-                    v-for="item in allNewsItems"
-                    :key="item.id"
-                    class="manage-item"
-                  >
-                    <div class="item-main">
-                      <div class="item-title">
-                        {{ item.title }}
-                      </div>
-                      <div class="item-meta">
-                        <span>{{ formatDate(item.created_at) }}</span>
-                        <span>{{ item.created_by_name || 'Система' }}</span>
-                        <span class="status-text">{{ item.is_active ? 'Активна' : 'Скрыта' }}</span>
-                      </div>
-                    </div>
-                    <div class="item-actions">
-                      <button
-                        class="action-btn edit-btn"
-                        @click="editNewsItem(item)"
-                      >
-                        Редактировать
-                      </button>
-                      <button
-                        class="action-btn toggle-btn"
-                        @click="toggleNewsActive(item)"
-                      >
-                        {{ item.is_active ? 'Скрыть' : 'Показать' }}
-                      </button>
-                      <button
-                        class="action-btn delete-btn"
-                        @click="deleteNewsItem(item.id)"
-                      >
-                        Удалить
-                      </button>
-                    </div>
-                  </div>
-                  <div
-                    v-if="allNewsItems.length === 0"
-                    class="empty-manage"
-                  >
-                    Нет новостей
-                  </div>
-                </div>
-              </div>
-
-              <!-- Объявления -->
-              <div
-                v-if="activeTab === 'announcements'"
-                class="manage-section"
-              >
-                <div class="section-header">
-                  <div class="section-title">
-                    Список объявлений
-                  </div>
-                  <button
-                    class="add-btn"
-                    @click="openCreateAnnouncementModal"
-                  >
-                    + Добавить объявление
-                  </button>
-                </div>
-                <div class="info-message">
-                  <span>Активно может быть только одно объявление</span>
-                </div>
-                <div class="items-list">
-                  <div
-                    v-for="item in allAnnouncements"
-                    :key="item.id"
-                    class="manage-item"
-                  >
-                    <div class="item-main">
-                      <div class="item-title">
-                        {{ item.title }}
-                        <span
-                          v-if="item.is_important"
-                          class="important-badge"
-                        >Важное</span>
-                        <span
-                          v-if="item.is_active"
-                          class="active-badge"
-                        >Активно</span>
-                      </div>
-                      <div class="item-meta">
-                        <span>{{ formatDate(item.created_at) }}</span>
-                        <span>Создал: {{ item.created_by_name || 'Система' }}</span>
-                        <span v-if="item.activated_by_name">Активировал: {{ item.activated_by_name }}</span>
-                      </div>
-                    </div>
-                    <div class="item-actions">
-                      <button
-                        class="action-btn edit-btn"
-                        @click="editAnnouncement(item)"
-                      >
-                        Редактировать
-                      </button>
-                      <button
-                        v-if="!item.is_active"
-                        class="action-btn activate-btn"
-                        @click="setActiveAnnouncement(item.id)"
-                      >
-                        Показать
-                      </button>
-                      <button
-                        v-if="item.is_active"
-                        class="action-btn deactivate-btn"
-                        @click="deactivateAnnouncement(item.id)"
-                      >
-                        Скрыть
-                      </button>
-                      <button
-                        class="action-btn delete-btn"
-                        @click="deleteAnnouncement(item.id)"
-                      >
-                        Удалить
-                      </button>
-                    </div>
-                  </div>
-                  <div
-                    v-if="allAnnouncements.length === 0"
-                    class="empty-manage"
-                  >
-                    Нет объявлений
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <div class="modal-footer">
-              <button
-                class="btn close-btn"
-                @click="closeManageModal"
-              >
-                Закрыть
-              </button>
-            </div>
-          </div>
-        </div>
-      </transition>
-    </Teleport>
-
-    <!-- Модальное окно создания/редактирования новости -->
-    <Teleport to="body">
-      <transition name="modal-fade">
-        <div
-          v-if="showNewsModal"
-          class="modal-overlay"
-          @click.self="closeNewsModal"
-        >
-          <div class="modal-content">
-            <div class="modal-header">
-              <h3 class="modal-title">
-                {{ editingNews ? 'Редактировать новость' : 'Создать новость' }}
-              </h3>
-              <button
-                class="modal-close"
-                @click="closeNewsModal"
-              >
-                <svg
-                  width="10"
-                  height="10"
-                  viewBox="0 0 14 14"
-                  fill="none"
-                ><path
-                  d="M13 1L1 13M1 1L13 13"
-                  stroke="#666"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                /></svg>
-              </button>
-            </div>
-            <div class="modal-body">
-              <div class="form-group">
-                <label class="form-label">Заголовок</label><input
-                  v-model="newsForm.title"
-                  type="text"
-                  class="form-input"
-                  placeholder="Введите заголовок"
-                >
-              </div>
-              <div class="form-group">
-                <label class="form-label">Краткое описание</label><textarea
-                  v-model="newsForm.description"
-                  class="form-textarea"
-                  placeholder="Введите краткое описание"
-                  rows="3"
-                />
-              </div>
-              <div class="form-group">
-                <label class="form-label">Полный текст</label>
-                <TextConstructor v-model="newsForm.fullText" />
-              </div>
-            </div>
-            <div class="modal-footer">
-              <button
-                class="btn cancel-btn"
-                @click="closeNewsModal"
-              >
-                Отмена
-              </button>
-              <button
-                class="btn save-btn"
-                @click="submitNews"
-              >
-                Сохранить
-              </button>
-            </div>
-          </div>
-        </div>
-      </transition>
-    </Teleport>
-
-    <!-- Модальное окно создания/редактирования объявления -->
-    <Teleport to="body">
-      <transition name="modal-fade">
-        <div
-          v-if="showAnnouncementModal"
-          class="modal-overlay"
-          @click.self="closeAnnouncementModal"
-        >
-          <div class="modal-content">
-            <div class="modal-header">
-              <h3 class="modal-title">
-                {{ editingAnnouncement ? 'Редактировать объявление' : 'Создать объявление' }}
-              </h3>
-              <button
-                class="modal-close"
-                @click="closeAnnouncementModal"
-              >
-                <svg
-                  width="10"
-                  height="10"
-                  viewBox="0 0 14 14"
-                  fill="none"
-                ><path
-                  d="M13 1L1 13M1 1L13 13"
-                  stroke="#666"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                /></svg>
-              </button>
-            </div>
-            <div class="modal-body">
-              <div class="form-group">
-                <label class="form-label">Заголовок</label><input
-                  v-model="announcementForm.title"
-                  type="text"
-                  class="form-input"
-                  placeholder="Введите заголовок"
-                >
-              </div>
-              <div class="form-group">
-                <label class="form-label">Краткое описание</label><textarea
-                  v-model="announcementForm.description"
-                  class="form-textarea"
-                  placeholder="Введите краткое описание"
-                  rows="3"
-                />
-              </div>
-              <div class="form-group">
-                <label class="form-label">Полный текст</label>
-                <TextConstructor v-model="announcementForm.fullText" />
-              </div>
-              <div class="form-group">
-                <label class="checkbox-label"><input
-                  v-model="announcementForm.isImportant"
-                  type="checkbox"
-                ><span>Важное объявление</span></label>
-              </div>
-            </div>
-            <div class="modal-footer">
-              <button
-                class="btn cancel-btn"
-                @click="closeAnnouncementModal"
-              >
-                Отмена
-              </button>
-              <button
-                class="btn save-btn"
-                @click="submitAnnouncement"
-              >
-                Сохранить
-              </button>
-            </div>
-          </div>
-        </div>
-      </transition>
-    </Teleport>
 
     <!-- Модальное окно просмотра новости -->
     <Teleport to="body">
@@ -572,7 +212,6 @@ import RefreshButton from '../components/RefreshButton.vue'
 import AnnouncementModal from '../components/AnnouncementModal.vue'
 import LoaderSpinner from '@/components/ui/LoaderSpinner.vue'
 import UserGuideModal from '../components/news/UserGuideModal.vue'
-import TextConstructor from '@/components/TextConstructor.vue'
 import { USER_GUIDE_SECTIONS } from '../components/news/userGuideSections.js'
 import { ADMIN_GUIDE_SECTIONS } from '../components/news/adminGuideSections.js'
 import { useAuthStore } from '@/stores/auth'
@@ -587,30 +226,19 @@ export default {
     AnnouncementModal,
     LoaderSpinner,
     UserGuideModal,
-    TextConstructor,
     DocumentsBlock,
     OnboardingButton,
   },
   data() {
     return {
       loadingNews: false,
-      showManageModal: false,
       showNewsDetailsModal: false,
-      showNewsModal: false,
-      showAnnouncementModal: false,
       showViewAnnouncementModal: false,
       showGuide: false,
-      activeTab: 'news',
       selectedNews: null,
       viewingAnnouncement: null,
-      editingNews: null,
-      editingAnnouncement: null,
-      newsForm: { title: '', description: '', fullText: '' },
-      announcementForm: { title: '', description: '', fullText: '', isImportant: false },
       newsItems: [],
-      allNewsItems: [],
       activeAnnouncement: null,
-      allAnnouncements: []
     }
   },
   computed: {
@@ -634,12 +262,12 @@ export default {
       const date = new Date(dateString)
       // Добавляем 3 часа для UTC+3 (Москва)
       const mskDate = new Date(date.getTime() + 3 * 60 * 60 * 1000)
-      return mskDate.toLocaleDateString('ru-RU', { 
-        day: '2-digit', 
-        month: '2-digit', 
-        year: 'numeric', 
-        hour: '2-digit', 
-        minute: '2-digit' 
+      return mskDate.toLocaleDateString('ru-RU', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit'
       }).replace(',', '')
     },
 
@@ -651,12 +279,6 @@ export default {
       } catch (error) { console.error('Ошибка загрузки новостей:', error) }
       finally { this.loadingNews = false }
     },
-    async fetchAllNews() {
-      try {
-        const response = await apiRequest('/news/all')
-        if (response.ok) this.allNewsItems = await response.json()
-      } catch (error) { console.error('Ошибка загрузки всех новостей:', error) }
-    },
     async fetchActiveAnnouncement() {
       try {
         const response = await apiRequest('/announcements/active')
@@ -667,162 +289,20 @@ export default {
         }
       } catch (error) { console.error('Ошибка загрузки активного объявления:', error) }
     },
-    async fetchAllAnnouncements() {
-      try {
-        const response = await apiRequest('/announcements/all')
-        if (response.ok) this.allAnnouncements = await response.json()
-      } catch (error) { console.error('Ошибка загрузки всех объявлений:', error) }
-    },
     async fetchAllData() {
       await Promise.all([this.fetchNews(), this.fetchActiveAnnouncement()])
     },
 
-    buildNewsPayload() {
-      return {
-        title: this.newsForm.title,
-        description: this.newsForm.description,
-        full_text: this.newsForm.fullText,
-      }
-    },
-    async createNews() {
-      try {
-        const response = await apiRequest('/news', {
-          method: 'POST',
-          body: JSON.stringify(this.buildNewsPayload())
-        })
-        if (response.ok) {
-          await this.fetchAllNews()
-          await this.fetchNews()
-          this.closeNewsModal()
-        } else alert('Ошибка создания новости')
-      } catch (error) { console.error('Ошибка создания новости:', error) }
-    },
-    async updateNews() {
-      try {
-        const response = await apiRequest(`/news/${this.editingNews.id}`, {
-          method: 'PUT',
-          body: JSON.stringify(this.buildNewsPayload())
-        })
-        if (response.ok) {
-          await this.fetchAllNews()
-          await this.fetchNews()
-          this.closeNewsModal()
-        } else alert('Ошибка обновления новости')
-      } catch (error) { console.error('Ошибка обновления новости:', error) }
-    },
-    async toggleNewsActive(item) {
-      try {
-        const response = await apiRequest(`/news/${item.id}`, {
-          method: 'PUT',
-          body: JSON.stringify({ is_active: !item.is_active })
-        })
-        if (response.ok) {
-          await this.fetchAllNews()
-          await this.fetchNews()
-        } else alert('Ошибка изменения статуса')
-      } catch (error) { console.error('Ошибка изменения статуса:', error) }
-    },
-    async deleteNewsItem(id) {
-      if (!confirm('Удалить новость?')) return
-      try {
-        const response = await apiRequest(`/news/${id}`, { method: 'DELETE' })
-        if (response.ok) {
-          await this.fetchAllNews()
-          await this.fetchNews()
-        } else alert('Ошибка удаления новости')
-      } catch (error) { console.error('Ошибка удаления новости:', error) }
-    },
-
-    buildAnnouncementPayload() {
-      return {
-        title: this.announcementForm.title,
-        description: this.announcementForm.description,
-        full_text: this.announcementForm.fullText,
-        is_important: this.announcementForm.isImportant,
-      }
-    },
-    async createAnnouncement() {
-      try {
-        const response = await apiRequest('/announcements', {
-          method: 'POST',
-          body: JSON.stringify(this.buildAnnouncementPayload())
-        })
-        if (response.ok) {
-          await this.fetchAllAnnouncements()
-          await this.fetchActiveAnnouncement()
-          this.closeAnnouncementModal()
-        } else alert('Ошибка создания объявления')
-      } catch (error) { console.error('Ошибка создания объявления:', error) }
-    },
-    async updateAnnouncement() {
-      try {
-        const response = await apiRequest(`/announcements/${this.editingAnnouncement.id}`, {
-          method: 'PUT',
-          body: JSON.stringify(this.buildAnnouncementPayload())
-        })
-        if (response.ok) {
-          await this.fetchAllAnnouncements()
-          await this.fetchActiveAnnouncement()
-          this.closeAnnouncementModal()
-        } else alert('Ошибка обновления объявления')
-      } catch (error) { console.error('Ошибка обновления объявления:', error) }
-    },
-    async setActiveAnnouncement(id) {
-      if (!confirm('Активировать это объявление?')) return
-      try {
-        const response = await apiRequest('/announcements/set-active', {
-          method: 'POST',
-          body: JSON.stringify({ announcement_id: id })
-        })
-        if (response.ok) {
-          await this.fetchAllAnnouncements()
-          await this.fetchActiveAnnouncement()
-        } else alert('Ошибка активации объявления')
-      } catch (error) { console.error('Ошибка активации объявления:', error) }
-    },
-    async deactivateAnnouncement(id) {
-      if (!confirm('Скрыть объявление?')) return
-      try {
-        const response = await apiRequest(`/announcements/${id}/hide`, {
-          method: 'POST'
-        })
-        if (response.ok) {
-          await this.fetchAllAnnouncements()
-          await this.fetchActiveAnnouncement()
-        } else alert('Ошибка скрытия объявления')
-      } catch (error) { console.error('Ошибка скрытия объявления:', error) }
-    },
-    async deleteAnnouncement(id) {
-      if (!confirm('Удалить объявление?')) return
-      try {
-        const response = await apiRequest(`/announcements/${id}`, { method: 'DELETE' })
-        if (response.ok) {
-          await this.fetchAllAnnouncements()
-          await this.fetchActiveAnnouncement()
-        } else alert('Ошибка удаления объявления')
-      } catch (error) { console.error('Ошибка удаления объявления:', error) }
-    },
-
-    openManageModal() { this.fetchAllNews(); this.fetchAllAnnouncements(); this.showManageModal = true },
-    closeManageModal() { this.showManageModal = false },
     openNewsModal(item) { this.selectedNews = item; this.showNewsDetailsModal = true },
     closeNewsDetailsModal() { this.showNewsDetailsModal = false; this.selectedNews = null },
-    openAnnouncementModal(announcement) { 
-      this.viewingAnnouncement = announcement; 
-      this.showViewAnnouncementModal = true; 
+    openAnnouncementModal(announcement) {
+      this.viewingAnnouncement = announcement;
+      this.showViewAnnouncementModal = true;
     },
-    closeViewAnnouncementModal() { 
-      this.showViewAnnouncementModal = false; 
-      this.viewingAnnouncement = null; 
+    closeViewAnnouncementModal() {
+      this.showViewAnnouncementModal = false;
+      this.viewingAnnouncement = null;
     },
-    openCreateNewsModal() { this.editingNews = null; this.newsForm = { title: '', description: '', fullText: '' }; this.showNewsModal = true },
-    editNewsItem(item) { this.editingNews = item; this.newsForm = { title: item.title, description: item.description, fullText: item.full_text || '' }; this.showNewsModal = true },
-    closeNewsModal() { this.showNewsModal = false; this.editingNews = null },
-    submitNews() { if (!this.newsForm.title || !this.newsForm.description) { alert('Заполните заголовок и описание'); return } this.editingNews ? this.updateNews() : this.createNews() },
-    openCreateAnnouncementModal() { this.editingAnnouncement = null; this.announcementForm = { title: '', description: '', fullText: '', isImportant: false }; this.showAnnouncementModal = true },
-    editAnnouncement(item) { this.editingAnnouncement = item; this.announcementForm = { title: item.title, description: item.description, fullText: item.full_text || '', isImportant: item.is_important }; this.showAnnouncementModal = true },
-    closeAnnouncementModal() { this.showAnnouncementModal = false; this.editingAnnouncement = null },
-    submitAnnouncement() { if (!this.announcementForm.title || !this.announcementForm.description) { alert('Заполните заголовок и описание'); return } this.editingAnnouncement ? this.updateAnnouncement() : this.createAnnouncement() },
     openGuide() { this.showGuide = true; },
     closeGuide() { this.showGuide = false; }
   }
@@ -830,8 +310,6 @@ export default {
 </script>
 
 <style scoped>
-/* ... все существующие стили ... */
-
 /* Добавляем стили для лоадера */
 .loading-message {
   text-align: center;
@@ -905,25 +383,6 @@ export default {
 .header-actions {
     display: flex;
     gap: 8px;
-}
-
-.manage-btn {
-    width: 115px;
-    height: 25px;
-    background: white;
-    border: 1px solid #e6e6e6;
-    border-radius: 30px;
-    font-family: 'Montserrat', sans-serif;
-    font-weight: 500;
-    font-size: 13px;
-    color: #000000;
-    cursor: pointer;
-    transition: all 0.2s ease;
-}
-
-.manage-btn:hover {
-    background: #f5f5f5;
-    border-color: #4F5BDF;
 }
 
 .divider {
@@ -1203,208 +662,6 @@ export default {
     color: #a2a2a2;
 }
 
-.manage-modal .modal-content {
-    width: 680px;
-}
-
-.manage-tabs {
-    display: flex;
-    gap: 8px;
-    margin-bottom: 24px;
-    border-bottom: 1px solid #e6e6e6;
-    padding-bottom: 12px;
-}
-
-.tab-btn {
-    background: none;
-    border: none;
-    padding: 8px 20px;
-    font-family: 'Montserrat', sans-serif;
-    font-size: 14px;
-    font-weight: 500;
-    color: #a2a2a2;
-    cursor: pointer;
-    border-radius: 20px;
-    transition: all 0.2s ease;
-}
-
-.tab-btn:hover {
-    color: #4F5BDF;
-    background: #f8f9ff;
-}
-
-.tab-btn.active {
-    color: #4F5BDF;
-    background: #f0f4ff;
-}
-
-.manage-section {
-    margin-top: 8px;
-}
-
-.section-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 16px;
-}
-
-.section-title {
-    font-size: 14px;
-    font-weight: 600;
-    color: #333;
-}
-
-.add-btn {
-    background: #4F5BDF;
-    border: none;
-    border-radius: 20px;
-    padding: 6px 16px;
-    font-family: 'Montserrat', sans-serif;
-    font-size: 12px;
-    font-weight: 500;
-    color: white;
-    cursor: pointer;
-    transition: all 0.2s ease;
-}
-
-.add-btn:hover {
-    background: #3a45c0;
-}
-
-.info-message {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    background: #f0f4ff;
-    padding: 10px 14px;
-    border-radius: 12px;
-    margin-bottom: 16px;
-    font-size: 12px;
-    color: #4F5BDF;
-}
-
-.items-list {
-    max-height: 420px;
-    overflow-y: auto;
-}
-
-.manage-item {
-    display: flex;
-    justify-content: space-between;
-    flex-direction: column;
-
-    padding: 14px;
-    border-bottom: 1px solid #f0f0f0;
-    transition: background 0.2s ease;
-    border: 1px solid #e6e6e6;
-    border-radius: 20px;
-    margin-bottom: 10px;
-}
-
-.manage-item:hover {
-    background: #fafafa;
-}
-
-.item-main {
-    flex: 1;
-}
-
-.item-title {
-    font-weight: 500;
-    font-size: 14px;
-    color: #333;
-    margin-bottom: 6px;
-}
-
-.item-meta {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 12px;
-    font-size: 11px;
-    color: #a2a2a2;
-}
-
-.status-text {
-    color: #666;
-}
-
-.active-badge {
-    margin-left: 8px;
-    padding: 2px 8px;
-    background: #4F5BDF;
-    color: white;
-    border-radius: 12px;
-    font-size: 10px;
-    font-weight: 500;
-}
-
-.important-badge {
-    margin-left: 8px;
-    padding: 2px 8px;
-    background: #ff9800;
-    color: white;
-    border-radius: 12px;
-    font-size: 10px;
-    font-weight: 500;
-}
-
-.item-actions {
-    display: flex;
-    gap: 8px;
-    padding-top: 10px;
-}
-
-.action-btn {
-    background: none;
-    border: none;
-    padding: 3px 12px;
-    border-radius: 20px;
-    font-family: 'Montserrat', sans-serif;
-    font-size: 12px;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    color: #666;
-    border: 1px solid #e6e6e6;
-}
-
-.action-btn:hover {
-    background: #f0f0f0;
-}
-
-.edit-btn:hover {
-    color: #4F5BDF;
-    background: #f0f4ff;
-}
-
-.delete-btn:hover {
-    color: #dc2626;
-    background: #ffebee;
-}
-
-.toggle-btn:hover {
-    color: #4F5BDF;
-    background: #f0f4ff;
-}
-
-.activate-btn:hover {
-    color: #4F5BDF;
-    background: #f0f4ff;
-}
-
-.deactivate-btn:hover {
-    color: #dc2626;
-    background: #ffebee;
-}
-
-.empty-manage {
-    text-align: center;
-    padding: 48px;
-    color: #a2a2a2;
-    font-size: 13px;
-}
-
 .modal-overlay {
     position: fixed;
     top: 0;
@@ -1463,22 +720,6 @@ export default {
     color: #1a1a1a;
 }
 
-.modal-close {
-    background: none;
-    border: none;
-    cursor: pointer;
-    padding: 6px;
-    border-radius: 6px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: background-color 0.2s ease;
-}
-
-.modal-close:hover {
-    background-color: #f5f5f5;
-}
-
 .modal-body {
     padding: 20px 30px;
     overflow-y: auto;
@@ -1504,11 +745,6 @@ export default {
     border-radius: 20px;
     background: #f0f4ff;
     color: #4F5BDF;
-}
-
-.modal-type.announcement {
-    background: #fff3cd;
-    color: #856404;
 }
 
 .modal-description {
@@ -1556,72 +792,6 @@ export default {
     background: #3a45c0;
 }
 
-.cancel-btn {
-    background: white;
-    color: #666;
-    border-color: #e6e6e6;
-}
-
-.cancel-btn:hover {
-    background: #f5f5f5;
-}
-
-.save-btn {
-    background: #4F5BDF;
-    color: white;
-    border-color: #4F5BDF;
-}
-
-.save-btn:hover {
-    background: #3a45c0;
-}
-
-.form-group {
-    margin-bottom: 20px;
-}
-
-.form-label {
-    display: block;
-    font-size: 13px;
-    font-weight: 500;
-    color: #333;
-    margin-bottom: 8px;
-}
-
-.form-input,
-.form-textarea {
-    width: 100%;
-    padding: 10px 14px;
-    border: 1px solid #e6e6e6;
-    border-radius: var(--radius-md);
-    font-family: 'Montserrat', sans-serif;
-    font-size: 13px;
-    transition: all 0.2s ease;
-    resize: vertical;
-}
-
-.form-input:focus,
-.form-textarea:focus {
-    outline: none;
-    border-color: #4F5BDF;
-}
-
-.checkbox-label {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    cursor: pointer;
-    font-size: 13px;
-    color: #333;
-}
-
-.checkbox-label input {
-    width: 16px;
-    height: 16px;
-    cursor: pointer;
-    accent-color: #4F5BDF;
-}
-
 @media (max-width: 820px) {
     .content-wrapper {
         flex-direction: column;
@@ -1636,8 +806,7 @@ export default {
         width: 100%;
     }
 
-    .modal-content,
-    .manage-modal .modal-content {
+    .modal-content {
         width: 95vw;
     }
 }
@@ -1659,10 +828,6 @@ export default {
         width: 100%;
         justify-content: flex-start;
         flex-wrap: wrap;
-    }
-
-    .manage-btn {
-        flex-shrink: 0;
     }
 }
 

--- a/frontend/src/views/admin/NewsManagement.vue
+++ b/frontend/src/views/admin/NewsManagement.vue
@@ -1,0 +1,15 @@
+<template>
+  <AdminPageShell>
+    <NewsManagementComponent />
+  </AdminPageShell>
+</template>
+
+<script>
+import AdminPageShell from './AdminPageShell.vue';
+import NewsManagementComponent from '@/components/NewsManagement.vue';
+
+export default {
+  name: 'NewsManagementView',
+  components: { AdminPageShell, NewsManagementComponent },
+};
+</script>


### PR DESCRIPTION
Новый раздел Администрирование -> Новости и объявления (views/admin/NewsManagement.vue + components/NewsManagement.vue, роут /admin/news, пункт в NavMenu). Из публичной страницы Обзор и новости убрано управление, остался только показ. Уведомления управления на эталон notify/ui.confirm.