### PR TITLE
feat(permissions): фундамент фронтового гейтинга прав

### DIFF
--- a/frontend/src/composables/__tests__/usePermission.spec.js
+++ b/frontend/src/composables/__tests__/usePermission.spec.js
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { usePermissionsStore } from '@/stores/permissions'
+import { usePermission } from '../usePermission'
+
+describe('usePermission', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  describe('can()', () => {
+    it('возвращает true для mode super', () => {
+      const store = usePermissionsStore()
+      store.mode = 'super'
+
+      const { can } = usePermission()
+      expect(can('page.admin')).toBe(true)
+      expect(can('action.export.applications')).toBe(true)
+    })
+
+    it('возвращает false для mode banned', () => {
+      const store = usePermissionsStore()
+      store.mode = 'banned'
+      store.effective = { 'page.center': { value: 'allow', source: 'role' } }
+
+      const { can } = usePermission()
+      expect(can('page.center')).toBe(false)
+    })
+
+    it('возвращает true для mode admin когда ключ не в denied', () => {
+      const store = usePermissionsStore()
+      store.mode = 'admin'
+      store.denied = new Set()
+
+      const { can } = usePermission()
+      expect(can('entity.cars.read')).toBe(true)
+    })
+
+    it('возвращает false для mode admin когда ключ в denied', () => {
+      const store = usePermissionsStore()
+      store.mode = 'admin'
+      store.denied = new Set(['permission.audit.manage'])
+
+      const { can } = usePermission()
+      expect(can('permission.audit.manage')).toBe(false)
+    })
+
+    it('работает для mode normal с allow', () => {
+      const store = usePermissionsStore()
+      store.mode = 'normal'
+      store.effective = { 'page.cars': { value: 'allow', source: 'group' } }
+
+      const { can } = usePermission()
+      expect(can('page.cars')).toBe(true)
+    })
+
+    it('работает для mode normal с deny', () => {
+      const store = usePermissionsStore()
+      store.mode = 'normal'
+      store.effective = { 'page.cars': { value: 'deny', source: 'base' } }
+
+      const { can } = usePermission()
+      expect(can('page.cars')).toBe(false)
+    })
+
+    it('работает с динамическими ключами вида table.<slug>.view', () => {
+      const store = usePermissionsStore()
+      store.mode = 'normal'
+      store.effective = {
+        'table.visitors.view': { value: 'allow', source: 'role' },
+        'table.access.view':   { value: 'deny', source: 'base' },
+      }
+
+      const { can } = usePermission()
+      expect(can('table.visitors.view')).toBe(true)
+      expect(can('table.access.view')).toBe(false)
+      expect(can('table.unknown.view')).toBe(false)
+    })
+  })
+
+  describe('sourceOf()', () => {
+    it('возвращает источник из effective', () => {
+      const store = usePermissionsStore()
+      store.effective = {
+        'entity.cars.read': { value: 'allow', source: 'group' },
+        'action.ban.user':  { value: 'allow', source: 'override' },
+      }
+
+      const { sourceOf } = usePermission()
+      expect(sourceOf('entity.cars.read')).toBe('group')
+      expect(sourceOf('action.ban.user')).toBe('override')
+    })
+
+    it('возвращает null для отсутствующего ключа', () => {
+      const store = usePermissionsStore()
+      store.effective = {}
+
+      const { sourceOf } = usePermission()
+      expect(sourceOf('entity.cars.read')).toBe(null)
+    })
+  })
+})

--- a/frontend/src/composables/usePermission.js
+++ b/frontend/src/composables/usePermission.js
@@ -1,0 +1,39 @@
+import { usePermissionsStore } from '@/stores/permissions'
+
+/**
+ * Composable для проверки прав в Composition API.
+ *
+ * Пример:
+ *   const { can, sourceOf } = usePermission()
+ *   const canExport = computed(() => can('action.export.applications'))
+ *   // Динамический ключ (например, для таблиц):
+ *   const canViewTable = computed(() => can(`table.${slug}.view`))
+ *
+ * @returns {{ can: (key: string) => boolean, sourceOf: (key: string) => string|null }}
+ */
+export function usePermission() {
+  const store = usePermissionsStore()
+
+  /**
+   * Реактивная проверка права. Работает с любыми ключами, в том числе
+   * с динамическими вида `table.<slug>.<verb>`.
+   *
+   * @param {string} key
+   * @returns {boolean}
+   */
+  function can(key) {
+    return store.hasPermission(key)
+  }
+
+  /**
+   * Возвращает источник права: 'role'|'group'|'override'|'admin'|'base'|null.
+   *
+   * @param {string} key
+   * @returns {string|null}
+   */
+  function sourceOf(key) {
+    return store.permissionSource(key)
+  }
+
+  return { can, sourceOf }
+}

