### PR TITLE
fix(create-application): карточка просмотра человека/машины в списках заявки (#46)

### DIFF
--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -244,12 +244,13 @@
               @edit-cancelled="handleVehicleEditCancelled"
               @update:unload-places="onApplicationUnloadPlacesChange"
             />
-            <VehiclesList 
+            <VehiclesList
               :vehicles="sortedVehicles"
               :sort-field="sortField"
               :sort-direction="sortDirection"
               :all-unloading-places="allUnloadingPlaces"
               :license-plate-formats="licensePlateFormats"
+              :detail-info="detailViewInfo"
               @sort="sortBy"
               @edit-vehicle="editVehicle"
               @delete-vehicle="deleteVehicle"
@@ -272,11 +273,12 @@
               @employee-updated="handleEmployeeUpdated"
               @edit-cancelled="handleEmployeeEditCancelled"
             />
-            <EmployeesList 
+            <EmployeesList
               :employees="sortedEmployees"
               :sort-field="sortField"
               :sort-direction="sortDirection"
               :all-tables="allPassageTables"
+              :detail-info="detailViewInfo"
               @sort="sortBy"
               @edit-employee="editEmployee"
               @delete-employee="deleteEmployee"
@@ -528,6 +530,20 @@ export default {
             }
             const data = this.attachmentDatesByAttachment[this.attachmentKey(this.selectedAttachment)];
             return data || this.getDefaultDateData();
+        },
+
+        // Орг/компания заявки и срок+время текущего вложения для карточек просмотра
+        // в списках (сущности в форме этих полей не несут). Дата -> формат API
+        // (YYYY-MM-DD), как ждут модалки; время остаётся HH:MM.
+        detailViewInfo() {
+            const d = this.currentAttachmentData;
+            return {
+                organization: this.organization,
+                company: this.company,
+                entryDateTo: this.formatDateForAPI(d.isOneDay ? d.singleDate : d.endDate),
+                timeFrom: d.startTime || '',
+                timeTo: d.endTime || ''
+            };
         },
 
         currentAttachmentErrors() {

--- a/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
@@ -26,14 +26,14 @@
                   <span>Полная история</span>
                 </button>
                 <button
-                  v-if="source !== 'application' && employee?.applicationId"
+                  v-if="!readonly && source !== 'application' && employee?.applicationId"
                   class="application-btn"
                   @click="openApplication"
                 >
                   <span>Открыть заявку</span>
                 </button>
                 <button
-                  v-if="canManageBlacklist && hasPersonIdentity && !isBlacklisted"
+                  v-if="!readonly && canManageBlacklist && hasPersonIdentity && !isBlacklisted"
                   class="blacklist-add-btn"
                   @click="openAddBlacklist"
                 >
@@ -496,6 +496,11 @@ export default {
         },
         // Право снять подтверждение (DELETE override) - ответственный или принимающий.
         canCancelOverride: {
+            type: Boolean,
+            default: false
+        },
+        // Режим просмотра (список заявки): прячет кнопки действий (ЧС, открыть заявку).
+        readonly: {
             type: Boolean,
             default: false
         }

--- a/frontend/src/components/CreateApplication/EmployeesList.vue
+++ b/frontend/src/components/CreateApplication/EmployeesList.vue
@@ -134,6 +134,7 @@
       :employee="selectedEmployee"
       :all-tables="allTables"
       source="employeeslist"
+      :readonly="true"
       @close="closeDetailsModal"
     />
   </div>
@@ -156,6 +157,12 @@ export default {
         allTables: {
             type: Array,
             default: () => []
+        },
+        // Орг/компания и дата+время текущего вложения - сущность в форме их не несёт,
+        // подмешиваем при открытии карточки просмотра (организация/компания/срок/время).
+        detailInfo: {
+            type: Object,
+            default: () => ({})
         }
     },
     emits: ['sort', 'edit-employee', 'delete-employee'],
@@ -172,6 +179,8 @@ export default {
             // EmployeeDetailsModal читает snake_case (last_name, ..., target_tables).
             // Трансформируем перед передачей — иначе ФИО, места прохода, паспорт
             // не отображаются в модалке details (баг из issue #116).
+            const info = this.detailInfo || {};
+            const passTime = info.timeFrom && info.timeTo ? `${info.timeFrom} - ${info.timeTo}` : '';
             this.selectedEmployee = {
                 id: employee.id,
                 last_name: employee.lastName,
@@ -183,10 +192,12 @@ export default {
                 patent_number: employee.patentNumber,
                 other_permission: employee.otherPermission,
                 target_tables: employee.targetTables || [],
-                entry_date_to: employee.entryDateTo,
-                pass_time: employee.passTime,
-                organization: employee.organization,
-                company: employee.company,
+                // entry_date_to/pass_time/organization/company хранятся на уровне
+                // вложения/заявки, не на сущности формы - берём из detailInfo.
+                entry_date_to: employee.entryDateTo || info.entryDateTo,
+                pass_time: employee.passTime || passTime,
+                organization: employee.organization || info.organization,
+                company: employee.company || info.company,
                 applicationId: employee.applicationId
             };
             this.showDetailsModal = true;

--- a/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
@@ -20,7 +20,7 @@
                 {{ modalTitle }}
               </h3>
               <div
-                v-if="showCarFeatures || (canManageBlacklist && hasVehicleIdentity)"
+                v-if="showCarFeatures || (!readonly && canManageBlacklist && hasVehicleIdentity)"
                 class="header-actions"
               >
                 <button
@@ -31,14 +31,14 @@
                   <span>Полная история</span>
                 </button>
                 <button
-                  v-if="canOpenApplication"
+                  v-if="!readonly && canOpenApplication"
                   class="application-btn"
                   @click="openApplication"
                 >
                   <span>Открыть заявку</span>
                 </button>
                 <button
-                  v-if="canManageBlacklist && hasVehicleIdentity && !isBlacklisted"
+                  v-if="!readonly && canManageBlacklist && hasVehicleIdentity && !isBlacklisted"
                   class="blacklist-add-btn"
                   @click="openAddBlacklist"
                 >
@@ -475,6 +475,11 @@ export default {
         },
         // Право снять подтверждение (DELETE override) - ответственный или принимающий.
         canCancelOverride: {
+            type: Boolean,
+            default: false
+        },
+        // Режим просмотра (список заявки): прячет кнопки действий (ЧС, открыть заявку).
+        readonly: {
             type: Boolean,
             default: false
         }

--- a/frontend/src/components/CreateApplication/VehiclesList.vue
+++ b/frontend/src/components/CreateApplication/VehiclesList.vue
@@ -123,6 +123,7 @@
       :all-unloading-places="allUnloadingPlaces"
       :license-plate-formats="licensePlateFormats"
       :show-car-features="false"
+      :readonly="true"
       :active-info="selectedVehicle?.activeInfo"
       @close="closeDetailsModal"
     />
@@ -157,6 +158,12 @@ export default {
         showStatus: {
             type: Boolean,
             default: true
+        },
+        // Дата+время текущего вложения - на сущности машины их нет, подмешиваем
+        // при открытии карточки просмотра (срок действия и время пребывания).
+        detailInfo: {
+            type: Object,
+            default: () => ({})
         }
     },
     emits: ['sort', 'edit-vehicle', 'delete-vehicle'],
@@ -168,7 +175,15 @@ export default {
     },
     methods: {
         showVehicleDetails(vehicle) {
-            this.selectedVehicle = vehicle;
+            const info = this.detailInfo || {};
+            this.selectedVehicle = {
+                ...vehicle,
+                organization: vehicle.organization || info.organization,
+                company: vehicle.company || info.company,
+                entry_date_to: vehicle.entry_date_to || info.entryDateTo,
+                entry_time_from: vehicle.entry_time_from || info.timeFrom,
+                entry_time_to: vehicle.entry_time_to || info.timeTo
+            };
             this.showDetailsModal = true;
         },
 

--- a/frontend/src/components/CreateApplication/__tests__/DetailModalsReadonlyView.spec.js
+++ b/frontend/src/components/CreateApplication/__tests__/DetailModalsReadonlyView.spec.js
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { setActivePinia, createPinia } from 'pinia';
+
+import EmployeeDetailsModal from '../EmployeeDetailsModal.vue';
+import VehicleDetailsModal from '../VehicleDetailsModal.vue';
+import { usePermissionsStore } from '@/stores/permissions';
+
+// Карточки просмотра добавляемого человека/машины в списках заявки (EmployeesList/
+// VehiclesList) открывают эти модалки с readonly=true: кнопки действий (ЧС, открыть
+// заявку) скрыты, а раздел «Документы» сотрудника показывается всегда (свои данные
+// формы). Вспомогательные API на show=true глушим.
+vi.mock('@/api/client', () => ({ apiRequest: vi.fn().mockResolvedValue({ ok: false }) }));
+vi.mock('@/api/blacklist', () => ({
+  checkPersonBlacklist: vi.fn().mockResolvedValue({ is_blacklisted: false }),
+  createPersonBlacklist: vi.fn().mockResolvedValue({}),
+  listVehicleBlacklist: vi.fn().mockResolvedValue([]),
+  createVehicleBlacklist: vi.fn().mockResolvedValue({}),
+}));
+vi.mock('exceljs', () => ({ default: {} }));
+
+const stubs = {
+  teleport: true,
+  EmployeeHistoryModal: true,
+  CarHistoryModal: true,
+  TableInfoModal: true,
+  UnloadingPlaceModal: true,
+  AddToBlacklistModal: true,
+};
+
+const PASSPORT_LABEL = 'Серия и номер паспорта';
+
+function mountEmployee(props, setupStore) {
+  setActivePinia(createPinia());
+  setupStore(usePermissionsStore());
+  return mount(EmployeeDetailsModal, {
+    props: {
+      show: true,
+      employee: { id: 1, last_name: 'Иваноф', first_name: 'Иван', passport_series_number: '1234 567890', target_tables: [] },
+      source: 'employeeslist',
+      ...props,
+    },
+    global: { stubs },
+  });
+}
+
+function mountVehicle(props, setupStore) {
+  setActivePinia(createPinia());
+  setupStore(usePermissionsStore());
+  return mount(VehicleDetailsModal, {
+    props: {
+      show: true,
+      vehicle: { id: 1, plateNumber: 'А123ВС777', mark: 'Toyota', unloadPlaces: [] },
+      ...props,
+    },
+    global: { stubs },
+  });
+}
+
+describe('Карточки просмотра в списках заявки (readonly)', () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  it('employeeslist + readonly: кнопка «В ЧС» скрыта даже у super', () => {
+    const w = mountEmployee({ readonly: true }, (s) => { s.mode = 'super'; });
+    expect(w.find('.blacklist-add-btn').exists()).toBe(false);
+  });
+
+  it('employeeslist без readonly: кнопка «В ЧС» у super видна (readonly - то, что её гасит)', () => {
+    const w = mountEmployee({ readonly: false }, (s) => { s.mode = 'super'; });
+    expect(w.find('.blacklist-add-btn').exists()).toBe(true);
+  });
+
+  it('employeeslist: документы сотрудника видны без явного права (свои данные формы)', () => {
+    const w = mountEmployee({ readonly: true }, (s) => {
+      s.mode = 'normal';
+      s.effective = {};
+    });
+    expect(w.text()).toContain(PASSPORT_LABEL);
+  });
+
+  it('vehicle readonly: кнопка «В ЧС» скрыта даже у super', () => {
+    const w = mountVehicle({ readonly: true }, (s) => { s.mode = 'super'; });
+    expect(w.find('.blacklist-add-btn').exists()).toBe(false);
+  });
+
+  it('vehicle без readonly: кнопка «В ЧС» у super видна', () => {
+    const w = mountVehicle({ readonly: false }, (s) => { s.mode = 'super'; });
+    expect(w.find('.blacklist-add-btn').exists()).toBe(true);
+  });
+});

--- a/frontend/src/constants/detailModalActions.js
+++ b/frontend/src/constants/detailModalActions.js
@@ -123,13 +123,15 @@ export const EMPLOYEE_MODAL_ACTIONS = {
     passHistory:     'entity.employees.read',
   },
   employeeslist: {
-    // Список сотрудников внутри создания/редактирования заявки:
-    // ограниченный набор, "открыть заявку" недоступно
+    // Список сотрудников внутри создания/редактирования заявки: режим просмотра
+    // добавляемого человека. Документы показываем всегда (true) - это собственные
+    // только что введённые данные формы, а не чувствительные чужие. Кнопки действий
+    // (ЧС/история/открыть заявку) гасятся пропом readonly у модалки.
     history:         false,
     openApplication: false,
-    blacklist:       'page.admin.blacklist',
+    blacklist:       false,
     entryExit:       false,
-    documents:       false,
+    documents:       true,
     passHistory:     false,
   },
   peopletable: {


### PR DESCRIPTION
## Что и зачем

В потоке «Оформление и подача заявки» из списков сотрудников/машин (`EmployeesList`/`VehiclesList`) открывались те же `EmployeeDetailsModal`/`VehicleDetailsModal`, что и в детали заявки - с кнопкой «В ЧС» и без подтянутых Организации/Компании/срока/времени. Нужен режим просмотра добавляемого человека/машины с местами прохода/разгрузки, без действий.

## Что сделал

- **Проп `readonly`** (default `false`) у обеих модалок - прячет кнопки действий («В ЧС», «Открыть заявку»). `EmployeesList`/`VehiclesList` передают `:readonly="true"`. Default `false` => остальные 7 контекстов использования (ApplicationDetail, CarsView, EmployeeView, Trash, blacklist-табы, таблицы) не затронуты.
- **Документы сотрудника** в контексте `employeeslist`: в карте `detailModalActions` `documents` переведён в `true` - это собственные только что введённые данные формы (паспорт/патент/иное), а не чувствительные чужие. Машине секцию документов не добавлял (её там нет).
- **Организация/Компания/срок/время**: этих полей нет на сущности формы (живут на уровне заявки/вложения). Прокидываю их в карточку при открытии через computed `detailViewInfo` (орг/компания заявки + срок и время текущего вложения, дата в формат `YYYY-MM-DD`, время `HH:MM`). Для машины орг/компания уже дотягивались - теперь ещё и срок/время.

## Проверка

- Новый `DetailModalsReadonlyView.spec.js` (5 тестов): readonly прячет «В ЧС» у обеих модалок (и подтверждает, что именно readonly её гасит - без него у super видна), документы сотрудника видны в `employeeslist` без явного права.
- Существующие `EmployeeDetailsModalDocumentsGate.spec.js` (контексты employeesview/trash) и `DetailModalsBlacklistSuspicion.spec.js` - зелёные (поведение прочих контекстов не изменено).
- Форматы сверены: `formatDate` ждёт `YYYY-MM-DD`, `formatTimeRange` корректно ест `HH:MM`.

Скриншот create-флоу могу снять локально перед мержем, если нужно глазами.