### PR TITLE
feat(search): единый util мощного поиска + раскатка на справочники

### DIFF
--- a/frontend/src/components/AttachmentsManagement.vue
+++ b/frontend/src/components/AttachmentsManagement.vue
@@ -483,6 +483,7 @@
 
 <script>
 import SearchComponent from './SearchComponent.vue';
+import { buildSearchVariants, matchesSearch } from '@/utils/searchVariants';
 import RefreshButton from './RefreshButton.vue';
 import ConfirmationModal from './ConfirmationModal.vue';
 import TextConstructor from './TextConstructor.vue';
@@ -566,14 +567,13 @@ export default {
   },
   computed: {
     filteredAttachments() {
-      const q = this.searchQuery.trim().toLowerCase();
+      const variants = buildSearchVariants(this.searchQuery);
       let list = this.items.filter(a => (this.showArchive ? !a.is_active : a.is_active));
-      if (q) {
-        list = list.filter(a =>
-          (a.display_name || '').toLowerCase().includes(q)
-          || (a.name || '').toLowerCase().includes(q)
-          || (a.title || '').toLowerCase().includes(q)
-          || String(a.id).includes(q));
+      if (variants.length) {
+        list = list.filter(a => matchesSearch(
+          `${a.display_name || ''} ${a.name || ''} ${a.title || ''} ${a.id}`,
+          variants,
+        ));
       }
       return this.sortList(list);
     },

--- a/frontend/src/components/CitizenshipManagement.vue
+++ b/frontend/src/components/CitizenshipManagement.vue
@@ -365,6 +365,7 @@
 
 <script>
 import SearchComponent from './SearchComponent.vue';
+import { buildSearchVariants, matchesSearch } from '@/utils/searchVariants';
 import RefreshButton from './RefreshButton.vue';
 import ConfirmationModal from './ConfirmationModal.vue';
 import BaseDropdown from './ui/BaseDropdown.vue';
@@ -418,10 +419,10 @@ export default {
   },
   computed: {
     filteredCitizenships() {
-      const q = this.searchQuery.trim().toLowerCase();
+      const variants = buildSearchVariants(this.searchQuery);
       let list = this.items.filter(c => (this.showArchive ? !c.is_active : c.is_active));
-      if (q) {
-        list = list.filter(c => c.name.toLowerCase().includes(q) || String(c.id).includes(q));
+      if (variants.length) {
+        list = list.filter(c => matchesSearch(`${c.name} ${c.id}`, variants));
       }
       return this.sortList(list);
     },

--- a/frontend/src/components/CompaniesManagement.vue
+++ b/frontend/src/components/CompaniesManagement.vue
@@ -363,6 +363,7 @@
 <script>
 import { mapState, mapActions } from 'pinia';
 import { apiRequest } from '@/api/client';
+import { buildSearchVariants, matchesSearch } from '@/utils/searchVariants';
 import { useCompaniesStore } from '@/stores/companies';
 import { useDeletionsStore } from '@/stores/deletions';
 import { registerDirtyTracker, confirmIfAnyDirty } from '@/utils/dirtyTracker';
@@ -428,12 +429,9 @@ export default {
       const byMode = this.companiesWithUsers.filter(comp =>
         this.showArchive ? !comp.is_active : comp.is_active
       );
-      if (!this.searchQuery) return byMode;
-      const query = this.searchQuery.toLowerCase();
-      return byMode.filter(comp =>
-        comp.name.toLowerCase().includes(query) ||
-        comp.id.toString().includes(query)
-      );
+      const variants = buildSearchVariants(this.searchQuery);
+      if (!variants.length) return byMode;
+      return byMode.filter(comp => matchesSearch(`${comp.name} ${comp.id}`, variants));
     },
     sortedCompanies() {
       const companies = [...this.filteredCompanies];

--- a/frontend/src/components/MarksManagement.vue
+++ b/frontend/src/components/MarksManagement.vue
@@ -296,6 +296,7 @@
 
 <script>
 import SearchComponent from './SearchComponent.vue';
+import { buildSearchVariants, matchesSearch } from '@/utils/searchVariants';
 import RefreshButton from './RefreshButton.vue';
 import MarkHistoryModal from './MarkHistoryModal.vue';
 import ConfirmationModal from './ConfirmationModal.vue';
@@ -349,10 +350,10 @@ export default {
   },
   computed: {
     filteredMarks() {
-      const q = this.searchQuery.trim().toLowerCase();
+      const variants = buildSearchVariants(this.searchQuery);
       let list = this.marks.filter(m => (this.showArchive ? !m.is_active : m.is_active));
-      if (q) {
-        list = list.filter(m => m.name.toLowerCase().includes(q) || String(m.id).includes(q));
+      if (variants.length) {
+        list = list.filter(m => matchesSearch(`${m.name} ${m.id}`, variants));
       }
       return this.sortList(list);
     },

--- a/frontend/src/components/NumberFormat.vue
+++ b/frontend/src/components/NumberFormat.vue
@@ -668,6 +668,7 @@
 
 <script>
 import SearchComponent from './SearchComponent.vue';
+import { buildSearchVariants, matchesSearch } from '@/utils/searchVariants';
 import RefreshButton from './RefreshButton.vue';
 import ConfirmationModal from './ConfirmationModal.vue';
 import BaseDropdown from './ui/BaseDropdown.vue';
@@ -745,14 +746,14 @@ export default {
   },
   computed: {
     filteredFormats() {
-      const q = this.searchQuery.trim().toLowerCase();
+      const variants = buildSearchVariants(this.searchQuery);
       let list = this.formats.filter(item =>
         this.showArchive ? !item.format.is_active : item.format.is_active);
-      if (q) {
-        list = list.filter(item =>
-          item.format.name.toLowerCase().includes(q)
-          || String(item.format.id).includes(q)
-          || (item.format.country_code && item.format.country_code.toLowerCase().includes(q)));
+      if (variants.length) {
+        list = list.filter(item => matchesSearch(
+          `${item.format.name} ${item.format.id} ${item.format.country_code || ''}`,
+          variants,
+        ));
       }
       return this.sortList(list);
     },

--- a/frontend/src/components/OrganizationsManagement.vue
+++ b/frontend/src/components/OrganizationsManagement.vue
@@ -363,6 +363,7 @@
 <script>
 import { mapState, mapActions } from 'pinia';
 import { apiRequest } from '@/api/client';
+import { buildSearchVariants, matchesSearch } from '@/utils/searchVariants';
 import { useOrganizationsStore } from '@/stores/organizations';
 import { useDeletionsStore } from '@/stores/deletions';
 import { registerDirtyTracker, confirmIfAnyDirty } from '@/utils/dirtyTracker';
@@ -428,12 +429,9 @@ export default {
       const byMode = this.organizationsWithUsers.filter(org =>
         this.showArchive ? !org.is_active : org.is_active
       );
-      if (!this.searchQuery) return byMode;
-      const query = this.searchQuery.toLowerCase();
-      return byMode.filter(org =>
-        org.name.toLowerCase().includes(query) ||
-        org.id.toString().includes(query)
-      );
+      const variants = buildSearchVariants(this.searchQuery);
+      if (!variants.length) return byMode;
+      return byMode.filter(org => matchesSearch(`${org.name} ${org.id}`, variants));
     },
     sortedOrganizations() {
       const organizations = [...this.filteredOrganizations];

--- a/frontend/src/components/UnloadPlaces/UnloadPlacesContainer.vue
+++ b/frontend/src/components/UnloadPlaces/UnloadPlacesContainer.vue
@@ -601,6 +601,7 @@
 
 <script>
 import { apiRequest } from '@/api/client'
+import { buildSearchVariants, matchesSearch } from '@/utils/searchVariants'
 import { useDeletionsStore } from '@/stores/deletions';
 import { useOverlayClose } from '@/composables/useOverlayClose';
 import RefreshButton from '../RefreshButton.vue';
@@ -673,12 +674,9 @@ export default {
       const byMode = this.unloadPlaces.filter(place =>
         this.showArchive ? !place.is_active : place.is_active
       );
-      if (!this.searchQuery) return byMode;
-      const query = this.searchQuery.toLowerCase();
-      return byMode.filter(place =>
-        place.name.toLowerCase().includes(query) ||
-        place.id.toString().includes(query)
-      );
+      const variants = buildSearchVariants(this.searchQuery);
+      if (!variants.length) return byMode;
+      return byMode.filter(place => matchesSearch(`${place.name} ${place.id}`, variants));
     },
     sortedUnloadPlaces() {
       const places = [...this.filteredUnloadPlaces];

--- a/frontend/src/components/UserTypes.vue
+++ b/frontend/src/components/UserTypes.vue
@@ -314,6 +314,7 @@
 
 <script>
 import { apiRequest } from '@/api/client'
+import { buildSearchVariants, matchesSearch } from '@/utils/searchVariants'
 import RefreshButton from './RefreshButton.vue';
 import SearchComponent from './SearchComponent.vue';
 import ConfirmationModal from './ConfirmationModal.vue';
@@ -362,13 +363,12 @@ export default {
       return this.searchQuery.trim() ? 'Ничего не найдено по запросу' : 'Типов пока нет';
     },
     filteredTypes() {
-      if (!this.searchQuery) return this.types;
-      const query = this.searchQuery.toLowerCase();
-      return this.types.filter(type => 
-        type.name.toLowerCase().includes(query) || 
-        type.code.toLowerCase().includes(query) ||
-        type.id.toString().includes(query)
-      );
+      const variants = buildSearchVariants(this.searchQuery);
+      if (!variants.length) return this.types;
+      return this.types.filter(type => matchesSearch(
+        `${type.name} ${type.code} ${type.id}`,
+        variants,
+      ));
     },
     sortedTypes() {
       const types = [...this.filteredTypes];

--- a/frontend/src/utils/__tests__/searchVariants.spec.js
+++ b/frontend/src/utils/__tests__/searchVariants.spec.js
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { buildSearchVariants, matchesSearch } from '../searchVariants';
+
+describe('buildSearchVariants', () => {
+    it('пустой ввод -> пустой набор', () => {
+        expect(buildSearchVariants('')).toEqual([]);
+        expect(buildSearchVariants('   ')).toEqual([]);
+        expect(buildSearchVariants(null)).toEqual([]);
+    });
+
+    it('включает оригинал в нижнем регистре', () => {
+        expect(buildSearchVariants('Иванов')).toContain('иванов');
+    });
+
+    it('раскладка EN->RU: набрано на латинице вместо кириллицы', () => {
+        // "bdfyjd" на физических клавишах = "иванов"
+        expect(buildSearchVariants('bdfyjd')).toContain('иванов');
+    });
+
+    it('раскладка RU->EN: набрано на кириллице вместо латиницы', () => {
+        // "фвьшт" на физических клавишах = "admin"
+        expect(buildSearchVariants('фвьшт')).toContain('admin');
+    });
+
+    it('фонетический транслит кириллица->латиница', () => {
+        expect(buildSearchVariants('иванов')).toContain('ivanov');
+    });
+
+    it('фонетический транслит латиница->кириллица', () => {
+        expect(buildSearchVariants('ivanov')).toContain('иванов');
+    });
+
+    it('добавляет вариант без пробелов', () => {
+        expect(buildSearchVariants('а 123 вс')).toContain('а123вс');
+    });
+
+    it('варианты уникальны', () => {
+        const v = buildSearchVariants('test');
+        expect(new Set(v).size).toBe(v.length);
+    });
+});
+
+describe('matchesSearch', () => {
+    const variants = buildSearchVariants('иванов');
+
+    it('пустые варианты -> совпадает всё', () => {
+        expect(matchesSearch('что угодно', [])).toBe(true);
+        expect(matchesSearch('что угодно', null)).toBe(true);
+    });
+
+    it('прямое вхождение', () => {
+        expect(matchesSearch('Иванов Иван Иванович', variants)).toBe(true);
+    });
+
+    it('находит при вводе в неверной раскладке', () => {
+        expect(matchesSearch('Иванов Пётр', buildSearchVariants('bdfyjd'))).toBe(true);
+    });
+
+    it('находит транслит', () => {
+        expect(matchesSearch('Ivanov Ivan', buildSearchVariants('иванов'))).toBe(true);
+    });
+
+    it('номер слитно находит раздельный', () => {
+        expect(matchesSearch('А 123 ВС 77', buildSearchVariants('а123вс'))).toBe(true);
+    });
+
+    it('номер раздельно находит слитный', () => {
+        expect(matchesSearch('А123ВС77', buildSearchVariants('а 123 вс'))).toBe(true);
+    });
+
+    it('не матчит несвязанное', () => {
+        expect(matchesSearch('Петров Сидор', variants)).toBe(false);
+    });
+});

--- a/frontend/src/utils/searchVariants.js
+++ b/frontend/src/utils/searchVariants.js
@@ -1,0 +1,81 @@
+/**
+ * Единое ядро "мощного" клиентского поиска: из запроса строит варианты,
+ * устойчивые к неправильной раскладке клавиатуры (RU<->EN QWERTY), фонетическому
+ * транслиту (кириллица<->латиница), регистру и пробелам (номера слитно/раздельно).
+ *
+ * Зеркалит логику серверного поиска заявок (normalize.SwitchLayout + варианты),
+ * чтобы справочники/таблицы, фильтруемые на клиенте, искали так же "умно".
+ */
+
+/** EN-клавиша -> RU-символ на той же физической клавише (ЙЦУКЕН <-> QWERTY). */
+const EN_TO_RU_LAYOUT = {
+    q: 'й', w: 'ц', e: 'у', r: 'к', t: 'е', y: 'н', u: 'г', i: 'ш', o: 'щ', p: 'з',
+    '[': 'х', ']': 'ъ', a: 'ф', s: 'ы', d: 'в', f: 'а', g: 'п', h: 'р', j: 'о',
+    k: 'л', l: 'д', ';': 'ж', "'": 'э', z: 'я', x: 'ч', c: 'с', v: 'м', b: 'и',
+    n: 'т', m: 'ь', ',': 'б', '.': 'ю', '`': 'ё',
+};
+
+/** RU-символ -> EN-клавиша (обратное отображение EN_TO_RU_LAYOUT). */
+const RU_TO_EN_LAYOUT = Object.fromEntries(
+    Object.entries(EN_TO_RU_LAYOUT).map(([en, ru]) => [ru, en]),
+);
+
+/** Фонетический транслит кириллица -> латиница. */
+const CYR_TO_LAT = {
+    а: 'a', б: 'b', в: 'v', г: 'g', д: 'd', е: 'e', ё: 'e', ж: 'zh', з: 'z', и: 'i',
+    й: 'y', к: 'k', л: 'l', м: 'm', н: 'n', о: 'o', п: 'p', р: 'r', с: 's', т: 't',
+    у: 'u', ф: 'f', х: 'h', ц: 'ts', ч: 'ch', ш: 'sh', щ: 'sch', ъ: '', ы: 'y',
+    ь: '', э: 'e', ю: 'yu', я: 'ya',
+};
+
+/** Фонетический транслит латиница -> кириллица. */
+const LAT_TO_CYR = {
+    a: 'а', b: 'б', c: 'ц', d: 'д', e: 'е', f: 'ф', g: 'г', h: 'х', i: 'и', j: 'й',
+    k: 'к', l: 'л', m: 'м', n: 'н', o: 'о', p: 'п', q: 'к', r: 'р', s: 'с', t: 'т',
+    u: 'у', v: 'в', w: 'в', x: 'кс', y: 'ы', z: 'з',
+};
+
+/** Посимвольно применяет карту к строке (символы без записи в карте остаются как есть). */
+function mapChars(text, map) {
+    let out = '';
+    for (const char of text) out += map[char] ?? char;
+    return out;
+}
+
+/**
+ * Строит набор вариантов поискового запроса.
+ * @param {string} query - сырой пользовательский ввод
+ * @returns {string[]} уникальные непустые варианты в нижнем регистре
+ */
+export function buildSearchVariants(query) {
+    const base = (query ?? '').toString().toLowerCase().trim();
+    if (!base) return [];
+
+    const variants = new Set([base]);
+    variants.add(mapChars(base, EN_TO_RU_LAYOUT));
+    variants.add(mapChars(base, RU_TO_EN_LAYOUT));
+    variants.add(mapChars(base, CYR_TO_LAT));
+    variants.add(mapChars(base, LAT_TO_CYR));
+
+    // Версии без пробелов - для номеров и слитного написания.
+    for (const variant of [...variants]) {
+        if (/\s/.test(variant)) variants.add(variant.replace(/\s+/g, ''));
+    }
+
+    variants.delete('');
+    return [...variants];
+}
+
+/**
+ * Проверяет, совпадает ли haystack хотя бы с одним вариантом запроса.
+ * Сравнивает и как есть, и без пробелов (номера слитно/раздельно).
+ * @param {string} haystack - искомый текст (склейка полей сущности)
+ * @param {string[]} variants - результат buildSearchVariants
+ * @returns {boolean}
+ */
+export function matchesSearch(haystack, variants) {
+    if (!variants || variants.length === 0) return true;
+    const hay = (haystack ?? '').toString().toLowerCase();
+    const hayNoSpace = hay.replace(/\s+/g, '');
+    return variants.some((v) => hay.includes(v) || hayNoSpace.includes(v));
+}


### PR DESCRIPTION
## Фаза 1 распространения мощного поиска (срез 1/N)

Ядро мощного поиска есть только в заявках. Эта фаза распространяет его на остальную систему. Срез 1 — общий фронт-util + справочники управления данными.

### Что
- Новый `frontend/src/utils/searchVariants.js`:
  - `buildSearchVariants(query)` — раскладка клавиатуры RU↔EN (QWERTY), фонетический транслит кириллица↔латиница, устойчивость к пробелам (номера слитно/раздельно) и регистру.
  - `matchesSearch(haystack, variants)` — совпадение по любому варианту, сравнение с пробелами и без.
  - Юнит-тесты (15 кейсов): раскладка обе стороны, транслит, номера слитно/раздельно.
- Переведены на util клиентские фильтры справочников: Гражданства, Марки, Компании, Организации, Форматы номеров, Типы пользователей, Типы вложений, Места разгрузки.

### Проверка
- vitest `searchVariants.spec.js`: 15/15.
- eslint всех изменённых файлов: 0 errors.

### Дальше (следующие срезы фазы 1 + фаза 2)
- Фронт-util на: Пользователи, Согласующие, вкладка «Таблицы» (Cars/PeopleTable, TableConstructor), списки Машин/Сотрудников, заявки пользователя, модалки выбора.
- Фаза 2: серверный fuzzy с опечатками (trgm/strict_word_similarity) для крупных списков с ФИО/номерами (Пользователи, Сотрудники, Машины, Согласующие, Корзина).