### PR TITLE
fix(permissions): документы сотрудника по detail.documents (Фаза 2, detail-modals)

### DIFF
--- a/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
@@ -205,8 +205,11 @@
                   </div>
                 </div>
 
-                <!-- Документы (чувствительные данные) -->
-                <div class="details-section">
+                <!-- Документы (чувствительные данные) - под правом detail.documents -->
+                <div
+                  v-if="allowedActions.documents"
+                  class="details-section"
+                >
                   <div class="section-header">
                     <h4 class="section-title">
                       Документы
@@ -450,6 +453,7 @@ import EmployeeHistoryModal from './EmployeeHistoryModal.vue';
 import AddToBlacklistModal from '@/components/admin/blacklist/AddToBlacklistModal.vue';
 import { usePermissionsStore } from '@/stores/permissions';
 import { useDeletionsStore } from '@/stores/deletions';
+import { getModalActionPermission } from '@/constants/detailModalActions';
 import { checkPersonBlacklist, createPersonBlacklist } from '@/api/blacklist';
 import ExcelJS from 'exceljs';
 
@@ -567,6 +571,26 @@ export default {
         },
         canManageBlacklist() {
             return usePermissionsStore().hasPermission('page.admin.blacklist');
+        },
+        // Доступные действия/разделы модалки по контексту (source) и правам (#187
+        // Фаза 2). Значение из карты: boolean - по контексту; строка - ключ права,
+        // резолвится через hasPermission. Сейчас гейтит раздел «Документы»
+        // (detail.documents есть в базовой роли -> владелец видит документы своих
+        // сотрудников; в корзине/списке/ЧС - скрыты).
+        allowedActions() {
+            const perms = usePermissionsStore();
+            const resolve = (action) => {
+                const v = getModalActionPermission('employee', this.source, action);
+                return typeof v === 'boolean' ? v : perms.hasPermission(v);
+            };
+            return {
+                history: resolve('history'),
+                openApplication: resolve('openApplication'),
+                blacklist: resolve('blacklist'),
+                entryExit: resolve('entryExit'),
+                documents: resolve('documents'),
+                passHistory: resolve('passHistory'),
+            };
         },
         personLast() {
             return (this.employee?.last_name || '').trim();

--- a/frontend/src/components/CreateApplication/__tests__/EmployeeDetailsModalDocumentsGate.spec.js
+++ b/frontend/src/components/CreateApplication/__tests__/EmployeeDetailsModalDocumentsGate.spec.js
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { setActivePinia, createPinia } from 'pinia';
+
+import EmployeeDetailsModal from '../EmployeeDetailsModal.vue';
+import { usePermissionsStore } from '@/stores/permissions';
+
+// Раздел «Документы» (паспорт/патент) гейтится правом detail.documents по карте
+// detailModalActions (#187 Фаза 2). Вспомогательные API на show=true глушим.
+vi.mock('@/api/client', () => ({ apiRequest: vi.fn().mockResolvedValue({ ok: false }) }));
+vi.mock('@/api/blacklist', () => ({
+  checkPersonBlacklist: vi.fn().mockResolvedValue({ is_blacklisted: false }),
+  createPersonBlacklist: vi.fn().mockResolvedValue({}),
+}));
+vi.mock('exceljs', () => ({ default: {} }));
+
+const stubs = { teleport: true, EmployeeHistoryModal: true, TableInfoModal: true, AddToBlacklistModal: true };
+
+const PASSPORT_LABEL = 'Серия и номер паспорта';
+
+function mountEmployee(source, setupStore) {
+  setActivePinia(createPinia());
+  setupStore(usePermissionsStore());
+  return mount(EmployeeDetailsModal, {
+    props: {
+      show: true,
+      employee: { id: 1, last_name: 'Иваноф', first_name: 'Иван', passport_series_number: '1234 567890', target_tables: [] },
+      source,
+    },
+    global: { stubs },
+  });
+}
+
+describe('EmployeeDetailsModal - гейтинг раздела Документы (#187 Фаза 2)', () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  it('обычный юзер с detail.documents видит документы своего сотрудника', () => {
+    const w = mountEmployee('employeesview', (s) => {
+      s.mode = 'normal';
+      s.effective = { 'detail.documents': { value: 'allow', source: 'role' } };
+    });
+    expect(w.text()).toContain(PASSPORT_LABEL);
+  });
+
+  it('без права detail.documents раздел скрыт', () => {
+    const w = mountEmployee('employeesview', (s) => {
+      s.mode = 'normal';
+      s.effective = {};
+    });
+    expect(w.text()).not.toContain(PASSPORT_LABEL);
+  });
+
+  it('super-admin видит документы', () => {
+    const w = mountEmployee('employeesview', (s) => { s.mode = 'super'; });
+    expect(w.text()).toContain(PASSPORT_LABEL);
+  });
+
+  it('в корзине документы скрыты по контексту даже у super', () => {
+    const w = mountEmployee('trash', (s) => { s.mode = 'super'; });
+    expect(w.text()).not.toContain(PASSPORT_LABEL);
+  });
+});

