### PR TITLE
feat(onboarding): сегмент таблиц и отметки въезда/выезда в туре охранника (#657)

### DIFF
--- a/frontend/src/api/onboarding.js
+++ b/frontend/src/api/onboarding.js
@@ -1,4 +1,5 @@
 import { apiRequest } from './client';
+import { resolveFactTableRoute } from '@/components/onboarding/securityOnboardingSteps';
 
 /**
  * API статуса онбординг-тура (per-user, #657). Источник правды - бэкенд:
@@ -33,6 +34,25 @@ export async function markOnboardingComplete(version) {
     body: JSON.stringify({ version }),
   });
   return unwrap(res, 'Не удалось сохранить статус обучения');
+}
+
+/**
+ * Резолв route фактовой таблицы для security-тура: тянет `/system-tables` (тот же
+ * список, что NavMenu в дропдауне «Таблицы») и выбирает первую активную фактовую
+ * таблицу машин. Сетевая ошибка/отсутствие подходящей таблицы -> null (сегмент
+ * отметки в туре просто не добавляется).
+ *
+ * @returns {Promise<string|null>} `/table/<name>` или null
+ */
+export async function getSecurityFactRoute() {
+  try {
+    const res = await apiRequest('/system-tables');
+    if (!res.ok) return null;
+    const tables = await res.json();
+    return resolveFactTableRoute(tables);
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/frontend/src/components/FactTable.vue
+++ b/frontend/src/components/FactTable.vue
@@ -172,10 +172,11 @@
             name="fade-list"
             tag="div"
           >
-            <div 
-              v-for="(item, index) in sortedData" 
-              :key="item.id" 
+            <div
+              v-for="(item, index) in sortedData"
+              :key="item.id"
               class="fact-item"
+              data-testid="ob-fact-row"
               :style="{ animationDelay: `${index * 0.1}s` }"
               @click="openItemDetails(item)"
             >
@@ -191,6 +192,7 @@
                     class="action-btn entry-btn"
                     :class="{ 'active': item.entry_checked }"
                     :disabled="item.entry_checked"
+                    data-testid="ob-fact-entry"
                     @click="handleEntryExit(item, 'entry')"
                   >
                     Въезд
@@ -206,6 +208,7 @@
                     class="action-btn exit-btn"
                     :class="{ 'active': item.exit_checked }"
                     :disabled="!item.entry_checked || item.exit_checked"
+                    data-testid="ob-fact-exit"
                     @click="handleEntryExit(item, 'exit')"
                   >
                     Выезд

--- a/frontend/src/components/onboarding/OnboardingTour.vue
+++ b/frontend/src/components/onboarding/OnboardingTour.vue
@@ -322,7 +322,13 @@ const removeAfterEach = router.afterEach((to) => {
     startSegment();
   } else {
     // Навигация увела не туда, куда вёл тур - не держим силой.
+    // Сегмент с динамическим route (фактовая таблица) опционален: если у
+    // охранника пока нет доступа к /table/:name и роут-гард редиректит, это не
+    // обрыв - штатно завершаем тур (авто-тур помечаем пройденным), а не считаем
+    // прерыванием. Когда доступ выдан, переход проходит и мы попадаем в ветку выше.
+    const missed = store.currentStep;
     store.clearPending();
+    if (missed?.optionalSegment) markIfAuto();
     store.stop();
   }
 });

--- a/frontend/src/components/onboarding/__tests__/securityOnboardingSteps.spec.js
+++ b/frontend/src/components/onboarding/__tests__/securityOnboardingSteps.spec.js
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { securityOnboardingSteps } from '../securityOnboardingSteps';
+import {
+  securityOnboardingSteps,
+  resolveFactTableRoute,
+  buildSecurityFactSteps,
+} from '../securityOnboardingSteps';
 import { collectSegment } from '../onboardingSteps';
 
 describe('securityOnboardingSteps', () => {
@@ -124,5 +128,82 @@ describe('securityOnboardingSteps - сегмент /accessible-attachments', () 
     );
     const lastRequired = [...seg].reverse().find((s) => !s.optional);
     expect(lastRequired.id).toBe('sec-aa-filters');
+  });
+
+  it('базовый массив не содержит шагов фактовой таблицы (добавляются динамически)', () => {
+    expect(securityOnboardingSteps.some((s) => s.id.startsWith('sec-fact-'))).toBe(false);
+  });
+});
+
+describe('resolveFactTableRoute', () => {
+  it('берёт первую активную фактовую таблицу машин (форма { table })', () => {
+    const tables = [
+      { table: { name: 'people_1', table_type: 'people', show_fact_table: true, is_active: true } },
+      { table: { name: 'kpp_1', table_type: 'cars', show_fact_table: true, is_active: true } },
+      { table: { name: 'kpp_2', table_type: 'cars', show_fact_table: true, is_active: true } },
+    ];
+    expect(resolveFactTableRoute(tables)).toBe('/table/kpp_1');
+  });
+
+  it('поддерживает плоскую форму элемента (без вложенного table)', () => {
+    const tables = [{ name: 'kpp_3', table_type: 'cars', show_fact_table: true, is_active: true }];
+    expect(resolveFactTableRoute(tables)).toBe('/table/kpp_3');
+  });
+
+  it('пропускает неактивные, не-фактовые и не-cars таблицы', () => {
+    const tables = [
+      { table: { name: 'a', table_type: 'cars', show_fact_table: true, is_active: false } },
+      { table: { name: 'b', table_type: 'cars', show_fact_table: false, is_active: true } },
+      { table: { name: 'c', table_type: 'people', show_fact_table: true, is_active: true } },
+    ];
+    expect(resolveFactTableRoute(tables)).toBe(null);
+  });
+
+  it('null на пустом списке и не-массиве', () => {
+    expect(resolveFactTableRoute([])).toBe(null);
+    expect(resolveFactTableRoute(null)).toBe(null);
+    expect(resolveFactTableRoute(undefined)).toBe(null);
+  });
+});
+
+describe('buildSecurityFactSteps', () => {
+  it('пустой массив без route', () => {
+    expect(buildSecurityFactSteps(null)).toEqual([]);
+    expect(buildSecurityFactSteps('')).toEqual([]);
+  });
+
+  it('строит intro + строка + Въезд + Выезд на переданный route', () => {
+    const steps = buildSecurityFactSteps('/table/kpp_1');
+    expect(steps.map((s) => s.id)).toEqual([
+      'sec-fact-intro',
+      'sec-fact-row',
+      'sec-fact-entry',
+      'sec-fact-exit',
+    ]);
+    expect(steps.every((s) => s.route === '/table/kpp_1')).toBe(true);
+  });
+
+  it('первый шаг - optionalSegment-центр-модал (граница для грациозной деградации)', () => {
+    const [intro] = buildSecurityFactSteps('/table/kpp_1');
+    expect(intro.element).toBe(null);
+    expect(intro.optionalSegment).toBe(true);
+  });
+
+  it('строка и кнопки опциональны и несут реюзимые ob-fact-* / fact-table якоря', () => {
+    const byId = (id) => buildSecurityFactSteps('/table/kpp_1').find((s) => s.id === id);
+    expect(byId('sec-fact-row').element).toBe('[data-testid="ob-fact-row"]');
+    expect(byId('sec-fact-entry').element).toBe('[data-testid="ob-fact-entry"]');
+    expect(byId('sec-fact-exit').element).toBe('[data-testid="ob-fact-exit"]');
+    for (const id of ['sec-fact-row', 'sec-fact-entry', 'sec-fact-exit']) {
+      expect(byId(id).optional).toBe(true);
+    }
+  });
+
+  it('сегмент отметки не ведёт к подаче заявки (нет cta)', () => {
+    const steps = buildSecurityFactSteps('/table/kpp_1');
+    expect(steps.some((s) => s.cta)).toBe(false);
+    for (const s of steps) {
+      expect(s.description).not.toMatch(/Подать заявку/);
+    }
   });
 });

