### PR TITLE
fix(security): места прохода в "Места доступа" показывали "Без названия" (#706)

### DIFF
--- a/frontend/src/components/admin/UserAccessPlacesModal.vue
+++ b/frontend/src/components/admin/UserAccessPlacesModal.vue
@@ -224,10 +224,8 @@ export default {
       const response = await apiRequest('/system-tables');
       if (!response.ok) return [];
       const data = await response.json();
-      // /system-tables отдаёт элементы в обёртке { table: {...} } поверх envelope -
-      // снимаем её, иначе места прохода рендерятся по плоским table.id/display_name:
-      // имя выходит "Без названия", cars не отсекается, а выбор по id не совпадает с
-      // плоскими id из GET /users/:username/tables.
+      // /system-tables оборачивает каждый элемент в { table: {...} }; разворачиваем,
+      // чтобы дальше читать плоско (как NavMenu) и совпасть с id из /users/:u/tables.
       return (data || [])
         .map(t => t.table || t)
         .filter(t => t.table_type !== 'cars');

--- a/frontend/src/components/admin/UserAccessPlacesModal.vue
+++ b/frontend/src/components/admin/UserAccessPlacesModal.vue
@@ -224,7 +224,13 @@ export default {
       const response = await apiRequest('/system-tables');
       if (!response.ok) return [];
       const data = await response.json();
-      return (data || []).filter(t => t.table_type !== 'cars');
+      // /system-tables отдаёт элементы в обёртке { table: {...} } поверх envelope -
+      // снимаем её, иначе места прохода рендерятся по плоским table.id/display_name:
+      // имя выходит "Без названия", cars не отсекается, а выбор по id не совпадает с
+      // плоскими id из GET /users/:username/tables.
+      return (data || [])
+        .map(t => t.table || t)
+        .filter(t => t.table_type !== 'cars');
     },
 
     toggleUnloadPlace(id) {

--- a/frontend/src/components/admin/__tests__/UserAccessPlacesModal.spec.js
+++ b/frontend/src/components/admin/__tests__/UserAccessPlacesModal.spec.js
@@ -10,10 +10,13 @@ const UNLOAD_PLACES = [
   { id: 3, name: 'Склад 3' },
 ];
 
+// /system-tables отдаёт элементы в обёртке { table: {...} } поверх envelope -
+// именно так, как боевой бэк (а не плоско). Раньше мок был плоским и пропустил баг
+// "Без названия" в местах прохода.
 const SYSTEM_TABLES = [
-  { id: 10, display_name: 'КПП Север', table_type: 'people' },
-  { id: 11, display_name: 'Гараж', table_type: 'cars' },
-  { id: 12, display_name: 'КПП Юг', table_type: 'people' },
+  { table: { id: 10, name: 'kpp_north', display_name: 'КПП Север', table_type: 'people' } },
+  { table: { id: 11, name: 'garage', display_name: 'Гараж', table_type: 'cars' } },
+  { table: { id: 12, name: 'kpp_south', display_name: 'КПП Юг', table_type: 'people' } },
 ];
 
 const notify = vi.fn();
@@ -69,6 +72,13 @@ describe('UserAccessPlacesModal (#706 FE-S5)', () => {
     const items = wrapper.findAll('.place-item');
     expect(items).toHaveLength(5);
     expect(wrapper.findAll('.place-item.selected')).toHaveLength(2);
+
+    // Места прохода показывают реальные имена из обёртки { table: {...} },
+    // а не "Без названия" (баг до снятия double-wrap в fetchAllTables).
+    const text = wrapper.text();
+    expect(text).toContain('КПП Север');
+    expect(text).toContain('КПП Юг');
+    expect(text).not.toContain('Без названия');
   });
 
   it('Сохранить заблокировано без изменений и разблокируется после toggle', async () => {


### PR DESCRIPTION
## Баг
В модалке «Места доступа» (карточка пользователя, FE-S5) места разгрузки отображались корректно, а места прохода — все как «Без названия». Дополнительно: cars-таблицы не отсекались из списка прохода, а выбор по id не совпадал (нельзя было отметить/снять место прохода).

## Причина
`/system-tables` отдаёт элементы в double-wrap форме `{success, data:[{table:{id,name,display_name,table_type}}]}` — после снятия envelope в `apiRequest` остаётся `[{table:{...}}]`. Модалка читала плоские `table.id`/`table.display_name`/`table.table_type` → undefined (→ «Без названия», cars не фильтровались). При этом `GET /users/:username/tables` отдаёт **плоский** `[]SystemTable`, поэтому `selectedTableIds` (плоские id) не совпадали с `table.id` (undefined под обёрткой). Формы подтверждены curl'ом боевого API на staging. NavMenu давно разворачивает ту же обёртку.

## Фикс
В `fetchAllTables` снял обёртку `.map(t => t.table || t)` перед фильтром cars (defensive — плоский ответ не сломается). Теперь имена реальные, cars отсекаются, выбор по id совпадает.

## Тест
Спека `UserAccessPlacesModal.spec.js` раньше мокала `/system-tables` **плоско** — потому баг и прошёл мимо. Поправил мок на реальную wrapped-форму (теперь тест падал бы без фикса) и добавил проверку, что рендерятся реальные имена, а не «Без названия». 5 vitest зелёных, eslint чисто, code-reviewer GO.

Примечание: при чтении нашёлся отладочный `console.log` дампа `/system-tables` в `EmployeeForm.vue` и `SelectTables.vue` (вне этого диффа) — вынесу отдельно.