### PR TITLE
fix(create-application): показывать актуальную инструкцию вложения при выборе

### DIFF
--- a/frontend/src/components/BlankSelector.vue
+++ b/frontend/src/components/BlankSelector.vue
@@ -326,8 +326,23 @@ export default {
         },
 
         selectAttachment(attachment) {
-            this.selectedAttachment = attachment;
-            this.$emit('attachment-selected', attachment);
+            // Инструкция принадлежит ТИПУ вложения (админка) и могла измениться после
+            // добавления черновика - объект вложения хранит снапшот на момент добавления.
+            // Берём актуальную инструкцию из загруженных шаблонов, иначе восстановленный
+            // черновик (или тип, которому инструкцию дописали позже) не покажет кнопку.
+            const enriched = this.withCurrentInstruction(attachment);
+            this.selectedAttachment = enriched;
+            this.$emit('attachment-selected', enriched);
+        },
+
+        withCurrentInstruction(attachment) {
+            if (!attachment) return attachment;
+            const templateId = attachment.template_id || attachment.id;
+            const template = this.allTemplates.find(t => t.id === templateId);
+            if (template && template.instruction !== attachment.instruction) {
+                return { ...attachment, instruction: template.instruction };
+            }
+            return attachment;
         },
 
         confirmDelete(attachment) {


### PR DESCRIPTION
Инструкция привязана к типу вложения (админка), но объект вложения снапшотил её при добавлении: если черновик добавлен до написания инструкции или тип обновили позже, кнопка Инструкция не появлялась. При выборе вложения подмешиваю актуальную instruction из загруженных шаблонов. Проверено: API /attachments отдаёт instruction (curl), логика fresh/restore/select корректна.