--- a/frontend/src/components/onboarding/securityOnboardingSteps.js
+++ b/frontend/src/components/onboarding/securityOnboardingSteps.js
@@ -126,3 +126,87 @@ export const securityOnboardingSteps = [
       'Кнопка «Посмотреть файл» открывает заполненный бланк вложения прямо в системе - скачивать его для просмотра не нужно.',
   },
 ];
+
+/**
+ * Выбрать route фактовой таблицы для шага отметки въезда/выезда из списка
+ * системных таблиц (тот же `/system-tables`, что NavMenu показывает в дропдауне
+ * «Таблицы»). Берём первую активную фактовую таблицу типа `cars`: кнопки
+ * «Въезд»/«Выезд» в FactTable есть только у машин (people-фактовая таблица их
+ * не имеет). Форма элемента - `{ table: {...} }` (как отдаёт GetAll) либо плоская.
+ *
+ * @param {Array<object>} systemTables ответ GET /system-tables
+ * @returns {string|null} `/table/<name>` или null, если подходящей таблицы нет
+ */
+export function resolveFactTableRoute(systemTables) {
+  if (!Array.isArray(systemTables)) return null;
+  for (const item of systemTables) {
+    const t = item?.table || item;
+    if (t && t.is_active && t.show_fact_table && t.table_type === 'cars' && t.name) {
+      return `/table/${t.name}`;
+    }
+  }
+  return null;
+}
+
+/**
+ * Сегмент «Таблицы и отметка въезда/выезда» с ДИНАМИЧЕСКИМ route: целевую
+ * фактовую таблицу резолвим в рантайме (resolveFactTableRoute) и подставляем
+ * сюда, потому что у разных охранников разные доступные таблицы. Сегмент
+ * добавляется в хвост `steps` стора только когда route резолвится - индексы
+ * ранних шагов он не сдвигает.
+ *
+ * Первый шаг помечен `optionalSegment`: если у охранника пока нет доступа к
+ * `/table/:name` (роут-гард редиректит), хост штатно завершает тур на границе
+ * сегмента, а не висит на недостижимой странице. Когда доступ выдан -
+ * навигация проходит, и шаги подсвечивают реальную таблицу. Шаги строки/кнопок
+ * `optional`: на пустой фактовой таблице (строк нет) они пропускаются.
+ *
+ * @param {string|null} route `/table/<name>` целевой фактовой таблицы
+ * @returns {Array<object>} шаги сегмента (пустой массив при отсутствии route)
+ */
+export function buildSecurityFactSteps(route) {
+  if (!route) return [];
+  return [
+    {
+      id: 'sec-fact-intro',
+      route,
+      element: null,
+      optionalSegment: true,
+      title: 'Отметка въезда и выезда',
+      description:
+        'Открыли таблицу «Автомобили по факту»: сюда попадает транспорт по согласованным заявкам. Здесь охрана отмечает въезд и выезд машин.',
+    },
+    {
+      id: 'sec-fact-row',
+      route,
+      element: '[data-testid="ob-fact-row"]',
+      optional: true,
+      side: 'bottom',
+      align: 'start',
+      title: 'Строка транспорта',
+      description:
+        'Каждая строка - автомобиль по согласованной заявке: номер, организация, время и срок действия пропуска.',
+    },
+    {
+      id: 'sec-fact-entry',
+      route,
+      element: '[data-testid="ob-fact-entry"]',
+      optional: true,
+      side: 'bottom',
+      align: 'start',
+      title: 'Отметка въезда',
+      description: 'Кнопкой «Въезд» отмечаете, что автомобиль заехал на территорию.',
+    },
+    {
+      id: 'sec-fact-exit',
+      route,
+      element: '[data-testid="ob-fact-exit"]',
+      optional: true,
+      side: 'bottom',
+      align: 'start',
+      title: 'Отметка выезда',
+      description:
+        'После отметки въезда станет активной кнопка «Выезд» - нажмите её, когда автомобиль покинет территорию.',
+    },
+  ];
+}