--- a/frontend/src/constants/detailModalActions.js
+++ b/frontend/src/constants/detailModalActions.js
@@ -1,0 +1,182 @@
+/**
+ * Карта контекст (source) -> действие -> ключ права для
+ * VehicleDetailsModal и EmployeeDetailsModal.
+ *
+ * Значения:
+ *   string  — permission key, требуемый для показа действия
+ *   true    — действие доступно без отдельного права (по контексту/роли)
+ *   false   — действие недоступно в этом контексте
+ *
+ * Источники (source), в которых может быть открыта модалка:
+ *   'application'  — открыта из детали заявки (ApplicationDetail)
+ *   'carstable'    — таблица Т/С внутри центра заявок
+ *   'facttable'    — таблица "по факту" в центре
+ *   'carsview'     — страница «Автомобили»
+ *   'employeesview'— страница «Сотрудники»
+ *   'employeeslist'— список сотрудников внутри заявки
+ *   'peopletable'  — таблица людей в центре заявок
+ *   'trash'        — корзина
+ *   'blacklist'    — раздел «Чёрный список»
+ *   'general'      — прочие/неопределённые контексты
+ *
+ * Действия:
+ *   history         — кнопка «Полная история» (история действий с сущностью)
+ *   openApplication — кнопка «Открыть заявку» (переход к связанной заявке)
+ *   blacklist       — кнопка «В ЧС» / управление чёрным списком
+ *   entryExit       — вкладка/секция «Въезд/Выезд» (история проходов на территорию)
+ *   documents       — раздел «Документы» (прикреплённые документы сущности)
+ *   passHistory     — История пропусков (выданные пропуска)
+ */
+
+/**
+ * Общие действия для автомобиля по контексту.
+ * @type {Record<string, Record<string, string|boolean>>}
+ */
+export const VEHICLE_MODAL_ACTIONS = {
+  application: {
+    // Открыта из деталей заявки: история есть, переход в заявку не нужен (уже в ней)
+    history:         'entity.cars.read',
+    openApplication: false,
+    blacklist:       'page.admin.blacklist',
+    entryExit:       'entity.cars.read',
+    documents:       false,
+    passHistory:     false,
+  },
+  carstable: {
+    history:         'entity.cars.read',
+    openApplication: true,   // есть application_id, доступ без доп. права
+    blacklist:       'page.admin.blacklist',
+    entryExit:       'entity.cars.read',
+    documents:       false,
+    passHistory:     false,
+  },
+  facttable: {
+    history:         'entity.cars.read',
+    openApplication: true,
+    blacklist:       'page.admin.blacklist',
+    entryExit:       'entity.cars.read',
+    documents:       false,
+    passHistory:     false,
+  },
+  carsview: {
+    // Страница «Автомобили»: нет связи с заявкой, документы и история пропусков доступны
+    history:         'entity.cars.read',
+    openApplication: false,
+    blacklist:       'page.admin.blacklist',
+    entryExit:       'entity.cars.read',
+    // Документы в контексте таблиц/центра скрыты у всех кроме админа/супера
+    documents:       'page.admin',
+    passHistory:     'entity.cars.read',
+  },
+  trash: {
+    // Корзина: только чтение, без ЧС и действий
+    history:         'entity.cars.read',
+    openApplication: false,
+    blacklist:       false,
+    entryExit:       false,
+    documents:       false,
+    passHistory:     false,
+  },
+  blacklist: {
+    // Открыта из раздела ЧС: переход в заявку не нужен, добавление в ЧС не нужно
+    history:         'page.admin.blacklist',
+    openApplication: false,
+    blacklist:       false,
+    entryExit:       false,
+    documents:       false,
+    passHistory:     false,
+  },
+  general: {
+    history:         'entity.cars.read',
+    openApplication: true,
+    blacklist:       'page.admin.blacklist',
+    entryExit:       'entity.cars.read',
+    documents:       'page.admin',
+    passHistory:     'entity.cars.read',
+  },
+}
+
+/**
+ * Общие действия для сотрудника по контексту.
+ * @type {Record<string, Record<string, string|boolean>>}
+ */
+export const EMPLOYEE_MODAL_ACTIONS = {
+  application: {
+    // Открыта из деталей заявки: "Открыть заявку" не нужно (уже в ней)
+    history:         'entity.employees.read',
+    openApplication: false,
+    blacklist:       'page.admin.blacklist',
+    entryExit:       'entity.employees.read',
+    // Документы в контексте заявки скрыты у обычных пользователей
+    documents:       'page.admin',
+    passHistory:     false,
+  },
+  employeesview: {
+    // Страница «Сотрудники»: полный набор действий для имеющих право
+    history:         'entity.employees.read',
+    openApplication: true,
+    blacklist:       'page.admin.blacklist',
+    entryExit:       'entity.employees.read',
+    documents:       'page.admin',
+    passHistory:     'entity.employees.read',
+  },
+  employeeslist: {
+    // Список сотрудников внутри создания/редактирования заявки:
+    // ограниченный набор, "открыть заявку" недоступно
+    history:         false,
+    openApplication: false,
+    blacklist:       'page.admin.blacklist',
+    entryExit:       false,
+    documents:       false,
+    passHistory:     false,
+  },
+  peopletable: {
+    // Таблица людей в центре заявок
+    history:         'entity.employees.read',
+    openApplication: true,
+    blacklist:       'page.admin.blacklist',
+    entryExit:       'entity.employees.read',
+    documents:       'page.admin',
+    passHistory:     false,
+  },
+  trash: {
+    history:         'entity.employees.read',
+    openApplication: false,
+    blacklist:       false,
+    entryExit:       false,
+    documents:       false,
+    passHistory:     false,
+  },
+  blacklist: {
+    history:         'page.admin.blacklist',
+    openApplication: false,
+    blacklist:       false,
+    entryExit:       false,
+    documents:       false,
+    passHistory:     false,
+  },
+  general: {
+    history:         'entity.employees.read',
+    openApplication: true,
+    blacklist:       'page.admin.blacklist',
+    entryExit:       'entity.employees.read',
+    documents:       'page.admin',
+    passHistory:     'entity.employees.read',
+  },
+}
+
+/**
+ * Возвращает ключ права для действия в данном контексте.
+ * Если контекст неизвестен — возвращает значение из 'general'.
+ *
+ * @param {'vehicle'|'employee'} entityType
+ * @param {string} source
+ * @param {string} action
+ * @returns {string|boolean}
+ */
+export function getModalActionPermission(entityType, source, action) {
+  const map = entityType === 'vehicle' ? VEHICLE_MODAL_ACTIONS : EMPLOYEE_MODAL_ACTIONS
+  const ctx = map[source] ?? map['general']
+  if (!(action in ctx)) return false
+  return ctx[action]
+}

