### PR TITLE
test(e2e): починил admin-тесты под рефактор UserControl и delete-модалок

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -80,14 +80,14 @@ jobs:
         run: |
           nohup ./bin/server > backend.log 2>&1 &
           echo $! > backend.pid
-          for i in $(seq 1 60); do
+          for i in $(seq 1 120); do
             if curl -sf http://localhost:8080/health > /dev/null; then
               echo "backend ready after ${i}s"
               exit 0
             fi
             sleep 1
           done
-          echo "::error::backend did not become healthy in 60s"
+          echo "::error::backend did not become healthy in 120s"
           echo "--- backend.log ---"
           cat backend.log || true
           exit 1

--- a/frontend/e2e/pages/UserControlPage.cjs
+++ b/frontend/e2e/pages/UserControlPage.cjs
@@ -19,8 +19,10 @@ class UserControlPage {
     // "Пользователи не найдены", без поиска - "Пользователи отсутствуют".
     this.emptyState = this.root.locator('.no-users');
 
-    this.detailsPanel = this.root.locator('.user-details-panel');
-    this.detailsTitle = this.detailsPanel.getByRole('heading', { name: 'Редактирование' });
+    // Редактирование переехало в модалку (#739): клик по строке открывает BaseModal
+    // c content-class user-edit-modal (телепортируется на body - ищем от page).
+    this.editModal = page.locator('.user-edit-modal');
+    this.detailsTitle = this.editModal.getByRole('heading', { name: 'Редактирование' });
   }
 
   async goto() {
@@ -42,7 +44,7 @@ class UserControlPage {
 
   async selectUser(username) {
     await this.row(username).click();
-    await this.detailsPanel.waitFor({ state: 'visible' });
+    await this.editModal.waitFor({ state: 'visible' });
   }
 
   async firstRowLogin() {

--- a/frontend/e2e/pages/UserControlPage.cjs
+++ b/frontend/e2e/pages/UserControlPage.cjs
@@ -21,7 +21,6 @@ class UserControlPage {
 
     this.detailsPanel = this.root.locator('.user-details-panel');
     this.detailsTitle = this.detailsPanel.getByRole('heading', { name: 'Редактирование' });
-    this.noSelectionMessage = this.root.locator('.no-selection-message');
   }
 
   async goto() {

--- a/frontend/e2e/tests/admin-groups-ui-delete.spec.cjs
+++ b/frontend/e2e/tests/admin-groups-ui-delete.spec.cjs
@@ -45,8 +45,9 @@ test.describe('AdminPermissionGroups - UI delete + tree open', () => {
     const groupsPage = new AdminPermissionGroupsPage(page);
     await groupsPage.goto();
 
-    page.once('dialog', dialog => dialog.accept().catch(() => {}));
     await groupsPage.clickDelete(name);
+    // Нативный confirm заменён на кастомную модалку ConfirmDialog - подтверждаем в ней.
+    await page.getByTestId('confirm-ok').click();
 
     await expect(groupsPage.card(name)).toHaveCount(0, { timeout: 5000 });
 

--- a/frontend/e2e/tests/admin-roles-ui-edit-delete.spec.cjs
+++ b/frontend/e2e/tests/admin-roles-ui-edit-delete.spec.cjs
@@ -51,9 +51,9 @@ test.describe('AdminRoles - UI edit/delete карточек', () => {
     const rolesPage = new AdminRolesPage(page);
     await rolesPage.goto();
 
-    // confirm dialog - принимаем
-    page.once('dialog', dialog => dialog.accept().catch(() => {}));
     await rolesPage.clickDelete(code);
+    // Нативный confirm заменён на кастомную модалку ConfirmDialog - подтверждаем в ней.
+    await page.getByTestId('confirm-ok').click();
 
     // Карточка пропала
     await expect(rolesPage.card(code)).toHaveCount(0, { timeout: 5000 });

--- a/frontend/e2e/tests/admin-usercontrol.spec.cjs
+++ b/frontend/e2e/tests/admin-usercontrol.spec.cjs
@@ -20,7 +20,8 @@ test.describe('UserControl - страница /admin/users', () => {
     expect(await users.rows.count()).toBeGreaterThan(0);
     // Футер отражает число строк - супер-админ видит ненулевой список.
     await expect(users.itemsCount).toContainText('Всего пользователей');
-    await expect(users.noSelectionMessage).toBeVisible();
+    // Пока пользователь не выбран, панель деталей скрыта (no-selection-заглушку убрали в #739).
+    await expect(users.detailsPanel).toBeHidden();
   });
 
   test('поиск сужает список до совпадающих строк', async () => {
@@ -53,7 +54,9 @@ test.describe('UserControl - страница /admin/users', () => {
   });
 
   test('выбор пользователя открывает detail-панель редактирования', async () => {
-    await expect(users.noSelectionMessage).toBeVisible();
+    // Дожидаемся загрузки списка, затем проверяем, что панель деталей пока скрыта.
+    await expect(users.rows.first()).toBeVisible();
+    await expect(users.detailsPanel).toBeHidden();
 
     const login = (await users.firstRowLogin()).trim();
     await users.selectUser(login);
@@ -62,6 +65,5 @@ test.describe('UserControl - страница /admin/users', () => {
     await expect(users.detailsTitle).toBeVisible();
     // Подзаголовок панели цитирует логин выбранной записи.
     await expect(users.detailsPanel).toContainText(login);
-    await expect(users.noSelectionMessage).toBeHidden();
   });
 });

--- a/frontend/e2e/tests/admin-usercontrol.spec.cjs
+++ b/frontend/e2e/tests/admin-usercontrol.spec.cjs
@@ -21,7 +21,7 @@ test.describe('UserControl - страница /admin/users', () => {
     // Футер отражает число строк - супер-админ видит ненулевой список.
     await expect(users.itemsCount).toContainText('Всего пользователей');
     // Пока пользователь не выбран, панель деталей скрыта (no-selection-заглушку убрали в #739).
-    await expect(users.detailsPanel).toBeHidden();
+    await expect(users.editModal).toBeHidden();
   });
 
   test('поиск сужает список до совпадающих строк', async () => {
@@ -56,14 +56,14 @@ test.describe('UserControl - страница /admin/users', () => {
   test('выбор пользователя открывает detail-панель редактирования', async () => {
     // Дожидаемся загрузки списка, затем проверяем, что панель деталей пока скрыта.
     await expect(users.rows.first()).toBeVisible();
-    await expect(users.detailsPanel).toBeHidden();
+    await expect(users.editModal).toBeHidden();
 
     const login = (await users.firstRowLogin()).trim();
     await users.selectUser(login);
 
-    await expect(users.detailsPanel).toBeVisible();
+    await expect(users.editModal).toBeVisible();
     await expect(users.detailsTitle).toBeVisible();
     // Подзаголовок панели цитирует логин выбранной записи.
-    await expect(users.detailsPanel).toContainText(login);
+    await expect(users.editModal).toContainText(login);
   });
 });


### PR DESCRIPTION
## Проблема
admin-E2E (`admin-usercontrol`, `admin-roles-ui-edit-delete`, `admin-groups-ui-delete`) падали на всех PR начиная с ~23:39 MSK — после серии admin-рефакторов (#739, #738, #748, notify-рефакторы). Тесты не обновили под новый UI.

## Причины и фиксы
- **UserControl (#739)**: убрана `no-selection`-заглушка, панель деталей теперь `v-if` по выбору. Тесты ждали `.no-selection-message` → заменил на проверку «панель деталей скрыта, пока не выбран». Добавил ожидание загрузки списка перед чтением первой строки.
- **Удаление ролей и групп**: нативный `confirm()` заменён на кастомную модалку `ConfirmDialog` (notify-рефактор). Тесты ждали нативный `dialog` через `page.once('dialog')` → переключил на клик `[data-testid="confirm-ok"]` в модалке.

## Проверка
Локально (dev-стек) roles/groups Delete и usercontrol-логика проходят стабильно. Локальный vite-dev даёт cold-compile флейк на `login` (в CI prod-build его нет) — финальная проверка через CI E2E здесь.

Не связано с PR #751 (тот backend-only); это починка чужой регрессии admin-UI.