### PR TITLE
fix(modals): анимация открытия/закрытия (аудит модалок, батч анимации)

### DIFF
--- a/frontend/src/components/ApplicationDetail/ApplicationHistory.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationHistory.vue
@@ -9,211 +9,213 @@
 
     <!-- Модальное окно истории -->
     <Teleport to="body">
-      <div
-        v-if="showModal"
-        class="history-modal-overlay"
-        @click.self="closeModal"
-      >
-        <div class="history-modal">
-          <div class="modal-header">
-            <h3>История заявки {{ applicationNumber }}</h3>
-            <div class="header-actions">
-              <button
-                class="export-btn"
-                :disabled="filteredHistory.length === 0 || isExporting"
-                @click="exportToExcel"
-              >
-                <img
-                  v-if="!isExporting"
-                  src="@/assets/icons/export.png"
-                  class="export-icon"
-                >
-                <span v-if="!isExporting">Экспорт</span>
-                <div
-                  v-else
-                  class="export-loader"
-                />
-              </button>
-              <button
-                class="close-btn"
-                @click="closeModal"
-              >
-                ×
-              </button>
-            </div>
-          </div>
-
-          <!-- Фильтры -->
-          <div class="history-filters">
-            <div class="filter-row">
-              <div class="user-filter">
-                <span class="filter-label">Пользователь:</span>
-                <div
-                  class="custom-select"
-                  @click="toggleUserDropdown"
-                >
-                  <div class="select-trigger">
-                    <span class="selected-value">{{ selectedUserName }}</span>
-                    <img 
-                      src="@/assets/icons/arrow.png" 
-                      class="select-arrow" 
-                      :class="{ 'arrow-open': userDropdownOpen }"
-                    >
-                  </div>
-                  <transition name="fade">
-                    <div
-                      v-if="userDropdownOpen"
-                      class="select-dropdown"
-                    >
-                      <div 
-                        class="select-option"
-                        :class="{ 'selected': selectedUserId === null }"
-                        @click="selectUser(null)"
-                      >
-                        Все пользователи
-                      </div>
-                      <div 
-                        v-for="user in uniqueUsers" 
-                        :key="user.id"
-                        class="select-option"
-                        :class="{ 'selected': selectedUserId === user.id }"
-                        @click="selectUser(user.id)"
-                      >
-                        {{ user.name }}
-                      </div>
-                    </div>
-                  </transition>
-                </div>
-              </div>
-                        
-              <div class="sort-filter">
-                <span class="filter-label">Сортировка:</span>
+      <transition name="modal-fade">
+        <div
+          v-if="showModal"
+          class="history-modal-overlay"
+          @click.self="closeModal"
+        >
+          <div class="history-modal">
+            <div class="modal-header">
+              <h3>История заявки {{ applicationNumber }}</h3>
+              <div class="header-actions">
                 <button
-                  class="sort-btn"
-                  @click="toggleSortOrder"
+                  class="export-btn"
+                  :disabled="filteredHistory.length === 0 || isExporting"
+                  @click="exportToExcel"
                 >
                   <img
-                    src="@/assets/icons/sort.png"
-                    class="sort-icon"
-                    :class="{ 'sort-asc': sortOrder === 'asc' }"
+                    v-if="!isExporting"
+                    src="@/assets/icons/export.png"
+                    class="export-icon"
                   >
-                  <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
+                  <span v-if="!isExporting">Экспорт</span>
+                  <div
+                    v-else
+                    class="export-loader"
+                  />
+                </button>
+                <button
+                  class="close-btn"
+                  @click="closeModal"
+                >
+                  ×
                 </button>
               </div>
             </div>
-          </div>
 
-          <div
-            ref="scrollContainer"
-            class="modal-content"
-          >
-            <div
-              v-if="loading"
-              class="history-loading"
-            >
-              <LoaderSpinner label="Загрузка истории…" />
-            </div>
-                    
-            <div
-              v-else-if="filteredHistory.length === 0"
-              class="history-empty"
-            >
-              История пуста
-            </div>
-                    
-            <div
-              v-else
-              class="history-timeline"
-            >
-              <template
-                v-for="group in historyGroupedByDate"
-                :key="group.date"
-              >
-                <div class="history-date-separator">
-                  {{ group.date }}
-                </div>
-                <div
-                  v-for="(item, i) in group.items"
-                  :key="item.id"
-                  class="history-item"
-                >
+            <!-- Фильтры -->
+            <div class="history-filters">
+              <div class="filter-row">
+                <div class="user-filter">
+                  <span class="filter-label">Пользователь:</span>
                   <div
-                    class="timeline-dot"
-                    :class="getActionClass(item.action_type)"
-                  />
-                  <div
-                    v-if="i < group.items.length - 1"
-                    class="timeline-line"
-                  />
-
-                  <div class="history-content">
-                    <div class="history-header">
-                      <!-- Для системных действий показываем "Система" -->
-                      <span
-                        v-if="item.action_type === 'confirmation_change' || item.action_type === 'status_change' || !item.user_id"
-                        class="user-name system-name"
+                    class="custom-select"
+                    @click="toggleUserDropdown"
+                  >
+                    <div class="select-trigger">
+                      <span class="selected-value">{{ selectedUserName }}</span>
+                      <img 
+                        src="@/assets/icons/arrow.png" 
+                        class="select-arrow" 
+                        :class="{ 'arrow-open': userDropdownOpen }"
                       >
