### PR TITLE
feat(analytics): плавное обновление чисел и графиков при смене периода (#632)

### DIFF
--- a/frontend/src/components/statistics/AnimatedNumber.vue
+++ b/frontend/src/components/statistics/AnimatedNumber.vue
@@ -1,0 +1,106 @@
+<template>{{ display }}</template>
+
+<script setup>
+import { ref, watch, onBeforeUnmount } from 'vue';
+
+const props = defineProps({
+  /** Число для показа. null/пусто -> прочерк. */
+  value: {
+    type: [Number, String],
+    default: null,
+  },
+  /** Длительность счётчика, мс. <=0 -> моментально (reduced-motion/тесты). */
+  duration: {
+    type: Number,
+    default: 600,
+  },
+});
+
+function toNumber(v) {
+  if (v === null || v === undefined || v === '') return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+function format(n) {
+  return n == null ? '—' : Math.round(n).toLocaleString('ru-RU');
+}
+
+function prefersReducedMotion() {
+  try {
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  } catch {
+    return false;
+  }
+}
+
+// current — числовое показанное значение (для продолжения анимации с середины),
+// display — строка в DOM.
+const current = ref(toNumber(props.value));
+const display = ref(format(current.value));
+
+let rafId = null;
+let started = false;
+let startTs = 0;
+let startVal = 0;
+let targetVal = 0;
+
+function cancel() {
+  if (rafId !== null) {
+    cancelAnimationFrame(rafId);
+    rafId = null;
+  }
+}
+
+function applyImmediate(n) {
+  cancel();
+  current.value = n;
+  display.value = format(n);
+}
+
+function step(ts) {
+  // Якорим стартовый timestamp на первом кадре (он может быть 0).
+  if (!started) {
+    started = true;
+    startTs = ts;
+  }
+  const p = Math.min(1, (ts - startTs) / props.duration);
+  // easeOutCubic — быстрый старт, мягкое торможение к финалу.
+  const eased = 1 - Math.pow(1 - p, 3);
+  const val = startVal + (targetVal - startVal) * eased;
+  current.value = val;
+  display.value = format(val);
+  if (p < 1) {
+    rafId = requestAnimationFrame(step);
+  } else {
+    applyImmediate(targetVal);
+  }
+}
+
+watch(
+  () => props.value,
+  (next) => {
+    const n = toNumber(next);
+    // Появление из прочерка, уход в прочерк, без изменения или без анимации —
+    // моментально, иначе count-up от текущего значения к новому.
+    if (
+      n == null
+      || current.value == null
+      || n === current.value
+      || props.duration <= 0
+      || prefersReducedMotion()
+      || typeof requestAnimationFrame !== 'function'
+    ) {
+      applyImmediate(n);
+      return;
+    }
+    cancel();
+    started = false;
+    startVal = current.value;
+    targetVal = n;
+    rafId = requestAnimationFrame(step);
+  }
+);
+
+onBeforeUnmount(cancel);
+</script>

--- a/frontend/src/components/statistics/StatisticsDashboard.vue
+++ b/frontend/src/components/statistics/StatisticsDashboard.vue
@@ -10,7 +10,7 @@
       </div>
 
       <div
-        v-if="summaryLoading"
+        v-if="summaryLoading && !summaryReady"
         class="dashboard__tiles"
       >
         <div
@@ -47,7 +47,9 @@
               aria-hidden="true"
             />
           </div>
-          <div class="dashboard__tile-val">{{ fmt(tile.value) }}</div>
+          <div class="dashboard__tile-val">
+            <AnimatedNumber :value="tile.value" />
+          </div>
           <div
             v-if="tile.comparison || tile.trend"
             class="dashboard__tile-insight"
@@ -135,7 +137,7 @@
       </div>
 
       <div
-        v-if="summaryLoading"
+        v-if="summaryLoading && !summaryReady"
         class="dashboard__tiles"
       >
         <div
@@ -162,7 +164,9 @@
           class="dashboard__tile"
         >
           <div class="dashboard__tile-label">{{ item.label }}</div>
-          <div class="dashboard__tile-val">{{ fmt(item.count) }}</div>
+          <div class="dashboard__tile-val">
+            <AnimatedNumber :value="item.count" />
+          </div>
         </div>
       </div>
     </div>
@@ -176,7 +180,7 @@
       </div>
 
       <div
-        v-if="summaryLoading"
+        v-if="summaryLoading && !summaryReady"
         class="dashboard__tiles"
       >
         <div
@@ -200,19 +204,27 @@
           @keydown.space.prevent="openOnlineUsers"
         >
           <div class="dashboard__tile-label">Пользователей онлайн</div>
-          <div class="dashboard__tile-val">{{ fmt(summary.users_online) }}</div>
+          <div class="dashboard__tile-val">
+            <AnimatedNumber :value="summary.users_online" />
+          </div>
         </div>
         <div class="dashboard__tile">
           <div class="dashboard__tile-label">Пользователи</div>
-          <div class="dashboard__tile-val">{{ fmt(summary.active_users) }}</div>
+          <div class="dashboard__tile-val">
+            <AnimatedNumber :value="summary.active_users" />
+          </div>
         </div>
         <div class="dashboard__tile">
           <div class="dashboard__tile-label">Заблокировано</div>
-          <div class="dashboard__tile-val">{{ fmt(summary.banned_users) }}</div>
+          <div class="dashboard__tile-val">
+            <AnimatedNumber :value="summary.banned_users" />
+          </div>
         </div>
         <div class="dashboard__tile">
           <div class="dashboard__tile-label">Открытых обращений</div>
-          <div class="dashboard__tile-val">{{ fmt(summary.open_feedback) }}</div>
+          <div class="dashboard__tile-val">
+            <AnimatedNumber :value="summary.open_feedback" />
+          </div>
         </div>
       </div>
     </div>
@@ -251,7 +263,7 @@
       </div>
 
       <div
-        v-if="timelineLoading"
+        v-if="timelineLoading && !timelineReady"
         class="dashboard__chart-skeleton"
       />
       <AnalyticsAreaChart
@@ -274,7 +286,7 @@
       </div>
 
       <div
-        v-if="onlinePeaksLoading"
+        v-if="onlinePeaksLoading && !onlinePeaksReady"
         class="dashboard__chart-skeleton"
       />
       <AnalyticsAreaChart
@@ -296,7 +308,7 @@
       </div>
 
       <div
-        v-if="insightsLoading"
+        v-if="insightsLoading && !insightsReady"
         class="dashboard__tops"
       >
         <div
@@ -449,6 +461,7 @@ import AnalyticsBarChart from '@/components/statistics/AnalyticsBarChart.vue';
 import DirIcon from '@/components/statistics/DirIcon.vue';
 import TrendSparkline from '@/components/statistics/TrendSparkline.vue';
 import TopList from '@/components/statistics/TopList.vue';
+import AnimatedNumber from '@/components/statistics/AnimatedNumber.vue';
 import RefreshButton from '@/components/RefreshButton.vue';
 import OnlineUsersModal from '@/components/statistics/OnlineUsersModal.vue';
 import { getSummary, getTimeline, getRecentPassages, getInsights, getOnlinePeaks, getOnlineUsers } from '@/api/statistics.js';
@@ -466,8 +479,12 @@ const props = defineProps({
 });
 
 // ---- состояние данных ----
+// *Ready-флаги: скелетон показываем только до первой загрузки источника. При смене
+// периода контент остаётся на месте (числа count-up, графики морфят серию),
+// а не мигает скелетоном - убирает "дёрганье" при перезагрузке (фидбэк #632).
 const summary = ref({});
 const summaryLoading = ref(false);
+const summaryReady = ref(false);
 
 // Инсайты обогащают карточки группы «Данные»: сравнение с прошлым периодом
 // (дельта/направление), тренд по дням (спарклайн) и профиль пика по часам.
@@ -476,6 +493,7 @@ const summaryLoading = ref(false);
 // top_places/top_orgs питают секцию «Топ за период» (лидерборды).
 const insights = reactive({ comparisons: [], trends: [], peak_hours: [], top_places: [], top_orgs: [] });
 const insightsLoading = ref(false);
+const insightsReady = ref(false);
 
 // Метрика развёрнутой карточки (ключ инсайта) либо null — раскрывает детальные
 // графики под сеткой «Данные». Клик по той же карточке сворачивает.
@@ -485,10 +503,12 @@ const timeline = ref([]);
 // Датированный тренд развёрнутой карточки — отдельно от серии инсайта (та без дат).
 const detailTimeline = ref([]);
 const timelineLoading = ref(false);
+const timelineReady = ref(false);
 
 // Дневные пики онлайна за период (area-график под основным графиком).
 const onlinePeaks = ref([]);
 const onlinePeaksLoading = ref(false);
+const onlinePeaksReady = ref(false);
 
 // Модалка «кто онлайн» по клику на плитку «Пользователей онлайн».
 const onlineModalOpen = ref(false);
@@ -621,11 +641,6 @@ const expandedDetail = computed(() => {
 });
 
 // ---- форматирование ----
-function fmt(val) {
-  if (val == null) return '—';
-  return Number(val).toLocaleString('ru-RU');
-}
-
 function deltaText(pct) {
   // Бэкенд округляет до 1 знака, но JSON->Number может дать хвост (16.700000003) —
   // повторно округляем, чтобы не показать артефакт.
@@ -689,7 +704,10 @@ async function loadSummary() {
     if (seq !== summarySeq) return;
     summary.value = {};
   } finally {
-    if (seq === summarySeq) summaryLoading.value = false;
+    if (seq === summarySeq) {
+      summaryLoading.value = false;
+      summaryReady.value = true;
+    }
   }
 }
 
@@ -714,7 +732,10 @@ async function loadInsights() {
     insights.top_places = [];
     insights.top_orgs = [];
   } finally {
-    if (seq === insightsSeq) insightsLoading.value = false;
+    if (seq === insightsSeq) {
+      insightsLoading.value = false;
+      insightsReady.value = true;
+    }
   }
 }
 
@@ -730,7 +751,10 @@ async function loadOnlinePeaks() {
     if (seq !== onlinePeaksSeq) return;
     onlinePeaks.value = [];
   } finally {
-    if (seq === onlinePeaksSeq) onlinePeaksLoading.value = false;
+    if (seq === onlinePeaksSeq) {
+      onlinePeaksLoading.value = false;
+      onlinePeaksReady.value = true;
+    }
   }
 }
 
