### PR TITLE
feat(security): фильтр "Ночь" по окну въезда в "Доступные мне"

### DIFF
--- a/frontend/src/views/AccessibleAttachmentsView.vue
+++ b/frontend/src/views/AccessibleAttachmentsView.vue
@@ -67,6 +67,17 @@
         </button>
         <button
           type="button"
+          class="lk-button filters__toggle"
+          :class="nightFilter ? 'lk-button--primary' : 'lk-button--ghost'"
+          :aria-pressed="nightFilter"
+          title="Окно въезда пересекает ночь (22:00-06:00)"
+          data-testid="aa-filter-night"
+          @click="toggleNight"
+        >
+          Ночь
+        </button>
+        <button
+          type="button"
           class="lk-button lk-button--danger filters__reset"
           :disabled="!hasActiveFilters"
           data-testid="aa-filter-reset"
@@ -346,6 +357,9 @@ const companyFilter = ref(Number(route.query.company) || 0);
 // Завершённые заявки по умолчанию скрыты; тоггл показывает только их. При активном
 // поиске бэк отдаёт и завершённые, и нет независимо от флага (см. сервис фильтра).
 const completedFilter = ref(route.query.completed === '1');
+// "Ночь" - окно въезда вложения пересекает [22:00, 06:00). Считается на бэке из
+// entry_time_from/to; при активном поиске бэк игнорирует флаг (как и completed).
+const nightFilter = ref(route.query.night === '1');
 
 const typeOptions = [
   { id: '', name: 'Все типы' },
@@ -361,7 +375,8 @@ const hasActiveFilters = computed(
     || !!typeFilter.value
     || orgFilter.value !== 0
     || companyFilter.value !== 0
-    || completedFilter.value,
+    || completedFilter.value
+    || nightFilter.value,
 );
 
 const items = ref([]);
@@ -447,6 +462,7 @@ function buildParams() {
   if (orgFilter.value) params.organization_id = orgFilter.value;
   if (companyFilter.value) params.company_id = companyFilter.value;
   if (completedFilter.value) params.completed = true;
+  if (nightFilter.value) params.night = true;
   return params;
 }
 
@@ -458,6 +474,7 @@ function syncUrl() {
   if (orgFilter.value) query.organization = String(orgFilter.value);
   if (companyFilter.value) query.company = String(companyFilter.value);
   if (completedFilter.value) query.completed = '1';
+  if (nightFilter.value) query.night = '1';
   // catch гасит navigation-cancel при быстрой смене фильтров: vue-router отклоняет
   // отменённую replace - это не ошибка приложения, а нормальная гонка ввода.
   router.replace({ query }).catch(() => {});
@@ -519,6 +536,11 @@ function toggleCompleted() {
   applyFilters();
 }
 
+function toggleNight() {
+  nightFilter.value = !nightFilter.value;
+  applyFilters();
+}
+
 function resetFilters() {
   clearTimeout(searchTimer);
   search.value = '';
@@ -526,6 +548,7 @@ function resetFilters() {
   orgFilter.value = 0;
   companyFilter.value = 0;
   completedFilter.value = false;
+  nightFilter.value = false;
   applyFilters();
 }
 

--- a/frontend/src/views/__tests__/AccessibleAttachmentsView.spec.js
+++ b/frontend/src/views/__tests__/AccessibleAttachmentsView.spec.js
@@ -349,6 +349,37 @@ describe('AccessibleAttachmentsView (FE-S6) фильтры', () => {
     );
   });
 
+  it('тоггл "Ночь" шлёт night, пишет URL и восстанавливается из query', async () => {
+    getAccessibleAttachments.mockResolvedValue({ items: [], meta: { total: 0 } });
+    wrapper = mountView();
+    await flushPromises();
+    getAccessibleAttachments.mockClear();
+
+    await wrapper.find('[data-testid="aa-filter-night"]').trigger('click');
+    await flushPromises();
+
+    expect(getAccessibleAttachments).toHaveBeenCalledWith(
+      expect.objectContaining({ night: true, page: 1 }),
+    );
+    expect(replace).toHaveBeenLastCalledWith({ query: { night: '1' } });
+
+    // Повторный клик снимает фильтр - night уходит из параметров и URL.
+    getAccessibleAttachments.mockClear();
+    await wrapper.find('[data-testid="aa-filter-night"]').trigger('click');
+    await flushPromises();
+    expect(getAccessibleAttachments.mock.calls.at(-1)[0]).not.toHaveProperty('night');
+    expect(replace).toHaveBeenLastCalledWith({ query: {} });
+
+    wrapper.unmount();
+    // Диплинк ?night=1 восстанавливает фильтр одним стартовым запросом.
+    getAccessibleAttachments.mockClear();
+    wrapper = mountView({ night: '1' });
+    await flushPromises();
+    expect(getAccessibleAttachments).toHaveBeenCalledWith(
+      expect.objectContaining({ night: true }),
+    );
+  });
+
   it('поиск применяется после debounce и шлёт search', async () => {
     vi.useFakeTimers();
     try {

--- a/internal/handlers/security_attachments.go
+++ b/internal/handlers/security_attachments.go
@@ -50,6 +50,8 @@ func (h *ApplicationHandler) requireSecurityOrAdmin(c echo.Context) (int, bool, 
 // @Param        attachment_type query string false "Тип вложения: cars/people/items"
 // @Param        organization_id query int    false "ID организации"
 // @Param        company_id      query int    false "ID компании"
+// @Param        completed       query bool   false "Только завершённые заявки (по умолчанию скрыты); при активном search игнорируется"
+// @Param        night           query bool   false "Только вложения с ночным окном въезда [22:00-06:00); при активном search игнорируется"
 // @Success      200 {array}  services.AvailableAttachment
 // @Failure      401 {object} models.HTTPError
 // @Failure      403 {object} models.HTTPError

--- a/internal/handlers/security_filters_test.go
+++ b/internal/handlers/security_filters_test.go
@@ -83,6 +83,12 @@ func (w secWorld) setAppNumber(t *testing.T, appID int, number string) {
 		Update("application_number", number).Error)
 }
 
+func (w secWorld) setAttachmentEntryTime(t *testing.T, attID int, from, to string) {
+	t.Helper()
+	require.NoError(t, w.db.Model(&models.Attachment{}).Where("id = ?", attID).
+		Updates(map[string]interface{}{"entry_time_from": from, "entry_time_to": to}).Error)
+}
+
 func (w secWorld) listFiltered(t *testing.T, ctx context.Context, f services.AvailableAttachmentFilters) ([]services.AvailableAttachment, int64) {
 	t.Helper()
 	rows, total, err := w.svc.GetAvailableAttachmentsForSecurity(ctx, w.guardID, false, f, 1, 50)
@@ -288,4 +294,93 @@ func TestAvailableAttachments_FilterDoesNotBypassPlaceGate(t *testing.T) {
 	rows, total = w.listFiltered(t, ctx, services.AvailableAttachmentFilters{OrganizationID: secPtrInt(org2)})
 	require.EqualValues(t, 0, total, "фильтр по чужой организации не раскрывает вложение вне мест охранника")
 	require.False(t, secContainsAttachment(rows, foreignCars))
+}
+
+// TestAvailableAttachments_FilterByNight закрепляет границы ночного окна [22:00, 06:00): 22:00
+// включается, 06:00 нет; смешанный формат HH:MM/HH:MM:SS считается одинаково; окно через полночь
+// и NULL-окно. Граничные времена - главный риск среза (string-сравнение HH:MM в SQL).
+func TestAvailableAttachments_FilterByNight(t *testing.T) {
+	w := setupSecurityWorld(t)
+	ctx := context.Background()
+
+	place := w.newUnloadPlace(t, "Склад А", true)
+	w.assignUnloadPlace(t, place)
+	app := w.newApp(t, models.ConfirmationApproved)
+
+	cases := []struct {
+		name      string
+		from, to  string
+		wantNight bool
+	}{
+		{"дневное 09-18 (HH:MM:SS)", "09:00:00", "18:00:00", false},
+		{"конец ровно 22:00 - граница включена", "19:00", "22:00", true},
+		{"вечер до 22:00 - не ночь", "21:00", "21:59", false},
+		{"начало ровно 22:00", "22:00", "23:00", true},
+		{"раннее утро до 06:00", "00:00", "05:00", true},
+		{"начало ровно 06:00 - граница исключена", "06:00", "08:00", false},
+		{"начало 05:59 < 06:00", "05:59", "06:30", true},
+		{"через полночь 23-02 (wrap)", "23:00", "02:00", true},
+		{"смешанный формат, конец >= 22:00", "08:00:00", "23:00", true},
+	}
+
+	type nightCase struct {
+		att  int
+		name string
+		want bool
+	}
+	ncs := make([]nightCase, 0, len(cases))
+	for _, c := range cases {
+		att := w.newAttachment(t, app, "cars")
+		w.attachPlace(t, att, place)
+		w.setAttachmentEntryTime(t, att, c.from, c.to)
+		ncs = append(ncs, nightCase{att, c.name, c.wantNight})
+	}
+
+	// Вложение без указанного окна (NULL-времена) - не ночь.
+	noTimeAtt := w.newAttachment(t, app, "cars")
+	w.attachPlace(t, noTimeAtt, place)
+
+	night := true
+	rows, _ := w.listFiltered(t, ctx, services.AvailableAttachmentFilters{Night: &night})
+	for _, nc := range ncs {
+		require.Equalf(t, nc.want, secContainsAttachment(rows, nc.att), "ночной фильтр: %s", nc.name)
+	}
+	require.False(t, secContainsAttachment(rows, noTimeAtt), "вложение без окна въезда не ночь")
+
+	// Фильтр аддитивен: без него видны все вложения (включая дневные и без окна).
+	_, totalAll := w.listFiltered(t, ctx, services.AvailableAttachmentFilters{})
+	require.EqualValues(t, len(cases)+1, totalAll, "без ночного фильтра видны все вложения")
+}
+
+// TestAvailableAttachments_NightIgnoredDuringSearch - при активном поиске ночной предикат не
+// навешивается (поиск отдаёт и ночные, и дневные), как и фильтр "Завершённые".
+func TestAvailableAttachments_NightIgnoredDuringSearch(t *testing.T) {
+	w := setupSecurityWorld(t)
+	ctx := context.Background()
+
+	place := w.newUnloadPlace(t, "Склад А", true)
+	w.assignUnloadPlace(t, place)
+	app := w.newApp(t, models.ConfirmationApproved)
+
+	dayAtt := w.newAttachmentNamed(t, app, "cars", "Ромашка дневная")
+	w.attachPlace(t, dayAtt, place)
+	w.setAttachmentEntryTime(t, dayAtt, "09:00", "18:00")
+
+	nightAtt := w.newAttachmentNamed(t, app, "cars", "Ромашка ночная")
+	w.attachPlace(t, nightAtt, place)
+	w.setAttachmentEntryTime(t, nightAtt, "23:00", "23:30")
+
+	// Без поиска night=true оставляет только ночное.
+	night := true
+	rows, total := w.listFiltered(t, ctx, services.AvailableAttachmentFilters{Night: &night})
+	require.EqualValues(t, 1, total)
+	require.True(t, secContainsAttachment(rows, nightAtt))
+	require.False(t, secContainsAttachment(rows, dayAtt))
+
+	// Поиск отменяет ночной предикат: видны и дневное, и ночное (даже при night=true).
+	query := "Ромашка"
+	rows, total = w.listFiltered(t, ctx, services.AvailableAttachmentFilters{Search: &query, Night: &night})
+	require.EqualValues(t, 2, total, "поиск показывает и ночные, и дневные")
+	require.True(t, secContainsAttachment(rows, dayAtt))
+	require.True(t, secContainsAttachment(rows, nightAtt))
 }

--- a/internal/handlers/security_filters_test.go
+++ b/internal/handlers/security_filters_test.go
@@ -384,3 +384,61 @@ func TestAvailableAttachments_NightIgnoredDuringSearch(t *testing.T) {
 	require.True(t, secContainsAttachment(rows, dayAtt))
 	require.True(t, secContainsAttachment(rows, nightAtt))
 }
+
+// TestAvailableAttachments_NightDoesNotBypassPlaceGate - ночной фильтр аддитивен поверх гейта мест:
+// ночное вложение на ЧУЖОМ месте не раскрывается (по образцу TestAvailableAttachments_FilterDoesNotBypassPlaceGate).
+func TestAvailableAttachments_NightDoesNotBypassPlaceGate(t *testing.T) {
+	w := setupSecurityWorld(t)
+	ctx := context.Background()
+
+	myPlace := w.newUnloadPlace(t, "Мой склад", true)
+	otherPlace := w.newUnloadPlace(t, "Чужой склад", true)
+	w.assignUnloadPlace(t, myPlace)
+
+	app := w.newApp(t, models.ConfirmationApproved)
+	mineNight := w.newAttachment(t, app, "cars")
+	w.attachPlace(t, mineNight, myPlace)
+	w.setAttachmentEntryTime(t, mineNight, "23:00", "23:30")
+
+	foreignNight := w.newAttachment(t, app, "cars")
+	w.attachPlace(t, foreignNight, otherPlace)
+	w.setAttachmentEntryTime(t, foreignNight, "23:00", "23:30")
+
+	night := true
+	rows, total := w.listFiltered(t, ctx, services.AvailableAttachmentFilters{Night: &night})
+	require.EqualValues(t, 1, total, "ночной фильтр не обходит гейт мест")
+	require.True(t, secContainsAttachment(rows, mineNight))
+	require.False(t, secContainsAttachment(rows, foreignNight), "ночное вложение на чужом месте скрыто")
+}
+
+// TestAvailableAttachments_NightAndCompletedCombined - оба тоггла активны (видны в UI рядом):
+// SQL даёт status='Завершено' AND ночное окно -> только ночные завершённые.
+func TestAvailableAttachments_NightAndCompletedCombined(t *testing.T) {
+	w := setupSecurityWorld(t)
+	ctx := context.Background()
+
+	place := w.newUnloadPlace(t, "Склад А", true)
+	w.assignUnloadPlace(t, place)
+
+	doneApp := w.newAppWithStatus(t, models.ConfirmationApproved, models.StatusCompleted)
+	activeApp := w.newAppWithStatus(t, models.ConfirmationApproved, models.StatusInWork)
+
+	doneNight := w.newAttachment(t, doneApp, "cars") // завершённая + ночь -> проходит
+	w.attachPlace(t, doneNight, place)
+	w.setAttachmentEntryTime(t, doneNight, "23:00", "23:30")
+
+	doneDay := w.newAttachment(t, doneApp, "cars") // завершённая, но день -> отсекается night
+	w.attachPlace(t, doneDay, place)
+	w.setAttachmentEntryTime(t, doneDay, "09:00", "18:00")
+
+	activeNight := w.newAttachment(t, activeApp, "cars") // ночь, но не завершённая -> отсекается completed
+	w.attachPlace(t, activeNight, place)
+	w.setAttachmentEntryTime(t, activeNight, "23:00", "23:30")
+
+	night, completed := true, true
+	rows, total := w.listFiltered(t, ctx, services.AvailableAttachmentFilters{Night: &night, Completed: &completed})
+	require.EqualValues(t, 1, total, "night+completed: только ночные завершённые")
+	require.True(t, secContainsAttachment(rows, doneNight))
+	require.False(t, secContainsAttachment(rows, doneDay))
+	require.False(t, secContainsAttachment(rows, activeNight))
+}

--- a/internal/services/security_visibility_service.go
+++ b/internal/services/security_visibility_service.go
@@ -57,7 +57,28 @@ type AvailableAttachmentFilters struct {
 	// завершённые (дефолт вкладки), true - показать только завершённые. При активном Search не
 	// применяется (поиск отдаёт и завершённые, и нет) - см. availableAttachmentFilterWhere.
 	Completed *bool `query:"completed"`
+	// Night фильтрует по ночному окну въезда: nil/false - не фильтровать, true - только
+	// вложения, чьё окно entry_time пересекает ночь [22:00, 06:00). Вычисляется в SQL из строк
+	// entry_time_from/to без новых колонок (см. availableAttachmentNightClause). При активном
+	// Search не применяется (поиск отдаёт всё) - см. availableAttachmentFilterWhere.
+	Night *bool `query:"night"`
 }
+
+// availableAttachmentNightClause - предикат "ночного" окна въезда для фильтра night=true. Ночь =
+// [22:00, 06:00) (22:00 включительно, 06:00 нет). Окно въезда хранится строками entry_time_from/to
+// в формате HH:MM или HH:MM:SS (varchar(20)); substr(...,1,5) приводит обе формы к 'HH:MM', а
+// зеро-паддинг часа делает лексикографическое сравнение хронологическим - без ::time-каста, который
+// упал бы (500) на нечисловом мусоре в колонке. Окно НЕ через полночь (from<=to) попадает в ночь,
+// если конец >= 22:00 или начало < 06:00; окно через полночь (from>to) всегда пересекает ночь
+// (содержит 00:00 < 06:00). Пустые/NULL-времена не считаются ночью (нет данных об окне).
+const availableAttachmentNightClause = `(
+	a.entry_time_from IS NOT NULL AND a.entry_time_to IS NOT NULL
+	AND a.entry_time_from <> '' AND a.entry_time_to <> ''
+	AND CASE WHEN substr(a.entry_time_from, 1, 5) <= substr(a.entry_time_to, 1, 5)
+		THEN substr(a.entry_time_to, 1, 5) >= '22:00' OR substr(a.entry_time_from, 1, 5) < '06:00'
+		ELSE true
+	END
+)`
 
 // availableAttachmentFrom - общий FROM листинга и счётчика "Доступные мне". LEFT JOIN'ы
 // organizations/companies/users держат отношение 1:1 к вложению (все по PK), поэтому НЕ меняют
@@ -174,6 +195,10 @@ func availableAttachmentFilterWhere(f AvailableAttachmentFilters) (string, []int
 		} else {
 			clauses = append(clauses, "app.status IS DISTINCT FROM ?")
 			args = append(args, models.StatusCompleted)
+		}
+		// Ночное окно въезда: предикат без плейсхолдеров (границы 22:00/06:00 - литералы).
+		if f.Night != nil && *f.Night {
+			clauses = append(clauses, availableAttachmentNightClause)
 		}
 	}
 	if f.Search != nil {


### PR DESCRIPTION
Срез S5 эпика aa-improvements (follow-up #706). Добавляет фильтр "Ночь" во вкладку "Доступные мне" охранника.

## Что
- BE: фильтр `night=true` поверх инварианта видимости мест. Ночь = окно въезда `[entry_time_from, entry_time_to]` пересекает `[22:00, 06:00)` (22:00 включительно, 06:00 нет). При активном поиске не применяется (показывает оба, как `completed`).
- FE: тоггл "Ночь" рядом с "Завершённые" (тот же паттерн: state, buildParams/syncUrl/hasActiveFilters/reset, URL `?night=1`).

## Как считается ночь (SQL)
`entry_time_from/to` - `varchar(20)`, формат непоследовательный (`HH:MM` и `HH:MM:SS`). Предикат берёт `substr(...,1,5)` -> нормализует к `HH:MM`; зеро-паддинг часа делает лексикографическое сравнение хронологическим - без `::time`-каста, который упал бы (500) на нечисловом мусоре в колонке. Окно non-wrap (from<=to) - ночь, если конец `>= 22:00` или начало `< 06:00`; окно через полночь (from>to) всегда ночь (содержит 00:00). Пустые/NULL-времена не ночь.

## Тесты
- `TestAvailableAttachments_FilterByNight` - граничные времена (22:00 вкл, 06:00 искл, смешанный формат, wrap через полночь, NULL-окно).
- `TestAvailableAttachments_NightIgnoredDuringSearch` - поиск отменяет ночной предикат.
- `TestAvailableAttachments_NightDoesNotBypassPlaceGate` - ночное вложение на чужом месте скрыто.
- `TestAvailableAttachments_NightAndCompletedCombined` - оба тоггла -> только ночные завершённые.
- FE-спека тоггла "Ночь" (включение/снятие/диплинк).

## Ревью
code-reviewer: GO, блокеров нет. Жёлтые учтены: добавлены swagger `@Param night`/`completed`, тест place-gate для night, тест комбо. Полный `go test ./...` локально ловит коллизию ОБЩЕЙ тест-БД с параллельной сессией (`internal/database` partition-тест, не связан с диффом); `internal/handlers` изолированно зелёный - SQL исполняется.

Генерируемые `docs/swagger.*` не регенерил (их сейчас правит другая сессия; `completed` тоже исторически без регена).