### PR TITLE
fix(security): фильтр "Завершённые" и читаемые места в "Доступные мне"

### DIFF
--- a/frontend/src/views/AccessibleAttachmentsView.vue
+++ b/frontend/src/views/AccessibleAttachmentsView.vue
@@ -57,6 +57,16 @@
         />
         <button
           type="button"
+          class="lk-button filters__toggle"
+          :class="completedFilter ? 'lk-button--primary' : 'lk-button--ghost'"
+          :aria-pressed="completedFilter"
+          data-testid="aa-filter-completed"
+          @click="toggleCompleted"
+        >
+          Завершённые
+        </button>
+        <button
+          type="button"
           class="lk-button lk-button--danger filters__reset"
           :disabled="!hasActiveFilters"
           data-testid="aa-filter-reset"
@@ -296,6 +306,9 @@ const search = ref(typeof route.query.search === 'string' ? route.query.search :
 const typeFilter = ref(VALID_TYPES.includes(route.query.type) ? route.query.type : '');
 const orgFilter = ref(Number(route.query.organization) || 0);
 const companyFilter = ref(Number(route.query.company) || 0);
+// Завершённые заявки по умолчанию скрыты; тоггл показывает только их. При активном
+// поиске бэк отдаёт и завершённые, и нет независимо от флага (см. сервис фильтра).
+const completedFilter = ref(route.query.completed === '1');
 
 const typeOptions = [
   { id: '', name: 'Все типы' },
@@ -310,7 +323,8 @@ const hasActiveFilters = computed(
   () => !!search.value.trim()
     || !!typeFilter.value
     || orgFilter.value !== 0
-    || companyFilter.value !== 0,
+    || companyFilter.value !== 0
+    || completedFilter.value,
 );
 
 const items = ref([]);
@@ -367,6 +381,7 @@ function buildParams() {
   if (typeFilter.value) params.attachment_type = typeFilter.value;
   if (orgFilter.value) params.organization_id = orgFilter.value;
   if (companyFilter.value) params.company_id = companyFilter.value;
+  if (completedFilter.value) params.completed = true;
   return params;
 }
 
@@ -377,6 +392,7 @@ function syncUrl() {
   if (typeFilter.value) query.type = typeFilter.value;
   if (orgFilter.value) query.organization = String(orgFilter.value);
   if (companyFilter.value) query.company = String(companyFilter.value);
+  if (completedFilter.value) query.completed = '1';
   // catch гасит navigation-cancel при быстрой смене фильтров: vue-router отклоняет
   // отменённую replace - это не ошибка приложения, а нормальная гонка ввода.
   router.replace({ query }).catch(() => {});
@@ -433,12 +449,18 @@ function setCompany(value) {
   applyFilters();
 }
 
+function toggleCompleted() {
+  completedFilter.value = !completedFilter.value;
+  applyFilters();
+}
+
 function resetFilters() {
   clearTimeout(searchTimer);
   search.value = '';
   typeFilter.value = '';
   orgFilter.value = 0;
   companyFilter.value = 0;
+  completedFilter.value = false;
   applyFilters();
 }
 
@@ -567,6 +589,7 @@ onBeforeUnmount(() => clearTimeout(searchTimer));
   flex: 0 0 180px;
 }
 
+.filters__toggle,
 .filters__reset {
   flex-shrink: 0;
 }

--- a/frontend/src/views/__tests__/AccessibleAttachmentsView.spec.js
+++ b/frontend/src/views/__tests__/AccessibleAttachmentsView.spec.js
@@ -222,6 +222,37 @@ describe('AccessibleAttachmentsView (FE-S6) фильтры', () => {
     expect(replace).toHaveBeenLastCalledWith({ query: { organization: '7' } });
   });
 
+  it('тоггл "Завершённые" шлёт completed, пишет URL и восстанавливается из query', async () => {
+    getAccessibleAttachments.mockResolvedValue({ items: [], meta: { total: 0 } });
+    wrapper = mountView();
+    await flushPromises();
+    getAccessibleAttachments.mockClear();
+
+    await wrapper.find('[data-testid="aa-filter-completed"]').trigger('click');
+    await flushPromises();
+
+    expect(getAccessibleAttachments).toHaveBeenCalledWith(
+      expect.objectContaining({ completed: true, page: 1 }),
+    );
+    expect(replace).toHaveBeenLastCalledWith({ query: { completed: '1' } });
+
+    // Повторный клик снимает фильтр - completed уходит из параметров и URL.
+    getAccessibleAttachments.mockClear();
+    await wrapper.find('[data-testid="aa-filter-completed"]').trigger('click');
+    await flushPromises();
+    expect(getAccessibleAttachments.mock.calls.at(-1)[0]).not.toHaveProperty('completed');
+    expect(replace).toHaveBeenLastCalledWith({ query: {} });
+
+    wrapper.unmount();
+    // Диплинк ?completed=1 восстанавливает фильтр одним стартовым запросом.
+    getAccessibleAttachments.mockClear();
+    wrapper = mountView({ completed: '1' });
+    await flushPromises();
+    expect(getAccessibleAttachments).toHaveBeenCalledWith(
+      expect.objectContaining({ completed: true }),
+    );
+  });
+
   it('поиск применяется после debounce и шлёт search', async () => {
     vi.useFakeTimers();
     try {

--- a/internal/handlers/security_visibility_test.go
+++ b/internal/handlers/security_visibility_test.go
@@ -77,6 +77,21 @@ func (w secWorld) newAttachment(t *testing.T, appID int, atype string) int {
 	return att.ID
 }
 
+func (w secWorld) newAppWithStatus(t *testing.T, confirmation, status string) int {
+	t.Helper()
+	now := time.Now()
+	conf, st := confirmation, status
+	app := models.Application{
+		OrganizationID:  w.orgID,
+		SenderUserID:    w.senderID,
+		Confirmation:    &conf,
+		Status:          &st,
+		SendingDatetime: &now,
+	}
+	require.NoError(t, w.db.Create(&app).Error)
+	return app.ID
+}
+
 func (w secWorld) newUnloadPlace(t *testing.T, name string, active bool) int {
 	t.Helper()
 	p := models.UnloadPlace{Name: name, IsActive: active}
@@ -87,6 +102,14 @@ func (w secWorld) newUnloadPlace(t *testing.T, name string, active bool) int {
 func (w secWorld) newPeopleTable(t *testing.T, name string) int {
 	t.Helper()
 	st := models.SystemTable{Name: name, TableType: "people", IsActive: true}
+	require.NoError(t, w.db.Create(&st).Error)
+	return st.ID
+}
+
+func (w secWorld) newPeopleTableWithDisplay(t *testing.T, name, display string) int {
+	t.Helper()
+	d := display
+	st := models.SystemTable{Name: name, DisplayName: &d, TableType: "people", IsActive: true}
 	require.NoError(t, w.db.Create(&st).Error)
 	return st.ID
 }
@@ -373,4 +396,63 @@ func TestCanSecurityViewAttachment(t *testing.T) {
 	can, err = w.svc.CanSecurityViewAttachment(ctx, w.guardID, true, pendingAtt)
 	require.NoError(t, err)
 	require.False(t, can, "approved-gate applies to super-admin")
+}
+
+func TestGetAvailableAttachments_CompletedFilter(t *testing.T) {
+	w := setupSecurityWorld(t)
+	ctx := context.Background()
+
+	myPlace := w.newUnloadPlace(t, "Склад А", true)
+	w.assignUnloadPlace(t, myPlace)
+
+	activeApp := w.newAppWithStatus(t, models.ConfirmationApproved, models.StatusInWork)
+	activeAtt := w.newAttachmentNamed(t, activeApp, "cars", "Ромашка активная")
+	w.attachPlace(t, activeAtt, myPlace)
+
+	doneApp := w.newAppWithStatus(t, models.ConfirmationApproved, models.StatusCompleted)
+	doneAtt := w.newAttachmentNamed(t, doneApp, "cars", "Ромашка завершённая")
+	w.attachPlace(t, doneAtt, myPlace)
+
+	// Дефолт вкладки: завершённые скрыты.
+	rows, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, false, services.AvailableAttachmentFilters{}, 1, 50)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, total)
+	require.True(t, secContainsAttachment(rows, activeAtt))
+	require.False(t, secContainsAttachment(rows, doneAtt), "завершённые скрыты по умолчанию")
+
+	// Фильтр "Завершённые": только завершённые.
+	completed := true
+	rows, total, err = w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, false, services.AvailableAttachmentFilters{Completed: &completed}, 1, 50)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, total)
+	require.True(t, secContainsAttachment(rows, doneAtt))
+	require.False(t, secContainsAttachment(rows, activeAtt), "фильтр Завершённые показывает только их")
+
+	// Поиск отменяет статус-предикат: видны и завершённые, и нет (даже при completed=true).
+	query := "Ромашка"
+	rows, total, err = w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, false, services.AvailableAttachmentFilters{Search: &query, Completed: &completed}, 1, 50)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, total, "поиск показывает и завершённые, и незавершённые")
+	require.True(t, secContainsAttachment(rows, activeAtt))
+	require.True(t, secContainsAttachment(rows, doneAtt))
+}
+
+func TestGetAvailableAttachments_PeoplePlacesUseDisplayName(t *testing.T) {
+	w := setupSecurityWorld(t)
+	ctx := context.Background()
+
+	// system_tables.name - технический код (post_72), display_name - человекочитаемое. В карточке
+	// "Места" должно быть display_name, а не код (баг "Места: post_72").
+	myTable := w.newPeopleTableWithDisplay(t, "post_72", "КПП Север")
+	w.assignTable(t, myTable)
+
+	app := w.newApp(t, models.ConfirmationApproved)
+	att := w.newAttachment(t, app, "people")
+	w.attachEmployeeWithTable(t, att, myTable)
+
+	rows, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, false, services.AvailableAttachmentFilters{}, 1, 50)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, total)
+	require.NotNil(t, rows[0].Places)
+	require.Equal(t, "КПП Север", *rows[0].Places, "места прохода показывают display_name, не код")
 }