--- a/frontend/src/constants/permissionKeys.js
+++ b/frontend/src/constants/permissionKeys.js
@@ -1,45 +1,50 @@
 /**
- * Список всех известных permission_key с описаниями.
+ * Список статических permission_key с человекочитаемыми описаниями.
  * Соответствует константам в internal/services/permission_keys.go.
  *
  * Naming convention (#187a):
- *   page.<route>                     -- маршруты страниц
- *   tab.<name>                       -- вкладки внутри страниц
- *   component.<name>.<verb>          -- компоненты
- *   action.<verb>.<entity>           -- действия
- *   entity.<name>.<crud>             -- CRUD сущности
- *   table.<slug>.<verb>              -- динамические таблицы (auto-generate)
- *   permission.audit.*               -- журналы и аудит
+ *   page.<route>              -- маршруты страниц
+ *   tab.<name>                -- вкладки внутри страниц
+ *   component.<name>.<verb>   -- компоненты
+ *   action.<verb>.<entity>    -- действия
+ *   entity.<name>.<crud>      -- CRUD сущности
+ *   table.<slug>.<verb>       -- динамические таблицы (auto-generate)
+ *   permission.audit.*        -- журналы и аудит
  *
  * Динамические table.* ключи создаются на бэке при создании таблицы и здесь
- * не перечисляются.
+ * не перечисляются. Vite-плагин build/vite-plugin-permissions.js собирает
+ * статические ключи из этого файла через regex (строки с 'page.'/'action.' и т.п.).
  */
 export const ALL_PERMISSION_KEYS = [
-  { value: 'page.center', description: 'Страница «Центр заявок»' },
-  { value: 'page.cars', description: 'Страница «Автомобили»' },
-  { value: 'page.employees', description: 'Страница «Сотрудники»' },
-  { value: 'page.statistics', description: 'Страница «Статистика»' },
-  { value: 'page.reports', description: 'Страница «Отчёты»' },
-  { value: 'page.news', description: 'Страница «Обзор и новости»' },
-  { value: 'page.admin', description: 'Раздел «Админка» (общий доступ)' },
-  { value: 'page.personal_cabinet', description: 'Личный кабинет' },
-  { value: 'page.admin.system_control', description: 'Системное управление (техработы)' },
-  { value: 'page.admin.users', description: 'Управление пользователями' },
-  { value: 'page.admin.feedback', description: 'Обратная связь' },
-  { value: 'page.admin.blacklist', description: 'Чёрный список (машины и люди)' },
+  // --- Навигация ---
+  { value: 'page.center',                description: 'Страница «Центр заявок»' },
+  { value: 'page.cars',                  description: 'Страница «Автомобили»' },
+  { value: 'page.employees',             description: 'Страница «Сотрудники»' },
+  { value: 'page.statistics',            description: 'Страница «Статистика»' },
+  { value: 'page.reports',              description: 'Страница «Отчёты»' },
+  { value: 'page.news',                  description: 'Страница «Обзор и новости»' },
+  { value: 'page.admin',                 description: 'Раздел «Админка» (общий доступ)' },
+  { value: 'page.personal_cabinet',      description: 'Личный кабинет' },
+  { value: 'page.admin.system_control',  description: 'Системное управление (техработы)' },
+  { value: 'page.admin.users',           description: 'Управление пользователями' },
+  { value: 'page.admin.feedback',        description: 'Обратная связь' },
+  { value: 'page.admin.blacklist',       description: 'Чёрный список (машины и люди)' },
 
-  { value: 'entity.cars.read', description: 'Просмотр автомобилей' },
-  { value: 'entity.cars.write', description: 'Создание и редактирование автомобилей' },
-  { value: 'entity.cars.delete', description: 'Удаление автомобилей' },
-  { value: 'entity.employees.read', description: 'Просмотр сотрудников' },
-  { value: 'entity.employees.write', description: 'Создание и редактирование сотрудников' },
-  { value: 'entity.employees.delete', description: 'Удаление сотрудников' },
+  // --- CRUD сущностей ---
+  { value: 'entity.cars.read',           description: 'Просмотр автомобилей' },
+  { value: 'entity.cars.write',          description: 'Создание и редактирование автомобилей' },
+  { value: 'entity.cars.delete',         description: 'Удаление автомобилей' },
+  { value: 'entity.employees.read',      description: 'Просмотр сотрудников' },
+  { value: 'entity.employees.write',     description: 'Создание и редактирование сотрудников' },
+  { value: 'entity.employees.delete',    description: 'Удаление сотрудников' },
 
+  // --- Действия ---
   { value: 'action.export.applications', description: 'Экспорт заявок' },
   { value: 'action.approve.application', description: 'Согласование заявок' },
   { value: 'action.forward.application', description: 'Пересылка заявок на согласование' },
-  { value: 'action.ban.user', description: 'Блокировка пользователей' },
+  { value: 'action.ban.user',            description: 'Блокировка пользователей' },
 
-  { value: 'permission.audit.read', description: 'Просмотр журнала отказов и аудита' },
-  { value: 'permission.audit.manage', description: 'Очистка и архивация журнала' },
-];
+  // --- Аудит ---
+  { value: 'permission.audit.read',      description: 'Просмотр журнала отказов и аудита' },
+  { value: 'permission.audit.manage',    description: 'Очистка и архивация журнала' },
+]