-                        Система
-                      </span>
-                      <span
-                        v-else
-                        class="user-name"
-                      >{{ item.user_name }}</span>
-                      <span class="action-time">{{ formatTime(item.created_at) }}</span>
                     </div>
-
-                    <div class="action-text">
-                      {{ getActionText(item) }}
-                    </div>
-
-                    <!-- Для пересылки показываем дополнительную информацию -->
-                    <div
-                      v-if="item.action_type === 'assigned_responsible' && item.metadata?.forwarded_by"
-                      class="forward-info"
-                    >
-                      Переслано пользователем {{ item.metadata.forwarded_by }}
-                    </div>
-
-                    <!-- Для просмотра показываем дополнительную информацию -->
-                    <div
-                      v-if="item.action_type === 'assigned_viewer' && item.metadata?.forwarded_by"
-                      class="forward-info"
-                    >
-                      Переслано пользователем {{ item.metadata.forwarded_by }}
-                    </div>
-
-                    <!-- Бейдж обязательного согласования -->
-                    <div
-                      v-if="item.metadata?.required_approval"
-                      class="required-badge"
-                    >
-                      Обязательно
-                    </div>
-
-                    <!-- Статус изменения -->
-                    <div
-                      v-if="item.old_value && item.new_value && item.old_value !== item.new_value"
-                      class="status-change"
-                    >
-                      <span class="old-status">{{ item.old_value }}</span>
-                      <span class="arrow">→</span>
-                      <span class="new-status">{{ item.new_value }}</span>
-                    </div>
-
-                    <!-- Комментарий (если есть) -->
-                    <div
-                      v-if="item.comment && item.action_type !== 'revoke_approval'"
-                      class="action-comment"
-                    >
-                      {{ item.comment }}
-                    </div>
+                    <transition name="fade">
+                      <div
+                        v-if="userDropdownOpen"
+                        class="select-dropdown"
+                      >
+                        <div 
+                          class="select-option"
+                          :class="{ 'selected': selectedUserId === null }"
+                          @click="selectUser(null)"
+                        >
+                          Все пользователи
+                        </div>
+                        <div 
+                          v-for="user in uniqueUsers" 
+                          :key="user.id"
+                          class="select-option"
+                          :class="{ 'selected': selectedUserId === user.id }"
+                          @click="selectUser(user.id)"
+                        >
+                          {{ user.name }}
+                        </div>
+                      </div>
+                    </transition>
                   </div>
                 </div>
-              </template>
+                        
+                <div class="sort-filter">
+                  <span class="filter-label">Сортировка:</span>
+                  <button
+                    class="sort-btn"
+                    @click="toggleSortOrder"
+                  >
+                    <img
+                      src="@/assets/icons/sort.png"
+                      class="sort-icon"
+                      :class="{ 'sort-asc': sortOrder === 'asc' }"
+                    >
+                    <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            <div
+              ref="scrollContainer"
+              class="modal-content"
+            >
+              <div
+                v-if="loading"
+                class="history-loading"
+              >
+                <LoaderSpinner label="Загрузка истории…" />
+              </div>
+                    
+              <div
+                v-else-if="filteredHistory.length === 0"
+                class="history-empty"
+              >
+                История пуста
+              </div>
+                    
+              <div
+                v-else
+                class="history-timeline"
+              >
+                <template
+                  v-for="group in historyGroupedByDate"
+                  :key="group.date"
+                >
+                  <div class="history-date-separator">
+                    {{ group.date }}
+                  </div>
+                  <div
+                    v-for="(item, i) in group.items"
+                    :key="item.id"
+                    class="history-item"
+                  >
+                    <div
+                      class="timeline-dot"
+                      :class="getActionClass(item.action_type)"
+                    />
+                    <div
+                      v-if="i < group.items.length - 1"
+                      class="timeline-line"
+                    />
+
+                    <div class="history-content">
+                      <div class="history-header">
+                        <!-- Для системных действий показываем "Система" -->
+                        <span
+                          v-if="item.action_type === 'confirmation_change' || item.action_type === 'status_change' || !item.user_id"
+                          class="user-name system-name"
+                        >
+                          Система
+                        </span>
+                        <span
+                          v-else
+                          class="user-name"
+                        >{{ item.user_name }}</span>
+                        <span class="action-time">{{ formatTime(item.created_at) }}</span>
+                      </div>
+
+                      <div class="action-text">
+                        {{ getActionText(item) }}
+                      </div>
+
+                      <!-- Для пересылки показываем дополнительную информацию -->
+                      <div
+                        v-if="item.action_type === 'assigned_responsible' && item.metadata?.forwarded_by"
+                        class="forward-info"
+                      >
+                        Переслано пользователем {{ item.metadata.forwarded_by }}
+                      </div>
+
+                      <!-- Для просмотра показываем дополнительную информацию -->
+                      <div
+                        v-if="item.action_type === 'assigned_viewer' && item.metadata?.forwarded_by"
+                        class="forward-info"
+                      >
+                        Переслано пользователем {{ item.metadata.forwarded_by }}
+                      </div>
+
+                      <!-- Бейдж обязательного согласования -->
+                      <div
+                        v-if="item.metadata?.required_approval"
+                        class="required-badge"
+                      >
+                        Обязательно
+                      </div>
+
+                      <!-- Статус изменения -->
+                      <div
+                        v-if="item.old_value && item.new_value && item.old_value !== item.new_value"
+                        class="status-change"
+                      >
+                        <span class="old-status">{{ item.old_value }}</span>
+                        <span class="arrow">→</span>
+                        <span class="new-status">{{ item.new_value }}</span>
+                      </div>
+
+                      <!-- Комментарий (если есть) -->
+                      <div
+                        v-if="item.comment && item.action_type !== 'revoke_approval'"
+                        class="action-comment"
+                      >
+                        {{ item.comment }}
+                      </div>
+                    </div>
+                  </div>
+                </template>
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      </transition>
     </Teleport>
   </div>
 </template>
