### PR TITLE
feat(feedback): вкладка обратной связи в раскладке эталона

### DIFF
--- a/frontend/src/api/feedback.js
+++ b/frontend/src/api/feedback.js
@@ -1,36 +1,75 @@
 import { apiRequest } from './client';
 
+/**
+ * Создать обращение обратной связи.
+ * @param {{ message: string }} data
+ * @returns {Promise<object>} данные созданного обращения
+ */
 export async function createFeedback(data) {
   const res = await apiRequest('/feedback', {
     method: 'POST',
     body: JSON.stringify(data),
   });
+  if (!res.ok) throw new Error('Не удалось отправить обращение');
   return res.json();
 }
 
+/**
+ * Получить все обращения (для администраторов).
+ * @returns {Promise<object[]>}
+ */
 export async function getAllFeedback() {
   const res = await apiRequest('/feedback/all');
+  if (!res.ok) throw new Error('Не удалось загрузить обращения');
   return res.json();
 }
 
+/**
+ * Получить обращения текущего пользователя.
+ * @returns {Promise<object[]>}
+ */
 export async function getMyFeedback() {
   const res = await apiRequest('/feedback/my');
+  if (!res.ok) throw new Error('Не удалось загрузить обращения');
   return res.json();
 }
 
+/**
+ * Получить статистику по обращениям.
+ * @returns {Promise<object>}
+ */
 export async function getFeedbackStats() {
   const res = await apiRequest('/feedback/stats');
+  if (!res.ok) throw new Error('Не удалось загрузить статистику обращений');
   return res.json();
 }
 
+/**
+ * Обновить статус обращения. При переводе в "Решено" можно передать ответ заявителю.
+ * @param {number} id
+ * @param {{ status: string, comment?: string }} data
+ * @returns {Promise<object>}
+ */
 export async function updateFeedbackStatus(id, data) {
   const res = await apiRequest(`/feedback/${id}/status`, {
     method: 'PUT',
     body: JSON.stringify(data),
   });
+  if (!res.ok) throw new Error('Не удалось обновить статус обращения');
   return res.json();
 }
 
-export async function markFeedbackAsRead(id) {
-  return apiRequest(`/feedback/${id}/read`, { method: 'PUT' });
+/**
+ * Отметить обращение прочитанным/непрочитанным.
+ * @param {number} id
+ * @param {boolean} [isRead=true]
+ * @returns {Promise<object>}
+ */
+export async function markFeedbackAsRead(id, isRead = true) {
+  const res = await apiRequest(`/feedback/${id}/read`, {
+    method: 'PUT',
+    body: JSON.stringify({ is_read: isRead }),
+  });
+  if (!res.ok) throw new Error('Не удалось обновить статус прочтения');
+  return res.json();
 }

--- a/frontend/src/views/FeedbackPage.vue
+++ b/frontend/src/views/FeedbackPage.vue
@@ -1,739 +1,746 @@
 <template>
-  <section class="feedback-admin">
-    <header class="feedback-admin__header">
-      <div class="header-row">
-        <h2 class="feedback-admin__title">
+  <AdminPageShell>
+    <div class="feedback-container dashboard-card">
+      <div class="management-header">
+        <h3 class="management-title">
           Обратная связь
-        </h2>
-        <RefreshButton
-          :loading="loading"
-          @refresh="fetchFeedbacks"
+        </h3>
+        <div class="header-controls">
+          <SearchComponent
+            v-model="searchQuery"
+            :title="'Поиск по автору или тексту...'"
+            @search="onSearch"
+          />
+          <RefreshButton
+            :loading="loading"
+            @refresh="refresh"
+          />
+        </div>
+      </div>
+
+      <div class="filter-strip">
+        <FilterTabs
+          v-model="activeFilter"
+          :tabs="filterTabs"
         />
       </div>
 
-      <div class="summary-cards">
-        <button
-          class="summary-card"
-          :class="{ 'summary-card--active': statusFilter === null && readFilter === null }"
-          @click="resetAllFilters"
-        >
-          <span class="summary-card__label">Всего</span>
-          <span class="summary-card__value">{{ feedbacks.length }}</span>
-        </button>
-        <button
-          class="summary-card summary-card--accent"
-          :class="{ 'summary-card--active': readFilter === 'false' }"
-          @click="toggleReadFilter('false')"
-        >
-          <span class="summary-card__label">Новые</span>
-          <span class="summary-card__value">{{ unreadCount }}</span>
-        </button>
-        <button
-          class="summary-card summary-card--warning"
-          :class="{ 'summary-card--active': statusFilter === 'Не решено' }"
-          @click="toggleStatusFilter('Не решено')"
-        >
-          <span class="summary-card__label">В работе</span>
-          <span class="summary-card__value">{{ pendingCount }}</span>
-        </button>
-        <button
-          class="summary-card summary-card--success"
-          :class="{ 'summary-card--active': statusFilter === 'Решено' }"
-          @click="toggleStatusFilter('Решено')"
-        >
-          <span class="summary-card__label">Решено</span>
-          <span class="summary-card__value">{{ resolvedCount }}</span>
-        </button>
-      </div>
-
-      <div class="filters-row">
-        <SearchComponent
-          v-model="searchQuery"
-          title="Поиск по имени или сообщению..."
-          class="search-component"
-          @search="handleSearch"
-        />
-        <div class="filter-toggle-group">
-          <button
-            class="lk-button"
-            :class="readFilter === 'false' ? 'lk-button--primary' : 'lk-button--ghost'"
-            @click="toggleReadFilter('false')"
-          >
-            Новые
-          </button>
-          <button
-            class="lk-button"
-            :class="readFilter === 'true' ? 'lk-button--primary' : 'lk-button--ghost'"
-            @click="toggleReadFilter('true')"
-          >
-            Просмотренные
-          </button>
-        </div>
-      </div>
-    </header>
-
-    <div class="feedback-admin__list">
-      <SkeletonTransition :loading="loading">
-        <template #skeleton>
-          <div class="skeleton-grid">
-            <SkeletonCard
-              v-for="i in 4"
-              :key="i"
-              :lines="3"
-            />
-          </div>
-        </template>
-
-        <div
-          v-if="filteredFeedbacks.length === 0"
-          class="empty-state"
-        >
-          <p>{{ getEmptyMessage() }}</p>
-        </div>
-
-        <div
-          v-else
-          class="cards-grid"
-        >
-          <article
-            v-for="feedback in filteredFeedbacks"
-            :key="feedback.id"
-            class="ticket-card"
-            :class="{
-              'ticket-card--unread': !feedback.is_read,
-              'ticket-card--resolved': feedback.status === 'Решено'
-            }"
-          >
-            <header class="ticket-card__header">
-              <div class="ticket-card__meta">
-                <span class="ticket-id">#{{ feedback.id }}</span>
-                <span class="ticket-author">{{ feedback.user_name || 'Неизвестный пользователь' }}</span>
-              </div>
-              <Badge
-                :variant="feedback.status === 'Решено' ? 'success' : 'warning'"
-                :label="feedback.status"
-                size="sm"
-              />
-            </header>
-
-            <p class="ticket-card__message">
-              {{ feedback.message }}
-            </p>
-
+      <div class="content-container">
+        <!-- Список обращений -->
+        <div class="list-section">
+          <div class="list-header">
             <div