@@ -750,7 +774,10 @@ async function loadTimeline() {
     if (seq !== timelineSeq) return;
     timeline.value = [];
   } finally {
-    if (seq === timelineSeq) timelineLoading.value = false;
+    if (seq === timelineSeq) {
+      timelineLoading.value = false;
+      timelineReady.value = true;
+    }
   }
 }
 

--- a/frontend/src/components/statistics/__tests__/AnimatedNumber.spec.js
+++ b/frontend/src/components/statistics/__tests__/AnimatedNumber.spec.js
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import AnimatedNumber from '../AnimatedNumber.vue';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete window.matchMedia;
+});
+
+describe('AnimatedNumber', () => {
+  it('пустое значение рендерит прочерк', () => {
+    expect(mount(AnimatedNumber, { props: { value: null } }).text()).toBe('—');
+    expect(mount(AnimatedNumber, { props: { value: '' } }).text()).toBe('—');
+  });
+
+  it('число форматируется в ru-RU при первом рендере (без анимации появления)', () => {
+    const wrapper = mount(AnimatedNumber, { props: { value: 12345 } });
+    expect(wrapper.text()).toBe((12345).toLocaleString('ru-RU'));
+  });
+
+  it('строковое число форматируется, нечисловая строка — прочерк', () => {
+    expect(mount(AnimatedNumber, { props: { value: '123' } }).text()).toBe('123');
+    expect(mount(AnimatedNumber, { props: { value: 'abc' } }).text()).toBe('—');
+  });
+
+  it('matchMedia бросает исключение — анимация не падает, идёт обычный путь', async () => {
+    window.matchMedia = vi.fn(() => { throw new Error('not supported'); });
+    const raf = vi.fn();
+    vi.stubGlobal('requestAnimationFrame', raf);
+
+    const wrapper = mount(AnimatedNumber, { props: { value: 10 } });
+    await wrapper.setProps({ value: 50 });
+
+    // prefersReducedMotion поглотил ошибку -> запланирован count-up через rAF.
+    expect(raf).toHaveBeenCalled();
+  });
+
+  it('duration<=0 меняет значение моментально', async () => {
+    const wrapper = mount(AnimatedNumber, { props: { value: 10, duration: 0 } });
+    await wrapper.setProps({ value: 99 });
+    expect(wrapper.text()).toBe('99');
+  });
+
+  it('при prefers-reduced-motion значение меняется моментально, без rAF', async () => {
+    window.matchMedia = vi.fn(() => ({ matches: true }));
+    const raf = vi.fn();
+    vi.stubGlobal('requestAnimationFrame', raf);
+
+    const wrapper = mount(AnimatedNumber, { props: { value: 10 } });
+    await wrapper.setProps({ value: 200 });
+
+    expect(wrapper.text()).toBe('200');
+    expect(raf).not.toHaveBeenCalled();
+  });
+
+  it('переход в прочерк и из прочерка — моментальный', async () => {
+    const wrapper = mount(AnimatedNumber, { props: { value: 50 } });
+    await wrapper.setProps({ value: null });
+    expect(wrapper.text()).toBe('—');
+    await wrapper.setProps({ value: 7 });
+    expect(wrapper.text()).toBe('7');
+  });
+
+  it('при смене числа делает count-up от старого к новому и доходит до цели', async () => {
+    // Управляемый rAF: захватываем колбэк и сами прогоняем кадры.
+    let cb = null;
+    const raf = vi.fn((fn) => { cb = fn; return 1; });
+    vi.stubGlobal('requestAnimationFrame', raf);
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+
+    const wrapper = mount(AnimatedNumber, { props: { value: 10, duration: 100 } });
+    await wrapper.setProps({ value: 110 });
+
+    // Старт анимации запланирован, но кадры ещё не прогнаны — значение прежнее.
+    expect(raf).toHaveBeenCalled();
+    expect(wrapper.text()).toBe('10');
+
+    cb(0); // первый кадр якорит время, p=0
+    await wrapper.vm.$nextTick();
+    expect(wrapper.text()).toBe('10');
+
+    cb(50); // середина — между старым и новым
+    await wrapper.vm.$nextTick();
+    const mid = Number(wrapper.text());
+    expect(mid).toBeGreaterThan(10);
+    expect(mid).toBeLessThan(110);
+
+    cb(100); // финал — ровно цель
+    await wrapper.vm.$nextTick();
+    expect(wrapper.text()).toBe('110');
+  });
+});

