### PR TITLE
fix(permissions): кнопки таблиц по правам (корзина/экспорт/история/удаление)

### DIFF
--- a/frontend/src/components/CarsTable.vue
+++ b/frontend/src/components/CarsTable.vue
@@ -21,6 +21,7 @@
         <span class="items-count">
           Машин на территории: {{ carsOnTerritory }}
           <button
+            v-if="can(`table.${tableName}.history`)"
             class="history-btn"
             @click="openCarsTableHistory"
           >
@@ -382,6 +383,7 @@
                   </button>
                 </div>
                 <div
+                  v-if="can('entity.cars.delete')"
                   class="col actions-col"
                   style="order: 9999;"
                   @click.stop
@@ -462,6 +464,7 @@
 import { apiRequest } from '@/api/client'
 import { buildSearchVariants, matchesSearch } from '@/utils/searchVariants'
 import { useDeletionsStore } from '@/stores/deletions';
+import { usePermissionsStore } from '@/stores/permissions';
 import { useOrientation } from '@/composables/useOrientation';
 import RefreshButton from './RefreshButton.vue';
 import VehicleDetailsModal from './CreateApplication/VehicleDetailsModal.vue';
@@ -485,7 +488,8 @@ export default {
   },
   setup() {
     const { isPortrait, isCompact } = useOrientation();
-    return { isPortrait, isCompact };
+    const permissionsStore = usePermissionsStore();
+    return { isPortrait, isCompact, permissionsStore };
   },
   props: {
     tableName: { type: String, default: '' },
@@ -693,6 +697,11 @@ export default {
     this.stopPolling();
   },
   methods: {
+    // Гейтинг по правам (#187 Фаза 2). super -> всегда true, admin -> всё кроме
+    // denied, обычный -> по эффективному гранту. Реактивно: читает стор прав.
+    can(key) {
+      return this.permissionsStore.hasPermission(key);
+    },
     // Основной метод загрузки данных с флагом silent (без показа лоадера)
     async _loadData(silent = false) {
       if (!silent && this.isLoading) return;

--- a/frontend/src/components/PeopleTable.vue
+++ b/frontend/src/components/PeopleTable.vue
@@ -21,6 +21,7 @@
         <span class="items-count">
           Людей зашло: {{ peopleOnTerritory }}
           <button
+            v-if="can(`table.${tableName}.history`)"
             class="history-btn"
             @click="openEmployeesHistory"
           >История</button>
@@ -415,6 +416,7 @@
                   </button>
                 </div>
                 <div
+                  v-if="can('entity.employees.delete')"
                   class="col actions-col"
                   style="order: 9999;"
                   @click.stop
@@ -486,6 +488,7 @@
 import { apiRequest } from '@/api/client';
 import { buildSearchVariants, matchesSearch } from '@/utils/searchVariants';
 import { useDeletionsStore } from '@/stores/deletions';
+import { usePermissionsStore } from '@/stores/permissions';
 import { useOrientation } from '@/composables/useOrientation';
 import RefreshButton from './RefreshButton.vue';
 import EmployeeDetailsModal from './CreateApplication/EmployeeDetailsModal.vue';
@@ -509,7 +512,8 @@ export default {
   },
   setup() {
     const { isPortrait, isCompact } = useOrientation();
-    return { isPortrait, isCompact };
+    const permissionsStore = usePermissionsStore();
+    return { isPortrait, isCompact, permissionsStore };
   },
   props: {
     tableName: {
@@ -741,6 +745,11 @@ export default {
     this.stopPolling();
   },
   methods: {
+    // Гейтинг по правам (#187 Фаза 2). super -> всегда true, admin -> всё кроме
+    // denied, обычный -> по эффективному гранту. Реактивно: читает стор прав.
+    can(key) {
+      return this.permissionsStore.hasPermission(key);
+    },
     async _loadData(silent = false) {
       if (!silent && this.isLoading) return;
       if (!silent) this.isLoading = true;

--- a/frontend/src/components/TablesComponent.vue
+++ b/frontend/src/components/TablesComponent.vue
@@ -124,6 +124,7 @@
       </div>
       <div class="filters__options">
         <RouterLink
+          v-if="can(`table.${$route.params.tableName}.trash`)"
           :to="`/table/${$route.params.tableName}/trash`"
           class="options__trash-link"
           title="Корзина таблицы"
@@ -137,6 +138,7 @@
           >
         </RouterLink>
         <button
+          v-if="can(`table.${$route.params.tableName}.export`)"
           class="options__export"
           @click="handleExport"
         >
@@ -256,6 +258,7 @@ import CarsTable from './CarsTable.vue';
 import PeopleTable from './PeopleTable.vue';
 import ApplicationDetail from './ApplicationDetail/ApplicationDetail.vue';
 import TableExportModal from './TableExportModal.vue';
+import { usePermissionsStore } from '@/stores/permissions';
 
 export default {
     name: 'TablesComponent',
@@ -290,7 +293,9 @@ export default {
             document.body.style.overflow = '';
         });
 
-        return { showInstruction, openInstruction, closeInstruction, onOverlayMousedown, onOverlayMouseup };
+        const permissionsStore = usePermissionsStore();
+
+        return { showInstruction, openInstruction, closeInstruction, onOverlayMousedown, onOverlayMouseup, permissionsStore };
     },
     data() {
         return {
@@ -383,6 +388,11 @@ export default {
         this.fetchTableData();          // потом таблицы
     },
     methods: {
+        // Гейтинг по правам (#187 Фаза 2). super -> всегда true, admin -> всё кроме
+        // denied, обычный -> по эффективному гранту. Реактивно: читает стор прав.
+        can(key) {
+            return this.permissionsStore.hasPermission(key);
+        },
         handleApplicationUpdate(updatedApp) {
             console.log('Application updated:', updatedApp);
             this.refreshData();


### PR DESCRIPTION
Действия в таблицах показывались всем. Гейтнул по правам (#187, Фаза 2 эпика прав, fe-views):

- **TablesComponent** (тулбар): Корзина -> `table.<slug>.trash`, Экспорт -> `table.<slug>.export` (slug = `$route.params.tableName`, совпадает с route-гейтом view/trash).
- **CarsTable**: История -> `table.<slug>.history`, удаление строки -> `entity.cars.delete`.
- **PeopleTable**: История -> `table.<slug>.history`, удаление строки -> `entity.employees.delete`.

Все ключи реальны: бэк генерит на таблицу view/entry/exit/detail/history/export/trash/delete (AutoGenerateForTable); entity.cars/employees.delete - в статическом каталоге. super -> всё, admin -> всё кроме denied, обычный -> по гранту (база delete не даёт). Preview-режим админ-вкладок не задет (кнопки и так за `v-if=!preview`).

Паттерн как в NavMenu: permissionsStore в setup + метод `can(key)`. eslint без ошибок; CarsTable/PeopleTable enlarged-спеки зелёные (8/8).