### PR TITLE
feat(analytics): раздел Мониторинг с occupancy и постом прохода (#632)

### DIFF
--- a/frontend/src/components/statistics/StatisticsDashboard.vue
+++ b/frontend/src/components/statistics/StatisticsDashboard.vue
@@ -335,111 +335,156 @@
       </div>
     </div>
 
-    <!-- ===== ЖИВЫЕ ЛЕНТЫ ===== -->
-    <div class="dashboard__feeds">
+    <!-- ===== ГРУППА: МОНИТОРИНГ (реальное время, не зависит от периода) ===== -->
+    <div class="dashboard__group dashboard__group--monitoring">
+      <div class="dashboard__group-head">
+        <h2 class="dashboard__group-title">Мониторинг</h2>
+        <span class="dashboard__live-dot" />
+        <span class="dashboard__group-chip">в реальном времени · сейчас</span>
+        <span class="dashboard__group-rule" />
+      </div>
 
-      <!-- Лента людей -->
-      <div class="dashboard__feed">
-        <div class="dashboard__feed-head">
-          <h3 class="dashboard__feed-title">
-            <span class="dashboard__live-dot" />
-            Проход людей
-          </h3>
-          <RefreshButton
-            :loading="feedRefreshing"
-            @refresh="refreshFeeds"
-          />
-        </div>
-
-        <div class="dashboard__feed-list">
-          <template v-if="feedLoading">
-            <div
-              v-for="n in 5"
-              :key="n"
-              class="dashboard__feed-row dashboard__feed-row--skeleton"
-            />
-          </template>
-          <template v-else-if="peopleFeed.length === 0">
-            <div class="dashboard__feed-empty">Нет записей</div>
-          </template>
-          <template v-else>
-            <div
-              v-for="row in peopleFeed"
-              :key="feedRowKey(row)"
-              class="dashboard__feed-row"
-            >
-              <div class="dashboard__feed-main">
-                <div class="dashboard__feed-name">{{ row.subject }}</div>
-                <div class="dashboard__feed-sub">
-                  {{ row.organization }}<template v-if="row.place && row.place !== '—'"> · {{ row.place }}</template>
-                </div>
-              </div>
-              <div class="dashboard__feed-right">
-                <div class="dashboard__feed-date">{{ formatDate(row.created_at) }}</div>
-                <div class="dashboard__feed-time">{{ formatTime(row.created_at) }}</div>
-                <span
-                  class="dashboard__dir-badge"
-                  :class="row.action_type === 'entry' ? 'dashboard__dir-badge--in' : 'dashboard__dir-badge--out'"
-                >
-                  {{ row.action_type === 'entry' ? 'Вход' : 'Выход' }}
-                </span>
-              </div>
-            </div>
-          </template>
+      <!-- Снимок территории: сколько внутри прямо сейчас -->
+      <div
+        v-if="summaryLoading && !summaryReady"
+        class="dashboard__tiles"
+      >
+        <div
+          v-for="n in 2"
+          :key="n"
+          class="dashboard__tile dashboard__tile--skeleton"
+        />
+      </div>
+      <div
+        v-else
+        class="dashboard__tiles"
+      >
+        <div
+          v-for="tile in occupancyTiles"
+          :key="tile.label"
+          class="dashboard__tile"
+        >
+          <div class="dashboard__tile-label">{{ tile.label }}</div>
+          <div class="dashboard__tile-val">
+            <AnimatedNumber :value="tile.value" />
+          </div>
         </div>
       </div>
 
-      <!-- Лента машин -->
-      <div class="dashboard__feed">
-        <div class="dashboard__feed-head">
-          <h3 class="dashboard__feed-title">
-            <span class="dashboard__live-dot" />
-            Проезд машин
-          </h3>
-          <RefreshButton
-            :loading="feedRefreshing"
-            @refresh="refreshFeeds"
-          />
+      <!-- Живые ленты проходов/проездов -->
+      <div class="dashboard__feeds">
+
+        <!-- Лента людей -->
+        <div class="dashboard__feed">
+          <div class="dashboard__feed-head">
+            <h3 class="dashboard__feed-title">
+              <span class="dashboard__live-dot" />
+              Проход людей
+            </h3>
+            <RefreshButton
+              :loading="feedRefreshing"
+              @refresh="refreshFeeds"
+            />
+          </div>
+
+          <div class="dashboard__feed-list">
+            <template v-if="feedLoading">
+              <div
+                v-for="n in 5"
+                :key="n"
+                class="dashboard__feed-row dashboard__feed-row--skeleton"
+              />
+            </template>
+            <template v-else-if="peopleFeed.length === 0">
+              <div class="dashboard__feed-empty">Нет записей</div>
+            </template>
+            <template v-else>
+              <div
+                v-for="row in peopleFeed"
+                :key="feedRowKey(row)"
+                class="dashboard__feed-row"
+              >
+                <div class="dashboard__feed-main">
+                  <div class="dashboard__feed-name">{{ row.subject }}</div>
+                  <div class="dashboard__feed-sub">{{ row.organization }}</div>
+                  <div
+                    class="dashboard__feed-post"
+                    :class="{ 'dashboard__feed-post--empty': !hasPlace(row) }"
+                  >
+                    Пост: {{ placeLabel(row) }}
+                  </div>
+                </div>
+                <div class="dashboard__feed-right">
+                  <div class="dashboard__feed-date">{{ formatDate(row.created_at) }}</div>
+                  <div class="dashboard__feed-time">{{ formatTime(row.created_at) }}</div>
+                  <span
+                    class="dashboard__dir-badge"
+                    :class="row.action_type === 'entry' ? 'dashboard__dir-badge--in' : 'dashboard__dir-badge--out'"
+                  >
+                    {{ row.action_type === 'entry' ? 'Вход' : 'Выход' }}
+                  </span>
+                </div>
+              </div>
+            </template>
+          </div>
         </div>
 
-        <div class="dashboard__feed-list">
-          <template v-if="feedLoading">
-            <div
-              v-for="n in 5"
-              :key="n"
-              class="dashboard__feed-row dashboard__feed-row--skeleton"
+        <!-- Лента машин -->
+        <div class="dashboard__feed">
+          <div class="dashboard__feed-head">
+            <h3 class="dashboard__feed-title">
+              <span class="dashboard__live-dot" />
+              Проезд машин
+            </h3>
+            <RefreshButton
+              :loading="feedRefreshing"
+              @refresh="refreshFeeds"
             />
-          </template>
-          <template v-else-if="carsFeed.length === 0">
-            <div class="dashboard__feed-empty">Нет записей</div>
-          </template>
-          <template v-else>
-            <div
-              v-for="row in carsFeed"
-              :key="feedRowKey(row)"
-              class="dashboard__feed-row"
-            >
-              <div class="dashboard__plate">{{ row.subject }}</div>
-              <div class="dashboard__feed-main">
-                <div class="dashboard__feed-name">
-                  {{ row.mark || '' }}
+          </div>
+
+          <div class="dashboard__feed-list">
+            <template v-if="feedLoading">
+              <div
+                v-for="n in 5"
+                :key="n"
+                class="dashboard__feed-row dashboard__feed-row--skeleton"
+              />
+            </template>
+            <template v-else-if="carsFeed.length === 0">
+              <div class="dashboard__feed-empty">Нет записей</div>
+            </template>
+            <template v-else>
+              <div
+                v-for="row in carsFeed"
+                :key="feedRowKey(row)"
+                class="dashboard__feed-row"
+              >
+                <div class="dashboard__plate">{{ row.subject }}</div>
+                <div class="dashboard__feed-main">
+                  <div class="dashboard__feed-name">
+                    {{ row.mark || '' }}
+                  </div>
+                  <div class="dashboard__feed-sub">{{ row.organization }}</div>
+                  <div
+                    class="dashboard__feed-post"
+                    :class="{ 'dashboard__feed-post--empty': !hasPlace(row) }"
+                  >
+                    Пост: {{ placeLabel(row) }}
+                  </div>
                 </div>
-                <div class="dashboard__feed-sub">
-                  {{ row.organization }}<template v-if="row.place && row.place !== '—'"> · {{ row.place }}</template>
+                <div class="dashboard__feed-right">
+                  <div class="dashboard__feed-date">{{ formatDate(row.created_at) }}</div>
+                  <div class="dashboard__feed-time">{{ formatTime(row.created_at) }}</div>
+                  <span
+                    class="dashboard__dir-badge"
+                    :class="row.action_type === 'entry' ? 'dashboard__dir-badge--in' : 'dashboard__dir-badge--out'"
+                  >
+                    {{ row.action_type === 'entry' ? 'Въезд' : 'Выезд' }}
+                  </span>
                 </div>
               </div>
-              <div class="dashboard__feed-right">
-                <div class="dashboard__feed-date">{{ formatDate(row.created_at) }}</div>
-                <div class="dashboard__feed-time">{{ formatTime(row.created_at) }}</div>
-                <span
-                  class="dashboard__dir-badge"
-                  :class="row.action_type === 'entry' ? 'dashboard__dir-badge--in' : 'dashboard__dir-badge--out'"
-                >
-                  {{ row.action_type === 'entry' ? 'Въезд' : 'Выезд' }}
-                </span>
-              </div>
-            </div>
-          </template>
+            </template>
+          </div>
         </div>
       </div>
     </div>
@@ -610,8 +655,6 @@ const dataTiles = computed(() => {
     { label: 'Обработано', value: s.processed },
     { label: 'Машин заехало', value: s.cars_entered, metric: 'car_entries_count' },
     { label: 'Людей прошло', value: s.people_entered, metric: 'people_entries_count' },
-    { label: 'Машин на территории', value: s.cars_on_territory },
-    { label: 'Людей на территории', value: s.people_on_territory },
   ];
   return defs.map((t) => {
     const comparison = t.metric ? insights.comparisons.find((c) => c.metric === t.metric) || null : null;
@@ -619,6 +662,17 @@ const dataTiles = computed(() => {
     const peak = t.metric ? insights.peak_hours.find((p) => p.metric === t.metric) || null : null;
     return { ...t, comparison, trend, peak, expandable: Boolean(comparison || trend || peak) };
   });
+});
+
+// Снимок «сейчас»: сколько машин/людей на территории прямо сейчас (territory_status=1).
+// Живёт в Мониторинге, а не в «Данные» — значение не зависит от выбранного периода,
+// поэтому смотреть его «за год» бессмысленно (фидбэк #632 п.6).
+const occupancyTiles = computed(() => {
+  const s = summary.value;
+  return [
+    { label: 'Машин на территории', value: s.cars_on_territory },
+    { label: 'Людей на территории', value: s.people_on_territory },
+  ];
 });
 
 // Развёрнутая карточка -> данные её детальных графиков. Тренд по дням берём из
@@ -681,6 +735,17 @@ function formatDate(iso) {
   // Смещение UTC+3: дату ленты считаем по МСК, иначе у ночных отметок съезжает день.
   const s = new Date(d.getTime() + 3 * 60 * 60 * 1000).toISOString();
   return `${s.substring(8, 10)}.${s.substring(5, 7)}.${s.substring(0, 4)}`;
+}
+
+// Пост (place) прохода: бэк может вернуть пусто или плейсхолдер «—». Показываем
+// явный лейбл у каждой строки, при отсутствии — заглушку, а не прячем (фидбэк #632 п.7).
+function hasPlace(row) {
+  const p = (row.place || '').trim();
+  return Boolean(p) && p !== '—';
+}
+
+function placeLabel(row) {
+  return hasPlace(row) ? row.place.trim() : 'не указан';
 }
 
 // ---- загрузка данных ----
@@ -1362,6 +1427,24 @@ onUnmounted(() => {
   overflow: hidden;
   text-overflow: ellipsis;
   margin-top: 2px;
+}
+
+/* Пост прохода — отдельной строкой, чтобы длинная организация не вытесняла его
+   через ellipsis: пост виден у каждой строки (фидбэк #632 п.7). */
+.dashboard__feed-post {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 2px;
+}
+
+.dashboard__feed-post--empty {
+  color: var(--color-text-muted);
+  font-weight: 500;
+  font-style: italic;
 }
 
 .dashboard__feed-right {

--- a/frontend/src/components/statistics/__tests__/StatisticsDashboard.spec.js
+++ b/frontend/src/components/statistics/__tests__/StatisticsDashboard.spec.js
@@ -5,12 +5,12 @@ import { nextTick } from 'vue';
 // Управляемое состояние моков: фабрика vi.mock поднимается над импортами,
 // поэтому summary/deferred выносим в hoisted.
 const { state } = vi.hoisted(() => ({
-  state: { deferred: [], onlineDeferred: [], summary: {}, insights: {}, onlinePeaks: [], insightsHang: false, summaryReject: false },
+  state: { deferred: [], onlineDeferred: [], summary: {}, insights: {}, onlinePeaks: [], passages: { people: [], cars: [] }, insightsHang: false, summaryReject: false },
 }));
 
 vi.mock('@/api/statistics.js', () => ({
   getSummary: () => (state.summaryReject ? Promise.reject(new Error('net')) : Promise.resolve(state.summary)),
-  getRecentPassages: () => Promise.resolve({ people: [], cars: [] }),
+  getRecentPassages: () => Promise.resolve(state.passages),
   getTimeline: () => new Promise((resolve) => { state.deferred.push(resolve); }),
   // insightsHang оставляет промис вечно pending — для проверки состояния загрузки.
   getInsights: () => (state.insightsHang ? new Promise(() => {}) : Promise.resolve(state.insights)),
@@ -39,6 +39,7 @@ beforeEach(() => {
   state.summary = {};
   state.insights = {};
   state.onlinePeaks = [];
+  state.passages = { people: [], cars: [] };
   state.insightsHang = false;
   state.summaryReject = false;
 });
@@ -345,6 +346,53 @@ describe('StatisticsDashboard — плитка онлайна', () => {
     const modal = wrapper.findComponent(OnlineUsersModal);
     expect(modal.props('users')).toHaveLength(1);
     expect(modal.props('users')[0].login).toBe('fresh'); // не stale от устаревшего ответа
+  });
+});
+
+describe('StatisticsDashboard — секция Мониторинг', () => {
+  it('occupancy-плитки (на территории) рендерятся в Мониторинге, а не в группе Данные', async () => {
+    state.summary = { total_applications: 5, cars_on_territory: 17, people_on_territory: 42 };
+    const wrapper = mountDashboard();
+    await flushPromises();
+
+    const monitoring = wrapper.find('.dashboard__group--monitoring');
+    expect(monitoring.exists()).toBe(true);
+    expect(monitoring.text()).toContain('Мониторинг');
+    expect(monitoring.text()).toContain('в реальном времени');
+    expect(monitoring.text()).toContain('Машин на территории');
+    expect(monitoring.text()).toContain('Людей на территории');
+    expect(monitoring.text()).toContain((17).toLocaleString('ru-RU'));
+    expect(monitoring.text()).toContain((42).toLocaleString('ru-RU'));
+
+    // Группа «Данные» (первая) больше не содержит снимок территории.
+    const dataGroup = wrapper.findAll('.dashboard__group')[0];
+    expect(dataGroup.text()).toContain('Данные');
+    expect(dataGroup.text()).not.toContain('на территории');
+  });
+
+  it('пост (place) виден явным лейблом в строке прохода, при отсутствии — заглушка', async () => {
+    state.passages = {
+      people: [
+        { subject: 'Иванов И.', organization: 'ООО Ромашка', place: 'КПП-1', created_at: '2026-06-20T10:00:00Z', action_type: 'entry' },
+        { subject: 'Петров П.', organization: 'ООО Ромашка', place: '—', created_at: '2026-06-20T10:01:00Z', action_type: 'exit' },
+        { subject: 'Сидоров С.', organization: 'ООО Ромашка', place: null, created_at: '2026-06-20T10:02:00Z', action_type: 'entry' },
+        { subject: 'Кузнецов К.', organization: 'ООО Ромашка', place: '   ', created_at: '2026-06-20T10:03:00Z', action_type: 'exit' },
+      ],
+      cars: [
+        { subject: 'А123АА', mark: 'BMW', organization: 'ООО Ромашка', place: '', created_at: '2026-06-20T10:05:00Z', action_type: 'entry' },
+      ],
+    };
+    const wrapper = mountDashboard();
+    await flushPromises();
+
+    const posts = wrapper.findAll('.dashboard__feed-post');
+    // Четыре прохода людей + один проезд машины = пять строк, у каждой явный пост.
+    expect(posts).toHaveLength(5);
+    expect(wrapper.text()).toContain('Пост: КПП-1');
+    // Плейсхолдер «—», null, пробелы и пустая строка -> заглушка «не указан».
+    const empties = posts.filter((p) => p.text().includes('не указан'));
+    expect(empties).toHaveLength(4);
+    expect(empties[0].classes()).toContain('dashboard__feed-post--empty');
   });
 });
 


### PR DESCRIPTION
Срез P4 эпика 37-analytics-v2. Фидбэк владельца #632 п.6, п.7.

## Что и зачем
- Снимок «Машин/Людей на территории» лежал в period-группе «Данные», из-за чего смотреть его «за год» не имело смысла (п.6). Вынес occupancy в отдельную realtime-секцию **«Мониторинг»** (чип «в реальном времени · сейчас») вместе с живыми лентами проходов/проездов. «Данные» остались только с period-метриками (Получено заявок / Обработано / Машин заехало / Людей прошло).
- Пост (place) прохода теперь виден явным лейблом «Пост: …» у каждой строки; при пустом значении или плейсхолдере «—» — заглушка «не указан», колонка не пропадает (п.7).

## Решение «таб vs секция»
Владелец выбрал **секцию внутри Дашборда** (не отдельный таб): всё на одном экране, период влияет только на «Данные». Зафиксировано в context.md эпика.

## Объём
FE-only, BE не трогали (occupancy берётся из существующего `summary`, посты — из `recent-passages`). Off-limits не задеты.

## Проверки
- vitest `StatisticsDashboard.spec.js` — 24 теста зелёные (+2 новых: occupancy в Мониторинге и не в «Данные»; пост виден с заглушкой для null/«—»/пробелов/пустой строки).
- eslint изменённых файлов — 0 errors.
- `code-reviewer` — go, блокеров нет; две suggestion по edge-cases тестов закрыты.
- Скрин до мержа снят локально (vite из worktree). Локальный backend устаревший и не отдаёт свежие `/statistics/*` (404), поэтому данные дашборда в скрине замоканы реалистичной формой — рендер именно этого кода. Боевая проверка с реальными данными — ship-check на staging после деплоя.