@@ -1230,5 +1232,15 @@ export default {
     .sort-btn {
         width: 100%;
     }
+}
+
+.modal-fade-enter-active,
+.modal-fade-leave-active {
+  transition: opacity 0.25s ease;
+}
+
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+  opacity: 0;
 }
 </style>

--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -225,7 +225,8 @@
             <VehicleForm
               :key="vehicleFormKey"
               ref="vehicleForm"
-              :field-config="currentFieldConfig"              :user-organization="organization"
+              :field-config="currentFieldConfig"
+              :user-organization="organization"
               :user-organization-id="organizationId"
               :user-company="company"
               :user-company-id="companyId"
@@ -254,7 +255,8 @@
             <EmployeeForm
               :key="employeeFormKey"
               ref="employeeForm"
-              :field-config="currentFieldConfig"              :user-organization="organization"
+              :field-config="currentFieldConfig"
+              :user-organization="organization"
               :user-organization-id="organizationId"
               :user-company="company"
               :user-company-id="companyId"
@@ -280,7 +282,8 @@
             <ItemsForm
               :key="itemsFormKey"
               ref="itemsForm"
-              :field-config="currentFieldConfig"              :existing-items="items"
+              :field-config="currentFieldConfig"
+              :existing-items="items"
               :show-unload-places="showItemsUnloadPlaces"
               :all-unloading-places="allUnloadingPlaces"
               :selected-unload-places="applicationUnloadPlaces"
@@ -299,7 +302,6 @@
               @delete-item="deleteItem"
             />
           </template>
-
         </div>
       </div>
             
@@ -316,7 +318,7 @@
 
     <!-- Универсальное модальное окно привязки -->
     <UniversalBindingModal
-      v-if="showBindingModal"
+      :show="showBindingModal"
       :new-vehicles-to-bind="newVehiclesToBind"
       :new-employees-to-bind="newEmployeesToBind"
       :organization="organization"

--- a/frontend/src/components/CreateApplication/UniversalBindingModal.vue
+++ b/frontend/src/components/CreateApplication/UniversalBindingModal.vue
@@ -1,208 +1,211 @@
 <template>
   <Teleport to="body">
-    <div
-      class="modal-overlay"
-      @click.self="closeModal"
-    >
-      <div class="modal-content">
-        <div class="modal-header">
-          <h3 class="modal-title">
-            Привязка новых данных
-          </h3>
-          <button
-            class="modal-close"
-            @click="closeModal"
-          >
-            <svg
-              width="10"
-              height="10"
-              viewBox="0 0 14 14"
-              fill="none"
+    <transition name="modal-fade">
+      <div
+        v-if="show"
+        class="modal-overlay"
+        @click.self="closeModal"
+      >
+        <div class="modal-content">
+          <div class="modal-header">
+            <h3 class="modal-title">
+              Привязка новых данных
+            </h3>
+            <button
+              class="modal-close"
+              @click="closeModal"
             >
-              <path
-                d="M13 1L1 13M1 1L13 13"
-                stroke="#666"
-                stroke-width="2"
-                stroke-linecap="round"
-              />
-            </svg>
-          </button>
-        </div>
-
-        <div class="modal-body">
-          <div class="binding-description">
-            Все добавленные данные будут <strong>автоматически привязаны</strong> к вашему аккаунту.
-            Вы можете дополнительно привязать их к организации и/или компании для использования <strong>другими сотрудниками</strong>:
+              <svg
+                width="10"
+                height="10"
+                viewBox="0 0 14 14"
+                fill="none"
+              >
+                <path
+                  d="M13 1L1 13M1 1L13 13"
+                  stroke="#666"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                />
+              </svg>
+            </button>
           </div>
 
-          <div
-            v-if="newVehiclesToBind.length > 0"
-            class="data-section"
-          >
-            <div class="section-header">
-              <h4 class="section-title">
-                Новые автомобили
-              </h4>
-              <span class="count-badge">{{ newVehiclesToBind.length }}</span>
+          <div class="modal-body">
+            <div class="binding-description">
+              Все добавленные данные будут <strong>автоматически привязаны</strong> к вашему аккаунту.
+              Вы можете дополнительно привязать их к организации и/или компании для использования <strong>другими сотрудниками</strong>:
             </div>
