### PR TITLE
feat(analytics): выбор дат отчёта через календарь вместо нативных инпутов (#632)

### DIFF
--- a/frontend/src/components/statistics/ReportBuilder.vue
+++ b/frontend/src/components/statistics/ReportBuilder.vue
@@ -204,24 +204,15 @@
           </button>
         </div>
         <div class="rb__period-dates">
-          <label class="rb__date">
-            <span class="rb__field-label">С</span>
-            <input
-              v-model="form.period.from"
-              type="date"
-              class="lk-input"
-              @change="activePeriodPreset = 'custom'"
-            >
-          </label>
-          <label class="rb__date">
-            <span class="rb__field-label">По</span>
-            <input
-              v-model="form.period.to"
-              type="date"
-              class="lk-input"
-              @change="activePeriodPreset = 'custom'"
-            >
-          </label>
+          <DateFilter
+            mode="range"
+            :date-range-start="periodStartDate"
+            :date-range-end="periodEndDate"
+            @update:date-range-start="onPeriodRangeStart"
+            @update:date-range-end="onPeriodRangeEnd"
+            @apply="onPeriodApply"
+            @clear="onPeriodClear"
+          />
         </div>
       </div>
     </div>
@@ -291,6 +282,7 @@
 import { reactive, ref, computed, watch, nextTick } from 'vue';
 import FilterTabs from '@/components/ui/FilterTabs.vue';
 import BaseDropdown from '@/components/ui/BaseDropdown.vue';
+import DateFilter from '@/components/DateFilter.vue';
 import { buildReportRequest } from '@/composables/useReportRequest';
 import { formatDateRu } from '@/utils/datetime';
 
@@ -598,15 +590,14 @@ function toggleFilter(key, value) {
 function computePeriod(kind) {
   if (kind === 'all') return { from: '', to: '' };
   const now = new Date();
-  const fmt = (dt) => `${dt.getFullYear()}-${String(dt.getMonth() + 1).padStart(2, '0')}-${String(dt.getDate()).padStart(2, '0')}`;
-  const to = fmt(now);
+  const to = dateToIso(now);
   if (kind === 'week') {
     const monday = new Date(now);
     monday.setDate(now.getDate() - ((now.getDay() + 6) % 7)); // Пн = начало недели
-    return { from: fmt(monday), to };
+    return { from: dateToIso(monday), to };
   }
-  if (kind === 'month') return { from: fmt(new Date(now.getFullYear(), now.getMonth(), 1)), to };
-  if (kind === 'year') return { from: fmt(new Date(now.getFullYear(), 0, 1)), to };
+  if (kind === 'month') return { from: dateToIso(new Date(now.getFullYear(), now.getMonth(), 1)), to };
+  if (kind === 'year') return { from: dateToIso(new Date(now.getFullYear(), 0, 1)), to };
   return { from: '', to: '' };
 }
 
@@ -615,6 +606,42 @@ function applyPeriodPreset(kind) {
   form.period.from = range.from;
   form.period.to = range.to;
   activePeriodPreset.value = kind;
+}
+
+// Период хранится в form как ISO YYYY-MM-DD (формат бэка), а DateFilter работает с
+// Date-объектами в локальной зоне. Разбираем/собираем по календарным частям, не через
+// toISOString, чтобы не словить сдвиг даты на границе суток.
+function dateToIso(dt) {
+  return `${dt.getFullYear()}-${String(dt.getMonth() + 1).padStart(2, '0')}-${String(dt.getDate()).padStart(2, '0')}`;
+}
+
+function isoToDate(iso) {
+  if (!iso) return null;
+  const [y, m, d] = iso.split('-').map(Number);
+  if (!y || !m || !d) return null;
+  return new Date(y, m - 1, d);
+}
+
+const periodStartDate = computed(() => isoToDate(form.period.from));
+const periodEndDate = computed(() => isoToDate(form.period.to));
+
+function onPeriodRangeStart(date) {
+  form.period.from = date ? dateToIso(date) : '';
+}
+
+function onPeriodRangeEnd(date) {
+  form.period.to = date ? dateToIso(date) : '';
+}
+
+// Любой ручной выбор/очистка диапазона в календаре уводит период из-под пресета.
+function onPeriodApply() {
+  activePeriodPreset.value = 'custom';
+}
+
+function onPeriodClear() {
+  form.period.from = '';
+  form.period.to = '';
+  activePeriodPreset.value = 'custom';
 }
 
 // Снимок состояния формы для индикатора шагов мастера (родитель считает по нему
@@ -968,12 +995,6 @@ function run() {
   display: flex;
   flex-wrap: wrap;
   gap: 14px;
-}
-
-.rb__date {
-  display: flex;
-  flex-direction: column;
-  gap: 7px;
 }
 
 .rb__preview {

--- a/frontend/src/components/statistics/ReportBuilder.vue
+++ b/frontend/src/components/statistics/ReportBuilder.vue
@@ -210,7 +210,6 @@
             :date-range-end="periodEndDate"
             @update:date-range-start="onPeriodRangeStart"
             @update:date-range-end="onPeriodRangeEnd"
-            @apply="onPeriodApply"
             @clear="onPeriodClear"
           />
         </div>
@@ -625,16 +624,21 @@ function isoToDate(iso) {
 const periodStartDate = computed(() => isoToDate(form.period.from));
 const periodEndDate = computed(() => isoToDate(form.period.to));
 
+// DateFilter эмитит update:* при каждом «Применить», даже когда даты не менялись.
+// Уводим период в 'custom' только при РЕАЛЬНОЙ смене границы — иначе «Применить»
+// на выставленном пресете без правок сбивал бы его подсветку (нативный input
+// раньше тоже молчал, пока значение не изменится).
 function onPeriodRangeStart(date) {
-  form.period.from = date ? dateToIso(date) : '';
+  const iso = date ? dateToIso(date) : '';
+  if (iso === form.period.from) return;
+  form.period.from = iso;
+  activePeriodPreset.value = 'custom';
 }
 
 function onPeriodRangeEnd(date) {
-  form.period.to = date ? dateToIso(date) : '';
-}
-
-// Любой ручной выбор/очистка диапазона в календаре уводит период из-под пресета.
-function onPeriodApply() {
+  const iso = date ? dateToIso(date) : '';
+  if (iso === form.period.to) return;
+  form.period.to = iso;
   activePeriodPreset.value = 'custom';
 }
 

--- a/frontend/src/components/statistics/__tests__/ReportBuilder.spec.js
+++ b/frontend/src/components/statistics/__tests__/ReportBuilder.spec.js
@@ -4,6 +4,7 @@ import { nextTick } from 'vue';
 import ReportBuilder from '../ReportBuilder.vue';
 import FilterTabs from '@/components/ui/FilterTabs.vue';
 import BaseDropdown from '@/components/ui/BaseDropdown.vue';
+import DateFilter from '@/components/DateFilter.vue';
 
 const CATALOG = {
   metrics: [
@@ -386,5 +387,38 @@ describe('ReportBuilder', () => {
     const summary = wrapper.find('.rb__summary').text();
     expect(summary).toContain('01.06.2026 — 07.06.2026');
     expect(summary).not.toContain('2026-06-01');
+  });
+
+  it('начальный период из шапки прокинут в календарь DateFilter как Date-диапазон', () => {
+    const wrapper = mountBuilder();
+    const cal = wrapper.findComponent(DateFilter);
+    expect(cal.exists()).toBe(true);
+    expect(cal.props('mode')).toBe('range');
+
+    const start = cal.props('dateRangeStart');
+    const end = cal.props('dateRangeEnd');
+    expect(start.getFullYear()).toBe(2026);
+    expect(start.getMonth()).toBe(5); // июнь (0-based)
+    expect(start.getDate()).toBe(1);
+    expect(end.getMonth()).toBe(5);
+    expect(end.getDate()).toBe(7);
+  });
+
+  it('выбор диапазона в DateFilter обновляет период запроса (ISO) и снимает пресет', async () => {
+    const wrapper = mountBuilder();
+    await nextTick();
+
+    const cal = wrapper.findComponent(DateFilter);
+    cal.vm.$emit('update:dateRangeStart', new Date(2026, 2, 5)); // 5 марта 2026
+    cal.vm.$emit('update:dateRangeEnd', new Date(2026, 2, 20)); // 20 марта 2026
+    cal.vm.$emit('apply');
+    await nextTick();
+
+    await clickBuild(wrapper);
+    const dr = lastRun(wrapper).filters.find((f) => f.key === 'date_range');
+    expect(dr).toEqual({ key: 'date_range', from: '2026-03-05', to: '2026-03-20' });
+
+    // Ручной выбор уводит период из-под пресета — ни одна кнопка не подсвечена.
+    expect(wrapper.find('.rb__period-presets').findAll('.rb__pill--on').length).toBe(0);
   });
 });

--- a/frontend/src/components/statistics/__tests__/ReportBuilder.spec.js
+++ b/frontend/src/components/statistics/__tests__/ReportBuilder.spec.js
@@ -421,4 +421,26 @@ describe('ReportBuilder', () => {
     // Ручной выбор уводит период из-под пресета — ни одна кнопка не подсвечена.
     expect(wrapper.find('.rb__period-presets').findAll('.rb__pill--on').length).toBe(0);
   });
+
+  it('«Применить» в календаре без смены дат не сбивает активный пресет', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 5, 18)); // 18 июня 2026
+    const wrapper = mountBuilder();
+    await nextTick();
+
+    const yearBtn = wrapper.find('.rb__period-presets').findAll('.rb__pill').find((b) => b.text() === 'Этот год');
+    await yearBtn.trigger('click');
+    await nextTick();
+    expect(yearBtn.classes()).toContain('rb__pill--on');
+
+    // DateFilter всегда эмитит update:* + apply, даже когда даты пресета не менялись.
+    const cal = wrapper.findComponent(DateFilter);
+    cal.vm.$emit('update:dateRangeStart', new Date(2026, 0, 1));
+    cal.vm.$emit('update:dateRangeEnd', new Date(2026, 5, 18));
+    cal.vm.$emit('apply');
+    await nextTick();
+
+    // Пресет «Этот год» остаётся активным — границы те же, в custom не ушло.
+    expect(yearBtn.classes()).toContain('rb__pill--on');
+  });
 });


