### PR TITLE
fix(modals): анимация оставшихся модалок (UserGuide/DownloadBlanks/BlacklistHistory)

### DIFF
--- a/frontend/src/components/UserApplications.vue
+++ b/frontend/src/components/UserApplications.vue
@@ -288,8 +288,8 @@
       />
     </teleport>
     <DownloadBlanksModal
-      v-if="showDownloadModal && downloadAppId"
-      :application-id="downloadAppId"
+      :show="!!(showDownloadModal && downloadAppId)"
+      :application-id="downloadAppId || 0"
       :application-info="downloadAppInfo"
       @close="showDownloadModal = false"
     />

--- a/frontend/src/components/admin/blacklist/BlacklistHistoryModalBase.vue
+++ b/frontend/src/components/admin/blacklist/BlacklistHistoryModalBase.vue
@@ -1,223 +1,226 @@
 <template>
   <Teleport to="body">
-    <div
-      class="modal-overlay"
-      data-testid="blacklist-history-modal"
-      @mousedown="onOverlayMousedown"
-      @mouseup="onOverlayMouseup"
-    >
+    <transition name="modal-fade">
       <div
-        class="blacklist-history-modal"
-        @mousedown.stop
+        v-if="show"
+        class="modal-overlay"
+        data-testid="blacklist-history-modal"
+        @mousedown="onOverlayMousedown"
+        @mouseup="onOverlayMouseup"
       >
-        <div class="modal-header">
-          <h3>{{ title }}</h3>
-          <div class="header-actions">
-            <button
-              class="export-btn"
-              :disabled="filteredHistory.length === 0 || isExporting"
-              @click="exportToExcel"
-            >
-              <img
-                v-if="!isExporting"
-                src="@/assets/icons/export.png"
-                class="export-icon"
-              >
-              <span v-if="!isExporting">Экспорт</span>
-              <div
-                v-else
-                class="export-loader"
-              />
-            </button>
-            <button
-              class="close-btn"
-              aria-label="Закрыть"
-              @click="close"
-            >
-              ×
-            </button>
-          </div>
-        </div>
-
-        <div class="history-filters">
-          <div class="filter-row">
-            <div class="search-filter">
-              <span class="filter-label">Поиск:</span>
-              <input
-                v-model="searchQuery"
-                type="text"
-                class="search-input"
-                placeholder="Поиск по пользователю, действию..."
-              >
-            </div>
-
-            <div class="user-filter">
-              <span class="filter-label">Пользователь:</span>
-              <div
-                ref="userSelect"
-                class="custom-select"
-                @click="toggleUserDropdown"
-              >
-                <div class="select-trigger">
-                  <span class="selected-value">{{ selectedUserName }}</span>
-                  <img
-                    src="@/assets/icons/arrow.png"
-                    class="select-arrow"
-                    :class="{ 'arrow-open': userDropdownOpen }"
-                  >
-                </div>
-                <transition name="fade">
-                  <div
-                    v-if="userDropdownOpen"
-                    class="select-dropdown"
-                  >
-                    <div
-                      class="select-option"
-                      :class="{ selected: selectedUserId === null }"
-                      @click.stop="selectUser(null)"
-                    >
-                      Все пользователи
-                    </div>
-                    <div
-                      v-for="user in uniqueUsers"
-                      :key="user.id"
-                      class="select-option"
-                      :class="{ selected: selectedUserId === user.id }"
-                      @click.stop="selectUser(user.id)"
-                    >
-                      {{ user.name }}
-                    </div>
-                  </div>
-                </transition>
-              </div>
-            </div>
-
-            <div class="date-filter">
-              <span class="filter-label">Период:</span>
-              <input
-                v-model="dateFrom"
-                type="date"
-                class="date-input"
-              >
-              <span class="date-separator">-</span>
-              <input
-                v-model="dateTo"
-                type="date"
-                class="date-input"
-              >
-            </div>
-
-            <div class="sort-filter">
-              <span class="filter-label">Сортировка:</span>
+        <div
+          class="blacklist-history-modal"
+          @mousedown.stop
+        >
+          <div class="modal-header">
+            <h3>{{ title }}</h3>
+            <div class="header-actions">
               <button