-            <div class="section-body">
-              <div class="items-list">
-                <div
-                  v-for="vehicle in newVehiclesToBind"
-                  :key="vehicle.id"
-                  class="item"
-                  :class="{ 'item-fact': isVehicleByFact(vehicle) }"
-                >
-                  <div class="item-info">
-                    <span class="item-number">{{ vehicle.plateNumber }}</span>
-                    <span class="item-detail">{{ vehicle.mark }}</span>
-                    <span
-                      v-if="isVehicleByFact(vehicle)"
-                      class="fact-badge"
-                    >По факту</span>
+
+            <div
+              v-if="newVehiclesToBind.length > 0"
+              class="data-section"
+            >
+              <div class="section-header">
+                <h4 class="section-title">
+                  Новые автомобили
+                </h4>
+                <span class="count-badge">{{ newVehiclesToBind.length }}</span>
+              </div>
+              <div class="section-body">
+                <div class="items-list">
+                  <div
+                    v-for="vehicle in newVehiclesToBind"
+                    :key="vehicle.id"
+                    class="item"
+                    :class="{ 'item-fact': isVehicleByFact(vehicle) }"
+                  >
+                    <div class="item-info">
+                      <span class="item-number">{{ vehicle.plateNumber }}</span>
+                      <span class="item-detail">{{ vehicle.mark }}</span>
+                      <span
+                        v-if="isVehicleByFact(vehicle)"
+                        class="fact-badge"
+                      >По факту</span>
+                    </div>
                   </div>
                 </div>
-              </div>
 
-              <div
-                v-if="hasVehiclesForBinding"
-                class="binding-options"
-              >
-                <p class="options-title">
-                  Привязать автомобили к:
-                </p>
-                <div class="options-group">
-                  <label
-                    v-if="hasOrganization"
-                    class="binding-option"
-                  >
-                    <input
-                      v-model="vehiclesBindToOrganization"
-                      type="checkbox"
-                    >
-                    <span>Организации "{{ organization }}"</span>
-                  </label>
-                  <label
-                    v-if="hasCompany"
-                    class="binding-option"
-                  >
-                    <input
-                      v-model="vehiclesBindToCompany"
-                      type="checkbox"
-                    >
-                    <span>Компании "{{ company }}"</span>
-                  </label>
-                </div>
-              </div>
-              <div
-                v-else
-                class="no-binding-message"
-              >
-                Автомобили "По факту" не требуют привязки к организации/компании
-              </div>
-            </div>
-          </div>
-
-          <div
-            v-if="newEmployeesToBind.length > 0"
-            class="data-section"
-          >
-            <div class="section-header">
-              <h4 class="section-title">
-                Новые сотрудники
-              </h4>
-              <span class="count-badge">{{ newEmployeesToBind.length }}</span>
-            </div>
-            <div class="section-body">
-              <div class="items-list">
                 <div
-                  v-for="employee in newEmployeesToBind"
-                  :key="employee.id"
-                  class="item"
-                  :class="{ 'item-fact': isEmployeeByFact(employee) }"
+                  v-if="hasVehiclesForBinding"
+                  class="binding-options"
                 >
-                  <div class="item-info">
-                    <span class="item-name">{{ formatFullName(employee) }}</span>
-                    <span class="item-detail">{{ employee.position }}</span>
-                    <span
-                      v-if="isEmployeeByFact(employee)"
-                      class="fact-badge"
-                    >По факту</span>
+                  <p class="options-title">
+                    Привязать автомобили к:
+                  </p>
+                  <div class="options-group">
+                    <label
+                      v-if="hasOrganization"
+                      class="binding-option"
+                    >
+                      <input
+                        v-model="vehiclesBindToOrganization"
+                        type="checkbox"
+                      >
+                      <span>Организации "{{ organization }}"</span>
+                    </label>
+                    <label
+                      v-if="hasCompany"
+                      class="binding-option"
+                    >
+                      <input
+                        v-model="vehiclesBindToCompany"
+                        type="checkbox"
+                      >
+                      <span>Компании "{{ company }}"</span>
+                    </label>
                   </div>
                 </div>
-              </div>
-
-              <div
-                v-if="hasEmployeesForBinding"
-                class="binding-options"
-              >
-                <p class="options-title">
-                  Привязать сотрудников к:
-                </p>
-                <div class="options-group">
-                  <label
-                    v-if="hasOrganization"
-                    class="binding-option"
-                  >
-                    <input
-                      v-model="employeesBindToOrganization"
-                      type="checkbox"
-                    >
-                    <span>Организации "{{ organization }}"</span>
-                  </label>
-                  <label
-                    v-if="hasCompany"
-                    class="binding-option"
-                  >
-                    <input
-                      v-model="employeesBindToCompany"
-                      type="checkbox"
-                    >
-                    <span>Компании "{{ company }}"</span>
-                  </label>
+                <div
+                  v-else
+                  class="no-binding-message"
+                >
+                  Автомобили "По факту" не требуют привязки к организации/компании
                 </div>
               </div>
