### PR TITLE
feat(analytics): круговые диаграммы вложений и тип графика в отчётах (#632)

### DIFF
--- a/frontend/src/components/statistics/AnalyticsDonutChart.vue
+++ b/frontend/src/components/statistics/AnalyticsDonutChart.vue
@@ -1,0 +1,169 @@
+<template>
+  <div
+    class="donut-chart"
+    :style="{ height: height + 'px' }"
+  >
+    <VueApexCharts
+      v-if="hasData"
+      type="donut"
+      :height="height"
+      :options="options"
+      :series="series"
+    />
+    <div
+      v-else
+      class="donut-chart__empty"
+    >
+      Нет данных для отображения
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import VueApexCharts from 'vue3-apexcharts';
+
+const props = defineProps({
+  /** Сегменты в форме [{ label, value }]; label — подпись доли (тип вложения, статус). */
+  data: {
+    type: Array,
+    default: () => [],
+  },
+  height: {
+    type: Number,
+    default: 280,
+  },
+  /**
+   * Палитра сегментов. Приглушённый аналитический набор от primary проекта,
+   * без неона; токена-палитры в проекте нет, поэтому держим дефолт здесь.
+   */
+  colors: {
+    type: Array,
+    default: () => [
+      '#4F5BDF', '#6E8BE8', '#34A0A4', '#E0A458',
+      '#D1697F', '#7B6FCB', '#5BA88A', '#C2823C',
+    ],
+  },
+  /** Подпись по центру кольца (итог по всем сегментам). */
+  totalLabel: {
+    type: String,
+    default: 'Всего',
+  },
+  /** Три формы склонения единицы тултипа [одна, две-четыре, пять+]. */
+  unitForms: {
+    type: Array,
+    default: () => ['значение', 'значения', 'значений'],
+  },
+  /** Дробная метрика: тултип/итог не округляют до целых. */
+  isFloat: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+// Нулевые сегменты не рисуем — пустые доли искажают кольцо и легенду.
+const segments = computed(() =>
+  props.data
+    .map((d) => ({ label: String(d.label), value: Number(d.value) || 0 }))
+    .filter((d) => d.value > 0),
+);
+
+const hasData = computed(() => segments.value.length > 0);
+
+const labels = computed(() => segments.value.map((d) => d.label));
+const series = computed(() => segments.value.map((d) => d.value));
+
+function pluralize(n) {
+  const [one, few, many] = props.unitForms;
+  const mod10 = n % 10;
+  const mod100 = n % 100;
+  if (mod10 === 1 && mod100 !== 11) return one;
+  if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) return few;
+  return many;
+}
+
+function formatValue(v) {
+  const num = Number(v) || 0;
+  return props.isFloat
+    ? num.toLocaleString('ru-RU', { maximumFractionDigits: 2 })
+    : Math.round(num).toLocaleString('ru-RU');
+}
+
+const options = computed(() => ({
+  chart: {
+    type: 'donut',
+    height: props.height,
+    fontFamily: 'inherit',
+    toolbar: { show: false },
+    animations: { enabled: true, easing: 'easeinout', speed: 400 },
+  },
+  colors: props.colors,
+  labels: labels.value,
+  stroke: { width: 2, colors: ['#fff'] },
+  dataLabels: {
+    enabled: true,
+    // Внутри сегмента — доля в процентах (val уже процент для donut).
+    formatter: (val) => `${Math.round(val)}%`,
+    style: { fontSize: '12px', fontWeight: 600 },
+    dropShadow: { enabled: false },
+  },
+  plotOptions: {
+    pie: {
+      donut: {
+        size: '64%',
+        labels: {
+          show: true,
+          value: {
+            color: '#333',
+            fontSize: '20px',
+            fontWeight: 700,
+            formatter: (v) => formatValue(v),
+          },
+          total: {
+            show: true,
+            label: props.totalLabel,
+            color: '#a2a2a2',
+            fontSize: '12px',
+            formatter: (w) => {
+              const sum = w.globals.seriesTotals.reduce((a, b) => a + b, 0);
+              return formatValue(sum);
+            },
+          },
+        },
+      },
+    },
+  },
+  states: { hover: { filter: { type: 'lighten', value: 0.06 } } },
+  legend: {
+    position: 'bottom',
+    fontSize: '12px',
+    labels: { colors: '#666' },
+    markers: { width: 10, height: 10, radius: 4 },
+    itemMargin: { horizontal: 8, vertical: 2 },
+  },
+  tooltip: {
+    theme: 'dark',
+    y: {
+      formatter: (v) => `${formatValue(v)} ${pluralize(Math.round(Number(v) || 0))}`,
+      title: { formatter: (name) => `${name}:` },
+    },
+  },
+}));
+</script>
+
+<style scoped>
+.donut-chart {
+  position: relative;
+  width: 100%;
+}
+
+.donut-chart__empty {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #a2a2a2;
+  font-size: 13px;
+}
+</style>

--- a/frontend/src/components/statistics/ReportResult.vue
+++ b/frontend/src/components/statistics/ReportResult.vue
@@ -81,6 +81,31 @@
             {{ col.label }}
           </button>
         </div>
+        <!-- Тип графика для категориального разреза: столбцы или доли (кольцо).
+             Период — динамика во времени, доли не имеют смысла -> тоггл скрыт. -->
+        <div
+          v-if="view === 'chart' && hasRows && canDonut"
+          class="rr__seg rr__seg--kind"
+        >
+          <button
+            type="button"
+            class="rr__seg-btn"
+            :class="{ 'rr__seg-btn--active': chartKind === 'bar' }"
+            data-testid="rr-kind-bar"
+            @click="chartKind = 'bar'"
+          >
+            Столбцы
+          </button>
+          <button
+            type="button"
+            class="rr__seg-btn"
+            :class="{ 'rr__seg-btn--active': chartKind === 'donut' }"
+            data-testid="rr-kind-donut"
+            @click="chartKind = 'donut'"
+          >
+            Кольцо
+          </button>
+        </div>
         <ReportExportButton
           class="rr__export"
           :disabled="!canExport"
@@ -89,32 +114,50 @@
         />
       </div>
 
-      <!-- Период рисуем area-графиком (динамика во времени), прочие разрезы —
-           столбцами. Apex (AnalyticsAreaChart/AnalyticsBarChart), без Chart.js. -->
-      <AnalyticsAreaChart
-        v-if="view === 'chart' && hasRows && isPeriod"
-        :data="chartAreaData"
-        :height="chartHeight"
-        :series-name="chartSeriesName"
-        :unit-forms="chartUnitForms"
-        :is-float="chartIsFloat"
-        data-testid="rr-chart-area"
-      />
-      <AnalyticsBarChart
-        v-else-if="view === 'chart' && hasRows"
-        :data="chartBarData"
-        :height="chartHeight"
-        :series-name="chartSeriesName"
-        :unit-forms="chartUnitForms"
-        :is-float="chartIsFloat"
-        data-testid="rr-chart-bar"
-      />
-
-      <div
-        v-else
-        class="rr__table-wrap"
+      <!-- Период -> area (динамика во времени); категориальный разрез -> столбцы
+           или кольцо (доли) по выбору. Apex (Area/Bar/Donut), без Chart.js.
+           Keyed Transition даёт мягкий fade при смене вида/типа. -->
+      <Transition
+        name="rr-fade"
+        mode="out-in"
       >
-        <table class="rr__table">
+        <div
+          :key="chartType"
+          class="rr__slot"
+        >
+          <AnalyticsAreaChart
+            v-if="chartType === 'area'"
+            :data="chartAreaData"
+            :height="chartHeight"
+            :series-name="chartSeriesName"
+            :unit-forms="chartUnitForms"
+            :is-float="chartIsFloat"
+            data-testid="rr-chart-area"
+          />
+          <AnalyticsBarChart
+            v-else-if="chartType === 'bar'"
+            :data="chartBarData"
+            :height="chartHeight"
+            :series-name="chartSeriesName"
+            :unit-forms="chartUnitForms"
+            :is-float="chartIsFloat"
+            data-testid="rr-chart-bar"
+          />
+          <AnalyticsDonutChart
+            v-else-if="chartType === 'donut'"
+            :data="chartBarData"
+            :height="chartHeight"
+            :total-label="chartSeriesName"
+            :unit-forms="chartUnitForms"
+            :is-float="chartIsFloat"
+            data-testid="rr-chart-donut"
+          />
+
+          <div
+            v-else
+            class="rr__table-wrap"
+          >
+            <table class="rr__table">
           <thead>
             <tr>
               <th>{{ dimensionHeader }}</th>
@@ -163,7 +206,9 @@
             </tr>
           </tfoot>
         </table>
-      </div>
+          </div>
+        </div>
+      </Transition>
       <div class="rr__footer">
         строк: {{ aggRows.length }}
       </div>
@@ -229,6 +274,7 @@ import { ref, computed, watch } from 'vue';
 import LoaderSpinner from '@/components/ui/LoaderSpinner.vue';
 import AnalyticsAreaChart from './AnalyticsAreaChart.vue';
 import AnalyticsBarChart from './AnalyticsBarChart.vue';
+import AnalyticsDonutChart from './AnalyticsDonutChart.vue';
 import ReportExportButton from './ReportExportButton.vue';
 import { useReportExport } from '@/composables/useReportExport';
 import { formatDateRu, formatReportCell } from '@/utils/datetime';
@@ -244,6 +290,7 @@ const props = defineProps({
 const emit = defineEmits(['export-error']);
 
 const view = ref('table'); // 'table' | 'chart'
+const chartKind = ref('bar'); // 'bar' | 'donut' — тип категориального графика
 const chartMetric = ref(''); // ключ колонки-метрики, отображаемой на графике
 
 // Мультиметрика и одиночная сводка приведены к единому виду: колонки-метрики +
@@ -279,6 +326,19 @@ const hasRows = computed(() => aggRows.value.length > 0);
 const showTotals = computed(() => props.result?.dimension !== 'none');
 
 const isPeriod = computed(() => props.result?.dimension === 'period');
+
+// Кольцо осмысленно для категориального распределения с >=2 долями: период —
+// динамика во времени (доли бессмысленны), один разрез — доля 100% сама по себе.
+const canDonut = computed(() => !isPeriod.value && aggRows.value.length >= 2);
+
+// Что показываем в слоте графика: area (период), кольцо (доли по выбору) или
+// столбцы; вне режима графика/без строк — таблица. Один источник для v-if и :key.
+const chartType = computed(() => {
+  if (view.value !== 'chart' || !hasRows.value) return 'table';
+  if (isPeriod.value) return 'area';
+  if (chartKind.value === 'donut' && canDonut.value) return 'donut';
+  return 'bar';
+});
 
 const dimensionHeader = computed(() => (props.result?.dimension === 'none' ? 'Итог' : 'Значение разреза'));
 
@@ -339,8 +399,10 @@ const chartHeight = computed(() => {
 
 // Новый результат: list/пусто — только таблица; aggregate — метрику графика на первую
 // колонку. Вид оставляем как выбрал пользователь, чтобы повторный отчёт не сбрасывал
-// его на таблицу.
+// его на таблицу, но тип категориального графика сбрасываем на столбцы: выбор кольца
+// относился к прошлому отчёту, для нового он не должен залипать.
 watch(() => props.result, (r) => {
+  chartKind.value = 'bar';
   if (r?.mode !== 'aggregate') {
     view.value = 'table';
     return;
@@ -495,6 +557,22 @@ function formatCell(value, type) {
 .rr__seg-btn:disabled {
   opacity: 0.45;
   cursor: not-allowed;
+}
+
+.rr__slot {
+  width: 100%;
+}
+
+/* Мягкий fade при смене вида/типа графика (transform+opacity, без layout-анимаций). */
+.rr-fade-enter-active,
+.rr-fade-leave-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.rr-fade-enter-from,
+.rr-fade-leave-to {
+  opacity: 0;
+  transform: translateY(6px);
 }
 
 .rr__table-wrap {

--- a/frontend/src/components/statistics/StatisticsDashboard.vue
+++ b/frontend/src/components/statistics/StatisticsDashboard.vue
@@ -156,16 +156,31 @@
 
       <div
         v-else
-        class="dashboard__tiles"
+        class="dashboard__attach"
       >
-        <div
-          v-for="item in attachmentBreakdown"
-          :key="item.label"
-          class="dashboard__tile"
-        >
-          <div class="dashboard__tile-label">{{ item.label }}</div>
-          <div class="dashboard__tile-val">
-            <AnimatedNumber :value="item.count" />
+        <Transition name="dashboard__chart-fade">
+          <div
+            v-if="attachmentDonutData.length > 0"
+            class="dashboard__attach-chart"
+          >
+            <AnalyticsDonutChart
+              :data="attachmentDonutData"
+              :height="280"
+              total-label="Вложений"
+              :unit-forms="['вложение', 'вложения', 'вложений']"
+            />
+          </div>
+        </Transition>
+        <div class="dashboard__tiles dashboard__attach-tiles">
+          <div
+            v-for="item in attachmentBreakdown"
+            :key="item.label"
+            class="dashboard__tile"
+          >
+            <div class="dashboard__tile-label">{{ item.label }}</div>
+            <div class="dashboard__tile-val">
+              <AnimatedNumber :value="item.count" />
+            </div>
           </div>
         </div>
       </div>
@@ -503,6 +518,7 @@
 import { ref, reactive, computed, watch, onMounted, onUnmounted } from 'vue';
 import AnalyticsAreaChart from '@/components/statistics/AnalyticsAreaChart.vue';
 import AnalyticsBarChart from '@/components/statistics/AnalyticsBarChart.vue';
+import AnalyticsDonutChart from '@/components/statistics/AnalyticsDonutChart.vue';
 import DirIcon from '@/components/statistics/DirIcon.vue';
 import TrendSparkline from '@/components/statistics/TrendSparkline.vue';
 import TopList from '@/components/statistics/TopList.vue';
@@ -645,6 +661,14 @@ const attachmentBreakdown = computed(() => {
   if (!Array.isArray(list)) return [];
   return list.map((item) => ({ label: item.name, count: item.count }));
 });
+
+// Donut распределения по типам вложений: только ненулевые доли (пустые типы
+// засоряют легенду и не несут смысла для распределения).
+const attachmentDonutData = computed(() =>
+  attachmentBreakdown.value
+    .filter((item) => Number(item.count) > 0)
+    .map((item) => ({ label: item.label, value: item.count })),
+);
 
 // Карточки группы «Данные». metric связывает карточку с инсайтом того же ключа;
 // карточки без metric (Обработано, На территории) инсайтом не покрыты.
@@ -1022,6 +1046,42 @@ onUnmounted(() => {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(158px, 1fr));
   gap: 12px;
+}
+
+/* Распределение вложений: donut слева, плитки-числа справа; на узких — стопкой. */
+.dashboard__attach {
+  display: grid;
+  grid-template-columns: minmax(280px, 360px) 1fr;
+  gap: 20px;
+  align-items: start;
+}
+
+.dashboard__attach-chart {
+  background: #fff;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 12px 14px;
+}
+
+.dashboard__attach-tiles {
+  min-width: 0;
+}
+
+.dashboard__chart-fade-enter-active,
+.dashboard__chart-fade-leave-active {
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.dashboard__chart-fade-enter-from,
+.dashboard__chart-fade-leave-to {
+  opacity: 0;
+  transform: translateY(8px);
+}
+
+@media (max-width: 900px) {
+  .dashboard__attach {
+    grid-template-columns: 1fr;
+  }
 }
 
 .dashboard__tile {

--- a/frontend/src/components/statistics/__tests__/AnalyticsDonutChart.spec.js
+++ b/frontend/src/components/statistics/__tests__/AnalyticsDonutChart.spec.js
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+// apexcharts требует реального SVG/измерений — мокаем vue3-apexcharts стабом,
+// который запоминает последние props, чтобы проверять собранный конфиг (тип,
+// серию, метки, форматтеры), а не рендер в jsdom.
+const { rendered } = vi.hoisted(() => ({ rendered: { last: null } }));
+vi.mock('vue3-apexcharts', () => ({
+  default: {
+    name: 'ApexStub',
+    props: ['type', 'height', 'options', 'series'],
+    render() {
+      rendered.last = { type: this.type, options: this.options, series: this.series };
+      return null;
+    },
+  },
+}));
+
+import AnalyticsDonutChart from '../AnalyticsDonutChart.vue';
+
+const DATA = [
+  { label: 'Автозаявки', value: 12 },
+  { label: 'Проведение работ', value: 8 },
+];
+
+describe('AnalyticsDonutChart', () => {
+  it('строит donut: серия значений, метки сегментов, палитра проекта', () => {
+    rendered.last = null;
+    mount(AnalyticsDonutChart, {
+      props: { data: DATA, unitForms: ['вложение', 'вложения', 'вложений'] },
+    });
+
+    expect(rendered.last).not.toBeNull();
+    expect(rendered.last.type).toBe('donut');
+    expect(rendered.last.series).toEqual([12, 8]);
+    expect(rendered.last.options.labels).toEqual(['Автозаявки', 'Проведение работ']);
+    expect(rendered.last.options.colors[0]).toBe('#4F5BDF');
+  });
+
+  it('отбрасывает нулевые сегменты, чтобы не искажать кольцо', () => {
+    rendered.last = null;
+    mount(AnalyticsDonutChart, {
+      props: { data: [{ label: 'A', value: 5 }, { label: 'B', value: 0 }, { label: 'C', value: 3 }] },
+    });
+    expect(rendered.last.series).toEqual([5, 3]);
+    expect(rendered.last.options.labels).toEqual(['A', 'C']);
+  });
+
+  it('тултип склоняет единицу по числу сегмента', () => {
+    rendered.last = null;
+    mount(AnalyticsDonutChart, {
+      props: { data: DATA, unitForms: ['проезд', 'проезда', 'проездов'] },
+    });
+    const tip = rendered.last.options.tooltip;
+    expect(tip.y.formatter(1)).toBe('1 проезд');
+    expect(tip.y.formatter(2)).toBe('2 проезда');
+    expect(tip.y.formatter(5)).toBe('5 проездов');
+  });
+
+  it('тултип с isFloat: дробное значение с запятой, склонение по округлению', () => {
+    rendered.last = null;
+    mount(AnalyticsDonutChart, {
+      props: { data: [{ label: 'A', value: 1.7 }], isFloat: true, unitForms: ['проезд', 'проезда', 'проездов'] },
+    });
+    expect(rendered.last.options.tooltip.y.formatter(1.7)).toBe('1,7 проезда');
+  });
+
+  it('центр кольца суммирует сегменты', () => {
+    rendered.last = null;
+    mount(AnalyticsDonutChart, { props: { data: DATA } });
+    const total = rendered.last.options.plotOptions.pie.donut.labels.total;
+    expect(total.formatter({ globals: { seriesTotals: [12, 8] } })).toBe('20');
+  });
+
+  it('пустые данные: показывает заглушку, график не рендерит', () => {
+    rendered.last = null;
+    const wrapper = mount(AnalyticsDonutChart, { props: { data: [] } });
+    expect(wrapper.text()).toContain('Нет данных');
+    expect(rendered.last).toBeNull();
+  });
+});

--- a/frontend/src/components/statistics/__tests__/ReportResult.spec.js
+++ b/frontend/src/components/statistics/__tests__/ReportResult.spec.js
@@ -23,11 +23,18 @@ const barStub = {
   props: ['data', 'height', 'seriesName', 'unitForms', 'isFloat'],
   template: '<div class="bar-stub" />',
 };
+const donutStub = {
+  name: 'AnalyticsDonutChart',
+  props: ['data', 'height', 'totalLabel', 'unitForms', 'isFloat'],
+  template: '<div class="donut-stub" />',
+};
 
 function mountResult(result) {
   return mount(ReportResult, {
     props: { result },
-    global: { stubs: { AnalyticsAreaChart: areaStub, AnalyticsBarChart: barStub } },
+    global: {
+      stubs: { AnalyticsAreaChart: areaStub, AnalyticsBarChart: barStub, AnalyticsDonutChart: donutStub },
+    },
   });
 }
 
@@ -347,6 +354,38 @@ describe('ReportResult — переключатель Таблица/Графи�
     await w.find('[data-testid="rr-export-pdf"]').trigger('click');
     await nextTick();
     expect(w.emitted('export-error')[0]).toEqual(['диск переполнен']);
+  });
+
+  it('категориальный разрез (>=2 долей): тоггл Столбцы/Кольцо, кольцо рисует доли', async () => {
+    const w = mountResult(aggMulti);
+    await w.find('[data-testid="rr-view-chart"]').trigger('click');
+    await nextTick();
+    // По умолчанию столбцы.
+    expect(w.findComponent(barStub).exists()).toBe(true);
+    expect(w.find('[data-testid="rr-kind-donut"]').exists()).toBe(true);
+
+    await w.find('[data-testid="rr-kind-donut"]').trigger('click');
+    await nextTick();
+    expect(w.findComponent(donutStub).exists()).toBe(true);
+    expect(w.findComponent(barStub).exists()).toBe(false);
+    expect(w.findComponent(donutStub).props('data')).toEqual([
+      { label: 'ООО А', value: 10 }, { label: 'ООО Б', value: 4 },
+    ]);
+    expect(w.findComponent(donutStub).props('totalLabel')).toBe('Количество заявок');
+  });
+
+  it('период: тоггла Кольцо нет (доли по времени бессмысленны)', async () => {
+    const w = mountResult(aggPeriod);
+    await w.find('[data-testid="rr-view-chart"]').trigger('click');
+    await nextTick();
+    expect(w.find('[data-testid="rr-kind-donut"]').exists()).toBe(false);
+  });
+
+  it('один разрез (1 строка): тоггла Кольцо нет', async () => {
+    const w = mountResult(aggStatus);
+    await w.find('[data-testid="rr-view-chart"]').trigger('click');
+    await nextTick();
+    expect(w.find('[data-testid="rr-kind-donut"]').exists()).toBe(false);
   });
 
   it('смена разреза period->status переключает график area->столбцы', async () => {

--- a/frontend/src/components/statistics/__tests__/StatisticsDashboard.spec.js
+++ b/frontend/src/components/statistics/__tests__/StatisticsDashboard.spec.js
@@ -27,7 +27,7 @@ import OnlineUsersModal from '../OnlineUsersModal.vue';
 
 const mountDashboard = () => mount(StatisticsDashboard, {
   props: { from: '2026-06-01', to: '2026-06-07' },
-  global: { stubs: { AnalyticsAreaChart: true, AnalyticsBarChart: true, RefreshButton: true, OnlineUsersModal: true } },
+  global: { stubs: { AnalyticsAreaChart: true, AnalyticsBarChart: true, AnalyticsDonutChart: true, RefreshButton: true, OnlineUsersModal: true } },
 });
 
 const tileByText = (wrapper, label) =>


### PR DESCRIPTION
## Что

Срез P8 эпика аналитики (#632), фидбэк #9 владельца «больше типов диаграмм».

- Новый компонент `AnalyticsDonutChart.vue` — донат на vue3-apexcharts (без новых зависимостей). Палитра проекта, центр кольца суммирует сегменты, нулевые сегменты отбрасываются, легенда снизу, склонение единиц в тултипе, пустое состояние.
- Дашборд, блок «Вложения»: рядом с плитками с точными числами добавлена донат-диаграмма распределения (count > 0), плавное появление.
- Результат отчёта: переключатель столбцы/кольцо для категориальных данных (>= 2 строк, не период). Период остаётся area, одиночная строка скрывает переключатель. Тип графика сбрасывается на столбцы при новом отчёте, плавный переход между типами (transform+opacity).

## Тесты

- `AnalyticsDonutChart.spec.js` — 6 тестов (тип donut, серия/метки, палитра, отбрасывание нулей, склонение тултипа на целых и дробных, сумма в центре, пустое состояние).
- `ReportResult.spec.js` +3 (переключатель и донат на категориальных, скрыт на периоде и одиночной строке).
- `StatisticsDashboard.spec.js` — стаб доната.
- Итого 57 зелёных по 3 спекам, eslint 0 errors.

## Ревью

Прошёл code-reviewer: блокеров нет. Закрыты три замечания - сброс типа графика между отчётами, leave-фаза анимации на дашборде, тест склонения для дробных.