--- a/frontend/src/constants/detailModalActions.js
+++ b/frontend/src/constants/detailModalActions.js
@@ -64,8 +64,9 @@ export const VEHICLE_MODAL_ACTIONS = {
     openApplication: false,
     blacklist:       'page.admin.blacklist',
     entryExit:       'entity.cars.read',
-    // Документы в контексте таблиц/центра скрыты у всех кроме админа/супера
-    documents:       'page.admin',
+    // Документы доступны по detail.documents (есть в базовой роли) - владелец видит
+    // документы своих машин; админ/супер - всегда.
+    documents:       'detail.documents',
     passHistory:     'entity.cars.read',
   },
   trash: {
@@ -91,7 +92,7 @@ export const VEHICLE_MODAL_ACTIONS = {
     openApplication: true,
     blacklist:       'page.admin.blacklist',
     entryExit:       'entity.cars.read',
-    documents:       'page.admin',
+    documents:       'detail.documents',
     passHistory:     'entity.cars.read',
   },
 }
@@ -107,8 +108,9 @@ export const EMPLOYEE_MODAL_ACTIONS = {
     openApplication: false,
     blacklist:       'page.admin.blacklist',
     entryExit:       'entity.employees.read',
-    // Документы в контексте заявки скрыты у обычных пользователей
-    documents:       'page.admin',
+    // Документы доступны по detail.documents (есть в базовой роли): обычный юзер
+    // видит документы своих сотрудников в заявке; админ/супер - всегда.
+    documents:       'detail.documents',
     passHistory:     false,
   },
   employeesview: {
@@ -117,7 +119,7 @@ export const EMPLOYEE_MODAL_ACTIONS = {
     openApplication: true,
     blacklist:       'page.admin.blacklist',
     entryExit:       'entity.employees.read',
-    documents:       'page.admin',
+    documents:       'detail.documents',
     passHistory:     'entity.employees.read',
   },
   employeeslist: {
@@ -136,7 +138,7 @@ export const EMPLOYEE_MODAL_ACTIONS = {
     openApplication: true,
     blacklist:       'page.admin.blacklist',
     entryExit:       'entity.employees.read',
-    documents:       'page.admin',
+    documents:       'detail.documents',
     passHistory:     false,
   },
   trash: {
@@ -160,7 +162,7 @@ export const EMPLOYEE_MODAL_ACTIONS = {
     openApplication: true,
     blacklist:       'page.admin.blacklist',
     entryExit:       'entity.employees.read',
-    documents:       'page.admin',
+    documents:       'detail.documents',
     passHistory:     'entity.employees.read',
   },
 }


### PR DESCRIPTION
## Что
Раздел «Документы» (паспорт/патент) в `EmployeeDetailsModal` показывался **всем без гейта**, а карта `detailModalActions` держала `documents=page.admin` (при подключении скрыло бы документы у обычных юзеров).

- Карта: `documents` -> `detail.documents` (есть в базовой роли). Владелец видит документы своих сотрудников/машин; админ/супер - всегда.
- `EmployeeDetailsModal`: подключил карту через computed `allowedActions`, гейтнул раздел «Документы» по `allowedActions.documents`.

## Поведение
| Контекст | Документы |
|---|---|
| Сотрудники / в заявке / общий | по `detail.documents` (обычный юзер своих видит) |
| Корзина / список-пикер при создании заявки / ЧС | скрыты по контексту (PD-безопасность) - **раньше показывались** |

VehicleDetailsModal раздела документов не имеет - там действия (ЧС/история/въезд-выезд) остаются на текущих рабочих гейтах.

## Тест
`EmployeeDetailsModalDocumentsGate.spec.js` (4 кейса): с правом видно, без - скрыто, super видит, в корзине скрыто по контексту. Существующая spec модалок зелёная.