### PR TITLE
perf: ресурсы prod под 6c/32g, ротация логов, тёплый кэш аналитики

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -204,7 +204,7 @@ func main() {
 	documentFileService := services.NewDocumentFileService(cfg.UploadPath)
 	documentGroupService := services.NewDocumentGroupService(db)
 	documentService := services.NewDocumentService(db, documentFileService, settingsService)
-	statisticsService := services.NewStatisticsService(db)
+	statisticsService := services.NewStatisticsService(db, time.Duration(cfg.AnalyticsCacheRefreshSec)*time.Second)
 
 	// Handlers
 	authHandler := handlers.NewAuthHandler(authService, maintenanceService, cfg.CookieSecure, cfg.JWTRefreshTTL)
@@ -341,6 +341,11 @@ func main() {
 	// Снимок дневного пика онлайна (#632): раз в минуту фиксирует текущий онлайн
 	// как пик за сегодня (peak_count = MAX(...)). Останавливается по ctxSig.
 	go startOnlinePeakSnapshotter(ctxSig, statisticsService, time.Minute)
+
+	// Тёплый кэш аналитики: прогрев из БД при старте + фоновое обновление, чтобы
+	// дашборд/insights не считались с нуля после рестарта или деплоя.
+	statisticsService.WarmCache(ctxSig)
+	go statisticsService.StartCacheRefresh(ctxSig)
 
 	// Graceful shutdown
 	go func() {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -24,6 +25,7 @@ import (
 	"github.com/labstack/echo/v4"
 	echomw "github.com/labstack/echo/v4/middleware"
 	echoSwagger "github.com/swaggo/echo-swagger"
+	"gopkg.in/natefinch/lumberjack.v2"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
@@ -58,7 +60,20 @@ func main() {
 	default:
 		logLevel = slog.LevelInfo
 	}
-	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: logLevel})))
+	// Writer для логов: stdout всегда (для docker logs), плюс ротируемый файл,
+	// если задан LOG_FILE_PATH. lumberjack ротирует по размеру и удаляет файлы
+	// старше MaxAge дней (по умолчанию 30 - месячная ротация).
+	var logOut io.Writer = os.Stdout
+	if cfg.LogFilePath != "" {
+		logOut = io.MultiWriter(os.Stdout, &lumberjack.Logger{
+			Filename:   cfg.LogFilePath,
+			MaxSize:    cfg.LogMaxSizeMB,
+			MaxAge:     cfg.LogMaxAgeDays,
+			MaxBackups: cfg.LogMaxBackups,
+			Compress:   cfg.LogCompress,
+		})
+	}
+	slog.SetDefault(slog.New(slog.NewTextHandler(logOut, &slog.HandlerOptions{Level: logLevel})))
 
 	encKey, err := crypto.ParseHexKey(cfg.DataEncryptionKey)
 	if err != nil {
@@ -113,7 +128,7 @@ func main() {
 
 	// Global middleware
 	e.Use(mw.RequestID())
-	e.Use(echomw.Logger())
+	e.Use(echomw.LoggerWithConfig(echomw.LoggerConfig{Output: logOut}))
 	e.Use(echomw.Recover())
 	// Security headers: HSTS, CSP, X-Frame-Options и т.д. HSTS включается только
 	// в режиме CookieSecure (prod/staging) - на http://localhost HSTS бесполезен

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -39,6 +39,10 @@ services:
       # Soft-лимит GC: сглаживает пики выделения после снятия mem_limit, не давая
       # процессу разрастаться неконтролируемо.
       GOMEMLIMIT: "6GiB"
+      # Логи приложения (slog + Echo) пишутся в stdout И в ротируемый файл (месяц).
+      LOG_FILE_PATH: /app/logs/app.log
+    volumes:
+      - logs:/app/logs
 
   frontend:
     mem_limit: !reset null
@@ -55,3 +59,6 @@ services:
       - backend
       - frontend
     restart: always
+
+volumes:
+  logs:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,4 +1,49 @@
 services:
+  # На выделенном prod-сервере (6 vCPU / 32 GB, только prod) снимаем лимиты памяти
+  # из base.yml: они заданы под слабые машины. !reset убирает ключ из base-оверлея.
+  db:
+    mem_limit: !reset null
+    memswap_limit: !reset null
+    # Без явного тюнинга Postgres сидит на дефолтных shared_buffers=128MB независимо
+    # от объёма контейнера - снятие лимита тогда косметическое. Значения под 32 GB хоста,
+    # где БД делит память с backend.
+    command:
+      - "postgres"
+      - "-c"
+      - "shared_buffers=8GB"
+      - "-c"
+      - "effective_cache_size=20GB"
+      - "-c"
+      - "work_mem=32MB"
+      - "-c"
+      - "maintenance_work_mem=1GB"
+      - "-c"
+      - "max_connections=150"
+      - "-c"
+      - "max_wal_size=4GB"
+      - "-c"
+      - "min_wal_size=1GB"
+      - "-c"
+      - "checkpoint_completion_target=0.9"
+      - "-c"
+      - "random_page_cost=1.1"
+      - "-c"
+      - "effective_io_concurrency=200"
+
+  backend:
+    mem_limit: !reset null
+    memswap_limit: !reset null
+    environment:
+      # Go в контейнере без CPU-лимита неверно определяет число ядер - фиксируем под 6 vCPU.
+      GOMAXPROCS: "6"
+      # Soft-лимит GC: сглаживает пики выделения после снятия mem_limit, не давая
+      # процессу разрастаться неконтролируемо.
+      GOMEMLIMIT: "6GiB"
+
+  frontend:
+    mem_limit: !reset null
+    memswap_limit: !reset null
+
   nginx:
     image: nginx:1.25-alpine
     ports:

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/swaggo/swag v1.16.6
 	github.com/xuri/excelize/v2 v2.10.1
 	golang.org/x/crypto v0.50.0
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/gorm v1.31.1
 )

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,15 @@ type Config struct {
 	LogLevel         string        `env:"LOG_LEVEL" envDefault:"info"`
 	SwaggerEnabled   bool          `env:"SWAGGER_ENABLED" envDefault:"false"`
 
+	// Файловое логирование с ротацией (lumberjack). LogFilePath пустой - пишем только
+	// в stdout (как раньше). При заданном пути логи идут и в stdout (docker logs),
+	// и в ротируемый файл. LogMaxAgeDays=30 - месячная ротация по времени.
+	LogFilePath   string `env:"LOG_FILE_PATH" envDefault:""`
+	LogMaxSizeMB  int    `env:"LOG_MAX_SIZE_MB" envDefault:"100"`
+	LogMaxAgeDays int    `env:"LOG_MAX_AGE_DAYS" envDefault:"30"`
+	LogMaxBackups int    `env:"LOG_MAX_BACKUPS" envDefault:"14"`
+	LogCompress   bool   `env:"LOG_COMPRESS" envDefault:"true"`
+
 	CORSAllowedOrigins      []string `env:"CORS_ALLOWED_ORIGINS" envDefault:"http://localhost:8081" envSeparator:","`
 	UploadMaxFileSize       int64    `env:"UPLOAD_MAX_FILE_SIZE" envDefault:"10485760"`
 	UploadAllowedImageTypes []string `env:"UPLOAD_ALLOWED_IMAGE_TYPES" envDefault:"image/jpeg,image/png,image/webp" envSeparator:","`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,6 +63,10 @@ type Config struct {
 	// ResetTimezone задаёт часовой пояс для ежедневного сброса территориальных статусов.
 	// Используется для расчёта 06:00 локального времени. По умолчанию Europe/Moscow.
 	ResetTimezone string `env:"RESET_TIMEZONE" envDefault:"Europe/Moscow"`
+
+	// AnalyticsCacheRefreshSec - интервал обновления тёплого кэша аналитики дашборда
+	// (in-memory + снимок в БД для прогрева после рестарта). 0 отключает кэш.
+	AnalyticsCacheRefreshSec int `env:"ANALYTICS_CACHE_REFRESH_SEC" envDefault:"60"`
 }
 
 func Load() (*Config, error) {

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -166,6 +166,8 @@ func AllModels() []interface{} {
 		&models.ReportTemplate{},
 		// Дневные пики онлайна пользователей (#632): снимок фонового тикера
 		&models.UserOnlinePeak{},
+		// Снимок тёплого кэша аналитики дашборда/insights (прогрев после рестарта)
+		&models.AnalyticsCache{},
 	}
 }
 

--- a/internal/handlers/insights_integration_test.go
+++ b/internal/handlers/insights_integration_test.go
@@ -37,7 +37,7 @@ func TestGetInsights_Structure(t *testing.T) {
 	}
 	require.NoError(t, db.Create(&app).Error)
 
-	svc := services.NewStatisticsService(db)
+	svc := services.NewStatisticsService(db, 0)
 	res, err := svc.GetInsights(context.Background(), "2026-06-01", "2026-06-30")
 	require.NoError(t, err)
 

--- a/internal/handlers/report_template_test.go
+++ b/internal/handlers/report_template_test.go
@@ -33,7 +33,7 @@ func TestReportTemplates_Scoping(t *testing.T) {
 	testutil.CleanDB(t, db)
 	require.NoError(t, database.SeedReportTemplates(db)) // CleanDB чистит report_templates -> пересеваем системные
 
-	svc := services.NewStatisticsService(db)
+	svc := services.NewStatisticsService(db, 0)
 	ctx := context.Background()
 	cfg := json.RawMessage(`{"mode":"list","entity":"cars"}`)
 
@@ -93,7 +93,7 @@ func TestReportTemplates_Protection(t *testing.T) {
 	testutil.CleanDB(t, db)
 	require.NoError(t, database.SeedReportTemplates(db)) // CleanDB чистит report_templates -> пересеваем системные
 
-	svc := services.NewStatisticsService(db)
+	svc := services.NewStatisticsService(db, 0)
 	ctx := context.Background()
 	cfg := json.RawMessage(`{"mode":"list","entity":"cars"}`)
 

--- a/internal/handlers/statistics_online_integration_test.go
+++ b/internal/handlers/statistics_online_integration_test.go
@@ -44,7 +44,7 @@ func TestUsersOnline_CountsByLastSeenWindow(t *testing.T) {
 	mk("offline_stale", &stale)
 	mk("never_seen", nil)
 
-	svc := services.NewStatisticsService(db)
+	svc := services.NewStatisticsService(db, 0)
 	summary, err := svc.GetSummary(context.Background(), now.Add(-24*time.Hour), now)
 	require.NoError(t, err)
 
@@ -59,7 +59,7 @@ func TestSnapshotOnlinePeak_MaxAndUpsert(t *testing.T) {
 	testutil.CleanDB(t, db)
 
 	now := time.Now().UTC()
-	svc := services.NewStatisticsService(db)
+	svc := services.NewStatisticsService(db, 0)
 
 	// Снимок 1: 3 пользователя онлайн.
 	for _, name := range []string{"p1", "p2", "p3"} {
@@ -154,7 +154,7 @@ func TestGetOnlineUsers_WindowSortAndFields(t *testing.T) {
 	require.NoError(t, db.Model(&models.User{}).Where("id = ?", inactive.ID).
 		Updates(map[string]any{"is_active": false, "last_seen": recent}).Error)
 
-	svc := services.NewStatisticsService(db)
+	svc := services.NewStatisticsService(db, 0)
 	users, err := svc.GetOnlineUsers(context.Background())
 	require.NoError(t, err)
 
@@ -189,7 +189,7 @@ func TestGetOnlineUsersHandler_HTTP(t *testing.T) {
 	require.NoError(t, db.Model(&models.User{}).Where("id = ?", u.ID).
 		Update("last_seen", now.Add(-1*time.Minute)).Error)
 
-	h := handlers.NewStatisticsHandler(services.NewStatisticsService(db))
+	h := handlers.NewStatisticsHandler(services.NewStatisticsService(db, 0))
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodGet, "/statistics/online-users", nil)
 	rec := httptest.NewRecorder()
@@ -232,7 +232,7 @@ func TestGetOnlinePeaks_Series(t *testing.T) {
 	mkPeak(d2, 3)
 	mkPeak(d1, 5)
 
-	svc := services.NewStatisticsService(db)
+	svc := services.NewStatisticsService(db, 0)
 	points, err := svc.GetOnlinePeaks(context.Background(), now.Add(-3*24*time.Hour), now)
 	require.NoError(t, err)
 
@@ -263,7 +263,7 @@ func TestGetOnlinePeaksHandler_HTTP(t *testing.T) {
 	mkPeak(d1, 4)
 	mkPeak(now, 9)
 
-	h := handlers.NewStatisticsHandler(services.NewStatisticsService(db))
+	h := handlers.NewStatisticsHandler(services.NewStatisticsService(db, 0))
 
 	e := echo.New()
 	from := now.Add(-72 * time.Hour).Format("2006-01-02")
@@ -293,7 +293,7 @@ func TestGetOnlinePeaksHandler_InvalidRange(t *testing.T) {
 	_, db, cleanup := testutil.SetupTestApp(t)
 	defer cleanup()
 
-	h := handlers.NewStatisticsHandler(services.NewStatisticsService(db))
+	h := handlers.NewStatisticsHandler(services.NewStatisticsService(db, 0))
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodGet, "/statistics/online-peaks?from=2026-06-10&to=2026-06-01", nil)
 	rec := httptest.NewRecorder()

--- a/internal/handlers/statistics_report_crosstab_integration_test.go
+++ b/internal/handlers/statistics_report_crosstab_integration_test.go
@@ -50,7 +50,7 @@ func TestRunReport_CrossTabAttachmentType(t *testing.T) {
 	mk("CT/3", week1, "Люди")
 	mk("CT/4", week2, "Машины")
 
-	svc := services.NewStatisticsService(db)
+	svc := services.NewStatisticsService(db, 0)
 	res, err := svc.RunReport(context.Background(), models.ReportRequest{
 		Mode:        "aggregate",
 		Metrics:     []string{"applications_count"},
@@ -117,7 +117,7 @@ func TestRunReport_NoPivotUnchanged(t *testing.T) {
 	dn := "Машины"
 	require.NoError(t, db.Create(&models.Attachment{ApplicationID: app.ID, AttachmentType: "cars", AttachmentDisplayName: &dn}).Error)
 
-	svc := services.NewStatisticsService(db)
+	svc := services.NewStatisticsService(db, 0)
 	res, err := svc.RunReport(context.Background(), models.ReportRequest{
 		Mode:        "aggregate",
 		Metrics:     []string{"applications_count"},
@@ -177,7 +177,7 @@ func TestRunReport_AvgCarsPerDayWeekly(t *testing.T) {
 		}
 	}
 
-	svc := services.NewStatisticsService(db)
+	svc := services.NewStatisticsService(db, 0)
 	res, err := svc.RunReport(context.Background(), models.ReportRequest{
 		Mode:        "aggregate",
 		Metrics:     []string{"avg_cars_per_day"},
@@ -238,7 +238,7 @@ func TestRunReport_AvgCarsPartialBin(t *testing.T) {
 		}
 	}
 
-	svc := services.NewStatisticsService(db)
+	svc := services.NewStatisticsService(db, 0)
 	res, err := svc.RunReport(context.Background(), models.ReportRequest{
 		Mode:        "aggregate",
 		Metrics:     []string{"avg_cars_per_day"},

--- a/internal/handlers/statistics_report_list_integration_test.go
+++ b/internal/handlers/statistics_report_list_integration_test.go
@@ -72,7 +72,7 @@ func TestRunReportList_WorkApplications(t *testing.T) {
 		require.NoError(t, db.Create(&models.Employee{AttachmentID: &att.ID, LastName: &name}).Error)
 	}
 
-	svc := services.NewStatisticsService(db)
+	svc := services.NewStatisticsService(db, 0)
 	res, err := svc.RunReportList(context.Background(), models.ReportRequest{Mode: "list", Entity: "work_applications"})
 	require.NoError(t, err)
 	require.Equal(t, "list", res.Mode)
@@ -99,7 +99,7 @@ func TestRunReportList_AllEntitiesExecute(t *testing.T) {
 	defer cleanup()
 	testutil.CleanDB(t, db)
 
-	svc := services.NewStatisticsService(db)
+	svc := services.NewStatisticsService(db, 0)
 	for _, entity := range []string{"work_applications", "applications", "cars", "people"} {
 		t.Run(entity, func(t *testing.T) {
 			res, err := svc.RunReportList(context.Background(), models.ReportRequest{Mode: "list", Entity: entity})

--- a/internal/handlers/statistics_report_multimetric_integration_test.go
+++ b/internal/handlers/statistics_report_multimetric_integration_test.go
@@ -39,7 +39,7 @@ func TestRunReport_MultiMetric(t *testing.T) {
 	cnt := 4
 	require.NoError(t, db.Create(&models.Item{AttachmentID: att.ID, Count: &cnt}).Error)
 
-	svc := services.NewStatisticsService(db)
+	svc := services.NewStatisticsService(db, 0)
 	res, err := svc.RunReport(context.Background(), models.ReportRequest{
 		Mode:      "aggregate",
 		Metrics:   []string{"applications_count", "items_sum"},
@@ -89,7 +89,7 @@ func TestRunReport_DimensionNone(t *testing.T) {
 		require.NoError(t, db.Create(&app).Error)
 	}
 
-	svc := services.NewStatisticsService(db)
+	svc := services.NewStatisticsService(db, 0)
 	res, err := svc.RunReport(context.Background(), models.ReportRequest{
 		Mode:      "aggregate",
 		Metrics:   []string{"applications_count"},

--- a/internal/models/analytics_cache.go
+++ b/internal/models/analytics_cache.go
@@ -1,0 +1,18 @@
+package models
+
+import "time"
+
+// AnalyticsCache — персистентный снимок тяжёлой аналитики за период [from,to].
+// Пишется сервисом статистики при пересчёте, читается при старте для прогрева
+// in-memory кэша, чтобы дашборд/insights не считались с нуля после рестарта или
+// деплоя. Ключ кодирует тип снимка и период (см. periodCache.key).
+type AnalyticsCache struct {
+	CacheKey   string    `gorm:"primaryKey;column:cache_key;size:200" json:"cache_key"`
+	PeriodFrom time.Time `gorm:"column:period_from;not null" json:"period_from"`
+	PeriodTo   time.Time `gorm:"column:period_to;not null" json:"period_to"`
+	Payload    string    `gorm:"type:jsonb;not null" json:"payload"`
+	ComputedAt time.Time `gorm:"column:computed_at;not null" json:"computed_at"`
+}
+
+// TableName задаёт имя таблицы.
+func (AnalyticsCache) TableName() string { return "analytics_cache" }

--- a/internal/services/analytics_cache.go
+++ b/internal/services/analytics_cache.go
@@ -1,0 +1,165 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"sync"
+	"time"
+
+	"systemburo/internal/models"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// periodCache — тёплый кэш значения T, считаемого за период [from,to]. Держит
+// результат in-memory для скорости и снимок в таблице analytics_cache для
+// durability через рестарт. Фоновый refresh держит горячие ключи свежими и
+// выселяет давно не используемые. Параметризован типом значения (summary/insights).
+type periodCache[T any] struct {
+	db      *gorm.DB
+	name    string // префикс ключа и тип снимка: "summary" / "insights"
+	evict   time.Duration
+	compute func(ctx context.Context, from, to time.Time) (T, error)
+
+	mu    sync.Mutex
+	items map[string]*cacheItem[T]
+}
+
+type cacheItem[T any] struct {
+	value      T
+	from, to   time.Time
+	computedAt time.Time
+	lastAccess time.Time
+}
+
+func newPeriodCache[T any](db *gorm.DB, name string, evict time.Duration,
+	compute func(context.Context, time.Time, time.Time) (T, error)) *periodCache[T] {
+	return &periodCache[T]{
+		db: db, name: name, evict: evict, compute: compute,
+		items: make(map[string]*cacheItem[T]),
+	}
+}
+
+func (c *periodCache[T]) key(from, to time.Time) string {
+	return c.name + "|" + from.UTC().Format(time.RFC3339) + "|" + to.UTC().Format(time.RFC3339)
+}
+
+// get отдаёт кэшированное значение (refresh держит его свежим), а при первом
+// обращении к периоду считает синхронно и сохраняет снимок.
+func (c *periodCache[T]) get(ctx context.Context, from, to time.Time) (T, error) {
+	k := c.key(from, to)
+	now := time.Now()
+
+	c.mu.Lock()
+	if it, ok := c.items[k]; ok {
+		it.lastAccess = now
+		v := it.value
+		c.mu.Unlock()
+		return v, nil
+	}
+	c.mu.Unlock()
+
+	v, err := c.compute(ctx, from, to)
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+	c.mu.Lock()
+	c.items[k] = &cacheItem[T]{value: v, from: from, to: to, computedAt: now, lastAccess: now}
+	c.mu.Unlock()
+	c.persist(ctx, k, from, to, v, now)
+	return v, nil
+}
+
+// persist делает upsert снимка в analytics_cache. Ошибку логируем, но не валим
+// запрос - значение уже лежит в памяти.
+func (c *periodCache[T]) persist(ctx context.Context, key string, from, to time.Time, v T, at time.Time) {
+	if c.db == nil { // кэш без persistence (тесты/деградация) - только in-memory
+		return
+	}
+	payload, err := json.Marshal(v)
+	if err != nil {
+		slog.Error("analytics cache marshal", "key", key, "error", err)
+		return
+	}
+	row := models.AnalyticsCache{
+		CacheKey: key, PeriodFrom: from, PeriodTo: to,
+		Payload: string(payload), ComputedAt: at,
+	}
+	if err := c.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "cache_key"}},
+		DoUpdates: clause.AssignmentColumns([]string{"payload", "computed_at", "period_from", "period_to"}),
+	}).Create(&row).Error; err != nil {
+		slog.Error("analytics cache persist", "key", key, "error", err)
+	}
+}
+
+// warmup загружает снимки из БД в память при старте, чтобы дашборд не считался
+// с нуля после рестарта/деплоя.
+func (c *periodCache[T]) warmup(ctx context.Context) {
+	if c.db == nil {
+		return
+	}
+	var rows []models.AnalyticsCache
+	if err := c.db.WithContext(ctx).Where("cache_key LIKE ?", c.name+"|%").Find(&rows).Error; err != nil {
+		slog.Error("analytics cache warmup", "name", c.name, "error", err)
+		return
+	}
+	now := time.Now()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, r := range rows {
+		var v T
+		if err := json.Unmarshal([]byte(r.Payload), &v); err != nil {
+			slog.Error("analytics cache warmup unmarshal", "key", r.CacheKey, "error", err)
+			continue
+		}
+		c.items[r.CacheKey] = &cacheItem[T]{
+			value: v, from: r.PeriodFrom, to: r.PeriodTo,
+			computedAt: r.ComputedAt, lastAccess: now,
+		}
+	}
+	if len(rows) > 0 {
+		slog.Info("analytics cache warmed", "name", c.name, "entries", len(rows))
+	}
+}
+
+// refresh пересчитывает горячие ключи и выселяет давно не используемые (из памяти
+// и БД). Ошибка пересчёта оставляет прошлое значение (stale-while-revalidate).
+func (c *periodCache[T]) refresh(ctx context.Context) {
+	now := time.Now()
+	c.mu.Lock()
+	snapshot := make(map[string]*cacheItem[T], len(c.items))
+	for k, v := range c.items {
+		snapshot[k] = v
+	}
+	c.mu.Unlock()
+
+	for k, it := range snapshot {
+		if now.Sub(it.lastAccess) > c.evict {
+			c.mu.Lock()
+			delete(c.items, k)
+			c.mu.Unlock()
+			if c.db != nil {
+				if err := c.db.WithContext(ctx).Where("cache_key = ?", k).Delete(&models.AnalyticsCache{}).Error; err != nil {
+					slog.Error("analytics cache evict", "key", k, "error", err)
+				}
+			}
+			continue
+		}
+		v, err := c.compute(ctx, it.from, it.to)
+		if err != nil {
+			slog.Error("analytics cache refresh", "key", k, "error", err)
+			continue
+		}
+		c.mu.Lock()
+		if cur, ok := c.items[k]; ok {
+			cur.value = v
+			cur.computedAt = now
+		}
+		c.mu.Unlock()
+		c.persist(ctx, k, it.from, it.to, v, now)
+	}
+}

--- a/internal/services/analytics_cache_test.go
+++ b/internal/services/analytics_cache_test.go
@@ -1,0 +1,85 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// db=nil переводит periodCache в чисто in-memory режим (persist/warmup - no-op),
+// что позволяет тестировать логику кэширования без БД.
+
+func TestPeriodCache_GetCachesPerPeriod(t *testing.T) {
+	var calls int64
+	compute := func(_ context.Context, from, _ time.Time) (int, error) {
+		atomic.AddInt64(&calls, 1)
+		return int(from.Unix()), nil
+	}
+	c := newPeriodCache[int](nil, "test", time.Hour, compute)
+	ctx := context.Background()
+	from := time.Date(2026, 6, 14, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 6, 21, 0, 0, 0, 0, time.UTC)
+
+	if _, err := c.get(ctx, from, to); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.get(ctx, from, to); err != nil {
+		t.Fatal(err)
+	}
+	if got := atomic.LoadInt64(&calls); got != 1 {
+		t.Fatalf("compute calls = %d, want 1 (повторный get того же периода должен брать из кэша)", got)
+	}
+
+	if _, err := c.get(ctx, from, to.AddDate(0, 0, 1)); err != nil {
+		t.Fatal(err)
+	}
+	if got := atomic.LoadInt64(&calls); got != 2 {
+		t.Fatalf("compute calls = %d, want 2 (другой период - новый расчёт)", got)
+	}
+}
+
+func TestPeriodCache_RefreshRecomputesHotKey(t *testing.T) {
+	var calls int64
+	compute := func(_ context.Context, _, _ time.Time) (int, error) {
+		return int(atomic.AddInt64(&calls, 1)), nil
+	}
+	c := newPeriodCache[int](nil, "test", time.Hour, compute)
+	ctx := context.Background()
+	from, to := time.Now(), time.Now().Add(time.Hour)
+
+	v1, _ := c.get(ctx, from, to) // calls=1
+	c.refresh(ctx)                // горячий ключ пересчитан, calls=2
+	v2, _ := c.get(ctx, from, to) // из кэша - уже обновлённое значение
+	if v1 == v2 {
+		t.Fatalf("refresh должен пересчитать горячий ключ: v1=%d v2=%d", v1, v2)
+	}
+}
+
+func TestPeriodCache_RefreshEvictsCold(t *testing.T) {
+	var calls int64
+	compute := func(_ context.Context, _, _ time.Time) (int, error) {
+		return int(atomic.AddInt64(&calls, 1)), nil
+	}
+	// evict=0 - любой ключ при refresh считается холодным и выселяется.
+	c := newPeriodCache[int](nil, "test", 0, compute)
+	ctx := context.Background()
+	from, to := time.Now(), time.Now().Add(time.Hour)
+
+	c.get(ctx, from, to) // calls=1, ключ в кэше
+	c.refresh(ctx)       // выселяет (lastAccess старше evict=0)
+	c.get(ctx, from, to) // miss -> снова считает, calls=2
+	if got := atomic.LoadInt64(&calls); got != 2 {
+		t.Fatalf("compute calls = %d, want 2 (после выселения - пересчёт)", got)
+	}
+}
+
+func TestPeriodCache_GetPropagatesError(t *testing.T) {
+	wantErr := errors.New("boom")
+	c := newPeriodCache[int](nil, "test", time.Hour,
+		func(_ context.Context, _, _ time.Time) (int, error) { return 0, wantErr })
+	if _, err := c.get(context.Background(), time.Now(), time.Now()); !errors.Is(err, wantErr) {
+		t.Fatalf("get error = %v, want %v", err, wantErr)
+	}
+}

--- a/internal/services/insights_service.go
+++ b/internal/services/insights_service.go
@@ -21,13 +21,27 @@ const (
 // динамики» (flat), чтобы шум не выглядел трендом.
 const insightDeltaThreshold = 5.0
 
-// GetInsights собирает готовые инсайты за период: пик нагрузки по часам, сравнение
+// GetInsights отдаёт инсайты за период из тёплого кэша (если включён), иначе
+// считает напрямую. Результат кэшируется снимком в БД и переживает рестарт.
+func (s *statisticsService) GetInsights(ctx context.Context, from, to string) (*models.InsightsResponse, error) {
+	if s.insightsCache == nil {
+		return s.computeInsights(ctx, from, to)
+	}
+	f, errF := time.Parse("2006-01-02", from)
+	t, errT := time.Parse("2006-01-02", to)
+	if errF != nil || errT != nil {
+		return s.computeInsights(ctx, from, to) // невалидные даты - мимо кэша
+	}
+	return s.insightsCache.get(ctx, f, t)
+}
+
+// computeInsights собирает инсайты за период: пик нагрузки по часам, сравнение
 // с предыдущим периодом, топ мест и организаций, тренды. Всё считается вызовами
 // RunReport (движок отчётов), нового SQL нет.
 //
 // MVP: ~13 последовательных запросов на вызов. Если станет узким местом — блок
 // comparison (6 запросов) сворачивается в один запрос с двумя CTE по периодам.
-func (s *statisticsService) GetInsights(ctx context.Context, from, to string) (*models.InsightsResponse, error) {
+func (s *statisticsService) computeInsights(ctx context.Context, from, to string) (*models.InsightsResponse, error) {
 	resp := &models.InsightsResponse{
 		PeakHours:   []models.PeakHoursInsight{},
 		Comparisons: []models.ComparisonInsight{},

--- a/internal/services/statistics_service.go
+++ b/internal/services/statistics_service.go
@@ -39,19 +39,95 @@ type StatisticsService interface {
 	CreateReportTemplate(ctx context.Context, userID int, req models.SaveReportTemplateRequest) (*models.ReportTemplate, error)
 	UpdateReportTemplate(ctx context.Context, userID, id int, req models.SaveReportTemplateRequest) (*models.ReportTemplate, error)
 	DeleteReportTemplate(ctx context.Context, userID, id int) error
+
+	// WarmCache прогревает кэш аналитики из БД (вызывать при старте до приёма трафика).
+	WarmCache(ctx context.Context)
+	// StartCacheRefresh запускает фоновое обновление кэша аналитики до отмены ctx
+	// (блокирует, вызывать в горутине). No-op, если кэш отключён.
+	StartCacheRefresh(ctx context.Context)
 }
 
 type statisticsService struct {
-	db *gorm.DB
+	db            *gorm.DB
+	cacheRefresh  time.Duration
+	summaryCache  *periodCache[*models.StatsSummary]
+	insightsCache *periodCache[*models.InsightsResponse]
 }
 
-// NewStatisticsService создаёт реализацию StatisticsService.
-func NewStatisticsService(db *gorm.DB) StatisticsService {
-	return &statisticsService{db: db}
+// NewStatisticsService создаёт реализацию StatisticsService. cacheRefresh > 0
+// включает тёплый кэш дашборда/insights (in-memory + снимок в БД) с обновлением
+// раз в cacheRefresh; 0 - кэш отключён, всё считается на каждый запрос.
+func NewStatisticsService(db *gorm.DB, cacheRefresh time.Duration) StatisticsService {
+	s := &statisticsService{db: db, cacheRefresh: cacheRefresh}
+	if cacheRefresh > 0 {
+		const evict = time.Hour // период, не запрашиваемый дольше часа, выселяется
+		s.summaryCache = newPeriodCache[*models.StatsSummary](db, "summary", evict, s.computeHeavySummary)
+		s.insightsCache = newPeriodCache[*models.InsightsResponse](db, "insights", evict,
+			func(ctx context.Context, from, to time.Time) (*models.InsightsResponse, error) {
+				return s.computeInsights(ctx, from.Format("2006-01-02"), to.Format("2006-01-02"))
+			})
+	}
+	return s
 }
 
-// GetSummary возвращает сводную статистику за период [from, to].
+// WarmCache загружает снимки аналитики из БД в память (прогрев после рестарта).
+func (s *statisticsService) WarmCache(ctx context.Context) {
+	if s.summaryCache != nil {
+		s.summaryCache.warmup(ctx)
+	}
+	if s.insightsCache != nil {
+		s.insightsCache.warmup(ctx)
+	}
+}
+
+// StartCacheRefresh периодически обновляет кэш аналитики до отмены ctx.
+func (s *statisticsService) StartCacheRefresh(ctx context.Context) {
+	if s.cacheRefresh <= 0 {
+		return
+	}
+	ticker := time.NewTicker(s.cacheRefresh)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if s.summaryCache != nil {
+				s.summaryCache.refresh(ctx)
+			}
+			if s.insightsCache != nil {
+				s.insightsCache.refresh(ctx)
+			}
+		}
+	}
+}
+
+// GetSummary возвращает сводную статистику за период [from, to]. Тяжёлые агрегаты
+// берутся из тёплого кэша (если включён), realtime-показатели (онлайн, на
+// территории) всегда считаются на лету и домешиваются к снимку.
 func (s *statisticsService) GetSummary(ctx context.Context, from, to time.Time) (*models.StatsSummary, error) {
+	var heavy *models.StatsSummary
+	var err error
+	if s.summaryCache != nil {
+		heavy, err = s.summaryCache.get(ctx, from, to)
+	} else {
+		heavy, err = s.computeHeavySummary(ctx, from, to)
+	}
+	if err != nil {
+		return nil, err
+	}
+	// Копия, чтобы realtime-поля не мутировали общий кэшированный снимок.
+	out := *heavy
+	if err := s.computeRealtimeSummary(ctx, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// computeHeavySummary считает дорогие агрегаты за период и медленно меняющиеся
+// счётчики - всё, что кэшируется. Realtime-показатели здесь не заполняются, их
+// добавляет computeRealtimeSummary.
+func (s *statisticsService) computeHeavySummary(ctx context.Context, from, to time.Time) (*models.StatsSummary, error) {
 	var summary models.StatsSummary
 
 	// total_applications
@@ -153,38 +229,6 @@ func (s *statisticsService) GetSummary(ctx context.Context, from, to time.Time) 
 	}
 	summary.ItemsSum = itemsSum.Sum
 
-	// cars_on_territory (territory_status = 1)
-	if err := s.db.WithContext(ctx).
-		Table("cars").
-		Where("territory_status = 1").
-		Count(&summary.CarsOnTerritory).Error; err != nil {
-		return nil, fmt.Errorf("statistics: cars_on_territory: %w", err)
-	}
-
-	// people_on_territory (territory_status = 1)
-	if err := s.db.WithContext(ctx).
-		Table("employees").
-		Where("territory_status = 1").
-		Count(&summary.PeopleOnTerritory).Error; err != nil {
-		return nil, fmt.Errorf("statistics: people_on_territory: %w", err)
-	}
-
-	// users_online: онлайн = активность (last_seen) за последние onlineWindowMinutes.
-	online, err := s.countOnline(ctx, time.Now().UTC())
-	if err != nil {
-		return nil, fmt.Errorf("statistics: users_online: %w", err)
-	}
-	summary.UsersOnline = online
-
-	// users_online_peak_today: пик одновременного онлайна за сегодня из снимков тикера.
-	if err := s.db.WithContext(ctx).
-		Table("user_online_peaks").
-		Where("date = ?", time.Now().UTC().Format("2006-01-02")).
-		Select("COALESCE(MAX(peak_count), 0)").
-		Scan(&summary.UsersOnlinePeakToday).Error; err != nil {
-		return nil, fmt.Errorf("statistics: users_online_peak_today: %w", err)
-	}
-
 	// active_users
 	if err := s.db.WithContext(ctx).
 		Table("users").
@@ -248,6 +292,44 @@ func (s *statisticsService) GetSummary(ctx context.Context, from, to time.Time) 
 	}
 
 	return &summary, nil
+}
+
+// computeRealtimeSummary заполняет показатели текущего состояния: на территории
+// и онлайн. Дёшево (точечные запросы), считается на каждый запрос дашборда.
+func (s *statisticsService) computeRealtimeSummary(ctx context.Context, summary *models.StatsSummary) error {
+	// cars_on_territory (territory_status = 1)
+	if err := s.db.WithContext(ctx).
+		Table("cars").
+		Where("territory_status = 1").
+		Count(&summary.CarsOnTerritory).Error; err != nil {
+		return fmt.Errorf("statistics: cars_on_territory: %w", err)
+	}
+
+	// people_on_territory (territory_status = 1)
+	if err := s.db.WithContext(ctx).
+		Table("employees").
+		Where("territory_status = 1").
+		Count(&summary.PeopleOnTerritory).Error; err != nil {
+		return fmt.Errorf("statistics: people_on_territory: %w", err)
+	}
+
+	// users_online: онлайн = активность (last_seen) за последние onlineWindowMinutes.
+	online, err := s.countOnline(ctx, time.Now().UTC())
+	if err != nil {
+		return fmt.Errorf("statistics: users_online: %w", err)
+	}
+	summary.UsersOnline = online
+
+	// users_online_peak_today: пик одновременного онлайна за сегодня из снимков тикера.
+	if err := s.db.WithContext(ctx).
+		Table("user_online_peaks").
+		Where("date = ?", time.Now().UTC().Format("2006-01-02")).
+		Select("COALESCE(MAX(peak_count), 0)").
+		Scan(&summary.UsersOnlinePeakToday).Error; err != nil {
+		return fmt.Errorf("statistics: users_online_peak_today: %w", err)
+	}
+
+	return nil
 }
 
 // onlineThreshold — граница окна онлайна на момент now: пользователь онлайн, если


### PR DESCRIPTION
## Что
Три самостоятельных улучшения под нагрузку и эксплуатацию (цель — 1-2k одновременных пользователей на сервере 6 ядер / 32 ГБ).

### Ресурсы prod (6 ядер / 32 ГБ)
В prod-оверлее сняты лимиты памяти (`!reset`), Postgres настроен под 32 ГБ (`shared_buffers`, `effective_cache_size`, `max_connections`) — без этого БД сидела бы на дефолтных 128 МБ. Go зафиксирован под 6 ядер (`GOMAXPROCS`/`GOMEMLIMIT`).

### Ротация stdout-логов
При заданном `LOG_FILE_PATH` логи пишутся через MultiWriter и в stdout (docker logs), и в ротируемый файл (lumberjack, `MaxAge` 30 дней). Без переменной — поведение прежнее.

### Тёплый кэш аналитики
`GetSummary` (22 запроса) и insights (~13) считались на каждый запрос, а после рестарта — с нуля. summary разделён на тяжёлые агрегаты (кэшируются) и realtime (онлайн/территория — на лету). Снимок в `analytics_cache` прогревается из БД при старте. Без Redis. Управляется `ANALYTICS_CACHE_REFRESH_SEC`.

## Проверка (dev-стек)
build/vet чистые, unit-тесты `periodCache` зелёные, ротация и кэш проверены вживую (`analytics cache warmed entries=1` после рестарта).

Партиции `request_logs` + дневные агрегаты и редизайн экрана `/admin/requests` — отдельным PR.