### PR TITLE
fix(analytics): лента проходов - переименовал «Пост» в «Место» + регресс-тест поста (#632)

### DIFF
--- a/frontend/src/components/statistics/StatisticsDashboard.vue
+++ b/frontend/src/components/statistics/StatisticsDashboard.vue
@@ -411,7 +411,7 @@
                     class="dashboard__feed-post"
                     :class="{ 'dashboard__feed-post--empty': !hasPlace(row) }"
                   >
-                    Пост: {{ placeLabel(row) }}
+                    Место: {{ placeLabel(row) }}
                   </div>
                 </div>
                 <div class="dashboard__feed-right">
@@ -469,7 +469,7 @@
                     class="dashboard__feed-post"
                     :class="{ 'dashboard__feed-post--empty': !hasPlace(row) }"
                   >
-                    Пост: {{ placeLabel(row) }}
+                    Место: {{ placeLabel(row) }}
                   </div>
                 </div>
                 <div class="dashboard__feed-right">
@@ -737,7 +737,7 @@ function formatDate(iso) {
   return `${s.substring(8, 10)}.${s.substring(5, 7)}.${s.substring(0, 4)}`;
 }
 
-// Пост (place) прохода: бэк может вернуть пусто или плейсхолдер «—». Показываем
+// Место (place) прохода: бэк может вернуть пусто или плейсхолдер «—». Показываем
 // явный лейбл у каждой строки, при отсутствии — заглушку, а не прячем (фидбэк #632 п.7).
 function hasPlace(row) {
   const p = (row.place || '').trim();
@@ -1429,8 +1429,8 @@ onUnmounted(() => {
   margin-top: 2px;
 }
 
-/* Пост прохода — отдельной строкой, чтобы длинная организация не вытесняла его
-   через ellipsis: пост виден у каждой строки (фидбэк #632 п.7). */
+/* Место прохода — отдельной строкой, чтобы длинная организация не вытесняла его
+   через ellipsis: место видно у каждой строки (фидбэк #632 п.7). */
 .dashboard__feed-post {
   font-size: 11px;
   font-weight: 600;

--- a/frontend/src/components/statistics/__tests__/StatisticsDashboard.spec.js
+++ b/frontend/src/components/statistics/__tests__/StatisticsDashboard.spec.js
@@ -388,7 +388,7 @@ describe('StatisticsDashboard — секция Мониторинг', () => {
     const posts = wrapper.findAll('.dashboard__feed-post');
     // Четыре прохода людей + один проезд машины = пять строк, у каждой явный пост.
     expect(posts).toHaveLength(5);
-    expect(wrapper.text()).toContain('Пост: КПП-1');
+    expect(wrapper.text()).toContain('Место: КПП-1');
     // Плейсхолдер «—», null, пробелы и пустая строка -> заглушка «не указан».
     const empties = posts.filter((p) => p.text().includes('не указан'));
     expect(empties).toHaveLength(4);

--- a/internal/handlers/employees_history_actions_test.go
+++ b/internal/handlers/employees_history_actions_test.go
@@ -342,3 +342,41 @@ func TestEmployeeTerritoryStatus_RecordsTableInHistory(t *testing.T) {
 	assert.Equal(t, float64(st.ID), entry["table_id"])
 	assert.Equal(t, "Test Table", entry["table_name"], "entry record should resolve table_name from system_tables")
 }
+
+// TestRecentPassages_ResolvesPostFromTableID фиксирует регрессию ленты «Проход людей»
+// на дашборде: после реальной отметки входа через /table (territory-status с table_id)
+// лента должна показывать пост (system_tables.display_name), а не пусто (фронт рисует
+// «не указан»). Источник поста - только history.table_id -> system_tables; пустой пост
+// в ленте = у записи нет table_id (как у проходов, отмеченных до фикса #703).
+func TestRecentPassages_ResolvesPostFromTableID(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "recentpasspost1", "pass123", 1, td.OrgID, td.CompanyID)
+	_, _, empID := seedEmployeeViaCompleteApp(t, e, db, token, "Test Organization")
+
+	var st models.SystemTable
+	require.NoError(t, db.Where("name = ?", "test_table").First(&st).Error)
+
+	// Реальная отметка входа через тот же endpoint, что и страница /table.
+	rec := testutil.PUT(t, e, fmt.Sprintf("/employees/%d/territory-status", empID),
+		fmt.Sprintf(`{"territory_status": 1, "table_id": %d}`, st.ID), testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	svc := services.NewStatisticsService(db, 0)
+	res, err := svc.GetRecentPassages(context.Background(), 15)
+	require.NoError(t, err)
+	require.NotEmpty(t, res.People, "лента проходов людей не должна быть пустой после отметки")
+
+	var entry *models.RecentPassage
+	for i := range res.People {
+		if res.People[i].ActionType == "entry" {
+			entry = &res.People[i]
+			break
+		}
+	}
+	require.NotNil(t, entry, "в ленте должна быть запись entry")
+	assert.Equal(t, "Test Table", entry.Place, "пост в ленте должен резолвиться из system_tables.display_name по table_id")
+}


### PR DESCRIPTION
Лента «Проход людей»/«Проезд машин» на дашборде показывала место прохода под лейблом «Пост:» - по фидбэку владельца переименовал в «Место:».

## Контекст бага «не указан»
Жалоба: в ленте «Проход людей» место писалось «не указан». Разобрал: место резолвится ТОЛЬКО из `history.table_id -> system_tables.display_name` (одинаковый join в дашборде `statistics_service.go:527,533` и в истории сотрудника `employees_history_service.go:116`), фолбэка нет. Бэк дропал присланный фронтом `table_id` до #703 (`f8e4bdd`, «вернул таблицу въезда/выезда в историю») - проходы из того окна остались с `table_id = NULL` и показывают «не указан». Текущий код пишет `table_id` безусловно, новые отметки место показывают (владелец подтвердил). Старым проходам место не нужно - бэкфилл не делаем.

## Что в PR
- FE: лейбл `Пост:` -> `Место:` в обеих лентах дашборда (`StatisticsDashboard.vue`), плюс синхронизированы комментарии и спека (`StatisticsDashboard.spec.js`).
- BE: регресс-тест `TestRecentPassages_ResolvesPostFromTableID` - после реальной отметки через `territory-status` лента дашборда отдаёт `place = display_name`. Раньше тестом покрыта была только история сотрудника, сама лента - нет; #703 пришёл без теста на неё.

## Проверка
- `go test ./internal/handlers -run "TestRecentPassages_ResolvesPostFromTableID|TestEmployeeTerritoryStatus_RecordsTableInHistory"` - зелёные.
- `vitest StatisticsDashboard.spec.js` - 24/24.
- eslint изменённых файлов - 0 errors.