### PR TITLE
feat(permissions): эндпоинт эффективных прав юзера с источником

### DIFF
--- a/internal/handlers/permissions.go
+++ b/internal/handlers/permissions.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"net/http"
+
 	"systemburo/internal/models"
 	"systemburo/internal/services"
 
@@ -29,12 +31,37 @@ func NewPermissionHandler(service services.PermissionService, resolver *services
 //
 // Источник данных -- PermissionResolver (роли + группы + grants + overrides).
 func (h *PermissionHandler) GetMyPermissions(c echo.Context) error {
-	userID := GetUserID(c)
+	set, err := h.resolver.Resolve(c.Request().Context(), GetUserID(c))
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, buildPermissionsResponse(set))
+}
+
+// GetUserEffectivePermissions возвращает эффективные права указанного пользователя
+// с источником (роль/группа/override) -- для админ-экрана настройки доступа (#187 Фаза 3).
+// Только super-admin. Формат идентичен GetMyPermissions, но считается для целевого юзера,
+// чтобы в правом столбце модалки прав показать бейдж источника каждого права и
+// унаследованные от роли/групп права (а не только личные override из /user/:id).
+func (h *PermissionHandler) GetUserEffectivePermissions(c echo.Context) error {
+	if !IsSuperAdmin(c) {
+		return echo.NewHTTPError(http.StatusForbidden, "Доступ только для супер-администратора")
+	}
+	userID, err := ParseID(c, "id")
+	if err != nil {
+		return err
+	}
 	set, err := h.resolver.Resolve(c.Request().Context(), userID)
 	if err != nil {
 		return err
 	}
+	return RespondSuccess(c, buildPermissionsResponse(set))
+}
 
+// buildPermissionsResponse собирает ответ {mode, permissions[{key,value,source}],
+// denied, banned, ban_reason} из вычисленного набора прав. Общий код для
+// GetMyPermissions (текущий юзер) и GetUserEffectivePermissions (целевой юзер).
+func buildPermissionsResponse(set services.PermissionSet) models.MyPermissionsResponse {
 	keys := set.Keys()
 	perms := make([]models.MyPermissionItem, 0, len(keys))
 	for _, k := range keys {
@@ -44,14 +71,13 @@ func (h *PermissionHandler) GetMyPermissions(c echo.Context) error {
 			Source: set.Source(k),
 		})
 	}
-
-	return RespondSuccess(c, models.MyPermissionsResponse{
+	return models.MyPermissionsResponse{
 		Mode:        set.Mode(),
 		Permissions: perms,
 		Denied:      set.Denies(),
 		Banned:      set.IsBanned(),
 		BanReason:   set.BanReason(),
-	})
+	}
 }
 
 // GetUserPermissions возвращает разрешения указанного пользователя (только super-admin).

--- a/internal/handlers/permissions_effective_test.go
+++ b/internal/handlers/permissions_effective_test.go
@@ -1,0 +1,61 @@
+package handlers_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"systemburo/internal/models"
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// GET /permissions/user/:id/effective -- эффективные права целевого юзера с источником
+// для админ-экрана прав (#187 Фаза 3). Доступ только super-admin.
+func TestPermissions_GetUserEffective_SuperAdminOnly(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	userToken := testutil.RegisterAndLogin(t, e, "effectiveuser", "password123", 1, td.OrgID, td.CompanyID)
+	var userID int
+	require.NoError(t, db.Table("users").Select("id").Where("username = ?", "effectiveuser").Row().Scan(&userID))
+
+	// Обычный юзер -> 403.
+	rec := testutil.GET(t, e, fmt.Sprintf("/permissions/user/%d/effective", userID), testutil.AuthHeader(userToken))
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+
+	// Super-admin -> 200, обычный юзер в режиме normal и не забанен.
+	adminToken := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	rec = testutil.GET(t, e, fmt.Sprintf("/permissions/user/%d/effective", userID), testutil.AuthHeader(adminToken))
+	require.Equal(t, http.StatusOK, rec.Code)
+	data := testutil.ParseResponse[models.MyPermissionsResponse](t, rec)
+	assert.Equal(t, "normal", data.Mode)
+	assert.False(t, data.Banned)
+}
+
+// Эндпоинт должен резолвить ЦЕЛЕВОГО юзера, а не вызывающего: super-admin запрашивает
+// забаненного юзера и видит его banned-набор с причиной, а не свой super-доступ.
+func TestPermissions_GetUserEffective_ResolvesTargetNotCaller(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	testutil.RegisterAndLogin(t, e, "bannedtarget", "password123", 1, td.OrgID, td.CompanyID)
+	var userID int
+	require.NoError(t, db.Table("users").Select("id").Where("username = ?", "bannedtarget").Row().Scan(&userID))
+	reason := "нарушение регламента"
+	require.NoError(t, db.Table("users").Where("id = ?", userID).
+		Updates(map[string]any{"is_banned": true, "ban_reason": reason}).Error)
+
+	adminToken := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	rec := testutil.GET(t, e, fmt.Sprintf("/permissions/user/%d/effective", userID), testutil.AuthHeader(adminToken))
+	require.Equal(t, http.StatusOK, rec.Code)
+	data := testutil.ParseResponse[models.MyPermissionsResponse](t, rec)
+	assert.True(t, data.Banned)
+	assert.Equal(t, reason, data.BanReason)
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -479,6 +479,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	permGroup := protected.Group("/permissions")
 	permGroup.GET("/my", permissions.GetMyPermissions)
 	permGroup.GET("/user/:id", permissions.GetUserPermissions)
+	permGroup.GET("/user/:id/effective", permissions.GetUserEffectivePermissions)
 	permGroup.PUT("/user/:id", permissions.UpdateUserPermissions)
 	permGroup.GET("/tree", permissions.GetPermissionTree)
 	permGroup.GET("/catalog", permissions.GetCatalog)


### PR DESCRIPTION
## Зачем
Ф3 эпика прав - редизайн UserAccessModal в 2 колонки. Правому столбцу нужны **эффективные** права целевого юзера с **источником** (роль/группа/лично) и унаследованные от роли/групп. Текущий `GET /permissions/user/:id` отдаёт только личные override (строки user_permissions), без источника и без наследования.

## Что
- Новый `GET /permissions/user/:id/effective` (super-admin only). Формат идентичен `/permissions/my` (`{mode, permissions[{key,value,source}], denied, banned, ban_reason}`), но резолвится для целевого `:id` через существующий `PermissionResolver`. Сервис/резолвер/модель не менялись - только handler + route + тест.
- Общий код сборки ответа вынес в `buildPermissionsResponse` (использует и `GetMyPermissions`).

## Тесты
- `TestPermissions_GetUserEffective_SuperAdminOnly`: обычный юзер 403, super 200, normal-режим.
- `TestPermissions_GetUserEffective_ResolvesTargetNotCaller`: super смотрит забаненного - видит banned-набор целевого + причину (доказывает резолв ЦЕЛЕВОГО, не вызывающего).

Полный `go test ./...`: `internal/handlers` зелёный (80.7s). Падает только `TestLogPartitionMaintenance` (internal/database) - известный локальный флак на аккумуляции request_logs_daily, на свежей БД CI зелёный; мой дифф партиций не касается.