### PR TITLE
feat(permissions): бэкенд-фундамент новой системы прав (Фаза 0)

### DIFF
--- a/frontend/e2e/tests/misc-api.spec.cjs
+++ b/frontend/e2e/tests/misc-api.spec.cjs
@@ -73,15 +73,15 @@ test.describe('Misc API endpoints', () => {
     expect(data).toBeTruthy();
   });
 
-  test('GET /permissions/my возвращает массив (пустой для superadmin - у него bypass)', async ({ request }) => {
+  test('GET /permissions/my отдаёт режим super для суперадмина (bypass)', async ({ request }) => {
     const token = await loginAsSuperAdmin(request);
     const res = await request.get(`${API_BASE}/permissions/my`, { headers: headers(token) });
     expect(res.ok()).toBeTruthy();
-    const data = (await res.json()).data || [];
-    // Суперадмин обходит resolver через is_super_admin - resolver возвращает
-    // PermissionSet с IsSuperAdmin=true и пустыми keys. Фронт проверяет
-    // isSuperAdmin отдельно в usePermissionsStore.hasPermission. Здесь просто
-    // убеждаемся что endpoint работает и возвращает массив.
-    expect(Array.isArray(data)).toBeTruthy();
+    const data = (await res.json()).data || {};
+    // Новый формат: { mode, permissions[{key,value,source}], denied, banned, ban_reason }.
+    // Суперадмин -> mode=super, permissions пуст (всё разрешено через is_super_admin,
+    // фронт проверяет режим отдельно).
+    expect(data.mode).toBe('super');
+    expect(Array.isArray(data.permissions)).toBeTruthy();
   });
 });

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -475,6 +476,73 @@ func installExtensions(db *gorm.DB) error {
 	return nil
 }
 
+// baseRoleGrants -- дефолтный набор прав базовой роли "Пользователь" (ТЗ).
+// Строки синхронизированы с ключами permission_catalog.go (избегаем import services,
+// чтобы не создавать цикл database->services).
+var baseRoleGrants = []string{
+	"page.new_application",
+	"page.employees",
+	"page.cars",
+	"page.news",
+	"page.personal_cabinet",
+	"header.create_application",
+	"entity.employees.read",
+	"entity.cars.read",
+	"section.registry.organization",
+	"section.registry.company",
+	"guide.user",
+	"detail.open_application",
+	"detail.documents",
+}
+
+// seedBaseRole создаёт неудаляемую базовую роль "Пользователь" и её дефолтные
+// grants (идемпотентно). Это фундамент, от которого наследуются новые роли.
+func seedBaseRole(db *gorm.DB) error {
+	var role models.Role
+	err := db.Where("code = ?", "user").First(&role).Error
+	switch {
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		role = models.Role{Code: "user", Name: "Пользователь", IsSystem: true}
+		if err := db.Create(&role).Error; err != nil {
+			return fmt.Errorf("failed to seed base role: %w", err)
+		}
+		slog.Info("seeded base role 'Пользователь'")
+	case err != nil:
+		return fmt.Errorf("failed to check base role: %w", err)
+	case !role.IsSystem:
+		if err := db.Model(&models.Role{}).Where("id = ?", role.ID).Update("is_system", true).Error; err != nil {
+			return fmt.Errorf("failed to mark base role system: %w", err)
+		}
+	}
+
+	for _, key := range baseRoleGrants {
+		grant := models.RolePermissionGrant{RoleID: role.ID, PermissionKey: key, Value: "allow"}
+		if err := db.Where("role_id = ? AND permission_key = ?", role.ID, key).
+			FirstOrCreate(&grant).Error; err != nil {
+			return fmt.Errorf("failed to seed base role grant %s: %w", key, err)
+		}
+	}
+	return nil
+}
+
+// backfillAdminFromType разово переносит админство с типа на флаг: пользователи
+// типа "manager" (кроме супер-админа) становятся is_admin=true. После этого
+// авторизация идёт по флагу, а не по user_type (см. эпик прав). Идемпотентно.
+func backfillAdminFromType(db *gorm.DB) error {
+	res := db.Exec(`
+		UPDATE users SET is_admin = true
+		WHERE is_admin = false AND is_super_admin = false
+		  AND type_id IN (SELECT id FROM user_types WHERE code = 'manager')
+	`)
+	if res.Error != nil {
+		return fmt.Errorf("backfill is_admin from type manager: %w", res.Error)
+	}
+	if res.RowsAffected > 0 {
+		slog.Info("is_admin backfilled from type manager", "users_updated", res.RowsAffected)
+	}
+	return nil
+}
+
 // Seed inserts initial data if tables are empty.
 func Seed(db *gorm.DB) error {
 	// Миграция: переводим заявки "Непрочитано" -> "В обработке"
@@ -601,6 +669,16 @@ func Seed(db *gorm.DB) error {
 				return err
 			}
 		}
