### PR TITLE
fix(account): колонки списка заявок выровнены заголовок-к-данным

### DIFF
--- a/frontend/src/components/UserApplications.vue
+++ b/frontend/src/components/UserApplications.vue
@@ -826,7 +826,6 @@ export default {
   transition: .2s;
   cursor: pointer;
   user-select: none;
-  flex: 1;
   padding: 0 16px;
   overflow: hidden;
   white-space: nowrap;
@@ -1108,6 +1107,8 @@ export default {
   min-height: 40px;
 }
 
+/* flex НЕ задаём здесь: ширину колонок задают пер-колоночные правила (.id-col и т.д.),
+   общие для .header-col и .application-col - иначе данные и заголовки разъезжаются. */
 .application-col {
   padding: 0 16px;
   text-align: left;
@@ -1115,14 +1116,9 @@ export default {
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 14px;
-  flex: 1;
   align-items: center;
   display: flex;
   height: 100%;
-}
-
-.application-col:first-child {
-  padding-left: 16px;
 }
 
 .application-id {


### PR DESCRIPTION
Личный кабинет -> список заявок: заголовки и данные столбцов были по разной ширине (не по линеечке).

Причина: `.application-col { flex: 1 }` объявлен ПОСЛЕ пер-колоночных правил (.id-col и т.д.) -> для данных перебивал их (все колонки flex 1), а у заголовков (.header-col объявлен ДО пер-колоночных) выигрывали пер-колоночные (1.2/1.3/1.4...). Ширины header и data не совпадали.

Фикс: убрал базовый flex у .header-col и .application-col - ширину колонок задают общие single-class пер-колоночные правила (применяются к обоим одинаково). Заголовки и данные теперь по левому краю по линеечке. Заодно убрал избыточный .application-col:first-child padding-left (дублировал 16px). eslint 0 errors.