### PR TITLE
feat(onboarding): отдельный тур охранника - навигация и "Доступные мне" (#657)

### DIFF
--- a/frontend/src/components/onboarding/__tests__/securityOnboardingSteps.spec.js
+++ b/frontend/src/components/onboarding/__tests__/securityOnboardingSteps.spec.js
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import { securityOnboardingSteps } from '../securityOnboardingSteps';
+import { collectSegment } from '../onboardingSteps';
+
+describe('securityOnboardingSteps', () => {
+  it('каждый шаг имеет непустые id, title и строковый description', () => {
+    for (const step of securityOnboardingSteps) {
+      expect(typeof step.id).toBe('string');
+      expect(step.id.length).toBeGreaterThan(0);
+      expect(typeof step.title).toBe('string');
+      expect(step.title.length).toBeGreaterThan(0);
+      expect(typeof step.description).toBe('string');
+      expect(step.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('element - либо строка-селектор, либо null', () => {
+    for (const step of securityOnboardingSteps) {
+      const ok = step.element === null || (typeof step.element === 'string' && step.element.length > 0);
+      expect(ok).toBe(true);
+    }
+  });
+
+  it('route у каждого шага - непустая строка', () => {
+    for (const step of securityOnboardingSteps) {
+      expect(typeof step.route).toBe('string');
+      expect(step.route.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('нет дублей id', () => {
+    const ids = securityOnboardingSteps.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('есть центр-модал (element null) для старта', () => {
+    expect(securityOnboardingSteps[0].element).toBe(null);
+  });
+
+  it('expandRail только true и только у nav-шагов', () => {
+    const railSteps = securityOnboardingSteps.filter((s) => s.expandRail);
+    expect(railSteps.length).toBeGreaterThan(0);
+    for (const s of railSteps) {
+      expect(s.expandRail).toBe(true);
+      expect(s.id.startsWith('sec-nav-')).toBe(true);
+    }
+  });
+
+  it('тур охранника НЕ ведёт к подаче заявки', () => {
+    const ids = securityOnboardingSteps.map((s) => s.id);
+    // нет шагов оформления заявки и кнопки «Подать заявку» в шапке
+    expect(ids.some((id) => id.startsWith('createapp-'))).toBe(false);
+    expect(ids).not.toContain('header-submit');
+    for (const s of securityOnboardingSteps) {
+      expect(s.element).not.toBe('[data-testid="header-button-submit-app"]');
+      expect(s.description).not.toMatch(/Подать заявку/);
+    }
+    // финал-CTA на оформление заявки в этом сценарии нет
+    expect(securityOnboardingSteps.some((s) => s.cta)).toBe(false);
+  });
+});
+
+describe('securityOnboardingSteps - сегмент /news', () => {
+  it('собирается из приветствия, шапки и навигации', () => {
+    const seg = collectSegment(securityOnboardingSteps, 0, '/news');
+    expect(seg.map((s) => s.id)).toEqual([
+      'sec-start',
+      'sec-header-feedback',
+      'sec-header-time',
+      'sec-header-notifications',
+      'sec-nav-rail',
+      'sec-nav-accessible',
+      'sec-nav-tables',
+    ]);
+  });
+
+  it('подсвечивает nav «Доступные мне» и «Таблицы» по реальным testid', () => {
+    const byId = (id) => securityOnboardingSteps.find((s) => s.id === id);
+    expect(byId('sec-nav-accessible').element).toBe('[data-testid="nav-link-accessible-attachments"]');
+    expect(byId('sec-nav-tables').element).toBe('[data-testid="nav-link-tables"]');
+  });
+
+  it('шаги шапки несут целевой селектор и поповер снизу', () => {
+    for (const s of securityOnboardingSteps.filter((x) => x.id.startsWith('sec-header-'))) {
+      expect(typeof s.element).toBe('string');
+      expect(s.side).toBe('bottom');
+    }
+  });
+});
+
+describe('securityOnboardingSteps - сегмент /accessible-attachments', () => {
+  it('отделён границей route и идёт после сегмента /news', () => {
+    const first = securityOnboardingSteps.findIndex((s) => s.route === '/accessible-attachments');
+    expect(first).toBeGreaterThan(0);
+    expect(securityOnboardingSteps[first - 1].route).toBe('/news');
+    expect(collectSegment(securityOnboardingSteps, first, '/accessible-attachments').map((s) => s.id)).toEqual([
+      'sec-aa-intro',
+      'sec-aa-filters',
+      'sec-aa-card',
+      'sec-aa-detail',
+      'sec-aa-preview',
+    ]);
+  });
+
+  it('реюзит существующие aa-* testid страницы «Доступные мне»', () => {
+    const byId = (id) => securityOnboardingSteps.find((s) => s.id === id);
+    expect(byId('sec-aa-filters').element).toBe('[data-testid="aa-filters"]');
+    expect(byId('sec-aa-card').element).toBe('[data-testid="aa-card"]');
+    expect(byId('sec-aa-detail').element).toBe('[data-testid="aa-detail"]');
+    expect(byId('sec-aa-preview').element).toBe('[data-testid="aa-preview-blank"]');
+  });
+
+  it('карточка, деталь и предпросмотр опциональны (нет выбранной карточки - шаг пропускается)', () => {
+    for (const id of ['sec-aa-card', 'sec-aa-detail', 'sec-aa-preview']) {
+      expect(securityOnboardingSteps.find((s) => s.id === id).optional).toBe(true);
+    }
+  });
+
+  it('последний обязательный шаг сегмента - фильтры (хвост опционален, тур завершается на нём)', () => {
+    const seg = collectSegment(
+      securityOnboardingSteps,
+      securityOnboardingSteps.findIndex((s) => s.route === '/accessible-attachments'),
+      '/accessible-attachments',
+    );
+    const lastRequired = [...seg].reverse().find((s) => !s.optional);
+    expect(lastRequired.id).toBe('sec-aa-filters');
+  });
+});

--- a/frontend/src/components/onboarding/securityOnboardingSteps.js
+++ b/frontend/src/components/onboarding/securityOnboardingSteps.js
@@ -1,0 +1,128 @@
+/**
+ * Шаги онбординг-тура для сотрудника охраны (auth.isSecurity). Отдельный сценарий:
+ * охранник не подаёт заявки и не ведёт свои справочники, а смотрит согласованные
+ * вложения по своим местам и отмечает въезд/выезд. Поэтому тур ведёт по разделам
+ * «Доступные мне» и «Таблицы», а не по оформлению заявки.
+ *
+ * Структура и поля шага - те же, что у applicant-тура (см. onboardingSteps.js):
+ * движок группирует подряд идущие шаги с общим `route` в сегмент driver.js, смена
+ * `route` = cross-page граница. Версия тура и флаг завершения общие с основным
+ * сценарием - аргументация в stores/onboarding.js, где ветвится `steps`.
+ * collectSegment живёт в onboardingSteps.js и работает с любым массивом шагов.
+ *
+ * @type {Array<{ id: string, route: string, element: string|null, title: string, description: string, expandRail?: boolean, optional?: boolean, side?: string, align?: string }>}
+ */
+export const securityOnboardingSteps = [
+  // ── Сегмент /news: знакомство, шапка, навигация охранника ──
+  {
+    id: 'sec-start',
+    route: '/news',
+    element: null,
+    title: 'Добро пожаловать!',
+    description:
+      'Коротко покажем, что доступно вам как сотруднику охраны. Это займёт минуту. Двигайтесь кнопкой «Далее» или стрелками, выйти можно в любой момент клавишей Esc.',
+  },
+  {
+    id: 'sec-header-feedback',
+    side: 'bottom',
+    route: '/news',
+    element: '[data-testid="header-button-feedback"]',
+    title: 'Сообщить о проблеме',
+    description: 'Заметили ошибку или есть предложение - напишите нам прямо отсюда, не покидая систему.',
+  },
+  {
+    id: 'sec-header-time',
+    side: 'bottom',
+    route: '/news',
+    element: '[data-testid="ob-header-time"]',
+    title: 'Дата и время',
+    description: 'Текущие дата и время системы - удобно сверяться при проверке пропусков.',
+  },
+  {
+    id: 'sec-header-notifications',
+    side: 'bottom',
+    route: '/news',
+    element: '[data-testid="ob-header-notifications"]',
+    title: 'Уведомления',
+    description: 'Колокольчик показывает количество непрочитанных уведомлений системы. Нажмите, чтобы открыть список.',
+  },
+  {
+    id: 'sec-nav-rail',
+    route: '/news',
+    element: '[data-testid="ob-nav-rail"]',
+    title: 'Навигация',
+    description:
+      'Боковое меню - главный способ перемещаться по системе. Отсюда вы попадаете в нужные разделы, а внизу - кнопка «Выйти».',
+    expandRail: true,
+  },
+  {
+    id: 'sec-nav-accessible',
+    route: '/news',
+    element: '[data-testid="nav-link-accessible-attachments"]',
+    title: 'Доступные мне',
+    description:
+      'Раздел «Доступные мне» - согласованные вложения заявок по местам, которые вы охраняете. Здесь вы смотрите оформленные пропуска и открываете их бланки. Сейчас перейдём туда.',
+    expandRail: true,
+  },
+  {
+    id: 'sec-nav-tables',
+    route: '/news',
+    element: '[data-testid="nav-link-tables"]',
+    title: 'Таблицы',
+    description:
+      'Раздел «Таблицы» - журналы по вашим местам. Внутри открываются таблицы со списками машин и людей.',
+    expandRail: true,
+  },
+  // ── Сегмент /accessible-attachments: страница «Доступные мне» ──
+  {
+    id: 'sec-aa-intro',
+    route: '/accessible-attachments',
+    element: null,
+    title: 'Раздел «Доступные мне»',
+    description:
+      'Мы открыли раздел «Доступные мне». Здесь собраны согласованные вложения заявок по местам, которые вы охраняете.',
+  },
+  {
+    id: 'sec-aa-filters',
+    side: 'bottom',
+    align: 'start',
+    route: '/accessible-attachments',
+    element: '[data-testid="aa-filters"]',
+    title: 'Поиск и фильтры',
+    description:
+      'Сверху - поиск по заявке, машине, ФИО или месту разгрузки и фильтры: тип вложения, организация и компания. Кнопки «Завершённые» и «Ночь» (окно въезда 22:00-06:00) сужают список, «Сбросить» очищает всё.',
+  },
+  {
+    id: 'sec-aa-card',
+    side: 'right',
+    align: 'start',
+    optional: true,
+    route: '/accessible-attachments',
+    element: '[data-testid="aa-card"]',
+    title: 'Карточка вложения',
+    description:
+      'Каждая карточка - это вложение: тип, организация, статус и срок действия. Нажмите на карточку, чтобы справа открылись детали со списком машин или людей.',
+  },
+  {
+    id: 'sec-aa-detail',
+    side: 'left',
+    align: 'start',
+    optional: true,
+    route: '/accessible-attachments',
+    element: '[data-testid="aa-detail"]',
+    title: 'Детали вложения',
+    description:
+      'Справа - подробности выбранного вложения: данные заявки и её содержимое. Отсюда же открывается прикреплённый бланк.',
+  },
+  {
+    id: 'sec-aa-preview',
+    side: 'left',
+    align: 'start',
+    optional: true,
+    route: '/accessible-attachments',
+    element: '[data-testid="aa-preview-blank"]',
+    title: 'Посмотреть файл',
+    description:
+      'Кнопка «Посмотреть файл» открывает заполненный бланк вложения прямо в системе - скачивать его для просмотра не нужно.',
+  },
+];

--- a/frontend/src/stores/__tests__/onboarding.spec.js
+++ b/frontend/src/stores/__tests__/onboarding.spec.js
@@ -3,6 +3,7 @@ import { setActivePinia, createPinia } from 'pinia';
 import { useOnboardingStore } from '../onboarding';
 import { useAuthStore } from '../auth';
 import { onboardingSteps, ONBOARDING_VERSION } from '@/components/onboarding/onboardingSteps';
+import { securityOnboardingSteps } from '@/components/onboarding/securityOnboardingSteps';
 import { getOnboardingStatus, markOnboardingComplete } from '@/api/onboarding';
 
 vi.mock('@/api/onboarding', () => ({
@@ -97,6 +98,35 @@ describe('onboarding store', () => {
     it('равен длине onboardingSteps', () => {
       const store = useOnboardingStore();
       expect(store.totalSteps).toBe(onboardingSteps.length);
+    });
+  });
+
+  describe('ветвление сценария по типу пользователя', () => {
+    it('обычный пользователь получает applicant-тур', () => {
+      const auth = useAuthStore();
+      auth.userTypeCode = 'organization';
+      const store = useOnboardingStore();
+      expect(store.steps).toBe(onboardingSteps);
+      expect(store.totalSteps).toBe(onboardingSteps.length);
+    });
+
+    it('охранник (isSecurity) получает security-тур', () => {
+      const auth = useAuthStore();
+      auth.userTypeCode = 'security';
+      const store = useOnboardingStore();
+      expect(auth.isSecurity).toBe(true);
+      expect(store.steps).toBe(securityOnboardingSteps);
+      expect(store.currentStep).toBe(securityOnboardingSteps[0]);
+    });
+
+    it('смена типа пользователя реактивно переключает набор шагов в обе стороны', () => {
+      const auth = useAuthStore();
+      const store = useOnboardingStore();
+      expect(store.steps).toBe(onboardingSteps);
+      auth.userTypeCode = 'security';
+      expect(store.steps).toBe(securityOnboardingSteps);
+      auth.userTypeCode = 'organization';
+      expect(store.steps).toBe(onboardingSteps);
     });
   });
 

--- a/frontend/src/stores/onboarding.js
+++ b/frontend/src/stores/onboarding.js
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 import { ref, computed } from 'vue';
 import { useAuthStore } from '@/stores/auth';
 import { onboardingSteps, ONBOARDING_VERSION } from '@/components/onboarding/onboardingSteps';
+import { securityOnboardingSteps } from '@/components/onboarding/securityOnboardingSteps';
 import { getOnboardingStatus, markOnboardingComplete } from '@/api/onboarding';
 
 /**
@@ -38,7 +39,13 @@ export const useOnboardingStore = defineStore('onboarding', () => {
   // (onMounted + watch route) не слали два GET (урок про гонки авто-fetch).
   let loadStatusPromise = null;
 
-  const steps = computed(() => onboardingSteps);
+  // Тур ветвится по типу пользователя: охранник смотрит вложения и таблицы, а не
+  // подаёт заявки - ему отдельный сценарий. Версия и per-user флаг завершения общие
+  // (юзер ровно одного типа). Автозапуск на /news сам покажет нужный сценарий.
+  const steps = computed(() => {
+    const auth = useAuthStore();
+    return auth.isSecurity ? securityOnboardingSteps : onboardingSteps;
+  });
   const totalSteps = computed(() => steps.value.length);
   const currentStep = computed(() => steps.value[currentIndex.value] || null);
 


### PR DESCRIPTION
## Что

Срез S6.1 эпика aa-improvements. Онбординг-тур вёл всех пользователей по оформлению заявки, но охранник (`auth.isSecurity`) заявки не подаёт - он смотрит согласованные вложения по своим местам и работает с таблицами. Добавил отдельный сценарий тура для охранника и ветвление по типу пользователя.

## Как

- `securityOnboardingSteps.js` (новый) - сценарий охранника двумя сегментами:
  - `/news`: приветствие, шапка (Сообщить о проблеме / время / уведомления, БЕЗ "Подать заявку"), навигация - подсветка nav «Доступные мне» и «Таблицы». Без ЛК-заявок и оформления.
  - `/accessible-attachments`: intro страницы, фильтры (поиск/тип/орг/компания/Завершённые/Ночь), карточка вложения, деталь и кнопка «Посмотреть файл». Реюз существующих `aa-*` testid.
- `stores/onboarding.js`: `steps` computed теперь ветвится `auth.isSecurity ? securityOnboardingSteps : onboardingSteps`. Весь движок (`OnboardingTour.vue`/`useOnboarding.js`) читает шаги через `store.steps`, так что ветвления в сторе достаточно. Изменение аддитивное - applicant-тур не тронут.
- Флаг завершения единый (`ONBOARDING_VERSION`, per-user) - юзер ровно одного типа, второй версии-ключ не нужен.

## Граничные решения

- Карточка/деталь/предпросмотр в сегменте `/accessible-attachments` помечены `optional`: деталь и кнопка предпросмотра в DOM только при выбранной карточке. Движок штатно пропускает трейлинг-optional шаги без элемента и завершает тур на последнем обязательном (`aa-filters`). Интерактивный авто-выбор карточки (чтобы реально подсветить деталь/предпросмотр) - кандидат на S6.2/S6.3.
- Все 10 селекторов сверены с реальным DOM (NavMenu/TheHeader/AccessibleAttachmentsView).

## Тесты

- `securityOnboardingSteps.spec.js` (новый): целостность шагов, сегменты /news и /accessible-attachments, реюз aa-* testid, негативная проверка "тур НЕ ведёт к подаче заявки", optional-хвост.
- `onboarding.spec.js` (+): ветвление steps по `isSecurity` в обе стороны, реактивность computed.
- Локально: онбординг-спеки зелёные (4 файла), eslint чистый.

## Ревью

`code-reviewer` - вердикт GO, блокеров нет. Два yellow закрыты: добавил реверс-переход в тест реактивности, убрал дубль WHY про общий флаг (оставил в сторе). Третий yellow (expandRail на последнем шаге сегмента) - это 1:1 поведение applicant-тура (`nav-group-data`), `advanceToSegment` зовёт `restoreRail()` при переходе; проверю визуально на ship-check финального среза.

## Верификация текста

Текст шагов выведен из чтения компонентов (точные подписи: «Доступные мне», «Таблицы», «Сообщить о проблеме», «Завершённые», «Ночь», «Посмотреть файл»; деталь справа от списка - подтверждено CSS). Полная сверка текста по живому staging как охранник и проход всего тура - в финальном срезе S6.3 (ship-check).