-              v-if="feedback.resolution_comment"
-              class="ticket-card__response"
+              class="header-col col-id"
+              :class="{ 'active-sort': sortKey === 'id' }"
+              @click="sortBy('id')"
             >
-              <span class="response-label">Ответ:</span>
-              <p>{{ feedback.resolution_comment }}</p>
+              #
+            </div>
+            <div
+              class="header-col col-author"
+              :class="{ 'active-sort': sortKey === 'author' }"
+              @click="sortBy('author')"
+            >
+              Автор
+            </div>
+            <div class="header-col col-status">
+              Статус
+            </div>
+            <div
+              class="header-col col-date"
+              :class="{ 'active-sort': sortKey === 'date' }"
+              @click="sortBy('date')"
+            >
+              Дата
+            </div>
+          </div>
+
+          <div class="list-body">
+            <SkeletonTransition :loading="loading">
+              <template #skeleton>
+                <SkeletonCard
+                  v-for="i in 6"
+                  :key="i"
+                  :lines="2"
+                  :show-badge="false"
+                />
+              </template>
+
+              <div
+                v-if="!filteredFeedbacks.length"
+                class="empty-list"
+                data-testid="fb-empty"
+              >
+                {{ emptyText }}
+              </div>
+              <div v-else>
+                <div
+                  v-for="f in filteredFeedbacks"
+                  :key="f.id"
+                  class="ticket-row"
+                  data-testid="fb-row"
+                  :class="{ unread: !f.is_read, selected: f.id === selectedId }"
+                  @click="selectRow(f.id)"
+                >
+                  <div class="cell col-id">
+                    <span class="unread-dot" />
+                    <span class="id-value">{{ f.id }}</span>
+                  </div>
+                  <div class="cell col-author">
+                    <span
+                      class="author"
+                      :title="f.user_name"
+                    >{{ f.user_name || 'Неизвестный пользователь' }}</span>
+                  </div>
+                  <div class="cell col-status">
+                    <span
+                      class="status-badge"
+                      :class="f.status === STATUS.RESOLVED ? 'status-resolved' : 'status-open'"
+                    >
+                      {{ statusLabel(f.status) }}
+                    </span>
+                  </div>
+                  <div class="cell col-date cell-date">
+                    {{ formatShortDate(f.created_at) }}
+                  </div>
+                </div>
+              </div>
+            </SkeletonTransition>
+          </div>
+
+          <div class="list-footer">
+            <span class="items-count">Всего: {{ filteredFeedbacks.length }}</span>
+          </div>
+        </div>
+
+        <!-- Детали обращения -->
+        <div class="detail-section">
+          <div
+            v-if="!selectedFeedback"
+            class="no-selection"
+          >
+            Выберите обращение слева для просмотра и ответа
+          </div>
+          <div
+            v-else
+            class="detail-body"
+            data-testid="fb-detail"
+          >
+            <div class="detail-header">
+              <h3 class="detail-title">
+                Обращение #{{ selectedFeedback.id }}
+              </h3>
+              <span
+                class="status-badge"
+                :class="selectedFeedback.status === STATUS.RESOLVED ? 'status-resolved' : 'status-open'"
+              >
+                {{ statusLabel(selectedFeedback.status) }}
+              </span>
             </div>
 
-            <footer class="ticket-card__footer">
-              <div class="ticket-card__times">
-                <span class="ticket-time">{{ formatDateTime(feedback.created_at) }}</span>
-                <span
-                  v-if="feedback.resolved_at"
-                  class="ticket-time ticket-time--resolved"
-                >
-                  Решено: {{ formatDateTime(feedback.resolved_at) }}
-                </span>
-              </div>
-              <div class="ticket-card__actions">
-                <button
-                  v-if="!feedback.is_read"
-                  class="lk-button lk-button--ghost"
-                  :disabled="updating === feedback.id"
-                  @click="markAsRead(feedback.id)"
-                >
-                  Прочитано
-                </button>
-                <button
-                  v-if="feedback.status === 'Не решено'"
-                  class="lk-button lk-button--primary"
-                  :disabled="updating === feedback.id"
-                  @click="openResolveModal(feedback)"
-                >
-                  Ответить
-                </button>
-                <button
-                  v-if="feedback.status === 'Решено'"
-                  class="lk-button lk-button--danger"
-                  :disabled="updating === feedback.id"
-                  @click="markAsPending(feedback.id)"
-                >
-                  Вернуть в обращение
-                </button>
-              </div>
-            </footer>
-          </article>
-        </div>
-      </SkeletonTransition>
-    </div>
+            <div class="detail-meta">
+              <span class="meta-author">{{ selectedFeedback.user_name || 'Неизвестный пользователь' }}</span>
+              <span class="meta-dates">
+                Создано: {{ formatDateTime(selectedFeedback.created_at) }}<template v-if="selectedFeedback.resolved_at"> · Решено: {{ formatDateTime(selectedFeedback.resolved_at) }}</template>
+              </span>
+            </div>
 
-    <Teleport to="body">
-      <div
-        v-if="resolveTarget"
-        class="modal-overlay"
-        @click.self="closeResolveModal"
-      >
-        <div class="modal-content">
-          <header class="modal-content__header">
-            <h3>Ответ на обращение #{{ resolveTarget.id }}</h3>
-            <button
-              class="modal-close-btn"
-              @click="closeResolveModal"
+            <div class="message-card">
+              {{ selectedFeedback.message }}
+            </div>
+
+            <div
+              v-if="selectedFeedback.status === STATUS.RESOLVED && selectedFeedback.resolution_comment"
+              class="answer-card"
+              data-testid="fb-answer"
             >
-              ×
-            </button>
-          </header>
-          <section class="modal-content__body">
-            <p class="resolve-context"><strong>{{ resolveTarget.user_name || 'Пользователь' }}:</strong> {{ resolveTarget.message }}</p>
-            <label class="resolve-label">
-              Ответ заявителю
+              <div class="answer-label">
+                Ответ
+              </div>
+              <div class="answer-text">
+                {{ selectedFeedback.resolution_comment }}
+              </div>
+            </div>
+
+            <div
+              v-if="selectedFeedback.status !== STATUS.RESOLVED"
+              class="reply-block"
+            >
+              <label
+                class="reply-label"
+                :for="`reply-${selectedFeedback.id}`"
+              >Ответ заявителю</label>
               <textarea
-                v-model="resolveCommentValue"
+                :id="`reply-${selectedFeedback.id}`"
+                v-model="replyText"
                 class="lk-textarea"
+                data-testid="fb-reply"
                 rows="4"