--- a/frontend/src/directives/__tests__/permission.spec.js
+++ b/frontend/src/directives/__tests__/permission.spec.js
@@ -32,48 +32,55 @@ describe('v-permission directive', () => {
     localStorage.clear()
   })
 
-  it('hides element when permission is denied', () => {
+  it('скрывает элемент когда право deny', () => {
     const store = usePermissionsStore()
-    store.permissions = { 'passes.create': 'deny' }
+    store.mode = 'normal'
+    store.effective = { 'passes.create': { value: 'deny', source: 'base' } }
 
     const wrapper = mountWithPermission('passes.create', pinia)
 
     expect(wrapper.find('div').element.style.display).toBe('none')
   })
 
-  it('hides element when permission is missing', () => {
+  it('скрывает элемент когда ключ отсутствует', () => {
     const store = usePermissionsStore()
-    store.permissions = {}
+    store.mode = 'normal'
+    store.effective = {}
 
     const wrapper = mountWithPermission('passes.create', pinia)
 
     expect(wrapper.find('div').element.style.display).toBe('none')
   })
 
-  it('shows element when permission is allowed', () => {
+  it('показывает элемент когда право allow', () => {
     const store = usePermissionsStore()
-    store.permissions = { 'passes.create': 'allow' }
+    store.mode = 'normal'
+    store.effective = { 'passes.create': { value: 'allow', source: 'role' } }
 
     const wrapper = mountWithPermission('passes.create', pinia)
 
     expect(wrapper.find('div').element.style.display).not.toBe('none')
   })
 
-  it('shows element for admin regardless of permission', () => {
+  it('показывает элемент для super независимо от effective', () => {
     const authStore = useAuthStore()
     authStore.setTokens(createMockJWT({ type_id: 6, is_super_admin: true }))
 
     const store = usePermissionsStore()
-    store.permissions = { 'passes.create': 'deny' }
+    store.mode = 'super'
+    store.effective = { 'passes.create': { value: 'deny', source: 'base' } }
 
     const wrapper = mountWithPermission('passes.create', pinia)
 
     expect(wrapper.find('div').element.style.display).not.toBe('none')
   })
 
-  it('shows element for admin even when permission is missing', () => {
+  it('показывает элемент для super при пустом effective', () => {
     const authStore = useAuthStore()
     authStore.setTokens(createMockJWT({ type_id: 6, is_super_admin: true }))
+
+    const store = usePermissionsStore()
+    store.mode = 'super'
 
     const wrapper = mountWithPermission('passes.create', pinia)
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2,7 +2,6 @@ import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import App from './App.vue'
 import router from './router'
-import { vPermission } from './directives/permission'
 import { vPermissionScope } from './directives/permission-scope'
 import bus from './eventBus'
 import { tryRestoreSession } from '@/api/client'
@@ -15,7 +14,6 @@ import './assets/onboarding.css'
 const app = createApp(App)
 app.config.globalProperties.$bus = bus
 app.use(createPinia())
-app.directive('permission', vPermission)
 app.directive('permission-scope', vPermissionScope)
 
 // Bootstrap: восстанавливаем сессию из HttpOnly refresh cookie ДО app.use(router).

--- a/frontend/src/stores/__tests__/permissions.spec.js
+++ b/frontend/src/stores/__tests__/permissions.spec.js
@@ -24,64 +24,221 @@ describe('permissions store', () => {
     vi.clearAllMocks()
   })
 
-  describe('hasPermission', () => {
-    it('returns true when permission value is allow', () => {
+  describe('hasPermission — mode: normal', () => {
+    it('возвращает true если effective[key].value === allow', () => {
       const store = usePermissionsStore()
-      store.permissions = { 'passes.create': 'allow' }
+      store.mode = 'normal'
+      store.effective = { 'passes.create': { value: 'allow', source: 'role' } }
 
       expect(store.hasPermission('passes.create')).toBe(true)
     })
 
-    it('returns false when permission value is deny', () => {
+    it('возвращает false если effective[key].value === deny', () => {
       const store = usePermissionsStore()
-      store.permissions = { 'passes.create': 'deny' }
+      store.mode = 'normal'
+      store.effective = { 'passes.create': { value: 'deny', source: 'base' } }
 
       expect(store.hasPermission('passes.create')).toBe(false)
     })
 
-    it('returns false when permission key is missing', () => {
+    it('возвращает false если ключ отсутствует в effective', () => {
       const store = usePermissionsStore()
-      store.permissions = {}
+      store.mode = 'normal'
+      store.effective = {}
+
+      expect(store.hasPermission('passes.create')).toBe(false)
+    })
+  })
+
+  describe('hasPermission — mode: super', () => {
+    it('возвращает true для любого ключа', () => {
+      const store = usePermissionsStore()
+      store.mode = 'super'
+      store.effective = {}
+
+      expect(store.hasPermission('passes.create')).toBe(true)
+      expect(store.hasPermission('page.admin.blacklist')).toBe(true)
+    })
+
+    it('возвращает true даже если ключ в effective deny', () => {
+      const store = usePermissionsStore()
+      store.mode = 'super'
+      store.effective = { 'passes.create': { value: 'deny', source: 'base' } }
+
+      expect(store.hasPermission('passes.create')).toBe(true)
+    })
+  })
+
+  describe('hasPermission — mode: admin', () => {
+    it('возвращает true если ключ не в denied', () => {
+      const store = usePermissionsStore()
+      store.mode = 'admin'
+      store.denied = new Set()
+
+      expect(store.hasPermission('passes.create')).toBe(true)
+    })
+
+    it('возвращает false если ключ в denied', () => {
+      const store = usePermissionsStore()
+      store.mode = 'admin'
+      store.denied = new Set(['passes.create'])
 
       expect(store.hasPermission('passes.create')).toBe(false)
     })
 
-    it('returns true for admin regardless of permission value', () => {
-      const authStore = useAuthStore()
-      authStore.setTokens(createMockJWT({ type_id: 6, is_super_admin: true }))
-
+    it('не зависит от effective при mode admin', () => {
       const store = usePermissionsStore()
-      store.permissions = { 'passes.create': 'deny' }
+      store.mode = 'admin'
+      store.effective = { 'passes.create': { value: 'deny', source: 'base' } }
+      store.denied = new Set()
 
       expect(store.hasPermission('passes.create')).toBe(true)
     })
+  })
 
-    it('returns true for admin even when permission is missing', () => {
-      const authStore = useAuthStore()
-      authStore.setTokens(createMockJWT({ type_id: 6, is_super_admin: true }))
-
+  describe('hasPermission — mode: banned', () => {
+    it('возвращает false для любого ключа', () => {
       const store = usePermissionsStore()
-      store.permissions = {}
+      store.mode = 'banned'
+      store.effective = { 'passes.create': { value: 'allow', source: 'role' } }
 
-      expect(store.hasPermission('passes.create')).toBe(true)
+      expect(store.hasPermission('passes.create')).toBe(false)
+      expect(store.hasPermission('page.admin')).toBe(false)
+    })
+  })
+
+  describe('permissionSource', () => {
+    it('возвращает источник из effective', () => {
+      const store = usePermissionsStore()
+      store.effective = { 'entity.cars.read': { value: 'allow', source: 'group' } }
+
+      expect(store.permissionSource('entity.cars.read')).toBe('group')
+    })
+
+    it('возвращает null для отсутствующего ключа', () => {
+      const store = usePermissionsStore()
+      store.effective = {}
+
+      expect(store.permissionSource('entity.cars.read')).toBe(null)
     })
   })
 
   describe('clearPermissions', () => {
-    it('resets permissions to empty object and loaded to false', () => {
+    it('сбрасывает все поля в начальное состояние', () => {
       const store = usePermissionsStore()
+      store.effective = { 'passes.create': { value: 'allow', source: 'role' } }
       store.permissions = { 'passes.create': 'allow' }
+      store.mode = 'admin'
+      store.denied = new Set(['x.key'])
+      store.banned = true
       store.loaded = true
 
       store.clearPermissions()
 
+      expect(store.effective).toEqual({})
       expect(store.permissions).toEqual({})
+      expect(store.mode).toBe('normal')
+      expect(store.denied.size).toBe(0)
+      expect(store.banned).toBe(false)
       expect(store.loaded).toBe(false)
     })
   })
 
-  describe('fetchPermissions', () => {
-    it('populates permissions from API response', async () => {
+  describe('fetchPermissions — новый формат', () => {
+    it('разбирает новый объект и заполняет mode/effective/denied', async () => {
+      getMyPermissions.mockResolvedValue({
+        mode: 'normal',
+        permissions: [
+          { key: 'passes.create', value: 'allow', source: 'role' },
+          { key: 'passes.delete', value: 'deny', source: 'base' },
+        ],
+        denied: [],
+        banned: false,
+        banReason: null,
+      })
+
+      const store = usePermissionsStore()
+      await store.fetchPermissions()
+
+      expect(store.mode).toBe('normal')
+      expect(store.effective['passes.create']).toEqual({ value: 'allow', source: 'role' })
+      expect(store.effective['passes.delete']).toEqual({ value: 'deny', source: 'base' })
+      // Плоская карта для совместимости
+      expect(store.permissions['passes.create']).toBe('allow')
+      expect(store.loaded).toBe(true)
+    })
+
+    it('разбирает mode: admin с denied', async () => {
+      getMyPermissions.mockResolvedValue({
+        mode: 'admin',
+        permissions: [],
+        denied: ['permission.audit.manage'],
+        banned: false,
+        banReason: null,
+      })
+
+      const store = usePermissionsStore()
+      await store.fetchPermissions()
+
+      expect(store.mode).toBe('admin')
+      expect(store.denied.has('permission.audit.manage')).toBe(true)
+      expect(store.hasPermission('passes.create')).toBe(true)
+      expect(store.hasPermission('permission.audit.manage')).toBe(false)
+    })
+
+    it('разбирает mode: banned', async () => {
+      getMyPermissions.mockResolvedValue({
+        mode: 'banned',
+        permissions: [],
+        denied: [],
+        banned: true,
+        banReason: 'Нарушение правил',
+      })
+
+      const store = usePermissionsStore()
+      await store.fetchPermissions()
+
+      expect(store.mode).toBe('banned')
+      expect(store.banned).toBe(true)
+      expect(store.banReason).toBe('Нарушение правил')
+      expect(store.hasPermission('passes.create')).toBe(false)
+    })
+
+    it('разбирает mode: super', async () => {
+      getMyPermissions.mockResolvedValue({
+        mode: 'super',
+        permissions: [],
+        denied: [],
+        banned: false,
+        banReason: null,
+      })
+
+      const store = usePermissionsStore()
+      await store.fetchPermissions()
+
+      expect(store.mode).toBe('super')
+      expect(store.hasPermission('any.key')).toBe(true)
+    })
+
+    it('sets loaded to true при пустом permissions', async () => {
+      getMyPermissions.mockResolvedValue({
+        mode: 'normal',
+        permissions: [],
+        denied: [],
+        banned: false,
+        banReason: null,
+      })
+
+      const store = usePermissionsStore()
+      await store.fetchPermissions()
+
+      expect(store.effective).toEqual({})
+      expect(store.loaded).toBe(true)
+    })
+  })
+
+  describe('fetchPermissions — defensive-parse старого формата (массив)', () => {
+    it('разбирает старый массив [{key,value}] как normal/super', async () => {
       getMyPermissions.mockResolvedValue([
         { key: 'passes.create', value: 'allow' },
         { key: 'passes.delete', value: 'deny' },
@@ -90,37 +247,35 @@ describe('permissions store', () => {
       const store = usePermissionsStore()
       await store.fetchPermissions()
 
-      expect(store.permissions).toEqual({
-        'passes.create': 'allow',
-        'passes.delete': 'deny',
-      })
+      expect(store.effective['passes.create']).toEqual({ value: 'allow', source: 'base' })
+      expect(store.effective['passes.delete']).toEqual({ value: 'deny', source: 'base' })
       expect(store.loaded).toBe(true)
     })
 
-    it('sets loaded to true even with empty response', async () => {
+    it('не падает при пустом массиве', async () => {
       getMyPermissions.mockResolvedValue([])
 
       const store = usePermissionsStore()
       await store.fetchPermissions()
 
-      expect(store.permissions).toEqual({})
+      expect(store.effective).toEqual({})
       expect(store.loaded).toBe(true)
     })
 
-    it('keeps permissions empty on API error', async () => {
+    it('сохраняет старые permissions при ошибке API', async () => {
       getMyPermissions.mockRejectedValue(new Error('Network error'))
 
       const store = usePermissionsStore()
-      store.permissions = { 'old.key': 'allow' }
+      store.effective = { 'old.key': { value: 'allow', source: 'role' } }
       await store.fetchPermissions()
 
-      expect(store.permissions).toEqual({ 'old.key': 'allow' })
+      expect(store.effective['old.key']).toEqual({ value: 'allow', source: 'role' })
       expect(store.loaded).toBe(false)
     })
 
-    it('overwrites previous permissions on re-fetch', async () => {
+    it('перезаписывает permissions при повторном fetch', async () => {
       const store = usePermissionsStore()
-      store.permissions = { 'old.key': 'allow' }
+      store.effective = { 'old.key': { value: 'allow', source: 'role' } }
 
       getMyPermissions.mockResolvedValue([
         { key: 'new.key', value: 'allow' },
@@ -128,8 +283,23 @@ describe('permissions store', () => {
 
       await store.fetchPermissions()
 
-      expect(store.permissions).toEqual({ 'new.key': 'allow' })
-      expect(store.permissions).not.toHaveProperty('old.key')
+      expect(store.effective['new.key']).toBeDefined()
+      expect(store.effective['old.key']).toBeUndefined()
+    })
+
+    it('для super_admin из auth определяет mode super при старом формате', async () => {
+      const authStore = useAuthStore()
+      authStore.setTokens(createMockJWT({ is_super_admin: true }))
+
+      getMyPermissions.mockResolvedValue([
+        { key: 'passes.create', value: 'deny' },
+      ])
+
+      const store = usePermissionsStore()
+      await store.fetchPermissions()
+
+      expect(store.mode).toBe('super')
+      expect(store.hasPermission('passes.create')).toBe(true)
     })
   })
 })

--- a/frontend/src/stores/permissions.js
+++ b/frontend/src/stores/permissions.js
@@ -7,20 +7,109 @@ import { getMyPermissions } from '@/api/permissions'
 // слишком часто — endpoint /permissions/my делает 1 SQL.
 const CACHE_TTL_MS = 30 * 1000
 
+/**
+ * Разбирает ответ /permissions/my, поддерживая два формата:
+ *   - новый объект: { mode, permissions, denied, banned, banReason }
+ *   - старый массив: [{ key, value }]
+ *
+ * @param {unknown} data
+ * @returns {{ mode: string, effective: Object, denied: Set, banned: boolean, banReason: string|null }}
+ */
+function parsePermissionsResponse(data) {
+  // Новый формат
+  if (data && typeof data === 'object' && !Array.isArray(data) && 'mode' in data) {
+    const mode = data.mode || 'normal'
+    const effective = {}
+    const rawPerms = Array.isArray(data.permissions) ? data.permissions : []
+    rawPerms.forEach(p => {
+      if (p && p.key) {
+        effective[p.key] = { value: p.value || 'deny', source: p.source || 'base' }
+      }
+    })
+    const denied = new Set(Array.isArray(data.denied) ? data.denied : [])
+    const banned = Boolean(data.banned)
+    const banReason = data.banReason ?? data.ban_reason ?? null
+    return { mode, effective, denied, banned, banReason }
+  }
+
+  // Старый формат — массив [{key, value}]
+  const effective = {}
+  const rawPerms = Array.isArray(data) ? data : []
+  rawPerms.forEach(p => {
+    if (p && p.key) {
+      effective[p.key] = { value: p.value || 'deny', source: 'base' }
+    }
+  })
+  // Режим определяем через auth store (isSuperAdmin)
+  const auth = useAuthStore()
+  const mode = auth.isSuperAdmin ? 'super' : 'normal'
+  return { mode, effective, denied: new Set(), banned: false, banReason: null }
+}
+
 export const usePermissionsStore = defineStore('permissions', {
   state: () => ({
-    permissions: {},
+    /**
+     * Эффективная карта: { [key]: { value: 'allow'|'deny', source: string } }
+     */
+    effective: {},
+    /**
+     * Режим: 'super' | 'admin' | 'normal' | 'banned'
+     */
+    mode: 'normal',
+    /**
+     * Ключи, недоступные для admin-режима (бэк сигнализирует через denied).
+     */
+    denied: new Set(),
+    banned: false,
+    banReason: null,
     loaded: false,
     fetchedAt: 0,
     inflight: null,
+    /**
+     * Плоская карта { key: value } — сохраняем для обратной совместимости
+     * с кодом, который напрямую читает store.permissions[key].
+     * Синхронизируется при каждом fetchPermissions.
+     */
+    permissions: {},
   }),
 
   getters: {
+    /**
+     * Проверяет, разрешён ли ключ для текущего пользователя.
+     *
+     * Семантика по mode:
+     *   super  -> всегда true
+     *   admin  -> true если ключ не в denied
+     *   normal -> true если effective[key].value === 'allow'
+     *   banned -> всегда false
+     *
+     * @param {string} key
+     * @returns {boolean}
+     */
     hasPermission: (state) => (key) => {
-      const auth = useAuthStore()
-      if (auth.isSuperAdmin) return true
-      return state.permissions[key] === 'allow'
+      switch (state.mode) {
+        case 'super':
+          return true
+        case 'admin':
+          return !state.denied.has(key)
+        case 'banned':
+          return false
+        default: // 'normal'
+          return state.effective[key]?.value === 'allow'
+      }
     },
+
+    /**
+     * Возвращает источник права: 'role'|'group'|'override'|'admin'|'base'|null.
+     * Используется в админ-UI для индикатора источника.
+     *
+     * @param {string} key
+     * @returns {string|null}
+     */
+    permissionSource: (state) => (key) => {
+      return state.effective[key]?.source ?? null
+    },
+
     isStale: (state) => {
       if (!state.loaded) return true
       return Date.now() - state.fetchedAt > CACHE_TTL_MS
@@ -39,14 +128,21 @@ export const usePermissionsStore = defineStore('permissions', {
       this.inflight = (async () => {
         try {
           const data = await getMyPermissions()
+          const parsed = parsePermissionsResponse(data)
+          this.mode = parsed.mode
+          this.effective = parsed.effective
+          this.denied = parsed.denied
+          this.banned = parsed.banned
+          this.banReason = parsed.banReason
+          // Синхронизируем плоскую карту для обратной совместимости
           this.permissions = {}
-          if (Array.isArray(data)) {
-            data.forEach(p => { this.permissions[p.key] = p.value })
-          }
+          Object.entries(parsed.effective).forEach(([k, v]) => {
+            this.permissions[k] = v.value
+          })
           this.loaded = true
           this.fetchedAt = Date.now()
         } catch {
-          // ignore — permissions will stay empty
+          // игнорируем ошибку — permissions остаются как есть
         } finally {
           this.inflight = null
         }
@@ -59,7 +155,12 @@ export const usePermissionsStore = defineStore('permissions', {
     },
 
     clearPermissions() {
+      this.effective = {}
       this.permissions = {}
+      this.mode = 'normal'
+      this.denied = new Set()
+      this.banned = false
+      this.banReason = null
       this.loaded = false
       this.fetchedAt = 0
     },


### PR DESCRIPTION
Стор прав под 4 режима (super/admin/normal/banned) с источником каждого права, defensive-parse нового и старого формата /permissions/my. Composable usePermission (can/sourceOf, работает с динамическими table.* ключами). Каталог ключей и карта detailModalActions (контекст модалки -> действие -> ключ). Убран дубль-директивы v-permission.

Часть эпика по правам (Фаза 1, FE-фундамент). Внедрение в компоненты - отдельными срезами Фазы 2. vitest по затронутым спекам: 36/36, eslint чисто.