### PR TITLE
fix(security): фильтры в "Доступные мне" под раскладку Центра заявок

### DIFF
--- a/frontend/src/views/AccessibleAttachmentsView.vue
+++ b/frontend/src/views/AccessibleAttachmentsView.vue
@@ -56,9 +56,9 @@
           @update:model-value="setCompany"
         />
         <button
-          v-if="hasActiveFilters"
           type="button"
-          class="lk-button lk-button--secondary filters__reset"
+          class="lk-button lk-button--danger filters__reset"
+          :disabled="!hasActiveFilters"
           data-testid="aa-filter-reset"
           @click="resetFilters"
         >
@@ -534,17 +534,18 @@ onBeforeUnmount(() => clearTimeout(searchTimer));
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: 10px;
   padding: 12px 20px;
   border-bottom: 1px solid #e6e6e6;
 }
 
+/* Раскладка как в Центре заявок: поиск фикс. ширины + дропдауны фикс. ширины в
+   один ряд с переносом. Поиск не растягиваем на всю строку, дропдауны не тянем -
+   иначе ширины скачут, а кнопка сброса (всегда видима, :disabled) не двигает ряд. */
 .filters__search {
   position: relative;
-  /* Поиск занимает свою строку целиком, дропдауны выстраиваются рядом ниже -
-     иначе растущий инпут отталкивает первый дропдаун к правому краю. */
-  flex: 1 1 100%;
-  min-width: 200px;
+  flex: 0 1 280px;
+  min-width: 220px;
 }
 
 .filters__search-icon {
@@ -563,12 +564,18 @@ onBeforeUnmount(() => clearTimeout(searchTimer));
 }
 
 .filters__dropdown {
-  flex: 1 1 160px;
-  min-width: 160px;
+  flex: 0 0 180px;
 }
 
 .filters__reset {
   flex-shrink: 0;
+}
+
+@media (max-width: 640px) {
+  .filters__search,
+  .filters__dropdown {
+    flex: 1 1 100%;
+  }
 }
 
 .content-container {

--- a/frontend/src/views/__tests__/AccessibleAttachmentsView.spec.js
+++ b/frontend/src/views/__tests__/AccessibleAttachmentsView.spec.js
@@ -261,4 +261,23 @@ describe('AccessibleAttachmentsView (FE-S6) фильтры', () => {
     expect(lastArg).toMatchObject({ page: 1, per_page: 30 });
     expect(replace).toHaveBeenLastCalledWith({ query: {} });
   });
+
+  it('кнопка сброса всегда в DOM: disabled без фильтров, активна с фильтром', async () => {
+    getAccessibleAttachments.mockResolvedValue({ items: [], meta: { total: 0 } });
+
+    wrapper = mountView();
+    await flushPromises();
+    // Кнопка не исчезает (раньше была через v-if и двигала ряд при появлении),
+    // а просто блокируется, пока нет активных фильтров.
+    const reset = wrapper.find('[data-testid="aa-filter-reset"]');
+    expect(reset.exists()).toBe(true);
+    expect(reset.attributes('disabled')).toBeDefined();
+    wrapper.unmount();
+
+    wrapper = mountView({ type: 'cars' });
+    await flushPromises();
+    expect(
+      wrapper.find('[data-testid="aa-filter-reset"]').attributes('disabled'),
+    ).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Панель поиска и фильтров во вкладке "Доступные мне" (охранник) выглядела криво: поиск занимал всю строку (`flex: 1 1 100%`), дропдауны растягивались разной шириной, а кнопка "Сбросить" рендерилась через `v-if` и при появлении сдвигала весь ряд фильтров.

Привёл к раскладке "Центра заявок":
- поиск фиксированной ширины (280px), не растягивается на строку;
- дропдауны фиксированной ширины (180px), не скачут;
- кнопка "Сбросить" всегда в DOM, блокируется через `:disabled` пока нет активных фильтров - ряд больше не двигается;
- на узких экранах (<640px) поиск и дропдауны разворачиваются на всю ширину.

Логика фильтров (debounce, seq-токен, URL-как-state) не менялась. Добавлен тест на новое поведение кнопки сброса. Срез S1 пакета правок "Доступные мне" (#706).