--- a/frontend/src/components/statistics/__tests__/StatisticsDashboard.spec.js
+++ b/frontend/src/components/statistics/__tests__/StatisticsDashboard.spec.js
@@ -5,11 +5,11 @@ import { nextTick } from 'vue';
 // Управляемое состояние моков: фабрика vi.mock поднимается над импортами,
 // поэтому summary/deferred выносим в hoisted.
 const { state } = vi.hoisted(() => ({
-  state: { deferred: [], onlineDeferred: [], summary: {}, insights: {}, onlinePeaks: [], insightsHang: false },
+  state: { deferred: [], onlineDeferred: [], summary: {}, insights: {}, onlinePeaks: [], insightsHang: false, summaryReject: false },
 }));
 
 vi.mock('@/api/statistics.js', () => ({
-  getSummary: () => Promise.resolve(state.summary),
+  getSummary: () => (state.summaryReject ? Promise.reject(new Error('net')) : Promise.resolve(state.summary)),
   getRecentPassages: () => Promise.resolve({ people: [], cars: [] }),
   getTimeline: () => new Promise((resolve) => { state.deferred.push(resolve); }),
   // insightsHang оставляет промис вечно pending — для проверки состояния загрузки.
@@ -40,6 +40,7 @@ beforeEach(() => {
   state.insights = {};
   state.onlinePeaks = [];
   state.insightsHang = false;
+  state.summaryReject = false;
 });
 
 describe('StatisticsDashboard — гонка таймлайна', () => {
@@ -364,5 +365,65 @@ describe('StatisticsDashboard — динамика онлайна', () => {
       { timestamp: '2026-06-01', count: 4 },
       { timestamp: '2026-06-02', count: 9 },
     ]);
+  });
+});
+
+describe('StatisticsDashboard — плавная перезагрузка без мигания', () => {
+  it('первичная загрузка таймлайна показывает скелетон графика', async () => {
+    const wrapper = mountDashboard();
+    await flushPromises(); // summary/insights/онлайн готовы; таймлайн в полёте (deferred[0])
+
+    expect(wrapper.find('.dashboard__chart-skeleton').exists()).toBe(true);
+  });
+
+  it('смена периода не возвращает скелетон графика — он остаётся смонтированным', async () => {
+    const wrapper = mountDashboard();
+    await flushPromises();
+    state.deferred[0]([{ date: '2026-06-01', count: 5 }]);
+    await flushPromises();
+
+    expect(wrapper.find('.dashboard__chart-skeleton').exists()).toBe(false);
+    expect(wrapper.findComponent(AnalyticsAreaChart).exists()).toBe(true);
+
+    // Новый период -> таймлайн снова в полёте, но без мигания скелетоном.
+    await wrapper.setProps({ from: '2026-05-01', to: '2026-05-07' });
+    await nextTick();
+
+    expect(state.deferred.length).toBeGreaterThanOrEqual(2);
+    expect(wrapper.find('.dashboard__chart-skeleton').exists()).toBe(false);
+    expect(wrapper.findComponent(AnalyticsAreaChart).exists()).toBe(true);
+  });
+
+  it('смена периода не возвращает скелетоны плиток — значения остаются на месте', async () => {
+    state.summary = { total_applications: 5 };
+    const wrapper = mountDashboard();
+    await flushPromises();
+    expect(wrapper.findAll('.dashboard__tile--skeleton')).toHaveLength(0);
+
+    await wrapper.setProps({ from: '2026-05-01', to: '2026-05-07' });
+    await nextTick();
+
+    expect(wrapper.findAll('.dashboard__tile--skeleton')).toHaveLength(0);
+    expect(tileByText(wrapper, 'Получено заявок')).toBeTruthy();
+  });
+
+  it('значение плитки рендерится через AnimatedNumber и отформатировано', async () => {
+    state.summary = { total_applications: 1234 };
+    const wrapper = mountDashboard();
+    await flushPromises();
+
+    const tile = tileByText(wrapper, 'Получено заявок');
+    expect(tile.text()).toContain((1234).toLocaleString('ru-RU'));
+  });
+
+  it('ошибка первичной загрузки убирает скелетон (не зависает на нём навсегда)', async () => {
+    state.summaryReject = true;
+    const wrapper = mountDashboard();
+    await flushPromises();
+
+    // summaryReady встал в finally даже при reject -> скелетон не висит вечно.
+    expect(wrapper.findAll('.dashboard__tile--skeleton')).toHaveLength(0);
+    // Плитки группы «Данные» рендерятся с прочерками вместо чисел.
+    expect(tileByText(wrapper, 'Получено заявок')).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Что было
Дашборд аналитики при смене периода мигал и «дёргался» (фидбэк владельца #632, п.1 «больно глазам»): блоки плиток и графики свопались `v-if`-ом в скелетон, а числа в плитках менялись мгновенным reflow.

## Что сделал
- **Ready-флаги** (`summaryReady`/`timelineReady`/`onlinePeaksReady`/`insightsReady`): скелетон показывается только до первой успешной/завершённой загрузки источника. При смене периода контент остаётся смонтированным — больше нет мигания «контент → серые пульсирующие боксы → контент». Ставятся в `finally` под seq-токеном, гонка устаревшего ответа не затрагивается.
- **`AnimatedNumber.vue`** (новый): count-up значений плиток через `requestAnimationFrame` (easeOutCubic), уважает `prefers-reduced-motion` и `duration<=0` (моментально), `null`/нечисло → прочерк. При быстрой смене продолжает с текущего значения, не сбрасывает в 0. `cancelAnimationFrame` на unmount. Заменил все `fmt()` в шаблоне, неиспользуемую `fmt` удалил.
- **Графики не размонтируются** на перезагрузке — ApexCharts (`AnalyticsAreaChart`) сам анимирует морф серии вместо пересоздания компонента.

FE-only, off-limits не задеты, миграций нет.

## Тесты
- `AnimatedNumber.spec.js` (новый): прочерк для null/'', формат ru-RU, строковый ввод, моментальный путь при `duration<=0` и reduced-motion, поглощение исключения matchMedia, count-up доходит до цели через управляемый rAF.
- `StatisticsDashboard.spec.js`: смена периода не возвращает скелетон графика/плиток (через deferred-таймлайн), значение рендерится через AnimatedNumber, error-путь первой загрузки убирает скелетон. Существующие тесты (гонка, инсайты, разворот, топы, онлайн) зелёные.
- `npx vitest run` по обоим спекам: 30 passed. ESLint: 0 errors.

## Ревью
Прогнал `code-reviewer` — вердикт GO, блокеров нет. Закрыл suggestions: переименовал `setImmediate` → `applyImmediate` (коллизия с Node-глобалом), добавил тесты на строковый ввод, исключение matchMedia и error-путь первичной загрузки.

## Верификация
Плавность — анимация, в статичном скрине не видна; владелец проверяет на staging после деплоя (как с прочими анимациями). Логика «без мигания» и count-up покрыты юнит-тестами.