### PR TITLE
refactor(access): гейт новостей и объявлений через middleware прав (Ф5)

### DIFF
--- a/internal/handlers/news.go
+++ b/internal/handlers/news.go
@@ -45,8 +45,7 @@ func (h *NewsHandler) GetActiveNews(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /news/all [get]
 func (h *NewsHandler) GetAllNews(c echo.Context) error {
-	typeID := GetTypeID(c)
-	news, err := h.service.GetAllNews(c.Request().Context(), typeID)
+	news, err := h.service.GetAllNews(c.Request().Context())
 	if err != nil {
 		return err
 	}
@@ -66,13 +65,12 @@ func (h *NewsHandler) GetAllNews(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /news [post]
 func (h *NewsHandler) CreateNews(c echo.Context) error {
-	typeID := GetTypeID(c)
 	userID := GetUserID(c)
 	var req models.CreateNewsRequest
 	if err := BindAndValidate(c, &req); err != nil {
 		return err
 	}
-	news, err := h.service.CreateNews(c.Request().Context(), typeID, userID, req)
+	news, err := h.service.CreateNews(c.Request().Context(), userID, req)
 	if err != nil {
 		return err
 	}
@@ -94,7 +92,6 @@ func (h *NewsHandler) CreateNews(c echo.Context) error {
 // @Failure      404 {object} models.HTTPError
 // @Router       /news/{id} [put]
 func (h *NewsHandler) UpdateNews(c echo.Context) error {
-	typeID := GetTypeID(c)
 	userID := GetUserID(c)
 	id, err := ParseID(c, "id")
 	if err != nil {
@@ -104,7 +101,7 @@ func (h *NewsHandler) UpdateNews(c echo.Context) error {
 	if err := BindAndValidate(c, &req); err != nil {
 		return err
 	}
-	news, err := h.service.UpdateNews(c.Request().Context(), typeID, userID, id, req)
+	news, err := h.service.UpdateNews(c.Request().Context(), userID, id, req)
 	if err != nil {
 		return err
 	}
@@ -123,12 +120,11 @@ func (h *NewsHandler) UpdateNews(c echo.Context) error {
 // @Failure      404 {object} models.HTTPError
 // @Router       /news/{id} [delete]
 func (h *NewsHandler) DeleteNews(c echo.Context) error {
-	typeID := GetTypeID(c)
 	id, err := ParseID(c, "id")
 	if err != nil {
 		return err
 	}
-	if err := h.service.DeleteNews(c.Request().Context(), typeID, id); err != nil {
+	if err := h.service.DeleteNews(c.Request().Context(), id); err != nil {
 		return err
 	}
 	return RespondMessage(c, "Новость удалена")
@@ -162,8 +158,7 @@ func (h *NewsHandler) GetActiveAnnouncement(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /announcements/all [get]
 func (h *NewsHandler) GetAllAnnouncements(c echo.Context) error {
-	typeID := GetTypeID(c)
-	announcements, err := h.service.GetAllAnnouncements(c.Request().Context(), typeID)
+	announcements, err := h.service.GetAllAnnouncements(c.Request().Context())
 	if err != nil {
 		return err
 	}
@@ -183,13 +178,12 @@ func (h *NewsHandler) GetAllAnnouncements(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /announcements [post]
 func (h *NewsHandler) CreateAnnouncement(c echo.Context) error {
-	typeID := GetTypeID(c)
 	userID := GetUserID(c)
 	var req models.CreateAnnouncementRequest
 	if err := BindAndValidate(c, &req); err != nil {
 		return err
 	}
-	announcement, err := h.service.CreateAnnouncement(c.Request().Context(), typeID, userID, req)
+	announcement, err := h.service.CreateAnnouncement(c.Request().Context(), userID, req)
 	if err != nil {
 		return err
 	}
@@ -211,13 +205,12 @@ func (h *NewsHandler) CreateAnnouncement(c echo.Context) error {
 // @Failure      404 {object} models.HTTPError
 // @Router       /announcements/set-active [post]
 func (h *NewsHandler) SetActiveAnnouncement(c echo.Context) error {
-	typeID := GetTypeID(c)
 	userID := GetUserID(c)
 	var req models.SetActiveAnnouncementRequest
 	if err := BindAndValidate(c, &req); err != nil {
 		return err
 	}
-	if err := h.service.SetActiveAnnouncement(c.Request().Context(), typeID, userID, req); err != nil {
+	if err := h.service.SetActiveAnnouncement(c.Request().Context(), userID, req); err != nil {
 		return err
 	}
 	return RespondMessage(c, "Активное объявление обновлено")
@@ -236,12 +229,11 @@ func (h *NewsHandler) SetActiveAnnouncement(c echo.Context) error {
 // @Failure      404 {object} models.HTTPError
 // @Router       /announcements/{id}/hide [post]
 func (h *NewsHandler) HideAnnouncement(c echo.Context) error {
-	typeID := GetTypeID(c)
 	id, err := ParseID(c, "id")
 	if err != nil {
 		return err
 	}
-	if err := h.service.HideAnnouncement(c.Request().Context(), typeID, id); err != nil {
+	if err := h.service.HideAnnouncement(c.Request().Context(), id); err != nil {
 		return err
 	}
 	return RespondMessage(c, "Объявление скрыто")
@@ -262,7 +254,6 @@ func (h *NewsHandler) HideAnnouncement(c echo.Context) error {
 // @Failure      404 {object} models.HTTPError
 // @Router       /announcements/{id} [put]
 func (h *NewsHandler) UpdateAnnouncement(c echo.Context) error {
-	typeID := GetTypeID(c)
 	userID := GetUserID(c)
 	id, err := ParseID(c, "id")
 	if err != nil {
@@ -272,7 +263,7 @@ func (h *NewsHandler) UpdateAnnouncement(c echo.Context) error {
 	if err := BindAndValidate(c, &req); err != nil {
 		return err
 	}
-	announcement, err := h.service.UpdateAnnouncement(c.Request().Context(), typeID, userID, id, req)
+	announcement, err := h.service.UpdateAnnouncement(c.Request().Context(), userID, id, req)
 	if err != nil {
 		return err
 	}
@@ -291,12 +282,11 @@ func (h *NewsHandler) UpdateAnnouncement(c echo.Context) error {
 // @Failure      404 {object} models.HTTPError
 // @Router       /announcements/{id} [delete]
 func (h *NewsHandler) DeleteAnnouncement(c echo.Context) error {
-	typeID := GetTypeID(c)
 	id, err := ParseID(c, "id")
 	if err != nil {
 		return err
 	}
-	if err := h.service.DeleteAnnouncement(c.Request().Context(), typeID, id); err != nil {
+	if err := h.service.DeleteAnnouncement(c.Request().Context(), id); err != nil {
 		return err
 	}
 	return RespondMessage(c, "Объявление удалено")

--- a/internal/handlers/news_test.go
+++ b/internal/handlers/news_test.go
@@ -1,0 +1,108 @@
+package handlers_test
+
+import (
+	"net/http"
+	"testing"
+
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Активные новости/объявления доступны любому авторизованному; управление (all/CUD)
+// гейтится page.admin на роут-middleware (Ф5, ранее service checkAdmin).
+
+func TestNews_GetActive_AnyAuthenticated(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "newsreader", "password123", 1, td.OrgID, td.CompanyID)
+	rec := testutil.GET(t, e, "/news", testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestNews_GetAll_AdminOnly(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	userToken := testutil.RegisterAndLogin(t, e, "newsuser", "password123", 1, td.OrgID, td.CompanyID)
+	rec := testutil.GET(t, e, "/news/all", testutil.AuthHeader(userToken))
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+
+	adminToken := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	rec = testutil.GET(t, e, "/news/all", testutil.AuthHeader(adminToken))
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestNews_Create_Forbidden_NonAdmin(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "newsnonadmin", "password123", 1, td.OrgID, td.CompanyID)
+	rec := testutil.POST(t, e, "/news", `{"title":"Запрещено"}`, testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestNews_Create_Admin(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	rec := testutil.POST(t, e, "/news", `{"title":"Новость от админа"}`, testutil.AuthHeader(token))
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	// созданная новость видна в админском списке
+	rec = testutil.GET(t, e, "/news/all", testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code)
+	list := testutil.ParseSlice(t, rec)
+	found := false
+	for _, item := range list {
+		if item["title"] == "Новость от админа" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "созданная новость не найдена в /news/all")
+}
+
+func TestAnnouncements_GetActive_AnyAuthenticated(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "annreader", "password123", 1, td.OrgID, td.CompanyID)
+	rec := testutil.GET(t, e, "/announcements/active", testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestAnnouncements_Create_Forbidden_NonAdmin(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "annnonadmin", "password123", 1, td.OrgID, td.CompanyID)
+	rec := testutil.POST(t, e, "/announcements", `{"title":"Запрещено"}`, testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestAnnouncements_Create_Admin(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	rec := testutil.POST(t, e, "/announcements", `{"title":"Объявление от админа"}`, testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusCreated, rec.Code)
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -551,23 +551,24 @@ func Setup(e *echo.Echo, d Dependencies) {
 	protected.GET("/settings/password-policy", settings.GetPasswordPolicy)
 	protected.PUT("/settings/:key", settings.Update)
 
-	// Новости
+	// Новости. Активные (GET "") - всем авторизованным; управление - page.admin
+	// (Ф5, ранее service checkAdmin).
 	ng := protected.Group("/news")
 	ng.GET("", news.GetActiveNews)
-	ng.GET("/all", news.GetAllNews)
-	ng.POST("", news.CreateNews)
-	ng.PUT("/:id", news.UpdateNews)
-	ng.DELETE("/:id", news.DeleteNews)
+	ng.GET("/all", news.GetAllNews, requireAdmin)
+	ng.POST("", news.CreateNews, requireAdmin)
+	ng.PUT("/:id", news.UpdateNews, requireAdmin)
+	ng.DELETE("/:id", news.DeleteNews, requireAdmin)
 
-	// Объявления
+	// Объявления. Активное (GET /active) - всем авторизованным; управление - page.admin.
 	ag := protected.Group("/announcements")
 	ag.GET("/active", news.GetActiveAnnouncement)
-	ag.GET("/all", news.GetAllAnnouncements)
-	ag.POST("", news.CreateAnnouncement)
-	ag.POST("/set-active", news.SetActiveAnnouncement)
-	ag.POST("/:id/hide", news.HideAnnouncement)
-	ag.PUT("/:id", news.UpdateAnnouncement)
-	ag.DELETE("/:id", news.DeleteAnnouncement)
+	ag.GET("/all", news.GetAllAnnouncements, requireAdmin)
+	ag.POST("", news.CreateAnnouncement, requireAdmin)
+	ag.POST("/set-active", news.SetActiveAnnouncement, requireAdmin)
+	ag.POST("/:id/hide", news.HideAnnouncement, requireAdmin)
+	ag.PUT("/:id", news.UpdateAnnouncement, requireAdmin)
+	ag.DELETE("/:id", news.DeleteAnnouncement, requireAdmin)
 
 	// Уведомления
 	notif := protected.Group("/notifications")

--- a/internal/services/news_service.go
+++ b/internal/services/news_service.go
@@ -12,22 +12,24 @@ import (
 )
 
 // NewsService -- интерфейс бизнес-логики новостей и объявлений.
+// Админ-операции (page.admin) авторизуются роут-middleware RequirePermissionV2;
+// активные новость/объявление (GetActive*) доступны всем авторизованным.
 type NewsService interface {
 	// News
 	GetActiveNews(ctx context.Context) ([]models.NewsWithUser, error)
-	GetAllNews(ctx context.Context, typeID int) ([]models.NewsWithUser, error)
-	CreateNews(ctx context.Context, typeID int, userID int, req models.CreateNewsRequest) (*models.NewsWithUser, error)
-	UpdateNews(ctx context.Context, typeID int, userID int, id int, req models.UpdateNewsRequest) (*models.NewsWithUser, error)
-	DeleteNews(ctx context.Context, typeID int, id int) error
+	GetAllNews(ctx context.Context) ([]models.NewsWithUser, error)
+	CreateNews(ctx context.Context, userID int, req models.CreateNewsRequest) (*models.NewsWithUser, error)
+	UpdateNews(ctx context.Context, userID int, id int, req models.UpdateNewsRequest) (*models.NewsWithUser, error)
+	DeleteNews(ctx context.Context, id int) error
 
 	// Announcements
 	GetActiveAnnouncement(ctx context.Context) (*models.AnnouncementWithUser, error)
-	GetAllAnnouncements(ctx context.Context, typeID int) ([]models.AnnouncementWithUser, error)
-	CreateAnnouncement(ctx context.Context, typeID int, userID int, req models.CreateAnnouncementRequest) (*models.AnnouncementWithUser, error)
-	SetActiveAnnouncement(ctx context.Context, typeID int, userID int, req models.SetActiveAnnouncementRequest) error
-	HideAnnouncement(ctx context.Context, typeID int, id int) error
-	UpdateAnnouncement(ctx context.Context, typeID int, userID int, id int, req models.UpdateAnnouncementRequest) (*models.AnnouncementWithUser, error)
-	DeleteAnnouncement(ctx context.Context, typeID int, id int) error
+	GetAllAnnouncements(ctx context.Context) ([]models.AnnouncementWithUser, error)
+	CreateAnnouncement(ctx context.Context, userID int, req models.CreateAnnouncementRequest) (*models.AnnouncementWithUser, error)
+	SetActiveAnnouncement(ctx context.Context, userID int, req models.SetActiveAnnouncementRequest) error
+	HideAnnouncement(ctx context.Context, id int) error
+	UpdateAnnouncement(ctx context.Context, userID int, id int, req models.UpdateAnnouncementRequest) (*models.AnnouncementWithUser, error)
+	DeleteAnnouncement(ctx context.Context, id int) error
 }
 
 type newsService struct {
@@ -37,23 +39,6 @@ type newsService struct {
 // NewNewsService создаёт реализацию NewsService.
 func NewNewsService(db *gorm.DB) NewsService {
 	return &newsService{db: db}
-}
-
-func (s *newsService) checkAdmin(ctx context.Context, typeID int) error {
-	var code string
-	err := s.db.WithContext(ctx).
-		Table("user_types").
-		Select("code").
-		Where("id = ?", typeID).
-		Row().
-		Scan(&code)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "User not found")
-	}
-	if code != "manager" && code != "buropropuskov" {
-		return echo.NewHTTPError(http.StatusForbidden, "Insufficient permissions")
-	}
-	return nil
 }
 
 // --- News ---
@@ -81,11 +66,7 @@ func (s *newsService) GetActiveNews(ctx context.Context) ([]models.NewsWithUser,
 	return results, nil
 }
 
-func (s *newsService) GetAllNews(ctx context.Context, typeID int) ([]models.NewsWithUser, error) {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return nil, err
-	}
-
+func (s *newsService) GetAllNews(ctx context.Context) ([]models.NewsWithUser, error) {
 	results := make([]models.NewsWithUser, 0)
 	err := s.newsSelectQuery(s.db.WithContext(ctx)).
 		Order("n.created_at DESC").
@@ -96,11 +77,7 @@ func (s *newsService) GetAllNews(ctx context.Context, typeID int) ([]models.News
 	return results, nil
 }
 
-func (s *newsService) CreateNews(ctx context.Context, typeID int, userID int, req models.CreateNewsRequest) (*models.NewsWithUser, error) {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return nil, err
-	}
-
+func (s *newsService) CreateNews(ctx context.Context, userID int, req models.CreateNewsRequest) (*models.NewsWithUser, error) {
 	now := time.Now().UTC()
 	isActive := true
 	if req.IsActive != nil {
@@ -131,11 +108,7 @@ func (s *newsService) CreateNews(ctx context.Context, typeID int, userID int, re
 	return &result, nil
 }
 
-func (s *newsService) UpdateNews(ctx context.Context, typeID int, userID int, id int, req models.UpdateNewsRequest) (*models.NewsWithUser, error) {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return nil, err
-	}
-
+func (s *newsService) UpdateNews(ctx context.Context, userID int, id int, req models.UpdateNewsRequest) (*models.NewsWithUser, error) {
 	var count int64
 	if err := s.db.WithContext(ctx).Model(&models.News{}).Where("id = ?", id).Count(&count).Error; err != nil {
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error checking news existence")
@@ -175,11 +148,7 @@ func (s *newsService) UpdateNews(ctx context.Context, typeID int, userID int, id
 	return &result, nil
 }
 
-func (s *newsService) DeleteNews(ctx context.Context, typeID int, id int) error {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return err
-	}
-
+func (s *newsService) DeleteNews(ctx context.Context, id int) error {
 	result := s.db.WithContext(ctx).Delete(&models.News{}, id)
 	if result.Error != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "Error deleting news")
@@ -219,11 +188,7 @@ func (s *newsService) GetActiveAnnouncement(ctx context.Context) (*models.Announ
 	return &result, nil
 }
 
-func (s *newsService) GetAllAnnouncements(ctx context.Context, typeID int) ([]models.AnnouncementWithUser, error) {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return nil, err
-	}
-
+func (s *newsService) GetAllAnnouncements(ctx context.Context) ([]models.AnnouncementWithUser, error) {
 	results := make([]models.AnnouncementWithUser, 0)
 	err := s.announcementSelectQuery(s.db.WithContext(ctx)).
 		Order("a.created_at DESC").
@@ -234,11 +199,7 @@ func (s *newsService) GetAllAnnouncements(ctx context.Context, typeID int) ([]mo
 	return results, nil
 }
 
-func (s *newsService) CreateAnnouncement(ctx context.Context, typeID int, userID int, req models.CreateAnnouncementRequest) (*models.AnnouncementWithUser, error) {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return nil, err
-	}
-
+func (s *newsService) CreateAnnouncement(ctx context.Context, userID int, req models.CreateAnnouncementRequest) (*models.AnnouncementWithUser, error) {
 	now := time.Now().UTC()
 	isImportant := false
 	if req.IsImportant != nil {
@@ -282,11 +243,7 @@ func (s *newsService) CreateAnnouncement(ctx context.Context, typeID int, userID
 	return &result, nil
 }
 
-func (s *newsService) SetActiveAnnouncement(ctx context.Context, typeID int, userID int, req models.SetActiveAnnouncementRequest) error {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return err
-	}
-
+func (s *newsService) SetActiveAnnouncement(ctx context.Context, userID int, req models.SetActiveAnnouncementRequest) error {
 	var count int64
 	if err := s.db.WithContext(ctx).Model(&models.Announcement{}).Where("id = ?", req.AnnouncementID).Count(&count).Error; err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "Error checking announcement existence")
@@ -325,11 +282,7 @@ func (s *newsService) SetActiveAnnouncement(ctx context.Context, typeID int, use
 // HideAnnouncement снимает is_active с конкретного объявления (admin only).
 // Не активирует другое - текущим активным остаётся то, что было до, либо
 // никакого (если скрываемое было активным).
-func (s *newsService) HideAnnouncement(ctx context.Context, typeID int, id int) error {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return err
-	}
-
+func (s *newsService) HideAnnouncement(ctx context.Context, id int) error {
 	res := s.db.WithContext(ctx).Model(&models.Announcement{}).
 		Where("id = ?", id).
 		Updates(map[string]interface{}{
@@ -346,11 +299,7 @@ func (s *newsService) HideAnnouncement(ctx context.Context, typeID int, id int) 
 	return nil
 }
 
-func (s *newsService) UpdateAnnouncement(ctx context.Context, typeID int, userID int, id int, req models.UpdateAnnouncementRequest) (*models.AnnouncementWithUser, error) {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return nil, err
-	}
-
+func (s *newsService) UpdateAnnouncement(ctx context.Context, userID int, id int, req models.UpdateAnnouncementRequest) (*models.AnnouncementWithUser, error) {
 	var count int64
 	if err := s.db.WithContext(ctx).Model(&models.Announcement{}).Where("id = ?", id).Count(&count).Error; err != nil {
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error checking announcement existence")
@@ -390,11 +339,7 @@ func (s *newsService) UpdateAnnouncement(ctx context.Context, typeID int, userID
 	return &result, nil
 }
 
-func (s *newsService) DeleteAnnouncement(ctx context.Context, typeID int, id int) error {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return err
-	}
-
+func (s *newsService) DeleteAnnouncement(ctx context.Context, id int) error {
 	result := s.db.WithContext(ctx).Delete(&models.Announcement{}, id)
 	if result.Error != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "Error deleting announcement")


### PR DESCRIPTION
## Что и зачем

Срез Ф5: снятие легаси type-code привязки на сервисе новостей и объявлений.

Управление `/news` и `/announcements` (all / create / update / delete / set-active / hide) авторизовалось внутри сервиса `checkAdmin(typeID)` по коду типа. Перевёл на роут-middleware `RequirePermissionV2(page.admin)` — тем же ключом фронт показывает раздел «Новости и объявления».

Активные новость и объявление (`GET /news`, `GET /announcements/active`) остаются доступны любому авторизованному (как и было — `GetActive*` без `checkAdmin`).

Изменения:
- `router.go`: `requireAdmin` на write/all-эндпоинты новостей и объявлений; активные — без гейта.
- `news_service.go`: удалён `checkAdmin`, из интерфейса и 10 методов убран `typeID`.
- `news.go` (handler): перестал извлекать/прокидывать `type_id`.
- **Новый `news_test.go`** — гейта новостей раньше не тестировали: активные доступны юзеру, all/create — 403 не-админу и 200/201 админу (для новостей и объявлений).

## Проверка

- `go build ./...` + `go vet` зелёные.
- `go test ./internal/handlers/` зелёный целиком (84s, свежая тест-БД) включая новые news-тесты.

## Дальше по Ф5

slice-6 request_logs (мониторинг), затем company, organization, user_service.