+                maxlength="1000"
                 placeholder="Заявитель увидит ваш ответ. Опишите решение или причину отказа."
               />
-            </label>
-          </section>
-          <footer class="modal-content__footer">
-            <button
-              class="lk-button lk-button--ghost"
-              @click="closeResolveModal"
-            >
-              Отмена
-            </button>
-            <button
-              class="lk-button lk-button--primary"
-              :disabled="updating === resolveTarget.id"
-              @click="confirmResolve"
-            >
-              Отметить решённым
-            </button>
-          </footer>
+            </div>
+
+            <div class="detail-actions">
+              <button
+                v-if="!selectedFeedback.is_read"
+                class="lk-button lk-button--ghost"
+                data-testid="fb-read"
+                :disabled="updatingId === selectedFeedback.id"
+                @click="markRead(selectedFeedback.id)"
+              >
+                Отметить прочитанным
+              </button>
+              <button
+                v-if="selectedFeedback.status !== STATUS.RESOLVED"
+                class="lk-button lk-button--primary"
+                data-testid="fb-resolve"
+                :disabled="updatingId === selectedFeedback.id"
+                @click="resolve(selectedFeedback.id)"
+              >
+                Отметить решённым
+              </button>
+              <button
+                v-else
+                class="lk-button lk-button--danger"
+                data-testid="fb-reopen"
+                :disabled="updatingId === selectedFeedback.id"
+                @click="reopen(selectedFeedback.id)"
+              >
+                Вернуть в работу
+              </button>
+            </div>
+          </div>
         </div>
       </div>
-    </Teleport>
-  </section>
+    </div>
+  </AdminPageShell>
 </template>
 
-<script>
-import { apiRequest } from '@/api/client'
-import { useAuthStore } from '@/stores/auth'
+<script setup>
+import { ref, computed, watch, onMounted } from 'vue';
+import AdminPageShell from '@/views/admin/AdminPageShell.vue';
 import SearchComponent from '@/components/SearchComponent.vue';
 import RefreshButton from '@/components/RefreshButton.vue';
-import { SkeletonTransition, SkeletonCard, Badge } from '@/components/ui';
+import { FilterTabs, SkeletonTransition, SkeletonCard } from '@/components/ui';
+import { useDeletionsStore } from '@/stores/deletions';
+import { getAllFeedback, updateFeedbackStatus, markFeedbackAsRead } from '@/api/feedback';
 
