### PR TITLE
fix(analytics): выровнял итоговую таблицу отчётов и стабилизировал кнопку Excel (#632)

### DIFF
--- a/frontend/src/components/statistics/ReportResult.vue
+++ b/frontend/src/components/statistics/ReportResult.vue
@@ -192,6 +192,7 @@
               <th
                 v-for="col in (result.columns || [])"
                 :key="col.key"
+                :class="{ 'rr__num': isNumCol(col) }"
               >
                 {{ col.label }}
               </th>
@@ -205,6 +206,7 @@
               <td
                 v-for="col in (result.columns || [])"
                 :key="col.key"
+                :class="{ 'rr__num': isNumCol(col) }"
               >
                 {{ formatCell(row[col.key], col.type) }}
               </td>
@@ -284,6 +286,33 @@ const showTotals = computed(() => props.result?.dimension !== 'none');
 const isPeriod = computed(() => props.result?.dimension === 'period');
 
 const dimensionHeader = computed(() => (props.result?.dimension === 'none' ? 'Итог' : 'Значение разреза'));
+
+// Числовые колонки list-таблицы выравниваем вправо (tabular-nums). Тип берём от
+// JSON-значения API (number), а не из col.type (бэк типизирует только date/time)
+// и не из содержимого regex'ом: счётчики (attachments_count, people_count) приходят
+// числами, идентификаторы (номер заявки) — строками и остаются слева. Выравнивание
+// не трансформирует значение, поэтому проверка по typeof здесь безопасна.
+const numericListColumns = computed(() => {
+  const r = props.result;
+  if (r?.mode === 'aggregate' || !Array.isArray(r?.rows) || !r.rows.length) return new Set();
+  const set = new Set();
+  for (const col of (r.columns || [])) {
+    let sawValue = false;
+    let allNumeric = true;
+    for (const row of r.rows) {
+      const v = row[col.key];
+      if (v === null || v === undefined || v === '') continue;
+      sawValue = true;
+      if (typeof v !== 'number') { allNumeric = false; break; }
+    }
+    if (sawValue && allNumeric) set.add(col.key);
+  }
+  return set;
+});
+
+function isNumCol(col) {
+  return numericListColumns.value.has(col.key);
+}
 
 // График рисует одну серию — берём выбранную метрику-колонку.
 const chartColumn = computed(
@@ -421,9 +450,13 @@ function formatCell(value, type) {
   justify-content: flex-end;
 }
 
-/* Кнопка выгрузки (стиль из lk-button--ghost) прижата вправо в панели инструментов. */
+/* Кнопка выгрузки (стиль из lk-button--ghost) прижата вправо в панели инструментов.
+   min-width фиксирует ширину, чтобы кнопка не дёргалась при смене «Excel» <-> «Готовим…». */
 .rr__export {
   margin-left: auto;
+  min-width: 104px;
+  justify-content: center;
+  text-align: center;
 }
 
 .rr__toolbar--end .rr__export {
@@ -500,6 +533,13 @@ function formatCell(value, type) {
   padding: 10px 14px;
   white-space: nowrap;
   border-bottom: 1px solid var(--color-border);
+}
+
+/* Числовой заголовок выравниваем вправо вслед за ячейками: у `.rr__table thead th`
+   выше специфичность, чем у `.rr__num`, поэтому без явного правила заголовок
+   оставался слева, а числа справа (рассогласование). */
+.rr__table thead th.rr__num {
+  text-align: right;
 }
 
 .rr__table tbody td {

--- a/frontend/src/components/statistics/__tests__/ReportResult.spec.js
+++ b/frontend/src/components/statistics/__tests__/ReportResult.spec.js
@@ -109,6 +109,50 @@ describe('ReportResult — переключатель Таблица/Графи�
     expect(cells[2]).toBe('Ремонт 2026-06-15'); // дата в тексте не тронута
   });
 
+  it('list-режим: числовые колонки получают rr__num (right), текст/идентификаторы — нет', () => {
+    const w = mountResult({
+      mode: 'list',
+      columns: [
+        { key: 'number', label: 'Номер заявки' }, // строка-идентификатор -> текст
+        { key: 'status', label: 'Статус' }, // текст
+        { key: 'attachments_count', label: 'Вложений' }, // число -> right
+        { key: 'people_count', label: 'Кол-во людей' }, // число (включая 0) -> right
+      ],
+      rows: [
+        { number: '2026-001', status: 'Завершено', attachments_count: 3, people_count: 12 },
+        { number: '2026-002', status: 'В работе', attachments_count: 0, people_count: 5 },
+      ],
+      total: 2,
+    });
+    const headers = w.findAll('.rr__table thead th');
+    expect(headers[0].classes()).not.toContain('rr__num'); // Номер заявки — строка
+    expect(headers[1].classes()).not.toContain('rr__num'); // Статус
+    expect(headers[2].classes()).toContain('rr__num'); // Вложений (включая 0 во 2-й строке)
+    expect(headers[3].classes()).toContain('rr__num'); // Кол-во людей
+
+    expect(w.findAll('.rr__table tbody tr')[0].findAll('td')[0].classes()).not.toContain('rr__num');
+    // Ячейка со значением 0 (2-я строка, Вложений) тоже выровнена — 0 не считается пустым.
+    expect(w.findAll('.rr__table tbody tr')[1].findAll('td')[2].classes()).toContain('rr__num');
+  });
+
+  it('list-режим: колонка целиком из пустых значений не считается числовой', () => {
+    const w = mountResult({
+      mode: 'list',
+      columns: [
+        { key: 'count', label: 'Вложений' }, // все значения null/пусто -> не числовая
+        { key: 'name', label: 'Наименование' },
+      ],
+      rows: [
+        { count: null, name: 'Ремонт' },
+        { count: '', name: 'Уборка' },
+      ],
+      total: 2,
+    });
+    const headers = w.findAll('.rr__table thead th');
+    expect(headers[0].classes()).not.toContain('rr__num');
+    expect(headers[1].classes()).not.toContain('rr__num');
+  });
+
   it('aggregate: переключатель есть, по умолчанию таблица', () => {
     const w = mountResult(aggStatus);
     expect(w.find('[data-testid="rr-view-chart"]').exists()).toBe(true);


### PR DESCRIPTION
Срез P5 эпика 37-analytics-v2. Фидбэк владельца #632 п.8a (PDF-экспорт — отдельный срез P6).

## Что и зачем
- **list-таблица:** числовые колонки (Вложений, Кол-во людей) шли слева наравне с текстом. Теперь числовая колонка определяется по типу значения от API (JSON number — счётчики числа, идентификаторы вроде номера заявки остаются строками) и выравнивается вправо (`rr__num`, tabular-nums) вместе с заголовком. Date/time-форматирование не задето.
- **агрегатная таблица:** заголовки числовых колонок оставались слева, хотя числа шли справа — рассогласование. Причина: `.rr__table thead th` (специфичность выше) бил `.rr__num`. Добавлено правило `.rr__table thead th.rr__num { text-align: right }`.
- **кнопка Excel:** дёргалась при смене текста на «Готовим…». Добавлен `min-width` + центрирование.

## Объём
FE-only, один компонент `ReportResult.vue` (+ спека). BE не трогали (выравнивание по типу значения, не по содержимому — в духе урока #632 про форматирование по типу колонки; здесь это только CSS-выравнивание, значение не трансформируется).

## Проверки
- vitest `ReportResult.spec.js` — 23 теста зелёные (+2: числовые колонки получают `rr__num`, колонка целиком из пустых — нет; ячейка со значением 0 выровнена).
- eslint — 0 errors.
- `code-reviewer` — go, блокеров нет; жёлтые по тест-покрытию закрыты.
- Скрин до мержа снят локально (рендер `ReportResult` с list- и aggregate-данными, computed `text-align` сверен: числа = right, текст/дата = left, заголовки агрегата = right). Локальный backend устаревший и не отдаёт свежие `/statistics/*`, поэтому рендер на репрезентативных данных компонента; боевая проверка — ship-check на staging после деплоя.