### PR TITLE
feat(permissions): причина блокировки при бане юзера

### DIFF
--- a/frontend/src/api/permissions.js
+++ b/frontend/src/api/permissions.js
@@ -159,8 +159,11 @@ export async function archiveAccessDenials(cutoff) {
 
 // --- Ban (#230) ---
 
-export async function banUser(userId) {
-  const res = await apiRequest(`/users/${userId}/ban`, { method: 'POST' });
+export async function banUser(userId, reason = '') {
+  const res = await apiRequest(`/users/${userId}/ban`, {
+    method: 'POST',
+    body: JSON.stringify({ reason }),
+  });
   return res.json();
 }
 

--- a/internal/handlers/permission_middleware_integration_test.go
+++ b/internal/handlers/permission_middleware_integration_test.go
@@ -196,7 +196,7 @@ func TestUserBanService_BanRevokesRefreshTokens(t *testing.T) {
 	}
 	defer db.Delete(&rt)
 
-	if err := banSvc.Ban(context.Background(), targetID, actorID); err != nil {
+	if err := banSvc.Ban(context.Background(), targetID, actorID, ""); err != nil {
 		t.Fatalf("ban: %v", err)
 	}
 
@@ -221,7 +221,7 @@ func TestUserBanService_CannotBanSelf(t *testing.T) {
 	userID, _, cleanup := setupMWUser(t, db, true, false)
 	defer cleanup()
 
-	err := banSvc.Ban(context.Background(), userID, userID)
+	err := banSvc.Ban(context.Background(), userID, userID, "")
 	if err == nil {
 		t.Error("expected error when banning self")
 	}
@@ -237,7 +237,7 @@ func TestUserBanService_CannotBanSuperAdmin(t *testing.T) {
 	actorID, _, cleanupActor := setupMWUser(t, db, true, false)
 	defer cleanupActor()
 
-	err := banSvc.Ban(context.Background(), targetID, actorID)
+	err := banSvc.Ban(context.Background(), targetID, actorID, "")
 	if err == nil {
 		t.Error("expected error when banning super-admin")
 	}
@@ -346,7 +346,7 @@ func TestBanCheck_InvalidationAfterBanReflectsImmediately(t *testing.T) {
 	}
 
 	// 2. Баним - должен инвалидировать кэш.
-	if err := banSvc.Ban(context.Background(), targetID, actorID); err != nil {
+	if err := banSvc.Ban(context.Background(), targetID, actorID, ""); err != nil {
 		t.Fatalf("ban: %v", err)
 	}
 

--- a/internal/handlers/user_ban.go
+++ b/internal/handlers/user_ban.go
@@ -18,13 +18,20 @@ func NewUserBanHandler(s *services.UserBanService) *UserBanHandler {
 
 // Ban -- POST /users/:id/ban.
 // Проверка прав делается через middleware (action.ban.user).
+// Тело {reason} опционально -- причина блокировки для показа заблокированному в ЛК.
 func (h *UserBanHandler) Ban(c echo.Context) error {
 	targetID, err := ParseID(c, "id")
 	if err != nil {
 		return err
 	}
+	// Причина -- необязательная метадата: пустое/отсутствующее тело трактуем как
+	// бан без причины, а не как ошибку запроса (бан срабатывает в любом случае).
+	var req struct {
+		Reason string `json:"reason"`
+	}
+	_ = c.Bind(&req)
 	actorID := GetUserID(c)
-	if err := h.service.Ban(c.Request().Context(), targetID, actorID); err != nil {
+	if err := h.service.Ban(c.Request().Context(), targetID, actorID, req.Reason); err != nil {
 		return err
 	}
 	return RespondSuccess(c, map[string]any{"banned": true})

--- a/internal/handlers/user_ban_reason_test.go
+++ b/internal/handlers/user_ban_reason_test.go
@@ -1,0 +1,66 @@
+package handlers_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// POST /users/:id/ban с телом {reason} сохраняет причину в users.ban_reason,
+// unban её очищает (#187 Фаза 3 -- причина показывается заблокированному в ЛК).
+func TestUserBan_StoresAndClearsReason(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	testutil.RegisterAndLogin(t, e, "banreasontarget", "password123", 1, td.OrgID, td.CompanyID)
+	var userID int
+	require.NoError(t, db.Table("users").Select("id").Where("username = ?", "banreasontarget").Row().Scan(&userID))
+	adminToken := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	reason := "грубое нарушение регламента"
+	rec := testutil.POST(t, e, fmt.Sprintf("/users/%d/ban", userID), fmt.Sprintf(`{"reason":%q}`, reason), testutil.AuthHeader(adminToken))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var stored *string
+	require.NoError(t, db.Table("users").Select("ban_reason").Where("id = ?", userID).Row().Scan(&stored))
+	require.NotNil(t, stored, "ban_reason должна сохраниться")
+	assert.Equal(t, reason, *stored)
+
+	// unban очищает причину.
+	rec = testutil.POST(t, e, fmt.Sprintf("/users/%d/unban", userID), "", testutil.AuthHeader(adminToken))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	stored = nil
+	require.NoError(t, db.Table("users").Select("ban_reason").Where("id = ?", userID).Row().Scan(&stored))
+	assert.Nil(t, stored, "unban должен очистить ban_reason")
+}
+
+// Бан без тела (пустой запрос) не падает и трактуется как бан без причины.
+func TestUserBan_NoReasonBodyOptional(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	testutil.RegisterAndLogin(t, e, "bannoreason", "password123", 1, td.OrgID, td.CompanyID)
+	var userID int
+	require.NoError(t, db.Table("users").Select("id").Where("username = ?", "bannoreason").Row().Scan(&userID))
+	adminToken := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	rec := testutil.POST(t, e, fmt.Sprintf("/users/%d/ban", userID), "", testutil.AuthHeader(adminToken))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var stored *string
+	require.NoError(t, db.Table("users").Select("ban_reason").Where("id = ?", userID).Row().Scan(&stored))
+	assert.Nil(t, stored)
+
+	var banned bool
+	require.NoError(t, db.Table("users").Select("is_banned").Where("id = ?", userID).Row().Scan(&banned))
+	assert.True(t, banned)
+}

--- a/internal/services/user_ban_service.go
+++ b/internal/services/user_ban_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"systemburo/internal/models"
@@ -30,7 +31,8 @@ func NewUserBanService(db *gorm.DB, resolver *PermissionResolver, banCache *BanC
 
 // Ban блокирует пользователя и отзывает его активные refresh-токены.
 // Запрещено блокировать самого себя и super-admin (защита от самоудаления).
-func (s *UserBanService) Ban(ctx context.Context, targetUserID, actorUserID int) error {
+// reason -- причина блокировки (показывается заблокированному в ЛК); пустая -> NULL.
+func (s *UserBanService) Ban(ctx context.Context, targetUserID, actorUserID int, reason string) error {
 	if targetUserID == actorUserID {
 		return fmt.Errorf("cannot ban yourself")
 	}
@@ -42,13 +44,19 @@ func (s *UserBanService) Ban(ctx context.Context, targetUserID, actorUserID int)
 		return echo.NewHTTPError(http.StatusForbidden, "Нельзя заблокировать супер-администратора")
 	}
 
+	var banReason *string
+	if trimmed := strings.TrimSpace(reason); trimmed != "" {
+		banReason = &trimmed
+	}
+
 	now := time.Now()
 	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Model(&models.User{}).Where("id = ?", targetUserID).
 			Updates(map[string]any{
-				"is_banned": true,
-				"banned_at": now,
-				"banned_by": actorUserID,
+				"is_banned":  true,
+				"banned_at":  now,
+				"banned_by":  actorUserID,
+				"ban_reason": banReason,
 			}).Error; err != nil {
 			return fmt.Errorf("update user: %w", err)
 		}
@@ -75,9 +83,10 @@ func (s *UserBanService) Ban(ctx context.Context, targetUserID, actorUserID int)
 func (s *UserBanService) Unban(ctx context.Context, targetUserID int) error {
 	if err := s.db.WithContext(ctx).Model(&models.User{}).Where("id = ?", targetUserID).
 		Updates(map[string]any{
-			"is_banned": false,
-			"banned_at": nil,
-			"banned_by": nil,
+			"is_banned":  false,
+			"banned_at":  nil,
+			"banned_by":  nil,
+			"ban_reason": nil,
 		}).Error; err != nil {
 		return fmt.Errorf("unban: %w", err)
 	}


### PR DESCRIPTION
## Зачем
Ф3 эпика прав: левый столбец экрана прав даёт поле «Причина блокировки (увидит пользователь)». `UserBanService.Ban` причину не сохранял, хотя `users.ban_reason` в модели есть и `/permissions/my` её отдаёт.

## Что
- `UserBanService.Ban(ctx, target, actor, reason)` пишет `ban_reason` (пустая/из пробелов -> NULL); `Unban` очищает причину.
- `POST /users/:id/ban` читает опциональное тело `{reason}` (пустое/отсутствующее -> бан без причины, не ошибка).
- FE `banUser(userId, reason='')` шлёт тело. Существующий вызов в RolesGroupsPanel совместим (textarea причины придёт в FE-срезе 2 колонок).
- Обновил 4 call-site сервисного `Ban` в тестах под новую сигнатуру.

## Тесты
- `TestUserBan_StoresAndClearsReason`: ban с reason -> сохранилось; unban -> NULL.
- `TestUserBan_NoReasonBodyOptional`: ban без тела -> 200, причина NULL, забанен.

Сериализованный `go test -p 1 ./internal/handlers ./internal/services` зелёный (91.5s). В параллельном `./...` ловится известный хазард #706 (две тест-БД-бинаря мигрируют одновременно -> AutoMigrate "tuple concurrently updated") и флак партиций - оба инфра, не код; CI гоняет иначе.