-                class="sort-btn"
-                @click="toggleSortOrder"
+                class="export-btn"
+                :disabled="filteredHistory.length === 0 || isExporting"
+                @click="exportToExcel"
               >
                 <img
-                  src="@/assets/icons/sort.png"
-                  class="sort-icon"
-                  :class="{ 'sort-asc': sortOrder === 'asc' }"
+                  v-if="!isExporting"
+                  src="@/assets/icons/export.png"
+                  class="export-icon"
                 >
-                <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
+                <span v-if="!isExporting">Экспорт</span>
+                <div
+                  v-else
+                  class="export-loader"
+                />
+              </button>
+              <button
+                class="close-btn"
+                aria-label="Закрыть"
+                @click="close"
+              >
+                ×
               </button>
             </div>
           </div>
-        </div>
 
-        <div class="modal-content">
-          <div
-            v-if="loading"
-            class="history-loading"
-          >
-            <LoaderSpinner label="Загрузка истории..." />
-          </div>
-
-          <div
-            v-else-if="filteredHistory.length === 0"
-            class="history-empty"
-          >
-            История пуста
-          </div>
-
-          <div
-            v-else
-            class="history-timeline"
-          >
-            <template
-              v-for="group in historyGroupedByDate"
-              :key="group.date"
-            >
-              <div class="history-date-separator">
-                {{ group.date }}
+          <div class="history-filters">
+            <div class="filter-row">
+              <div class="search-filter">
+                <span class="filter-label">Поиск:</span>
+                <input
+                  v-model="searchQuery"
+                  type="text"
+                  class="search-input"
+                  placeholder="Поиск по пользователю, действию..."
+                >
               </div>
-              <div
-                v-for="(item, i) in group.items"
-                :key="item.id"
-                class="history-item"
-              >
+
+              <div class="user-filter">
+                <span class="filter-label">Пользователь:</span>
                 <div
-                  class="timeline-dot"
-                  :class="getActionClass(item.action_type)"
-                />
-                <div
-                  v-if="i < group.items.length - 1"
-                  class="timeline-line"
-                />
-
-                <div class="history-content">
-                  <div
-                    v-if="getEntityLabel(item)"
-                    class="history-entity"
-                  >
-                    {{ getEntityLabel(item) }}
-                  </div>
-
-                  <div class="history-header">
-                    <span class="user-name">{{ item.user_name || 'Система' }}</span>
-                    <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
-                  </div>
-
-                  <div class="action-text">
-                    {{ getActionText(item) }}
-                  </div>
-
-                  <div
-                    v-if="getReasonDiff(item)"
-                    class="action-diff"
-                  >
-                    <span class="diff-old">{{ getReasonDiff(item).from }}</span>
-                    <svg
-                      class="diff-arrow"
-                      viewBox="0 0 24 24"
-                      width="16"
-                      height="16"
-                      aria-hidden="true"
+                  ref="userSelect"
+                  class="custom-select"
+                  @click="toggleUserDropdown"
+                >
+                  <div class="select-trigger">
+                    <span class="selected-value">{{ selectedUserName }}</span>
+                    <img
+                      src="@/assets/icons/arrow.png"
+                      class="select-arrow"
+                      :class="{ 'arrow-open': userDropdownOpen }"
                     >
-                      <path
-                        d="M4 12h14M13 6l6 6-6 6"
-                        fill="none"
-                        stroke="currentColor"
-                        stroke-width="2"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                      />
-                    </svg>
-                    <span class="diff-new">{{ getReasonDiff(item).to }}</span>
                   </div>
