### PR TITLE
feat(password-policy): настраиваемая политика требований к паролю

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -187,6 +187,7 @@ func main() {
 	approverService := services.NewApproverService(db)
 	consentService := services.NewConsentService(db)
 	settingsService := services.NewSettingsService(db, cfg)
+	userService.SetPasswordPolicyProvider(settingsService) // политика паролей при создании/смене
 	telegramService := services.NewTelegramService(cfg.TelegramBotToken, cfg.TelegramChatID)
 	bugReportService := services.NewBugReportService(db, telegramService)
 	maintenanceService := services.NewMaintenanceService(db)

--- a/frontend/src/api/settings.js
+++ b/frontend/src/api/settings.js
@@ -43,3 +43,17 @@ export async function getUploadSettings() {
 
   return response.json()
 }
+
+/**
+ * @returns {Promise<import('@/utils/passwordPolicy').PasswordPolicy>}
+ */
+export async function getPasswordPolicy() {
+  const response = await apiRequest('/settings/password-policy')
+
+  if (!response.ok) {
+    throw new Error(`Ошибка загрузки политики паролей: ${response.status}`)
+  }
+
+  const json = await response.json()
+  return json.data ?? json
+}

--- a/frontend/src/components/UserControl.vue
+++ b/frontend/src/components/UserControl.vue
@@ -449,7 +449,7 @@
                   Генерировать
                 </button>
                 <button
-                  :disabled="!selectedUser.newPassword"
+                  :disabled="!changePasswordValid"
                   class="save-password-btn"
                   @click="changeUserPassword(selectedUser)"
                 >
@@ -467,6 +467,19 @@
               >
                 {{ currentLanguage }} {{ isCapsLockOn ? '| CAPS LOCK' : '' }}
               </span>
+              <ul
+                v-if="selectedUser && selectedUser.newPassword"
+                class="password-checklist"
+              >
+                <li
+                  v-for="rule in changePasswordRules"
+                  :key="rule.key"
+                  :class="{ 'password-checklist__item--ok': rule.ok }"
+                  class="password-checklist__item"
+                >
+                  {{ rule.ok ? '✓' : '○' }} {{ rule.label }}
+                </li>
+              </ul>
             </div>
           </div>
         </div>
@@ -500,9 +513,19 @@
               placeholder="Введите пароль"
               @input="saveDraft"
             />
-            <div class="input-hint">
-              Минимум 6 символов
-            </div>
+            <ul
+              v-if="newUser.password"
+              class="password-checklist"
+            >
+              <li
+                v-for="rule in createPasswordRules"
+                :key="rule.key"
+                :class="{ 'password-checklist__item--ok': rule.ok }"
+                class="password-checklist__item"
+              >
+                {{ rule.ok ? '✓' : '○' }} {{ rule.label }}
+              </li>
+            </ul>
           </div>
           <div class="input-group half">
             <label class="input-label">Организация <span class="required">*</span></label>
@@ -664,6 +687,8 @@ import { buildSearchVariants, matchesSearch } from '@/utils/searchVariants'
 import SearchComponent from './SearchComponent.vue';
 import RefreshButton from './RefreshButton.vue';
 import PasswordInput from './ui/PasswordInput.vue';
+import { getPasswordPolicy } from '@/api/settings';
+import { evaluatePassword, passwordMeetsPolicy, generatePassword as buildPassword, DEFAULT_PASSWORD_POLICY } from '@/utils/passwordPolicy';
 import ConfirmationModal from './ConfirmationModal.vue';
 import BaseModal from './ui/BaseModal.vue';
 import BaseDropdown from './ui/BaseDropdown.vue';
@@ -726,6 +751,7 @@ export default {
       userTypes: [],
       sortField: null,
       sortDirection: 'desc',
+      passwordPolicy: { ...DEFAULT_PASSWORD_POLICY },
       newUser: {
         username: '',
         password: '',
@@ -826,10 +852,23 @@ export default {
         return 0;
       });
     },
+    createPasswordRules() {
+      return evaluatePassword(this.passwordPolicy, this.newUser.password || '');
+    },
+    createPasswordValid() {
+      return passwordMeetsPolicy(this.passwordPolicy, this.newUser.password || '');
+    },
+    changePasswordRules() {
+      return evaluatePassword(this.passwordPolicy, (this.selectedUser && this.selectedUser.newPassword) || '');
+    },
+    changePasswordValid() {
+      return passwordMeetsPolicy(this.passwordPolicy, (this.selectedUser && this.selectedUser.newPassword) || '');
+    },
     canCreateUser() {
       return (
         this.newUser.username &&
         this.newUser.password &&
+        this.createPasswordValid &&
         this.newUser.type_id &&
         this.hasOrgOrCompany
       );
@@ -848,6 +887,7 @@ export default {
       this.fetchUserTypes(),
       this.fetchCurrentUser()
     ]);
+    this.loadPasswordPolicy();
   },
   mounted() {
     this.fetchAllUsers();
@@ -1162,16 +1202,19 @@ export default {
     },
     
     generatePassword(user) {
-      const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!#$%&?';
-      const length = Math.floor(Math.random() * 6) + 6;
-      let password = '';
-      for (let i = 0; i < length; i++) {
-        password += chars.charAt(Math.floor(Math.random() * chars.length));
-      }
-      user.newPassword = password;
+      user.newPassword = buildPassword(this.passwordPolicy);
       this.showNewPass = true;
     },
     
+    async loadPasswordPolicy() {
+      try {
+        this.passwordPolicy = await getPasswordPolicy();
+      } catch (error) {
+        console.error('Не удалось загрузить политику паролей:', error);
+        this.passwordPolicy = { ...DEFAULT_PASSWORD_POLICY };
+      }
+    },
+
     async fetchUserTypes() {
       try {
         const response = await apiRequest("/user-types", {
@@ -1270,6 +1313,11 @@ export default {
     async changeUserPassword(user) {
       if (!user.newPassword) {
         useDeletionsStore().notify({ bold: 'Введите новый пароль', type: 'error' });
+        return;
+      }
+
+      if (!passwordMeetsPolicy(this.passwordPolicy, user.newPassword)) {
+        useDeletionsStore().notify({ bold: 'Пароль не соответствует требованиям', type: 'error' });
         return;
       }
 
@@ -1592,6 +1640,26 @@ export default {
 
 .password-group {
   margin-top: 8px;
+}
+
+.password-checklist {
+  list-style: none;
+  margin: 6px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.password-checklist__item {
+  font-size: 11px;
+  color: #999;
+  font-family: 'Montserrat', sans-serif;
+  transition: color 0.15s ease;
+}
+
+.password-checklist__item--ok {
+  color: #28a745;
 }
 
 .password-input-container {

--- a/frontend/src/components/__tests__/UserControl.passwordPolicy.spec.js
+++ b/frontend/src/components/__tests__/UserControl.passwordPolicy.spec.js
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import { createPinia, setActivePinia } from 'pinia'
+import UserControl from '@/components/UserControl.vue'
+
+// Мок политики: минимум 8 символов + буква + цифра (по умолчанию)
+vi.mock('@/api/settings', () => ({
+  getPasswordPolicy: vi.fn().mockResolvedValue({
+    min_length: 8,
+    require_letter: true,
+    require_uppercase: false,
+    require_lowercase: false,
+    require_digit: true,
+    require_special: false,
+  }),
+}))
+
+// UserControl дёргает apiRequest напрямую и через pinia-stores.
+// Мокаем транспорт и все API-зависимости чтобы монтирование не падало.
+vi.mock('@/api/client', () => ({
+  apiRequest: vi.fn().mockResolvedValue({
+    ok: true,
+    json: vi.fn().mockResolvedValue([]),
+  }),
+}))
+
+vi.mock('@/api/onboarding', () => ({
+  resetOnboardingForUser: vi.fn().mockResolvedValue({}),
+}))
+
+vi.mock('@/utils/notificationSound', () => ({
+  playPreset: vi.fn(),
+}))
+
+function mountUserControl() {
+  return mount(UserControl, {
+    props: {
+      allUsers: [],
+    },
+    global: {
+      mocks: {
+        $bus: { on: vi.fn(), off: vi.fn(), emit: vi.fn() },
+        $router: { push: vi.fn() },
+        $route: { path: '/admin/users', params: {} },
+      },
+    },
+  })
+}
+
+describe('UserControl — политика пароля при создании', () => {
+  let wrapper
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  afterEach(() => {
+    wrapper?.unmount()
+  })
+
+  it('слабый пароль блокирует создание', async () => {
+    wrapper = mountUserControl()
+    await flushPromises()
+
+    wrapper.vm.newUser.username = 'testuser'
+    wrapper.vm.newUser.type_id = 1
+    wrapper.vm.newUser.organization_id = 1
+    wrapper.vm.newUser.password = 'abc'
+    await nextTick()
+    expect(wrapper.vm.canCreateUser).toBeFalsy()
+  })
+
+  it('пароль по политике разрешает создание', async () => {
+    wrapper = mountUserControl()
+    await flushPromises()
+
+    wrapper.vm.newUser.username = 'testuser'
+    wrapper.vm.newUser.type_id = 1
+    wrapper.vm.newUser.organization_id = 1
+    wrapper.vm.newUser.password = 'password123'
+    await nextTick()
+    expect(wrapper.vm.canCreateUser).toBeTruthy()
+  })
+
+  it('createPasswordValid: false при слабом пароле', async () => {
+    wrapper = mountUserControl()
+    await flushPromises()
+
+    wrapper.vm.newUser.password = 'short'
+    await nextTick()
+    expect(wrapper.vm.createPasswordValid).toBe(false)
+  })
+
+  it('createPasswordValid: true при пароле по политике', async () => {
+    wrapper = mountUserControl()
+    await flushPromises()
+
+    wrapper.vm.newUser.password = 'Str0ngPass'
+    await nextTick()
+    expect(wrapper.vm.createPasswordValid).toBe(true)
+  })
+
+  it('changePasswordValid: false при пустом пароле', async () => {
+    wrapper = mountUserControl()
+    await flushPromises()
+
+    wrapper.vm.selectedUser = { username: 'u', newPassword: '' }
+    await nextTick()
+    expect(wrapper.vm.changePasswordValid).toBe(false)
+  })
+
+  it('changePasswordValid: true при пароле по политике', async () => {
+    wrapper = mountUserControl()
+    await flushPromises()
+
+    wrapper.vm.selectedUser = { username: 'u', newPassword: 'GoodPass1' }
+    await nextTick()
+    expect(wrapper.vm.changePasswordValid).toBe(true)
+  })
+})

--- a/frontend/src/utils/__tests__/passwordPolicy.spec.js
+++ b/frontend/src/utils/__tests__/passwordPolicy.spec.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import {
+  DEFAULT_PASSWORD_POLICY,
+  evaluatePassword,
+  passwordMeetsPolicy,
+  generatePassword,
+} from '@/utils/passwordPolicy'
+
+describe('evaluatePassword', () => {
+  it('дефолт: буква+цифра+8 проходит', () => {
+    expect(passwordMeetsPolicy(DEFAULT_PASSWORD_POLICY, 'password1')).toBe(true)
+  })
+  it('дефолт: без цифры не проходит', () => {
+    expect(passwordMeetsPolicy(DEFAULT_PASSWORD_POLICY, 'passwordonly')).toBe(false)
+  })
+  it('дефолт: короткий не проходит', () => {
+    expect(passwordMeetsPolicy(DEFAULT_PASSWORD_POLICY, 'pass1')).toBe(false)
+  })
+  it('выключенные требования не попадают в список', () => {
+    const rules = evaluatePassword({ min_length: 4 }, 'ab')
+    expect(rules).toHaveLength(1)
+    expect(rules[0].key).toBe('min_length')
+  })
+  it('спецсимвол распознаётся', () => {
+    const policy = { min_length: 4, require_special: true }
+    expect(passwordMeetsPolicy(policy, 'ab!9')).toBe(true)
+    expect(passwordMeetsPolicy(policy, 'abcd')).toBe(false)
+  })
+})
+
+describe('generatePassword', () => {
+  it('генерит пароль, проходящий любую политику', () => {
+    const policy = { min_length: 12, require_letter: true, require_uppercase: true, require_lowercase: true, require_digit: true, require_special: true }
+    for (let i = 0; i < 30; i++) {
+      const pw = generatePassword(policy)
+      expect(passwordMeetsPolicy(policy, pw)).toBe(true)
+    }
+  })
+})

--- a/frontend/src/utils/passwordPolicy.js
+++ b/frontend/src/utils/passwordPolicy.js
@@ -1,0 +1,87 @@
+// Набор спецсимволов синхронизирован с бэком (passwordSpecialChars в
+// internal/services/password_policy.go). Классы символов считаются по ASCII.
+const SPECIAL_CHARS = "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
+
+/**
+ * @typedef {Object} PasswordPolicy
+ * @property {number} min_length
+ * @property {boolean} [require_letter]
+ * @property {boolean} [require_uppercase]
+ * @property {boolean} [require_lowercase]
+ * @property {boolean} [require_digit]
+ * @property {boolean} [require_special]
+ */
+
+/** @type {PasswordPolicy} Совпадает с models.DefaultPasswordPolicy на бэке. */
+export const DEFAULT_PASSWORD_POLICY = {
+  min_length: 8,
+  require_letter: true,
+  require_uppercase: false,
+  require_lowercase: false,
+  require_digit: true,
+  require_special: false,
+}
+
+/**
+ * @param {PasswordPolicy} policy
+ * @param {string} password
+ * @returns {Array<{key: string, label: string, ok: boolean}>}
+ */
+export function evaluatePassword(policy, password) {
+  const chars = [...(password || '')]
+  const hasUpper = chars.some((c) => c >= 'A' && c <= 'Z')
+  const hasLower = chars.some((c) => c >= 'a' && c <= 'z')
+  const hasDigit = chars.some((c) => c >= '0' && c <= '9')
+  const hasLetter = hasUpper || hasLower
+  const hasSpecial = chars.some((c) => SPECIAL_CHARS.includes(c))
+
+  const rules = [
+    { key: 'min_length', label: `Минимум ${policy.min_length} символов`, ok: chars.length >= policy.min_length },
+  ]
+  if (policy.require_letter) rules.push({ key: 'letter', label: 'Хотя бы одна буква', ok: hasLetter })
+  if (policy.require_uppercase) rules.push({ key: 'uppercase', label: 'Хотя бы одна заглавная буква', ok: hasUpper })
+  if (policy.require_lowercase) rules.push({ key: 'lowercase', label: 'Хотя бы одна строчная буква', ok: hasLower })
+  if (policy.require_digit) rules.push({ key: 'digit', label: 'Хотя бы одна цифра', ok: hasDigit })
+  if (policy.require_special) rules.push({ key: 'special', label: 'Хотя бы один спецсимвол', ok: hasSpecial })
+  return rules
+}
+
+/**
+ * @param {PasswordPolicy} policy
+ * @param {string} password
+ * @returns {boolean}
+ */
+export function passwordMeetsPolicy(policy, password) {
+  return evaluatePassword(policy, password).every((r) => r.ok)
+}
+
+/**
+ * Генерит пароль, гарантированно проходящий политику.
+ * @param {PasswordPolicy} policy
+ * @returns {string}
+ */
+export function generatePassword(policy) {
+  const upper = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+  const lower = 'abcdefghijklmnopqrstuvwxyz'
+  const digits = '0123456789'
+  const special = '!#$%&?'
+  const pick = (set) => set[Math.floor(Math.random() * set.length)]
+
+  const out = []
+  if (policy.require_uppercase) out.push(pick(upper))
+  if (policy.require_lowercase) out.push(pick(lower))
+  if (policy.require_letter && !policy.require_uppercase && !policy.require_lowercase) out.push(pick(lower + upper))
+  if (policy.require_digit) out.push(pick(digits))
+  if (policy.require_special) out.push(pick(special))
+
+  const pool = lower + upper + digits + (policy.require_special ? special : '')
+  const target = Math.max(policy.min_length || 0, out.length, 8)
+  while (out.length < target) out.push(pick(pool))
+
+  // перемешиваем, чтобы обязательные символы не оказались в начале
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[out[i], out[j]] = [out[j], out[i]]
+  }
+  return out.join('')
+}

--- a/frontend/src/utils/passwordPolicy.js
+++ b/frontend/src/utils/passwordPolicy.js
@@ -64,6 +64,9 @@ export function generatePassword(policy) {
   const upper = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
   const lower = 'abcdefghijklmnopqrstuvwxyz'
   const digits = '0123456789'
+  // Намеренно узкое подмножество SPECIAL_CHARS (как в прежнем генераторе UserControl):
+  // безопасные для копипаста/шелла символы. Каждый входит в SPECIAL_CHARS, поэтому
+  // сгенерированный пароль всегда проходит require_special.
   const special = '!#$%&?'
   const pick = (set) => set[Math.floor(Math.random() * set.length)]
 

--- a/frontend/src/views/AdminSettings.vue
+++ b/frontend/src/views/AdminSettings.vue
@@ -42,6 +42,16 @@
         >
           Уведомления
         </div>
+        <div
+          class="sidebar-item"
+          :class="{ 'sidebar-item--active': activeSection === 'security' }"
+          role="button"
+          tabindex="0"
+          @click="activeSection = 'security'"
+          @keydown.enter="activeSection = 'security'"
+        >
+          Безопасность
+        </div>
       </nav>
 
       <div class="admin-settings__content">
@@ -291,6 +301,64 @@
               {{ saving ? 'Сохранение...' : 'Сохранить' }}
             </button>
           </div>
+
+          <!-- Безопасность: политика паролей -->
+          <div
+            v-else-if="activeSection === 'security'"
+            class="settings-section"
+          >
+            <h3 class="section-title">
+              Требования к паролю
+            </h3>
+
+            <div class="form-group">
+              <label
+                class="form-label"
+                for="pw-min-length"
+              >
+                Минимальная длина
+              </label>
+              <input
+                id="pw-min-length"
+                v-model.number="settings.password_min_length"
+                type="number"
+                class="form-input"
+                :min="6"
+                :max="128"
+              >
+              <span class="form-hint">От 6 до 128 символов</span>
+            </div>
+
+            <div
+              v-for="opt in passwordToggles"
+              :key="opt.key"
+              class="form-group"
+            >
+              <label class="switch-label">
+                <span class="switch-text">{{ opt.label }}</span>
+                <span
+                  class="switch"
+                  :class="{ 'switch--on': settings[opt.key] }"
+                  role="switch"
+                  :aria-checked="String(settings[opt.key])"
+                  tabindex="0"
+                  @click="settings[opt.key] = !settings[opt.key]"
+                  @keydown.enter="settings[opt.key] = !settings[opt.key]"
+                  @keydown.space.prevent="settings[opt.key] = !settings[opt.key]"
+                >
+                  <span class="switch__thumb" />
+                </span>
+              </label>
+            </div>
+
+            <button
+              class="btn btn--primary"
+              :disabled="saving"
+              @click="saveSecuritySettings"
+            >
+              {{ saving ? 'Сохранение...' : 'Сохранить' }}
+            </button>
+          </div>
         </SkeletonTransition>
       </div>
     </div>
@@ -325,9 +393,22 @@ export default {
         notifications_poll_interval: 30,
         notifications_delete_duration: 10,
         notifications_restore_duration: 5,
+        password_min_length: 8,
+        password_require_letter: true,
+        password_require_uppercase: false,
+        password_require_lowercase: false,
+        password_require_digit: true,
+        password_require_special: false,
       },
       availableImageTypes: ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/svg+xml'],
       availableDocTypes: ['application/pdf', 'application/msword', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', 'text/plain'],
+      passwordToggles: [
+        { key: 'password_require_letter', label: 'Требовать букву' },
+        { key: 'password_require_uppercase', label: 'Требовать заглавную букву' },
+        { key: 'password_require_lowercase', label: 'Требовать строчную букву' },
+        { key: 'password_require_digit', label: 'Требовать цифру' },
+        { key: 'password_require_special', label: 'Требовать спецсимвол' },
+      ],
     };
   },
   computed: {
@@ -398,6 +479,24 @@ export default {
             break;
           case 'notifications.restore_duration':
             this.settings.notifications_restore_duration = Number(item.value) || 5;
+            break;
+          case 'password.min_length':
+            this.settings.password_min_length = Number(item.value) || 8;
+            break;
+          case 'password.require_letter':
+            this.settings.password_require_letter = item.value === 'true';
+            break;
+          case 'password.require_uppercase':
+            this.settings.password_require_uppercase = item.value === 'true';
+            break;
+          case 'password.require_lowercase':
+            this.settings.password_require_lowercase = item.value === 'true';
+            break;
+          case 'password.require_digit':
+            this.settings.password_require_digit = item.value === 'true';
+            break;
+          case 'password.require_special':
+            this.settings.password_require_special = item.value === 'true';
             break;
         }
       }
@@ -480,6 +579,29 @@ export default {
         // вступят в силу только после полной перезагрузки страницы.
         useDeletionsStore().setDurations(del, res);
         useDeletionsStore().notify({ prefix: 'Настройки уведомлений сохранены' });
+      } catch (error) {
+        console.error('Ошибка сохранения:', error);
+        useDeletionsStore().notify({ prefix: 'Ошибка сохранения настроек', type: 'error' });
+      } finally {
+        this.saving = false;
+      }
+    },
+
+    async saveSecuritySettings() {
+      const len = this.settings.password_min_length;
+      if (len < 6 || len > 128) {
+        useDeletionsStore().notify({ prefix: 'Минимальная длина: от 6 до 128', type: 'error' });
+        return;
+      }
+      this.saving = true;
+      try {
+        await updateSetting('password.min_length', String(len));
+        await updateSetting('password.require_letter', String(this.settings.password_require_letter));
+        await updateSetting('password.require_uppercase', String(this.settings.password_require_uppercase));
+        await updateSetting('password.require_lowercase', String(this.settings.password_require_lowercase));
+        await updateSetting('password.require_digit', String(this.settings.password_require_digit));
+        await updateSetting('password.require_special', String(this.settings.password_require_special));
+        useDeletionsStore().notify({ prefix: 'Требования к паролю сохранены' });
       } catch (error) {
         console.error('Ошибка сохранения:', error);
         useDeletionsStore().notify({ prefix: 'Ошибка сохранения настроек', type: 'error' });

--- a/frontend/src/views/__tests__/AdminSettings.security.spec.js
+++ b/frontend/src/views/__tests__/AdminSettings.security.spec.js
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { shallowMount, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+
+const getSettings = vi.fn();
+const updateSetting = vi.fn();
+vi.mock('@/api/settings', () => ({
+  getSettings: (...a) => getSettings(...a),
+  updateSetting: (...a) => updateSetting(...a),
+}));
+
+import AdminSettings from '../AdminSettings.vue';
+
+async function mountView() {
+  getSettings.mockResolvedValue([
+    { key: 'password.min_length', value: '10', type: 'int' },
+    { key: 'password.require_special', value: 'true', type: 'bool' },
+  ]);
+  updateSetting.mockResolvedValue({});
+  const wrapper = shallowMount(AdminSettings);
+  await flushPromises();
+  return wrapper;
+}
+
+describe('AdminSettings - раздел безопасности', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    getSettings.mockReset();
+    updateSetting.mockReset();
+  });
+
+  it('маппит ключи password.* из ответа', async () => {
+    const wrapper = await mountView();
+    expect(wrapper.vm.settings.password_min_length).toBe(10);
+    expect(wrapper.vm.settings.password_require_special).toBe(true);
+  });
+
+  it('saveSecuritySettings шлёт все ключи политики', async () => {
+    const wrapper = await mountView();
+    await wrapper.vm.saveSecuritySettings();
+    const keys = updateSetting.mock.calls.map((c) => c[0]);
+    expect(keys).toEqual(expect.arrayContaining([
+      'password.min_length',
+      'password.require_letter',
+      'password.require_uppercase',
+      'password.require_lowercase',
+      'password.require_digit',
+      'password.require_special',
+    ]));
+  });
+});

--- a/internal/handlers/auth_test.go
+++ b/internal/handlers/auth_test.go
@@ -77,7 +77,7 @@ func TestCreateUser_DuplicateUsername(t *testing.T) {
 
 	testutil.RegisterUser(t, e, "dupuser", "pass123", 1, td.OrgID, td.CompanyID)
 
-	body := `{"username":"dupuser","password":"pass456","type_id":1,"organization_id":` +
+	body := `{"username":"dupuser","password":"password123","type_id":1,"organization_id":` +
 		itoa(td.OrgID) + `,"company_id":` + itoa(td.CompanyID) + `}`
 	rec := testutil.POST(t, e, "/users", body, h)
 

--- a/internal/handlers/settings.go
+++ b/internal/handlers/settings.go
@@ -56,3 +56,9 @@ func (h *SettingsHandler) GetNotificationSettings(c echo.Context) error {
 	}
 	return RespondSuccess(c, result)
 }
+
+// GetPasswordPolicy возвращает текущую политику требований к паролю для фронтенда
+// (живой чеклист в форме). Доступен любому авторизованному.
+func (h *SettingsHandler) GetPasswordPolicy(c echo.Context) error {
+	return RespondSuccess(c, h.service.GetPasswordPolicy())
+}

--- a/internal/handlers/settings_test.go
+++ b/internal/handlers/settings_test.go
@@ -128,3 +128,27 @@ func TestSettings_GetUploadSettings_AuthUser(t *testing.T) {
 	assert.NotNil(t, resp["max_file_size"])
 	assert.NotNil(t, resp["allowed_image_types"])
 }
+
+func TestSettings_PasswordPolicyValidation(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	// min_length вне диапазона -> 400
+	rec := testutil.PUT(t, e, "/settings/password.min_length", `{"value":"3"}`, testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	// валидный min_length -> 200
+	rec = testutil.PUT(t, e, "/settings/password.min_length", `{"value":"10"}`, testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// bool-ключ с мусором -> 400
+	rec = testutil.PUT(t, e, "/settings/password.require_digit", `{"value":"maybe"}`, testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	// валидный bool -> 200
+	rec = testutil.PUT(t, e, "/settings/password.require_special", `{"value":"true"}`, testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusOK, rec.Code)
+}

--- a/internal/handlers/settings_test.go
+++ b/internal/handlers/settings_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"testing"
 
+	"systemburo/internal/models"
 	"systemburo/internal/testutil"
 
 	"github.com/stretchr/testify/assert"
@@ -127,6 +128,21 @@ func TestSettings_GetUploadSettings_AuthUser(t *testing.T) {
 	resp := testutil.ParseMap(t, rec)
 	assert.NotNil(t, resp["max_file_size"])
 	assert.NotNil(t, resp["allowed_image_types"])
+}
+
+func TestGetPasswordPolicy(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAndLogin(t, e, "policy_reader", "password123456789012345678901234", 1, td.OrgID, td.CompanyID)
+
+	rec := testutil.GET(t, e, "/settings/password-policy", testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	policy := testutil.ParseResponse[models.PasswordPolicy](t, rec)
+	assert.Equal(t, 8, policy.MinLength)
+	assert.True(t, policy.RequireDigit)
 }
 
 func TestSettings_PasswordPolicyValidation(t *testing.T) {

--- a/internal/handlers/users_test.go
+++ b/internal/handlers/users_test.go
@@ -545,3 +545,53 @@ func TestUsers_ManagerAlsoHasAdminAccess(t *testing.T) {
 	rec := testutil.GET(t, e, "/users/all", h)
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
+
+func TestCreateUser_WeakPassword_Rejected(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	adminToken := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(adminToken)
+
+	// Пароль без цифры при require_digit=true (дефолт) -> 400
+	body := fmt.Sprintf(`{"username":"weakpw","password":"passwordonly","type_id":1,"organization_id":%d}`, td.OrgID)
+	rec := testutil.POST(t, e, "/users", body, h)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	// Слишком короткий пароль -> 400
+	body = fmt.Sprintf(`{"username":"weakpw2","password":"ab1","type_id":1,"organization_id":%d}`, td.OrgID)
+	rec = testutil.POST(t, e, "/users", body, h)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	// Валидный пароль (буква + цифра, >= 8 символов) -> 200
+	body = fmt.Sprintf(`{"username":"strongpw","password":"password123","type_id":1,"organization_id":%d}`, td.OrgID)
+	rec = testutil.POST(t, e, "/users", body, h)
+	assert.Contains(t, []int{http.StatusOK, http.StatusCreated}, rec.Code)
+}
+
+func TestUpdatePassword_WeakPassword_Rejected(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	adminToken := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(adminToken)
+
+	// Создаём целевого пользователя через DB (как в TestUsers_UpdatePassword)
+	testutil.RegisterUser(t, e, "pwpolicytarget", "password123", 1, td.OrgID, td.CompanyID)
+
+	// Слабый пароль (нет цифры) -> 400
+	rec := testutil.PUT(t, e, "/users/pwpolicytarget/password", `{"password":"weakpassword"}`, h)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	// Слишком короткий -> 400
+	rec = testutil.PUT(t, e, "/users/pwpolicytarget/password", `{"password":"short1"}`, h)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	// Валидный пароль -> 200
+	rec = testutil.PUT(t, e, "/users/pwpolicytarget/password", `{"password":"newpassword123"}`, h)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}

--- a/internal/models/password_policy.go
+++ b/internal/models/password_policy.go
@@ -1,0 +1,24 @@
+package models
+
+// PasswordPolicy — настраиваемые требования к паролю. Значения берутся из
+// system_settings (ключи password.*). Сериализуется как ответ
+// GET /api/settings/password-policy.
+type PasswordPolicy struct {
+	MinLength        int  `json:"min_length"`
+	RequireLetter    bool `json:"require_letter"`
+	RequireUppercase bool `json:"require_uppercase"`
+	RequireLowercase bool `json:"require_lowercase"`
+	RequireDigit     bool `json:"require_digit"`
+	RequireSpecial   bool `json:"require_special"`
+}
+
+// DefaultPasswordPolicy — дефолт "из коробки" (мин 8, буква + цифра).
+// Должен совпадать с defaults в NewSettingsService и с фронтовым
+// DEFAULT_PASSWORD_POLICY.
+func DefaultPasswordPolicy() PasswordPolicy {
+	return PasswordPolicy{
+		MinLength:     8,
+		RequireLetter: true,
+		RequireDigit:  true,
+	}
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -539,6 +539,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	protected.GET("/settings", settings.GetAll)
 	protected.GET("/settings/upload", settings.GetUploadSettings)
 	protected.GET("/settings/notifications", settings.GetNotificationSettings)
+	protected.GET("/settings/password-policy", settings.GetPasswordPolicy)
 	protected.PUT("/settings/:key", settings.Update)
 
 	// Новости

--- a/internal/services/password_policy.go
+++ b/internal/services/password_policy.go
@@ -1,0 +1,74 @@
+package services
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"systemburo/internal/models"
+
+	"github.com/labstack/echo/v4"
+)
+
+// passwordSpecialChars — печатаемые ASCII-символы, не входящие в [A-Za-z0-9].
+// Набор синхронизирован с фронтовым SPECIAL_CHARS (utils/passwordPolicy.js).
+const passwordSpecialChars = "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
+
+// PolicyRule — результат проверки одного включённого требования политики.
+type PolicyRule struct {
+	Key   string
+	Label string
+	OK    bool
+}
+
+// EvaluatePassword проверяет пароль против политики и возвращает результат по
+// каждому ВКЛЮЧЁННОМУ требованию (выключенные не попадают в список).
+// Классы символов считаются по ASCII, чтобы совпадать с фронтом.
+func EvaluatePassword(p models.PasswordPolicy, password string) []PolicyRule {
+	var hasUpper, hasLower, hasDigit, hasSpecial bool
+	for _, r := range password {
+		switch {
+		case r >= 'A' && r <= 'Z':
+			hasUpper = true
+		case r >= 'a' && r <= 'z':
+			hasLower = true
+		case r >= '0' && r <= '9':
+			hasDigit = true
+		case strings.ContainsRune(passwordSpecialChars, r):
+			hasSpecial = true
+		}
+	}
+	hasLetter := hasUpper || hasLower
+	length := len([]rune(password))
+
+	rules := []PolicyRule{
+		{Key: "min_length", Label: fmt.Sprintf("Минимум %d символов", p.MinLength), OK: length >= p.MinLength},
+	}
+	if p.RequireLetter {
+		rules = append(rules, PolicyRule{Key: "letter", Label: "Хотя бы одна буква", OK: hasLetter})
+	}
+	if p.RequireUppercase {
+		rules = append(rules, PolicyRule{Key: "uppercase", Label: "Хотя бы одна заглавная буква", OK: hasUpper})
+	}
+	if p.RequireLowercase {
+		rules = append(rules, PolicyRule{Key: "lowercase", Label: "Хотя бы одна строчная буква", OK: hasLower})
+	}
+	if p.RequireDigit {
+		rules = append(rules, PolicyRule{Key: "digit", Label: "Хотя бы одна цифра", OK: hasDigit})
+	}
+	if p.RequireSpecial {
+		rules = append(rules, PolicyRule{Key: "special", Label: "Хотя бы один спецсимвол", OK: hasSpecial})
+	}
+	return rules
+}
+
+// ValidatePassword возвращает echo 400 с текстом первого нарушенного требования,
+// либо nil. Вызывается ДО хеширования.
+func ValidatePassword(p models.PasswordPolicy, password string) error {
+	for _, r := range EvaluatePassword(p, password) {
+		if !r.OK {
+			return echo.NewHTTPError(http.StatusBadRequest, "Пароль не соответствует требованиям: "+r.Label)
+		}
+	}
+	return nil
+}

--- a/internal/services/password_policy_test.go
+++ b/internal/services/password_policy_test.go
@@ -1,0 +1,58 @@
+package services
+
+import (
+	"testing"
+
+	"systemburo/internal/models"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEvaluatePassword(t *testing.T) {
+	t.Parallel()
+	full := models.PasswordPolicy{MinLength: 8, RequireLetter: true, RequireUppercase: true, RequireLowercase: true, RequireDigit: true, RequireSpecial: true}
+
+	tests := []struct {
+		name      string
+		policy    models.PasswordPolicy
+		password  string
+		wantValid bool
+	}{
+		{"default ok", models.DefaultPasswordPolicy(), "password1", true},
+		{"default too short", models.DefaultPasswordPolicy(), "pass1", false},
+		{"default no digit", models.DefaultPasswordPolicy(), "passwordonly", false},
+		{"default no letter", models.DefaultPasswordPolicy(), "12345678", false},
+		{"full ok", full, "Passw0rd!", true},
+		{"full no special", full, "Passw0rdd", false},
+		{"full no upper", full, "passw0rd!", false},
+		{"length counts runes", models.PasswordPolicy{MinLength: 8}, "абвгдежз", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			rules := EvaluatePassword(tt.policy, tt.password)
+			valid := true
+			for _, r := range rules {
+				if !r.OK {
+					valid = false
+				}
+			}
+			assert.Equal(t, tt.wantValid, valid)
+		})
+	}
+}
+
+func TestEvaluatePassword_OnlyEnabledRules(t *testing.T) {
+	t.Parallel()
+	// Выключенные требования не появляются в списке.
+	rules := EvaluatePassword(models.PasswordPolicy{MinLength: 4}, "ab")
+	assert.Len(t, rules, 1)
+	assert.Equal(t, "min_length", rules[0].Key)
+}
+
+func TestValidatePassword_Returns400(t *testing.T) {
+	t.Parallel()
+	err := ValidatePassword(models.DefaultPasswordPolicy(), "short")
+	assert.Error(t, err)
+	assert.Nil(t, ValidatePassword(models.DefaultPasswordPolicy(), "password1"))
+}

--- a/internal/services/settings_service.go
+++ b/internal/services/settings_service.go
@@ -20,17 +20,24 @@ type SettingsService interface {
 	Update(ctx context.Context, isSuperAdmin bool, key string, value string) (*models.SystemSetting, error)
 	GetUploadSettings(ctx context.Context) (map[string]interface{}, error)
 	GetNotificationSettings(ctx context.Context) (map[string]interface{}, error)
+	GetPasswordPolicy() models.PasswordPolicy
 }
 
 var knownKeys = map[string]string{
-	"upload.max_file_size":            "int",
-	"upload.allowed_image_types":      "json",
-	"upload.allowed_doc_types":        "json",
-	"pagination.max_per_page":         "int",
-	"notifications.enabled":           "bool",
-	"notifications.poll_interval":     "int",
-	"notifications.delete_duration":   "int",
-	"notifications.restore_duration":  "int",
+	"upload.max_file_size":           "int",
+	"upload.allowed_image_types":     "json",
+	"upload.allowed_doc_types":       "json",
+	"pagination.max_per_page":        "int",
+	"notifications.enabled":          "bool",
+	"notifications.poll_interval":    "int",
+	"notifications.delete_duration":  "int",
+	"notifications.restore_duration": "int",
+	"password.min_length":            "int",
+	"password.require_letter":        "bool",
+	"password.require_uppercase":     "bool",
+	"password.require_lowercase":     "bool",
+	"password.require_digit":         "bool",
+	"password.require_special":       "bool",
 }
 
 type settingsService struct {
@@ -43,14 +50,20 @@ type settingsService struct {
 // NewSettingsService создаёт сервис для управления системными настройками.
 func NewSettingsService(db *gorm.DB, cfg *config.Config) SettingsService {
 	defaults := map[string]models.SystemSetting{
-		"upload.max_file_size":        {Key: "upload.max_file_size", Value: strconv.FormatInt(cfg.UploadMaxFileSize, 10), Type: "int"},
-		"upload.allowed_image_types":  {Key: "upload.allowed_image_types", Value: mustJSON(cfg.UploadAllowedImageTypes), Type: "json"},
-		"upload.allowed_doc_types":    {Key: "upload.allowed_doc_types", Value: mustJSON(cfg.UploadAllowedDocTypes), Type: "json"},
-		"pagination.max_per_page":     {Key: "pagination.max_per_page", Value: strconv.Itoa(cfg.PaginationMaxLimit), Type: "int"},
-		"notifications.enabled":         {Key: "notifications.enabled", Value: "true", Type: "bool"},
+		"upload.max_file_size":           {Key: "upload.max_file_size", Value: strconv.FormatInt(cfg.UploadMaxFileSize, 10), Type: "int"},
+		"upload.allowed_image_types":     {Key: "upload.allowed_image_types", Value: mustJSON(cfg.UploadAllowedImageTypes), Type: "json"},
+		"upload.allowed_doc_types":       {Key: "upload.allowed_doc_types", Value: mustJSON(cfg.UploadAllowedDocTypes), Type: "json"},
+		"pagination.max_per_page":        {Key: "pagination.max_per_page", Value: strconv.Itoa(cfg.PaginationMaxLimit), Type: "int"},
+		"notifications.enabled":          {Key: "notifications.enabled", Value: "true", Type: "bool"},
 		"notifications.poll_interval":    {Key: "notifications.poll_interval", Value: "30", Type: "int"},
 		"notifications.delete_duration":  {Key: "notifications.delete_duration", Value: "10", Type: "int"},
 		"notifications.restore_duration": {Key: "notifications.restore_duration", Value: "5", Type: "int"},
+		"password.min_length":            {Key: "password.min_length", Value: "8", Type: "int"},
+		"password.require_letter":        {Key: "password.require_letter", Value: "true", Type: "bool"},
+		"password.require_uppercase":     {Key: "password.require_uppercase", Value: "false", Type: "bool"},
+		"password.require_lowercase":     {Key: "password.require_lowercase", Value: "false", Type: "bool"},
+		"password.require_digit":         {Key: "password.require_digit", Value: "true", Type: "bool"},
+		"password.require_special":       {Key: "password.require_special", Value: "false", Type: "bool"},
 	}
 
 	s := &settingsService{db: db, defaults: defaults, cache: make(map[string]models.SystemSetting)}
@@ -172,6 +185,22 @@ func (s *settingsService) GetNotificationSettings(ctx context.Context) (map[stri
 	}, nil
 }
 
+// GetPasswordPolicy собирает текущую политику паролей из кэша настроек.
+func (s *settingsService) GetPasswordPolicy() models.PasswordPolicy {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	minLen, _ := strconv.Atoi(s.cache["password.min_length"].Value)
+	return models.PasswordPolicy{
+		MinLength:        minLen,
+		RequireLetter:    s.cache["password.require_letter"].Value == "true",
+		RequireUppercase: s.cache["password.require_uppercase"].Value == "true",
+		RequireLowercase: s.cache["password.require_lowercase"].Value == "true",
+		RequireDigit:     s.cache["password.require_digit"].Value == "true",
+		RequireSpecial:   s.cache["password.require_special"].Value == "true",
+	}
+}
+
 func validateSettingValue(key, value string) error {
 	switch key {
 	case "upload.max_file_size":
@@ -197,6 +226,15 @@ func validateSettingValue(key, value string) error {
 	case "notifications.enabled":
 		if value != "true" && value != "false" {
 			return fmt.Errorf("notifications.enabled: true/false (получено %s)", value)
+		}
+	case "password.min_length":
+		v, err := strconv.Atoi(value)
+		if err != nil || v < 6 || v > 128 {
+			return fmt.Errorf("password.min_length: 6-128 (получено %s)", value)
+		}
+	case "password.require_letter", "password.require_uppercase", "password.require_lowercase", "password.require_digit", "password.require_special":
+		if value != "true" && value != "false" {
+			return fmt.Errorf("%s: true/false (получено %s)", key, value)
 		}
 	case "upload.allowed_image_types", "upload.allowed_doc_types":
 		var arr []string

--- a/internal/services/user_service.go
+++ b/internal/services/user_service.go
@@ -41,6 +41,8 @@ type UserService interface {
 	// SetBanCache подключает кэш блокировок, чтобы архив/восстановление мгновенно
 	// сбрасывали его (офбординг без ожидания TTL). Опционально (может не вызываться).
 	SetBanCache(banCache *BanCheckService)
+	// SetPasswordPolicyProvider подключает источник политики паролей.
+	SetPasswordPolicyProvider(p PasswordPolicyProvider)
 
 	// GetUserUnloadPlaces возвращает активные места разгрузки, привязанные к охраннику.
 	GetUserUnloadPlaces(ctx context.Context, callerTypeID int, username string) ([]models.UnloadPlace, error)
@@ -52,11 +54,17 @@ type UserService interface {
 	SetUserTables(ctx context.Context, callerTypeID int, username string, req models.SetUserTablesRequest) error
 }
 
+// PasswordPolicyProvider отдаёт текущую политику паролей (реализуется SettingsService).
+type PasswordPolicyProvider interface {
+	GetPasswordPolicy() models.PasswordPolicy
+}
+
 type userService struct {
 	db                  *gorm.DB
 	notificationService NotificationService
 	history             UserHistoryService
 	banCache            *BanCheckService
+	policy              PasswordPolicyProvider
 }
 
 // NewUserService создаёт новый экземпляр сервиса управления пользователями.
@@ -76,6 +84,21 @@ func NewUserService(db *gorm.DB, notificationService NotificationService) UserSe
 // в main.go banCheckService создаётся позже userService).
 func (s *userService) SetBanCache(banCache *BanCheckService) {
 	s.banCache = banCache
+}
+
+// SetPasswordPolicyProvider подключает источник политики паролей (опционально,
+// после конструирования - settingsService в main.go создаётся позже userService).
+func (s *userService) SetPasswordPolicyProvider(p PasswordPolicyProvider) {
+	s.policy = p
+}
+
+// passwordPolicy возвращает активную политику, либо безопасный дефолт, если
+// провайдер не подключён (валидация НЕ отключается - это критичная проверка).
+func (s *userService) passwordPolicy() models.PasswordPolicy {
+	if s.policy != nil {
+		return s.policy.GetPasswordPolicy()
+	}
+	return models.DefaultPasswordPolicy()
 }
 
 // targetUserID резолвит id пользователя по username для записи в историю.
@@ -116,6 +139,10 @@ func (s *userService) Create(ctx context.Context, callerTypeID, callerUserID int
 
 	if req.OrganizationID <= 0 && req.CompanyID <= 0 {
 		return echo.NewHTTPError(http.StatusBadRequest, "Необходимо указать организацию или компанию (хотя бы одно)")
+	}
+
+	if err := ValidatePassword(s.passwordPolicy(), req.Password); err != nil {
+		return err
 	}
 
 	user := models.User{
@@ -229,6 +256,10 @@ func (s *userService) UpdateType(ctx context.Context, callerTypeID, callerUserID
 // сессии (возможно скомпрометированные) продолжили бы жить до истечения TTL.
 func (s *userService) UpdatePassword(ctx context.Context, callerTypeID, callerUserID int, username string, req models.UpdatePasswordRequest) error {
 	if err := s.checkAdmin(ctx, callerTypeID); err != nil {
+		return err
+	}
+
+	if err := ValidatePassword(s.passwordPolicy(), req.Password); err != nil {
 		return err
 	}
 

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -134,6 +134,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 		UploadAllowedDocTypes:   []string{"application/pdf"},
 		PaginationMaxLimit:      100,
 	})
+	userService.SetPasswordPolicyProvider(settingsService)
 
 	// Create maintenance service early so authHandler can get it.
 	maintenanceService := services.NewMaintenanceService(db)


### PR DESCRIPTION
Добавил настраиваемую super-admin'ом политику требований к паролю. Раньше требований не было кроме статического min=6 в валидаторе; теперь компания может задать свои правила через админку без правки кода.

## Что внутри
- Вкладка Настройки -> новый раздел "Безопасность": минимальная длина (6-128) и тогглы "требовать букву / заглавную / строчную / цифру / спецсимвол".
- Бэк применяет политику при создании пользователя и смене/сбросе пароля (до хеширования; auth-зона и Argon2 не тронуты).
- В управлении пользователями под полями пароля живой чеклист требований, кнопки блокируются пока пароль не подходит, генератор соблюдает политику.
- Эндпоинт GET /api/settings/password-policy отдаёт текущую политику форме (любой авторизованный); запись ключей остаётся под super-admin.

## Хранение
6 ключей password.* в существующей таблице system_settings (key-value), миграции не нужны - строки создаются лениво. Дефолт: мин 8, буква + цифра; остальное выключено и включается в UI.

## Тесты
- Go: юнит на валидатор (ASCII-классы, длина в рунах), хендлер-тесты на отклонение слабого пароля при создании/смене, валидацию ключей и диапазона, чтение политики.
- Front: vitest на util (классы, генератор проходит политику), раздел настроек (маппинг и сохранение ключей), чеклист и гейтинг в форме.

FE и BE классифицируют символы одинаково (ASCII), набор спецсимволов синхронизирован между internal/services/password_policy.go и frontend/src/utils/passwordPolicy.js.