-export default {
-  name: 'FeedbackPage',
-  components: {
-    SearchComponent,
-    RefreshButton,
-    SkeletonTransition,
-    SkeletonCard,
-    Badge,
-  },
-  data() {
-    return {
-      feedbacks: [],
-      loading: false,
-      updating: null,
-      statusFilter: null,
-      readFilter: null,
-      searchQuery: '',
-      searchVariants: [''],
-      resolveTarget: null,
-      resolveCommentValue: ''
-    };
-  },
-  computed: {
-    filteredFeedbacks() {
-      let filtered = this.feedbacks;
+const STATUS = { OPEN: 'Не решено', RESOLVED: 'Решено' };
 
-      if (this.searchQuery.trim() !== '') {
-        filtered = filtered.filter(feedback => {
-          const userName = (feedback.user_name || '').toLowerCase();
-          const message = (feedback.message || '').toLowerCase();
-          return this.searchVariants.some(variant => {
-            if (!variant) return false;
-            return userName.includes(variant) || message.includes(variant);
-          });
-        });
-      }
+const deletions = useDeletionsStore();
 
-      if (this.statusFilter) {
-        filtered = filtered.filter(f => f.status === this.statusFilter);
-      }
+const feedbacks = ref([]);
+const loading = ref(false);
+const updatingId = ref(null);
+const activeFilter = ref('all');
+const searchQuery = ref('');
+const searchVariants = ref([]);
+const sortKey = ref('id');
+const sortDir = ref('desc');
+const selectedId = ref(null);
+const replyText = ref('');
 
-      if (this.readFilter !== null) {
-        const isRead = this.readFilter === 'true';
-        filtered = filtered.filter(f => f.is_read === isRead);
-      }
+const unreadCount = computed(() => feedbacks.value.filter((f) => !f.is_read).length);
+const openCount = computed(() => feedbacks.value.filter((f) => f.status === STATUS.OPEN).length);
+const resolvedCount = computed(() => feedbacks.value.filter((f) => f.status === STATUS.RESOLVED).length);
 
-      return filtered.sort((a, b) => {
-        if (a.is_read !== b.is_read) return a.is_read ? 1 : -1;
-        return new Date(b.created_at) - new Date(a.created_at);
-      });
-    },
-    unreadCount() {
-      return this.feedbacks.filter(f => !f.is_read).length;
-    },
-    pendingCount() {
-      return this.feedbacks.filter(f => f.status === 'Не решено').length;
-    },
-    resolvedCount() {
-      return this.feedbacks.filter(f => f.status === 'Решено').length;
-    }
-  },
-  mounted() {
-    this.fetchFeedbacks();
-  },
-  methods: {
-    handleSearch(variants) {
-      this.searchVariants = variants;
-    },
-    toggleStatusFilter(status) {
-      this.statusFilter = this.statusFilter === status ? null : status;
-    },
-    toggleReadFilter(state) {
-      this.readFilter = this.readFilter === state ? null : state;
-    },
-    resetAllFilters() {
-      this.statusFilter = null;
-      this.readFilter = null;
-      this.searchQuery = '';
-      this.searchVariants = [''];
-    },
-    async fetchFeedbacks() {
-      this.loading = true;
-      try {
-        const authStore = useAuthStore();
-        if (!authStore.token) return;
-        const response = await apiRequest('/feedback/all', { method: 'GET' });
-        if (response.ok) {
-          this.feedbacks = await response.json();
-        }
-      } catch (e) {
-        console.error('Ошибка при загрузке обращений:', e);
-      } finally {
-        this.loading = false;
-      }
-    },
-    async markAsRead(feedbackId) {
-      await this.updateRead(feedbackId, true);
-    },
-    openResolveModal(feedback) {
-      this.resolveTarget = feedback;
-      this.resolveCommentValue = '';
-    },
-    closeResolveModal() {
-      this.resolveTarget = null;
-      this.resolveCommentValue = '';
-    },
-    async confirmResolve() {
-      const feedbackId = this.resolveTarget.id;
-      const comment = this.resolveCommentValue;
-      this.updating = feedbackId;
-      try {
-        const response = await apiRequest(`/feedback/${feedbackId}/status`, {
-          method: 'PUT',
-          body: JSON.stringify({ status: 'Решено', comment })
-        });
-        if (response.ok) {
-          const idx = this.feedbacks.findIndex(f => f.id === feedbackId);
-          if (idx !== -1) {
-            this.feedbacks[idx] = {
-              ...this.feedbacks[idx],
-              status: 'Решено',
-              resolution_comment: comment.trim() || null,
-              resolved_at: new Date().toISOString(),
-              is_read: true
-            };
-          }
-          this.closeResolveModal();
-        }
-      } catch (e) {
-        console.error('Ошибка при выполнении обращения:', e);
-      } finally {
-        this.updating = null;
-      }
-    },
-    async markAsPending(feedbackId) {
-      this.updating = feedbackId;
-      try {
-        const response = await apiRequest(`/feedback/${feedbackId}/status`, {
-          method: 'PUT',
-          body: JSON.stringify({ status: 'Не решено' })
-        });
-        if (response.ok) {
-          const idx = this.feedbacks.findIndex(f => f.id === feedbackId);
-          if (idx !== -1) {
-            this.feedbacks[idx] = {
-              ...this.feedbacks[idx],
-              status: 'Не решено',
-              resolution_comment: null,
-              resolved_at: null
-            };
-          }
-        }
-      } finally {
-        this.updating = null;
-      }
-    },
-    async updateRead(feedbackId, isRead) {
-      this.updating = feedbackId;
-      try {
-        const response = await apiRequest(`/feedback/${feedbackId}/read`, {
-          method: 'PUT',
-          body: JSON.stringify({ is_read: isRead })
-        });
-        if (response.ok) {
-          const idx = this.feedbacks.findIndex(f => f.id === feedbackId);
-          if (idx !== -1) this.feedbacks[idx] = { ...this.feedbacks[idx], is_read: isRead };
-        }
-      } finally {
-        this.updating = null;
-      }
-    },
-    formatDateTime(s) {
-      if (!s) return '';
-      const d = new Date(s);
-      return d.toLocaleString('ru-RU', {
-        day: '2-digit', month: '2-digit', year: 'numeric',
-        hour: '2-digit', minute: '2-digit'
-      });
-    },
-    getEmptyMessage() {
-      if (this.searchQuery.trim() !== '') return 'Нет обращений по вашему запросу';
-      if (this.statusFilter !== null || this.readFilter !== null) return 'Нет обращений по выбранным фильтрам';
-      return 'Обращений пока нет';
-    }
+const filterTabs = computed(() => [
+  { key: 'all', label: 'Все', count: feedbacks.value.length },
+  { key: 'new', label: 'Новые', count: unreadCount.value },
+  { key: 'open', label: 'В работе', count: openCount.value },
+  { key: 'resolved', label: 'Решено', count: resolvedCount.value },
+]);
+
+const filteredFeedbacks = computed(() => {
+  let list = feedbacks.value.slice();
+
+  if (activeFilter.value === 'new') list = list.filter((f) => !f.is_read);
+  else if (activeFilter.value === 'open') list = list.filter((f) => f.status === STATUS.OPEN);
+  else if (activeFilter.value === 'resolved') list = list.filter((f) => f.status === STATUS.RESOLVED);
+
+  const variants = searchVariants.value.filter(Boolean);
+  if (variants.length) {
+    list = list.filter((f) => {
+      const hay = `${f.user_name || ''} ${f.message || ''}`.toLowerCase();
+      return variants.some((v) => hay.includes(v));
+    });
   }
-};
+
+  const dir = sortDir.value === 'asc' ? 1 : -1;
+  list.sort((a, b) => {
+    if (sortKey.value === 'author') return (a.user_name || '').localeCompare(b.user_name || '') * dir;
+    if (sortKey.value === 'date') return (new Date(a.created_at) - new Date(b.created_at)) * dir;
+    if (a.is_read !== b.is_read) return a.is_read ? 1 : -1;
+    return (a.id - b.id) * dir;
+  });
+  return list;
+});
+
+const selectedFeedback = computed(() => feedbacks.value.find((f) => f.id === selectedId.value) || null);
+
+const emptyText = computed(() => {
+  if (searchVariants.value.filter(Boolean).length) return 'Ничего не найдено по запросу';
+  if (activeFilter.value === 'new') return 'Новых обращений нет';
+  if (activeFilter.value === 'open') return 'Обращений в работе нет';
+  if (activeFilter.value === 'resolved') return 'Решённых обращений нет';
+  return 'Обращений пока нет';
+});
+
+// Держим выбор валидным: если текущее обращение ушло из видимого списка
+// (сменили фильтр/поиск) -- выбираем первое, иначе показываем подсказку.
+watch(filteredFeedbacks, (list) => {
+  if (!list.length) {
+    selectedId.value = null;
+    return;
+  }
+  if (!list.some((f) => f.id === selectedId.value)) {
+    selectedId.value = list[0].id;
+  }
+});
+
+watch(selectedId, () => {
+  replyText.value = '';
+});
+
+function onSearch(variants) {
+  searchVariants.value = variants;
+}
+
+function selectRow(id) {
+  selectedId.value = id;
+}
+
+function sortBy(key) {
+  if (sortKey.value === key) {
+    sortDir.value = sortDir.value === 'asc' ? 'desc' : 'asc';
+  } else {
+    sortKey.value = key;
+    sortDir.value = key === 'author' ? 'asc' : 'desc';
+  }
+}
+
+function patchLocal(id, patch) {
+  const idx = feedbacks.value.findIndex((f) => f.id === id);
+  if (idx !== -1) feedbacks.value[idx] = { ...feedbacks.value[idx], ...patch };
+}
+
+async function refresh() {
+  loading.value = true;
+  try {
+    const data = await getAllFeedback();
+    feedbacks.value = Array.isArray(data) ? data : [];
+  } catch (e) {
+    console.error('Ошибка при загрузке обращений:', e);
+    deletions.notify({ prefix: 'Не удалось загрузить ', bold: 'обращения', type: 'error' });
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function markRead(id) {
+  updatingId.value = id;
+  try {
+    await markFeedbackAsRead(id, true);
+    patchLocal(id, { is_read: true });
+  } catch (e) {
+    console.error('Ошибка при отметке обращения прочитанным:', e);
+    deletions.notify({ prefix: 'Не удалось отметить обращение прочитанным', type: 'error' });
+  } finally {
+    updatingId.value = null;
+  }
+}
+
+async function resolve(id) {
+  updatingId.value = id;
+  const comment = replyText.value.trim();
+  try {
+    await updateFeedbackStatus(id, { status: STATUS.RESOLVED, ...(comment ? { comment } : {}) });
+    patchLocal(id, {
+      status: STATUS.RESOLVED,
+      is_read: true,
+      resolution_comment: comment || null,
+      resolved_at: new Date().toISOString(),
+    });
+    replyText.value = '';
+    deletions.notify({ prefix: 'Обращение ', bold: `#${id}`, suffix: ' отмечено решённым' });
+  } catch (e) {
+    console.error('Ошибка при обновлении обращения:', e);
+    deletions.notify({ prefix: 'Не удалось обновить обращение', type: 'error' });
+  } finally {
+    updatingId.value = null;
+  }
+}
+
+async function reopen(id) {
+  updatingId.value = id;
+  try {
+    await updateFeedbackStatus(id, { status: STATUS.OPEN });
+    patchLocal(id, { status: STATUS.OPEN, resolution_comment: null, resolved_at: null });
+    deletions.notify({ prefix: 'Обращение ', bold: `#${id}`, suffix: ' возвращено в работу' });
+  } catch (e) {
+    console.error('Ошибка при обновлении обращения:', e);
+    deletions.notify({ prefix: 'Не удалось обновить обращение', type: 'error' });
+  } finally {
+    updatingId.value = null;
+  }
+}
+
+function formatDateTime(s) {
+  if (!s) return '';
+  return new Date(s).toLocaleString('ru-RU', {
+    day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit',
+  });
+}
+
+function formatShortDate(s) {
+  if (!s) return '';
+  return new Date(s).toLocaleDateString('ru-RU', { day: '2-digit', month: '2-digit' });
+}
+
+function statusLabel(status) {
+  return status === STATUS.RESOLVED ? 'Решено' : 'В работе';
+}
+
+onMounted(refresh);
 </script>
 
 <style scoped>
-.feedback-admin {
-  padding: 16px;
+.feedback-container {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  background: #fff;
+  border: 1px solid #e6e6e6;
+  overflow: hidden;
 }
 
-.feedback-admin__header {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-}
-
-.header-row {
+/* Шапка (эталон management-header) */
+.management-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  height: 50px;
+  padding: 0 20px;
+  border-bottom: 1px solid #e6e6e6;
+  flex-shrink: 0;
+}
+
+.management-title {
+  margin: 0;
+  font-size: 1.2em;
+  font-weight: 600;
+  color: #000;
+}
+
+.header-controls {
+  display: flex;
+  align-items: center;
   gap: 12px;
 }
 
-.feedback-admin__title {
-  margin: 0;
-  font-size: 18px;
-  font-weight: 600;
-  color: var(--color-text);
+/* Полоса фильтр-чипов со счётчиками */
+.filter-strip {
+  flex-shrink: 0;
+  padding: 10px 20px;
+  border-bottom: 1px solid #e6e6e6;
 }
 
-.summary-cards {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 10px;
+/* Master-detail */
+.content-container {
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
-.summary-card {
-  background: #fff;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  padding: 12px 14px;
+/* Левая колонка: список */
+.list-section {
+  width: 40%;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  border-right: 1px solid #e6e6e6;
+  min-height: 0;
+}
+
+.list-header {
+  display: flex;
+  align-items: center;
+  height: 43px;
+  padding: 0 20px;
+  border-bottom: 1px solid #e6e6e6;
+  flex-shrink: 0;
+}
+
+.header-col {
+  font-size: 13px;
+  font-weight: 600;
+  color: #a2a2a2;
+  user-select: none;
+}
+
+.header-col.col-id,
+.header-col.col-author,
+.header-col.col-date {
   cursor: pointer;
-  text-align: left;
-  transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
-  font-family: inherit;
 }
 
-.summary-card:hover {
-  border-color: var(--color-primary);
-  box-shadow: var(--shadow-sm);
+.header-col.active-sort {
+  color: #000;
 }
 
-.summary-card--active {
-  border-color: var(--color-primary);
-  box-shadow: var(--shadow-focus);
+.col-id {
+  width: 14%;
 }
 
-.summary-card__label {
+.col-author {
+  width: 40%;
+}
+
+.col-status {
+  width: 28%;
+}
+
+.col-date {
+  width: 18%;
+  text-align: right;
+}
+
+.list-body {
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+}
+
+.ticket-row {
+  display: flex;
+  align-items: center;
+  height: 48px;
+  padding: 0 20px;
+  border-bottom: 1px solid #f0f0f0;
+  font-size: 14px;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.ticket-row:hover {
+  background-color: #fafafa;
+}
+
+.ticket-row.selected {
+  background-color: #f8f9ff;
+}
+
+.ticket-row.unread .author {
+  font-weight: 600;
+  color: #000;
+}
+
+.cell {
+  padding: 0 8px;
+  overflow: hidden;
+}
+
+.cell.col-id {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.id-value {
+  font-weight: 600;
+  color: #000;
+}
+
+.unread-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  flex-shrink: 0;
+}
+
+.ticket-row:not(.unread) .unread-dot {
+  visibility: hidden;
+}
+
+.author {
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: #444;
+}
+
+.cell-date {
+  text-align: right;
+  color: #a2a2a2;
   font-size: 12px;
-  color: var(--color-text-muted);
+}
+
+.status-badge {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 20px;
+  font-size: 11px;
+  font-weight: 600;
+  min-width: 78px;
+  text-align: center;
+}
+
+.status-open {
+  background-color: #fff3e0;
+  color: #ef6c00;
+  border: 1px solid #ffcc80;
+}
+
+.status-resolved {
+  background-color: #e6f7e6;
+  color: #2e7d32;
+  border: 1px solid #a5d6a7;
+}
+
+.empty-list {
+  padding: 40px 20px;
+  text-align: center;
+  color: #a2a2a2;
+  font-size: 14px;
+}
+
+.list-footer {
+  flex-shrink: 0;
+  padding: 6px 20px;
+  border-top: 1px solid #e6e6e6;
+  text-align: right;
+  background: #f8fafc;
+}
+
+.items-count {
+  font-size: 12px;
+  color: #a2a2a2;
   font-weight: 500;
 }
 
-.summary-card__value {
-  font-size: 22px;
-  font-weight: 600;
-  color: var(--color-text);
-}
-
-.summary-card--accent .summary-card__value { color: var(--color-primary); }
-.summary-card--warning .summary-card__value { color: #b45309; }
-.summary-card--success .summary-card__value { color: #15803d; }
-
-.filters-row {
-  display: flex;
-  gap: 12px;
-  align-items: center;
-  flex-wrap: wrap;
-}
-
-.search-component {
-  flex: 1 1 260px;
-  max-width: 360px;
-}
-
-.filter-toggle-group {
-  display: flex;
-  gap: 8px;
-}
-
-.feedback-admin__list {
-  min-height: 240px;
-}
-
-.skeleton-grid,
-.cards-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
-  gap: 12px;
-}
-
-.ticket-card {
-  background: #fff;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  padding: 14px 16px;
+/* Правая колонка: детали */
+.detail-section {
+  width: 60%;
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  min-height: 0;
 }
 
-.ticket-card:hover {
-  border-color: var(--color-primary);
-  box-shadow: var(--shadow-sm);
-}
-
-.ticket-card--unread {
-  border-left: 3px solid var(--color-primary);
-}
-
-.ticket-card--resolved {
-  background: #fafafa;
-}
-
-.ticket-card__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 8px;
-}
-
-.ticket-card__meta {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  min-width: 0;
-}
-
-.ticket-id {
-  font-family: 'JetBrains Mono', monospace, ui-monospace;
-  font-size: 12px;
-  color: var(--color-text-muted);
-  background: var(--color-bg-secondary);
-  padding: 2px 8px;
-  border-radius: var(--radius-sm);
-}
-
-.ticket-author {
-  font-weight: 600;
-  color: var(--color-text);
-  font-size: 13px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.ticket-card__message {
-  margin: 0;
-  font-size: 13px;
-  line-height: 1.5;
-  color: var(--color-text);
-  white-space: pre-wrap;
-}
-
-.ticket-card__response {
-  background: var(--color-bg);
-  border-radius: var(--radius-md);
-  padding: 8px 12px;
-  border-left: 3px solid var(--color-success);
-}
-
-.ticket-card__response p {
-  margin: 0;
-  font-size: 12px;
-  color: var(--color-text);
-}
-
-.response-label {
-  display: block;
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--color-text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  margin-bottom: 4px;
-}
-
-.ticket-card__footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  flex-wrap: wrap;
-  gap: 10px;
-  border-top: 1px solid var(--color-border);
-  padding-top: 10px;
-}
-
-.ticket-card__times {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  font-size: 11px;
-  color: var(--color-text-muted);
-}
-
-.ticket-time--resolved {
-  color: var(--color-success);
-}
-
-.ticket-card__actions {
-  display: flex;
-  gap: 8px;
-}
-
-.empty-state {
-  text-align: center;
-  padding: 48px 24px;
-  color: var(--color-text-muted);
-}
-
-.modal-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(15, 23, 42, 0.5);
+.no-selection {
+  flex: 1;
   display: flex;
   align-items: center;
   justify-content: center;
+  text-align: center;
   padding: 20px;
-  z-index: 1000;
+  color: #a2a2a2;
+  font-size: 14px;
 }
 
-.modal-content {
-  background: #fff;
-  border-radius: var(--radius-lg);
-  width: 100%;
-  max-width: 520px;
-  max-height: 90vh;
+.detail-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
-  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.2);
+  gap: 18px;
 }
 
-.modal-content__header {
+.detail-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 16px 20px;
-  border-bottom: 1px solid var(--color-border);
+  gap: 12px;
 }
 
-.modal-content__header h3 {
+.detail-title {
   margin: 0;
-  font-size: 16px;
+  font-size: 1.2em;
   font-weight: 600;
+  color: #000;
 }
 
-.modal-close-btn {
-  background: none;
-  border: none;
-  font-size: 24px;
-  cursor: pointer;
-  color: var(--color-text-muted);
-  line-height: 1;
-  padding: 0 4px;
-}
-
-.modal-content__body {
-  padding: 16px 20px;
-  overflow-y: auto;
-}
-
-.resolve-context {
-  background: var(--color-bg-secondary);
-  padding: 10px 12px;
-  border-radius: var(--radius-md);
-  font-size: 13px;
-  margin: 0 0 14px 0;
-  line-height: 1.5;
-}
-
-.resolve-label {
+.detail-meta {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  font-size: 13px;
-  font-weight: 500;
+  gap: 2px;
+}
+
+.meta-author {
+  font-size: 14px;
+  font-weight: 600;
   color: var(--color-text);
 }
 
-.modal-content__footer {
+.meta-dates {
+  font-size: 13px;
+  color: var(--color-text-muted);
+}
+
+.message-card {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg);
+  padding: 16px;
+  font-size: 14px;
+  line-height: 1.55;
+  color: #2c2c2c;
+  white-space: pre-wrap;
+}
+
+.answer-card {
+  border: 1px solid #a5d6a7;
+  border-radius: var(--radius-lg);
+  background: #f1faf1;
+  padding: 16px;
+}
+
+.answer-label {
+  font-size: 12px;
+  font-weight: 700;
+  color: #2e7d32;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  margin-bottom: 6px;
+}
+
+.answer-text {
+  font-size: 14px;
+  line-height: 1.55;
+  color: #2c2c2c;
+  white-space: pre-wrap;
+}
+
+.reply-block {
   display: flex;
-  justify-content: flex-end;
-  gap: 8px;
-  padding: 12px 20px;
-  border-top: 1px solid var(--color-border);
+  flex-direction: column;
+  gap: 10px;
+}
+
+.reply-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.detail-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
 }
 
 @media (max-width: 768px) {
-  .summary-cards {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-  .filters-row {
+  .content-container {
     flex-direction: column;
-    align-items: stretch;
   }
-  .search-component {
-    max-width: 100%;
-  }
-  .filter-toggle-group {
+  .list-section,
+  .detail-section {
     width: 100%;
   }
-  .filter-toggle-group .lk-button {
-    flex: 1;
-  }
-  .cards-grid,
-  .skeleton-grid {
-    grid-template-columns: 1fr;
+  .list-section {
+    border-right: none;
+    border-bottom: 1px solid #e6e6e6;
+    max-height: 320px;
   }
 }
 </style>

--- a/frontend/src/views/__tests__/FeedbackPage.spec.js
+++ b/frontend/src/views/__tests__/FeedbackPage.spec.js
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+
+// Админ-вкладка "Обратная связь" в раскладке эталона (master-detail): список слева,
+// деталь + инлайн-ответ справа. Проверяем рендер/счётчики, авто-выбор, ответ с
+// сохранением комментария, возврат в работу, фильтр по статусу и обработку ошибок.
+
+vi.mock('@/api/feedback', () => ({
+  getAllFeedback: vi.fn(),
+  updateFeedbackStatus: vi.fn(),
+  markFeedbackAsRead: vi.fn(),
+}));
+
+const notify = vi.fn();
+vi.mock('@/stores/deletions', () => ({
+  useDeletionsStore: () => ({ notify }),
+}));
+
+import FeedbackPage from '@/views/FeedbackPage.vue';
+import FilterTabs from '@/components/ui/FilterTabs.vue';
+import { getAllFeedback, updateFeedbackStatus, markFeedbackAsRead } from '@/api/feedback';
+
+const stubs = {
+  AdminPageShell: { template: '<div><slot /></div>' },
+  RefreshButton: { template: '<button class="refresh-stub" @click="$emit(\'refresh\')" />' },
+  SearchComponent: { props: ['modelValue', 'title'], template: '<input class="search-stub" />' },
+  SkeletonTransition: { props: ['loading'], template: '<div><slot /></div>' },
+  SkeletonCard: { template: '<div class="skeleton-stub" />' },
+};
+
+function fb(id, over = {}) {
+  return {
+    id,
+    user_id: id,
+    user_name: `Пользователь ${id}`,
+    message: `Сообщение обращения ${id} для теста системы`,
+    status: 'Не решено',
+    is_read: false,
+    created_at: '2026-06-20T10:00:00Z',
+    updated_at: '2026-06-20T10:00:00Z',
+    resolution_comment: null,
+    resolved_at: null,
+    ...over,
+  };
+}
+
+const resolved = (id, comment = 'Ответ оператора') => fb(id, {
+  status: 'Решено',
+  is_read: true,
+  resolution_comment: comment,
+  resolved_at: '2026-06-20T11:00:00Z',
+});
+
+function mountPage() {
+  return mount(FeedbackPage, { global: { stubs } });
+}
+
+let wrapper;
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  vi.clearAllMocks();
+  getAllFeedback.mockResolvedValue([]);
+  updateFeedbackStatus.mockResolvedValue({});
+  markFeedbackAsRead.mockResolvedValue({});
+});
+
+afterEach(() => {
+  wrapper?.unmount();
+});
+
+describe('FeedbackPage', () => {
+  it('рендерит список, счётчик "Всего" и счётчики вкладок', async () => {
+    getAllFeedback.mockResolvedValue([resolved(1), fb(2), fb(3)]);
+    wrapper = mountPage();
+    await flushPromises();
+
+    expect(wrapper.findAll('[data-testid="fb-row"]')).toHaveLength(3);
+    expect(wrapper.find('.list-footer').text()).toContain('Всего: 3');
+
+    expect(wrapper.findComponent(FilterTabs).props('tabs')).toEqual([
+      { key: 'all', label: 'Все', count: 3 },
+      { key: 'new', label: 'Новые', count: 2 },
+      { key: 'open', label: 'В работе', count: 2 },
+      { key: 'resolved', label: 'Решено', count: 1 },
+    ]);
+  });
+
+  it('авто-выбирает первое обращение и показывает деталь', async () => {
+    getAllFeedback.mockResolvedValue([fb(5), fb(9)]);
+    wrapper = mountPage();
+    await flushPromises();
+
+    // сортировка по id desc -> первым идёт #9
+    expect(wrapper.find('[data-testid="fb-detail"]').exists()).toBe(true);
+    expect(wrapper.find('.detail-title').text()).toContain('Обращение #9');
+  });
+
+  it('клик по строке открывает её деталь', async () => {
+    getAllFeedback.mockResolvedValue([fb(5), fb(9)]);
+    wrapper = mountPage();
+    await flushPromises();
+
+    await wrapper.findAll('[data-testid="fb-row"]')[1].trigger('click');
+    expect(wrapper.find('.detail-title').text()).toContain('Обращение #5');
+  });
+
+  it('ответ: шлёт status+comment, уведомляет и показывает карточку ответа', async () => {
+    getAllFeedback.mockResolvedValue([fb(7)]);
+    wrapper = mountPage();
+    await flushPromises();
+
+    await wrapper.find('[data-testid="fb-reply"]').setValue('Готово, проверьте раздел');
+    await wrapper.find('[data-testid="fb-resolve"]').trigger('click');
+    await flushPromises();
+
+    expect(updateFeedbackStatus).toHaveBeenCalledWith(7, {
+      status: 'Решено',
+      comment: 'Готово, проверьте раздел',
+    });
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({ suffix: expect.stringContaining('решённым') }),
+    );
+    expect(wrapper.find('[data-testid="fb-answer"]').text()).toContain('Готово, проверьте раздел');
+    expect(wrapper.find('[data-testid="fb-reply"]').exists()).toBe(false);
+  });
+
+  it('ответ без текста не отправляет поле comment', async () => {
+    getAllFeedback.mockResolvedValue([fb(7)]);
+    wrapper = mountPage();
+    await flushPromises();
+
+    await wrapper.find('[data-testid="fb-resolve"]').trigger('click');
+    await flushPromises();
+
+    expect(updateFeedbackStatus).toHaveBeenCalledWith(7, { status: 'Решено' });
+  });
+
+  it('возврат в работу: шлёт "Не решено" и очищает ответ', async () => {
+    getAllFeedback.mockResolvedValue([resolved(7)]);
+    wrapper = mountPage();
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="fb-answer"]').exists()).toBe(true);
+    await wrapper.find('[data-testid="fb-reopen"]').trigger('click');
+    await flushPromises();
+
+    expect(updateFeedbackStatus).toHaveBeenCalledWith(7, { status: 'Не решено' });
+    expect(wrapper.find('[data-testid="fb-answer"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="fb-reply"]').exists()).toBe(true);
+  });
+
+  it('"Отметить прочитанным" шлёт is_read и убирает кнопку', async () => {
+    getAllFeedback.mockResolvedValue([fb(4)]);
+    wrapper = mountPage();
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="fb-read"]').exists()).toBe(true);
+    await wrapper.find('[data-testid="fb-read"]').trigger('click');
+    await flushPromises();
+
+    expect(markFeedbackAsRead).toHaveBeenCalledWith(4, true);
+    expect(wrapper.find('[data-testid="fb-read"]').exists()).toBe(false);
+  });
+
+  it('фильтр "Решено" оставляет только решённые обращения', async () => {
+    getAllFeedback.mockResolvedValue([resolved(1), fb(2)]);
+    wrapper = mountPage();
+    await flushPromises();
+
+    wrapper.findComponent(FilterTabs).vm.$emit('update:modelValue', 'resolved');
+    await flushPromises();
+
+    const rows = wrapper.findAll('[data-testid="fb-row"]');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].text()).toContain('Пользователь 1');
+  });
+
+  it('пустой список показывает подсказку, деталь скрыта', async () => {
+    getAllFeedback.mockResolvedValue([]);
+    wrapper = mountPage();
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="fb-empty"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="fb-detail"]').exists()).toBe(false);
+  });
+
+  it('ошибка загрузки уведомляет пользователя', async () => {
+    getAllFeedback.mockRejectedValue(new Error('boom'));
+    wrapper = mountPage();
+    await flushPromises();
+
+    expect(notify).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+  });
+});

--- a/internal/handlers/feedback_test.go
+++ b/internal/handlers/feedback_test.go
@@ -214,6 +214,58 @@ func TestFeedback_MarkAsRead(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 }
 
+func findFeedbackByID(items []map[string]interface{}, id int) map[string]interface{} {
+	for _, it := range items {
+		if v, ok := it["id"].(float64); ok && int(v) == id {
+			return it
+		}
+	}
+	return nil
+}
+
+func TestFeedback_Resolve_PersistsComment(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	userToken := testutil.RegisterAndLogin(t, e, "commentuser", "password123", 1, td.OrgID, td.CompanyID)
+	rec := testutil.POST(t, e, "/feedback",
+		`{"message":"Feedback that will be resolved with a comment"}`,
+		testutil.AuthHeader(userToken))
+	require.Equal(t, http.StatusOK, rec.Code)
+	fbID := int(testutil.ParseMap(t, rec)["id"].(float64))
+
+	adminToken := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	adminH := testutil.AuthHeader(adminToken)
+
+	// Решаем с ответом -- ответ и дата решения должны сохраниться.
+	rec = testutil.PUT(t, e, fmt.Sprintf("/feedback/%d/status", fbID),
+		`{"status":"Решено","comment":"Готово, проверьте раздел Транспорт"}`, adminH)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = testutil.GET(t, e, "/feedback/all", adminH)
+	require.Equal(t, http.StatusOK, rec.Code)
+	got := findFeedbackByID(testutil.ParseSlice(t, rec), fbID)
+	require.NotNil(t, got)
+	assert.Equal(t, "Решено", got["status"])
+	assert.Equal(t, "Готово, проверьте раздел Транспорт", got["resolution_comment"])
+	assert.NotNil(t, got["resolved_at"])
+
+	// Возврат в работу очищает ответ и дату решения.
+	rec = testutil.PUT(t, e, fmt.Sprintf("/feedback/%d/status", fbID),
+		`{"status":"Не решено"}`, adminH)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = testutil.GET(t, e, "/feedback/all", adminH)
+	require.Equal(t, http.StatusOK, rec.Code)
+	got = findFeedbackByID(testutil.ParseSlice(t, rec), fbID)
+	require.NotNil(t, got)
+	assert.Equal(t, "Не решено", got["status"])
+	assert.Nil(t, got["resolution_comment"])
+	assert.Nil(t, got["resolved_at"])
+}
+
 func TestFeedback_Stats_AfterCreation(t *testing.T) {
 	e, db, cleanup := testutil.SetupTestApp(t)
 	defer cleanup()

--- a/internal/models/feedback.go
+++ b/internal/models/feedback.go
@@ -20,14 +20,16 @@ func (Feedback) TableName() string { return "feedback" }
 
 // FeedbackWithUser -- обращение с именем пользователя (для администраторов).
 type FeedbackWithUser struct {
-	ID        int       `json:"id"`
-	UserID    int       `json:"user_id"`
-	UserName  string    `json:"user_name"`
-	Message   string    `json:"message"`
-	Status    string    `json:"status"`
-	IsRead    bool      `json:"is_read"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	ID                int        `json:"id"`
+	UserID            int        `json:"user_id"`
+	UserName          string     `json:"user_name"`
+	Message           string     `json:"message"`
+	Status            string     `json:"status"`
+	IsRead            bool       `json:"is_read"`
+	CreatedAt         time.Time  `json:"created_at"`
+	UpdatedAt         time.Time  `json:"updated_at"`
+	ResolutionComment *string    `json:"resolution_comment"`
+	ResolvedAt        *time.Time `json:"resolved_at"`
 }
 
 // MyFeedback -- обращение текущего пользователя.
@@ -55,8 +57,10 @@ type CreateFeedbackRequest struct {
 }
 
 // UpdateFeedbackStatusRequest -- запрос на обновление статуса обращения.
+// Comment -- необязательный ответ заявителю; сохраняется при переводе в "Решено".
 type UpdateFeedbackStatusRequest struct {
-	Status string `json:"status" validate:"required,oneof='Не решено' 'Решено'"`
+	Status  string  `json:"status" validate:"required,oneof='Не решено' 'Решено'"`
+	Comment *string `json:"comment" validate:"omitempty,max=1000"`
 }
 
 // MarkAsReadRequest -- запрос на отметку обращения прочитанным/непрочитанным.

--- a/internal/services/feedback_service.go
+++ b/internal/services/feedback_service.go
@@ -109,7 +109,8 @@ func (s *feedbackService) GetAll(ctx context.Context, typeID int) ([]models.Feed
 		Table("feedback f").
 		Select(`f.id, f.user_id,
 			CONCAT(u.last_name, ' ', u.first_name) AS user_name,
-			f.message, f.status, f.is_read, f.created_at, f.updated_at`).
+			f.message, f.status, f.is_read, f.created_at, f.updated_at,
+			f.resolution_comment, f.resolved_at`).
 		Joins("JOIN users u ON f.user_id = u.id").
 		Order("f.created_at DESC").
 		Scan(&results).Error
@@ -192,14 +193,27 @@ func (s *feedbackService) UpdateStatus(ctx context.Context, typeID int, id int, 
 	}
 
 	now := time.Now().UTC()
-	err := s.db.WithContext(ctx).
+	updates := map[string]interface{}{
+		"status":     req.Status,
+		"updated_at": now,
+	}
+	if req.Status == models.FeedbackResolved {
+		updates["resolved_at"] = now
+		if req.Comment != nil {
+			if trimmed := strings.TrimSpace(*req.Comment); trimmed != "" {
+				updates["resolution_comment"] = trimmed
+			}
+		}
+	} else {
+		// Возврат в работу очищает ответ и дату решения.
+		updates["resolved_at"] = nil
+		updates["resolution_comment"] = nil
+	}
+
+	if err := s.db.WithContext(ctx).
 		Table("feedback").
 		Where("id = ?", id).
-		Updates(map[string]interface{}{
-			"status":     req.Status,
-			"updated_at": now,
-		}).Error
-	if err != nil {
+		Updates(updates).Error; err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "Error updating feedback status")
 	}
 


### PR DESCRIPTION
## Что и зачем
Админ-вкладка "Обратная связь" была карточной сеткой с модалкой ответа и структурно выбивалась из остальной админки. Привёл к эталону `TableConstructor` (master-detail), по утверждённому мокапу (ветка `mockup/feedback-etalon`).

## Фронтенд (`FeedbackPage.vue`)
- Раскладка master-detail: слева сортируемый список обращений (# / Автор / Статус / Дата, синяя точка непрочитанного, pill-бейджи), справа панель деталей с ответом инлайн (как редактирование в эталоне, а не отдельной модалкой).
- Полоса фильтр-чипов со счётчиками: Все / Новые / В работе / Решено (переиспользован `FilterTabs`).
- Обёртка `AdminPageShell` (карточка 35px), шапка `management-header`, футер "Всего: N".
- Переписан на `<script setup>` (был Options API), уведомления через `useDeletionsStore.notify` вместо локальной логики, работа через `@/api/feedback.js` вместо прямого `apiRequest`.

## Бэкенд
- `UpdateStatus` теперь сохраняет `resolution_comment` и `resolved_at` при переводе в "Решено" и очищает их при возврате в работу; раньше ответ не сохранялся и `comment` игнорировался.
- `GetAll` (`FeedbackWithUser`) отдаёт `resolution_comment` и `resolved_at` - до этого ответ жил только в памяти фронта и пропадал после перезагрузки.
- Поле `comment` (необязательное, max 1000) добавлено в `UpdateFeedbackStatusRequest`.

## Проверки
- Go: `go test ./internal/handlers -run TestFeedback` зелёные, включая новый `TestFeedback_Resolve_PersistsComment` (ответ сохраняется и очищается при reopen); `go build ./...` + `go vet` чисто.
- Front: 10 unit-тестов `FeedbackPage.spec.js` (рендер/счётчики, авто-выбор, ответ с comment, возврат в работу, фильтр, mark-read, пусто, ошибка); eslint чисто.
- Браузер (локальный dev): master-detail рендерится, computed-радиусы 35px карточка / 15px textarea, resolve-флоу показывает зелёную карточку ответа, фильтр по статусу работает, 0 ошибок консоли.