-              <div
-                v-else
-                class="no-binding-message"
-              >
-                Сотрудники "По факту" не требуют привязки к организации/компании
+            </div>
+
+            <div
+              v-if="newEmployeesToBind.length > 0"
+              class="data-section"
+            >
+              <div class="section-header">
+                <h4 class="section-title">
+                  Новые сотрудники
+                </h4>
+                <span class="count-badge">{{ newEmployeesToBind.length }}</span>
+              </div>
+              <div class="section-body">
+                <div class="items-list">
+                  <div
+                    v-for="employee in newEmployeesToBind"
+                    :key="employee.id"
+                    class="item"
+                    :class="{ 'item-fact': isEmployeeByFact(employee) }"
+                  >
+                    <div class="item-info">
+                      <span class="item-name">{{ formatFullName(employee) }}</span>
+                      <span class="item-detail">{{ employee.position }}</span>
+                      <span
+                        v-if="isEmployeeByFact(employee)"
+                        class="fact-badge"
+                      >По факту</span>
+                    </div>
+                  </div>
+                </div>
+
+                <div
+                  v-if="hasEmployeesForBinding"
+                  class="binding-options"
+                >
+                  <p class="options-title">
+                    Привязать сотрудников к:
+                  </p>
+                  <div class="options-group">
+                    <label
+                      v-if="hasOrganization"
+                      class="binding-option"
+                    >
+                      <input
+                        v-model="employeesBindToOrganization"
+                        type="checkbox"
+                      >
+                      <span>Организации "{{ organization }}"</span>
+                    </label>
+                    <label
+                      v-if="hasCompany"
+                      class="binding-option"
+                    >
+                      <input
+                        v-model="employeesBindToCompany"
+                        type="checkbox"
+                      >
+                      <span>Компании "{{ company }}"</span>
+                    </label>
+                  </div>
+                </div>
+                <div
+                  v-else
+                  class="no-binding-message"
+                >
+                  Сотрудники "По факту" не требуют привязки к организации/компании
+                </div>
               </div>
             </div>
-          </div>
 
-          <div class="warning-section">
-            <p class="warning-text">
-              <strong class="warning-strong">Внимание!</strong> При привязке данных к организации или компании,
-              они будут доступны для отображения и использования <strong>всем</strong> сотрудникам, которые в них числятся.
-            </p>
-          </div>
+            <div class="warning-section">
+              <p class="warning-text">
+                <strong class="warning-strong">Внимание!</strong> При привязке данных к организации или компании,
+                они будут доступны для отображения и использования <strong>всем</strong> сотрудникам, которые в них числятся.
+              </p>
+            </div>
 
-          <div class="modal-actions">
-            <button
-              class="btn skip-btn"
-              @click="handleSkip"
-            >
-              Отправить без привязки
-            </button>
-            <button
-              class="btn confirm-btn"
-              @click="handleConfirm"
-            >
-              <transition
-                name="fade"
-                mode="out-in"
+            <div class="modal-actions">
+              <button
+                class="btn skip-btn"
+                @click="handleSkip"
               >
-                <span
-                  :key="buttonText"
-                  class="button-text"
-                >{{ buttonText }}</span>
-              </transition>
-            </button>
+                Отправить без привязки
+              </button>
+              <button
+                class="btn confirm-btn"
+                @click="handleConfirm"
+              >
+                <transition
+                  name="fade"
+                  mode="out-in"
+                >
+                  <span
+                    :key="buttonText"
+                    class="button-text"
+                  >{{ buttonText }}</span>
+                </transition>
+              </button>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </transition>
   </Teleport>
 </template>
 
@@ -210,6 +213,10 @@
 export default {
     name: 'UniversalBindingModal',
     props: {
+        show: {
+            type: Boolean,
+            default: false
+        },
         newVehiclesToBind: {
             type: Array,
             default: () => []
@@ -255,6 +262,18 @@ export default {
         },
         hasEmployeesForBinding() {
             return this.newEmployeesToBind.some(employee => !this.isEmployeeByFact(employee));
+        }
+    },
+    watch: {
+        // Модалка теперь всегда смонтирована (для leave-анимации), поэтому
+        // сбрасываем галочки при каждом открытии, как было при v-if.
+        show(visible) {
+            if (visible) {
+                this.vehiclesBindToOrganization = false;
+                this.vehiclesBindToCompany = false;
+                this.employeesBindToOrganization = false;
+                this.employeesBindToCompany = false;
+            }
         }
     },
     methods: {
@@ -686,5 +705,15 @@ export default {
         width: 100%;
         min-width: auto;
     }
+}
+
+.modal-fade-enter-active,
+.modal-fade-leave-active {
+    transition: opacity 0.25s ease;
+}
+
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+    opacity: 0;
 }
 </style>

--- a/frontend/src/components/admin/PermissionTreeModal.vue
+++ b/frontend/src/components/admin/PermissionTreeModal.vue
@@ -1,115 +1,117 @@
 <template>
   <Teleport to="body">
-    <div
-      v-if="show"
-      class="modal-overlay"
-      @click.self="$emit('close')"
-    >
+    <transition name="modal-fade">
       <div
-        class="modal-content"
-        data-testid="permission-tree-modal"
+        v-if="show"
+        class="modal-overlay"
+        @click.self="$emit('close')"
       >
-        <header class="modal-content__header">
-          <h3>{{ title }}</h3>
-          <button
-            class="close-btn"
-            data-testid="permission-tree-close"
-            @click="$emit('close')"
-          >
-            ×
-          </button>
-        </header>
-
-        <div class="modal-content__body">
-          <input
-            v-model="search"
-            type="text"
-            placeholder="Поиск по ключу или описанию..."
-            class="lk-input search-input"
-            data-testid="permission-tree-search"
-          >
-
-          <div class="tree">
-            <div
-              v-for="group in filteredGroups"
-              :key="group.prefix"
-              class="tree-group"
-              :data-testid="`permission-tree-group-${group.prefix.replace('.', '')}`"
+        <div
+          class="modal-content"
+          data-testid="permission-tree-modal"
+        >
+          <header class="modal-content__header">
+            <h3>{{ title }}</h3>
+            <button
+              class="close-btn"
+              data-testid="permission-tree-close"
+              @click="$emit('close')"
             >
-              <button
-                class="tree-group__header"
-                :class="{ 'tree-group__header--collapsed': collapsed[group.prefix] }"
-                :data-testid="`permission-tree-group-toggle-${group.prefix.replace('.', '')}`"
-                @click="toggleGroup(group.prefix)"
-              >
-                <span class="tree-group__chevron">▾</span>
-                <span class="tree-group__title">{{ group.title }}</span>
-                <span class="tree-group__count">
-                  {{ groupSelectedCount(group) }}/{{ group.keys.length }}
-                </span>
-                <span
-                  class="tree-group__toggle-all"
-                  @click.stop="toggleAllInGroup(group)"
-                >
-                  {{ allInGroupSelected(group) ? 'Снять все' : 'Выбрать все' }}
-                </span>
-              </button>
+              ×
+            </button>
+          </header>
+
+          <div class="modal-content__body">
+            <input
+              v-model="search"
+              type="text"
+              placeholder="Поиск по ключу или описанию..."
+              class="lk-input search-input"
+              data-testid="permission-tree-search"
+            >
+
+            <div class="tree">
               <div
-                v-show="!collapsed[group.prefix]"
-                class="tree-group__items"
+                v-for="group in filteredGroups"
+                :key="group.prefix"
+                class="tree-group"
+                :data-testid="`permission-tree-group-${group.prefix.replace('.', '')}`"
               >
-                <label
-                  v-for="key in group.keys"
-                  :key="key.value"
-                  class="tree-item"
-                  :class="{
-                    'tree-item--changed': hasChanged(key.value)
-                  }"
-                  :data-testid="`permission-tree-key-${key.value}`"
+                <button
+                  class="tree-group__header"
+                  :class="{ 'tree-group__header--collapsed': collapsed[group.prefix] }"
+                  :data-testid="`permission-tree-group-toggle-${group.prefix.replace('.', '')}`"
+                  @click="toggleGroup(group.prefix)"
                 >
