### PR TITLE
refactor(access): гейт обратной связи через middleware прав (Ф5)

### DIFF
--- a/internal/handlers/feedback.go
+++ b/internal/handlers/feedback.go
@@ -57,8 +57,7 @@ func (h *FeedbackHandler) Create(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /feedback/all [get]
 func (h *FeedbackHandler) GetAll(c echo.Context) error {
-	typeID := c.Get("type_id").(int)
-	feedbacks, err := h.service.GetAll(c.Request().Context(), typeID)
+	feedbacks, err := h.service.GetAll(c.Request().Context())
 	if err != nil {
 		return err
 	}
@@ -75,8 +74,7 @@ func (h *FeedbackHandler) GetAll(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /feedback/stats [get]
 func (h *FeedbackHandler) GetStats(c echo.Context) error {
-	typeID := c.Get("type_id").(int)
-	stats, err := h.service.GetStats(c.Request().Context(), typeID)
+	stats, err := h.service.GetStats(c.Request().Context())
 	if err != nil {
 		return err
 	}
@@ -115,7 +113,6 @@ func (h *FeedbackHandler) GetMy(c echo.Context) error {
 // @Failure      404 {object} models.HTTPError
 // @Router       /feedback/{id}/status [put]
 func (h *FeedbackHandler) UpdateStatus(c echo.Context) error {
-	typeID := c.Get("type_id").(int)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
@@ -124,7 +121,7 @@ func (h *FeedbackHandler) UpdateStatus(c echo.Context) error {
 	if err := BindAndValidate(c, &req); err != nil {
 		return err
 	}
-	if err := h.service.UpdateStatus(c.Request().Context(), typeID, id, req); err != nil {
+	if err := h.service.UpdateStatus(c.Request().Context(), id, req); err != nil {
 		return err
 	}
 	return RespondMessage(c, "Статус обращения успешно обновлен")
@@ -143,7 +140,6 @@ func (h *FeedbackHandler) UpdateStatus(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /feedback/{id}/read [put]
 func (h *FeedbackHandler) MarkAsRead(c echo.Context) error {
-	typeID := c.Get("type_id").(int)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid id")
@@ -152,7 +148,7 @@ func (h *FeedbackHandler) MarkAsRead(c echo.Context) error {
 	if err := BindAndValidate(c, &req); err != nil {
 		return err
 	}
-	if err := h.service.MarkAsRead(c.Request().Context(), typeID, id, req); err != nil {
+	if err := h.service.MarkAsRead(c.Request().Context(), id, req); err != nil {
 		return err
 	}
 	return RespondMessage(c, "Статус прочтения обновлен")

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -426,14 +426,17 @@ func Setup(e *echo.Echo, d Dependencies) {
 	ueg.GET("/lookup", ue.Lookup, requireBlacklist)
 	ueg.GET("/:id/history", ue.GetHistory)
 
-	// Обратная связь
+	// Обратная связь. Отправка (POST) и свои обращения (GET /my) - любому
+	// авторизованному; админ-операции (список/статистика/статус/прочтение) -
+	// page.admin.feedback (Ф5, ранее service checkAdmin).
+	requireFeedbackAdmin := mw.RequirePermissionV2(permResolver, denialLog, services.KeyPageAdminFeedback)
 	fbg := protected.Group("/feedback")
 	fbg.POST("", fb.Create)
-	fbg.GET("/all", fb.GetAll)
-	fbg.GET("/stats", fb.GetStats)
+	fbg.GET("/all", fb.GetAll, requireFeedbackAdmin)
+	fbg.GET("/stats", fb.GetStats, requireFeedbackAdmin)
 	fbg.GET("/my", fb.GetMy)
-	fbg.PUT("/:id/status", fb.UpdateStatus)
-	fbg.PUT("/:id/read", fb.MarkAsRead)
+	fbg.PUT("/:id/status", fb.UpdateStatus, requireFeedbackAdmin)
+	fbg.PUT("/:id/read", fb.MarkAsRead, requireFeedbackAdmin)
 
 	// Заявки
 	apg := protected.Group("/applications")

--- a/internal/services/feedback_service.go
+++ b/internal/services/feedback_service.go
@@ -14,13 +14,15 @@ import (
 )
 
 // FeedbackService -- интерфейс бизнес-логики обратной связи.
+// Админ-операции (page.admin.feedback) авторизуются роут-middleware RequirePermissionV2;
+// Create и GetMy доступны любому авторизованному (своя обратная связь).
 type FeedbackService interface {
 	Create(ctx context.Context, username string, req models.CreateFeedbackRequest) (int, error)
-	GetAll(ctx context.Context, typeID int) ([]models.FeedbackWithUser, error)
-	GetStats(ctx context.Context, typeID int) (*models.FeedbackStats, error)
+	GetAll(ctx context.Context) ([]models.FeedbackWithUser, error)
+	GetStats(ctx context.Context) (*models.FeedbackStats, error)
 	GetMy(ctx context.Context, username string) ([]models.MyFeedback, error)
-	UpdateStatus(ctx context.Context, typeID int, id int, req models.UpdateFeedbackStatusRequest) error
-	MarkAsRead(ctx context.Context, typeID int, id int, req models.MarkAsReadRequest) error
+	UpdateStatus(ctx context.Context, id int, req models.UpdateFeedbackStatusRequest) error
+	MarkAsRead(ctx context.Context, id int, req models.MarkAsReadRequest) error
 }
 
 type feedbackService struct {
@@ -30,24 +32,6 @@ type feedbackService struct {
 // NewFeedbackService создаёт реализацию FeedbackService.
 func NewFeedbackService(db *gorm.DB) FeedbackService {
 	return &feedbackService{db: db}
-}
-
-// checkAdmin проверяет, что пользователь является администратором.
-func (s *feedbackService) checkAdmin(ctx context.Context, typeID int) error {
-	var code string
-	err := s.db.WithContext(ctx).
-		Table("user_types").
-		Select("code").
-		Where("id = ?", typeID).
-		Row().
-		Scan(&code)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "User not found")
-	}
-	if code != "manager" && code != "buropropuskov" {
-		return echo.NewHTTPError(http.StatusForbidden, "Insufficient permissions")
-	}
-	return nil
 }
 
 // getUserIDByUsername возвращает ID пользователя по username.
@@ -99,11 +83,7 @@ func (s *feedbackService) Create(ctx context.Context, username string, req model
 }
 
 // GetAll возвращает все обращения обратной связи с информацией о пользователях.
-func (s *feedbackService) GetAll(ctx context.Context, typeID int) ([]models.FeedbackWithUser, error) {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return nil, err
-	}
-
+func (s *feedbackService) GetAll(ctx context.Context) ([]models.FeedbackWithUser, error) {
 	results := make([]models.FeedbackWithUser, 0)
 	err := s.db.WithContext(ctx).
 		Table("feedback f").
@@ -129,11 +109,7 @@ func (s *feedbackService) GetAll(ctx context.Context, typeID int) ([]models.Feed
 }
 
 // GetStats возвращает статистику обращений обратной связи.
-func (s *feedbackService) GetStats(ctx context.Context, typeID int) (*models.FeedbackStats, error) {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return nil, err
-	}
-
+func (s *feedbackService) GetStats(ctx context.Context) (*models.FeedbackStats, error) {
 	var stats models.FeedbackStats
 	err := s.db.WithContext(ctx).
 		Table("feedback").
@@ -173,11 +149,7 @@ func (s *feedbackService) GetMy(ctx context.Context, username string) ([]models.
 }
 
 // UpdateStatus обновляет статус обращения обратной связи.
-func (s *feedbackService) UpdateStatus(ctx context.Context, typeID int, id int, req models.UpdateFeedbackStatusRequest) error {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return err
-	}
-
+func (s *feedbackService) UpdateStatus(ctx context.Context, id int, req models.UpdateFeedbackStatusRequest) error {
 	// Проверяем существование обращения
 	var count int64
 	if err := s.db.WithContext(ctx).Table("feedback").Where("id = ?", id).Count(&count).Error; err != nil {
@@ -221,11 +193,7 @@ func (s *feedbackService) UpdateStatus(ctx context.Context, typeID int, id int, 
 }
 
 // MarkAsRead отмечает обращение обратной связи как прочитанное или непрочитанное.
-func (s *feedbackService) MarkAsRead(ctx context.Context, typeID int, id int, req models.MarkAsReadRequest) error {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return err
-	}
-
+func (s *feedbackService) MarkAsRead(ctx context.Context, id int, req models.MarkAsReadRequest) error {
 	// Обновляем только is_read без updated_at (как в Rust)
 	err := s.db.WithContext(ctx).
 		Table("feedback").


### PR DESCRIPTION
## Что и зачем

Срез Ф5: снятие легаси type-code привязки на сервисе обратной связи.

Админ-операции `/feedback` (`GET /all`, `GET /stats`, `PUT /:id/status`, `PUT /:id/read`) авторизовались внутри сервиса методом `checkAdmin(typeID)` по коду типа. Перевёл на роут-middleware `RequirePermissionV2(page.admin.feedback)` - тот же ключ, по которому фронт показывает раздел «Обратная связь».

Отправка обращения (`POST /feedback`) и свои обращения (`GET /feedback/my`) остаются доступны любому авторизованному (как и было - `Create`/`GetMy` без `checkAdmin`).

Изменения:
- `router.go`: `requireFeedbackAdmin` (page.admin.feedback) на 4 админ-эндпоинта; POST и /my без гейта.
- `feedback_service.go`: удалён `checkAdmin`, из интерфейса и 4 методов убран `typeID`.
- `feedback.go` (handler): перестал извлекать/прокидывать `type_id`.

## Проверка

- `go build ./...` + `go vet` зелёные.
- `go test ./internal/handlers/` зелёный целиком (86s, свежая тест-БД): `TestFeedback_GetAll_AdminOnly`/`GetStats_AdminOnly`/`UpdateStatus`/`MarkAsRead` проверяют middleware-гейт (403 не-админу), `TestFeedback_Create`/`GetMy` - что юзерские эндпоинты доступны.

## Дальше по Ф5

slice-5 news (news.manage на write), затем request_logs, company, organization, user_service.