### PR TITLE
feat(feedback): бейдж новых обращений в навигации

### DIFF
--- a/frontend/src/components/NavMenu.vue
+++ b/frontend/src/components/NavMenu.vue
@@ -330,12 +330,27 @@
               @click="toggleAdmin"
             >
               <div class="nav-item-content">
-                <NavIcon
-                  name="admin"
-                  :size="18"
-                  class="nav-icon"
-                />
+                <div class="nav-icon-wrapper">
+                  <NavIcon
+                    name="admin"
+                    :size="18"
+                    class="nav-icon"
+                  />
+                  <span
+                    v-if="newFeedbackCount > 0"
+                    class="icon-badge"
+                  >
+                    {{ newFeedbackCount > 9 ? '9+' : newFeedbackCount }}
+                  </span>
+                </div>
                 <span class="nav-text">Администрирование</span>
+                <span
+                  v-if="newFeedbackCount > 0"
+                  class="notification-badge admin-feedback-badge"
+                  data-testid="nav-feedback-badge"
+                >
+                  {{ newFeedbackCount > 9 ? '9+' : newFeedbackCount }}
+                </span>
               </div>
               <!-- Не дропдаун, а открытие боковой колонки: прямая стрелка вправо. -->
               <svg
@@ -497,6 +512,13 @@
                 class="admin-link__icon"
               />
               <span class="admin-link__label">{{ item.label }}</span>
+              <span
+                v-if="item.path === '/admin/feedback' && newFeedbackCount > 0"
+                class="admin-link__badge"
+                data-testid="admin-link-feedback-badge"
+              >
+                {{ newFeedbackCount > 9 ? '9+' : newFeedbackCount }}
+              </span>
             </div>
           </div>
           <div
@@ -557,6 +579,7 @@
 <script>
 import { apiRequest } from '@/api/client'
 import { getUnreadCount } from '@/api/applications'
+import { getFeedbackStats } from '@/api/feedback'
 import { useAuthStore } from '@/stores/auth'
 import { useUiStore } from '@/stores/ui'
 import { useSoundStore } from '@/stores/sound'
@@ -584,6 +607,9 @@ export default {
       hoverTimeout: null,
       systemTables: [],
       newApplicationsCount: 0,
+      // Непрочитанные обращения обратной связи (бейдж у Администрирования). Тянем
+      // только супер-админу - эндпоинт /feedback/stats закрыт checkAdmin (иначе 403).
+      newFeedbackCount: 0,
       // Звук новой заявки: primed=true после ПЕРВОЙ загрузки счётчика (чтобы не играть на
       // логине при 0 -> N); lastSoundAt - метка для кулдауна (пачка заявок -> один звук).
       soundPrimed: false,
@@ -996,10 +1022,25 @@ export default {
       }
     },
 
+    async fetchNewFeedbackCount() {
+      if (!this.authStore.isSuperAdmin) {
+        this.newFeedbackCount = 0;
+        return;
+      }
+      try {
+        const stats = await getFeedbackStats();
+        this.newFeedbackCount = stats?.unread || 0;
+      } catch {
+        this.newFeedbackCount = 0;
+      }
+    },
+
     startApplicationsPolling() {
       this.fetchNewApplicationsCount();
+      this.fetchNewFeedbackCount();
       this.applicationsPollingInterval = setInterval(() => {
         this.fetchNewApplicationsCount();
+        this.fetchNewFeedbackCount();
       }, 30000);
     },
 
@@ -1591,6 +1632,11 @@ export default {
   transition-delay: 0.2s;
 }
 
