### PR TITLE
fix(search): искать заявки по наименованию работ (items)

### DIFF
--- a/internal/handlers/applications_test.go
+++ b/internal/handlers/applications_test.go
@@ -198,11 +198,46 @@ func TestGetApplications_FuzzySearchExecutes(t *testing.T) {
 
 	token := testutil.RegisterAndLogin(t, e, "searchuser", "pass123", 1, td.OrgID, td.CompanyID)
 
-	for _, q := range []string{"грязевой", "А777АА", "А 777 АА", "ghbdtn", "иванов", "70"} {
+	for _, q := range []string{"грязевой", "А777АА", "А 777 АА", "ghbdtn", "иванов", "70", "ремонт крыши"} {
 		rec := testutil.GET(t, e, "/applications?search_query="+url.QueryEscape(q), testutil.AuthHeader(token))
 		assert.Equalf(t, http.StatusOK, rec.Code,
 			"search_query=%q должен вернуть 200, а не %d: %s", q, rec.Code, rec.Body.String())
 	}
+}
+
+// TestGetApplications_SearchFindsItemWork: поиск находит заявку по наименованию
+// работ из items-вложения ("Заявка на работы"). Раньше items не джойнились в
+// мега-поиске - заявка с "Ремонт крыши" не находилась.
+func TestGetApplications_SearchFindsItemWork(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "itemsearch", "pass123", 1, td.OrgID, td.CompanyID)
+	appID := createSimpleApplication(t, e, token, td.OrgID)
+
+	var attID int
+	require.NoError(t, db.Raw(
+		`INSERT INTO attachments (application_id, attachment_type, created_at, updated_at)
+		 VALUES (?, 'items', now(), now()) RETURNING id`, appID).Scan(&attID).Error)
+	require.NoError(t, db.Exec(
+		`INSERT INTO items (attachment_id, name, created_at, updated_at)
+		 VALUES (?, ?, now(), now())`, attID, "Ремонт уникальнойкрыши zzqx").Error)
+
+	rec := testutil.GET(t, e,
+		"/applications?search_query="+url.QueryEscape("уникальнойкрыши zzqx"),
+		testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	apps := testutil.ParseResponse[[]map[string]interface{}](t, rec)
+	found := false
+	for _, a := range apps {
+		if id, ok := a["id"].(float64); ok && int(id) == appID {
+			found = true
+		}
+	}
+	assert.True(t, found, "заявка должна находиться по наименованию работ из items-вложения")
 }
 
 // --- GET /applications/user ---

--- a/internal/services/application_helpers.go
+++ b/internal/services/application_helpers.go
@@ -326,7 +326,17 @@ func applyApplicationFilters(query *gorm.DB, filter ApplicationFilter, includeUs
 			)
 		)`
 
-		fullCond := baseCond + " OR " + carSubquery + " OR " + empSubquery + " OR " + upSubquery + " OR " + apprSubquery
+		// --- вложения: работы (items) ---
+		// Наименование работ в items-вложениях ("Заявка на работы") хранится в items.name.
+		itemCond, itemArgs := ilikePatternsArgs([]string{"it.name"}, variants)
+		itemSubquery := `EXISTS(
+			SELECT 1 FROM attachments att5
+			JOIN items it ON it.attachment_id = att5.id
+			WHERE att5.application_id = a.id AND (` + itemCond + `)
+		)`
+
+		fullCond := baseCond + " OR " + carSubquery + " OR " + empSubquery +
+			" OR " + upSubquery + " OR " + apprSubquery + " OR " + itemSubquery
 
 		allArgs := baseArgs
 		allArgs = append(allArgs, carNumArgs...)
@@ -338,6 +348,7 @@ func applyApplicationFilters(query *gorm.DB, filter ApplicationFilter, includeUs
 		allArgs = append(allArgs, upArgs...)
 		allArgs = append(allArgs, apprIlikeArgs...)
 		allArgs = append(allArgs, raw) // для word_similarity согласующих
+		allArgs = append(allArgs, itemArgs...)
 
 		query = query.Where(fullCond, allArgs...)
 	}


### PR DESCRIPTION
## Баг
Заявка №20260619/001 с items-вложением «Заявка на работы» (наименование работ «Ремонт крыши») не находилась поиском. Мега-поиск джойнил машины/сотрудников/места/согласующих, но не items.

## Фикс
- Добавил EXISTS-подзапрос по `items.name` в `applyApplicationFilters` (args в конце — порядок `?` не нарушен).
- Тест `TestGetApplications_SearchFindsItemWork`: заявка с items находится по названию работы; в `FuzzySearchExecutes` добавлен термин «ремонт крыши» (страхует исполнение JOIN).

## Проверка (локально, контейнер)
- `go test -run 'FuzzySearchExecutes|SearchFindsItemWork' ./internal/handlers/` — оба PASS.

## Примечание
dev CI сейчас флапает на стороннем race в partitions-тесте (#706, не моя правка); если Go Tests покраснеют, это не из-за этого диффа.