### PR TITLE
style(security): срок действия вложения в бейдже карточки "Доступные мне"

### DIFF
--- a/frontend/src/views/AccessibleAttachmentsView.vue
+++ b/frontend/src/views/AccessibleAttachmentsView.vue
@@ -116,6 +116,13 @@
                   {{ typeLabel(a.attachment_type) }}
                 </Badge>
                 <span class="attachment-card__org">{{ orgLine(a) }}</span>
+                <span
+                  v-if="dateRange(a)"
+                  class="attachment-card__date"
+                  data-testid="aa-card-date"
+                >
+                  {{ dateRange(a) }}
+                </span>
                 <StatusBadge
                   v-if="statusText(a)"
                   class="attachment-card__status"
@@ -422,13 +429,13 @@ function orgLine(a) {
 }
 
 // Компактная строка меты под названием: номер, отправитель, даты через разделитель.
+// Даты сюда не кладём: срок действия вынесен в отдельный контрастный бейдж шапки
+// (рядом со статусом), чтобы читался чётко, а не терялся в серой мете.
 function metaLine(a) {
   const parts = [];
   if (a.application_number) parts.push(`№ ${a.application_number}`);
   const sender = senderName(a);
   if (sender) parts.push(sender);
-  const dates = dateRange(a);
-  if (dates) parts.push(dates);
   return parts.join(' · ');
 }
 
@@ -749,17 +756,36 @@ onBeforeUnmount(() => clearTimeout(searchTimer));
 .attachment-card__head {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
 }
 
+/* min-width держит организацию читаемой: на узкой карточке (открыта деталь, 40%)
+   дата и статус переносятся на вторую строку, а не сжимают организацию в ничто. */
 .attachment-card__org {
   flex: 1;
-  min-width: 0;
+  min-width: 90px;
   font-weight: 700;
   font-size: 14.5px;
   color: #1a1a1a;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Срок действия: контрастный бейдж (тёмный текст на белом + обводка), чтобы дата
+   читалась чётко рядом со статусом, а не терялась в серой мете. */
+.attachment-card__date {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 9px;
+  border-radius: 999px;
+  background: #fff;
+  border: 1px solid #d0d0d0;
+  color: #1a1a1a;
+  font-size: 12px;
+  font-weight: 600;
   white-space: nowrap;
 }
 

--- a/frontend/src/views/__tests__/AccessibleAttachmentsView.spec.js
+++ b/frontend/src/views/__tests__/AccessibleAttachmentsView.spec.js
@@ -125,6 +125,22 @@ describe('AccessibleAttachmentsView (FE-S3)', () => {
     expect(cards[1].find('.attachment-card__org').text()).toBe('ООО Один');
   });
 
+  it('срок действия - в отдельном бейдже шапки, не в серой мете', async () => {
+    getAccessibleAttachments.mockResolvedValue({
+      items: [makeItem(1)],
+      meta: { total: 1 },
+    });
+    wrapper = mountView();
+    await flushPromises();
+
+    const card = wrapper.find('[data-testid="aa-card"]');
+    const dateBadge = card.find('[data-testid="aa-card-date"]');
+    expect(dateBadge.exists()).toBe(true);
+    expect(dateBadge.text()).toBe('01.06.2026 - 02.06.2026');
+    // Дата ушла из меты (там остаются номер и отправитель) - не дублируем.
+    expect(card.find('.attachment-card__meta').text()).not.toContain('01.06.2026');
+  });
+
   it('показывает пустое состояние без вложений', async () => {
     getAccessibleAttachments.mockResolvedValue({
       items: [],


### PR DESCRIPTION
Polish-срез aa-improvements (#706 follow-up). По просьбе юзера: срок действия вложения был в серой мете под названием и плохо читался.

## Что
- Срок действия вынесен в отдельный контрастный бейдж в шапке карточки рядом со статусом: тёмный текст (#1a1a1a) на белом фоне с обводкой - читается чётко.
- Из `metaLine` дату убрал (остаются номер заявки и отправитель) - не дублируем.
- Шапка карточки: `flex-wrap` + `min-width` у организации, чтобы на узкой карточке (открыта деталь, список 40%) дата и статус переносились на вторую строку, а не сжимали организацию (главный ориентир охранника) в ничто.

## Тесты
FE-спека: новый тест на бейдж даты (текст `01.06.2026 - 02.06.2026`, отсутствие даты в мете). Vitest 17/17, eslint чист.

Визуал юзер проверит на staging.