### PR TITLE
fix(applications): 500 в поиске заявок - неверный JOIN мест разгрузки

### DIFF
--- a/internal/handlers/applications_test.go
+++ b/internal/handlers/applications_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"systemburo/internal/database"
@@ -183,6 +184,25 @@ func TestGetApplications_EmptyList(t *testing.T) {
 
 	apps := testutil.ParseResponse[[]interface{}](t, rec)
 	assert.Empty(t, apps)
+}
+
+// TestGetApplications_FuzzySearchExecutes защищает большой SQL мега-поиска (#46):
+// подзапросы по машинам/сотрудникам/местам разгрузки/согласующим + word_similarity.
+// Регрессия: неверный JOIN car_unload_places.attachment_id (нет такой колонки) ронял
+// весь запрос в 500. Проверяем, что разные формы запроса исполняются (200), а не падают.
+func TestGetApplications_FuzzySearchExecutes(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "searchuser", "pass123", 1, td.OrgID, td.CompanyID)
+
+	for _, q := range []string{"грязевой", "А777АА", "А 777 АА", "ghbdtn", "иванов", "70"} {
+		rec := testutil.GET(t, e, "/applications?search_query="+url.QueryEscape(q), testutil.AuthHeader(token))
+		assert.Equalf(t, http.StatusOK, rec.Code,
+			"search_query=%q должен вернуть 200, а не %d: %s", q, rec.Code, rec.Body.String())
+	}
 }
 
 // --- GET /applications/user ---

--- a/internal/services/application_helpers.go
+++ b/internal/services/application_helpers.go
@@ -266,7 +266,7 @@ func applyApplicationFilters(query *gorm.DB, filter ApplicationFilter, includeUs
 		// --- вложения: машины ---
 		// Госномер ищем по всем вариантам (включая normalize.Plate для омоглифов/нулей);
 		// марку - по тексту. EXISTS чтобы не размножать строки заявки.
-		carNumCond, carNumArgs := ilikePatternsArgs([]string{"c2.car_number", "c2.mark_name"}, variants)
+		carNumCond, carNumArgs := ilikePatternsArgs([]string{"c2.car_number", "c2.mark_name", "c2.unload_place"}, variants)
 		// Слитно/раздельно: сравниваем номер без пробелов с нормализованным запросом,
 		// чтобы "А 777 АА" находился по "А777АА" и наоборот (только если в запросе есть цифры).
 		platePattern := ""
@@ -299,9 +299,12 @@ func applyApplicationFilters(query *gorm.DB, filter ApplicationFilter, includeUs
 
 		// --- вложения: места разгрузки ---
 		upCond, upArgs := ilikePatternsArgs([]string{"up.name"}, variants)
+		// car_unload_places связывает МАШИНУ (car_id) с местом, а не вложение напрямую:
+		// attachments -> cars -> car_unload_places -> unload_places.
 		upSubquery := `EXISTS(
 			SELECT 1 FROM attachments att4
-			JOIN car_unload_places cup ON cup.attachment_id = att4.id
+			JOIN cars c4 ON c4.attachment_id = att4.id
+			JOIN car_unload_places cup ON cup.car_id = c4.id
 			JOIN unload_places up ON up.id = cup.unload_place_id
 			WHERE att4.application_id = a.id AND (` + upCond + `)
 		)`


### PR DESCRIPTION
search_query ронял весь GET /applications в 500: подзапрос мест разгрузки джойнил несуществующую car_unload_places.attachment_id. Правильный путь attachments->cars->car_unload_places->unload_places. + поиск по cars.unload_place. + регресс-тест (handlers, GET с search_query -> 200). Полный go test ./... зелёный.