### PR TITLE
feat(search): мощный поиск в Таблицах и списках машин/сотрудников

### DIFF
--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -460,6 +460,7 @@
 
 <script>
 import { apiRequest } from '@/api/client'
+import { buildSearchVariants, matchesSearch } from '@/utils/searchVariants'
 import { useDeletionsStore } from '@/stores/deletions';
 import { useOrientation } from '@/composables/useOrientation';
 import RefreshButton from './RefreshButton.vue';
@@ -541,7 +542,7 @@ export default {
     displayItems() {
       let filtered = this.itemsData.filter(i => !this.pendingDeleteIds.includes(i.id));
       if (this.searchQuery) {
-        const query = this.searchQuery.toLowerCase().trim();
+        const variants = buildSearchVariants(this.searchQuery);
         filtered = filtered.filter(item => {
           const searchFields = [
             item.car_number,
@@ -552,9 +553,7 @@ export default {
             this.formatDate(item.entry_date_to),
             item.status
           ];
-          return searchFields.some(field => 
-            field && field.toString().toLowerCase().includes(query)
-          );
+          return matchesSearch(searchFields.filter(Boolean).join(' '), variants);
         });
       }
       if (this.selectedOrganizationId) {

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -484,6 +484,7 @@
 
 <script>
 import { apiRequest } from '@/api/client';
+import { buildSearchVariants, matchesSearch } from '@/utils/searchVariants';
 import { useDeletionsStore } from '@/stores/deletions';
 import { useOrientation } from '@/composables/useOrientation';
 import RefreshButton from './RefreshButton.vue';
@@ -594,7 +595,7 @@ export default {
       let filtered = this.itemsData.filter(i => !this.pendingDeleteIds.includes(i.id));
 
       if (this.searchQuery) {
-        const query = this.searchQuery.toLowerCase().trim();
+        const variants = buildSearchVariants(this.searchQuery);
         filtered = filtered.filter(item => {
           const searchFields = [
             item.last_name,
@@ -605,9 +606,7 @@ export default {
             item.pass_time || '',
             item.status
           ];
-          return searchFields.some(field => 
-            field && field.toString().toLowerCase().includes(query)
-          );
+          return matchesSearch(searchFields.filter(Boolean).join(' '), variants);
         });
       }
 

--- a/frontend/src/components/TableConstructor.vue
+++ b/frontend/src/components/TableConstructor.vue
@@ -630,6 +630,7 @@
 
 <script>
 import { apiRequest } from '@/api/client'
+import { buildSearchVariants, matchesSearch } from '@/utils/searchVariants'
 import { confirmIfAnyDirty } from '@/utils/dirtyTracker';
 import { useDeletionsStore } from '@/stores/deletions';
 import RefreshButton from './RefreshButton.vue';
@@ -689,13 +690,12 @@ export default {
       return this.showArchive ? 'В архиве пусто' : 'Таблиц пока нет';
     },
     filteredTables() {
-      if (!this.searchQuery) return this.tables;
-      const query = this.searchQuery.toLowerCase();
-      return this.tables.filter(table => 
-        table.table.display_name.toLowerCase().includes(query) || 
-        table.table.name.toLowerCase().includes(query) ||
-        table.table.id.toString().includes(query)
-      );
+      const variants = buildSearchVariants(this.searchQuery);
+      if (!variants.length) return this.tables;
+      return this.tables.filter(table => matchesSearch(
+        `${table.table.display_name} ${table.table.name} ${table.table.id}`,
+        variants,
+      ));
     },
     sortedTables() {
       const tables = [...this.filteredTables];

--- a/frontend/src/components/UserApplications.vue
+++ b/frontend/src/components/UserApplications.vue
@@ -298,6 +298,7 @@
 
 <script>
 import { apiRequest } from '@/api/client'
+import { buildSearchVariants, matchesSearch } from '@/utils/searchVariants'
 import { useAuthStore } from '@/stores/auth'
 import RefreshButton from './RefreshButton.vue';
 import SearchComponent from './SearchComponent.vue';
@@ -350,23 +351,23 @@ export default {
   },
   computed: {
     filteredApplications() {
-      if (!this.searchQuery) return this.applications;
-      
-      const searchTerm = this.searchQuery.toLowerCase();
-      return this.applications.filter(application => {
-        return (
-          application.application_number?.toLowerCase().includes(searchTerm) ||
-          application.organization_name?.toLowerCase().includes(searchTerm) ||
-          application.sender_name?.toLowerCase().includes(searchTerm) ||
-          application.sender_full_name?.toLowerCase().includes(searchTerm) ||
-          application.confirmation?.toLowerCase().includes(searchTerm) ||
-          application.status?.toLowerCase().includes(searchTerm) ||
-          application.message?.toLowerCase().includes(searchTerm) ||
-          application.responsible_name?.toLowerCase().includes(searchTerm) ||
-          application.responsible_full_name?.toLowerCase().includes(searchTerm) ||
-          application.responsible_comment?.toLowerCase().includes(searchTerm)
-        );
-      });
+      const variants = buildSearchVariants(this.searchQuery);
+      if (!variants.length) return this.applications;
+      return this.applications.filter(application => matchesSearch(
+        [
+          application.application_number,
+          application.organization_name,
+          application.sender_name,
+          application.sender_full_name,
+          application.confirmation,
+          application.status,
+          application.message,
+          application.responsible_name,
+          application.responsible_full_name,
+          application.responsible_comment,
+        ].filter(Boolean).join(' '),
+        variants,
+      ));
     },
     
     sortedApplications() {

--- a/frontend/src/views/CarsView.vue
+++ b/frontend/src/views/CarsView.vue
@@ -624,6 +624,7 @@
 
 <script>
 import { apiRequest } from '@/api/client'
+import { buildSearchVariants, matchesSearch } from '@/utils/searchVariants'
 import { useDeletionsStore } from '@/stores/deletions';
 import SearchComponent from '@/components/SearchComponent.vue';
 import RefreshButton from '@/components/RefreshButton.vue';
@@ -699,17 +700,15 @@ export default {
     },
     computed: {
         filteredCars() {
-            if (!this.searchQuery.trim()) {
+            const variants = buildSearchVariants(this.searchQuery);
+            if (!variants.length) {
                 return this.carsData;
             }
-            
-            const query = this.searchQuery.toLowerCase().trim();
-            return this.carsData.filter(car => 
-                car.number.toLowerCase().includes(query) ||
-                car.mark.toLowerCase().includes(query) ||
-                (car.format_name && car.format_name.toLowerCase().includes(query)) ||
-                (car.status ? 'активна' : 'неактивна').includes(query)
-            );
+            return this.carsData.filter(car => matchesSearch(
+                `${car.number} ${car.mark} ${car.format_name || ''} `
+                + (car.status ? 'активна' : 'неактивна'),
+                variants,
+            ));
         },
 
         sortedCars() {

--- a/frontend/src/views/EmployeeView.vue
+++ b/frontend/src/views/EmployeeView.vue
@@ -390,6 +390,7 @@
 
 <script>
 import { apiRequest } from '@/api/client'
+import { buildSearchVariants, matchesSearch } from '@/utils/searchVariants'
 import { useDeletionsStore } from '@/stores/deletions';
 import { useUiStore } from '@/stores/ui';
 import SearchComponent from '@/components/SearchComponent.vue';
@@ -433,17 +434,15 @@ export default {
     },
     computed: {
         filteredEmployees() {
-            if (!this.searchQuery.trim()) {
+            const variants = buildSearchVariants(this.searchQuery);
+            if (!variants.length) {
                 return this.employeesData;
             }
-            
-            const query = this.searchQuery.toLowerCase().trim();
-            return this.employeesData.filter(employee => {
-                const fullName = this.formatFullName(employee).toLowerCase();
-                return fullName.includes(query) ||
-                       (employee.position && employee.position.toLowerCase().includes(query)) ||
-                       (employee.status ? 'активен' : 'неактивен').includes(query)
-            });
+            return this.employeesData.filter(employee => matchesSearch(
+                `${this.formatFullName(employee)} ${employee.position || ''} `
+                + (employee.status ? 'активен' : 'неактивен'),
+                variants,
+            ));
         },
 
         sortedEmployees() {


### PR DESCRIPTION
## Фаза 1, срез 3+4

Раскатка util `searchVariants` (#764) на:
- **Таблицы:** CarsTable, PeopleTable, TableConstructor.
- **Списки:** CarsView (Машины), EmployeeView (Сотрудники), UserApplications (заявки пользователя).

Раскладка RU↔EN, транслит, пробелы в номерах, регистр.

### Не вошло (намеренно)
- ExistingCarsModal — уже имеет свой плейт-aware поиск (нормализация номера + вариации), не слабый includes; чувствительная рабочая модалка, не переписываю без нужды.

### Проверка
- eslint 6 файлов: 0 errors (warnings про порядок props/emits в PeopleTable - pre-existing). Спеки на эти фильтры отсутствуют.