### PR TITLE
feat(permissions): инвариант единственного супер-админа (Фаза 2, ШАГ 0)

### DIFF
--- a/docs/access-control/migration-from-type-id-6.md
+++ b/docs/access-control/migration-from-type-id-6.md
@@ -44,15 +44,19 @@ JWT Claims расширены полем `is_super_admin` — middleware кла�
 
 ## Data migration
 
-`internal/database/migrate.go::backfillSuperAdmin`:
+`internal/database/migrate.go::EnforceSingleSuperAdmin`:
 
-```sql
-UPDATE users SET is_super_admin = true
-WHERE is_super_admin = false
-  AND type_id IN (SELECT id FROM user_types WHERE code = 'buropropuskov');
-```
+Поддерживает инвариант «ровно один супер-админ». Канонический супер-админ —
+аккаунт `username='buropropuskov'` (иначе самый ранний существующий супер-админ,
+иначе первый пользователь). Канонику флаг гарантируется, у всех остальных
+снимается, а сами они становятся обычными администраторами (`is_admin=true`),
+чтобы не потерять доступ. Имя пустого системного аккаунта нормализуется в
+«Системный Администратор».
 
 Запускается в `AutoMigrate()` при старте сервера. Идемпотентна (повторный запуск — noop).
+
+Прежняя версия (`backfillSuperAdmin`) делала супером всех пользователей типа
+`buropropuskov` — при нескольких buro-аккаунтах появлялось несколько супер-админов.
 
 ## Что осталось от `user_types`
 
@@ -72,7 +76,7 @@ WHERE is_super_admin = false
 
 1. `internal/auth/permissions.go` — целиком, никто не вызывает.
 2. `frontend/src/stores/auth.js::isAdmin` getter (deprecated alias).
