### PR TITLE
fix(header): цвета объявления в шапке как на странице Обзор

### DIFF
--- a/frontend/src/components/TheHeader/TheHeader.vue
+++ b/frontend/src/components/TheHeader/TheHeader.vue
@@ -357,12 +357,12 @@ h3 {
   padding: 0 15px;
   height: 35px;
   font-size: 14px;
-  color: #9A3412;
-  border: 1px solid #FFE0B2;
+  color: #856404;
+  border: 1px solid #fff3cd;
   outline: none;
   border-radius: 50px;
   font-weight: 500;
-  background: #FFE0B2;
+  background: #fff3cd;
   cursor: pointer;
   white-space: nowrap;
   transition: filter 0.2s ease;
@@ -373,20 +373,13 @@ h3 {
 }
 
 .broadcast--important {
-  color: #fff;
-  background: linear-gradient(135deg, #FF6B6B 0%, #DC2626 50%, #B91C1C 100%);
-  border-color: transparent;
-  box-shadow: 0 2px 8px rgba(220, 38, 38, 0.25);
-  animation: broadcast-glow 2.4s ease-in-out infinite;
+  color: #c62828;
+  background: #ffb3b3;
+  border-color: #ffb3b3;
 }
 
 .broadcast--important:hover {
-  filter: brightness(1.05);
-}
-
-@keyframes broadcast-glow {
-  0%, 100% { box-shadow: 0 2px 8px rgba(220, 38, 38, 0.25); }
-  50% { box-shadow: 0 2px 14px rgba(220, 38, 38, 0.55); }
+  filter: brightness(0.96);
 }
 
 .time {


### PR DESCRIPTION
Задача 4: бейдж объявления в шапке привёл к палитре карточки на Обзоре и новостях. Обычное: #fff3cd/#856404 (было #FFE0B2/#9A3412). Важное: плоское #ffb3b3/#c62828 (был градиент + белый текст + glow-тень/анимация - убрал, чтобы совпадало с плоским бейджем страницы).