### PR TITLE
feat(settings): раздел обработки данных с документом согласия

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -237,7 +237,7 @@ func main() {
 	accessDenialHandler := handlers.NewAccessDenialHandler(accessDenialService)
 	userBanHandler := handlers.NewUserBanHandler(userBanService)
 	consentHandler := handlers.NewConsentHandler(consentService, db)
-	settingsHandler := handlers.NewSettingsHandler(settingsService)
+	settingsHandler := handlers.NewSettingsHandler(settingsService, documentFileService, cfg.UploadMaxFileSize)
 	bugReportHandler := handlers.NewBugReportHandler(bugReportService)
 	maintenanceHandler := handlers.NewMaintenanceHandler(maintenanceService)
 	markHandler := handlers.NewMarkHandler(markService)

--- a/frontend/src/api/dataProcessing.js
+++ b/frontend/src/api/dataProcessing.js
@@ -1,0 +1,74 @@
+import { apiRequest, apiRequestRaw } from './client';
+
+/**
+ * API-клиент документа согласия на обработку персональных данных.
+ * Метаданные хранятся в системных настройках, файл -- на диске бэкенда.
+ * @typedef {{stored_name: string, file_name: string, mime_type: string, ext: string, uploaded_at: string}} DataProcessingDocMeta
+ */
+
+const BASE = '/settings/data-processing/document';
+
+/**
+ * Метаданные текущего документа согласия или null, если он не загружен.
+ * @returns {Promise<DataProcessingDocMeta|null>}
+ */
+export async function getDataProcessingMeta() {
+  const res = await apiRequest(`${BASE}/meta`);
+  if (!res.ok) throw new Error(`Не удалось загрузить данные документа: ${res.status}`);
+  return res.json();
+}
+
+/**
+ * Загружает (заменяет) документ согласия. Только для администратора.
+ * @param {File} file
+ * @returns {Promise<DataProcessingDocMeta>}
+ */
+export async function uploadDataProcessingDoc(file) {
+  const form = new FormData();
+  form.append('file', file);
+  const res = await apiRequest(BASE, { method: 'POST', body: form });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body?.message || `Ошибка загрузки документа: ${res.status}`);
+  }
+  return res.json();
+}
+
+/**
+ * Удаляет документ согласия. Только для администратора.
+ * @returns {Promise<void>}
+ */
+export async function deleteDataProcessingDoc() {
+  const res = await apiRequest(BASE, { method: 'DELETE' });
+  if (!res.ok) throw new Error(`Ошибка удаления документа: ${res.status}`);
+}
+
+/**
+ * Загружает файл документа как Blob (для inline-просмотра или скачивания).
+ * Запрос идёт с Authorization-заголовком, поэтому файл нельзя встроить
+ * напрямую через <embed src>, а только через object URL над полученным Blob.
+ * @param {{download?: boolean}} [opts]
+ * @returns {Promise<Blob>}
+ */
+export async function fetchDataProcessingBlob({ download = false } = {}) {
+  const res = await apiRequestRaw(download ? `${BASE}?download=1` : BASE);
+  if (!res.ok) throw new Error(`Не удалось загрузить документ: ${res.status}`);
+  return res.blob();
+}
+
+/**
+ * Скачивает документ согласия в браузере пользователя.
+ * @param {string} fileName
+ * @returns {Promise<void>}
+ */
+export async function downloadDataProcessingDoc(fileName) {
+  const blob = await fetchDataProcessingBlob({ download: true });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = fileName || 'soglasie-na-obrabotku-dannyh';
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}

--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -83,7 +83,13 @@
                   required
                 >
                 <label for="consent">
-                  Даю <span class="blue">согласие</span> на обработку, хранение, передачу
+                  Даю <a
+                    href="/data-processing"
+                    target="_blank"
+                    rel="noopener"
+                    class="blue consent-link"
+                    @click.stop
+                  >согласие</a> на обработку, хранение, передачу
                   персональных данных, изложенных в заявке
                 </label>
               </div>
