### PR TITLE
feat(security): предпросмотр заполненного бланка в "Доступные мне"

### DIFF
--- a/frontend/src/api/attachment-templates.js
+++ b/frontend/src/api/attachment-templates.js
@@ -180,6 +180,22 @@ export async function downloadBlank(applicationID, attachmentID) {
 }
 
 /**
+ * Загрузить заполненный бланк вложения как ArrayBuffer для предпросмотра в XlsxViewer (#706 S4).
+ * Тот же эндпоинт, что downloadBlank, но без сохранения в файл - буфер парсит exceljs во вьювере.
+ * @param {number} applicationID
+ * @param {number} attachmentID
+ * @returns {Promise<ArrayBuffer>}
+ */
+export async function previewBlank(applicationID, attachmentID) {
+  const { apiRequestRaw } = await import('./client');
+  const res = await apiRequestRaw(`/applications/${applicationID}/blank?attachment_id=${attachmentID}`);
+  if (!res.ok) {
+    throw new Error(`Failed to preview blank: ${res.status}`);
+  }
+  return res.arrayBuffer();
+}
+
+/**
  * Триггерит сохранение Blob под filename на стороне браузера.
  */
 export function saveBlobAs(blob, filename) {

--- a/frontend/src/views/AccessibleAttachmentsView.vue
+++ b/frontend/src/views/AccessibleAttachmentsView.vue
@@ -235,6 +235,21 @@
               </div>
             </div>
 
+            <div
+              v-if="detail.attachment.has_blank"
+              class="detail-actions"
+            >
+              <button
+                type="button"
+                class="lk-button lk-button--primary"
+                :disabled="previewLoading"
+                data-testid="aa-preview-blank"
+                @click="openPreview"
+              >
+                {{ previewLoading ? 'Загрузка...' : 'Посмотреть файл' }}
+              </button>
+            </div>
+
             <!-- AvailableAttachment не несёт roof_access/free_parking/custom_values -
                  эти опц. блоки детали просто не отрисуются (v-if по undefined). -->
             <ApplicationAttachmentDetail
@@ -255,6 +270,35 @@
         </div>
       </div>
     </div>
+
+    <BaseModal
+      :show="previewOpen"
+      title="Предпросмотр бланка"
+      width="900px"
+      @close="closePreview"
+    >
+      <div class="blank-preview">
+        <div
+          v-if="previewLoading"
+          class="blank-preview__state"
+          data-testid="aa-preview-loading"
+        >
+          Загрузка превью...
+        </div>
+        <div
+          v-else-if="previewError"
+          class="blank-preview__state blank-preview__state--error"
+          data-testid="aa-preview-error"
+        >
+          {{ previewError }}
+        </div>
+        <XlsxViewer
+          v-else
+          :file-buffer="previewBuffer"
+          data-testid="aa-preview-viewer"
+        />
+      </div>
+    </BaseModal>
   </AdminPageShell>
 </template>
 
@@ -268,7 +312,10 @@ import Badge from '@/components/ui/Badge.vue';
 import StatusBadge from '@/components/ui/StatusBadge.vue';
 import SkeletonCard from '@/components/ui/SkeletonCard.vue';
 import ApplicationAttachmentDetail from '@/components/ApplicationDetail/ApplicationAttachmentDetail.vue';
+import BaseModal from '@/components/ui/BaseModal.vue';
+import XlsxViewer from '@/components/admin/XlsxViewer.vue';
 import { getAccessibleAttachments, getAccessibleAttachmentDetail } from '@/api/applications';
+import { previewBlank } from '@/api/attachment-templates';
 import { getOrganizations, getCompanies } from '@/api/organizations';
 import { useDeletionsStore } from '@/stores/deletions';
 import { formatDateRu, formatDateTime } from '@/utils/datetime';
@@ -317,6 +364,13 @@ const listLoading = ref(false);
 
 const selectedId = ref(null);
 const detail = ref(null);
+
+// Предпросмотр заполненного бланка (#706 S4): модалка с XlsxViewer по тому же
+// эндпоинту, что и скачивание, но буфер парсится во вьювере, а не сохраняется файлом.
+const previewOpen = ref(false);
+const previewBuffer = ref(null);
+const previewLoading = ref(false);
+const previewError = ref('');
 // Токен последовательности: быстрые клики по карточкам пускают параллельные
 // запросы детали в общий ref, и медленный ответ предыдущего вложения мог бы
 // затереть актуальный (#632). Применяем только ответ последнего запроса.
@@ -517,6 +571,30 @@ async function selectAttachment(id) {
       suffix: 'вложение',
     });
   }