--- a/frontend/src/stores/__tests__/onboarding.spec.js
+++ b/frontend/src/stores/__tests__/onboarding.spec.js
@@ -4,11 +4,12 @@ import { useOnboardingStore } from '../onboarding';
 import { useAuthStore } from '../auth';
 import { onboardingSteps, ONBOARDING_VERSION } from '@/components/onboarding/onboardingSteps';
 import { securityOnboardingSteps } from '@/components/onboarding/securityOnboardingSteps';
-import { getOnboardingStatus, markOnboardingComplete } from '@/api/onboarding';
+import { getOnboardingStatus, markOnboardingComplete, getSecurityFactRoute } from '@/api/onboarding';
 
 vi.mock('@/api/onboarding', () => ({
   getOnboardingStatus: vi.fn(),
   markOnboardingComplete: vi.fn(),
+  getSecurityFactRoute: vi.fn(),
 }));
 
 function createMockJWT(payload, expiresInSeconds = 3600) {
@@ -26,6 +27,8 @@ describe('onboarding store', () => {
     getOnboardingStatus.mockReset();
     markOnboardingComplete.mockReset();
     markOnboardingComplete.mockResolvedValue({ message: 'ok' });
+    getSecurityFactRoute.mockReset();
+    getSecurityFactRoute.mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -127,6 +130,84 @@ describe('onboarding store', () => {
       expect(store.steps).toBe(securityOnboardingSteps);
       auth.userTypeCode = 'organization';
       expect(store.steps).toBe(onboardingSteps);
+    });
+  });
+
+  describe('ensureFactRoute (сегмент фактовой таблицы охранника)', () => {
+    it('для не-охранника - no-op, route не резолвится', async () => {
+      const auth = useAuthStore();
+      auth.userTypeCode = 'organization';
+      const store = useOnboardingStore();
+      await store.ensureFactRoute();
+
+      expect(getSecurityFactRoute).not.toHaveBeenCalled();
+      expect(store.factTableRoute).toBe(null);
+    });
+
+    it('для охранника резолвит route и добавляет сегмент отметки в хвост steps', async () => {
+      getSecurityFactRoute.mockResolvedValue('/table/kpp_1');
+      const auth = useAuthStore();
+      auth.userTypeCode = 'security';
+      const store = useOnboardingStore();
+      const baseLen = securityOnboardingSteps.length;
+      await store.ensureFactRoute();
+
+      expect(store.factTableRoute).toBe('/table/kpp_1');
+      expect(store.totalSteps).toBe(baseLen + 4);
+      const tail = store.steps.slice(baseLen);
+      expect(tail.map((s) => s.id)).toEqual([
+        'sec-fact-intro',
+        'sec-fact-row',
+        'sec-fact-entry',
+        'sec-fact-exit',
+      ]);
+      expect(tail.every((s) => s.route === '/table/kpp_1')).toBe(true);
+    });
+
+    it('для охранника без доступной фактовой таблицы (null) сегмент не добавляется', async () => {
+      getSecurityFactRoute.mockResolvedValue(null);
+      const auth = useAuthStore();
+      auth.userTypeCode = 'security';
+      const store = useOnboardingStore();
+      await store.ensureFactRoute();
+
+      expect(store.factTableRoute).toBe(null);
+      expect(store.steps).toBe(securityOnboardingSteps);
+    });
+
+    it('идемпотентен - резолвит один раз за сессию', async () => {
+      getSecurityFactRoute.mockResolvedValue('/table/kpp_1');
+      const auth = useAuthStore();
+      auth.userTypeCode = 'security';
+      const store = useOnboardingStore();
+      await store.ensureFactRoute();
+      await store.ensureFactRoute();
+
+      expect(getSecurityFactRoute).toHaveBeenCalledOnce();
+    });
+
+    it('start() запускает резолв фоном для охранника', async () => {
+      getSecurityFactRoute.mockResolvedValue('/table/kpp_1');
+      const auth = useAuthStore();
+      auth.userTypeCode = 'security';
+      const store = useOnboardingStore();
+      store.start();
+
+      expect(getSecurityFactRoute).toHaveBeenCalledOnce();
+      await vi.waitFor(() => expect(store.factTableRoute).toBe('/table/kpp_1'));
+    });
+
+    it('reset очищает route и позволяет резолву повториться для следующего юзера', async () => {
+      getSecurityFactRoute.mockResolvedValue('/table/kpp_1');
+      const auth = useAuthStore();
+      auth.userTypeCode = 'security';
+      const store = useOnboardingStore();
+      await store.ensureFactRoute();
+      store.reset();
+
+      expect(store.factTableRoute).toBe(null);
+      await store.ensureFactRoute();
+      expect(getSecurityFactRoute).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/frontend/src/stores/onboarding.js
+++ b/frontend/src/stores/onboarding.js
@@ -2,8 +2,8 @@ import { defineStore } from 'pinia';
 import { ref, computed } from 'vue';
 import { useAuthStore } from '@/stores/auth';
 import { onboardingSteps, ONBOARDING_VERSION } from '@/components/onboarding/onboardingSteps';
-import { securityOnboardingSteps } from '@/components/onboarding/securityOnboardingSteps';
-import { getOnboardingStatus, markOnboardingComplete } from '@/api/onboarding';
+import { securityOnboardingSteps, buildSecurityFactSteps } from '@/components/onboarding/securityOnboardingSteps';
+import { getOnboardingStatus, markOnboardingComplete, getSecurityFactRoute } from '@/api/onboarding';
 
 /**
  * Стор онбординг-тура. Держит ГЛОБАЛЬНЫЙ индекс активного шага по всему
@@ -39,12 +39,25 @@ export const useOnboardingStore = defineStore('onboarding', () => {
   // (onMounted + watch route) не слали два GET (урок про гонки авто-fetch).
   let loadStatusPromise = null;
 
+  // Route фактовой таблицы для шага отметки въезда/выезда в security-туре.
+  // Резолвится один раз за сессию (ensureFactRoute) из /system-tables: у разных
+  // охранников разные доступные таблицы. null = подходящей таблицы нет ->
+  // сегмент отметки в тур не добавляется.
+  const factTableRoute = ref(null);
+  let factRouteResolved = false;
+
   // Тур ветвится по типу пользователя: охранник смотрит вложения и таблицы, а не
   // подаёт заявки - ему отдельный сценарий. Версия и per-user флаг завершения общие
   // (юзер ровно одного типа). Автозапуск на /news сам покажет нужный сценарий.
+  //
+  // Сегмент «Таблицы и отметка въезда/выезда» добавляется в ХВОСТ (не в базовый
+  // массив), когда factTableRoute резолвлен - так индексы ранних шагов не
+  // сдвигаются, даже если route доезжает уже после старта тура.
   const steps = computed(() => {
     const auth = useAuthStore();
-    return auth.isSecurity ? securityOnboardingSteps : onboardingSteps;
+    if (!auth.isSecurity) return onboardingSteps;
+    if (!factTableRoute.value) return securityOnboardingSteps;
+    return [...securityOnboardingSteps, ...buildSecurityFactSteps(factTableRoute.value)];
   });
   const totalSteps = computed(() => steps.value.length);
   const currentStep = computed(() => steps.value[currentIndex.value] || null);
@@ -86,6 +99,20 @@ export const useOnboardingStore = defineStore('onboarding', () => {
   }
 
   /**
+   * Предвычислить route фактовой таблицы для security-тура (один раз за сессию).
+   * Только для охранника; на ошибке/отсутствии таблицы route остаётся null и
+   * сегмент отметки не добавляется. Запускается фоном из start() - сегмент в
+   * хвосте steps, поэтому индексы ранних шагов не сдвигаются, даже если route
+   * доедет уже после показа первого шага.
+   */
+  async function ensureFactRoute() {
+    const auth = useAuthStore();
+    if (!auth.isSecurity || factRouteResolved) return;
+    factRouteResolved = true;
+    factTableRoute.value = await getSecurityFactRoute();
+  }
+
+  /**
    * Запустить тур с первого шага. Идемпотентно: повторный вызов при активном
    * туре ничего не делает.
    *
@@ -96,6 +123,9 @@ export const useOnboardingStore = defineStore('onboarding', () => {
     isManual.value = manual;
     currentIndex.value = 0;
     isActive.value = true;
+    // Фоновый резолв фактовой таблицы (security): не блокирует показ первого
+    // шага, сегмент отметки добавится в хвост, как только route приедет.
+    ensureFactRoute();
   }
 
   function stop() {
@@ -155,6 +185,9 @@ export const useOnboardingStore = defineStore('onboarding', () => {
     // Сброс статуса при logout - следующий юзер на этом устройстве подтянет свой.
     completedVersion.value = null;
     statusLoaded.value = false;
+    // Route фактовой таблицы тоже per-user - следующий охранник резолвит свой.
+    factTableRoute.value = null;
+    factRouteResolved = false;
   }
 
   return {
@@ -170,6 +203,8 @@ export const useOnboardingStore = defineStore('onboarding', () => {
     pendingSegment,
     completedVersion,
     statusLoaded,
+    factTableRoute,
+    ensureFactRoute,
     loadStatus,
     hasCompleted,
     start,


### PR DESCRIPTION
## Что и зачем
Срез **S6.2** эпика aa-improvements. Тур охранника заканчивался на «Доступные мне» и не показывал, где отмечать въезд/выезд. Добавил финальный сегмент по фактовой таблице.

## Реализация
- **Динамический route шага.** Движок тура группирует шаги по `route`; целевую фактовую таблицу нельзя зашить статически (у разных охранников разные таблицы). `resolveFactTableRoute()` берёт первую активную фактовую таблицу типа `cars` из того же `/system-tables`, что NavMenu показывает в дропдауне «Таблицы». Cars — потому что кнопки «Въезд»/«Выезд» в `FactTable` есть только у машин (`v-if="tableType==='cars'"`), у people их нет.
- **Хвостовой сегмент.** Резолв идёт фоном при `start()` (один раз за сессию, per-user, чистится в `reset()`), а сегмент добавляется в ХВОСТ `steps` (computed), а не в базовый массив — поэтому индексы ранних шагов не сдвигаются, даже если route доедет после показа первого шага.
- **Грациозная деградация.** Обычный охранник (не super-admin) сейчас не проходит роут-гард `/table/:tableName` (`requiresBuro`). Первый шаг сегмента помечен `optionalSegment`: при редиректе гарда тур штатно завершается на границе (для авто-тура — `markCompleted`), а не виснет. Когда охраннику выдадут доступ — навигация пройдёт и шаги подсветят реальную таблицу. Поведение applicant-тура не задето (там `optionalSegment` нет).
- **Якоря.** В `FactTable` добавил `ob-fact-row`/`ob-fact-entry`/`ob-fact-exit` (реюз существующего `data-testid="fact-table"`).

## Известное ограничение (по решению пользователя)
Бэкенд охраннику данные таблиц отдаёт (`/system-tables`, `/cars/fact-for-tables`, `territory-status` — только JWT), но фронтовый роут-гард `/table/:tableName` = `requiresBuro` (super-admin). Real-nav сработает после выдачи охраннику доступа к роуту — отдельное auth-решение. Доступ-гэп (охранник видит «Таблицы» в навигации, но клик редиректит) — кандидат на отдельный тикет.

## Проверки
- ESLint изменённых файлов: 0 errors.
- Vitest scoped (onboarding store/steps/button/demo): 94 passed. Резолвер, append-сегмента, грациозная деградация, идемпотентность, per-user reset — покрыты.
- `code-reviewer`: GO, блокеров нет; жёлтую находку (хрупкий флаш в тесте) закрыл через `vi.waitFor`.

Текст шагов и позиции подсветки сверяются на живом fact-экране staging в финальном срезе **S6.3** (#657, урок #657).