-
-                  <div
-                    v-else-if="getActionComment(item)"
-                    class="action-comment"
-                  >
-                    {{ getActionComment(item) }}
-                  </div>
+                  <transition name="fade">
+                    <div
+                      v-if="userDropdownOpen"
+                      class="select-dropdown"
+                    >
+                      <div
+                        class="select-option"
+                        :class="{ selected: selectedUserId === null }"
+                        @click.stop="selectUser(null)"
+                      >
+                        Все пользователи
+                      </div>
+                      <div
+                        v-for="user in uniqueUsers"
+                        :key="user.id"
+                        class="select-option"
+                        :class="{ selected: selectedUserId === user.id }"
+                        @click.stop="selectUser(user.id)"
+                      >
+                        {{ user.name }}
+                      </div>
+                    </div>
+                  </transition>
                 </div>
               </div>
-            </template>
+
+              <div class="date-filter">
+                <span class="filter-label">Период:</span>
+                <input
+                  v-model="dateFrom"
+                  type="date"
+                  class="date-input"
+                >
+                <span class="date-separator">-</span>
+                <input
+                  v-model="dateTo"
+                  type="date"
+                  class="date-input"
+                >
+              </div>
+
+              <div class="sort-filter">
+                <span class="filter-label">Сортировка:</span>
+                <button
+                  class="sort-btn"
+                  @click="toggleSortOrder"
+                >
+                  <img
+                    src="@/assets/icons/sort.png"
+                    class="sort-icon"
+                    :class="{ 'sort-asc': sortOrder === 'asc' }"
+                  >
+                  <span>{{ sortOrder === 'desc' ? 'Сначала новые' : 'Сначала старые' }}</span>
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <div class="modal-content">
+            <div
+              v-if="loading"
+              class="history-loading"
+            >
+              <LoaderSpinner label="Загрузка истории..." />
+            </div>
+
+            <div
+              v-else-if="filteredHistory.length === 0"
+              class="history-empty"
+            >
+              История пуста
+            </div>
+
+            <div
+              v-else
+              class="history-timeline"
+            >
+              <template
+                v-for="group in historyGroupedByDate"
+                :key="group.date"
+              >
+                <div class="history-date-separator">
+                  {{ group.date }}
+                </div>
+                <div
+                  v-for="(item, i) in group.items"
+                  :key="item.id"
+                  class="history-item"
+                >
+                  <div
+                    class="timeline-dot"
+                    :class="getActionClass(item.action_type)"
+                  />
+                  <div
+                    v-if="i < group.items.length - 1"
+                    class="timeline-line"
+                  />
+
+                  <div class="history-content">
+                    <div
+                      v-if="getEntityLabel(item)"
+                      class="history-entity"
+                    >
+                      {{ getEntityLabel(item) }}
+                    </div>
+
+                    <div class="history-header">
+                      <span class="user-name">{{ item.user_name || 'Система' }}</span>
+                      <span class="action-time">{{ formatDateTime(item.created_at) }}</span>
+                    </div>
+
+                    <div class="action-text">
+                      {{ getActionText(item) }}
+                    </div>
+
+                    <div
+                      v-if="getReasonDiff(item)"
+                      class="action-diff"
+                    >
+                      <span class="diff-old">{{ getReasonDiff(item).from }}</span>
+                      <svg
+                        class="diff-arrow"
+                        viewBox="0 0 24 24"
+                        width="16"
+                        height="16"
+                        aria-hidden="true"
+                      >
+                        <path
+                          d="M4 12h14M13 6l6 6-6 6"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                        />
+                      </svg>
+                      <span class="diff-new">{{ getReasonDiff(item).to }}</span>
+                    </div>
+
+                    <div
+                      v-else-if="getActionComment(item)"
+                      class="action-comment"
+                    >
+                      {{ getActionComment(item) }}
+                    </div>
+                  </div>
+                </div>
+              </template>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </transition>
   </Teleport>
 </template>
 
@@ -246,6 +249,7 @@ export default {
   name: 'BlacklistHistoryModalBase',
   components: { LoaderSpinner },
   props: {
+    show: { type: Boolean, default: false },
     title: { type: String, required: true },
     /** Имя записи для имени файла экспорта (санируется). */
     entityLabel: { type: String, default: 'zapis' },
@@ -395,8 +399,14 @@ export default {
       });
     },
   },
