### PR TITLE
feat(permissions): базовая роль юзерам без роли (Фаза 2, бэкфилл)

### DIFF
--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -559,6 +559,33 @@ func seedBaseRole(db *gorm.DB) error {
 	return nil
 }
 
+// BackfillBaseRole назначает базовую роль "Пользователь" существующим обычным
+// пользователям без роли (role_id IS NULL, не супер-админ). После #187 (Фаза 2)
+// навигация и доступ гейтятся правами, а права обычного юзера приходят от роли:
+// без роли резолвер отдаёт пустой набор, и юзер увидел бы пустое меню. Супер-админа
+// не трогаем (его доступ - allowAll по флагу, роль не нужна). Идемпотентно - берёт
+// только role_id IS NULL.
+func BackfillBaseRole(db *gorm.DB) error {
+	var role models.Role
+	if err := db.Where("code = ? AND is_system = ?", "user", true).First(&role).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil // базовая роль ещё не засеяна - нечего назначать
+		}
+		return fmt.Errorf("load base role for backfill: %w", err)
+	}
+	res := db.Exec(`
+		UPDATE users SET role_id = ?
+		WHERE role_id IS NULL AND is_super_admin = false`, role.ID)
+	if res.Error != nil {
+		return fmt.Errorf("backfill base role: %w", res.Error)
+	}
+	if res.RowsAffected > 0 {
+		slog.Info("backfilled base role for users without role",
+			"users_updated", res.RowsAffected, "role_id", role.ID)
+	}
+	return nil
+}
+
 // backfillAdminFromType разово переносит админство с типа на флаг: пользователи
 // типа "manager" (кроме супер-админа) становятся is_admin=true. После этого
 // авторизация идёт по флагу, а не по user_type (см. эпик прав). Идемпотентно.
@@ -712,6 +739,12 @@ func Seed(db *gorm.DB) error {
 
 	// Разовый перенос админства с типа manager на флаг is_admin.
 	if err := backfillAdminFromType(db); err != nil {
+		return err
+	}
+
+	// Обычным юзерам без роли выдаём базовую "Пользователь" (#187 Фаза 2): без роли
+	// резолвер отдаёт пустые права, и гейтинг навигации скрыл бы все вкладки.
+	if err := BackfillBaseRole(db); err != nil {
 		return err
 	}
 

--- a/internal/handlers/base_role_backfill_test.go
+++ b/internal/handlers/base_role_backfill_test.go
@@ -1,0 +1,47 @@
+package handlers_test
+
+import (
+	"errors"
+	"testing"
+
+	"systemburo/internal/database"
+	"systemburo/internal/models"
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// TestBackfillBaseRole_AssignsToRolelessNormalUsers: миграция выдаёт базовую роль
+// обычным пользователям без роли (role_id IS NULL), супер-админа не трогает.
+// В транзакции с откатом - глобальный UPDATE не персистится (урок #706).
+func TestBackfillBaseRole_AssignsToRolelessNormalUsers(t *testing.T) {
+	_, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+
+	rollback := errors.New("rollback")
+	err := db.Transaction(func(tx *gorm.DB) error {
+		var baseRole models.Role
+		require.NoError(t, tx.Where("code = ?", "user").First(&baseRole).Error)
+
+		normal := models.User{Username: uniq("norole-normal"), TypeID: 1}
+		super := models.User{Username: uniq("norole-super"), TypeID: 6, IsSuperAdmin: true}
+		require.NoError(t, tx.Create(&normal).Error)
+		require.NoError(t, tx.Create(&super).Error)
+		require.Nil(t, normal.RoleID, "предусловие: обычный юзер без роли")
+
+		require.NoError(t, database.BackfillBaseRole(tx))
+
+		var gotNormal, gotSuper models.User
+		require.NoError(t, tx.First(&gotNormal, normal.ID).Error)
+		require.NoError(t, tx.First(&gotSuper, super.ID).Error)
+
+		require.NotNil(t, gotNormal.RoleID, "обычному юзеру без роли назначена базовая роль")
+		assert.Equal(t, baseRole.ID, *gotNormal.RoleID)
+		assert.Nil(t, gotSuper.RoleID, "супер-админа бэкфилл не трогает")
+
+		return rollback
+	})
+	require.ErrorIs(t, err, rollback)
+}


### PR DESCRIPTION
## Зачем
После перевода навигации/доступа на права (Фаза 2) права обычного юзера приходят от роли. У легаси-юзеров `role_id` пустой -> резолвер отдаёт пустой набор -> при гейтинге навигации они увидят **пустое меню**.

## Что
`BackfillBaseRole` (`internal/database/migrate.go`): обычным юзерам без роли (`role_id IS NULL AND is_super_admin = false`) выставляет базовую роль «Пользователь». Идемпотентно, супер-админа не трогает (его доступ - allowAll по флагу). Вызывается в `Seed` после `seedBaseRole`.

Это **обязательный предшественник** fe-navmenu-гейтинга базовых вкладок: мержить и задеплоить ПЕРВЫМ, иначе легаси-юзеры потеряют пункты меню.

## Тест
`TestBackfillBaseRole_AssignsToRolelessNormalUsers` (internal/handlers, tx-с-откатом): обычному юзеру без роли назначается базовая, супер-админ не тронут.

## Off-limits
`migrate.go` - мерж по твоему OK.