+/* У Администрирования справа стрелка-индикатор колонки - бейдж сдвигаем левее неё. */
+.admin-feedback-badge {
+  right: 40px;
+}
+
 /*
  * Двухколоночная Админка (#510): колонка справа от свёрнутого в иконки рельса
  * (left: 50px). Без теней - отделение бордером. Палитра - от .nav-root.
@@ -1761,6 +1807,22 @@ export default {
   line-height: 16px;
   color: var(--nav-text);
   white-space: nowrap;
+}
+
+.admin-link__badge {
+  margin-left: auto;
+  background-color: var(--nav-primary);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 600;
+  min-width: 16px;
+  height: 16px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 4px;
+  line-height: 1;
 }
 
 .admin-link:hover {

--- a/frontend/src/components/NavMenu.vue
+++ b/frontend/src/components/NavMenu.vue
@@ -338,19 +338,13 @@
                   />
                   <span
                     v-if="newFeedbackCount > 0"
-                    class="icon-badge"
+                    class="icon-badge admin-icon-badge"
+                    data-testid="nav-feedback-badge"
                   >
                     {{ newFeedbackCount > 9 ? '9+' : newFeedbackCount }}
                   </span>
                 </div>
                 <span class="nav-text">Администрирование</span>
-                <span
-                  v-if="newFeedbackCount > 0"
-                  class="notification-badge admin-feedback-badge"
-                  data-testid="nav-feedback-badge"
-                >
-                  {{ newFeedbackCount > 9 ? '9+' : newFeedbackCount }}
-                </span>
               </div>
               <!-- Не дропдаун, а открытие боковой колонки: прямая стрелка вправо. -->
               <svg
@@ -1632,9 +1626,11 @@ export default {
   transition-delay: 0.2s;
 }
 
-/* У Администрирования справа стрелка-индикатор колонки - бейдж сдвигаем левее неё. */
-.admin-feedback-badge {
-  right: 40px;
+/* У Администрирования длинный лейбл + стрелка-индикатор не оставляют места справа,
+   поэтому счётчик держим на иконке и в развёрнутом рельсе (не прячем как у других). */
+.nav-menu.expanded .admin-icon-badge {
+  opacity: 1;
+  transform: scale(1);
 }
 
 /*

--- a/frontend/src/components/__tests__/NavMenuFeedbackBadge.spec.js
+++ b/frontend/src/components/__tests__/NavMenuFeedbackBadge.spec.js
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import NavMenu from '../NavMenu.vue';
+import { useAuthStore } from '@/stores/auth';
+import { getFeedbackStats } from '@/api/feedback';
+
+// Бейдж с числом новых (непрочитанных) обращений у пункта "Администрирование".
+// Тянем /feedback/stats только супер-админу (эндпоинт закрыт checkAdmin -> иначе 403).
+
+vi.mock('@/stores/auth', () => ({ useAuthStore: vi.fn() }));
+vi.mock('@/api/client', () => ({
+  apiRequest: vi.fn().mockResolvedValue({ ok: false, json: vi.fn().mockResolvedValue([]) }),
+}));
+vi.mock('@/api/applications', () => ({
+  getUnreadCount: vi.fn().mockResolvedValue({ count: 0 }),
+}));
+vi.mock('@/api/feedback', () => ({ getFeedbackStats: vi.fn() }));
+vi.mock('@/utils/notificationSound', () => ({ playPreset: vi.fn() }));
+
+const BADGE = '[data-testid="nav-feedback-badge"]';
+
+function mountNav() {
+  return mount(NavMenu, {
+    global: {
+      mocks: {
+        $bus: { on: vi.fn(), off: vi.fn(), emit: vi.fn() },
+        $router: { push: vi.fn() },
+        $route: { path: '/news', params: {} },
+      },
+    },
+  });
+}
+
+let wrapper;
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  wrapper?.unmount();
+});
+
+describe('NavMenu: бейдж новых обращений', () => {
+  it('супер-админ: бейдж показывает число непрочитанных обращений', async () => {
+    useAuthStore.mockReturnValue({ isSuperAdmin: true });
+    getFeedbackStats.mockResolvedValue({ unread: 3 });
+    wrapper = mountNav();
+    await flushPromises();
+
+    expect(getFeedbackStats).toHaveBeenCalled();
+    const badge = wrapper.find(BADGE);
+    expect(badge.exists()).toBe(true);
+    expect(badge.text()).toBe('3');
+  });
+
+  it('больше 9 непрочитанных показывает "9+"', async () => {
+    useAuthStore.mockReturnValue({ isSuperAdmin: true });
+    getFeedbackStats.mockResolvedValue({ unread: 15 });
+    wrapper = mountNav();
+    await flushPromises();
+
+    expect(wrapper.find(BADGE).text()).toBe('9+');
+  });
+
+  it('нет непрочитанных - бейджа нет', async () => {
+    useAuthStore.mockReturnValue({ isSuperAdmin: true });
+    getFeedbackStats.mockResolvedValue({ unread: 0 });
+    wrapper = mountNav();
+    await flushPromises();
+
+    expect(wrapper.find(BADGE).exists()).toBe(false);
+  });
+
+  it('не супер-админ: stats не запрашивается и бейджа нет', async () => {
+    useAuthStore.mockReturnValue({ isSuperAdmin: false });
+    getFeedbackStats.mockResolvedValue({ unread: 5 });
+    wrapper = mountNav();
+    await flushPromises();
+
+    expect(getFeedbackStats).not.toHaveBeenCalled();
+    expect(wrapper.find(BADGE).exists()).toBe(false);
+  });
+
+  it('ошибка запроса stats не роняет навигацию, бейджа нет', async () => {
+    useAuthStore.mockReturnValue({ isSuperAdmin: true });
+    getFeedbackStats.mockRejectedValue(new Error('boom'));
+    wrapper = mountNav();
+    await flushPromises();
+
+    expect(wrapper.find(BADGE).exists()).toBe(false);
+    expect(wrapper.find('[data-testid="nav-link-admin"]').exists()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Что
У пункта "Администрирование" (на иконке рельса) и под-пункта "Обратная связь" в админ-колонке показываем счётчик непрочитанных обращений - чтобы видеть новые, не открывая раздел. Стиль и логика как у бейджа "Центра заявок".

## Детали
- Источник - `GET /feedback/stats` (`unread`). Тянем **только супер-админу**: эндпоинт закрыт `checkAdmin`, иначе обычный юзер ловил бы 403-тост на каждый опрос.
- Обновляется тем же 30s-поллингом, что и счётчик заявок (initial + interval, silent-catch).
- Счётчик у Администрирования держим на иконке (`icon-badge`) в обоих состояниях рельса - у длинного лейбла "Администрирование" notification-badge наезжал на текст.
- "9+" при >9.

## Проверка
- Vitest `NavMenuFeedbackBadge.spec.js` (5): рендер/счётчик, "9+", ноль->нет бейджа, не-супер-админ не фетчит, ошибка не роняет навигацию. Существующий NavMenu-spec зелёный.
- Браузер (локальный dev, супер-админ, 3 непрочитанных): "3" на иконке Администрирования в свёрнутом и развёрнутом рельсе + "3" у под-пункта "Обратная связь"; лейбл не перекрыт; 0 ошибок из своего кода.