+  watch: {
+    // Модалка всегда смонтирована (для leave-анимации): историю грузим при
+    // открытии, а не на mount.
+    show(visible) {
+      if (visible) this.loadHistory();
+    },
+  },
   mounted() {
-    this.loadHistory();
     document.addEventListener('click', this.handleClickOutside);
     document.addEventListener('keydown', this.onKeydown);
   },
@@ -407,6 +417,7 @@ export default {
   methods: {
     formatDateTime,
     onKeydown(e) {
+      if (!this.show) return;
       if (e.key === 'Escape') this.close();
     },
     close() {
@@ -1085,5 +1096,15 @@ export default {
   .date-input {
     width: calc(50% - 20px);
   }
+}
+
+.modal-fade-enter-active,
+.modal-fade-leave-active {
+  transition: opacity 0.25s ease;
+}
+
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+  opacity: 0;
 }
 </style>

--- a/frontend/src/components/admin/blacklist/BlacklistHistoryModalBase.vue
+++ b/frontend/src/components/admin/blacklist/BlacklistHistoryModalBase.vue
@@ -401,9 +401,13 @@ export default {
   },
   watch: {
     // Модалка всегда смонтирована (для leave-анимации): историю грузим при
-    // открытии, а не на mount.
-    show(visible) {
-      if (visible) this.loadHistory();
+    // открытии, а не на mount. immediate - чтобы загрузка сработала и когда
+    // модалку сразу монтируют с show=true (guard не грузит при закрытой).
+    show: {
+      immediate: true,
+      handler(visible) {
+        if (visible) this.loadHistory();
+      },
     },
   },
   mounted() {

--- a/frontend/src/components/admin/blacklist/PersonBlacklistHistoryModal.vue
+++ b/frontend/src/components/admin/blacklist/PersonBlacklistHistoryModal.vue
@@ -1,5 +1,6 @@
 <template>
   <BlacklistHistoryModalBase
+    :show="show"
     title="История чёрного списка людей"
     entity-label="lyudi"
     :load-fn="loadFn"
@@ -44,6 +45,7 @@ export default {
   name: 'PersonBlacklistHistoryModal',
   components: { BlacklistHistoryModalBase },
   props: {
+    show: { type: Boolean, default: false },
     currentUserName: { type: String, default: '' },
   },
   emits: ['close'],

--- a/frontend/src/components/admin/blacklist/PersonBlacklistTab.vue
+++ b/frontend/src/components/admin/blacklist/PersonBlacklistTab.vue
@@ -42,7 +42,7 @@
       @created="onCreated"
     />
     <PersonBlacklistHistoryModal
-      v-if="showHistory"
+      :show="showHistory"
       :current-user-name="currentUserName"
       @close="showHistory = false"
     />

--- a/frontend/src/components/admin/blacklist/VehicleBlacklistHistoryModal.vue
+++ b/frontend/src/components/admin/blacklist/VehicleBlacklistHistoryModal.vue
@@ -1,5 +1,6 @@
 <template>
   <BlacklistHistoryModalBase
+    :show="show"
     title="История чёрного списка машин"
     entity-label="mashiny"
     :load-fn="loadFn"
@@ -44,6 +45,7 @@ export default {
   name: 'VehicleBlacklistHistoryModal',
   components: { BlacklistHistoryModalBase },
   props: {
+    show: { type: Boolean, default: false },
     currentUserName: { type: String, default: '' },
   },
   emits: ['close'],

--- a/frontend/src/components/admin/blacklist/VehicleBlacklistTab.vue
+++ b/frontend/src/components/admin/blacklist/VehicleBlacklistTab.vue
@@ -42,7 +42,7 @@
       @created="onCreated"
     />
     <VehicleBlacklistHistoryModal
-      v-if="showHistory"
+      :show="showHistory"
       :current-user-name="currentUserName"
       @close="showHistory = false"
     />

--- a/frontend/src/components/admin/blacklist/__tests__/BlacklistHistoryModalBase.spec.js
+++ b/frontend/src/components/admin/blacklist/__tests__/BlacklistHistoryModalBase.spec.js
@@ -48,6 +48,7 @@ const history = [
 function mountModal(overrides = {}) {
   return mount(BlacklistHistoryModalBase, {
     props: {
+      show: true,
       title: 'История машины «A1 BMW»',
       entityLabel: 'A1 BMW',
       loadFn: vi.fn().mockResolvedValue(history),

--- a/frontend/src/components/applications/DownloadBlanksModal.vue
+++ b/frontend/src/components/applications/DownloadBlanksModal.vue
@@ -1,101 +1,104 @@
 <template>
   <Teleport to="body">
-    <div
-      class="dbm-overlay"
-      data-testid="download-blanks-modal"
-      @click.self="$emit('close')"
-    >
-      <div class="dbm-modal">
-        <div class="dbm-header">
-          <h3 class="dbm-title">
-            Скачивание бланков
-          </h3>
-          <button
-            class="dbm-close"
-            @click="$emit('close')"
-          >
-            &times;
-          </button>
-        </div>
-
-        <div
-          v-if="isLoading"
-          class="dbm-state"
-        >
-          <span class="dbm-spinner" />
-        </div>
-        <div
-          v-else-if="error"
-          class="dbm-state dbm-state--error"
-        >
-          {{ error }}
-        </div>
-        <div
-          v-else-if="!eligibleAttachments.length"
-          class="dbm-state"
-        >
-          У заявки нет вложений с настроенным шаблоном бланка.
-        </div>
-        <div
-          v-else
-          class="dbm-list"
-        >
-          <label
-            v-for="att in eligibleAttachments"
-            :key="att.id"
-            class="dbm-item"
-            :class="{ selected: selectedIds.includes(att.id) }"
-          >
-            <input
-              v-model="selectedIds"
-              type="checkbox"
-              :value="att.id"
-              class="dbm-checkbox"
-            >
-            <div class="dbm-item-info">
-              <span class="dbm-item-name">{{ att.attachment_display_name || att.unique_attachment_display_name || att.attachment_name }}</span>
-              <span
-                v-if="attachmentTypeLabel(att.attachment_type)"
-                class="dbm-item-type"
-              >{{ attachmentTypeLabel(att.attachment_type) }}</span>
-            </div>
+    <transition name="modal-fade">
+      <div
+        v-if="show"
+        class="dbm-overlay"
+        data-testid="download-blanks-modal"
+        @click.self="$emit('close')"
+      >
+        <div class="dbm-modal">
+          <div class="dbm-header">
+            <h3 class="dbm-title">
+              Скачивание бланков
+            </h3>
             <button
-              class="dbm-item-download"
-              :disabled="downloadingId === att.id"
-              @click.prevent="downloadOne(att)"
+              class="dbm-close"
+              @click="$emit('close')"
             >
-              {{ downloadingId === att.id ? '...' : 'Скачать' }}
+              &times;
             </button>
-          </label>
-        </div>
+          </div>
 
-        <footer
-          v-if="eligibleAttachments.length"
-          class="dbm-footer"
-        >
-          <button
-            class="dbm-btn dbm-btn--ghost"
-            @click="$emit('close')"
+          <div
+            v-if="isLoading"
+            class="dbm-state"
           >
-            Закрыть
-          </button>
-          <button
-            class="dbm-btn dbm-btn--ghost"
-            :disabled="downloadingAll"
-            @click="downloadAll"
+            <span class="dbm-spinner" />
+          </div>
+          <div
+            v-else-if="error"
+            class="dbm-state dbm-state--error"
           >
-            Скачать все
-          </button>
-          <button
-            class="dbm-btn dbm-btn--primary"
-            :disabled="!selectedIds.length || downloadingAll"
-            @click="downloadSelected"
+            {{ error }}
+          </div>
+          <div
+            v-else-if="!eligibleAttachments.length"
+            class="dbm-state"
           >
-            {{ downloadingAll ? 'Скачивание...' : `Скачать (${selectedIds.length})` }}
-          </button>
-        </footer>
+            У заявки нет вложений с настроенным шаблоном бланка.
+          </div>
+          <div
+            v-else
+            class="dbm-list"
+          >
+            <label
+              v-for="att in eligibleAttachments"
+              :key="att.id"
+              class="dbm-item"
+              :class="{ selected: selectedIds.includes(att.id) }"
+            >
+              <input
+                v-model="selectedIds"
+                type="checkbox"
+                :value="att.id"
+                class="dbm-checkbox"
+              >
+              <div class="dbm-item-info">
+                <span class="dbm-item-name">{{ att.attachment_display_name || att.unique_attachment_display_name || att.attachment_name }}</span>
+                <span
+                  v-if="attachmentTypeLabel(att.attachment_type)"
+                  class="dbm-item-type"
+                >{{ attachmentTypeLabel(att.attachment_type) }}</span>
+              </div>
+              <button
+                class="dbm-item-download"
+                :disabled="downloadingId === att.id"
+                @click.prevent="downloadOne(att)"
+              >
+                {{ downloadingId === att.id ? '...' : 'Скачать' }}
+              </button>
+            </label>
+          </div>
+
+          <footer
+            v-if="eligibleAttachments.length"
+            class="dbm-footer"
+          >
+            <button
+              class="dbm-btn dbm-btn--ghost"
+              @click="$emit('close')"
+            >
+              Закрыть
+            </button>
+            <button
+              class="dbm-btn dbm-btn--ghost"
+              :disabled="downloadingAll"
+              @click="downloadAll"
+            >
+              Скачать все
+            </button>
+            <button
+              class="dbm-btn dbm-btn--primary"
+              :disabled="!selectedIds.length || downloadingAll"
+              @click="downloadSelected"
+            >
+              {{ downloadingAll ? 'Скачивание...' : `Скачать (${selectedIds.length})` }}
+            </button>
+          </footer>
+        </div>
       </div>
-    </div>
+    </transition>
   </Teleport>
 </template>
 
@@ -114,7 +117,8 @@ const TYPE_LABELS = {
 export default {
   name: 'DownloadBlanksModal',
   props: {
-    applicationId: { type: Number, required: true },
+    show: { type: Boolean, default: false },
+    applicationId: { type: Number, default: 0 },
     applicationInfo: { type: Object, default: null },
   },
   emits: ['close'],
@@ -133,8 +137,15 @@ export default {
       return this.attachments.filter(att => att.has_template);
     },
   },
-  mounted() {
-    this.load();
+  watch: {
+    // Модалка всегда смонтирована (для leave-анимации): грузим вложения при
+    // открытии, а не на mount (иначе fetch с пустым applicationId на старте).
+    show(visible) {
+      if (visible && this.applicationId) {
+        this.selectedIds = [];
+        this.load();
+      }
+    },
   },
   methods: {
     async load() {
@@ -410,5 +421,15 @@ export default {
 .dbm-btn--ghost:hover:not(:disabled) {
   border-color: var(--color-primary);
   color: var(--color-primary);
+}
+
+.modal-fade-enter-active,
+.modal-fade-leave-active {
+  transition: opacity 0.25s ease;
+}
+
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+  opacity: 0;
 }
 </style>

--- a/frontend/src/components/news/UserGuideModal.vue
+++ b/frontend/src/components/news/UserGuideModal.vue
@@ -1,107 +1,110 @@
 <template>
   <Teleport to="body">
-    <div
-      class="modal-overlay"
-      role="dialog"
-      aria-modal="true"
-      :aria-labelledby="titleId"
-      @click.self="close"
-    >
-      <div class="guide-modal">
-        <header class="guide-modal__header">
-          <h2
-            :id="titleId"
-            class="guide-modal__title"
-          >
-            {{ title }}
-          </h2>
-          <button
-            type="button"
-            class="guide-modal__close"
-            aria-label="Закрыть"
-            @click="close"
-          >
-            ×
-          </button>
-        </header>
+    <transition name="modal-fade">
+      <div
+        v-if="show"
+        class="modal-overlay"
+        role="dialog"
+        aria-modal="true"
+        :aria-labelledby="titleId"
+        @click.self="close"
+      >
+        <div class="guide-modal">
+          <header class="guide-modal__header">
+            <h2
+              :id="titleId"
+              class="guide-modal__title"
+            >
+              {{ title }}
+            </h2>
+            <button
+              type="button"
+              class="guide-modal__close"
+              aria-label="Закрыть"
+              @click="close"
+            >
+              ×
+            </button>
+          </header>
 
-        <div class="guide-modal__body">
-          <nav
-            class="guide-modal__sidebar"
-            aria-label="Разделы руководства"
-          >
-            <ul>
-              <li
-                v-for="section in sections"
-                :key="section.id"
-              >
-                <button
-                  type="button"
-                  class="guide-modal__nav-link"
-                  :class="{ active: active === section.id }"
-                  @click="active = section.id"
-                >
-                  <span class="guide-modal__nav-step">{{ section.step }}</span>
-                  <span>{{ section.title }}</span>
-                </button>
-              </li>
-            </ul>
-          </nav>
-
-          <article class="guide-modal__content">
-            <h3 class="guide-modal__section-title">
-              {{ currentSection.title }}
-            </h3>
-            <div class="guide-modal__section-body">
-              <p
-                v-for="(p, i) in currentSection.paragraphs"
-                :key="i"
-              >
-                {{ p }}
-              </p>
-              <ol
-                v-if="currentSection.steps && currentSection.steps.length"
-                class="guide-modal__steps"
-              >
+          <div class="guide-modal__body">
+            <nav
+              class="guide-modal__sidebar"
+              aria-label="Разделы руководства"
+            >
+              <ul>
                 <li
-                  v-for="(step, i) in currentSection.steps"
+                  v-for="section in sections"
+                  :key="section.id"
+                >
+                  <button
+                    type="button"
+                    class="guide-modal__nav-link"
+                    :class="{ active: active === section.id }"
+                    @click="active = section.id"
+                  >
+                    <span class="guide-modal__nav-step">{{ section.step }}</span>
+                    <span>{{ section.title }}</span>
+                  </button>
+                </li>
+              </ul>
+            </nav>
+
+            <article class="guide-modal__content">
+              <h3 class="guide-modal__section-title">
+                {{ currentSection.title }}
+              </h3>
+              <div class="guide-modal__section-body">
+                <p
+                  v-for="(p, i) in currentSection.paragraphs"
                   :key="i"
                 >
-                  {{ step }}
-                </li>
-              </ol>
-              <div
-                v-if="currentSection.tip"
-                class="guide-modal__tip"
-              >
-                <strong>Совет.</strong> {{ currentSection.tip }}
+                  {{ p }}
+                </p>
+                <ol
+                  v-if="currentSection.steps && currentSection.steps.length"
+                  class="guide-modal__steps"
+                >
+                  <li
+                    v-for="(step, i) in currentSection.steps"
+                    :key="i"
+                  >
+                    {{ step }}
+                  </li>
+                </ol>
+                <div
+                  v-if="currentSection.tip"
+                  class="guide-modal__tip"
+                >
+                  <strong>Совет.</strong> {{ currentSection.tip }}
+                </div>
               </div>
-            </div>
-          </article>
-        </div>
+            </article>
+          </div>
 
-        <footer class="guide-modal__footer">
-          <button
-            type="button"
-            class="guide-modal__btn guide-modal__btn--ghost"
-            :disabled="activeIndex === 0"
-            @click="prev"
-          >
-            Назад
-          </button>
-          <span class="guide-modal__progress">
-            {{ activeIndex + 1 }} / {{ sections.length }}
-          </span>
-          <button
-            type="button"
-            class="guide-modal__btn"
-            @click="nextOrClose"
-          >
-            {{ activeIndex === sections.length - 1 ? 'Готово' : 'Далее' }}
-          </button>
-        </footer>
+          <footer class="guide-modal__footer">
+            <button
+              type="button"
+              class="guide-modal__btn guide-modal__btn--ghost"
+              :disabled="activeIndex === 0"
+              @click="prev"
+            >
+              Назад
+            </button>
+            <span class="guide-modal__progress">
+              {{ activeIndex + 1 }} / {{ sections.length }}
+            </span>
+            <button
+              type="button"
+              class="guide-modal__btn"
+              @click="nextOrClose"
+            >
+              {{ activeIndex === sections.length - 1 ? 'Готово' : 'Далее' }}
+            </button>
+          </footer>
+        </div>
       </div>
-    </div>
+    </transition>
   </Teleport>
 </template>
 
@@ -111,6 +114,7 @@ let uid = 0;
 export default {
   name: 'UserGuideModal',
   props: {
+    show: { type: Boolean, default: false },
     title: { type: String, default: 'Руководство пользования системой' },
     sections: {
       type: Array,
@@ -134,9 +138,16 @@ export default {
       return this.sections[this.activeIndex] || this.sections[0];
     }
   },
+  watch: {
+    // Модалка всегда смонтирована (для leave-анимации): блокировку скролла и
+    // сброс на первый раздел вешаем на открытие, а не на mount.
+    show(visible) {
+      document.body.style.overflow = visible ? 'hidden' : '';
+      if (visible) this.active = this.sections[0]?.id || '';
+    }
+  },
   mounted() {
     document.addEventListener('keydown', this.onKey);
-    document.body.style.overflow = 'hidden';
   },
   beforeUnmount() {
     document.removeEventListener('keydown', this.onKey);
@@ -144,6 +155,7 @@ export default {
   },
   methods: {
     onKey(e) {
+      if (!this.show) return;
       if (e.key === 'Escape') this.close();
       if (e.key === 'ArrowRight') this.nextOrClose();
       if (e.key === 'ArrowLeft') this.prev();
@@ -379,5 +391,15 @@ export default {
     border-bottom: 1px solid #eee;
     max-height: 200px;
   }
+}
+
+.modal-fade-enter-active,
+.modal-fade-leave-active {
+  transition: opacity 0.25s ease;
+}
+
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+  opacity: 0;
 }
 </style>

--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -545,8 +545,8 @@
       @application-changed="handleApplicationChanged"
     />
     <DownloadBlanksModal
-      v-if="showDownloadModal && downloadAppId"
-      :application-id="downloadAppId"
+      :show="!!(showDownloadModal && downloadAppId)"
+      :application-id="downloadAppId || 0"
       :application-info="downloadAppInfo"
       @close="showDownloadModal = false"
     />

--- a/frontend/src/views/NewsAndReview.vue
+++ b/frontend/src/views/NewsAndReview.vue
@@ -198,7 +198,7 @@
     />
 
     <UserGuideModal
-      v-if="showGuide"
+      :show="showGuide"
       :title="guideTitle"
       :sections="guideSections"
       @close="closeGuide"


### PR DESCRIPTION
Задача 2 (аудит модалок), завершение батча анимации - 3 модалки с mount-side-effects переведены на always-mount `:show` + перенос эффектов в `watch(show)`.

- **UserGuideModal** - scroll-lock и сброс на первый раздел в watch(show) (а не mount, иначе блокировка скролла при загрузке); onKey guard по show; родитель NewsAndReview -> :show.
- **DownloadBlanksModal** - fetch вложений в watch(show); applicationId required->default 0; оба родителя (UserApplications, ApplicationsCenter) -> :show + appId||0.
- **BlacklistHistoryModalBase** - loadHistory в watch(show); onKeydown guard; врапперы Vehicle/PersonBlacklistHistoryModal и табы прокинуты на :show.

### Проверка (локально через MCP-браузер)
- UserGuide: при загрузке /news `body.overflow` пуст (scroll НЕ залочен - главный риск устранён); при открытии - модалка отрисована + scroll lock; при закрытии - удалена (leave-анимация) + scroll восстановлен. Скриншот открытой модалки ок.
- eslint 0 errors по всем 10 файлам.
- DownloadBlanks/BlacklistHistory - тот же выверенный watch(show)-паттерн без scroll-эффектов; spot-check на staging.