### PR TITLE
feat(access): оверлей блокировки забаненного пользователя

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -39,6 +39,7 @@
     <DirtyConfirmModal />
     <DeleteNotifications />
     <OnboardingTour v-if="isAuthenticated" />
+    <BanOverlay @logout="logout" />
   </div>
 </template>
 
@@ -55,6 +56,7 @@ import ConfirmDialog from './components/ConfirmDialog.vue';
 import DirtyConfirmModal from './components/DirtyConfirmModal.vue';
 import DeleteNotifications from './components/DeleteNotifications.vue';
 import OnboardingTour from './components/onboarding/OnboardingTour.vue';
+import BanOverlay from './components/BanOverlay.vue';
 
 export default {
   name: "App",
@@ -67,6 +69,7 @@ export default {
     DirtyConfirmModal,
     DeleteNotifications,
     OnboardingTour,
+    BanOverlay,
   },
   computed: {
     isAuthenticated() {
@@ -87,6 +90,23 @@ export default {
     showChrome() {
       const hidePaths = ['/', '/500', '/maintenance']
       return this.isAuthenticated && !hidePaths.includes(this.$route.path);
+    },
+    isBanned() {
+      return usePermissionsStore().banned
+    }
+  },
+  watch: {
+    /**
+     * Реактивная блокировка: как только permissions-стор узнаёт о бане
+     * (на навигации/загрузке), уводим юзера в ЛК - единственную доступную
+     * забаненному страницу. BanOverlay поверх неё блокирует взаимодействие.
+     * router-guard делает то же на навигации; здесь - для случая, когда бан
+     * прилетел без смены маршрута.
+     */
+    isBanned(banned) {
+      if (banned && this.isAuthenticated && this.$route.name !== 'Account') {
+        this.$router.push('/personal-cabinet').catch(() => {})
+      }
     }
   },
   created() {

--- a/frontend/src/components/BanOverlay.vue
+++ b/frontend/src/components/BanOverlay.vue
@@ -1,0 +1,256 @@
+<template>
+  <Teleport to="body">
+    <transition name="ban-fade">
+      <div
+        v-if="isBanned"
+        class="ban-overlay"
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="ban-title"
+        @click.self="blockClose"
+      >
+        <div class="ban-modal">
+          <div class="ban-modal__top">
+            <div
+              class="ban-modal__icon"
+              aria-hidden="true"
+            >
+              <svg
+                width="30"
+                height="30"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.9"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <rect
+                  x="4"
+                  y="11"
+                  width="16"
+                  height="10"
+                  rx="2"
+                />
+                <path d="M8 11V7a4 4 0 0 1 8 0v4" />
+              </svg>
+            </div>
+            <h2
+              id="ban-title"
+              class="ban-modal__title"
+            >
+              Аккаунт заблокирован
+            </h2>
+            <p class="ban-modal__subtitle">
+              Доступ к системе ограничен администратором
+            </p>
+          </div>
+
+          <div class="ban-modal__body">
+            <div
+              v-if="banReason"
+              class="ban-reason"
+            >
+              <div class="ban-reason__label">
+                Причина блокировки
+              </div>
+              <div class="ban-reason__text">
+                {{ banReason }}
+              </div>
+            </div>
+
+            <p class="ban-modal__hint">
+              Если вы считаете, что блокировка ошибочна, обратитесь к администратору системы.
+            </p>
+
+            <div class="ban-modal__actions">
+              <button
+                type="button"
+                class="ban-modal__logout"
+                @click="handleLogout"
+              >
+                Выйти из системы
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </transition>
+  </Teleport>
+</template>
+
+<script>
+import { usePermissionsStore } from '@/stores/permissions'
+
+/**
+ * Полноэкранный неснимаемый оверлей для забаненного пользователя (Фаза 4
+ * эпика прав). Источник статуса - permissions-стор (banned/banReason из
+ * GET /permissions/my). Лежит выше всей лестницы модалок (z-index 26000),
+ * но ниже тоста (29000), чтобы уведомление "Учётная запись заблокирована"
+ * оставалось видно. Закрыть нельзя - выход только кнопкой или после
+ * разблокировки администратором (стор обновится на навигации, ≤30s).
+ */
+export default {
+  name: 'BanOverlay',
+  emits: ['logout'],
+  computed: {
+    isBanned() {
+      return usePermissionsStore().banned
+    },
+    banReason() {
+      return usePermissionsStore().banReason
+    },
+  },
+  methods: {
+    handleLogout() {
+      this.$emit('logout')
+    },
+    blockClose() {
+      // Блокирующий takeover: клик по оверлею не закрывает.
+    },
+  },
+}
+</script>
+
+<style scoped>
+.ban-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  /* Бан - перманентный блокирующий takeover: поверх любых стопок модалок
+     (деталь/карточка/override/история ≤12000, confirm 20000, session 25000).
+     Ниже тоста (29000) - уведомление о блокировке остаётся видно. */
+  z-index: 26000;
+  background:
+    radial-gradient(900px 500px at 50% 18%, rgba(220, 53, 69, 0.1), transparent 70%),
+    rgba(120, 18, 28, 0.62);
+  backdrop-filter: blur(3px) saturate(0.85);
+  -webkit-backdrop-filter: blur(3px) saturate(0.85);
+}
+
+.ban-modal {
+  width: 480px;
+  max-width: 95vw;
+  background: #fff;
+  border-radius: 30px;
+  overflow: hidden;
+  box-shadow: 0 30px 80px rgba(70, 6, 12, 0.5);
+  text-align: center;
+}
+
+.ban-modal__top {
+  padding: 30px 28px 26px;
+  color: #fff;
+  background: linear-gradient(135deg, #dc3545, #b21f2d);
+}
+
+.ban-modal__icon {
+  width: 64px;
+  height: 64px;
+  margin: 0 auto 14px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.16);
+}
+
+.ban-modal__title {
+  font-size: 21px;
+  font-weight: 700;
+}
+
+.ban-modal__subtitle {
+  margin-top: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  opacity: 0.92;
+}
+
+.ban-modal__body {
+  padding: 24px 28px 26px;
+}
+
+.ban-reason {
+  text-align: left;
+  padding: 14px 16px;
+  border: 1px solid #f2d4d8;
+  border-radius: var(--radius-md, 15px);
+  background: #fdecee;
+}
+
+.ban-reason__label {
+  margin-bottom: 6px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-danger, #dc3545);
+}
+
+.ban-reason__text {
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--color-text, #333);
+  overflow-wrap: anywhere;
+}
+
+.ban-modal__hint {
+  margin-top: 18px;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--color-text-muted, #999);
+}
+
+.ban-modal__actions {
+  margin-top: 22px;
+}
+
+.ban-modal__logout {
+  width: 100%;
+  padding: 11px 20px;
+  border: 1px solid var(--color-border, #e6e6e6);
+  border-radius: var(--radius-pill, 999px);
+  background: transparent;
+  color: var(--color-text, #333);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.ban-modal__logout:hover {
+  background: #f7f7f9;
+  border-color: #d6d6dd;
+}
+
+/* Анимация: только transform/opacity (rules/web). */
+.ban-fade-enter-active {
+  transition: opacity 0.25s ease-out;
+}
+.ban-fade-leave-active {
+  transition: opacity 0.2s ease-in;
+}
+.ban-fade-enter-from,
+.ban-fade-leave-to {
+  opacity: 0;
+}
+.ban-fade-enter-active .ban-modal {
+  transition: transform 0.25s ease-out;
+}
+.ban-fade-enter-from .ban-modal {
+  transform: translateY(16px);
+}
+
+@media (max-width: 480px) {
+  .ban-modal__top {
+    padding: 26px 22px 22px;
+  }
+  .ban-modal__body {
+    padding: 22px 22px 24px;
+  }
+}
+</style>

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -317,6 +317,12 @@ router.beforeEach(async (to, from, next) => {
     const { usePermissionsStore } = await import('@/stores/permissions');
     const store = usePermissionsStore();
     if (store.isStale) await store.fetchPermissions();
+    // Забаненного уводим в ЛК (а не в /403): там BanOverlay блокирует
+    // взаимодействие, но единственная доступная ему страница - личный кабинет.
+    if (store.banned && to.name !== 'Account') {
+      next('/personal-cabinet');
+      return;
+    }
     const requiredPermission = typeof to.meta.permission === 'function'
       ? to.meta.permission(to)
       : to.meta.permission;


### PR DESCRIPTION
Фаза 4 эпика прав. Раньше забаненный видел приглушённое меню и тосты при 403, но контент страниц оставался доступен - блокирующего экрана не было.

## Что внутри
- **BanOverlay.vue** (новый) - полноэкранный неснимаемый блок по мокапу `mockups/permissions/banned-cabinet.html`. Источник статуса - permissions-стор (`banned`/`banReason` из `GET /permissions/my`). `z-index: 26000` - выше всей лестницы модалок (confirm 20000, session-expired 25000), но ниже тоста (29000), чтобы уведомление о блокировке оставалось видно. Клик по оверлею не закрывает, анимация на transform/opacity. Причина рендерится только если `banReason` не пуст. Вместо плейсхолдер-контактов из мокапа - строка про обращение к администратору (реального источника контактов в настройках нет).
- **App.vue** - смонтировал `<BanOverlay @logout="logout" />`, computed `isBanned` + watch: реактивный редирект забаненного в личный кабинет, если бан прилетел без смены маршрута.
- **router.js** - в polling-блоке guard забаненного уводим в `/personal-cabinet`, а не в `/403`.

## Проверка
Локально (vite worktree + Playwright, реальный вход): `z-index` = 26000, редирект `/news -> /personal-cabinet` отрабатывает, заголовок и причина из `ban_reason` рендерятся. Скрин сверен с мокапом и одобрен до мержа.