@@ -2559,6 +2565,15 @@ export default {
 
     .blue {
         color: #4F5BDF;
+    }
+
+    .consent-link {
+        text-decoration: underline;
+        cursor: pointer;
+    }
+
+    .consent-link:hover {
+        color: #3d49c7;
     }
 
     .form-placeholder {

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -38,6 +38,12 @@ const routes = [
     meta: { requiresAuth: true }
   },
   {
+    path: '/data-processing',
+    name: 'DataProcessing',
+    component: () => import('./views/DataProcessingView.vue'),
+    meta: { requiresAuth: true }
+  },
+  {
     path: '/submit-form',
     redirect: '/new-application'
   },

--- a/frontend/src/views/AdminSettings.vue
+++ b/frontend/src/views/AdminSettings.vue
@@ -52,6 +52,16 @@
         >
           Безопасность
         </div>
+        <div
+          class="sidebar-item"
+          :class="{ 'sidebar-item--active': activeSection === 'data-processing' }"
+          role="button"
+          tabindex="0"
+          @click="activeSection = 'data-processing'"
+          @keydown.enter="activeSection = 'data-processing'"
+        >
+          Обработка данных
+        </div>
       </nav>
 
       <div class="admin-settings__content">
@@ -359,6 +369,93 @@
               {{ saving ? 'Сохранение...' : 'Сохранить' }}
             </button>
           </div>
+
+          <!-- Обработка данных -->
+          <div
+            v-else-if="activeSection === 'data-processing'"
+            class="settings-section"
+          >
+            <h3 class="section-title">
+              Обработка данных
+            </h3>
+            <p class="dp-desc">
+              Документ открывается по ссылке «согласие» при подаче заявки и доступен по адресу
+              <code>/data-processing</code>. PDF показывается прямо на странице, DOC и DOCX —
+              только для скачивания.
+            </p>
+
+            <p
+              v-if="dpLoading"
+              class="form-hint"
+            >
+              Загрузка...
+            </p>
+
+            <div
+              v-else-if="dpMeta"
+              class="dp-card"
+            >
+              <div class="dp-card__info">
+                <span class="dp-card__name">{{ dpMeta.file_name }}</span>
+                <span class="dp-card__meta">{{ dpExtLabel }} · загружен {{ dpUploadedLabel }}</span>
+              </div>
+              <div class="dp-card__actions">
+                <a
+                  class="btn btn--ghost"
+                  href="/data-processing"
+                  target="_blank"
+                  rel="noopener"
+                >Открыть</a>
+                <button
+                  class="btn btn--ghost"
+                  :disabled="dpBusy"
+                  @click="downloadDp"
+                >
+                  Скачать
+                </button>
+                <label
+                  class="btn btn--ghost"
+                  :class="{ 'btn--disabled': dpBusy }"
+                >
+                  {{ dpUploading ? 'Загрузка...' : 'Заменить' }}
+                  <input
+                    type="file"
+                    accept=".pdf,.doc,.docx"
+                    hidden
+                    :disabled="dpBusy"
+                    @change="onDpFileChange"
+                  >
+                </label>
+                <button
+                  class="btn btn--danger"
+                  :disabled="dpBusy"
+                  @click="deleteDp"
+                >
+                  {{ dpDeleting ? 'Удаление...' : 'Удалить' }}
+                </button>
+              </div>
+            </div>
+
+            <div
+              v-else
+              class="dp-upload"
+            >
+              <label
+                class="btn btn--primary"
+                :class="{ 'btn--disabled': dpUploading }"
+              >
+                {{ dpUploading ? 'Загрузка...' : 'Загрузить документ' }}
+                <input
+                  type="file"
+                  accept=".pdf,.doc,.docx"
+                  hidden
+                  :disabled="dpUploading"
+                  @change="onDpFileChange"
+                >
+              </label>
+              <span class="form-hint">PDF, DOC или DOCX.</span>
+            </div>
+          </div>
         </SkeletonTransition>
       </div>
     </div>
@@ -368,8 +465,15 @@
 
 <script>
 import { getSettings, updateSetting } from '@/api/settings';
+import {
+  getDataProcessingMeta,
+  uploadDataProcessingDoc,
+  deleteDataProcessingDoc,
+  downloadDataProcessingDoc,
+} from '@/api/dataProcessing';
 import { SkeletonTransition, SkeletonLine, SkeletonBlock } from '@/components/ui';
 import { useDeletionsStore } from '@/stores/deletions';
+import { useUiStore } from '@/stores/ui';
 
 export default {
   name: 'AdminSettings',
@@ -409,6 +513,11 @@ export default {
         { key: 'password_require_digit', label: 'Требовать цифру' },
         { key: 'password_require_special', label: 'Требовать спецсимвол' },
       ],
+      dpMeta: null,
+      dpLoaded: false,
+      dpLoading: false,
+      dpUploading: false,
+      dpDeleting: false,
     };
   },
   computed: {
@@ -431,6 +540,26 @@ export default {
         return Array.isArray(parsed) ? parsed : [];
       } catch {
         return this.settings.allowed_doc_types.split(',').map(t => t.trim()).filter(Boolean);
+      }
+    },
+    dpBusy() {
+      return this.dpUploading || this.dpDeleting;
+    },
+    dpExtLabel() {
+      const ext = (this.dpMeta?.ext || '').replace('.', '').toUpperCase();
+      return ext || 'Документ';
+    },
+    dpUploadedLabel() {
+      if (!this.dpMeta?.uploaded_at) return '';
+      const d = new Date(this.dpMeta.uploaded_at);
+      if (Number.isNaN(d.getTime())) return '';
+      return d.toLocaleDateString('ru-RU');
+    },
+  },
+  watch: {
+    activeSection(section) {
+      if (section === 'data-processing' && !this.dpLoaded) {
+        this.fetchDataProcessingDoc();
       }
     },
   },
@@ -607,6 +736,66 @@ export default {
         useDeletionsStore().notify({ prefix: 'Ошибка сохранения настроек', type: 'error' });
       } finally {
         this.saving = false;
+      }
+    },
+
+    async fetchDataProcessingDoc() {
+      this.dpLoading = true;
+      try {
+        this.dpMeta = await getDataProcessingMeta();
+        this.dpLoaded = true;
+      } catch (error) {
+        console.error('Ошибка загрузки документа согласия:', error);
+        useDeletionsStore().notify({ prefix: 'Не удалось загрузить документ', type: 'error' });
+      } finally {
+        this.dpLoading = false;
+      }
+    },
+
+    async onDpFileChange(event) {
+      const file = event.target.files?.[0];
+      // Сбрасываем input, иначе повторный выбор того же файла не вызовет change.
+      event.target.value = '';
+      if (!file) return;
+      this.dpUploading = true;
+      try {
+        this.dpMeta = await uploadDataProcessingDoc(file);
+        this.dpLoaded = true;
+        useDeletionsStore().notify({ prefix: 'Документ ', bold: this.dpMeta.file_name, suffix: ' загружен' });
+      } catch (error) {
+        useDeletionsStore().notify({ prefix: error?.message || 'Ошибка загрузки документа', type: 'error' });
+      } finally {
+        this.dpUploading = false;
+      }
+    },
+
+    async downloadDp() {
+      if (!this.dpMeta) return;
+      try {
+        await downloadDataProcessingDoc(this.dpMeta.file_name);
+      } catch (error) {
+        console.error('Ошибка скачивания документа согласия:', error);
+        useDeletionsStore().notify({ prefix: 'Не удалось скачать документ', type: 'error' });
+      }
+    },
+
+    async deleteDp() {
+      if (!this.dpMeta) return;
+      const ok = await useUiStore().confirm({
+        message: `Удалить документ «${this.dpMeta.file_name}»? Пользователи перестанут видеть его при подаче заявки.`,
+      });
+      if (!ok) return;
+      const name = this.dpMeta.file_name;
+      this.dpDeleting = true;
+      try {
+        await deleteDataProcessingDoc();
+        this.dpMeta = null;
+        useDeletionsStore().notify({ prefix: 'Документ ', bold: name, suffix: ' удалён' });
+      } catch (error) {
+        console.error('Ошибка удаления документа согласия:', error);
+        useDeletionsStore().notify({ prefix: 'Ошибка удаления документа', type: 'error' });
+      } finally {
+        this.dpDeleting = false;
       }
     },
   },
