### PR TITLE
refactor(access): гейт принимающих через middleware прав (Ф5)

### DIFF
--- a/internal/handlers/application_approvers.go
+++ b/internal/handlers/application_approvers.go
@@ -27,8 +27,7 @@ func NewApproverHandler(service services.ApproverService) *ApproverHandler {
 // @Failure      403 {object} models.HTTPError
 // @Router       /application-approvers [get]
 func (h *ApproverHandler) GetAll(c echo.Context) error {
-	typeID := c.Get("type_id").(int)
-	result, err := h.service.GetAll(c.Request().Context(), typeID)
+	result, err := h.service.GetAll(c.Request().Context())
 	if err != nil {
 		return err
 	}
@@ -44,8 +43,7 @@ func (h *ApproverHandler) GetAll(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /application-approvers/available-users [get]
 func (h *ApproverHandler) GetAvailableUsers(c echo.Context) error {
-	typeID := c.Get("type_id").(int)
-	result, err := h.service.GetAvailableUsers(c.Request().Context(), typeID)
+	result, err := h.service.GetAvailableUsers(c.Request().Context())
 	if err != nil {
 		return err
 	}
@@ -64,7 +62,6 @@ func (h *ApproverHandler) GetAvailableUsers(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /application-approvers [post]
 func (h *ApproverHandler) Create(c echo.Context) error {
-	typeID := c.Get("type_id").(int)
 	username := c.Get("username").(string)
 
 	var req models.CreateApproverRequest
@@ -72,7 +69,7 @@ func (h *ApproverHandler) Create(c echo.Context) error {
 		return err
 	}
 
-	if err := h.service.Create(c.Request().Context(), typeID, req.UserID, username); err != nil {
+	if err := h.service.Create(c.Request().Context(), req.UserID, username); err != nil {
 		return err
 	}
 	return RespondCreated(c, map[string]string{
@@ -91,13 +88,12 @@ func (h *ApproverHandler) Create(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /application-approvers/{id} [delete]
 func (h *ApproverHandler) Delete(c echo.Context) error {
-	typeID := c.Get("type_id").(int)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
 	}
 	actorUsername, _ := c.Get("username").(string)
-	if err := h.service.Delete(c.Request().Context(), typeID, id, actorUsername); err != nil {
+	if err := h.service.Delete(c.Request().Context(), id, actorUsername); err != nil {
 		return err
 	}
 	return RespondSuccess(c, map[string]string{

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -471,13 +471,14 @@ func Setup(e *echo.Echo, d Dependencies) {
 	att.GET("/:id/employees", app.GetAttachmentEmployees)
 	att.GET("/:id/items", app.GetAttachmentItems)
 
-	// Утверждающие заявок
+	// Утверждающие заявок. Управление - page.admin (Ф5, ранее service checkAdmin);
+	// журнал (history) доступен всем авторизованным (как и раньше - без checkAdmin).
 	aag := protected.Group("/application-approvers")
-	aag.GET("", approvers.GetAll)
-	aag.GET("/available-users", approvers.GetAvailableUsers)
+	aag.GET("", approvers.GetAll, requireAdmin)
+	aag.GET("/available-users", approvers.GetAvailableUsers, requireAdmin)
 	aag.GET("/history", approvers.GetHistory)
-	aag.POST("", approvers.Create)
-	aag.DELETE("/:id", approvers.Delete)
+	aag.POST("", approvers.Create, requireAdmin)
+	aag.DELETE("/:id", approvers.Delete, requireAdmin)
 
 	// Разрешения
 	permGroup := protected.Group("/permissions")

--- a/internal/services/approver_service.go
+++ b/internal/services/approver_service.go
@@ -11,11 +11,13 @@ import (
 )
 
 // ApproverService определяет интерфейс управления утверждающими заявок.
+// Авторизация изменяющих/листинговых операций (page.admin) - на роут-middleware
+// RequirePermissionV2; история (GetHistory) доступна всем авторизованным.
 type ApproverService interface {
-	GetAll(ctx context.Context, typeID int) ([]models.ApplicationApproverWithUser, error)
-	GetAvailableUsers(ctx context.Context, typeID int) ([]models.AvailableApproverUser, error)
-	Create(ctx context.Context, typeID int, userID int, createdByUsername string) error
-	Delete(ctx context.Context, typeID int, id int, actorUsername string) error
+	GetAll(ctx context.Context) ([]models.ApplicationApproverWithUser, error)
+	GetAvailableUsers(ctx context.Context) ([]models.AvailableApproverUser, error)
+	Create(ctx context.Context, userID int, createdByUsername string) error
+	Delete(ctx context.Context, id int, actorUsername string) error
 	GetHistory(ctx context.Context) ([]models.ApplicationApproverHistoryItem, error)
 }
 
@@ -29,29 +31,8 @@ func NewApproverService(db *gorm.DB) ApproverService {
 	return &approverService{db: db, history: NewApproverHistoryService(db)}
 }
 
-func (s *approverService) checkAdmin(ctx context.Context, typeID int) error {
-	var code string
-	err := s.db.WithContext(ctx).
-		Table("user_types").
-		Select("code").
-		Where("id = ?", typeID).
-		Row().
-		Scan(&code)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "User not found")
-	}
-	if code != "manager" && code != "buropropuskov" {
-		return echo.NewHTTPError(http.StatusForbidden, "Insufficient permissions")
-	}
-	return nil
-}
-
 // GetAll возвращает список всех утверждающих с информацией о пользователях.
-func (s *approverService) GetAll(ctx context.Context, typeID int) ([]models.ApplicationApproverWithUser, error) {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return nil, err
-	}
-
+func (s *approverService) GetAll(ctx context.Context) ([]models.ApplicationApproverWithUser, error) {
 	result := make([]models.ApplicationApproverWithUser, 0)
 	err := s.db.WithContext(ctx).
 		Table("application_approvers aa").
@@ -69,11 +50,7 @@ func (s *approverService) GetAll(ctx context.Context, typeID int) ([]models.Appl
 }
 
 // GetAvailableUsers возвращает пользователей, которые ещё не назначены утверждающими.
-func (s *approverService) GetAvailableUsers(ctx context.Context, typeID int) ([]models.AvailableApproverUser, error) {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return nil, err
-	}
-
+func (s *approverService) GetAvailableUsers(ctx context.Context) ([]models.AvailableApproverUser, error) {
 	result := make([]models.AvailableApproverUser, 0)
 	err := s.db.WithContext(ctx).
 		Table("users u").
@@ -91,11 +68,7 @@ func (s *approverService) GetAvailableUsers(ctx context.Context, typeID int) ([]
 }
 
 // Create назначает пользователя утверждающим заявок.
-func (s *approverService) Create(ctx context.Context, typeID int, userID int, createdByUsername string) error {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return err
-	}
-
+func (s *approverService) Create(ctx context.Context, userID int, createdByUsername string) error {
 	var userExists int64
 	s.db.WithContext(ctx).Table("users").Where("id = ?", userID).Count(&userExists)
 	if userExists == 0 {
@@ -128,11 +101,7 @@ func (s *approverService) Create(ctx context.Context, typeID int, userID int, cr
 }
 
 // Delete удаляет утверждающего по ID.
-func (s *approverService) Delete(ctx context.Context, typeID int, id int, actorUsername string) error {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return err
-	}
-
+func (s *approverService) Delete(ctx context.Context, id int, actorUsername string) error {
 	// Снимок до удаления: берём user_id и имя принимающего.
 	type approverRow struct {
 		UserID int


### PR DESCRIPTION
## Что и зачем

Срез Ф5: снятие легаси type-code привязки на сервисе принимающих заявок.

`GetAll`/`GetAvailableUsers`/`Create`/`Delete` у `/application-approvers` авторизовались внутри сервиса методом `checkAdmin(typeID)` по коду типа (`manager`/`buropropuskov`). Перевёл на роут-middleware `RequirePermissionV2(page.admin)`.

`GET /application-approvers/history` (журнал) оставлен доступным всем авторизованным - так было и раньше (у `GetHistory` `checkAdmin` не вызывался).

Изменения:
- `router.go`: `requireAdmin` на `GET ""`, `GET /available-users`, `POST ""`, `DELETE /:id`; `/history` без гейта.
- `approver_service.go`: удалён `checkAdmin`, из интерфейса и 4 методов убран `typeID`.
- `application_approvers.go` (handler): перестал извлекать/прокидывать `type_id`.

## Проверка

- `go build ./...` + `go vet` зелёные.
- `go test ./internal/handlers/` зелёный целиком (85s, свежая тест-БД): `TestApprovers_GetAll_AdminOnly`, `TestApprovers_GetAvailableUsers_AdminOnly`, `TestApprovers_Create_RegularUserForbidden` теперь проверяют middleware-гейт; `TestApprovers_History_*` подтверждают журнал.

## Дальше по Ф5

Следующий срез - `feedback` (page.admin.feedback на admin-операциях, отправка фидбэка остаётся юзеру).