-                  <input
-                    type="checkbox"
-                    :checked="isSelected(key.value)"
-                    @change="toggleKey(key.value)"
-                  >
-                  <span class="tree-item__key">{{ key.value }}</span>
-                  <span
-                    v-if="key.description"
-                    class="tree-item__desc"
-                  >
-                    {{ key.description }}
+                  <span class="tree-group__chevron">▾</span>
+                  <span class="tree-group__title">{{ group.title }}</span>
+                  <span class="tree-group__count">
+                    {{ groupSelectedCount(group) }}/{{ group.keys.length }}
                   </span>
-                </label>
+                  <span
+                    class="tree-group__toggle-all"
+                    @click.stop="toggleAllInGroup(group)"
+                  >
+                    {{ allInGroupSelected(group) ? 'Снять все' : 'Выбрать все' }}
+                  </span>
+                </button>
+                <div
+                  v-show="!collapsed[group.prefix]"
+                  class="tree-group__items"
+                >
+                  <label
+                    v-for="key in group.keys"
+                    :key="key.value"
+                    class="tree-item"
+                    :class="{
+                      'tree-item--changed': hasChanged(key.value)
+                    }"
+                    :data-testid="`permission-tree-key-${key.value}`"
+                  >
+                    <input
+                      type="checkbox"
+                      :checked="isSelected(key.value)"
+                      @change="toggleKey(key.value)"
+                    >
+                    <span class="tree-item__key">{{ key.value }}</span>
+                    <span
+                      v-if="key.description"
+                      class="tree-item__desc"
+                    >
+                      {{ key.description }}
+                    </span>
+                  </label>
+                </div>
               </div>
             </div>
           </div>
-        </div>
 
-        <footer class="modal-content__footer">
-          <span
-            v-if="changedCount > 0"
-            class="changed-hint"
-          >
-            Несохранённых изменений: {{ changedCount }}
-          </span>
-          <button
-            class="lk-button lk-button--ghost"
-            data-testid="permission-tree-cancel"
-            @click="$emit('close')"
-          >
-            Отмена
-          </button>
-          <button
-            class="lk-button lk-button--primary"
-            :disabled="changedCount === 0 || saving"
-            data-testid="permission-tree-save"
-            @click="save"
-          >
-            {{ saving ? 'Сохранение...' : 'Сохранить' }}
-          </button>
-        </footer>
+          <footer class="modal-content__footer">
+            <span
+              v-if="changedCount > 0"
+              class="changed-hint"
+            >
+              Несохранённых изменений: {{ changedCount }}
+            </span>
+            <button
+              class="lk-button lk-button--ghost"
+              data-testid="permission-tree-cancel"
+              @click="$emit('close')"
+            >
+              Отмена
+            </button>
+            <button
+              class="lk-button lk-button--primary"
+              :disabled="changedCount === 0 || saving"
+              data-testid="permission-tree-save"
+              @click="save"
+            >
+              {{ saving ? 'Сохранение...' : 'Сохранить' }}
+            </button>
+          </footer>
+        </div>
       </div>
-    </div>
+    </transition>
   </Teleport>
 </template>
 
