### PR TITLE
feat(search): мощный поиск в Пользователях и Согласующих

### DIFF
--- a/frontend/src/components/ApplicationApprovers.vue
+++ b/frontend/src/components/ApplicationApprovers.vue
@@ -325,6 +325,7 @@ import ApplicationApproverHistoryModal from './ApplicationApproverHistoryModal.v
 import { useDeletionsStore } from '@/stores/deletions';
 import { useOverlayClose } from '@/composables/useOverlayClose';
 import { apiRequest } from '@/api/client';
+import { buildSearchVariants, matchesSearch } from '@/utils/searchVariants';
 import { getApprovers, getAllUsers, addApprover, deleteApprover } from '@/api/approvers';
 
 export default {
@@ -356,10 +357,10 @@ export default {
   },
   computed: {
     filteredApprovers() {
-      const q = this.searchQuery.trim().toLowerCase();
+      const variants = buildSearchVariants(this.searchQuery);
       let list = this.approvers.filter(a => !this.pendingDeleteIds.includes(a.id));
-      if (q) {
-        list = list.filter(a => this.getFullName(a).toLowerCase().includes(q));
+      if (variants.length) {
+        list = list.filter(a => matchesSearch(this.getFullName(a), variants));
       }
       return list;
     },
@@ -394,15 +395,12 @@ export default {
       );
     },
     filteredAvailableUsers() {
-      const q = this.userSearchQuery.trim().toLowerCase();
-      if (!q) return this.availableUsers.slice(0, 10);
-      return this.availableUsers.filter(u => {
-        return (
-          this.getFullName(u).toLowerCase().includes(q) ||
-          u.username.toLowerCase().includes(q) ||
-          (u.position || '').toLowerCase().includes(q)
-        );
-      }).slice(0, 10);
+      const variants = buildSearchVariants(this.userSearchQuery);
+      if (!variants.length) return this.availableUsers.slice(0, 10);
+      return this.availableUsers.filter(u => matchesSearch(
+        `${this.getFullName(u)} ${u.username} ${u.position || ''}`,
+        variants,
+      )).slice(0, 10);
     },
   },
   created() {

--- a/frontend/src/components/UserControl.vue
+++ b/frontend/src/components/UserControl.vue
@@ -660,6 +660,7 @@ import { useOrganizationsStore } from '@/stores/organizations';
 import { useCompaniesStore } from '@/stores/companies';
 import { formatRussianPhone } from '@/composables/useRussianPhoneMask'
 import { formatShortName } from '@/utils/formatName'
+import { buildSearchVariants, matchesSearch } from '@/utils/searchVariants'
 import SearchComponent from './SearchComponent.vue';
 import RefreshButton from './RefreshButton.vue';
 import PasswordInput from './ui/PasswordInput.vue';
@@ -758,19 +759,14 @@ export default {
       return type?.code === 'security';
     },
     filteredUsers() {
-      const searchTerm = this.userSearch.toLowerCase();
+      const variants = buildSearchVariants(this.userSearch);
       return this.allUsers
         .filter(user => (this.showArchive ? user.is_active === false : user.is_active !== false))
-        .filter(user => {
-          return (
-            user.username.toLowerCase().includes(searchTerm) ||
-            (user.organization && user.organization.toLowerCase().includes(searchTerm)) ||
-            (user.company && user.company.toLowerCase().includes(searchTerm)) ||
-            (user.user_type && user.user_type.toLowerCase().includes(searchTerm)) ||
-            (user.position && user.position.toLowerCase().includes(searchTerm)) ||
-            (this.formatUserName(user).toLowerCase().includes(searchTerm))
-          );
-        })
+        .filter(user => matchesSearch(
+          `${user.username} ${user.organization || ''} ${user.company || ''} `
+          + `${user.user_type || ''} ${user.position || ''} ${this.formatUserName(user)}`,
+          variants,
+        ))
         .map(user => ({
           ...user,
           newPassword: '',


### PR DESCRIPTION
## Фаза 1, срез 2

Раскатка единого util `searchVariants` (из #764) на:
- **UserControl** (Пользователи) — фильтр по username/организация/компания/тип/должность/ФИО.
- **ApplicationApprovers** (Согласующие) — список принимающих + пикер добавления (ФИО/username/должность).

Теперь ищут с учётом раскладки RU↔EN, транслита, пробелов и регистра.

### Проверка
- eslint: 0 errors. Юнит-спек на эти фильтры нет (фильтр поведенчески совместим).
- util покрыт тестами в #764.