### PR TITLE
fix(modals): Escape для глобальных и confirm-модалок (аудит, батч 1)

### DIFF
--- a/frontend/src/components/AnnouncementModal.vue
+++ b/frontend/src/components/AnnouncementModal.vue
@@ -79,6 +79,15 @@ export default {
       this.$emit('update:show', false);
       this.$emit('close');
     }
+  },
+  mounted() {
+    this.escHandler = (e) => {
+      if (e.key === 'Escape' && this.show) this.close();
+    };
+    document.addEventListener('keydown', this.escHandler);
+  },
+  beforeUnmount() {
+    document.removeEventListener('keydown', this.escHandler);
   }
 }
 </script>

--- a/frontend/src/components/ConfirmDialog.vue
+++ b/frontend/src/components/ConfirmDialog.vue
@@ -53,6 +53,7 @@
 <script>
 import { computed } from 'vue';
 import { useUiStore } from '@/stores/ui';
+import { useEscapeClose } from '@/composables/useEscapeClose';
 
 export default {
   name: 'ConfirmDialog',
@@ -66,6 +67,8 @@ export default {
     function cancel() {
       ui.resolveConfirm(false);
     }
+
+    useEscapeClose(cancel, () => !!state.value);
 
     return { state, confirm, cancel };
   },

--- a/frontend/src/components/ConfirmationModal.vue
+++ b/frontend/src/components/ConfirmationModal.vue
@@ -77,6 +77,15 @@ export default {
         handleCancel() {
             this.$emit('cancel');
         }
+    },
+    mounted() {
+        this.escHandler = (e) => {
+            if (e.key === 'Escape' && this.show) this.handleCancel();
+        };
+        document.addEventListener('keydown', this.escHandler);
+    },
+    beforeUnmount() {
+        document.removeEventListener('keydown', this.escHandler);
     }
 }
 </script>

--- a/frontend/src/components/DirtyConfirmModal.vue
+++ b/frontend/src/components/DirtyConfirmModal.vue
@@ -108,6 +108,15 @@ export default {
       }
     },
   },
+  mounted() {
+    this.escHandler = (e) => {
+      if (e.key === 'Escape' && this.confirmState.show) this.onCancel();
+    };
+    document.addEventListener('keydown', this.escHandler);
+  },
+  beforeUnmount() {
+    document.removeEventListener('keydown', this.escHandler);
+  },
 };
 </script>
 

--- a/frontend/src/composables/useEscapeClose.js
+++ b/frontend/src/composables/useEscapeClose.js
@@ -1,0 +1,24 @@
+import { onMounted, onBeforeUnmount, unref } from 'vue';
+
+/**
+ * Закрытие модалки по Escape. Вешает один keydown-листенер на document,
+ * снимает при размонтировании.
+ *
+ * @param {(e: KeyboardEvent) => void} onEscape - что вызвать на Escape (close/cancel)
+ * @param {undefined | (() => boolean) | import('vue').Ref<boolean>} isActive -
+ *   необязательный guard для всегда-смонтированных модалок (store-driven, visible-prop):
+ *   Escape сработает только когда isActive истинно. Для модалок, монтируемых по v-if
+ *   (присутствуют в DOM только когда открыты), guard не нужен - не передавай.
+ */
+export function useEscapeClose(onEscape, isActive) {
+    const handler = (e) => {
+        if (e.key !== 'Escape') return;
+        if (isActive !== undefined) {
+            const active = typeof isActive === 'function' ? isActive() : unref(isActive);
+            if (!active) return;
+        }
+        onEscape(e);
+    };
+    onMounted(() => document.addEventListener('keydown', handler));
+    onBeforeUnmount(() => document.removeEventListener('keydown', handler));
+}


### PR DESCRIPTION
Задача 2 (аудит модалок), батч 1: closeOnEscape там, где его не было.
- Новый composable `useEscapeClose` (опц. guard isActive для всегда-смонтированных модалок).
- ESC добавлен: ConfirmDialog, DirtyConfirmModal (глобальные), AnnouncementModal, ConfirmationModal. Анимация откр/закр и оверлей-клик у них уже были.

Следующие батчи: detail-модалки (Vehicle/Employee) ESC; биндинг-модалки (Cars/Employee/Universal) - добавить анимацию; history-модалки без анимации (ApplicationHistory, BlacklistHistoryModalBase); admin-модалки (PermissionTree, AdminRoles, RolesGroupsPanel, UserAccess). Орфаны (SessionExpiredModal, CarDetailsModal/ViewModal) - кандидаты на удаление, не на починку.