### PR TITLE
refactor(access): гейт типов пользователей через middleware прав (Ф5)

### DIFF
--- a/internal/handlers/user_types.go
+++ b/internal/handlers/user_types.go
@@ -32,8 +32,7 @@ func NewUserTypesHandler(service services.UserTypeService) *UserTypesHandler {
 // @Failure      500 {object} models.HTTPError
 // @Router       /user-types-management [get]
 func (h *UserTypesHandler) GetAll(c echo.Context) error {
-	typeID := c.Get("type_id").(int)
-	result, err := h.service.GetAllWithCount(c.Request().Context(), typeID)
+	result, err := h.service.GetAllWithCount(c.Request().Context())
 	if err != nil {
 		return err
 	}
@@ -54,13 +53,12 @@ func (h *UserTypesHandler) GetAll(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /user-types-management [post]
 func (h *UserTypesHandler) Create(c echo.Context) error {
-	typeID := c.Get("type_id").(int)
 	userID, _ := c.Get("user_id").(int)
 	var req services.CreateUserTypeRequest
 	if err := BindAndValidate(c, &req); err != nil {
 		return err
 	}
-	id, err := h.service.Create(c.Request().Context(), typeID, userID, req)
+	id, err := h.service.Create(c.Request().Context(), userID, req)
 	if err != nil {
 		return err
 	}
@@ -85,7 +83,6 @@ func (h *UserTypesHandler) Create(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /user-types-management/{id} [put]
 func (h *UserTypesHandler) Update(c echo.Context) error {
-	typeID := c.Get("type_id").(int)
 	userID, _ := c.Get("user_id").(int)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
@@ -95,7 +92,7 @@ func (h *UserTypesHandler) Update(c echo.Context) error {
 	if err := BindAndValidate(c, &req); err != nil {
 		return err
 	}
-	if err := h.service.Update(c.Request().Context(), typeID, userID, id, req); err != nil {
+	if err := h.service.Update(c.Request().Context(), userID, id, req); err != nil {
 		return err
 	}
 	return RespondMessage(c, "Тип пользователя успешно обновлен")
@@ -115,13 +112,12 @@ func (h *UserTypesHandler) Update(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /user-types-management/{id} [delete]
 func (h *UserTypesHandler) Delete(c echo.Context) error {
-	typeID := c.Get("type_id").(int)
 	userID, _ := c.Get("user_id").(int)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid user type ID")
 	}
-	if err := h.service.Delete(c.Request().Context(), typeID, userID, id); err != nil {
+	if err := h.service.Delete(c.Request().Context(), userID, id); err != nil {
 		return err
 	}
 	return RespondMessage(c, "Тип пользователя успешно удален")
@@ -138,12 +134,11 @@ func (h *UserTypesHandler) Delete(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /user-types-management/{id}/history [get]
 func (h *UserTypesHandler) GetHistory(c echo.Context) error {
-	typeID := c.Get("type_id").(int)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid user type ID")
 	}
-	items, err := h.service.GetHistory(c.Request().Context(), typeID, id)
+	items, err := h.service.GetHistory(c.Request().Context(), id)
 	if err != nil {
 		return err
 	}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -114,6 +114,9 @@ func Setup(e *echo.Echo, d Dependencies) {
 	statistics := d.Statistics
 	permResolver := d.PermResolver
 	denialLog := d.DenialLog
+	// requireAdmin — гейт admin-страниц по page.admin (super/admin проходят,
+	// обычные — по гранту). Заменяет легаси type-code проверки в сервисах (Ф5).
+	requireAdmin := mw.RequirePermissionV2(permResolver, denialLog, services.KeyPageAdmin)
 	maintenanceBlock := d.MaintenanceBlock
 	banCheck := d.BanCheck
 	loginLimiter := d.LoginLimiter
@@ -183,8 +186,8 @@ func Setup(e *echo.Echo, d Dependencies) {
 	att.GET("/:id/history", attachments.GetHistory)
 	att.GET("/:id", attachments.GetByID)
 
-	// Управление типами пользователей (admin-only)
-	utm := protected.Group("/user-types-management")
+	// Управление типами пользователей (admin-only, page.admin)
+	utm := protected.Group("/user-types-management", requireAdmin)
 	utm.GET("", userTypes.GetAll)
 	utm.POST("", userTypes.Create)
 	utm.PUT("/:id", userTypes.Update)
@@ -587,8 +590,8 @@ func Setup(e *echo.Echo, d Dependencies) {
 	adminMaint.GET("/maintenance", maintenance.GetAdminStatus)
 	adminMaint.PUT("/maintenance", maintenance.ToggleMaintenance)
 
-	// Документы (#39). Admin-операции под page.admin; скачивание и публичный список -- под auth.
-	requireAdmin := mw.RequirePermissionV2(permResolver, denialLog, services.KeyPageAdmin)
+	// Документы (#39). Admin-операции под page.admin (requireAdmin определён выше);
+	// скачивание и публичный список -- под auth.
 
 	// Сброс онбординг-тура пользователю - админ-действие (после сброса у юзера
 	// снова автозапуск). Под page.admin, в отличие от self-эндпоинтов /onboarding.

--- a/internal/services/user_type_service.go
+++ b/internal/services/user_type_service.go
@@ -34,17 +34,18 @@ type UpdateUserTypeRequest struct {
 }
 
 // UserTypeService — интерфейс бизнес-логики управления типами пользователей.
+// Авторизация (page.admin) выполняется роут-middleware RequirePermissionV2.
 type UserTypeService interface {
 	// GetAllWithCount возвращает все типы пользователей с количеством пользователей каждого типа.
-	GetAllWithCount(ctx context.Context, typeID int) ([]UserTypeWithCount, error)
+	GetAllWithCount(ctx context.Context) ([]UserTypeWithCount, error)
 	// Create создаёт новый тип пользователя и возвращает его ID. callerUserID - актор для аудита.
-	Create(ctx context.Context, typeID, callerUserID int, req CreateUserTypeRequest) (int, error)
+	Create(ctx context.Context, callerUserID int, req CreateUserTypeRequest) (int, error)
 	// Update обновляет имя типа пользователя по ID. callerUserID - актор для аудита.
-	Update(ctx context.Context, typeID, callerUserID, id int, req UpdateUserTypeRequest) error
+	Update(ctx context.Context, callerUserID, id int, req UpdateUserTypeRequest) error
 	// Delete удаляет тип пользователя по ID, если с ним не связаны пользователи. callerUserID - актор для аудита.
-	Delete(ctx context.Context, typeID, callerUserID, id int) error
+	Delete(ctx context.Context, callerUserID, id int) error
 	// GetHistory возвращает историю изменений типа пользователя.
-	GetHistory(ctx context.Context, typeID, id int) ([]models.UserTypeHistoryItem, error)
+	GetHistory(ctx context.Context, id int) ([]models.UserTypeHistoryItem, error)
 }
 
 type userTypeService struct {
@@ -55,25 +56,6 @@ type userTypeService struct {
 // NewUserTypeService создаёт новый экземпляр сервиса управления типами пользователей.
 func NewUserTypeService(db *gorm.DB) UserTypeService {
 	return &userTypeService{db: db, history: NewUserTypeHistoryService(db)}
-}
-
-// checkAdmin проверяет, что пользователь с данным type_id является администратором
-// (код типа "manager" или "buropropuskov").
-func (s *userTypeService) checkAdmin(ctx context.Context, typeID int) error {
-	var code string
-	err := s.db.WithContext(ctx).
-		Table("user_types").
-		Select("code").
-		Where("id = ?", typeID).
-		Row().
-		Scan(&code)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "User not found")
-	}
-	if code != "manager" && code != "buropropuskov" {
-		return echo.NewHTTPError(http.StatusForbidden, "Insufficient permissions")
-	}
-	return nil
 }
 
 // typeFlags возвращает признак системного типа и факт его существования.
@@ -96,11 +78,7 @@ func (s *userTypeService) typeFlags(ctx context.Context, id int) (isSystem bool,
 }
 
 // GetAllWithCount возвращает все типы пользователей с количеством связанных пользователей.
-func (s *userTypeService) GetAllWithCount(ctx context.Context, typeID int) ([]UserTypeWithCount, error) {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return nil, err
-	}
-
+func (s *userTypeService) GetAllWithCount(ctx context.Context) ([]UserTypeWithCount, error) {
 	result := make([]UserTypeWithCount, 0)
 	err := s.db.WithContext(ctx).
 		Table("user_types ut").
@@ -117,11 +95,7 @@ func (s *userTypeService) GetAllWithCount(ctx context.Context, typeID int) ([]Us
 }
 
 // Create создаёт новый тип пользователя. Возвращает ошибку, если тип с таким кодом уже существует.
-func (s *userTypeService) Create(ctx context.Context, typeID, callerUserID int, req CreateUserTypeRequest) (int, error) {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return 0, err
-	}
-
+func (s *userTypeService) Create(ctx context.Context, callerUserID int, req CreateUserTypeRequest) (int, error) {
 	// Проверяем уникальность кода
 	var count int64
 	if err := s.db.WithContext(ctx).Table("user_types").Where("code = ?", req.Code).Count(&count).Error; err != nil {
@@ -152,11 +126,7 @@ func (s *userTypeService) Create(ctx context.Context, typeID, callerUserID int, 
 }
 
 // Update обновляет имя типа пользователя. Возвращает ошибку, если тип не найден.
-func (s *userTypeService) Update(ctx context.Context, typeID, callerUserID, id int, req UpdateUserTypeRequest) error {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return err
-	}
-
+func (s *userTypeService) Update(ctx context.Context, callerUserID, id int, req UpdateUserTypeRequest) error {
 	// Проверяем существование типа и его системность одним запросом
 	isSystem, found, err := s.typeFlags(ctx, id)
 	if err != nil {
@@ -180,11 +150,7 @@ func (s *userTypeService) Update(ctx context.Context, typeID, callerUserID, id i
 }
 
 // Delete удаляет тип пользователя. Возвращает ошибку, если с типом связаны пользователи.
-func (s *userTypeService) Delete(ctx context.Context, typeID, callerUserID, id int) error {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return err
-	}
-
+func (s *userTypeService) Delete(ctx context.Context, callerUserID, id int) error {
 	// Снимок name/code до удаления - для деталей аудита (после удаления строки нет).
 	var snapshot struct {
 		Name     string
@@ -231,9 +197,6 @@ func (s *userTypeService) Delete(ctx context.Context, typeID, callerUserID, id i
 }
 
 // GetHistory возвращает историю изменений типа пользователя (admin-only).
-func (s *userTypeService) GetHistory(ctx context.Context, typeID, id int) ([]models.UserTypeHistoryItem, error) {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return nil, err
-	}
+func (s *userTypeService) GetHistory(ctx context.Context, id int) ([]models.UserTypeHistoryItem, error) {
 	return s.history.GetHistory(ctx, id)
 }


### PR DESCRIPTION
## Что и зачем

Срез Ф5 эпика прав: снятие легаси-привязки админства к `user_type` code на сервисе типов пользователей.

`/user-types-management` авторизовался внутри сервиса методом `checkAdmin(typeID)` по коду типа (`manager`/`buropropuskov`) - это был единственный гейт (роут middleware прав не имел). Перевёл на роут-middleware `RequirePermissionV2(page.admin)` - тот же ключ, по которому фронт (`NavMenu.vue`) показывает пункт «Типы пользователей», так что BE и FE согласованы.

Изменения:
- `router.go`: `requireAdmin` (page.admin) поднят к определению `permResolver`/`denialLog` и навешен на группу `/user-types-management`; дублирующее определение у группы документов убрано (переиспользую общее).
- `user_type_service.go`: удалён `checkAdmin`, из интерфейса и 5 методов убран параметр `typeID` (авторизация теперь на middleware); `callerUserID` для аудита сохранён.
- `user_types.go` (handler): перестал извлекать/прокидывать `type_id`.

Семантика сохранена: super-admin и `is_admin` проходят как раньше (бывшие buro/manager аккаунты мигрированы на флаги в Ф0-Ф2); обычным нужен грант `page.admin`. 403 теперь отдаёт middleware (с denial-логированием), а не сервис.

## Проверка

- `go build ./...` + `go vet` зелёные.
- `go test ./internal/handlers/` зелёный целиком (84s, свежая тест-БД) - включая `TestUserTypes_*_Forbidden_NonAdmin` (теперь проверяют middleware-гейт), CRUD, History.

## Дальше по Ф5

Следующий срез - `citizenship` (тот же паттерн, ключ `page.admin`).