### PR TITLE
refactor(access): гейт мониторинга запросов через middleware прав (Ф5)

### DIFF
--- a/internal/handlers/request_logs.go
+++ b/internal/handlers/request_logs.go
@@ -37,12 +37,11 @@ func NewRequestLogsHandler(service services.RequestLogsService) *RequestLogsHand
 // @Failure      403 {object} models.HTTPError
 // @Router       /request-logs [get]
 func (h *RequestLogsHandler) GetLogs(c echo.Context) error {
-	typeID := GetTypeID(c)
 	var q models.RequestLogsQuery
 	if err := c.Bind(&q); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid query parameters")
 	}
-	logs, total, err := h.service.GetLogs(c.Request().Context(), typeID, q)
+	logs, total, err := h.service.GetLogs(c.Request().Context(), q)
 	if err != nil {
 		return err
 	}
@@ -63,8 +62,7 @@ func (h *RequestLogsHandler) GetLogs(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /request-logs/users [get]
 func (h *RequestLogsHandler) GetUsers(c echo.Context) error {
-	typeID := GetTypeID(c)
-	users, err := h.service.GetUsers(c.Request().Context(), typeID)
+	users, err := h.service.GetUsers(c.Request().Context())
 	if err != nil {
 		return err
 	}
@@ -81,8 +79,7 @@ func (h *RequestLogsHandler) GetUsers(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /request-logs/stats [get]
 func (h *RequestLogsHandler) GetStats(c echo.Context) error {
-	typeID := GetTypeID(c)
-	stats, err := h.service.GetStats(c.Request().Context(), typeID)
+	stats, err := h.service.GetStats(c.Request().Context())
 	if err != nil {
 		return err
 	}
@@ -99,8 +96,7 @@ func (h *RequestLogsHandler) GetStats(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /request-logs/realtime [get]
 func (h *RequestLogsHandler) GetRealtime(c echo.Context) error {
-	typeID := GetTypeID(c)
-	stats, err := h.service.GetRealtime(c.Request().Context(), typeID)
+	stats, err := h.service.GetRealtime(c.Request().Context())
 	if err != nil {
 		return err
 	}
@@ -121,12 +117,11 @@ func (h *RequestLogsHandler) GetRealtime(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /request-logs/timeline [get]
 func (h *RequestLogsHandler) GetTimeline(c echo.Context) error {
-	typeID := GetTypeID(c)
 	var q models.TimelineQuery
 	if err := c.Bind(&q); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid query parameters")
 	}
-	points, err := h.service.GetTimeline(c.Request().Context(), typeID, q)
+	points, err := h.service.GetTimeline(c.Request().Context(), q)
 	if err != nil {
 		return err
 	}
@@ -149,12 +144,11 @@ func (h *RequestLogsHandler) GetTimeline(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /request-logs/export [get]
 func (h *RequestLogsHandler) Export(c echo.Context) error {
-	typeID := GetTypeID(c)
 	var q models.RequestLogsQuery
 	if err := c.Bind(&q); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid query parameters")
 	}
-	text, err := h.service.Export(c.Request().Context(), typeID, q)
+	text, err := h.service.Export(c.Request().Context(), q)
 	if err != nil {
 		return err
 	}
@@ -173,12 +167,11 @@ func (h *RequestLogsHandler) Export(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /request-logs/history [get]
 func (h *RequestLogsHandler) GetHistory(c echo.Context) error {
-	typeID := GetTypeID(c)
 	var q models.RequestLogsHistoryQuery
 	if err := c.Bind(&q); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid query parameters")
 	}
-	res, err := h.service.GetHistory(c.Request().Context(), typeID, q)
+	res, err := h.service.GetHistory(c.Request().Context(), q)
 	if err != nil {
 		return err
 	}

--- a/internal/handlers/request_logs_test.go
+++ b/internal/handlers/request_logs_test.go
@@ -1,0 +1,53 @@
+package handlers_test
+
+import (
+	"net/http"
+	"testing"
+
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Раздел «Мониторинг запросов» целиком admin-only (page.admin) -- авторизация на
+// роут-middleware (Ф5, ранее service checkAdmin).
+
+func TestRequestLogs_Forbidden_NonAdmin(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "rluser", "password123", 1, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	for _, path := range []string{"/request-logs", "/request-logs/stats", "/request-logs/users", "/request-logs/export"} {
+		rec := testutil.GET(t, e, path, h)
+		assert.Equal(t, http.StatusForbidden, rec.Code, "non-admin must be forbidden on %s", path)
+	}
+}
+
+func TestRequestLogs_Admin_Ok(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	rec := testutil.GET(t, e, "/request-logs", h)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	rec = testutil.GET(t, e, "/request-logs/stats", h)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestRequestLogs_Unauthorized(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	rec := testutil.GET(t, e, "/request-logs", nil)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -577,8 +577,8 @@ func Setup(e *echo.Echo, d Dependencies) {
 	notif.DELETE("/:id", notifications.Delete)
 	notif.DELETE("", notifications.DeleteAll)
 
-	// Логи запросов
-	rlg := protected.Group("/request-logs")
+	// Логи запросов (мониторинг) - целиком admin-only, page.admin (Ф5, ранее service checkAdmin).
+	rlg := protected.Group("/request-logs", requireAdmin)
 	rlg.GET("", requestLogs.GetLogs)
 	rlg.GET("/users", requestLogs.GetUsers)
 	rlg.GET("/stats", requestLogs.GetStats)

--- a/internal/services/request_logs_service.go
+++ b/internal/services/request_logs_service.go
@@ -14,14 +14,15 @@ import (
 )
 
 // RequestLogsService -- интерфейс бизнес-логики логов запросов.
+// Весь раздел мониторинга admin-only (page.admin) -- авторизация на роут-middleware.
 type RequestLogsService interface {
-	GetLogs(ctx context.Context, typeID int, q models.RequestLogsQuery) ([]models.RequestLogs, int64, error)
-	GetUsers(ctx context.Context, typeID int) ([]models.RequestLogsUser, error)
-	GetStats(ctx context.Context, typeID int) (*models.RequestLogsStats, error)
-	GetRealtime(ctx context.Context, typeID int) (*models.RealtimeStats, error)
-	GetTimeline(ctx context.Context, typeID int, q models.TimelineQuery) ([]models.TimelinePoint, error)
-	GetHistory(ctx context.Context, typeID int, q models.RequestLogsHistoryQuery) (*models.RequestLogsHistory, error)
-	Export(ctx context.Context, typeID int, q models.RequestLogsQuery) (string, error)
+	GetLogs(ctx context.Context, q models.RequestLogsQuery) ([]models.RequestLogs, int64, error)
+	GetUsers(ctx context.Context) ([]models.RequestLogsUser, error)
+	GetStats(ctx context.Context) (*models.RequestLogsStats, error)
+	GetRealtime(ctx context.Context) (*models.RealtimeStats, error)
+	GetTimeline(ctx context.Context, q models.TimelineQuery) ([]models.TimelinePoint, error)
+	GetHistory(ctx context.Context, q models.RequestLogsHistoryQuery) (*models.RequestLogsHistory, error)
+	Export(ctx context.Context, q models.RequestLogsQuery) (string, error)
 }
 
 type requestLogsService struct {
@@ -31,23 +32,6 @@ type requestLogsService struct {
 // NewRequestLogsService создаёт реализацию RequestLogsService.
 func NewRequestLogsService(db *gorm.DB) RequestLogsService {
 	return &requestLogsService{db: db}
-}
-
-func (s *requestLogsService) checkAdmin(_ context.Context, typeID int) error {
-	var code string
-	err := s.db.
-		Table("user_types").
-		Select("code").
-		Where("id = ?", typeID).
-		Row().
-		Scan(&code)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "User not found")
-	}
-	if code != "manager" && code != "buropropuskov" {
-		return echo.NewHTTPError(http.StatusForbidden, "Insufficient permissions")
-	}
-	return nil
 }
 
 func (s *requestLogsService) applyFilters(tx *gorm.DB, q models.RequestLogsQuery) *gorm.DB {
@@ -78,11 +62,7 @@ func (s *requestLogsService) applyFilters(tx *gorm.DB, q models.RequestLogsQuery
 }
 
 // GetLogs возвращает логи с пагинацией и фильтрацией.
-func (s *requestLogsService) GetLogs(ctx context.Context, typeID int, q models.RequestLogsQuery) ([]models.RequestLogs, int64, error) {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return nil, 0, err
-	}
-
+func (s *requestLogsService) GetLogs(ctx context.Context, q models.RequestLogsQuery) ([]models.RequestLogs, int64, error) {
 	if q.Page < 1 {
 		q.Page = 1
 	}
@@ -111,11 +91,7 @@ func (s *requestLogsService) GetLogs(ctx context.Context, typeID int, q models.R
 }
 
 // GetUsers возвращает уникальных пользователей из логов.
-func (s *requestLogsService) GetUsers(ctx context.Context, typeID int) ([]models.RequestLogsUser, error) {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return nil, err
-	}
-
+func (s *requestLogsService) GetUsers(ctx context.Context) ([]models.RequestLogsUser, error) {
 	users := make([]models.RequestLogsUser, 0)
 	err := s.db.WithContext(ctx).
 		Table("request_logs").
@@ -131,11 +107,7 @@ func (s *requestLogsService) GetUsers(ctx context.Context, typeID int) ([]models
 }
 
 // GetStats возвращает агрегированную статистику.
-func (s *requestLogsService) GetStats(ctx context.Context, typeID int) (*models.RequestLogsStats, error) {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return nil, err
-	}
-
+func (s *requestLogsService) GetStats(ctx context.Context) (*models.RequestLogsStats, error) {
 	var stats models.RequestLogsStats
 
 	// Total
@@ -174,11 +146,7 @@ func (s *requestLogsService) GetStats(ctx context.Context, typeID int) (*models.
 }
 
 // GetRealtime возвращает количество запросов за последнюю секунду и минуту.
-func (s *requestLogsService) GetRealtime(ctx context.Context, typeID int) (*models.RealtimeStats, error) {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return nil, err
-	}
-
+func (s *requestLogsService) GetRealtime(ctx context.Context) (*models.RealtimeStats, error) {
 	now := time.Now().UTC()
 	var stats models.RealtimeStats
 
@@ -194,11 +162,7 @@ func (s *requestLogsService) GetRealtime(ctx context.Context, typeID int) (*mode
 }
 
 // GetTimeline возвращает точки для графика, сгруппированные по интервалу.
-func (s *requestLogsService) GetTimeline(ctx context.Context, typeID int, q models.TimelineQuery) ([]models.TimelinePoint, error) {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return nil, err
-	}
-
+func (s *requestLogsService) GetTimeline(ctx context.Context, q models.TimelineQuery) ([]models.TimelinePoint, error) {
 	if q.Interval < 1 {
 		q.Interval = 60
 	}
@@ -247,11 +211,7 @@ func (s *requestLogsService) GetTimeline(ctx context.Context, typeID int, q mode
 }
 
 // Export экспортирует логи в текстовый формат.
-func (s *requestLogsService) Export(ctx context.Context, typeID int, q models.RequestLogsQuery) (string, error) {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return "", err
-	}
-
+func (s *requestLogsService) Export(ctx context.Context, q models.RequestLogsQuery) (string, error) {
 	// Снимаем лимит пагинации для экспорта, но ограничиваем 10000 записей
 	q.Page = 1
 	q.PerPage = 10000
@@ -295,10 +255,7 @@ func (s *requestLogsService) Export(ctx context.Context, typeID int, q models.Re
 
 // GetHistory собирает агрегаты логов за период из request_logs_daily для вкладки
 // «Аналитика»: итоги, ряд по дням, топ эндпоинтов и топ пользователей.
-func (s *requestLogsService) GetHistory(ctx context.Context, typeID int, q models.RequestLogsHistoryQuery) (*models.RequestLogsHistory, error) {
-	if err := s.checkAdmin(ctx, typeID); err != nil {
-		return nil, err
-	}
+func (s *requestLogsService) GetHistory(ctx context.Context, q models.RequestLogsHistoryQuery) (*models.RequestLogsHistory, error) {
 	from, to := historyRange(q.From, q.To)
 	res := &models.RequestLogsHistory{
 		Daily:        []models.HistoryDailyPoint{},


### PR DESCRIPTION
## Что и зачем

Срез Ф5: снятие легаси type-code привязки на сервисе логов запросов.

Весь раздел `/request-logs` (мониторинг) авторизовался внутри сервиса `checkAdmin(typeID)` по коду типа. Раздел admin-only целиком — перевёл на роут-middleware `RequirePermissionV2(page.admin)` на всей группе (как «Мониторинг запросов» во фронте).

Изменения:
- `router.go`: `requireAdmin` на группе `/request-logs`.
- `request_logs_service.go`: удалён `checkAdmin`, из интерфейса и 7 методов убран `typeID`.
- `request_logs.go` (handler): перестал извлекать/прокидывать `type_id`.
- **Новый `request_logs_test.go`** — гейта не тестировали: 403 не-админу на всех эндпоинтах, 200 админу, 401 без токена.

## Проверка

- `go build`+`go vet` зелёные; `go test ./internal/handlers/` зелёный целиком (82s, свежая БД).

## Дальше по Ф5

company, organization, user_service.