+	}
+
+	// Базовая роль "Пользователь" с дефолтными правами (фундамент новой системы прав).
+	if err := seedBaseRole(db); err != nil {
+		return err
+	}
+
+	// Разовый перенос админства с типа manager на флаг is_admin.
+	if err := backfillAdminFromType(db); err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -41,6 +41,7 @@ func AllModels() []interface{} {
 		// Users (depends on UserType, Organization, Company)
 		&models.User{},
 		&models.UserHistory{},
+		&models.UserBanHistory{},
 		&models.RefreshToken{},
 		&models.AuthEvent{},
 		&models.OrganizationUser{},
@@ -147,6 +148,7 @@ func AllModels() []interface{} {
 		&models.Role{},
 		&models.RoleDefaultGroup{},
 		&models.PermissionGroupGrant{},
+		&models.RolePermissionGrant{},
 		&models.UserGroup{},
 		&models.UserPermissionOverride{},
 

--- a/internal/handlers/permission_groups.go
+++ b/internal/handlers/permission_groups.go
@@ -128,6 +128,24 @@ func (h *PermissionGroupHandler) SetUserRole(c echo.Context) error {
 	return RespondSuccess(c, map[string]any{"updated": true})
 }
 
+// SetUserAdmin -- PUT /users/:id/admin (super-only через middleware action.grant.admin).
+func (h *PermissionGroupHandler) SetUserAdmin(c echo.Context) error {
+	userID, err := ParseID(c, "id")
+	if err != nil {
+		return err
+	}
+	var req struct {
+		IsAdmin bool `json:"is_admin"`
+	}
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid body: "+err.Error())
+	}
+	if err := h.service.SetUserAdmin(c.Request().Context(), userID, req.IsAdmin); err != nil {
+		return err
+	}
+	return RespondSuccess(c, map[string]any{"updated": true})
+}
+
 // AssignToUser -- POST /users/:user_id/permission-groups/:group_id.
 func (h *PermissionGroupHandler) AssignToUser(c echo.Context) error {
 	userID, err := ParseID(c, "user_id")

--- a/internal/handlers/permissions.go
+++ b/internal/handlers/permissions.go
@@ -20,27 +20,38 @@ func NewPermissionHandler(service services.PermissionService, resolver *services
 	return &PermissionHandler{service: service, resolver: resolver}
 }
 
-// GetMyPermissions возвращает разрешения текущего пользователя в виде
-// массива {key, value:"allow"} - формат сохранён ради backward-compat
-// с usePermissionsStore на фронте. Источник данных - PermissionResolver
-// из #187 (roles + permission_groups + user_groups + overrides), а не
-// старая таблица user_permissions (она устарела и не отражает реальные
-// права после миграции на новую систему).
+// GetMyPermissions возвращает эффективные права текущего пользователя.
+// Формат {mode, permissions[{key,value,source}], denied, banned, ban_reason}:
+//   - mode=super  -> всё разрешено (permissions пуст, фронт включает всё readonly);
+//   - mode=admin  -> всё кроме super-only и denied (личных deny-override);
+//   - mode=normal -> permissions = allow-список с источником (роль/группа/override);
+//   - mode=banned -> прав нет.
+//
+// Источник данных -- PermissionResolver (роли + группы + grants + overrides).
 func (h *PermissionHandler) GetMyPermissions(c echo.Context) error {
 	userID := GetUserID(c)
 	set, err := h.resolver.Resolve(c.Request().Context(), userID)
 	if err != nil {
 		return err
 	}
+
 	keys := set.Keys()
-	perms := make([]models.UserPermissionResponse, 0, len(keys))
+	perms := make([]models.MyPermissionItem, 0, len(keys))
 	for _, k := range keys {
-		perms = append(perms, models.UserPermissionResponse{
-			Key:   k,
-			Value: "allow",
+		perms = append(perms, models.MyPermissionItem{
+			Key:    k,
+			Value:  "allow",
+			Source: set.Source(k),
 		})
 	}
-	return RespondSuccess(c, perms)
+
+	return RespondSuccess(c, models.MyPermissionsResponse{
+		Mode:        set.Mode(),
+		Permissions: perms,
+		Denied:      set.Denies(),
+		Banned:      set.IsBanned(),
+		BanReason:   set.BanReason(),
+	})
 }
 
 // GetUserPermissions возвращает разрешения указанного пользователя (только super-admin).

--- a/internal/handlers/permissions.go
+++ b/internal/handlers/permissions.go
@@ -81,6 +81,15 @@ func (h *PermissionHandler) GetPermissionTree(c echo.Context) error {
 	return RespondSuccess(c, tree)
 }
 
+// GetCatalog возвращает каталог прав (статика + динамические table.*) для UI настройки.
+func (h *PermissionHandler) GetCatalog(c echo.Context) error {
+	catalog, err := h.service.GetCatalog(c.Request().Context())
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, catalog)
+}
+
 // AutoGenerate создаёт разрешения для таблицы (только admin).
 func (h *PermissionHandler) AutoGenerate(c echo.Context) error {
 	var req models.AutoGenerateRequest

--- a/internal/handlers/permissions_edge_test.go
+++ b/internal/handlers/permissions_edge_test.go
@@ -60,8 +60,8 @@ func TestPermissions_AutoGenerate_AnyAuthenticatedUser(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code,
 		"auto-generate has no admin check -- any authenticated user can call it")
 
-	// Verify permissions were created
+	// Verify permissions were created (по одному на глагол, всего 8)
 	var count int64
 	db.Model(&models.Permission{}).Where("key LIKE ?", "table.edge_test_table.%").Count(&count)
-	assert.Equal(t, int64(2), count)
+	assert.Equal(t, int64(8), count)
 }

--- a/internal/handlers/permissions_test.go
+++ b/internal/handlers/permissions_test.go
@@ -32,8 +32,9 @@ func TestPermissions_GetMy_Empty(t *testing.T) {
 	rec := testutil.GET(t, e, "/permissions/my", h)
 	require.Equal(t, http.StatusOK, rec.Code)
 
-	perms := testutil.ParseResponse[[]models.UserPermissionResponse](t, rec)
-	assert.Equal(t, 0, len(perms))
+	resp := testutil.ParseResponse[models.MyPermissionsResponse](t, rec)
+	assert.Equal(t, "normal", resp.Mode)
+	assert.Equal(t, 0, len(resp.Permissions))
 }
 
 func TestPermissions_GetMy_WithPermissions(t *testing.T) {
@@ -203,10 +204,10 @@ func TestPermissions_AutoGenerate(t *testing.T) {
 	rec := testutil.POST(t, e, "/permissions/auto-generate", body, h)
 	require.Equal(t, http.StatusOK, rec.Code)
 
-	// Verify permissions were created
+	// Verify permissions were created (по одному на глагол, всего 8).
 	var count int64
 	db.Model(&models.Permission{}).Where("key LIKE ?", "table.test_table.%").Count(&count)
-	assert.Equal(t, int64(2), count)
+	assert.Equal(t, int64(8), count)
 
 	// Verify specific keys
 	var perm models.Permission
@@ -214,9 +215,9 @@ func TestPermissions_AutoGenerate(t *testing.T) {
 	assert.Equal(t, "table", perm.Category)
 	assert.Contains(t, perm.DisplayName, "test_table")
 
-	var editPerm models.Permission
-	require.NoError(t, db.Where("key = ?", "table.test_table.edit").First(&editPerm).Error)
-	assert.Equal(t, "table", editPerm.Category)
+	var entryPerm models.Permission
+	require.NoError(t, db.Where("key = ?", "table.test_table.entry").First(&entryPerm).Error)
+	assert.Equal(t, "table", entryPerm.Category)
 }
 
 func TestPermissions_AutoGenerate_Idempotent(t *testing.T) {
@@ -237,10 +238,10 @@ func TestPermissions_AutoGenerate_Idempotent(t *testing.T) {
 	rec = testutil.POST(t, e, "/permissions/auto-generate", body, h)
 	require.Equal(t, http.StatusOK, rec.Code)
 
-	// Should still only have 2 permissions
+	// Should still only have 8 permissions (идемпотентно, без дублей)
 	var count int64
 	db.Model(&models.Permission{}).Where("key LIKE ?", "table.idem_table.%").Count(&count)
-	assert.Equal(t, int64(2), count)
+	assert.Equal(t, int64(8), count)
 }
 
 func TestPermissions_DefaultSeeded(t *testing.T) {
@@ -276,8 +277,12 @@ func TestPermissions_SystemTableCreate_AutoGenerates(t *testing.T) {
 	rec := testutil.POST(t, e, "/system-tables", body, h)
 	require.Equal(t, http.StatusOK, rec.Code)
 
-	// Verify permissions were auto-generated
+	// Verify permissions were auto-generated (по одному на глагол: view/entry/exit/
+	// detail/history/export/trash/delete).
 	var count int64
 	db.Model(&models.Permission{}).Where("key LIKE ?", "table.autogen_test.%").Count(&count)
-	assert.Equal(t, int64(2), count)
+	assert.Equal(t, int64(8), count)
+
+	var viewPerm models.Permission
+	require.NoError(t, db.Where("key = ?", "table.autogen_test.view").First(&viewPerm).Error)
 }

--- a/internal/models/permission_view.go
+++ b/internal/models/permission_view.go
@@ -1,0 +1,19 @@
+package models
+
+// MyPermissionItem -- одно эффективное право текущего пользователя.
+type MyPermissionItem struct {
+	Key    string `json:"key"`
+	Value  string `json:"value"`  // allow (для normal-режима)
+	Source string `json:"source"` // role|group|override
+}
+
+// MyPermissionsResponse -- ответ GET /permissions/my для фронтового стора прав.
+// mode определяет трактовку: super -> всё (тумблеры readonly), admin -> всё кроме
+// denied и super-only, normal -> только permissions, banned -> ничего.
+type MyPermissionsResponse struct {
+	Mode        string             `json:"mode"`
+	Permissions []MyPermissionItem `json:"permissions"`
+	Denied      []string           `json:"denied"`
+	Banned      bool               `json:"banned"`
+	BanReason   string             `json:"ban_reason,omitempty"`
+}

--- a/internal/models/role.go
+++ b/internal/models/role.go
@@ -6,12 +6,15 @@ import "time"
 // Не путать с группой прав: роль определяет "кто", группа -- "что разрешено".
 // К каждой роли можно привязать несколько default-групп прав через RoleDefaultGroup.
 type Role struct {
-	ID          int       `json:"id"`
-	Code        string    `gorm:"uniqueIndex;size:50" json:"code"`
-	Name        string    `gorm:"size:100" json:"name"`
-	Description *string   `gorm:"type:text" json:"description"`
-	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
+	ID          int     `json:"id"`
+	Code        string  `gorm:"uniqueIndex;size:50" json:"code"`
+	Name        string  `gorm:"size:100" json:"name"`
+	Description *string `gorm:"type:text" json:"description"`
+	// IsSystem помечает встроенную роль "Пользователь" (базовый фундамент прав).
+	// Системную роль нельзя удалить; новые роли создаются со снимком её grants.
+	IsSystem  bool      `gorm:"default:false" json:"is_system"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 // RoleDefaultGroup -- M:N связь "роль -> default-группа прав".

--- a/internal/models/role_grant.go
+++ b/internal/models/role_grant.go
@@ -1,0 +1,15 @@
+package models
+
+import "time"
+
+// RolePermissionGrant -- собственный точечный grant роли (allow/deny на конкретный ключ).
+// Параллелен PermissionGroupGrant, но привязан к роли напрямую: роль -- живой источник
+// прав (правка роли сразу отражается на всех её носителях). Резолвер объединяет
+// role_permission_grants + role.default_groups + user_groups, затем user overrides.
+type RolePermissionGrant struct {
+	RoleID        int       `gorm:"primaryKey;autoIncrement:false" json:"role_id"`
+	Role          Role      `gorm:"foreignKey:RoleID;constraint:OnDelete:CASCADE" json:"-"`
+	PermissionKey string    `gorm:"primaryKey;size:255" json:"permission_key"`
+	Value         string    `gorm:"size:10;default:'allow'" json:"value"`
+	CreatedAt     time.Time `json:"created_at"`
+}

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -15,18 +15,25 @@ type User struct {
 	RoleID         *int         `json:"role_id"`
 	Role           *Role        `gorm:"foreignKey:RoleID" json:"role,omitempty"`
 	IsSuperAdmin   bool         `gorm:"default:false;index" json:"is_super_admin"`
-	IsActive       bool         `gorm:"default:true;index" json:"is_active"`
-	IsBanned       bool         `gorm:"default:false;index" json:"is_banned"`
-	IsImportant    bool         `gorm:"default:false" json:"is_important"`
-	BannedAt       *time.Time   `json:"banned_at,omitempty"`
-	BannedBy       *int         `json:"banned_by,omitempty"`
-	LastName       *string      `gorm:"size:100" json:"last_name"`
-	FirstName      *string      `gorm:"size:100" json:"first_name"`
-	MiddleName     *string      `gorm:"size:100" json:"middle_name"`
-	Position       *string      `gorm:"size:100;column:position" json:"position"`
-	Email          *string      `gorm:"size:100" json:"email"`
-	Phone          *string      `gorm:"size:20" json:"phone"`
-	LastLoginAt    *time.Time   `json:"last_login_at,omitempty"`
+	// IsAdmin -- администратор (тумблер в карточке). Базово получает все права,
+	// кроме super-only ключей и личных deny-override (см. PermissionResolver).
+	// Отвязано от user_type: админство задаётся флагом, а не кодом типа.
+	IsAdmin     bool       `gorm:"default:false;index" json:"is_admin"`
+	IsActive    bool       `gorm:"default:true;index" json:"is_active"`
+	IsBanned    bool       `gorm:"default:false;index" json:"is_banned"`
+	IsImportant bool       `gorm:"default:false" json:"is_important"`
+	BannedAt    *time.Time `json:"banned_at,omitempty"`
+	BannedBy    *int       `json:"banned_by,omitempty"`
+	// BanReason -- текущая причина блокировки (показывается заблокированному в ЛК).
+	// Обнуляется при разблокировке; хронология ведётся в UserBanHistory.
+	BanReason   *string    `gorm:"type:text" json:"ban_reason,omitempty"`
+	LastName    *string    `gorm:"size:100" json:"last_name"`
+	FirstName   *string    `gorm:"size:100" json:"first_name"`
+	MiddleName  *string    `gorm:"size:100" json:"middle_name"`
+	Position    *string    `gorm:"size:100;column:position" json:"position"`
+	Email       *string    `gorm:"size:100" json:"email"`
+	Phone       *string    `gorm:"size:20" json:"phone"`
+	LastLoginAt *time.Time `json:"last_login_at,omitempty"`
 	// LastSeen - момент последней активности (любой authenticated-запрос),
 	// обновляется middleware с троттлингом. В отличие от LastLoginAt отражает
 	// присутствие "онлайн" между логинами; по нему считается users_online (#632).
@@ -74,6 +81,7 @@ type UserInfoResponse struct {
 	IsActive       bool    `json:"is_active"`
 	IsBanned       bool    `json:"is_banned"`
 	IsSuperAdmin   bool    `json:"is_super_admin"`
+	IsAdmin        bool    `json:"is_admin"`
 	IsImportant    bool    `json:"is_important"`
 	Organization   *string `json:"organization"`
 	OrganizationID *int    `json:"organization_id"`

--- a/internal/models/user_ban_history.go
+++ b/internal/models/user_ban_history.go
@@ -1,0 +1,16 @@
+package models
+
+import "time"
+
+// UserBanHistory -- аудит блокировок/разблокировок пользователя (кто/когда/почему).
+// users.is_banned/banned_at/banned_by/ban_reason хранят ТЕКУЩЕЕ состояние для быстрого
+// чтения резолвером; история -- отдельная сущность ради 152-ФЗ-аудита и отображения
+// хронологии. Action: "ban" | "unban".
+type UserBanHistory struct {
+	ID        int       `json:"id"`
+	UserID    int       `gorm:"index" json:"user_id"`
+	Action    string    `gorm:"size:10" json:"action"`
+	Reason    *string   `gorm:"type:text" json:"reason"`
+	ActorID   *int      `json:"actor_id"`
+	CreatedAt time.Time `gorm:"index" json:"created_at"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -481,6 +481,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	permGroup.GET("/user/:id", permissions.GetUserPermissions)
 	permGroup.PUT("/user/:id", permissions.UpdateUserPermissions)
 	permGroup.GET("/tree", permissions.GetPermissionTree)
+	permGroup.GET("/catalog", permissions.GetCatalog)
 	permGroup.POST("/auto-generate", permissions.AutoGenerate)
 
 	// permission.audit.manage = управление системой прав

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -491,6 +491,8 @@ func Setup(e *echo.Echo, d Dependencies) {
 	// ничего секретного - только публичные метаданные ролей/групп).
 	auditRead := mw.RequirePermissionV2(permResolver, denialLog, services.KeyAuditRead)
 	auditManage := mw.RequirePermissionV2(permResolver, denialLog, services.KeyAuditManage)
+	// Выдача/снятие тумблера "Администратор" -- super-only (ключ action.grant.admin).
+	grantAdmin := mw.RequirePermissionV2(permResolver, denialLog, services.KeyActionGrantAdmin)
 
 	// Группы прав (#187a). CRUD защищён permission.audit.manage.
 	pgGroup := protected.Group("/permission-groups")
@@ -504,6 +506,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	protected.POST("/users/:user_id/permission-groups/:group_id", permGroups.AssignToUser, auditManage)
 	protected.DELETE("/users/:user_id/permission-groups/:group_id", permGroups.UnassignFromUser, auditManage)
 	protected.PUT("/users/:id/role", permGroups.SetUserRole, auditManage)
+	protected.PUT("/users/:id/admin", permGroups.SetUserAdmin, grantAdmin)
 
 	// Роли (#187a). CRUD защищён permission.audit.manage.
 	rolesGroup := protected.Group("/roles")

--- a/internal/services/permission_catalog.go
+++ b/internal/services/permission_catalog.go
@@ -1,0 +1,193 @@
+package services
+
+import "strings"
+
+// Единый каталог точечных прав (#эпик-прав). Источник правды для UI настройки
+// прав и для валидации входящих ключей. Иерархия: категория-заголовок -> листья.
+// Динамические table.<slug>.* в статический каталог не входят -- они приходят из
+// БД (AutoGenerateForTable) и доклеиваются к ответу /permissions/catalog.
+//
+// Именование новых ключей продолжает конвенцию permission_keys.go:
+//   page.*    -- пункты навигации,
+//   header.*  -- кнопки шапки,
+//   center.*  -- разделы/кнопки центра заявок,
+//   detail.*  -- кнопки/разделы карточек авто/сотрудника (общие для контекстов),
+//   section.* -- разделы внутри страниц (владельческие вкладки реестров),
+//   guide.*   -- вкладки руководства,
+//   news.*    -- управление новостями.
+
+// Новые ключи каталога (существующие переиспользуются из permission_keys.go).
+const (
+	KeyPageNewApplication = "page.new_application"
+	KeyPageAvailable      = "page.available"
+	KeyPageTables         = "page.tables"
+	KeyPageAnalytics      = "page.analytics"
+
+	KeyPageAdminMonitoring  = "page.admin.monitoring"
+	KeyPageAdminDirectories = "page.admin.directories"
+	KeyPageAdminTablesCtor  = "page.admin.tables_constructor"
+
+	KeyHeaderReportProblem     = "header.report_problem"
+	KeyHeaderCreateApplication = "header.create_application"
+
+	KeyCenterArchive            = "center.archive"
+	KeyCenterApplicationHistory = "center.application_history"
+
+	KeyDetailFullHistory      = "detail.full_history"
+	KeyDetailOpenApplication  = "detail.open_application"
+	KeyDetailBlacklist        = "detail.blacklist"
+	KeyDetailEntryExitHistory = "detail.entry_exit_history"
+	KeyDetailDocuments        = "detail.documents"
+	KeyDetailPassHistory      = "detail.pass_history"
+
+	KeySectionRegistryOrganization = "section.registry.organization"
+	KeySectionRegistryCompany      = "section.registry.company"
+	KeySectionRegistryAllSystem    = "section.registry.all_system"
+
+	KeyActionGrantAdmin = "action.grant.admin"
+
+	KeyNewsManage = "news.manage"
+	KeyGuideUser  = "guide.user"
+	KeyGuideAdmin = "guide.admin"
+)
+
+// Категории-заголовки для группировки в UI.
+const (
+	CatNavigation = "Навигация"
+	CatHeader     = "Шапка"
+	CatCenter     = "Центр заявок"
+	CatDetail     = "Карточка авто/сотрудника"
+	CatTables     = "Таблицы"
+	CatRegistry   = "Сотрудники и автомобили"
+	CatAdmin      = "Администрирование"
+	CatOverview   = "Обзор и новости"
+)
+
+// CatalogNode -- узел каталога прав для UI и валидации.
+type CatalogNode struct {
+	Key         string        `json:"key"`
+	DisplayName string        `json:"display_name"`
+	Category    string        `json:"category"`
+	SuperOnly   bool          `json:"super_only,omitempty"`
+	Children    []CatalogNode `json:"children,omitempty"`
+}
+
+// superOnlyKeys -- права, доступные ТОЛЬКО супер-админу. Обычный администратор
+// (is_admin) их не получает даже при allowAll.
+var superOnlyKeys = map[string]struct{}{
+	KeyPageSystemControl: {}, // режим техработ
+	KeyActionGrantAdmin:  {}, // выдача тумблера "Администратор" другим
+}
+
+// staticCatalog -- статическое дерево прав (без динамических table.*).
+func staticCatalog() []CatalogNode {
+	return []CatalogNode{
+		// Навигация
+		{Key: KeyPageCenter, DisplayName: "Центр заявок", Category: CatNavigation},
+		{Key: KeyPageNewApplication, DisplayName: "Новая заявка", Category: CatNavigation},
+		{Key: KeyPageAvailable, DisplayName: "Доступные мне", Category: CatNavigation},
+		{Key: KeyPageTables, DisplayName: "Таблицы", Category: CatNavigation},
+		{Key: KeyPageEmployees, DisplayName: "Сотрудники", Category: CatNavigation},
+		{Key: KeyPageCars, DisplayName: "Автомобили", Category: CatNavigation},
+		{Key: KeyPageAnalytics, DisplayName: "Аналитика", Category: CatNavigation},
+		{Key: KeyPageAdmin, DisplayName: "Администрирование", Category: CatNavigation},
+		{Key: KeyPageNews, DisplayName: "Обзор и новости", Category: CatNavigation},
+		{Key: KeyPagePersonal, DisplayName: "Личный кабинет", Category: CatNavigation},
+
+		// Шапка
+		{Key: KeyHeaderReportProblem, DisplayName: "Кнопка «Сообщить о проблеме»", Category: CatHeader},
+		{Key: KeyHeaderCreateApplication, DisplayName: "Кнопка «Подать заявку»", Category: CatHeader},
+
+		// Центр заявок
+		{Key: KeyCenterArchive, DisplayName: "Раздел «Архив»", Category: CatCenter},
+		{Key: KeyCenterApplicationHistory, DisplayName: "Кнопка «История заявки»", Category: CatCenter},
+		{Key: KeyActionForwardApplication, DisplayName: "Переслать заявку", Category: CatCenter},
+		{Key: KeyActionApproveApplication, DisplayName: "Согласовать заявку", Category: CatCenter},
+		{Key: KeyActionExportApplications, DisplayName: "Экспорт заявок", Category: CatCenter},
+
+		// Карточка авто/сотрудника (общие действия; где кнопка уместна -- определяет контекст на фронте)
+		{Key: KeyDetailFullHistory, DisplayName: "Кнопка «Полная история»", Category: CatDetail},
+		{Key: KeyDetailOpenApplication, DisplayName: "Кнопка «Открыть заявку»", Category: CatDetail},
+		{Key: KeyDetailBlacklist, DisplayName: "Кнопка «В ЧС»", Category: CatDetail},
+		{Key: KeyDetailEntryExitHistory, DisplayName: "Раздел «История въездов и выездов»", Category: CatDetail},
+		{Key: KeyDetailDocuments, DisplayName: "Раздел «Документы»", Category: CatDetail},
+		{Key: KeyDetailPassHistory, DisplayName: "Раздел «История проходов»", Category: CatDetail},
+
+		// Сотрудники и автомобили
+		{Key: KeyEntityCarsRead, DisplayName: "Автомобили: просмотр", Category: CatRegistry},
+		{Key: KeyEntityCarsWrite, DisplayName: "Автомобили: изменение", Category: CatRegistry},
+		{Key: KeyEntityCarsDelete, DisplayName: "Автомобили: удаление", Category: CatRegistry},
+		{Key: KeyEntityEmployeesRead, DisplayName: "Сотрудники: просмотр", Category: CatRegistry},
+		{Key: KeyEntityEmployeesWrite, DisplayName: "Сотрудники: изменение", Category: CatRegistry},
+		{Key: KeyEntityEmployeesDel, DisplayName: "Сотрудники: удаление", Category: CatRegistry},
+		{Key: KeySectionRegistryOrganization, DisplayName: "Раздел «...организации»", Category: CatRegistry},
+		{Key: KeySectionRegistryCompany, DisplayName: "Раздел «...компании»", Category: CatRegistry},
+		{Key: KeySectionRegistryAllSystem, DisplayName: "Раздел «Все ... системы»", Category: CatRegistry},
+
+		// Администрирование
+		{Key: KeyPageAdminUsers, DisplayName: "Раздел «Пользователи»", Category: CatAdmin},
+		{Key: KeyPageAdminMonitoring, DisplayName: "Раздел «Мониторинг запросов»", Category: CatAdmin},
+		{Key: KeyPageAdminFeedback, DisplayName: "Раздел «Обратная связь»", Category: CatAdmin},
+		{Key: KeyPageBlacklist, DisplayName: "Раздел «Чёрный список»", Category: CatAdmin},
+		{Key: KeyPageAdminDirectories, DisplayName: "Раздел «Справочники»", Category: CatAdmin},
+		{Key: KeyPageAdminTablesCtor, DisplayName: "Раздел «Конструктор таблиц»", Category: CatAdmin},
+		{Key: KeyAuditRead, DisplayName: "Журнал отказов в доступе", Category: CatAdmin},
+		{Key: KeyAuditManage, DisplayName: "Управление ролями и группами", Category: CatAdmin},
+		{Key: KeyActionBanUser, DisplayName: "Блокировка пользователей", Category: CatAdmin},
+		{Key: KeyActionGrantAdmin, DisplayName: "Выдача прав администратора", Category: CatAdmin, SuperOnly: true},
+		{Key: KeyPageSystemControl, DisplayName: "Режим техработ", Category: CatAdmin, SuperOnly: true},
+
+		// Обзор и новости
+		{Key: KeyNewsManage, DisplayName: "Управление новостями и объявлениями", Category: CatOverview},
+		{Key: KeyGuideUser, DisplayName: "Руководство пользователя", Category: CatOverview},
+		{Key: KeyGuideAdmin, DisplayName: "Руководство администратора", Category: CatOverview},
+	}
+}
+
+// Catalog возвращает статическое дерево прав каталога.
+func Catalog() []CatalogNode {
+	return staticCatalog()
+}
+
+// catalogKeySet -- множество всех статических ключей каталога (для O(1) валидации).
+var catalogKeySet = func() map[string]struct{} {
+	m := make(map[string]struct{})
+	for _, n := range staticCatalog() {
+		m[n.Key] = struct{}{}
+		for _, c := range n.Children {
+			m[c.Key] = struct{}{}
+		}
+	}
+	return m
+}()
+
+// AllCatalogKeys возвращает плоский список всех статических ключей каталога.
+func AllCatalogKeys() []string {
+	keys := make([]string, 0, len(catalogKeySet))
+	for k := range catalogKeySet {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// IsSuperOnly сообщает, что ключ доступен только супер-админу.
+func IsSuperOnly(key string) bool {
+	_, ok := superOnlyKeys[key]
+	return ok
+}
+
+// IsCatalogKey сообщает, что ключ есть в статическом каталоге.
+func IsCatalogKey(key string) bool {
+	_, ok := catalogKeySet[key]
+	return ok
+}
+
+// IsValidKey сообщает, что ключ валиден для назначения: либо статический из
+// каталога, либо динамический table.<slug>.* (существование конкретной table.*
+// проверяется отдельно по БД там, где это критично).
+func IsValidKey(key string) bool {
+	if IsCatalogKey(key) {
+		return true
+	}
+	return strings.HasPrefix(key, PrefixTable)
+}

--- a/internal/services/permission_catalog_test.go
+++ b/internal/services/permission_catalog_test.go
@@ -1,0 +1,91 @@
+package services
+
+import "testing"
+
+func TestCatalogNoDuplicateKeys(t *testing.T) {
+	t.Parallel()
+	seen := make(map[string]struct{})
+	for _, n := range Catalog() {
+		if _, dup := seen[n.Key]; dup {
+			t.Errorf("дубликат ключа в каталоге: %s", n.Key)
+		}
+		seen[n.Key] = struct{}{}
+		if n.Key == "" || n.DisplayName == "" || n.Category == "" {
+			t.Errorf("узел каталога с пустым полем: %+v", n)
+		}
+	}
+	if len(seen) == 0 {
+		t.Fatal("каталог пуст")
+	}
+}
+
+func TestIsSuperOnly(t *testing.T) {
+	t.Parallel()
+	cases := map[string]bool{
+		KeyPageSystemControl: true,
+		KeyActionGrantAdmin:  true,
+		KeyPageCenter:        false,
+		KeyPageAdminUsers:    false,
+		"table.kpp4.view":    false,
+	}
+	for key, want := range cases {
+		if got := IsSuperOnly(key); got != want {
+			t.Errorf("IsSuperOnly(%q) = %v, ожидалось %v", key, got, want)
+		}
+	}
+}
+
+func TestSuperOnlyKeysPresentInCatalog(t *testing.T) {
+	t.Parallel()
+	for k := range superOnlyKeys {
+		if !IsCatalogKey(k) {
+			t.Errorf("super-only ключ %q отсутствует в каталоге", k)
+		}
+	}
+}
+
+func TestIsCatalogKey(t *testing.T) {
+	t.Parallel()
+	if !IsCatalogKey(KeyPageCenter) {
+		t.Error("KeyPageCenter должен быть в каталоге")
+	}
+	if !IsCatalogKey(KeyDetailBlacklist) {
+		t.Error("KeyDetailBlacklist должен быть в каталоге")
+	}
+	if IsCatalogKey("nonexistent.key") {
+		t.Error("несуществующий ключ не должен быть в каталоге")
+	}
+	if IsCatalogKey("table.kpp4.view") {
+		t.Error("динамический table.* не входит в статический каталог")
+	}
+}
+
+func TestIsValidKey(t *testing.T) {
+	t.Parallel()
+	cases := map[string]bool{
+		KeyPageCenter:        true,
+		KeyDetailDocuments:   true,
+		"table.kpp4.view":    true, // динамический префикс
+		"table.post72.entry": true,
+		"garbage":            false,
+		"page.unknown":       false,
+	}
+	for key, want := range cases {
+		if got := IsValidKey(key); got != want {
+			t.Errorf("IsValidKey(%q) = %v, ожидалось %v", key, got, want)
+		}
+	}
+}
+
+func TestAllCatalogKeysMatchesSet(t *testing.T) {
+	t.Parallel()
+	keys := AllCatalogKeys()
+	if len(keys) == 0 {
+		t.Fatal("AllCatalogKeys пуст")
+	}
+	for _, k := range keys {
+		if !IsCatalogKey(k) {
+			t.Errorf("AllCatalogKeys вернул ключ %q вне каталога", k)
+		}
+	}
+}

--- a/internal/services/permission_group_service.go
+++ b/internal/services/permission_group_service.go
@@ -259,6 +259,16 @@ func (s *PermissionGroupService) SetUserRole(ctx context.Context, userID int, ro
 	return nil
 }
 
+// SetUserAdmin переключает флаг администратора у пользователя (выдача/снятие админки).
+func (s *PermissionGroupService) SetUserAdmin(ctx context.Context, userID int, isAdmin bool) error {
+	if err := s.db.WithContext(ctx).Model(&models.User{}).Where("id = ?", userID).
+		Update("is_admin", isAdmin).Error; err != nil {
+		return fmt.Errorf("failed to set admin flag: %w", err)
+	}
+	s.resolver.Invalidate(userID)
+	return nil
+}
+
 // UnassignFromUser убирает группу у юзера.
 func (s *PermissionGroupService) UnassignFromUser(ctx context.Context, userID, groupID int) error {
 	if err := s.db.WithContext(ctx).

--- a/internal/services/permission_resolver.go
+++ b/internal/services/permission_resolver.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -11,13 +12,15 @@ import (
 	"gorm.io/gorm"
 )
 
-// PermissionResolver вычисляет финальный набор прав пользователя на основе
-// его роли (default-группы), явных групп и точечных override.
+// PermissionResolver вычисляет финальный набор прав пользователя.
 //
-// Алгоритм (см. #187):
-//  1. Если IsSuperAdmin = true -> возвращает специальный allowAll set (HasPermission всегда true).
-//  2. Иначе union прав со всех групп: role.default_groups + user_groups.
-//  3. Поверх UserPermissionOverride: deny здесь побеждает любое allow из групп.
+// Уровни (приоритет сверху вниз):
+//  1. banned -> прав нет (Has всегда false).
+//  2. is_super_admin -> allowAll (Has всегда true, включая super-only).
+//  3. is_admin -> adminAll: всё, КРОМЕ super-only ключей и личных deny-override.
+//  4. обычный -> union(role_permission_grants + role.default_groups + user_groups),
+//     затем UserPermissionOverride (deny побеждает allow). Super-only режутся для всех,
+//     кроме super-admin.
 //
 // Кэш: in-memory sync.Map с TTL 30s, инвалидируется по Invalidate(userID).
 type PermissionResolver struct {
@@ -31,13 +34,21 @@ type cacheEntry struct {
 	expiresAt time.Time
 }
 
+// Источники права (для отображения в UI настройки).
+const (
+	SourceRole     = "role"
+	SourceGroup    = "group"
+	SourceOverride = "override"
+)
+
 // PermissionSet -- финальный набор прав юзера.
-// allowAll = true означает super-admin (HasPermission всегда true).
-// banned = true означает забаненный юзер (HasPermission всегда false).
 type PermissionSet struct {
-	allowAll bool
-	banned   bool
-	allows   map[string]struct{}
+	allowAll  bool                // super-admin: всё разрешено
+	adminAll  bool                // admin: всё, кроме super-only и личных deny
+	banned    bool                // забанен: ничего
+	banReason string              // причина бана (для забаненного)
+	allows    map[string]string   // key -> источник (role|group|override) -- для обычного юзера
+	denies    map[string]struct{} // явные deny (личные для admin; вычтенные для обычного)
 }
 
 // NewPermissionResolver конструирует resolver с кешом по умолчанию (30s TTL).
@@ -53,31 +64,69 @@ func (s *PermissionSet) Has(key string) bool {
 	if s.allowAll {
 		return true
 	}
+	// Super-only ключи доступны только супер-админу (выше).
+	if IsSuperOnly(key) {
+		return false
+	}
+	if s.adminAll {
+		_, denied := s.denies[key]
+		return !denied
+	}
 	_, ok := s.allows[key]
 	return ok
 }
 
 // IsBanned сообщает, что юзер заблокирован.
-func (s *PermissionSet) IsBanned() bool {
-	return s.banned
+func (s *PermissionSet) IsBanned() bool { return s.banned }
+
+// BanReason возвращает причину блокировки (пусто, если не забанен).
+func (s *PermissionSet) BanReason() string { return s.banReason }
+
+// IsSuperAdmin сообщает, что у юзера полный доступ.
+func (s *PermissionSet) IsSuperAdmin() bool { return s.allowAll }
+
+// IsAdmin сообщает, что юзер -- администратор (всё кроме super-only и личных deny).
+func (s *PermissionSet) IsAdmin() bool { return s.adminAll }
+
+// Mode возвращает режим набора: banned|super|admin|normal.
+func (s *PermissionSet) Mode() string {
+	switch {
+	case s.banned:
+		return "banned"
+	case s.allowAll:
+		return "super"
+	case s.adminAll:
+		return "admin"
+	default:
+		return "normal"
+	}
 }
 
-// Keys возвращает отсортированный список разрешённых ключей.
-// Для super-admin возвращает nil (всё разрешено, ключи перечислять нет смысла).
+// Source возвращает источник права (role|group|override) для обычного юзера.
+func (s *PermissionSet) Source(key string) string { return s.allows[key] }
+
+// Keys возвращает отсортированный список разрешённых ключей обычного юзера.
+// Для super/admin возвращает nil (перечислять смысла нет -- всё разрешено, кроме denied).
 func (s *PermissionSet) Keys() []string {
-	if s.allowAll {
+	if s.allowAll || s.adminAll {
 		return nil
 	}
 	keys := make([]string, 0, len(s.allows))
 	for k := range s.allows {
 		keys = append(keys, k)
 	}
+	sort.Strings(keys)
 	return keys
 }
 
-// IsSuperAdmin сообщает, что у юзера полный доступ.
-func (s *PermissionSet) IsSuperAdmin() bool {
-	return s.allowAll
+// Denies возвращает отсортированный список явных deny (личные исключения админа).
+func (s *PermissionSet) Denies() []string {
+	keys := make([]string, 0, len(s.denies))
+	for k := range s.denies {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // Resolve возвращает PermissionSet для юзера, используя кэш.
@@ -111,14 +160,13 @@ func (r *PermissionResolver) HasPermission(ctx context.Context, userID int, key 
 }
 
 // Invalidate сбрасывает кэш для конкретного юзера. Вызывается при изменении
-// роли, групп или override.
+// роли, групп, override или флага is_admin/бана.
 func (r *PermissionResolver) Invalidate(userID int) {
 	r.cache.Delete(userID)
 }
 
-// InvalidateAll сбрасывает кэш для всех юзеров. Вызывается при изменении
-// permission_group_grants любой группы (broad invalidation -- проще, чем
-// отслеживать какие юзеры в каких группах).
+// InvalidateAll сбрасывает кэш для всех юзеров. Вызывается при изменении grants
+// любой роли/группы (broad invalidation -- проще, чем отслеживать носителей).
 func (r *PermissionResolver) InvalidateAll() {
 	r.cache.Range(func(k, _ any) bool {
 		r.cache.Delete(k)
@@ -129,25 +177,43 @@ func (r *PermissionResolver) InvalidateAll() {
 // computeSet -- основная логика без кэша. Вынесена для тестируемости.
 func (r *PermissionResolver) computeSet(ctx context.Context, userID int) (PermissionSet, error) {
 	var user models.User
-	if err := r.db.WithContext(ctx).Select("id, role_id, is_super_admin, is_banned").First(&user, userID).Error; err != nil {
+	if err := r.db.WithContext(ctx).
+		Select("id, role_id, is_super_admin, is_admin, is_banned, ban_reason").
+		First(&user, userID).Error; err != nil {
 		return PermissionSet{}, fmt.Errorf("user not found: %w", err)
 	}
 
-	// Бан проверяется до super-admin: super-admin теоретически не может быть забанен,
-	// но даже если -- бан сильнее (защита от случайной самоблокировки и логичная семантика).
+	// Бан проверяется до super-admin: бан сильнее (защита от случайной самоблокировки).
 	if user.IsBanned {
-		return PermissionSet{banned: true}, nil
+		reason := ""
+		if user.BanReason != nil {
+			reason = *user.BanReason
+		}
+		return PermissionSet{banned: true, banReason: reason}, nil
 	}
 	if user.IsSuperAdmin {
 		return PermissionSet{allowAll: true}, nil
 	}
 
-	allows := make(map[string]struct{})
+	// Администратор: всё кроме super-only и личных deny-override. Роль/группы не нужны.
+	if user.IsAdmin {
+		denies, err := r.loadDenyOverrides(ctx, userID)
+		if err != nil {
+			return PermissionSet{}, err
+		}
+		return PermissionSet{adminAll: true, denies: denies}, nil
+	}
+
+	allows := make(map[string]string)
 	denies := make(map[string]struct{})
 
-	// 1. Default-группы роли.
+	// 1a. Собственные точечные grants роли.
 	if user.RoleID != nil {
-		if err := r.collectGroupGrants(ctx, []int{*user.RoleID}, true, allows, denies); err != nil {
+		if err := r.collectRoleGrants(ctx, *user.RoleID, allows, denies); err != nil {
+			return PermissionSet{}, err
+		}
+		// 1b. Default-группы роли.
+		if err := r.collectGroupGrants(ctx, []int{*user.RoleID}, true, SourceRole, allows, denies); err != nil {
 			return PermissionSet{}, err
 		}
 	}
@@ -160,7 +226,7 @@ func (r *PermissionResolver) computeSet(ctx context.Context, userID int) (Permis
 		Pluck("group_id", &userGroupIDs).Error; err != nil {
 		return PermissionSet{}, fmt.Errorf("failed to load user groups: %w", err)
 	}
-	if err := r.collectGroupGrants(ctx, userGroupIDs, false, allows, denies); err != nil {
+	if err := r.collectGroupGrants(ctx, userGroupIDs, false, SourceGroup, allows, denies); err != nil {
 		return PermissionSet{}, err
 	}
 
@@ -172,12 +238,13 @@ func (r *PermissionResolver) computeSet(ctx context.Context, userID int) (Permis
 		return PermissionSet{}, fmt.Errorf("failed to load overrides: %w", err)
 	}
 	for _, o := range overrides {
-		if o.Value == "deny" {
+		switch o.Value {
+		case "deny":
 			denies[o.PermissionKey] = struct{}{}
 			delete(allows, o.PermissionKey)
-		} else if o.Value == "allow" {
+		case "allow":
 			delete(denies, o.PermissionKey)
-			allows[o.PermissionKey] = struct{}{}
+			allows[o.PermissionKey] = SourceOverride
 		}
 	}
 
@@ -186,12 +253,41 @@ func (r *PermissionResolver) computeSet(ctx context.Context, userID int) (Permis
 		delete(allows, k)
 	}
 
-	return PermissionSet{allows: allows}, nil
+	return PermissionSet{allows: allows, denies: denies}, nil
 }
 
-// collectGroupGrants добавляет права из указанных групп.
-// Если byRole = true, вместо groupIDs используются default-группы роли (groupIDs[0] = roleID).
-func (r *PermissionResolver) collectGroupGrants(ctx context.Context, groupIDs []int, byRole bool, allows, denies map[string]struct{}) error {
+// loadDenyOverrides загружает личные deny-override юзера (для admin-режима).
+func (r *PermissionResolver) loadDenyOverrides(ctx context.Context, userID int) (map[string]struct{}, error) {
+	var overrides []models.UserPermissionOverride
+	if err := r.db.WithContext(ctx).
+		Where("user_id = ? AND value = ?", userID, "deny").
+		Find(&overrides).Error; err != nil {
+		return nil, fmt.Errorf("failed to load deny overrides: %w", err)
+	}
+	denies := make(map[string]struct{}, len(overrides))
+	for _, o := range overrides {
+		denies[o.PermissionKey] = struct{}{}
+	}
+	return denies, nil
+}
+
+// collectRoleGrants добавляет собственные точечные grants роли (source=role).
+func (r *PermissionResolver) collectRoleGrants(ctx context.Context, roleID int, allows map[string]string, denies map[string]struct{}) error {
+	var grants []models.RolePermissionGrant
+	if err := r.db.WithContext(ctx).
+		Where("role_id = ?", roleID).
+		Find(&grants).Error; err != nil {
+		return fmt.Errorf("failed to load role grants: %w", err)
+	}
+	for _, g := range grants {
+		applyGrant(g.PermissionKey, g.Value, SourceRole, allows, denies)
+	}
+	return nil
+}
+
+// collectGroupGrants добавляет права из указанных групп с заданным источником.
+// Если byRole = true, вместо groupIDs используются default-группы роли (groupIDs = roleIDs).
+func (r *PermissionResolver) collectGroupGrants(ctx context.Context, groupIDs []int, byRole bool, source string, allows map[string]string, denies map[string]struct{}) error {
 	if len(groupIDs) == 0 {
 		return nil
 	}
@@ -219,15 +315,20 @@ func (r *PermissionResolver) collectGroupGrants(ctx context.Context, groupIDs []
 	}
 
 	for _, g := range grants {
-		switch g.Value {
-		case "allow":
-			if _, denied := denies[g.PermissionKey]; !denied {
-				allows[g.PermissionKey] = struct{}{}
-			}
-		case "deny":
-			denies[g.PermissionKey] = struct{}{}
-			delete(allows, g.PermissionKey)
-		}
+		applyGrant(g.PermissionKey, g.Value, source, allows, denies)
 	}
 	return nil
+}
+
+// applyGrant применяет одну запись grant (allow/deny) к наборам, обновляя источник.
+func applyGrant(key, value, source string, allows map[string]string, denies map[string]struct{}) {
+	switch value {
+	case "allow":
+		if _, denied := denies[key]; !denied {
+			allows[key] = source
+		}
+	case "deny":
+		denies[key] = struct{}{}
+		delete(allows, key)
+	}
 }

--- a/internal/services/permission_resolver_set_test.go
+++ b/internal/services/permission_resolver_set_test.go
@@ -1,0 +1,111 @@
+package services
+
+import "testing"
+
+// Юнит-тесты чистой логики PermissionSet (без БД).
+
+func TestPermissionSetHasSuper(t *testing.T) {
+	t.Parallel()
+	s := PermissionSet{allowAll: true}
+	if !s.Has(KeyPageCenter) {
+		t.Error("super должен иметь обычное право")
+	}
+	if !s.Has(KeyPageSystemControl) {
+		t.Error("super должен иметь super-only право (техработы)")
+	}
+	if !s.Has(KeyActionGrantAdmin) {
+		t.Error("super должен иметь выдачу админки")
+	}
+	if s.Mode() != "super" {
+		t.Errorf("Mode = %q, ожидалось super", s.Mode())
+	}
+}
+
+func TestPermissionSetHasAdmin(t *testing.T) {
+	t.Parallel()
+	s := PermissionSet{adminAll: true, denies: map[string]struct{}{KeyPageAdminUsers: {}}}
+	if !s.Has(KeyPageCenter) {
+		t.Error("admin должен иметь обычное право")
+	}
+	if s.Has(KeyPageAdminUsers) {
+		t.Error("admin НЕ должен иметь право из личных deny")
+	}
+	if s.Has(KeyPageSystemControl) {
+		t.Error("admin НЕ должен иметь super-only (техработы)")
+	}
+	if s.Has(KeyActionGrantAdmin) {
+		t.Error("admin НЕ должен выдавать админки (super-only)")
+	}
+	if s.Mode() != "admin" {
+		t.Errorf("Mode = %q, ожидалось admin", s.Mode())
+	}
+	if len(s.Denies()) != 1 || s.Denies()[0] != KeyPageAdminUsers {
+		t.Errorf("Denies = %v, ожидался [%s]", s.Denies(), KeyPageAdminUsers)
+	}
+}
+
+func TestPermissionSetHasNormal(t *testing.T) {
+	t.Parallel()
+	s := PermissionSet{allows: map[string]string{
+		KeyPageCenter:        SourceRole,
+		KeyPageCars:          SourceGroup,
+		KeyPageSystemControl: SourceOverride, // даже если как-то попало -- super-only режется
+	}}
+	if !s.Has(KeyPageCenter) {
+		t.Error("normal должен иметь выданное право")
+	}
+	if s.Has(KeyPageEmployees) {
+		t.Error("normal НЕ должен иметь невыданное право")
+	}
+	if s.Has(KeyPageSystemControl) {
+		t.Error("normal НЕ должен иметь super-only даже при allow в наборе")
+	}
+	if s.Source(KeyPageCenter) != SourceRole {
+		t.Errorf("Source(center) = %q, ожидалось role", s.Source(KeyPageCenter))
+	}
+	if s.Source(KeyPageCars) != SourceGroup {
+		t.Errorf("Source(cars) = %q, ожидалось group", s.Source(KeyPageCars))
+	}
+	if s.Mode() != "normal" {
+		t.Errorf("Mode = %q, ожидалось normal", s.Mode())
+	}
+}
+
+func TestPermissionSetBanned(t *testing.T) {
+	t.Parallel()
+	s := PermissionSet{banned: true, banReason: "нарушение"}
+	if s.Has(KeyPageCenter) || s.Has(KeyPagePersonal) {
+		t.Error("забаненный не имеет прав")
+	}
+	if !s.IsBanned() {
+		t.Error("IsBanned должен быть true")
+	}
+	if s.BanReason() != "нарушение" {
+		t.Errorf("BanReason = %q", s.BanReason())
+	}
+	if s.Mode() != "banned" {
+		t.Errorf("Mode = %q, ожидалось banned", s.Mode())
+	}
+}
+
+func TestPermissionSetKeys(t *testing.T) {
+	t.Parallel()
+	// super/admin не перечисляют ключи
+	super := PermissionSet{allowAll: true}
+	if super.Keys() != nil {
+		t.Error("super.Keys должен быть nil")
+	}
+	admin := PermissionSet{adminAll: true}
+	if admin.Keys() != nil {
+		t.Error("admin.Keys должен быть nil")
+	}
+	normal := PermissionSet{allows: map[string]string{KeyPageCars: SourceRole, KeyPageCenter: SourceRole}}
+	keys := normal.Keys()
+	if len(keys) != 2 {
+		t.Fatalf("Keys len = %d, ожидалось 2", len(keys))
+	}
+	// отсортированы
+	if keys[0] != KeyPageCars || keys[1] != KeyPageCenter {
+		t.Errorf("Keys не отсортированы: %v", keys)
+	}
+}

--- a/internal/services/permission_service.go
+++ b/internal/services/permission_service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"systemburo/internal/models"
 
@@ -18,6 +19,7 @@ type PermissionService interface {
 	GetUserPermissions(ctx context.Context, isSuperAdmin bool, userID int) ([]models.UserPermissionResponse, error)
 	UpdateUserPermissions(ctx context.Context, isSuperAdmin bool, actorID int, userID int, req models.UpdatePermissionsRequest) error
 	GetPermissionTree(ctx context.Context) ([]models.PermissionTreeNode, error)
+	GetCatalog(ctx context.Context) ([]CatalogNode, error)
 	AutoGenerateForTable(ctx context.Context, tableID int, tableName string) error
 	HasPermission(ctx context.Context, userID int, key string) (bool, error)
 	HasPermissionValue(ctx context.Context, userID int, key string, value string) (bool, error)
@@ -103,18 +105,26 @@ func (s *permissionService) UpdateUserPermissions(ctx context.Context, isSuperAd
 		return echo.NewHTTPError(http.StatusNotFound, "Пользователь не найден")
 	}
 
-	// Validate all permission keys exist
-	keys := make([]string, len(req.Permissions))
-	for i, p := range req.Permissions {
-		keys[i] = p.Key
+	// Валидация ключей: статические -- по каталогу, динамические table.* -- по БД.
+	var tableKeys []string
+	for _, p := range req.Permissions {
+		switch {
+		case IsCatalogKey(p.Key):
+			// ок -- известный статический ключ
+		case strings.HasPrefix(p.Key, PrefixTable):
+			tableKeys = append(tableKeys, p.Key)
+		default:
+			return echo.NewHTTPError(http.StatusBadRequest, "Неизвестный ключ разрешения: "+p.Key)
+		}
 	}
-
-	var existingCount int64
-	if err := s.db.WithContext(ctx).Model(&models.Permission{}).Where("key IN ?", keys).Count(&existingCount).Error; err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка БД")
-	}
-	if int(existingCount) != len(keys) {
-		return echo.NewHTTPError(http.StatusBadRequest, "Некоторые ключи разрешений не существуют")
+	if len(tableKeys) > 0 {
+		var existingCount int64
+		if err := s.db.WithContext(ctx).Model(&models.Permission{}).Where("key IN ?", tableKeys).Count(&existingCount).Error; err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка БД")
+		}
+		if int(existingCount) != len(tableKeys) {
+			return echo.NewHTTPError(http.StatusBadRequest, "Некоторые ключи таблиц не существуют")
+		}
 	}
 
 	adminID := actorID
@@ -171,6 +181,28 @@ func (s *permissionService) GetPermissionTree(ctx context.Context) ([]models.Per
 	return tree, nil
 }
 
+// GetCatalog возвращает полный каталог прав: статическое дерево (Catalog) плюс
+// динамические права таблиц (table.<slug>.*) из БД под категорией "Таблицы".
+func (s *permissionService) GetCatalog(ctx context.Context) ([]CatalogNode, error) {
+	nodes := Catalog()
+
+	var tablePerms []models.Permission
+	if err := s.db.WithContext(ctx).
+		Where("category = ?", "table").
+		Order("display_name, key").
+		Find(&tablePerms).Error; err != nil {
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Ошибка получения каталога прав")
+	}
+	for _, p := range tablePerms {
+		nodes = append(nodes, CatalogNode{
+			Key:         p.Key,
+			DisplayName: p.DisplayName,
+			Category:    CatTables,
+		})
+	}
+	return nodes, nil
+}
+
 func (s *permissionService) buildTreeNode(p models.Permission, byParent map[string][]models.Permission) models.PermissionTreeNode {
 	node := models.PermissionTreeNode{
 		Key:         p.Key,
@@ -189,25 +221,33 @@ func (s *permissionService) buildTreeNode(p models.Permission, byParent map[stri
 	return node
 }
 
-// AutoGenerateForTable создаёт разрешения view/edit для системной таблицы.
+// tableVerbs -- набор прав, генерируемых для каждой системной таблицы.
+// Порядок = порядок отображения в UI. Глагол view -- родитель (доступ к таблице),
+// остальные -- действия внутри неё.
+var tableVerbs = []struct{ Verb, Title string }{
+	{"view", "Доступ к таблице"},
+	{"entry", "Отметка въезда/входа"},
+	{"exit", "Отметка выезда/выхода"},
+	{"detail", "Открытие карточки из таблицы"},
+	{"history", "История таблицы"},
+	{"export", "Экспорт"},
+	{"trash", "Корзина"},
+	{"delete", "Удаление записи"},
+}
+
+// AutoGenerateForTable создаёт права для системной таблицы (по одному на глагол).
 func (s *permissionService) AutoGenerateForTable(ctx context.Context, tableID int, tableName string) error {
 	displayName := tableName
 
-	permissions := []models.Permission{
-		{
-			Key:         fmt.Sprintf("table.%s.view", tableName),
+	permissions := make([]models.Permission, 0, len(tableVerbs))
+	for _, v := range tableVerbs {
+		permissions = append(permissions, models.Permission{
+			Key:         fmt.Sprintf("table.%s.%s", tableName, v.Verb),
 			Category:    "table",
 			EntityID:    &tableID,
-			DisplayName: fmt.Sprintf("Просмотр таблицы %s", displayName),
+			DisplayName: fmt.Sprintf("%s: %s", displayName, v.Title),
 			ParentKey:   nil,
-		},
-		{
-			Key:         fmt.Sprintf("table.%s.edit", tableName),
-			Category:    "table",
-			EntityID:    &tableID,
-			DisplayName: fmt.Sprintf("Редактирование таблицы %s", displayName),
-			ParentKey:   nil,
-		},
+		})
 	}
 
 	for i := range permissions {

--- a/internal/services/permission_service.go
+++ b/internal/services/permission_service.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"strings"
 
 	"systemburo/internal/models"
 
@@ -105,25 +104,21 @@ func (s *permissionService) UpdateUserPermissions(ctx context.Context, isSuperAd
 		return echo.NewHTTPError(http.StatusNotFound, "Пользователь не найден")
 	}
 
-	// Валидация ключей: статические -- по каталогу, динамические table.* -- по БД.
-	var tableKeys []string
+	// Валидация ключей: каталожные валидны сразу, остальные (динамические table.*
+	// и legacy-ключи из таблицы permissions) проверяются по БД.
+	var nonCatalogKeys []string
 	for _, p := range req.Permissions {
-		switch {
-		case IsCatalogKey(p.Key):
-			// ок -- известный статический ключ
-		case strings.HasPrefix(p.Key, PrefixTable):
-			tableKeys = append(tableKeys, p.Key)
-		default:
-			return echo.NewHTTPError(http.StatusBadRequest, "Неизвестный ключ разрешения: "+p.Key)
+		if !IsCatalogKey(p.Key) {
+			nonCatalogKeys = append(nonCatalogKeys, p.Key)
 		}
 	}
-	if len(tableKeys) > 0 {
+	if len(nonCatalogKeys) > 0 {
 		var existingCount int64
-		if err := s.db.WithContext(ctx).Model(&models.Permission{}).Where("key IN ?", tableKeys).Count(&existingCount).Error; err != nil {
+		if err := s.db.WithContext(ctx).Model(&models.Permission{}).Where("key IN ?", nonCatalogKeys).Count(&existingCount).Error; err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка БД")
 		}
-		if int(existingCount) != len(tableKeys) {
-			return echo.NewHTTPError(http.StatusBadRequest, "Некоторые ключи таблиц не существуют")
+		if int(existingCount) != len(nonCatalogKeys) {
+			return echo.NewHTTPError(http.StatusBadRequest, "Некоторые ключи разрешений не существуют")
 		}
 	}
 

--- a/internal/services/role_service.go
+++ b/internal/services/role_service.go
@@ -71,11 +71,44 @@ func (s *RoleService) List(ctx context.Context) ([]models.RoleResponse, error) {
 	return result, nil
 }
 
-// Create создаёт новую роль.
+// Create создаёт новую роль со снимком grants базовой роли "Пользователь"
+// на момент создания (фундамент-наследование из ТЗ). Дальше роль живёт независимо.
 func (s *RoleService) Create(ctx context.Context, req models.CreateRoleRequest) (models.Role, error) {
 	role := models.Role{Code: req.Code, Name: req.Name, Description: req.Description}
-	if err := s.db.WithContext(ctx).Create(&role).Error; err != nil {
-		return models.Role{}, fmt.Errorf("failed to create role: %w", err)
+	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(&role).Error; err != nil {
+			return fmt.Errorf("failed to create role: %w", err)
+		}
+		var base models.Role
+		if err := tx.Where("code = ? AND is_system = ?", "user", true).First(&base).Error; err != nil {
+			// Базовой роли нет (например, до seed) -- создаём роль без снимка.
+			return nil
+		}
+		if base.ID == role.ID {
+			return nil
+		}
+		var baseGrants []models.RolePermissionGrant
+		if err := tx.Where("role_id = ?", base.ID).Find(&baseGrants).Error; err != nil {
+			return fmt.Errorf("failed to load base role grants: %w", err)
+		}
+		if len(baseGrants) == 0 {
+			return nil
+		}
+		copied := make([]models.RolePermissionGrant, 0, len(baseGrants))
+		for _, g := range baseGrants {
+			copied = append(copied, models.RolePermissionGrant{
+				RoleID:        role.ID,
+				PermissionKey: g.PermissionKey,
+				Value:         g.Value,
+			})
+		}
+		if err := tx.Create(&copied).Error; err != nil {
+			return fmt.Errorf("failed to copy base grants: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return models.Role{}, err
 	}
 	return role, nil
 }
@@ -90,8 +123,16 @@ func (s *RoleService) Update(ctx context.Context, roleID int, req models.UpdateR
 	return nil
 }
 
-// Delete удаляет роль. Запрещено если есть юзеры с этой ролью.
+// Delete удаляет роль. Запрещено для системной роли и если есть юзеры с этой ролью.
 func (s *RoleService) Delete(ctx context.Context, roleID int) error {
+	var role models.Role
+	if err := s.db.WithContext(ctx).First(&role, roleID).Error; err != nil {
+		return fmt.Errorf("failed to load role: %w", err)
+	}
+	if role.IsSystem {
+		return fmt.Errorf("cannot delete system role")
+	}
+
 	var count int64
 	if err := s.db.WithContext(ctx).Model(&models.User{}).Where("role_id = ?", roleID).Count(&count).Error; err != nil {
 		return fmt.Errorf("failed to count users: %w", err)

--- a/internal/services/user_service.go
+++ b/internal/services/user_service.go
@@ -142,6 +142,18 @@ func (s *userService) Create(ctx context.Context, callerTypeID, callerUserID int
 		"username": user.Username,
 		"type_id":  user.TypeID,
 	})
+
+	// Новый пользователь получает базовую роль "Пользователь" по умолчанию -- так роль
+	// выдаёт стартовый набор прав (ТЗ). Best-effort: отсутствие базовой роли не валит создание.
+	if user.RoleID == nil {
+		var baseRole models.Role
+		if err := s.db.WithContext(ctx).Where("code = ? AND is_system = ?", "user", true).First(&baseRole).Error; err == nil {
+			if err := s.db.WithContext(ctx).Model(&models.User{}).Where("id = ?", user.ID).
+				Update("role_id", baseRole.ID).Error; err != nil {
+				slog.Error("не удалось назначить базовую роль", "user_id", user.ID, "error", err)
+			}
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
Фундамент переработки прав доступа (план эпика). OFF-LIMITS: миграции + resolver + каталог - на ревью, мерж по подтверждению.

Срезы:
- be-schema: таблица role_permission_grants, флаги users.is_admin / ban_reason, roles.is_system, таблица user_ban_history. Только схема, AutoMigrate не деструктивный.
- be-catalog: единый иерархический каталог точечных прав (permission_catalog.go) + GET /permissions/catalog. table.* расширен до 8 глаголов. Super-only: техработы и выдача админки.
- be-resolver: режим администратора (всё кроме super-only и личных deny), источник каждого права, собственные grants роли. Super-only режется для всех кроме супер-админа.
- be-my-format: /permissions/my отдаёт {mode, permissions[{key,value,source}], denied, banned, ban_reason}; PUT /users/:id/admin (super-only) для выдачи админки.
- be-seed: неудаляемая базовая роль Пользователь с дефолтными правами, наследование снимком, разовый перенос админства manager -> is_admin (отвязка от user_type), защита неудаляемости.

Верификация: go build + vet чисты, services-юниты зелёные, полный пакет handlers с БД зелёный (поправлены тесты под 8 table-прав и новый формат /my).