### PR TITLE
fix(permissions): закрыл all_system от не-админов, FE+BE (Фаза 2)

### DIFF
--- a/frontend/src/views/CarsView.vue
+++ b/frontend/src/views/CarsView.vue
@@ -56,6 +56,7 @@
             Мои машины
           </button>
           <button
+            v-if="canSeeAllSystem"
             class="filter-tab"
             data-testid="filter-tab-all-system"
             :class="{ 'filter-tab--active': currentFilter === 'all_system' }"
@@ -626,6 +627,7 @@
 import { apiRequest } from '@/api/client'
 import { buildSearchVariants, matchesSearch } from '@/utils/searchVariants'
 import { useDeletionsStore } from '@/stores/deletions';
+import { usePermissionsStore } from '@/stores/permissions';
 import SearchComponent from '@/components/SearchComponent.vue';
 import RefreshButton from '@/components/RefreshButton.vue';
 import LoaderSpinner from '@/components/ui/LoaderSpinner.vue';
@@ -699,6 +701,11 @@ export default {
         };
     },
     computed: {
+        // Вкладка «Все машины системы» (all_system) - только super/админ
+        // (page.admin). Бэк дополнительно отдаёт 403 на all_system без прав.
+        canSeeAllSystem() {
+            return usePermissionsStore().hasPermission('page.admin');
+        },
         filteredCars() {
             const variants = buildSearchVariants(this.searchQuery);
             if (!variants.length) {

--- a/frontend/src/views/EmployeeView.vue
+++ b/frontend/src/views/EmployeeView.vue
@@ -56,6 +56,7 @@
             Мои сотрудники
           </button>
           <button
+            v-if="canSeeAllSystem"
             class="filter-tab"
             data-testid="filter-tab-all-system"
             :class="{ 'filter-tab--active': currentFilter === 'all_system' }"
@@ -393,6 +394,7 @@ import { apiRequest } from '@/api/client'
 import { buildSearchVariants, matchesSearch } from '@/utils/searchVariants'
 import { useDeletionsStore } from '@/stores/deletions';
 import { useUiStore } from '@/stores/ui';
+import { usePermissionsStore } from '@/stores/permissions';
 import SearchComponent from '@/components/SearchComponent.vue';
 import RefreshButton from '@/components/RefreshButton.vue';
 import LoaderSpinner from '@/components/ui/LoaderSpinner.vue';
@@ -433,6 +435,11 @@ export default {
         };
     },
     computed: {
+        // Вкладка «Все сотрудники системы» (all_system) - только super/админ
+        // (page.admin). Бэк дополнительно отдаёт 403 на all_system без прав.
+        canSeeAllSystem() {
+            return usePermissionsStore().hasPermission('page.admin');
+        },
         filteredEmployees() {
             const variants = buildSearchVariants(this.searchQuery);
             if (!variants.length) {

--- a/internal/handlers/all_system_authz_test.go
+++ b/internal/handlers/all_system_authz_test.go
@@ -1,0 +1,51 @@
+package handlers_test
+
+import (
+	"net/http"
+	"testing"
+
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAllSystem_ForbiddenForNonAdmin: системный срез (filter_type=all_system)
+// закрыт для обычного юзера (не super, не admin) -> 403, а свой scope доступен.
+// Закрывает broken access control: раньше all_system шёл без фильтра для всех.
+func TestAllSystem_ForbiddenForNonAdmin(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	testutil.RegisterUser(t, e, "plainuser", "password123", 1, td.OrgID, td.CompanyID)
+	token, _ := testutil.LoginUser(t, e, "plainuser", "password123")
+	h := testutil.AuthHeader(token)
+
+	for _, path := range []string{"/unique-cars", "/unique-employees"} {
+		rec := testutil.GET(t, e, path+"?filter_type=all_system", h)
+		assert.Equal(t, http.StatusForbidden, rec.Code, "%s all_system без прав -> 403: %s", path, rec.Body.String())
+
+		rec = testutil.GET(t, e, path+"?filter_type=user", h)
+		assert.Equal(t, http.StatusOK, rec.Code, "%s свой scope -> 200: %s", path, rec.Body.String())
+	}
+}
+
+// TestAllSystem_AllowedForAdminFlag: администратор (is_admin) видит системный срез.
+func TestAllSystem_AllowedForAdminFlag(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	testutil.RegisterUser(t, e, "adminflag", "password123", 1, td.OrgID, td.CompanyID)
+	require.NoError(t, db.Table("users").Where("username = ?", "adminflag").Update("is_admin", true).Error)
+	token, _ := testutil.LoginUser(t, e, "adminflag", "password123")
+	h := testutil.AuthHeader(token)
+
+	for _, path := range []string{"/unique-cars", "/unique-employees"} {
+		rec := testutil.GET(t, e, path+"?filter_type=all_system", h)
+		assert.Equal(t, http.StatusOK, rec.Code, "%s all_system у админа -> 200: %s", path, rec.Body.String())
+	}
+}

--- a/internal/services/unique_car_service.go
+++ b/internal/services/unique_car_service.go
@@ -223,10 +223,31 @@ func (s *uniqueCarService) LookupByNumberMark(ctx context.Context, number, mark 
 }
 
 // GetAll возвращает список уникальных автомобилей с фильтрацией по типу владельца.
+// userCanSeeAllSystem сообщает, вправе ли пользователь смотреть системный срез
+// (filter_type=all_system - все записи системы без фильтра): super-admin или
+// администратор (is_admin). Остальным запрещено - иначе любой авторизованный юзер
+// вытащил бы все машины/сотрудников системы (broken access control).
+func userCanSeeAllSystem(ctx context.Context, db *gorm.DB, userID int) bool {
+	var u struct {
+		IsSuperAdmin bool
+		IsAdmin      bool
+	}
+	if err := db.WithContext(ctx).Table("users").
+		Select("is_super_admin, is_admin").
+		Where("id = ?", userID).Scan(&u).Error; err != nil {
+		return false
+	}
+	return u.IsSuperAdmin || u.IsAdmin
+}
+
 func (s *uniqueCarService) GetAll(ctx context.Context, username string, filterType string) ([]UniqueCarWithRelations, error) {
 	ownerInfo, err := s.getCarOwnerInfo(ctx, username)
 	if err != nil {
 		return nil, err
+	}
+
+	if filterType == "all_system" && !userCanSeeAllSystem(ctx, s.db, ownerInfo.UserID) {
+		return nil, echo.NewHTTPError(http.StatusForbidden, "Недостаточно прав для просмотра всех записей системы")
 	}
 
 	query := s.db.WithContext(ctx).

--- a/internal/services/unique_employee_service.go
+++ b/internal/services/unique_employee_service.go
@@ -249,6 +249,10 @@ func (s *uniqueEmployeeService) GetAll(ctx context.Context, username string, fil
 		return nil, err
 	}
 
+	if filterType == "all_system" && !userCanSeeAllSystem(ctx, s.db, ownerInfo.UserID) {
+		return nil, echo.NewHTTPError(http.StatusForbidden, "Недостаточно прав для просмотра всех записей системы")
+	}
+
 	query := s.db.WithContext(ctx).
 		Table("unique_employees ue").
 		Select(`ue.id, ue.last_name, ue.first_name, ue.middle_name,


### PR DESCRIPTION
## Дыра безопасности
`filter_type=all_system` в `unique_car_service` и `unique_employee_service` шёл `// Без фильтрации` — **любой авторизованный юзер через API вытаскивал ВСЕ машины/сотрудников системы** (broken access control). Вкладка «Все ... системы» в UI тоже была видна всем.

## Фикс
- **BE:** `userCanSeeAllSystem` — `all_system` пускается только super-админу и администратору (`is_admin`), остальным `403`. Свой scope (`user`/`organization`/`company`) у обычных юзеров не меняется.
- **FE:** вкладка «Все сотрудники/машины системы» гейтится по `can('page.admin')` в CarsView/EmployeeView (дефолт фильтра `user` — обычный юзер на all_system не попадёт).

Решение «super + админы» — по твоему выбору.

## Тесты
`all_system_authz_test.go`: обычный юзер -> 403 (cars + employees), свой scope -> 200; администратор (is_admin) -> 200. Существующий super-кейс зелёный.

## Это первый под-срез fe-views (безопасность)
Остаток fe-views отдельными PR: NewsAndReview (вкладки руководства + Управление), кнопки шапки, таблицы (Корзина/Экспорт/История/Удалить).