### PR TITLE
fix(onboarding): CTA финала security-тура не навигирует на текущий роут (#657)

### DIFF
--- a/frontend/src/components/onboarding/OnboardingTour.vue
+++ b/frontend/src/components/onboarding/OnboardingTour.vue
@@ -174,11 +174,17 @@ async function startSegment() {
  * задаёт ctaRoute -> дефолт «оформить заявку»; security-финал ведёт в «Доступные
  * мне» (ctaRoute), а не на подачу заявки.
  *
+ * Навигацию пропускаем, если уже на целевом роуте: security-финал показывается
+ * прямо на /accessible-attachments, и повторный push того же пути зря
+ * перезапускал бы navigation guard (а под кратковременно «протухшим» токеном
+ * guard может отбросить на /personal-cabinet). CTA тогда просто завершает тур.
+ *
  * @param {string} [ctaRoute] route из ctaRoute финального шага
  */
 function finishWithCta(ctaRoute) {
   finishTour();
-  router.push(ctaRoute || '/new-application').catch(() => {});
+  const target = ctaRoute || '/new-application';
+  if (route.path !== target) router.push(target).catch(() => {});
 }
 
 /**


### PR DESCRIPTION
Fix-forward по ship-check S6.3 (эпик aa-improvements).

## Проблема (поймана ship-check на staging)
CTA финала security-тура "Перейти к «Доступным мне»" делал `router.push('/accessible-attachments')`, хотя финальный шаг показывается ПРЯМО на этой странице. Повторный push того же пути зря перезапускал navigation guard `requiresSecurityOrAdmin`; при кратковременно протухшем токене (на staging VPS часы отстают от клиента на ~1.87ч -> JWT считается истёкшим -> `userTypeCode` транзитно null -> `canViewAccessibleAttachments` false) guard отбрасывал на `/personal-cabinet` циклом редиректов.

## Фикс
`finishWithCta`: пушим только если `route.path !== target`. Если уже на целевом роуте (security-финал на /accessible-attachments) - CTA просто завершает тур без навигации. Applicant-финал (на /news, CTA -> /new-application) не затронут: роуты разные, push сохраняется.

## Проверка
- eslint чист.
- Логика: security route.path=/accessible-attachments === target -> push скип -> guard не перезапускается -> нет bounce. Applicant /news !== /new-application -> push как раньше.
- Финал-шаг и его текст уже подтверждены ship-check на staging (6/6 PASS), автозапуск работает, без 404/500.

## Примечание (инфра, не этот PR)
Рассинхрон часов staging VPS (~1.87ч) делает JWT преждевременно истёкшими у клиентов с опережающими часами - кандидат на проверку NTP на VPS отдельно.