+}
+
+// Открывается по явному клику на текущей детали; модалка-оверлей блокирует список,
+// так что гонки с переключением вложения нет. Двойной клик гасит :disabled по previewLoading.
+async function openPreview() {
+  const att = detail.value?.attachment;
+  if (!att) return;
+  previewOpen.value = true;
+  previewError.value = '';
+  previewBuffer.value = null;
+  previewLoading.value = true;
+  try {
+    previewBuffer.value = await previewBlank(att.application_id, att.attachment_id);
+  } catch {
+    previewError.value = 'Не удалось загрузить бланк для предпросмотра';
+  } finally {
+    previewLoading.value = false;
+  }
+}
+
+function closePreview() {
+  previewOpen.value = false;
+  previewBuffer.value = null;
+  previewError.value = '';
 }
 
 onMounted(() => {
@@ -811,6 +889,28 @@ onBeforeUnmount(() => clearTimeout(searchTimer));
 
 .detail-loading {
   padding: 10px;
+}
+
+.detail-actions {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.blank-preview {
+  padding: 16px 20px 20px;
+}
+
+.blank-preview__state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+  color: #888;
+  font-size: 14px;
+}
+
+.blank-preview__state--error {
+  color: #d73a3a;
 }
 
 @media (max-width: 900px) {

--- a/frontend/src/views/__tests__/AccessibleAttachmentsView.spec.js
+++ b/frontend/src/views/__tests__/AccessibleAttachmentsView.spec.js
@@ -17,6 +17,10 @@ vi.mock('@/api/organizations', () => ({
   getCompanies: vi.fn(),
 }));
 
+vi.mock('@/api/attachment-templates', () => ({
+  previewBlank: vi.fn(),
+}));
+
 const notify = vi.fn();
 vi.mock('@/stores/deletions', () => ({
   useDeletionsStore: () => ({ notify }),
@@ -37,6 +41,7 @@ import AccessibleAttachmentsView from '@/views/AccessibleAttachmentsView.vue';
 import BaseDropdown from '@/components/ui/BaseDropdown.vue';
 import { getAccessibleAttachments, getAccessibleAttachmentDetail } from '@/api/applications';
 import { getOrganizations, getCompanies } from '@/api/organizations';
+import { previewBlank } from '@/api/attachment-templates';
 
 const stubs = {
   AdminPageShell: { template: '<div><slot /></div>' },
@@ -45,6 +50,9 @@ const stubs = {
     props: ['attachment', 'cars', 'employees', 'items'],
     template: '<div class="detail-stub">{{ attachment.attachment_id }}</div>',
   },
+  // BaseModal рендерит слот, только когда show=true - так проверяем содержимое превью.
+  BaseModal: { props: ['show'], template: '<div v-if="show" class="modal-stub"><slot /></div>' },
+  XlsxViewer: { props: ['fileBuffer'], template: '<div class="xlsx-stub" />' },
 };
 
 function makeItem(id, over = {}) {
@@ -180,6 +188,60 @@ describe('AccessibleAttachmentsView (FE-S3)', () => {
 
     // Деталь показывает вложение 2 (актуальный выбор), а не затёртое первым ответом.
     expect(wrapper.find('.detail-stub').text()).toBe('2');
+  });
+});
+
+describe('AccessibleAttachmentsView (S4) предпросмотр бланка', () => {
+  function mountWithDetail(detailOver = {}) {
+    getAccessibleAttachments.mockResolvedValue({
+      items: [makeItem(1)],
+      meta: { total: 1, page: 1, per_page: 30 },
+    });
+    getAccessibleAttachmentDetail.mockResolvedValue({
+      attachment: { ...makeItem(1), application_id: 42, attachment_id: 1, ...detailOver },
+      cars: [],
+    });
+    return mountView();
+  }
+
+  async function openDetail() {
+    await flushPromises();
+    await wrapper.find('[data-testid="aa-card"]').trigger('click');
+    await flushPromises();
+  }
+
+  it('кнопка превью видна по has_blank, открывает модалку и шлёт (app_id, att_id)', async () => {
+    wrapper = mountWithDetail({ has_blank: true });
+    previewBlank.mockResolvedValue(new ArrayBuffer(8));
+    await openDetail();
+
+    const btn = wrapper.find('[data-testid="aa-preview-blank"]');
+    expect(btn.exists()).toBe(true);
+
+    await btn.trigger('click');
+    await flushPromises();
+
+    expect(previewBlank).toHaveBeenCalledWith(42, 1);
+    expect(wrapper.find('[data-testid="aa-preview-viewer"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="aa-preview-loading"]').exists()).toBe(false);
+  });
+
+  it('без has_blank кнопки превью нет', async () => {
+    wrapper = mountWithDetail({ has_blank: false });
+    await openDetail();
+    expect(wrapper.find('[data-testid="aa-preview-blank"]').exists()).toBe(false);
+  });
+
+  it('показывает ошибку, если бланк не загрузился', async () => {
+    wrapper = mountWithDetail({ has_blank: true });
+    previewBlank.mockRejectedValue(new Error('boom'));
+    await openDetail();
+
+    await wrapper.find('[data-testid="aa-preview-blank"]').trigger('click');
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="aa-preview-error"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="aa-preview-viewer"]').exists()).toBe(false);
   });
 });
 

--- a/internal/handlers/security_attachments_test.go
+++ b/internal/handlers/security_attachments_test.go
@@ -191,3 +191,56 @@ func TestAvailableAttachmentDetail_ContentByType(t *testing.T) {
 	require.Len(t, peopleDetail.Employees, 1, "people-вложение возвращает сотрудников")
 	require.Empty(t, peopleDetail.Cars)
 }
+
+// secNewAttachmentWithUnique создаёт вложение, привязанное к UniqueAttachment, и при withActiveTemplate
+// добавляет ему активный Excel-шаблон. Возвращает ID вложения. Проверяет проекцию has_blank, которая
+// джойнит attachment_templates по unique_attachment_id вложения - newAttachment его не ставит.
+func secNewAttachmentWithUnique(t *testing.T, w secWorld, appID int, withActiveTemplate, templateActive bool) int {
+	t.Helper()
+	ua := models.UniqueAttachment{AttachmentType: "cars", IsActive: true}
+	require.NoError(t, w.db.Create(&ua).Error)
+	att := models.Attachment{ApplicationID: appID, AttachmentType: "cars", UniqueAttachmentID: &ua.ID}
+	require.NoError(t, w.db.Create(&att).Error)
+	if withActiveTemplate {
+		// IsActive имеет gorm default:true - при Create со значением false GORM опускает колонку и
+		// БД ставит true. Поэтому неактивность форсим явным Update после вставки.
+		tpl := models.AttachmentTemplate{
+			UniqueAttachmentID: ua.ID,
+			IsActive:           true,
+			FilePath:           "uploads/templates/test.xlsx",
+		}
+		require.NoError(t, w.db.Create(&tpl).Error)
+		if !templateActive {
+			require.NoError(t, w.db.Model(&tpl).Update("is_active", false).Error)
+		}
+	}
+	return att.ID
+}
+
+func TestAvailableAttachmentDetail_HasBlank(t *testing.T) {
+	h := setupSecurityHTTP(t)
+	w := h.w
+
+	place := w.newUnloadPlace(t, "Склад А", true)
+	w.assignUnloadPlace(t, place)
+	app := w.newApp(t, models.ConfirmationApproved)
+
+	// Вложение с активным шаблоном -> has_blank=true.
+	withBlank := secNewAttachmentWithUnique(t, w, app, true, true)
+	w.attachPlace(t, withBlank, place)
+
+	// Вложение с неактивным шаблоном -> has_blank=false (EXISTS фильтрует is_active).
+	inactiveTpl := secNewAttachmentWithUnique(t, w, app, true, false)
+	w.attachPlace(t, inactiveTpl, place)
+
+	// Вложение без unique_attachment и шаблона -> has_blank=false.
+	noBlank := w.newAttachment(t, app, "cars")
+	w.attachPlace(t, noBlank, place)
+
+	require.True(t, secGetDetail(t, h, withBlank, h.guardToken).Attachment.HasBlank,
+		"активный шаблон типа вложения -> бланк доступен")
+	require.False(t, secGetDetail(t, h, inactiveTpl, h.guardToken).Attachment.HasBlank,
+		"неактивный шаблон не даёт бланк")
+	require.False(t, secGetDetail(t, h, noBlank, h.guardToken).Attachment.HasBlank,
+		"без шаблона бланка нет")
+}

--- a/internal/handlers/security_attachments_test.go
+++ b/internal/handlers/security_attachments_test.go
@@ -199,6 +199,11 @@ func secNewAttachmentWithUnique(t *testing.T, w secWorld, appID int, withActiveT
 	t.Helper()
 	ua := models.UniqueAttachment{AttachmentType: "cars", IsActive: true}
 	require.NoError(t, w.db.Create(&ua).Error)
+	// attachment_templates держит FK на unique_attachments, а общий CleanDB удаляет unique_attachments
+	// без предварительной чистки шаблонов - без этого cleanup следующий тест упал бы на FK-violation.
+	t.Cleanup(func() {
+		w.db.Where("unique_attachment_id = ?", ua.ID).Delete(&models.AttachmentTemplate{})
+	})
 	att := models.Attachment{ApplicationID: appID, AttachmentType: "cars", UniqueAttachmentID: &ua.ID}
 	require.NoError(t, w.db.Create(&att).Error)
 	if withActiveTemplate {

--- a/internal/services/security_visibility_service.go
+++ b/internal/services/security_visibility_service.go
@@ -29,6 +29,9 @@ type AvailableAttachment struct {
 	EntryTimeTo           *string    `json:"entry_time_to"`
 	CreatedAt             *time.Time `json:"created_at"`
 	Places                *string    `json:"places"`
+	// HasBlank - у типа вложения (unique_attachment) есть активный Excel-шаблон, значит для этого
+	// вложения генерируется заполненный бланк (#706 S4). По нему фронт показывает "Посмотреть файл".
+	HasBlank bool `json:"has_blank"`
 
 	ApplicationID     int        `json:"application_id"`
 	ApplicationNumber *string    `json:"application_number"`
@@ -98,7 +101,11 @@ const availableAttachmentSelect = `
 		FROM attachment_unload_places aup
 		JOIN unload_places up ON up.id = aup.unload_place_id
 		WHERE aup.attachment_id = a.id
-	) END as places`
+	) END as places,
+	EXISTS (
+		SELECT 1 FROM attachment_templates t
+		WHERE t.unique_attachment_id = a.unique_attachment_id AND t.is_active = true
+	) as has_blank`
 
 // securityVisibilityWhere строит предикат доступности вложения для вкладки "Доступные мне"
 // (ссылается на алиасы a = attachments, app = applications) и его аргументы. Инвариант (#706):

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -53,6 +53,7 @@ var tables = []string{
 	"vehicle_blacklist_histories", "vehicle_blacklists",
 	"person_blacklist_histories", "person_blacklists",
 	"attachment_custom_values", "attachment_custom_fields", "attachment_field_configs",
+	"attachment_template_mappings", "attachment_templates",
 	"attachments",
 	"unique_employees_history", "unique_cars_history",
 	"unique_employees", "unique_cars", "unique_attachment_histories", "unique_attachments",

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -53,7 +53,6 @@ var tables = []string{
 	"vehicle_blacklist_histories", "vehicle_blacklists",
 	"person_blacklist_histories", "person_blacklists",
 	"attachment_custom_values", "attachment_custom_fields", "attachment_field_configs",
-	"attachment_template_mappings", "attachment_templates",
 	"attachments",
 	"unique_employees_history", "unique_cars_history",
 	"unique_employees", "unique_cars", "unique_attachment_histories", "unique_attachments",


### PR DESCRIPTION
Срез S4 эпика aa-improvements (#706 follow-up, пункт 8).

## Что
Охранник в детали доступного вложения теперь видит кнопку "Посмотреть файл" - открывается модалка с заполненным excel-бланком (XlsxViewer по тому же эндпоинту `/applications/:id/blank`, что и скачивание, но буфер парсится во вьювере, файл не сохраняется). Кнопка показывается только когда у типа вложения есть активный шаблон.

## Как
- BE: поле `has_blank` в проекции `availableAttachmentSelect` через `EXISTS` по active `attachment_templates` (по образцу `application_service.go has_blank_template`). Проекция шарится листингом и деталью, NULL `unique_attachment_id` корректно даёт false.
- FE: `previewBlank()` -> arrayBuffer (зеркало `downloadBlank`), кнопка по `detail.attachment.has_blank`, модалка через переиспользованные `BaseModal` + `XlsxViewer`. Состояния loading/error, защита от двойного клика.
- Тест создаёт `attachment_templates` (FK на `unique_attachments`); чистит их через `t.Cleanup`, чтобы общий `CleanDB` не упёрся в FK при удалении родителя.

## Тесты
- BE `TestAvailableAttachmentDetail_HasBlank`: active template -> true, inactive -> false, без шаблона -> false (через реальный endpoint). Полный пакет `internal/handlers` зелёный, `go build ./...` ок.
- FE: 3 теста (кнопка по has_blank + отправка (app_id, att_id), скрытие без флага, ошибка загрузки). Vitest спека 16/16.

## Ревью (code-reviewer, вердикт GO, red нет)
- 🟡 `attachment_blank.go` Download не проверяет ownership вызывающего - **pre-existing gap из #183**, не регрессия S4 (видимость детали гейтится через `CanSecurityViewAttachment`). Кандидат на отдельный тикет.

Визуал "Доступные мне" пользователь проверяет пачкой на staging после деплоя (договорённость эпика).