--- a/internal/services/security_visibility_service.go
+++ b/internal/services/security_visibility_service.go
@@ -50,6 +50,10 @@ type AvailableAttachmentFilters struct {
 	AttachmentType *string `query:"attachment_type"`
 	OrganizationID *int    `query:"organization_id"`
 	CompanyID      *int    `query:"company_id"`
+	// Completed управляет видимостью завершённых заявок (status='Завершено'): nil/false - скрыть
+	// завершённые (дефолт вкладки), true - показать только завершённые. При активном Search не
+	// применяется (поиск отдаёт и завершённые, и нет) - см. availableAttachmentFilterWhere.
+	Completed *bool `query:"completed"`
 }
 
 // availableAttachmentFrom - общий FROM листинга и счётчика "Доступные мне". LEFT JOIN'ы
@@ -84,7 +88,7 @@ const availableAttachmentSelect = `
 	format_short_name(su.last_name, su.first_name, su.middle_name) as sender_name,
 	format_full_name(su.last_name, su.first_name, su.middle_name) as sender_full_name,
 	CASE WHEN a.attachment_type = 'people' THEN (
-		SELECT string_agg(DISTINCT st.name, ', ')
+		SELECT string_agg(DISTINCT COALESCE(st.display_name, st.name), ', ')
 		FROM employees e
 		JOIN employee_target_tables ett ON ett.employee_id = e.id
 		JOIN system_tables st ON st.id = ett.table_id
@@ -136,6 +140,9 @@ func availableAttachmentFilterWhere(f AvailableAttachmentFilters) (string, []int
 	var clauses []string
 	var args []interface{}
 
+	// Поиск отдаёт и завершённые, и незавершённые: при активном search статус-предикат не вешаем.
+	searchActive := f.Search != nil && strings.TrimSpace(*f.Search) != ""
+
 	if f.AttachmentType != nil {
 		switch t := *f.AttachmentType; t {
 		case "cars", "people", "items":
@@ -150,6 +157,17 @@ func availableAttachmentFilterWhere(f AvailableAttachmentFilters) (string, []int
 	if f.CompanyID != nil {
 		clauses = append(clauses, "app.company_id = ?")
 		args = append(args, *f.CompanyID)
+	}
+	// Дефолт вкладки - скрыть завершённые; фильтр "Завершённые" (completed=true) - только их.
+	// IS DISTINCT FROM, чтобы строки с NULL-статусом попадали в дефолтную выдачу (не исключались).
+	if !searchActive {
+		if f.Completed != nil && *f.Completed {
+			clauses = append(clauses, "app.status = ?")
+			args = append(args, models.StatusCompleted)
+		} else {
+			clauses = append(clauses, "app.status IS DISTINCT FROM ?")
+			args = append(args, models.StatusCompleted)
+		}
 	}
 	if f.Search != nil {
 		if s := strings.TrimSpace(*f.Search); s != "" {


### PR DESCRIPTION
Срез S2 пакета правок "Доступные мне" (#706).

**Места: post_72 → название.** В карточке вложения секция "Места" для типа people показывала технический код `system_tables.name` (напр. `post_72`) вместо человекочитаемого `display_name`. Подзапрос `places` теперь агрегирует `COALESCE(st.display_name, st.name)` (фолбэк на код, если display_name пуст). Места разгрузки (ELSE-ветка, `unload_places.name`) не трогал - у них нет display_name.

**Фильтр "Завершённые".** Завершённые заявки (`status = "Завершено"`) больше не отображаются в списке по умолчанию. Поведение:
- дефолт: `app.status IS DISTINCT FROM Завершено` (null-статус попадает в выдачу);
- тоггл "Завершённые" (`completed=true`): только завершённые;
- при активном поиске статус-предикат не применяется - поиск отдаёт и завершённые, и незавершённые (явное требование).

Инвариант видимости (`confirmation=Согласовано` + пересечение мест охранника) не менялся - статус-фильтр аддитивен поверх него. Деталь и `CanSecurityViewAttachment` статусом не гейтятся (завершённое можно открыть по прямой ссылке).

FE: тоггл в панели фильтров (`completed` в query-параметрах и URL-как-state, сброс пагинации). Тесты: BE handler-тесты (дефолт прячет / фильтр показывает только / поиск показывает оба / места = display_name), FE-тест тоггла. Полный `go test ./internal/handlers/` (DB) зелёный.