### PR DESCRIPTION
## Что и зачем
Фидбэк владельца #632 п.10: в конструкторе отчётов период задавался двумя нативными `<input type="date">` — неудобно. Заменил их на уже используемый в дашборде компонент-календарь `DateFilter` (`mode="range"`).

- Даты показываются как дд.мм.гггг, в запрос уходят ISO `YYYY-MM-DD` (формат бэка) — конверсия через `isoToDate`/`dateToIso` по календарным частям (без `toISOString`, чтобы не словить таймзонный сдвиг на границе суток).
- Пресеты периода (Эта неделя / Этот месяц / Этот год / Весь период) продолжают работать и подсвечивают календарь.
- Reuse before create: переиспользован существующий `DateFilter`, новых компонентов не добавлял. Удалён осиротевший CSS нативных инпутов.

## Ревью (code-reviewer)
Поймал поведенческую регрессию: `DateFilter` эмитит `update:*`/`apply` при каждом «Применить», из-за чего открытие календаря на активном пресете и нажатие «Применить» без правок сбивало его подсветку в `custom`. Фикс: период уходит в `custom` только при РЕАЛЬНОЙ смене границы (сравнение ISO). Добавлен регресс-тест.

Прочие находки (защита `isoToDate` от заведомо битого ISO, доп. комментарии) — не приняты: бэк шлёт только полный `YYYY-MM-DD`/пусто, гард безопасно отдаёт `null`.

## Проверено
- vitest `ReportBuilder.spec.js` — 23/23 зелёные (3 новых: прокидывание периода в календарь как Date, обновление запроса при выборе диапазона, персистентность пресета при «Применить» без правок).
- eslint по изменённым файлам — чисто.
- Локально (vite + Playwright): шаг периода рендерит `DateFilter`, начальный период из шапки показан как дд.мм.гггг, календарь раскрывается с подсвеченным диапазоном, пресет «Этот год» -> поле `01.01.2026 — 21.06.2026`, подсветка пресета держится.