### PR TITLE
fix(permissions): уведомления о правах под эталон и дедуп 403

### DIFF
--- a/frontend/src/api/__tests__/client.spec.js
+++ b/frontend/src/api/__tests__/client.spec.js
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { createPinia, setActivePinia } from 'pinia';
 
+const notifyMock = vi.fn();
+vi.mock('@/stores/deletions', () => ({
+  useDeletionsStore: () => ({ notify: notifyMock }),
+}));
+
 const routerPush = vi.fn();
 vi.mock('@/router', () => ({
   default: {
@@ -9,7 +14,7 @@ vi.mock('@/router', () => ({
   },
 }));
 
-import { apiRequest, apiRequestRaw } from '../client';
+import { apiRequest, apiRequestRaw, _resetDedup403 } from '../client';
 
 function okJson(body, init = {}) {
   return new Response(JSON.stringify(body), {
@@ -205,5 +210,98 @@ describe('401 auto-refresh', () => {
 
     const resp = await apiRequestRaw('/items');
     expect(await resp.json()).toEqual({ success: true, data: { x: 1 }, meta: { total: 7 } });
+  });
+});
+
+describe('403 handling', () => {
+  let fetchMock;
+
+  beforeEach(async () => {
+    setActivePinia(createPinia());
+    localStorage.clear();
+    routerPush.mockReset();
+    notifyMock.mockReset();
+    _resetDedup403();
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('показывает notify с типом error при 403 на обычном пути', async () => {
+    fetchMock.mockResolvedValueOnce(errJson({ banned: false }, 403));
+
+    await apiRequest('/applications/1/confirm-pass', { method: 'POST' });
+
+    expect(notifyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error', prefix: 'Недостаточно прав для этого действия.' })
+    );
+  });
+
+  it('показывает специальный текст для заблокированной учётки (banned:true)', async () => {
+    fetchMock.mockResolvedValueOnce(errJson({ banned: true }, 403));
+
+    await apiRequest('/applications', { method: 'POST' });
+
+    expect(notifyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error', prefix: 'Учётная запись заблокирована. Обратитесь к администратору.' })
+    );
+  });
+
+  it('не вызывает notify при silent403:true', async () => {
+    fetchMock.mockResolvedValueOnce(errJson({ banned: false }, 403));
+
+    await apiRequest('/applications/1/action', { method: 'POST', silent403: true });
+
+    await Promise.resolve();
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it('не вызывает notify для тихих путей (/permissions/my)', async () => {
+    fetchMock.mockResolvedValueOnce(errJson({ banned: false }, 403));
+
+    await apiRequest('/permissions/my');
+
+    await Promise.resolve();
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it('не вызывает notify для тихих путей (/users/me)', async () => {
+    fetchMock.mockResolvedValueOnce(errJson({ banned: false }, 403));
+
+    await apiRequest('/users/me');
+
+    await Promise.resolve();
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it('не вызывает notify для тихих путей (/unique-cars/lookup)', async () => {
+    fetchMock.mockResolvedValueOnce(errJson({ banned: false }, 403));
+
+    await apiRequest('/unique-cars/lookup?q=test');
+
+    await Promise.resolve();
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it('дедуплицирует: два параллельных 403 с одним текстом = один notify', async () => {
+    fetchMock.mockResolvedValue(errJson({ banned: false }, 403));
+
+    await Promise.all([
+      apiRequest('/applications/1/confirm-pass', { method: 'POST' }),
+      apiRequest('/applications/1/confirm-pass', { method: 'POST' }),
+    ]);
+
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('возвращает response со статусом 403 (вызывающий код может обработать)', async () => {
+    fetchMock.mockResolvedValueOnce(errJson({ banned: false }, 403));
+
+    const resp = await apiRequest('/some-action', { method: 'POST' });
+
+    expect(resp.status).toBe(403);
   });
 });

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,5 +1,6 @@
 import { useAuthStore } from '@/stores/auth'
 import { useMaintenanceStore } from '@/stores/maintenance'
+import { useDeletionsStore } from '@/stores/deletions'
 import router from '@/router'
 import { buildBugContext, saveBugContext } from '@/composables/useBugReport'
 
@@ -8,6 +9,35 @@ import { buildBugContext, saveBugContext } from '@/composables/useBugReport'
 // location /api/ -> backend:8080.
 const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || '') + '/api'
 const AUTH_ENDPOINTS = ['/login', '/refresh-token', '/logout']
+
+// Пути, на которых 403 не показывает уведомление: фоновые/ожидаемые запросы,
+// где 403 — штатный ответ (нет прав или сессия не авторизована).
+const SILENT_403_PREFIXES = [
+  '/permissions/my',
+  '/permissions/catalog',
+  '/users/me',
+  '/users/current',
+  '/unique-cars/lookup',
+  '/unique-employees/lookup',
+]
+
+// Дедупликация 403-уведомлений: одинаковый текст в окне TTL показывается один раз.
+const DEDUP_TTL_MS = 4000
+const _403dedup = new Map()
+
+/** @internal только для тестов */
+export function _resetDedup403() { _403dedup.clear() }
+
+function shouldSilence403(path) {
+  return SILENT_403_PREFIXES.some((p) => path === p || path.startsWith(p + '?') || path.startsWith(p + '/'))
+}
+
+function show403Notify(msg) {
+  if (_403dedup.has(msg)) return
+  _403dedup.set(msg, true)
+  setTimeout(() => _403dedup.delete(msg), DEDUP_TTL_MS)
+  useDeletionsStore().notify({ prefix: msg, type: 'error' })
+}
 
 let refreshPromise = null
 
@@ -141,20 +171,21 @@ async function baseRequest(path, options = {}) {
     return response
   }
 
-  // 403 Forbidden -- логируется в access_denials на бэке. Здесь показываем
-  // тост, но НЕ редиректим: вызывающий код сам решит как обработать
-  // (например, ApplicationsCenter может остаться на месте). Для GET-роутов
-  // прямой переход через router guard уже сработал бы раньше.
+  // 403 Forbidden -- логируется в access_denials на бэке. Показываем уведомление,
+  // но НЕ редиректим: вызывающий код сам решит как обработать.
+  // Тихий режим: опция silent403 или путь из списка фоновых/ожидаемых запросов.
   if (response.status === 403 && !isAuthEndpoint(path)) {
-    try {
-      const body = await response.clone().json();
-      const msg = body?.banned
-        ? 'Учётная запись заблокирована. Обратитесь к администратору.'
-        : 'Нет прав на это действие.';
-      const { useUiStore } = await import('@/stores/ui');
-      useUiStore().error(msg);
-    } catch {
-      // body может быть пустым/не json -- это OK
+    if (!options.silent403 && !shouldSilence403(path)) {
+      try {
+        const body = await response.clone().json()
+        const msg = body?.banned
+          ? 'Учётная запись заблокирована. Обратитесь к администратору.'
+          : 'Недостаточно прав для этого действия.'
+        show403Notify(msg)
+      } catch {
+        // body может быть пустым/не json -- показываем дефолтное сообщение
+        show403Notify('Недостаточно прав для этого действия.')
+      }
     }
     return response
   }

--- a/frontend/src/components/ApplicationDetail/ApplicationDetail.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationDetail.vue
@@ -1069,8 +1069,7 @@ export default {
                     ]);
                     this.syncSelectedDetailFlags();
                     this.$emit('application-changed', this.applicationData);
-                } else if (response.status !== 403) {
-                    // 403 уже показывает тост через client.js - второй не дублируем
+                } else if (!response.ok) {
                     const data = await response.json();
                     useDeletionsStore().notify({
                         prefix: 'Не удалось подтвердить пропуск: ',
@@ -1171,7 +1170,7 @@ export default {
                     ]);
                     this.syncSelectedDetailFlags();
                     this.$emit('application-changed', this.applicationData);
-                } else if (response.status !== 403) {
+                } else if (!response.ok) {
                     const data = await response.json();
                     useDeletionsStore().notify({
                         prefix: 'Не удалось снять подтверждение: ',


### PR DESCRIPTION
Перевёл обработку 403 в client.js с примитивного ui.error на эталонный deletions.notify. Добавил дедупликацию (одинаковый текст в окне 4s показывается один раз) и список тихих путей (/permissions/my, /users/me, lookup и т.п.), где 403 штатный и тост не нужен - это убирает спам уведомлениями. Убрал костыли гашения дубль-403 в ApplicationDetail.

Часть эпика по правам доступа (Фаза 1, FE-фундамент). vitest: 667/667, eslint чисто.