@@ -872,6 +1061,101 @@ export default {
 .btn--primary:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.btn--ghost {
+  background: #fff;
+  color: #4F5BDF;
+  border-color: #4F5BDF;
+  text-decoration: none;
+}
+
+.btn--ghost:hover:not(:disabled):not(.btn--disabled) {
+  background: #f0f1ff;
+}
+
+.btn--danger {
+  background: #fff;
+  color: #dc3545;
+  border-color: #dc3545;
+}
+
+.btn--danger:hover:not(:disabled) {
+  background: #fdf0f1;
+}
+
+.btn--danger:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn--disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+/* Обработка данных */
+.dp-desc {
+  font-size: 12px;
+  color: #555;
+  line-height: 1.5;
+  margin: 0 0 16px 0;
+}
+
+.dp-desc code {
+  background: #f0f1ff;
+  color: #4F5BDF;
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  font-size: 11px;
+}
+
+.dp-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  padding: 14px 16px;
+  border: 1px solid #e6e6e6;
+  border-radius: var(--radius-lg);
+}
+
+.dp-card__info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.dp-card__name {
+  font-size: 13px;
+  font-weight: 600;
+  color: #333;
+  word-break: break-word;
+}
+
+.dp-card__meta {
+  font-size: 11px;
+  color: #888;
+}
+
+.dp-card__actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.dp-upload {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.dp-upload .form-hint {
+  margin-top: 0;
 }
 
 /* Состояния загрузки и ошибки */

--- a/frontend/src/views/DataProcessingView.vue
+++ b/frontend/src/views/DataProcessingView.vue
@@ -1,0 +1,244 @@
+<template>
+  <section class="data-processing">
+    <header class="dp-header">
+      <h1 class="dp-title">
+        Согласие на обработку персональных данных
+      </h1>
+      <button
+        v-if="meta"
+        class="dp-button dp-button--primary"
+        :disabled="downloading"
+        @click="download"
+      >
+        {{ downloading ? 'Скачивание...' : 'Скачать' }}
+      </button>
+    </header>
+
+    <div class="dp-body">
+      <p
+        v-if="loading"
+        class="dp-state"
+      >
+        Загрузка документа...
+      </p>
+
+      <div
+        v-else-if="error"
+        class="dp-state dp-state--error"
+      >
+        <p>{{ error }}</p>
+        <button
+          class="dp-button dp-button--ghost"
+          @click="load"
+        >
+          Повторить
+        </button>
+      </div>
+
+      <div
+        v-else-if="!meta"
+        class="dp-state"
+      >
+        <p class="dp-empty-title">
+          Документ ещё не загружен
+        </p>
+        <p class="dp-empty-hint">
+          Администратор пока не разместил документ о порядке обработки персональных данных.
+        </p>
+      </div>
+
+      <embed
+        v-else-if="isPdf && pdfUrl"
+        :src="pdfUrl"
+        type="application/pdf"
+        class="dp-pdf"
+      >
+
+      <div
+        v-else
+        class="dp-state"
+      >
+        <p class="dp-empty-title">
+          {{ meta.file_name }}
+        </p>
+        <p class="dp-empty-hint">
+          Этот формат нельзя открыть прямо на странице. Скачайте документ, чтобы прочитать его.
+        </p>
+        <button
+          class="dp-button dp-button--primary"
+          :disabled="downloading"
+          @click="download"
+        >
+          {{ downloading ? 'Скачивание...' : 'Скачать документ' }}
+        </button>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue';
+import {
+  getDataProcessingMeta,
+  fetchDataProcessingBlob,
+  downloadDataProcessingDoc,
+} from '@/api/dataProcessing';
+
+const meta = ref(null);
+const loading = ref(true);
+const error = ref(null);
+const pdfUrl = ref(null);
+const downloading = ref(false);
+
+const isPdf = computed(
+  () => meta.value && (meta.value.mime_type === 'application/pdf' || meta.value.ext === '.pdf'),
+);
+
+function revokePdf() {
+  if (pdfUrl.value) {
+    URL.revokeObjectURL(pdfUrl.value);
+    pdfUrl.value = null;
+  }
+}
+
+async function load() {
+  loading.value = true;
+  error.value = null;
+  revokePdf();
+  try {
+    meta.value = await getDataProcessingMeta();
+    if (isPdf.value) {
+      const blob = await fetchDataProcessingBlob();
+      pdfUrl.value = URL.createObjectURL(blob);
+    }
+  } catch {
+    error.value = 'Не удалось загрузить документ. Попробуйте обновить страницу.';
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function download() {
+  if (!meta.value) return;
+  downloading.value = true;
+  try {
+    await downloadDataProcessingDoc(meta.value.file_name);
+  } catch {
+    error.value = 'Не удалось скачать документ.';
+  } finally {
+    downloading.value = false;
+  }
+}
+
+onMounted(load);
+onBeforeUnmount(revokePdf);
+</script>
+
+<style scoped>
+.data-processing {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 24px;
+  min-height: calc(100vh - 48px);
+  font-family: 'Montserrat', sans-serif;
+}
+
+.dp-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.dp-title {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.dp-body {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+}
+
+.dp-pdf {
+  width: 100%;
+  height: 100%;
+  min-height: 70vh;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: #fff;
+}
+
+.dp-state {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  text-align: center;
+  padding: 48px 24px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: #fff;
+  color: var(--color-text-muted);
+}
+
+.dp-state--error {
+  color: var(--color-danger);
+}
+
+.dp-empty-title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.dp-empty-hint {
+  margin: 0;
+  max-width: 460px;
+  font-size: 14px;
+  color: var(--color-text-muted);
+}
+
+.dp-button {
+  padding: 10px 24px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  font-family: 'Montserrat', sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.dp-button--primary {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.dp-button--primary:hover:not(:disabled) {
+  background: var(--color-primary-hover);
+}
+
+.dp-button--ghost {
+  background: transparent;
+  color: var(--color-primary);
+  border-color: var(--color-primary);
+}
+
+.dp-button--ghost:hover:not(:disabled) {
+  background: var(--color-bg);
+}
+
+.dp-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+</style>

--- a/frontend/src/views/__tests__/AdminSettings.dataProcessing.spec.js
+++ b/frontend/src/views/__tests__/AdminSettings.dataProcessing.spec.js
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { shallowMount, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+
+const getSettings = vi.fn();
+const updateSetting = vi.fn();
+vi.mock('@/api/settings', () => ({
+  getSettings: (...a) => getSettings(...a),
+  updateSetting: (...a) => updateSetting(...a),
+}));
+
+const getDataProcessingMeta = vi.fn();
+const uploadDataProcessingDoc = vi.fn();
+const deleteDataProcessingDoc = vi.fn();
+const downloadDataProcessingDoc = vi.fn();
+vi.mock('@/api/dataProcessing', () => ({
+  getDataProcessingMeta: (...a) => getDataProcessingMeta(...a),
+  uploadDataProcessingDoc: (...a) => uploadDataProcessingDoc(...a),
+  deleteDataProcessingDoc: (...a) => deleteDataProcessingDoc(...a),
+  downloadDataProcessingDoc: (...a) => downloadDataProcessingDoc(...a),
+}));
+
+import AdminSettings from '../AdminSettings.vue';
+import { useDeletionsStore } from '@/stores/deletions';
+import { useUiStore } from '@/stores/ui';
+
+async function mountView() {
+  getSettings.mockResolvedValue([]);
+  const wrapper = shallowMount(AdminSettings);
+  await flushPromises();
+  return wrapper;
+}
+
+const pdfMeta = { file_name: 'soglasie.pdf', mime_type: 'application/pdf', ext: '.pdf', uploaded_at: '2026-06-21T10:00:00Z' };
+
+describe('AdminSettings - обработка данных', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    [getSettings, updateSetting, getDataProcessingMeta, uploadDataProcessingDoc,
+      deleteDataProcessingDoc, downloadDataProcessingDoc].forEach((m) => m.mockReset());
+  });
+
+  it('подгружает документ при первом открытии секции (lazy)', async () => {
+    getDataProcessingMeta.mockResolvedValue(pdfMeta);
+    const wrapper = await mountView();
+
+    expect(getDataProcessingMeta).not.toHaveBeenCalled();
+    wrapper.vm.activeSection = 'data-processing';
+    await flushPromises();
+
+    expect(getDataProcessingMeta).toHaveBeenCalledTimes(1);
+    expect(wrapper.vm.dpMeta.file_name).toBe('soglasie.pdf');
+  });
+
+  it('загрузка файла зовёт API и уведомляет об успехе', async () => {
+    getDataProcessingMeta.mockResolvedValue(null);
+    uploadDataProcessingDoc.mockResolvedValue(pdfMeta);
+    const wrapper = await mountView();
+    const notify = vi.spyOn(useDeletionsStore(), 'notify');
+
+    const file = new File(['%PDF'], 'soglasie.pdf', { type: 'application/pdf' });
+    await wrapper.vm.onDpFileChange({ target: { files: [file], value: '' } });
+
+    expect(uploadDataProcessingDoc).toHaveBeenCalledWith(file);
+    expect(wrapper.vm.dpMeta.file_name).toBe('soglasie.pdf');
+    expect(notify).toHaveBeenCalledWith(expect.objectContaining({ bold: 'soglasie.pdf' }));
+  });
+
+  it('удаление спрашивает подтверждение и очищает документ', async () => {
+    getDataProcessingMeta.mockResolvedValue(pdfMeta);
+    deleteDataProcessingDoc.mockResolvedValue();
+    const wrapper = await mountView();
+    wrapper.vm.dpMeta = { ...pdfMeta };
+    const confirmSpy = vi.spyOn(useUiStore(), 'confirm').mockResolvedValue(true);
+
+    await wrapper.vm.deleteDp();
+
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(deleteDataProcessingDoc).toHaveBeenCalledTimes(1);
+    expect(wrapper.vm.dpMeta).toBeNull();
+  });
+
+  it('отказ в подтверждении не удаляет документ', async () => {
+    getDataProcessingMeta.mockResolvedValue(pdfMeta);
+    const wrapper = await mountView();
+    wrapper.vm.dpMeta = { ...pdfMeta };
+    vi.spyOn(useUiStore(), 'confirm').mockResolvedValue(false);
+
+    await wrapper.vm.deleteDp();
+
+    expect(deleteDataProcessingDoc).not.toHaveBeenCalled();
+    expect(wrapper.vm.dpMeta).not.toBeNull();
+  });
+});

--- a/frontend/src/views/__tests__/DataProcessingView.spec.js
+++ b/frontend/src/views/__tests__/DataProcessingView.spec.js
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+
+const getDataProcessingMeta = vi.fn();
+const fetchDataProcessingBlob = vi.fn();
+const downloadDataProcessingDoc = vi.fn();
+
+vi.mock('@/api/dataProcessing', () => ({
+  getDataProcessingMeta: (...a) => getDataProcessingMeta(...a),
+  fetchDataProcessingBlob: (...a) => fetchDataProcessingBlob(...a),
+  downloadDataProcessingDoc: (...a) => downloadDataProcessingDoc(...a),
+}));
+
+import DataProcessingView from '../DataProcessingView.vue';
+
+describe('DataProcessingView', () => {
+  beforeEach(() => {
+    getDataProcessingMeta.mockReset();
+    fetchDataProcessingBlob.mockReset();
+    downloadDataProcessingDoc.mockReset();
+    global.URL.createObjectURL = vi.fn(() => 'blob:mock-url');
+    global.URL.revokeObjectURL = vi.fn();
+  });
+
+  it('показывает пустое состояние, если документ не загружен', async () => {
+    getDataProcessingMeta.mockResolvedValue(null);
+    const wrapper = mount(DataProcessingView);
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Документ ещё не загружен');
+    expect(wrapper.find('.dp-pdf').exists()).toBe(false);
+    expect(fetchDataProcessingBlob).not.toHaveBeenCalled();
+  });
+
+  it('встраивает PDF через object URL', async () => {
+    getDataProcessingMeta.mockResolvedValue({
+      file_name: 'soglasie.pdf', mime_type: 'application/pdf', ext: '.pdf', uploaded_at: '',
+    });
+    fetchDataProcessingBlob.mockResolvedValue(new Blob(['%PDF'], { type: 'application/pdf' }));
+    const wrapper = mount(DataProcessingView);
+    await flushPromises();
+
+    const embed = wrapper.find('.dp-pdf');
+    expect(embed.exists()).toBe(true);
+    expect(embed.attributes('src')).toBe('blob:mock-url');
+    expect(fetchDataProcessingBlob).toHaveBeenCalledTimes(1);
+  });
+
+  it('для DOCX показывает только скачивание, без встраивания', async () => {
+    getDataProcessingMeta.mockResolvedValue({
+      file_name: 'soglasie.docx',
+      mime_type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      ext: '.docx',
+      uploaded_at: '',
+    });
+    const wrapper = mount(DataProcessingView);
+    await flushPromises();
+
+    expect(wrapper.find('.dp-pdf').exists()).toBe(false);
+    expect(wrapper.text()).toContain('soglasie.docx');
+    expect(wrapper.text()).toContain('Скачайте документ');
+    expect(fetchDataProcessingBlob).not.toHaveBeenCalled();
+  });
+
+  it('кнопка «Скачать» вызывает загрузку с именем файла', async () => {
+    getDataProcessingMeta.mockResolvedValue({
+      file_name: 'soglasie.pdf', mime_type: 'application/pdf', ext: '.pdf', uploaded_at: '',
+    });
+    fetchDataProcessingBlob.mockResolvedValue(new Blob(['%PDF']));
+    downloadDataProcessingDoc.mockResolvedValue();
+    const wrapper = mount(DataProcessingView);
+    await flushPromises();
+
+    await wrapper.find('.dp-button--primary').trigger('click');
+    expect(downloadDataProcessingDoc).toHaveBeenCalledWith('soglasie.pdf');
+  });
+});

--- a/internal/handlers/settings.go
+++ b/internal/handlers/settings.go
@@ -8,12 +8,14 @@ import (
 )
 
 type SettingsHandler struct {
-	service services.SettingsService
+	service     services.SettingsService
+	fileSvc     services.DocumentFileService
+	maxFileSize int64
 }
 
 // NewSettingsHandler создаёт хендлер для управления системными настройками.
-func NewSettingsHandler(service services.SettingsService) *SettingsHandler {
-	return &SettingsHandler{service: service}
+func NewSettingsHandler(service services.SettingsService, fileSvc services.DocumentFileService, maxFileSize int64) *SettingsHandler {
+	return &SettingsHandler{service: service, fileSvc: fileSvc, maxFileSize: maxFileSize}
 }
 
 // GetAll возвращает все системные настройки (только для super-admin).

--- a/internal/handlers/settings_data_processing.go
+++ b/internal/handlers/settings_data_processing.go
@@ -1,0 +1,102 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+
+	"github.com/labstack/echo/v4"
+)
+
+// dataProcessingAllowedExt -- расширения, разрешённые для документа согласия на обработку данных.
+var dataProcessingAllowedExt = map[string]bool{".pdf": true, ".doc": true, ".docx": true}
+
+// GetDataProcessingMeta возвращает метаданные документа согласия (или null, если не загружен).
+func (h *SettingsHandler) GetDataProcessingMeta(c echo.Context) error {
+	meta, err := h.service.GetDataProcessingDoc(c.Request().Context())
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, meta)
+}
+
+// ServeDataProcessingDoc отдаёт файл документа согласия: inline для просмотра в браузере,
+// attachment при ?download=1 для скачивания.
+func (h *SettingsHandler) ServeDataProcessingDoc(c echo.Context) error {
+	meta, err := h.service.GetDataProcessingDoc(c.Request().Context())
+	if err != nil {
+		return err
+	}
+	if meta == nil {
+		return echo.NewHTTPError(http.StatusNotFound, "Документ согласия не загружен")
+	}
+	disposition := "inline"
+	if c.QueryParam("download") == "1" {
+		disposition = "attachment"
+	}
+	filePath := filepath.Join(h.fileSvc.UploadDir(), meta.StoredName)
+	c.Response().Header().Set("Content-Disposition",
+		fmt.Sprintf(`%s; filename="%s"`, disposition, meta.FileName))
+	c.Response().Header().Set("Content-Type", meta.MimeType)
+	return c.File(filePath)
+}
+
+// UploadDataProcessingDoc сохраняет новый документ согласия, заменяя предыдущий.
+func (h *SettingsHandler) UploadDataProcessingDoc(c echo.Context) error {
+	file, err := c.FormFile("file")
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Файл не передан")
+	}
+	ext := strings.ToLower(filepath.Ext(file.Filename))
+	if !dataProcessingAllowedExt[ext] {
+		return echo.NewHTTPError(http.StatusBadRequest, "Недопустимый тип файла. Разрешены: pdf, doc, docx")
+	}
+
+	ctx := c.Request().Context()
+	storedName, savedExt, err := h.fileSvc.Save(ctx, file, h.maxFileSize)
+	if err != nil {
+		return err
+	}
+
+	meta := &models.DataProcessingDocument{
+		StoredName: storedName,
+		FileName:   file.Filename,
+		MimeType:   services.DetectMimeType(savedExt),
+		Ext:        savedExt,
+		UploadedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+
+	// Старый файл удаляем только после успешной записи метаданных, чтобы при сбое
+	// записи не остаться без документа вовсе.
+	old, _ := h.service.GetDataProcessingDoc(ctx)
+	if err := h.service.SetDataProcessingDoc(ctx, meta); err != nil {
+		h.fileSvc.Delete(storedName)
+		return err
+	}
+	if old != nil && old.StoredName != "" && old.StoredName != storedName {
+		h.fileSvc.Delete(old.StoredName)
+	}
+	return RespondSuccess(c, meta)
+}
+
+// DeleteDataProcessingDoc удаляет документ согласия и его метаданные.
+func (h *SettingsHandler) DeleteDataProcessingDoc(c echo.Context) error {
+	ctx := c.Request().Context()
+	meta, err := h.service.GetDataProcessingDoc(ctx)
+	if err != nil {
+		return err
+	}
+	if meta == nil {
+		return RespondSuccess(c, map[string]bool{"deleted": true})
+	}
+	if err := h.service.ClearDataProcessingDoc(ctx); err != nil {
+		return err
+	}
+	h.fileSvc.Delete(meta.StoredName)
+	return RespondSuccess(c, map[string]bool{"deleted": true})
+}

--- a/internal/handlers/settings_data_processing_test.go
+++ b/internal/handlers/settings_data_processing_test.go
@@ -1,0 +1,182 @@
+package handlers_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"systemburo/internal/models"
+	"systemburo/internal/testutil"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const dpDocPath = "/api/settings/data-processing/document"
+
+// minimalPDF -- содержимое с корректной PDF magic-сигнатурой (%PDF).
+var minimalPDF = []byte("%PDF-1.4\n1 0 obj<<>>endobj\ntrailer<<>>\n%%EOF\n")
+
+// uploadDPDoc загружает документ согласия multipart-запросом от имени token.
+func uploadDPDoc(t *testing.T, e *echo.Echo, token, filename string, content []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	body, ct := buildMultipartDoc(t, filename, content, nil)
+	req := httptest.NewRequest(http.MethodPost, dpDocPath, body)
+	req.Header.Set("Content-Type", ct)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestDataProcessing_Upload_Admin_Success(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	rec := uploadDPDoc(t, e, token, "Согласие.pdf", minimalPDF)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	meta := testutil.ParseResponse[*models.DataProcessingDocument](t, rec)
+	require.NotNil(t, meta)
+	assert.Equal(t, "Согласие.pdf", meta.FileName)
+	assert.Equal(t, "application/pdf", meta.MimeType)
+	assert.Equal(t, ".pdf", meta.Ext)
+	assert.NotEmpty(t, meta.StoredName)
+	assert.NotEmpty(t, meta.UploadedAt)
+}
+
+func TestDataProcessing_GetMeta_AnyAuthUser(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	admin := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	require.Equal(t, http.StatusOK, uploadDPDoc(t, e, admin, "consent.pdf", minimalPDF).Code)
+
+	// Обычный пользователь видит метаданные (документ показывается при подаче заявки).
+	user := testutil.RegisterAndLogin(t, e, "dp_reader", "password123456789012345678901234", 1, td.OrgID, td.CompanyID)
+	rec := testutil.GET(t, e, "/settings/data-processing/document/meta", testutil.AuthHeader(user))
+	require.Equal(t, http.StatusOK, rec.Code)
+	meta := testutil.ParseResponse[*models.DataProcessingDocument](t, rec)
+	require.NotNil(t, meta)
+	assert.Equal(t, "consent.pdf", meta.FileName)
+}
+
+func TestDataProcessing_GetMeta_Empty_ReturnsNull(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	user := testutil.RegisterAndLogin(t, e, "dp_empty", "password123456789012345678901234", 1, td.OrgID, td.CompanyID)
+
+	rec := testutil.GET(t, e, "/settings/data-processing/document/meta", testutil.AuthHeader(user))
+	require.Equal(t, http.StatusOK, rec.Code)
+	meta := testutil.ParseResponse[*models.DataProcessingDocument](t, rec)
+	assert.Nil(t, meta, "без загруженного документа data должна быть null")
+}
+
+func TestDataProcessing_Serve_InlineAndDownload(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	admin := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	require.Equal(t, http.StatusOK, uploadDPDoc(t, e, admin, "consent.pdf", minimalPDF).Code)
+
+	user := testutil.RegisterAndLogin(t, e, "dp_viewer", "password123456789012345678901234", 1, td.OrgID, td.CompanyID)
+
+	// Просмотр: inline + реальное содержимое PDF.
+	inline := testutil.GET(t, e, "/settings/data-processing/document", testutil.AuthHeader(user))
+	require.Equal(t, http.StatusOK, inline.Code)
+	assert.Contains(t, inline.Header().Get("Content-Disposition"), "inline")
+	assert.Equal(t, "application/pdf", inline.Header().Get("Content-Type"))
+	assert.True(t, bytes.HasPrefix(inline.Body.Bytes(), []byte("%PDF")), "тело должно быть отдан PDF")
+
+	// Скачивание: attachment.
+	dl := testutil.GET(t, e, "/settings/data-processing/document?download=1", testutil.AuthHeader(user))
+	require.Equal(t, http.StatusOK, dl.Code)
+	assert.Contains(t, dl.Header().Get("Content-Disposition"), "attachment")
+}
+
+func TestDataProcessing_Serve_Empty_404(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	user := testutil.RegisterAndLogin(t, e, "dp_none", "password123456789012345678901234", 1, td.OrgID, td.CompanyID)
+
+	rec := testutil.GET(t, e, "/settings/data-processing/document", testutil.AuthHeader(user))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestDataProcessing_Delete_Admin_RemovesDoc(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	admin := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	require.Equal(t, http.StatusOK, uploadDPDoc(t, e, admin, "consent.pdf", minimalPDF).Code)
+
+	del := testutil.DELETE(t, e, "/settings/data-processing/document", testutil.AuthHeader(admin))
+	require.Equal(t, http.StatusOK, del.Code, del.Body.String())
+
+	// После удаления meta пуста, файл не отдаётся.
+	meta := testutil.ParseResponse[*models.DataProcessingDocument](t,
+		testutil.GET(t, e, "/settings/data-processing/document/meta", testutil.AuthHeader(admin)))
+	assert.Nil(t, meta)
+	serve := testutil.GET(t, e, "/settings/data-processing/document", testutil.AuthHeader(admin))
+	assert.Equal(t, http.StatusNotFound, serve.Code)
+}
+
+func TestDataProcessing_Upload_NonAdmin_Forbidden(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	user := testutil.RegisterAndLogin(t, e, "dp_nonadmin", "password123456789012345678901234", 1, td.OrgID, td.CompanyID)
+
+	rec := uploadDPDoc(t, e, user, "consent.pdf", minimalPDF)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestDataProcessing_Delete_NonAdmin_Forbidden(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	user := testutil.RegisterAndLogin(t, e, "dp_nonadmin_del", "password123456789012345678901234", 1, td.OrgID, td.CompanyID)
+
+	rec := testutil.DELETE(t, e, "/settings/data-processing/document", testutil.AuthHeader(user))
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestDataProcessing_Upload_InvalidExt(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	admin := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	rec := uploadDPDoc(t, e, admin, "evil.exe", []byte("MZ"))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestDataProcessing_Upload_WrongMagic(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	admin := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	// .pdf по имени, но содержимое не PDF.
+	content := append([]byte{0x4D, 0x5A}, bytes.Repeat([]byte("x"), 100)...)
+	rec := uploadDPDoc(t, e, admin, "fake.pdf", content)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}

--- a/internal/models/system_setting.go
+++ b/internal/models/system_setting.go
@@ -12,3 +12,14 @@ func (SystemSetting) TableName() string { return "system_settings" }
 type UpdateSettingRequest struct {
 	Value string `json:"value" validate:"required"`
 }
+
+// DataProcessingDocument -- метаданные загруженного документа согласия на обработку
+// персональных данных. Хранится как JSON в system_settings под ключом
+// legal.data_processing_document; сам файл лежит на диске под StoredName.
+type DataProcessingDocument struct {
+	StoredName string `json:"stored_name"`
+	FileName   string `json:"file_name"`
+	MimeType   string `json:"mime_type"`
+	Ext        string `json:"ext"`
+	UploadedAt string `json:"uploaded_at"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -614,6 +614,16 @@ func Setup(e *echo.Echo, d Dependencies) {
 		protected.GET("/public/documents", docs.GetPublic)
 	}
 
+	// Документ согласия на обработку данных. Просмотр/скачивание -- любому авторизованному
+	// (виден на странице подачи заявки), управление -- под page.admin.
+	if settings != nil {
+		dpGroup := protected.Group("/settings/data-processing")
+		dpGroup.GET("/document/meta", settings.GetDataProcessingMeta)
+		dpGroup.GET("/document", settings.ServeDataProcessingDoc)
+		dpGroup.POST("/document", settings.UploadDataProcessingDoc, requireAdmin)
+		dpGroup.DELETE("/document", settings.DeleteDataProcessingDoc, requireAdmin)
+	}
+
 	// Статистика дашборда (#632). Доступ ограничен page.statistics.
 	if statistics != nil {
 		requireStats := mw.RequirePermissionV2(permResolver, denialLog, services.KeyPageStatistics)

--- a/internal/services/settings_service.go
+++ b/internal/services/settings_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -15,12 +16,18 @@ import (
 	"gorm.io/gorm"
 )
 
+// dataProcessingDocKey -- ключ настройки с метаданными документа согласия на обработку данных.
+const dataProcessingDocKey = "legal.data_processing_document"
+
 type SettingsService interface {
 	GetAll(ctx context.Context, isSuperAdmin bool) ([]models.SystemSetting, error)
 	Update(ctx context.Context, isSuperAdmin bool, key string, value string) (*models.SystemSetting, error)
 	GetUploadSettings(ctx context.Context) (map[string]interface{}, error)
 	GetNotificationSettings(ctx context.Context) (map[string]interface{}, error)
 	GetPasswordPolicy() models.PasswordPolicy
+	GetDataProcessingDoc(ctx context.Context) (*models.DataProcessingDocument, error)
+	SetDataProcessingDoc(ctx context.Context, meta *models.DataProcessingDocument) error
+	ClearDataProcessingDoc(ctx context.Context) error
 }
 
 var knownKeys = map[string]string{
@@ -199,6 +206,77 @@ func (s *settingsService) GetPasswordPolicy() models.PasswordPolicy {
 		RequireDigit:     s.cache["password.require_digit"].Value == "true",
 		RequireSpecial:   s.cache["password.require_special"].Value == "true",
 	}
+}
+
+// GetDataProcessingDoc возвращает метаданные документа согласия или nil, если он не загружен.
+func (s *settingsService) GetDataProcessingDoc(ctx context.Context) (*models.DataProcessingDocument, error) {
+	var setting models.SystemSetting
+	err := s.db.WithContext(ctx).Where("key = ?", dataProcessingDocKey).First(&setting).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to load data processing document setting: %w", err)
+	}
+	if setting.Value == "" {
+		return nil, nil
+	}
+	var meta models.DataProcessingDocument
+	if err := json.Unmarshal([]byte(setting.Value), &meta); err != nil {
+		return nil, fmt.Errorf("failed to parse data processing document metadata: %w", err)
+	}
+	return &meta, nil
+}
+
+// SetDataProcessingDoc сохраняет (upsert) метаданные документа согласия.
+func (s *settingsService) SetDataProcessingDoc(ctx context.Context, meta *models.DataProcessingDocument) error {
+	payload, err := json.Marshal(meta)
+	if err != nil {
+		return fmt.Errorf("failed to marshal data processing document metadata: %w", err)
+	}
+	return s.upsertRaw(ctx, dataProcessingDocKey, string(payload), "json")
+}
+
+// ClearDataProcessingDoc удаляет настройку с метаданными документа согласия.
+func (s *settingsService) ClearDataProcessingDoc(ctx context.Context) error {
+	if err := s.db.WithContext(ctx).Where("key = ?", dataProcessingDocKey).Delete(&models.SystemSetting{}).Error; err != nil {
+		return fmt.Errorf("failed to clear data processing document setting: %w", err)
+	}
+	s.mu.Lock()
+	delete(s.cache, dataProcessingDocKey)
+	s.mu.Unlock()
+	return nil
+}
+
+// upsertRaw записывает значение настройки напрямую, без проверки knownKeys и прав
+// супер-администратора (авторизация для таких ключей -- на уровне роутов/middleware).
+func (s *settingsService) upsertRaw(ctx context.Context, key, value, typ string) error {
+	var existing models.SystemSetting
+	err := s.db.WithContext(ctx).Where("key = ?", key).First(&existing).Error
+	switch {
+	case err == nil:
+		existing.Value = value
+		existing.Type = typ
+		if err := s.db.WithContext(ctx).Save(&existing).Error; err != nil {
+			return fmt.Errorf("failed to save setting %s: %w", key, err)
+		}
+		s.cacheSet(existing)
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		setting := models.SystemSetting{Key: key, Value: value, Type: typ}
+		if err := s.db.WithContext(ctx).Create(&setting).Error; err != nil {
+			return fmt.Errorf("failed to create setting %s: %w", key, err)
+		}
+		s.cacheSet(setting)
+	default:
+		return fmt.Errorf("failed to load setting %s: %w", key, err)
+	}
+	return nil
+}
+
+func (s *settingsService) cacheSet(st models.SystemSetting) {
+	s.mu.Lock()
+	s.cache[st.Key] = st
+	s.mu.Unlock()
 }
 
 func validateSettingValue(key, value string) error {

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -183,7 +183,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	accessDenialHandler := handlers.NewAccessDenialHandler(accessDenialService)
 	userBanHandler := handlers.NewUserBanHandler(userBanService)
 	consentHandler := handlers.NewConsentHandler(consentService, db)
-	settingsHandler := handlers.NewSettingsHandler(settingsService)
+	settingsHandler := handlers.NewSettingsHandler(settingsService, documentFileService, 10*1024*1024)
 	telegramService := services.NewTelegramService("", "")
 	bugReportService := services.NewBugReportService(db, telegramService)
 	bugReportHandler := handlers.NewBugReportHandler(bugReportService)


### PR DESCRIPTION
Раздел "Обработка данных" в настройках системы: администратор загружает документ (PDF/DOC/DOCX), он открывается по роуту /data-processing прямо на сайте и скачивается. PDF рендерится на странице, DOC/DOCX - только скачивание. Слово "согласие" при подаче заявки теперь ссылка на эту страницу (новая вкладка).

Доступ: просмотр/скачивание - любой авторизованный (страница под requiresAuth, виден на подаче заявки), управление (загрузка/удаление) - под page.admin.

Хранение: метаданные документа - JSON в system_settings под ключом legal.data_processing_document, сам файл - через DocumentFileService (UUID-имя, валидация magic-bytes). Отдельной таблицы нет - документ всегда один.

Проверка:
- go: сборка чистая, изолированный прогон handlers (-run DataProcessing) 10/10 зелёный. Полный go test ./... локально шумит из-за параллельной сессии на общей тест-БД (каждый раз падает другой seed-тест) - оставляю авторитетный полный прогон CI на изолированной БД.
- front: vitest 11/11 (DataProcessingView 4, AdminSettings.dataProcessing 4, AdminSettings.notifications 3 - подтверждает, что секция не сломала уведомления на notify).
- eslint с vue-парсером локально недоступен (нет vue-eslint-parser в node_modules) - на CI Frontend Lint; новый SFC DataProcessingView многословный, undef/unused нет, токены проверены.

Визуальную проверку нового layout (страница + секция в настройках + ссылка в подаче) сделаю до мержа.