@@ -425,5 +427,15 @@ export default {
   font-size: 12px;
   color: #92400e;
   margin-right: auto;
+}
+
+.modal-fade-enter-active,
+.modal-fade-leave-active {
+  transition: opacity 0.25s ease;
+}
+
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+  opacity: 0;
 }
 </style>

--- a/frontend/src/components/admin/RolesGroupsPanel.vue
+++ b/frontend/src/components/admin/RolesGroupsPanel.vue
@@ -112,42 +112,44 @@
     </footer>
 
     <Teleport to="body">
-      <div
-        v-if="mergeOpen"
-        class="modal-overlay modal-overlay--nested"
-        @click.self="mergeOpen = false"
-      >
-        <div class="merge-modal">
-          <h3>Слияние групп</h3>
-          <p class="section__hint">
-            Создаётся новая обычная группа с объединением прав. Исходные группы остаются и снова доступны.
-          </p>
-          <label class="lk-label">
-            Имя новой группы
-            <input
-              v-model="mergeName"
-              class="lk-input"
-              type="text"
-              placeholder="Например, Менеджер по работе с клиентами"
-            >
-          </label>
-          <div class="merge-modal__footer">
-            <button
-              class="lk-button lk-button--ghost"
-              @click="mergeOpen = false"
-            >
-              Отмена
-            </button>
-            <button
-              class="lk-button lk-button--primary"
-              :disabled="!mergeName.trim() || saving"
-              @click="confirmMerge"
-            >
-              Слить
-            </button>
+      <transition name="modal-fade">
+        <div
+          v-if="mergeOpen"
+          class="modal-overlay modal-overlay--nested"
+          @click.self="mergeOpen = false"
+        >
+          <div class="merge-modal">
+            <h3>Слияние групп</h3>
+            <p class="section__hint">
+              Создаётся новая обычная группа с объединением прав. Исходные группы остаются и снова доступны.
+            </p>
+            <label class="lk-label">
+              Имя новой группы
+              <input
+                v-model="mergeName"
+                class="lk-input"
+                type="text"
+                placeholder="Например, Менеджер по работе с клиентами"
+              >
+            </label>
+            <div class="merge-modal__footer">
+              <button
+                class="lk-button lk-button--ghost"
+                @click="mergeOpen = false"
+              >
+                Отмена
+              </button>
+              <button
+                class="lk-button lk-button--primary"
+                :disabled="!mergeName.trim() || saving"
+                @click="confirmMerge"
+              >
+                Слить
+              </button>
+            </div>
           </div>
         </div>
-      </div>
+      </transition>
     </Teleport>
   </div>
 </template>
@@ -477,5 +479,15 @@ export default {
   justify-content: flex-end;
   gap: 8px;
   margin-top: 8px;
+}
+
+.modal-fade-enter-active,
+.modal-fade-leave-active {
+  transition: opacity 0.25s ease;
+}
+
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+  opacity: 0;
 }
 </style>

--- a/frontend/src/views/admin/AdminRoles.vue
+++ b/frontend/src/views/admin/AdminRoles.vue
@@ -98,110 +98,114 @@
     </div>
 
     <Teleport to="body">
-      <div
-        v-if="metaOpen"
-        class="modal-overlay"
-        @click.self="metaOpen = false"
-      >
-        <div class="form-modal">
-          <h3>{{ metaMode === 'create' ? 'Новая роль' : 'Редактировать роль' }}</h3>
-          <label class="lk-label">
-            Название
-            <input
-              v-model="metaForm.name"
-              class="lk-input"
-              type="text"
-              placeholder="Арендатор"
+      <transition name="modal-fade">
+        <div
+          v-if="metaOpen"
+          class="modal-overlay"
+          @click.self="metaOpen = false"
+        >
+          <div class="form-modal">
+            <h3>{{ metaMode === 'create' ? 'Новая роль' : 'Редактировать роль' }}</h3>
+            <label class="lk-label">
+              Название
+              <input
+                v-model="metaForm.name"
+                class="lk-input"
+                type="text"
+                placeholder="Арендатор"
+              >
+            </label>
+            <label
+              v-if="metaMode === 'create'"
+              class="lk-label"
             >
-          </label>
-          <label
-            v-if="metaMode === 'create'"
-            class="lk-label"
-          >
-            Код (латиницей, неизменный)
-            <input
-              v-model="metaForm.code"
-              class="lk-input"
-              type="text"
-              placeholder="tenant"
-            >
-          </label>
-          <label class="lk-label">
-            Описание
-            <textarea
-              v-model="metaForm.description"
-              class="lk-textarea"
-              rows="2"
-            />
-          </label>
-          <div class="form-modal__footer">
-            <button
-              class="lk-button lk-button--ghost"
-              @click="metaOpen = false"
-            >
-              Отмена
-            </button>
-            <button
-              class="lk-button lk-button--primary"
-              :disabled="saving || !metaForm.name.trim() || (metaMode === 'create' && !metaForm.code.trim())"
-              @click="saveMeta"
-            >
-              {{ saving ? 'Сохранение...' : 'Сохранить' }}
-            </button>
+              Код (латиницей, неизменный)
+              <input
+                v-model="metaForm.code"
+                class="lk-input"
+                type="text"
+                placeholder="tenant"
+              >
+            </label>
+            <label class="lk-label">
+              Описание
+              <textarea
+                v-model="metaForm.description"
+                class="lk-textarea"
+                rows="2"
+              />
+            </label>
+            <div class="form-modal__footer">
+              <button
+                class="lk-button lk-button--ghost"
+                @click="metaOpen = false"
+              >
+                Отмена
+              </button>
+              <button
+                class="lk-button lk-button--primary"
+                :disabled="saving || !metaForm.name.trim() || (metaMode === 'create' && !metaForm.code.trim())"
+                @click="saveMeta"
+              >
+                {{ saving ? 'Сохранение...' : 'Сохранить' }}
+              </button>
+            </div>
           </div>
         </div>