-3. `internal/database/migrate.go::backfillSuperAdmin` — после первого успешного прогона на всех средах.
+3. `internal/database/migrate.go::EnforceSingleSuperAdmin` — оставить: поддерживает инвариант единственного супер-админа на каждом старте.
 4. (Опционально, риск) `users.type_id` колонка — только если бизнес-роли полностью переехали в `users.role_id`. На момент написания (#187f) — нет, поле ещё используется.
 
 ## Восстановление при сбое миграции

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -198,7 +198,7 @@ func AutoMigrate(db *gorm.DB) error {
 	if err := installSQLFunctions(db); err != nil {
 		return err
 	}
-	if err := backfillSuperAdmin(db); err != nil {
+	if err := EnforceSingleSuperAdmin(db); err != nil {
 		return err
 	}
 	if err := SeedReportTemplates(db); err != nil {
@@ -316,23 +316,57 @@ func SeedReportTemplates(db *gorm.DB) error {
 	return nil
 }
 
-// backfillSuperAdmin проставляет is_super_admin=true пользователям с type_id,
-// соответствующим коду 'buropropuskov' в user_types (#231).
-// Безопасна для повторного запуска: WHERE not (already true) делает её noop.
-// После полного отказа от type_id=6 проверки эту миграцию можно удалить.
-func backfillSuperAdmin(db *gorm.DB) error {
-	res := db.Exec(`
-		UPDATE users SET is_super_admin = true
-		WHERE is_super_admin = false
-		  AND type_id IN (SELECT id FROM user_types WHERE code = 'buropropuskov')
-	`)
-	if res.Error != nil {
-		return fmt.Errorf("backfill is_super_admin: %w", res.Error)
+// EnforceSingleSuperAdmin поддерживает инвариант "ровно один супер-админ".
+// Канонический супер-админ выбирается так (приоритет сверху): аккаунт с
+// username='buropropuskov' (системный администратор), иначе самый ранний из уже
+// существующих супер-админов, иначе первый зарегистрированный пользователь.
+// Канонику флаг гарантируется, у всех остальных снимается -- но снятые супера
+// становятся обычными администраторами (is_admin), чтобы не потерять доступ
+// (admin = всё кроме super-only ключей и личных deny). Имя системного аккаунта
+// нормализуется в "Системный Администратор" только если оно пустое (реальное ФИО
+// не затирается). Идемпотентна.
+//
+// Заменяет прежний backfillSuperAdmin, который ошибочно делал супером ВСЕХ
+// пользователей типа buropropuskov: при двух+ buro-аккаунтах получалось несколько
+// супер-админов, что ломало модель "единственный неудаляемый владелец".
+func EnforceSingleSuperAdmin(db *gorm.DB) error {
+	var canonicalID int
+	if err := db.Raw(`
+		SELECT id FROM users
+		ORDER BY (username = 'buropropuskov') DESC, is_super_admin DESC, id ASC
+		LIMIT 1
+	`).Scan(&canonicalID).Error; err != nil {
+		return fmt.Errorf("pick canonical super-admin: %w", err)
 	}
-	if res.RowsAffected > 0 {
-		slog.Info("super-admin backfilled", "users_updated", res.RowsAffected)
+	if canonicalID == 0 {
+		// Пользователей ещё нет (миграция раньше сидов) -- применять нечего.
+		return nil
 	}
-	return nil
+	return db.Transaction(func(tx *gorm.DB) error {
+		demoted := tx.Exec(`
+			UPDATE users SET is_super_admin = false, is_admin = true
+			WHERE id <> ? AND is_super_admin = true`, canonicalID)
+		if demoted.Error != nil {
+			return fmt.Errorf("demote extra super-admins: %w", demoted.Error)
+		}
+		if demoted.RowsAffected > 0 {
+			slog.Warn("demoted extra super-admins to admin",
+				"count", demoted.RowsAffected, "kept_super_id", canonicalID)
+		}
+		if err := tx.Exec(`
+			UPDATE users SET is_super_admin = true
+			WHERE id = ? AND is_super_admin = false`, canonicalID).Error; err != nil {
+			return fmt.Errorf("promote canonical super-admin: %w", err)
+		}
+		if err := tx.Exec(`
+			UPDATE users SET last_name = 'Администратор', first_name = 'Системный'
+			WHERE id = ?
+			  AND (last_name IS NULL OR last_name = '')
+			  AND (first_name IS NULL OR first_name = '')`, canonicalID).Error; err != nil {
+			return fmt.Errorf("normalize super-admin name: %w", err)
+		}
+		return nil
+	})
 }
 
 // relaxApplicationOrgNotNull снимает NOT NULL с applications.organization_id:

--- a/internal/handlers/super_admin_invariant_test.go
+++ b/internal/handlers/super_admin_invariant_test.go
@@ -1,0 +1,122 @@
+package handlers_test
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"systemburo/internal/database"
+	"systemburo/internal/models"
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// TestEnforceSingleSuperAdmin_KeepsOnlyCanonical проверяет инвариант "ровно один
+// супер-админ": миграция оставляет супером только системный аккаунт
+// (username='buropropuskov'), а лишних разжалует в обычные администраторы.
+// Выполняется в транзакции с откатом -- глобальный UPDATE миграции не
+// персистится и не задевает параллельные пакеты на общей тест-БД (урок #706).
+func TestEnforceSingleSuperAdmin_KeepsOnlyCanonical(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+
+	rollback := errors.New("rollback")
+	err := db.Transaction(func(tx *gorm.DB) error {
+		// Возможный закоммиченный остаток системного аккаунта убираем в рамках
+		// транзакции (откатится), чтобы uniqueIndex по username не помешал INSERT.
+		if err := tx.Where("username = ?", "buropropuskov").Delete(&models.User{}).Error; err != nil {
+			return err
+		}
+
+		canon := models.User{Username: "buropropuskov", TypeID: 6, IsSuperAdmin: true}
+		extra1 := models.User{Username: uniq("extra-super"), TypeID: 6, IsSuperAdmin: true}
+		extra2 := models.User{Username: uniq("extra-super"), TypeID: 6, IsSuperAdmin: true}
+		require.NoError(t, tx.Create(&canon).Error)
+		require.NoError(t, tx.Create(&extra1).Error)
+		require.NoError(t, tx.Create(&extra2).Error)
+
+		require.NoError(t, database.EnforceSingleSuperAdmin(tx))
+
+		// Канонический остаётся супером и получает имя пустого системного аккаунта.
+		var got models.User
+		require.NoError(t, tx.First(&got, canon.ID).Error)
+		assert.True(t, got.IsSuperAdmin, "канонический аккаунт остаётся супер-админом")
+		require.NotNil(t, got.LastName)
+		assert.Equal(t, "Администратор", *got.LastName)
+
+		// Лишние супера разжалованы в обычных администраторов (доступ сохранён).
+		for _, id := range []int{extra1.ID, extra2.ID} {
+			var u models.User
+			require.NoError(t, tx.First(&u, id).Error)
+			assert.False(t, u.IsSuperAdmin, "лишний супер снят")
+			assert.True(t, u.IsAdmin, "снятый супер сохраняет admin-доступ")
+		}
+		return rollback
+	})
+	require.ErrorIs(t, err, rollback)
+}
+
+// TestBanSuperAdmin_Forbidden: супер-админа нельзя заблокировать -> 403.
+func TestBanSuperAdmin_Forbidden(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	adminToken := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(adminToken)
+
+	// Цель -- ещё один супер-админ (type 6 -> IsSuperAdmin=true).
+	testutil.RegisterUser(t, e, "supertarget", "password123", 6, td.OrgID, td.CompanyID)
+	var target models.User
+	require.NoError(t, db.Where("username = ?", "supertarget").First(&target).Error)
+
+	rec := testutil.POST(t, e, fmt.Sprintf("/users/%d/ban", target.ID), `{}`, h)
+	assert.Equal(t, http.StatusForbidden, rec.Code, rec.Body.String())
+}
+
+// TestArchiveSuperAdmin_Forbidden: супер-админа нельзя архивировать (soft-delete) -> 403.
+func TestArchiveSuperAdmin_Forbidden(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	adminToken := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(adminToken)
+
+	testutil.RegisterUser(t, e, "supertarget", "password123", 6, td.OrgID, td.CompanyID)
+
+	rec := testutil.DELETE(t, e, "/users/supertarget", h)
+	assert.Equal(t, http.StatusForbidden, rec.Code, rec.Body.String())
+}
+
+// TestCreateUser_CannotSetSuperAdmin: API создания пользователя не позволяет
+// выставить is_super_admin/is_admin (полей нет в RegisterRequest) -- второго
+// супер-админа через API не создать.
+func TestCreateUser_CannotSetSuperAdmin(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	adminToken := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(adminToken)
+
+	// Пытаемся "протащить" флаги через тело запроса -- они игнорируются биндингом.
+	body := fmt.Sprintf(
+		`{"username":"sneaky","password":"password123","is_super_admin":true,"is_admin":true,"organization_id":%d}`,
+		td.OrgID,
+	)
+	rec := testutil.POST(t, e, "/users", body, h)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var created models.User
+	require.NoError(t, db.Where("username = ?", "sneaky").First(&created).Error)
+	assert.False(t, created.IsSuperAdmin, "API не должен позволять выставить is_super_admin")
+	assert.False(t, created.IsAdmin, "API не должен позволять выставить is_admin при создании")
+}

--- a/internal/services/user_ban_service.go
+++ b/internal/services/user_ban_service.go
@@ -3,10 +3,12 @@ package services
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
 	"systemburo/internal/models"
 
+	"github.com/labstack/echo/v4"
 	"gorm.io/gorm"
 )
 
@@ -37,7 +39,7 @@ func (s *UserBanService) Ban(ctx context.Context, targetUserID, actorUserID int)
 		return fmt.Errorf("user not found: %w", err)
 	}
 	if target.IsSuperAdmin {
-		return fmt.Errorf("cannot ban super-admin")
+		return echo.NewHTTPError(http.StatusForbidden, "Нельзя заблокировать супер-администратора")
 	}
 
 	now := time.Now()


### PR DESCRIPTION
## Что
Гарантирует «ровно один супер-админ» и защищает системный аккаунт.

**`backfillSuperAdmin` -> `EnforceSingleSuperAdmin`** (`internal/database/migrate.go`)
Прежняя миграция делала супером ВСЕХ пользователей типа `buropropuskov` -> при нескольких buro-аккаунтах получалось несколько владельцев. Новая:
- выбирает канонического супера: `username='buropropuskov'` -> иначе самый ранний существующий супер -> иначе первый пользователь;
- гарантирует флаг канонику, у остальных снимает, **разжалуя их в обычных администраторов** (`is_admin=true`) — доступ не теряется;
- нормализует пустое имя системного аккаунта в «Системный Администратор» (реальное ФИО не затирает);
- идемпотентна, держит инвариант на каждом старте.

**Бан супер-админа -> чистый 403** (`internal/services/user_ban_service.go`)
Было `fmt.Errorf` -> 500; стало `echo.NewHTTPError(403, ...)`. Архив/бан/удаление супера уже блокировались.

**Создание/назначение второго супера через API/UI невозможно**
`RegisterRequest` не содержит `is_super_admin`/`is_admin`; `SetUserAdmin` ставит только `is_admin`; `UpdateType` флаг не трогает. В UI тумблера супера нет (`RolesGroupsPanel` лишь запрещает бан супера). Тест `TestCreateUser_CannotSetSuperAdmin` фиксирует контракт.

## Тесты (`internal/handlers/super_admin_invariant_test.go`)
- `TestEnforceSingleSuperAdmin_KeepsOnlyCanonical` — миграция в транзакции-с-откатом (не персистит глобальный UPDATE, не задевает параллельные пакеты, урок #706);
- `TestBanSuperAdmin_Forbidden` / `TestArchiveSuperAdmin_Forbidden` — 403;
- `TestCreateUser_CannotSetSuperAdmin` — флаги не протащить через тело.

Локально `go test ./...` серийно зелёный, кроме pre-existing `TestLogPartitionMaintenance` (аккумуляция `request_logs_daily` в персистентной локальной тест-БД, не связано — на свежей БД CI ждёт 1 и получит 1).

## Off-limits
Трогает `migrate.go` (миграция) + ban-сервис — мерж по явному OK.