### PR TITLE
refactor(access): гейт гражданств через middleware прав (Ф5)

### DIFF
--- a/internal/handlers/citizenships.go
+++ b/internal/handlers/citizenships.go
@@ -55,13 +55,12 @@ func (h *CitizenshipHandler) GetAll(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /citizenships [post]
 func (h *CitizenshipHandler) Create(c echo.Context) error {
-	typeID := c.Get("type_id").(int)
 	userID, _ := c.Get("user_id").(int)
 	var req models.CreateCitizenshipRequest
 	if err := BindAndValidate(c, &req); err != nil {
 		return err
 	}
-	id, err := h.service.Create(c.Request().Context(), typeID, userID, req)
+	id, err := h.service.Create(c.Request().Context(), userID, req)
 	if err != nil {
 		return err
 	}
@@ -86,7 +85,6 @@ func (h *CitizenshipHandler) Create(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /citizenships/{id} [put]
 func (h *CitizenshipHandler) Update(c echo.Context) error {
-	typeID := c.Get("type_id").(int)
 	userID, _ := c.Get("user_id").(int)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
@@ -96,7 +94,7 @@ func (h *CitizenshipHandler) Update(c echo.Context) error {
 	if err := BindAndValidate(c, &req); err != nil {
 		return err
 	}
-	if err := h.service.Update(c.Request().Context(), typeID, userID, id, req); err != nil {
+	if err := h.service.Update(c.Request().Context(), userID, id, req); err != nil {
 		return err
 	}
 	return RespondMessage(c, "Гражданство успешно обновлено")
@@ -118,13 +116,12 @@ func (h *CitizenshipHandler) Update(c echo.Context) error {
 // @Failure      409 {object} models.HTTPError
 // @Router       /citizenships/{id} [delete]
 func (h *CitizenshipHandler) Delete(c echo.Context) error {
-	typeID := c.Get("type_id").(int)
 	userID, _ := c.Get("user_id").(int)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
 	}
-	if err := h.service.Delete(c.Request().Context(), typeID, userID, id); err != nil {
+	if err := h.service.Delete(c.Request().Context(), userID, id); err != nil {
 		return err
 	}
 	return RespondMessage(c, "Гражданство архивировано")
@@ -146,13 +143,12 @@ func (h *CitizenshipHandler) Delete(c echo.Context) error {
 // @Failure      500 {object} models.HTTPError
 // @Router       /citizenships/{id}/restore [post]
 func (h *CitizenshipHandler) Restore(c echo.Context) error {
-	typeID := c.Get("type_id").(int)
 	userID, _ := c.Get("user_id").(int)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
 	}
-	if err := h.service.Restore(c.Request().Context(), typeID, userID, id); err != nil {
+	if err := h.service.Restore(c.Request().Context(), userID, id); err != nil {
 		return err
 	}
 	return RespondMessage(c, "Гражданство восстановлено из архива")
@@ -194,8 +190,7 @@ func (h *CitizenshipHandler) GetHistory(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /citizenships/clear-default [post]
 func (h *CitizenshipHandler) ClearDefaults(c echo.Context) error {
-	typeID := c.Get("type_id").(int)
-	if err := h.service.ClearDefaults(c.Request().Context(), typeID); err != nil {
+	if err := h.service.ClearDefaults(c.Request().Context()); err != nil {
 		return err
 	}
 	return RespondMessage(c, "Все гражданства по умолчанию сброшены")

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -194,15 +194,16 @@ func Setup(e *echo.Echo, d Dependencies) {
 	utm.DELETE("/:id", userTypes.Delete)
 	utm.GET("/:id/history", userTypes.GetHistory)
 
-	// Гражданства
+	// Гражданства. Список и история — для всех авторизованных (дропдаун гражданств
+	// в форме заявки); изменяющие операции — page.admin (Ф5, ранее service checkAdmin).
 	csg := protected.Group("/citizenships")
 	csg.GET("", cs.GetAll)
-	csg.POST("", cs.Create)
-	csg.PUT("/:id", cs.Update)
-	csg.DELETE("/:id", cs.Delete)
-	csg.POST("/:id/restore", cs.Restore)
+	csg.POST("", cs.Create, requireAdmin)
+	csg.PUT("/:id", cs.Update, requireAdmin)
+	csg.DELETE("/:id", cs.Delete, requireAdmin)
+	csg.POST("/:id/restore", cs.Restore, requireAdmin)
 	csg.GET("/:id/history", cs.GetHistory)
-	csg.POST("/clear-default", cs.ClearDefaults)
+	csg.POST("/clear-default", cs.ClearDefaults, requireAdmin)
 
 	// Форматы номерных знаков
 	lpfGroup := protected.Group("/license-plate-formats")

--- a/internal/services/citizenship_service.go
+++ b/internal/services/citizenship_service.go
@@ -13,14 +13,15 @@ import (
 )
 
 // CitizenshipService -- интерфейс бизнес-логики гражданств.
+// Авторизация изменяющих операций (page.admin) -- на роут-middleware RequirePermissionV2.
 type CitizenshipService interface {
 	GetAll(ctx context.Context, includeArchived bool) ([]models.Citizenship, error)
-	Create(ctx context.Context, typeID, userID int, req models.CreateCitizenshipRequest) (int, error)
-	Update(ctx context.Context, typeID, userID, id int, req models.UpdateCitizenshipRequest) error
-	Delete(ctx context.Context, typeID, userID, id int) error
-	Restore(ctx context.Context, typeID, userID, id int) error
+	Create(ctx context.Context, userID int, req models.CreateCitizenshipRequest) (int, error)
+	Update(ctx context.Context, userID, id int, req models.UpdateCitizenshipRequest) error
+	Delete(ctx context.Context, userID, id int) error
+	Restore(ctx context.Context, userID, id int) error
 	GetHistory(ctx context.Context, id int) ([]models.CitizenshipHistoryItem, error)
-	ClearDefaults(ctx context.Context, typeID int) error
+	ClearDefaults(ctx context.Context) error
 }
 
 type citizenshipService struct {
@@ -31,25 +32,6 @@ type citizenshipService struct {
 // NewCitizenshipService создаёт реализацию CitizenshipService.
 func NewCitizenshipService(db *gorm.DB) CitizenshipService {
 	return &citizenshipService{db: db, history: NewCitizenshipHistoryService(db)}
-}
-
-// checkAdmin проверяет, что пользователь с данным type_id является администратором
-// (код типа "manager" или "buropropuskov").
-func (s *citizenshipService) checkAdmin(ctx context.Context, typeID int) error {
-	var code string
-	err := s.db.WithContext(ctx).
-		Table("user_types").
-		Select("code").
-		Where("id = ?", typeID).
-		Row().
-		Scan(&code)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "User not found")
-	}
-	if code != "manager" && code != "buropropuskov" {
-		return echo.NewHTTPError(http.StatusForbidden, "Insufficient permissions")
-	}
-	return nil
 }
 
 // GetAll возвращает список гражданств.
@@ -67,11 +49,7 @@ func (s *citizenshipService) GetAll(ctx context.Context, includeArchived bool) (
 }
 
 // Create создаёт новое гражданство с опциональной установкой по умолчанию.
-func (s *citizenshipService) Create(ctx context.Context, typeID, userID int, req models.CreateCitizenshipRequest) (int, error) {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return 0, err
-	}
-
+func (s *citizenshipService) Create(ctx context.Context, userID int, req models.CreateCitizenshipRequest) (int, error) {
 	isDefault := req.IsDefault != nil && *req.IsDefault
 	patentRequired := req.PatentRequired != nil && *req.PatentRequired
 
@@ -111,11 +89,7 @@ func (s *citizenshipService) Create(ctx context.Context, typeID, userID int, req
 
 // Update обновляет гражданство по ID. is_active не трогает - архивацией/восстановлением
 // управляют Delete/Restore (отдельные действия в истории).
-func (s *citizenshipService) Update(ctx context.Context, typeID, userID, id int, req models.UpdateCitizenshipRequest) error {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return err
-	}
-
+func (s *citizenshipService) Update(ctx context.Context, userID, id int, req models.UpdateCitizenshipRequest) error {
 	isDefault := req.IsDefault != nil && *req.IsDefault
 	patentRequired := req.PatentRequired != nil && *req.PatentRequired
 
@@ -170,11 +144,7 @@ func (s *citizenshipService) Update(ctx context.Context, typeID, userID, id int,
 // Гражданство по умолчанию архивировать нельзя - сначала нужно назначить другое.
 // Гражданство, используемое сотрудниками (employees.citizenship_id), архивировать
 // можно: сотрудники уже созданы, архивное гражданство лишь скрывается из выбора новых.
-func (s *citizenshipService) Delete(ctx context.Context, typeID, userID, id int) error {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return err
-	}
-
+func (s *citizenshipService) Delete(ctx context.Context, userID, id int) error {
 	var citizenship models.Citizenship
 	if err := s.db.WithContext(ctx).First(&citizenship, id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -198,11 +168,7 @@ func (s *citizenshipService) Delete(ctx context.Context, typeID, userID, id int)
 }
 
 // Restore восстанавливает гражданство из архива (is_active=true).
-func (s *citizenshipService) Restore(ctx context.Context, typeID, userID, id int) error {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return err
-	}
-
+func (s *citizenshipService) Restore(ctx context.Context, userID, id int) error {
 	var citizenship models.Citizenship
 	if err := s.db.WithContext(ctx).First(&citizenship, id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -229,11 +195,7 @@ func (s *citizenshipService) GetHistory(ctx context.Context, id int) ([]models.C
 }
 
 // ClearDefaults сбрасывает флаг «по умолчанию» у всех гражданств.
-func (s *citizenshipService) ClearDefaults(ctx context.Context, typeID int) error {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return err
-	}
-
+func (s *citizenshipService) ClearDefaults(ctx context.Context) error {
 	if err := s.db.WithContext(ctx).
 		Model(&models.Citizenship{}).
 		Where("is_default = ?", true).


### PR DESCRIPTION
## Что и зачем

Срез Ф5: снятие легаси type-code привязки на сервисе гражданств.

Изменяющие операции `/citizenships` (create/update/delete/restore/clear-default) авторизовались внутри сервиса методом `checkAdmin(typeID)` по коду типа (`manager`/`buropropuskov`). Перевёл на роут-middleware `RequirePermissionV2(page.admin)`.

Ключевой нюанс - гейт **поэндпоинтный**, не на всю группу:
- `GET /citizenships` (список) и `GET /citizenships/:id/history` остаются доступны всем авторизованным - список гражданств нужен обычным юзерам для дропдауна в форме заявки, а `GetHistory` и раньше не имел `checkAdmin`;
- create/update/delete/restore/clear-default - под `page.admin` (паритет с прежним service-гейтом).

Изменения:
- `router.go`: `requireAdmin` навешен на изменяющие эндпоинты группы `/citizenships`.
- `citizenship_service.go`: удалён `checkAdmin`, из интерфейса и 5 методов убран `typeID`; `userID` для аудита сохранён.
- `citizenships.go` (handler): перестал извлекать/прокидывать `type_id`.

## Проверка

- `go build ./...` + `go vet` зелёные.
- `go test ./internal/handlers/` зелёный целиком (85s, свежая тест-БД): `TestCitizenships_*_Forbidden_NonAdmin` теперь проверяют middleware-гейт, `TestCitizenships_History` подтверждает что история осталась публичной.

## Дальше по Ф5

Следующий срез - `approvers` (application-approvers).