-      </div>
+      </transition>
     </Teleport>
 
     <Teleport to="body">
-      <div
-        v-if="groupsOpen"
-        class="modal-overlay"
-        @click.self="groupsOpen = false"
-      >
-        <div class="form-modal form-modal--wide">
-          <h3>Дефолтные группы для «{{ groupsRole?.name }}»</h3>
-          <p class="form-modal__hint">
-            Юзеры с этой ролью получают права из всех выбранных групп.
-          </p>
-          <div class="groups-list">
-            <label
-              v-for="g in allGroups"
-              :key="g.id"
-              class="group-row"
-            >
-              <input
-                type="checkbox"
-                :checked="selectedGroupIds.has(g.id)"
-                @change="toggleGroupId(g.id)"
-              >
-              <span class="group-row__name">{{ g.name }}</span>
-              <span class="group-row__count">{{ g.keys.length }} прав</span>
-            </label>
-            <p
-              v-if="allGroups.length === 0"
-              class="card__empty-text"
-            >
-              Нет ни одной группы. Сначала создайте группы прав.
+      <transition name="modal-fade">
+        <div
+          v-if="groupsOpen"
+          class="modal-overlay"
+          @click.self="groupsOpen = false"
+        >
+          <div class="form-modal form-modal--wide">
+            <h3>Дефолтные группы для «{{ groupsRole?.name }}»</h3>
+            <p class="form-modal__hint">
+              Юзеры с этой ролью получают права из всех выбранных групп.
             </p>
-          </div>
-          <div class="form-modal__footer">
-            <button
-              class="lk-button lk-button--ghost"
-              @click="groupsOpen = false"
-            >
-              Отмена
-            </button>
-            <button
-              class="lk-button lk-button--primary"
-              :disabled="saving"
-              @click="saveDefaultGroups"
-            >
-              {{ saving ? 'Сохранение...' : 'Сохранить' }}
-            </button>
+            <div class="groups-list">
+              <label
+                v-for="g in allGroups"
+                :key="g.id"
+                class="group-row"
+              >
+                <input
+                  type="checkbox"
+                  :checked="selectedGroupIds.has(g.id)"
+                  @change="toggleGroupId(g.id)"
+                >
+                <span class="group-row__name">{{ g.name }}</span>
+                <span class="group-row__count">{{ g.keys.length }} прав</span>
+              </label>
+              <p
+                v-if="allGroups.length === 0"
+                class="card__empty-text"
+              >
+                Нет ни одной группы. Сначала создайте группы прав.
+              </p>
+            </div>
+            <div class="form-modal__footer">
+              <button
+                class="lk-button lk-button--ghost"
+                @click="groupsOpen = false"
+              >
+                Отмена
+              </button>
+              <button
+                class="lk-button lk-button--primary"
+                :disabled="saving"
+                @click="saveDefaultGroups"
+              >
+                {{ saving ? 'Сохранение...' : 'Сохранить' }}
+              </button>
+            </div>
           </div>
         </div>
-      </div>
+      </transition>
     </Teleport>
   </section>
 </template>
@@ -529,5 +533,15 @@ export default {
 .group-row__count {
   font-size: 11px;
   color: var(--color-text-muted);
+}
+
+.modal-fade-enter-active,
+.modal-fade-leave-active {
+  transition: opacity 0.25s ease;
+}
+
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+  opacity: 0;
 }
 </style>


### PR DESCRIPTION
Задача 2 (аудит модалок), батч анимации. Окна без плавного открытия/закрытия обёрнуты в transition (modal-fade).

### Сделано (6 модалок)
Внутренний v-if (обёрнуты в `<transition name=modal-fade>`):
- PermissionTreeModal, ApplicationHistory, RolesGroupsPanel (merge), AdminRoles (создание + дефолтные группы).

Teleport + родительский v-if (переведены на always-mount `:show` + transition; чисто реентрантны):
- UniversalBindingModal (привязка при подаче заявки) - добавлен проп `show`, watch-сброс галочек на открытие, родитель CreateApplication теперь `:show`.

eslint 0 errors (template переотступлен авто-фиксом).

### НЕ вошло (нужен аккуратный проход + визуальная проверка)
3 модалки с mount-side-effects, у которых always-mount опасен вслепую (браузерный MCP сейчас недоступен):
- **UserGuideModal** - `mounted` ставит `body.overflow=hidden` (always-mount = блокировка скролла при загрузке страницы); нужно перенести в watch(show).
- **BlacklistHistoryModalBase** - `mounted` грузит историю; перенести loadHistory в watch(show). База для Person/Vehicle-табов.
- **DownloadBlanksModal** - два родителя (UserApplications + ApplicationsCenter); проверить mount-логику.

Сделаю их отдельно с проверкой анимации глазами, когда вернётся MCP.