### PR TITLE
refactor(access): гейт компаний через middleware прав (Ф5)

### DIFF
--- a/internal/handlers/companies.go
+++ b/internal/handlers/companies.go
@@ -92,15 +92,13 @@ func (h *CompanyHandler) GetWithUsersExtended(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /companies [post]
 func (h *CompanyHandler) Create(c echo.Context) error {
-	username := c.Get("username").(string)
-
 	var req services.CreateCompanyRequest
 	if err := BindAndValidate(c, &req); err != nil {
 		return err
 	}
 
 	userID, _ := c.Get("user_id").(int)
-	company, err := h.service.Create(c.Request().Context(), username, userID, req)
+	company, err := h.service.Create(c.Request().Context(), userID, req)
 	if err != nil {
 		return err
 	}
@@ -122,8 +120,6 @@ func (h *CompanyHandler) Create(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /companies/{id} [put]
 func (h *CompanyHandler) Update(c echo.Context) error {
-	username := c.Get("username").(string)
-
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid company ID")
@@ -135,7 +131,7 @@ func (h *CompanyHandler) Update(c echo.Context) error {
 	}
 
 	userID, _ := c.Get("user_id").(int)
-	company, err := h.service.Update(c.Request().Context(), username, userID, id, req)
+	company, err := h.service.Update(c.Request().Context(), userID, id, req)
 	if err != nil {
 		return err
 	}
@@ -157,15 +153,13 @@ func (h *CompanyHandler) Update(c echo.Context) error {
 // @Failure      409 {object} models.HTTPError
 // @Router       /companies/{id} [delete]
 func (h *CompanyHandler) Delete(c echo.Context) error {
-	username := c.Get("username").(string)
-
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid company ID")
 	}
 
 	userID, _ := c.Get("user_id").(int)
-	if err := h.service.Delete(c.Request().Context(), username, userID, id); err != nil {
+	if err := h.service.Delete(c.Request().Context(), userID, id); err != nil {
 		return err
 	}
 	return RespondMessage(c, "Company archived")
@@ -183,13 +177,12 @@ func (h *CompanyHandler) Delete(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /companies/{id}/restore [post]
 func (h *CompanyHandler) Restore(c echo.Context) error {
-	username := c.Get("username").(string)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid company ID")
 	}
 	userID, _ := c.Get("user_id").(int)
-	if err := h.service.Restore(c.Request().Context(), username, userID, id); err != nil {
+	if err := h.service.Restore(c.Request().Context(), userID, id); err != nil {
 		return err
 	}
 	return RespondMessage(c, "Company restored")
@@ -206,12 +199,11 @@ func (h *CompanyHandler) Restore(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /companies/{id}/history [get]
 func (h *CompanyHandler) GetHistory(c echo.Context) error {
-	username := c.Get("username").(string)
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid company ID")
 	}
-	items, err := h.service.GetHistory(c.Request().Context(), username, id)
+	items, err := h.service.GetHistory(c.Request().Context(), id)
 	if err != nil {
 		return err
 	}
@@ -313,8 +305,6 @@ func (h *CompanyHandler) GetUnloadPlaces(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /companies/{id}/unload-places [put]
 func (h *CompanyHandler) UpdateUnloadPlaces(c echo.Context) error {
-	username := c.Get("username").(string)
-
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid company ID")
@@ -325,7 +315,7 @@ func (h *CompanyHandler) UpdateUnloadPlaces(c echo.Context) error {
 		return err
 	}
 
-	if err := h.service.UpdateUnloadPlaces(c.Request().Context(), username, id, req); err != nil {
+	if err := h.service.UpdateUnloadPlaces(c.Request().Context(), id, req); err != nil {
 		return err
 	}
 	return RespondMessage(c, "Unload places updated successfully")
@@ -371,8 +361,6 @@ func (h *CompanyHandler) GetTables(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /companies/{id}/tables [put]
 func (h *CompanyHandler) UpdateTables(c echo.Context) error {
-	username := c.Get("username").(string)
-
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid company ID")
@@ -383,7 +371,7 @@ func (h *CompanyHandler) UpdateTables(c echo.Context) error {
 		return err
 	}
 
-	if err := h.service.UpdateTables(c.Request().Context(), username, id, req); err != nil {
+	if err := h.service.UpdateTables(c.Request().Context(), id, req); err != nil {
 		return err
 	}
 	return RespondMessage(c, "Company tables updated successfully")

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -290,22 +290,23 @@ func Setup(e *echo.Echo, d Dependencies) {
 	orgg.PUT("/:id/unload-places", org.UpdateOrganizationUnloadPlaces)
 	protected.GET("/get-organization", org.GetMyOrganization)
 
-	// Компании
+	// Компании. Изменяющие операции и история - page.admin (Ф5, ранее service checkAdmin);
+	// списки и привязка пользователей (UpdateUsers) - как было, без отдельного гейта.
 	cg := protected.Group("/companies")
 	cg.GET("", comp.GetAll)
-	cg.POST("", comp.Create)
-	cg.PUT("/:id", comp.Update)
-	cg.DELETE("/:id", comp.Delete)
-	cg.POST("/:id/restore", comp.Restore)
-	cg.GET("/:id/history", comp.GetHistory)
+	cg.POST("", comp.Create, requireAdmin)
+	cg.PUT("/:id", comp.Update, requireAdmin)
+	cg.DELETE("/:id", comp.Delete, requireAdmin)
+	cg.POST("/:id/restore", comp.Restore, requireAdmin)
+	cg.GET("/:id/history", comp.GetHistory, requireAdmin)
 	cg.GET("/with-users", comp.GetWithUsers)
 	cg.GET("/with-users-extended", comp.GetWithUsersExtended)
 	cg.GET("/:id/users", comp.GetUsers)
 	cg.PUT("/:id/users", comp.UpdateUsers)
 	cg.GET("/:id/tables", comp.GetTables)
-	cg.PUT("/:id/tables", comp.UpdateTables)
+	cg.PUT("/:id/tables", comp.UpdateTables, requireAdmin)
 	cg.GET("/:id/unload-places", comp.GetUnloadPlaces)
-	cg.PUT("/:id/unload-places", comp.UpdateUnloadPlaces)
+	cg.PUT("/:id/unload-places", comp.UpdateUnloadPlaces, requireAdmin)
 
 	// Места разгрузки
 	upg := protected.Group("/unload-places")

--- a/internal/services/company_service.go
+++ b/internal/services/company_service.go
@@ -23,20 +23,20 @@ type CompanyService interface {
 	// GetWithUsersExtended возвращает компании с количеством пользователей и местами разгрузки.
 	GetWithUsersExtended(ctx context.Context, includeArchived bool) ([]CompanyWithUsersExtendedResponse, error)
 
-	// Create создаёт новую компанию. callerUserID - актор для аудита. Требуются права buropropuskov.
-	Create(ctx context.Context, username string, callerUserID int, req CreateCompanyRequest) (*models.Company, error)
+	// Create создаёт новую компанию. callerUserID - актор для аудита. Авторизация (page.admin) - на роут-middleware.
+	Create(ctx context.Context, callerUserID int, req CreateCompanyRequest) (*models.Company, error)
 
-	// Update обновляет название компании. callerUserID - актор для аудита. Требуются права buropropuskov.
-	Update(ctx context.Context, username string, callerUserID, companyID int, req CreateCompanyRequest) (*models.Company, error)
+	// Update обновляет название компании. callerUserID - актор для аудита.
+	Update(ctx context.Context, callerUserID, companyID int, req CreateCompanyRequest) (*models.Company, error)
 
-	// Delete архивирует компанию (soft-delete). callerUserID - актор. Нельзя при активных пользователях. Требуются права buropropuskov.
-	Delete(ctx context.Context, username string, callerUserID, companyID int) error
+	// Delete архивирует компанию (soft-delete). callerUserID - актор. Нельзя при активных пользователях.
+	Delete(ctx context.Context, callerUserID, companyID int) error
 
-	// Restore восстанавливает компанию из архива. callerUserID - актор. Требуются права buropropuskov.
-	Restore(ctx context.Context, username string, callerUserID, companyID int) error
+	// Restore восстанавливает компанию из архива. callerUserID - актор.
+	Restore(ctx context.Context, callerUserID, companyID int) error
 
-	// GetHistory возвращает историю изменений компании. Требуются права buropropuskov.
-	GetHistory(ctx context.Context, username string, companyID int) ([]models.CompanyHistoryItem, error)
+	// GetHistory возвращает историю изменений компании.
+	GetHistory(ctx context.Context, companyID int) ([]models.CompanyHistoryItem, error)
 
 	// GetUsers возвращает ответственных пользователей компании.
 	GetUsers(ctx context.Context, companyID int) ([]CompanyUserResponse, error)
@@ -47,14 +47,14 @@ type CompanyService interface {
 	// GetUnloadPlaces возвращает активные места разгрузки компании.
 	GetUnloadPlaces(ctx context.Context, companyID int) ([]CompanyUnloadPlaceResponse, error)
 
-	// UpdateUnloadPlaces обновляет привязку мест разгрузки к компании. Требуются права buropropuskov.
-	UpdateUnloadPlaces(ctx context.Context, username string, companyID int, req UpdateCompanyUnloadPlacesRequest) error
+	// UpdateUnloadPlaces обновляет привязку мест разгрузки к компании.
+	UpdateUnloadPlaces(ctx context.Context, companyID int, req UpdateCompanyUnloadPlacesRequest) error
 
 	// GetTables возвращает активные таблицы компании.
 	GetTables(ctx context.Context, companyID int) ([]CompanyTableResponse, error)
 
-	// UpdateTables обновляет привязку таблиц к компании. Требуются права buropropuskov.
-	UpdateTables(ctx context.Context, username string, companyID int, req UpdateCompanyTablesRequest) error
+	// UpdateTables обновляет привязку таблиц к компании.
+	UpdateTables(ctx context.Context, companyID int, req UpdateCompanyTablesRequest) error
 }
 
 // --- DTO: запросы ---
@@ -226,11 +226,7 @@ func (s *companyService) GetWithUsersExtended(ctx context.Context, includeArchiv
 }
 
 // Create создаёт новую компанию (admin-only).
-func (s *companyService) Create(ctx context.Context, username string, callerUserID int, req CreateCompanyRequest) (*models.Company, error) {
-	if err := s.checkAdmin(ctx, username); err != nil {
-		return nil, err
-	}
-
+func (s *companyService) Create(ctx context.Context, callerUserID int, req CreateCompanyRequest) (*models.Company, error) {
 	var active int64
 	if err := s.db.WithContext(ctx).Model(&models.Company{}).
 		Where("name = ? AND is_active = ?", req.Name, true).Count(&active).Error; err != nil {
@@ -251,11 +247,7 @@ func (s *companyService) Create(ctx context.Context, username string, callerUser
 }
 
 // Update обновляет название компании (admin-only).
-func (s *companyService) Update(ctx context.Context, username string, callerUserID, companyID int, req CreateCompanyRequest) (*models.Company, error) {
-	if err := s.checkAdmin(ctx, username); err != nil {
-		return nil, err
-	}
-
+func (s *companyService) Update(ctx context.Context, callerUserID, companyID int, req CreateCompanyRequest) (*models.Company, error) {
 	var company models.Company
 	if err := s.db.WithContext(ctx).First(&company, companyID).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -289,11 +281,7 @@ func (s *companyService) Update(ctx context.Context, username string, callerUser
 // Delete архивирует компанию (soft-delete: is_active=false). Строка остаётся,
 // FK заявок/сотрудников/машин не осиротевают. Блокируется при активных
 // пользователях компании (как у организаций, #412).
-func (s *companyService) Delete(ctx context.Context, username string, callerUserID, companyID int) error {
-	if err := s.checkAdmin(ctx, username); err != nil {
-		return err
-	}
-
+func (s *companyService) Delete(ctx context.Context, callerUserID, companyID int) error {
 	var company models.Company
 	if err := s.db.WithContext(ctx).First(&company, companyID).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -326,11 +314,7 @@ func (s *companyService) Delete(ctx context.Context, username string, callerUser
 
 // Restore восстанавливает компанию из архива (is_active=true). Конфликт активного
 // имени -> 400.
-func (s *companyService) Restore(ctx context.Context, username string, callerUserID, companyID int) error {
-	if err := s.checkAdmin(ctx, username); err != nil {
-		return err
-	}
-
+func (s *companyService) Restore(ctx context.Context, callerUserID, companyID int) error {
 	var company models.Company
 	if err := s.db.WithContext(ctx).First(&company, companyID).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -362,10 +346,7 @@ func (s *companyService) Restore(ctx context.Context, username string, callerUse
 }
 
 // GetHistory возвращает историю изменений компании (admin-only).
-func (s *companyService) GetHistory(ctx context.Context, username string, companyID int) ([]models.CompanyHistoryItem, error) {
-	if err := s.checkAdmin(ctx, username); err != nil {
-		return nil, err
-	}
+func (s *companyService) GetHistory(ctx context.Context, companyID int) ([]models.CompanyHistoryItem, error) {
 	return s.history.GetHistory(ctx, companyID)
 }
 
@@ -467,11 +448,7 @@ func (s *companyService) GetUnloadPlaces(ctx context.Context, companyID int) ([]
 }
 
 // UpdateUnloadPlaces заменяет привязку мест разгрузки к компании (admin-only).
-func (s *companyService) UpdateUnloadPlaces(ctx context.Context, username string, companyID int, req UpdateCompanyUnloadPlacesRequest) error {
-	if err := s.checkAdmin(ctx, username); err != nil {
-		return err
-	}
-
+func (s *companyService) UpdateUnloadPlaces(ctx context.Context, companyID int, req UpdateCompanyUnloadPlacesRequest) error {
 	tx := s.db.WithContext(ctx).Begin()
 	if tx.Error != nil {
 		slog.Error("не удалось начать транзакцию", "error", tx.Error)
@@ -523,11 +500,7 @@ func (s *companyService) GetTables(ctx context.Context, companyID int) ([]Compan
 }
 
 // UpdateTables заменяет привязку таблиц к компании (admin-only).
-func (s *companyService) UpdateTables(ctx context.Context, username string, companyID int, req UpdateCompanyTablesRequest) error {
-	if err := s.checkAdmin(ctx, username); err != nil {
-		return err
-	}
-
+func (s *companyService) UpdateTables(ctx context.Context, companyID int, req UpdateCompanyTablesRequest) error {
 	tx := s.db.WithContext(ctx).Begin()
 	if tx.Error != nil {
 		slog.Error("не удалось начать транзакцию", "error", tx.Error)
@@ -561,22 +534,3 @@ func (s *companyService) UpdateTables(ctx context.Context, username string, comp
 	return nil
 }
 
-// checkAdmin проверяет что пользователь имеет тип buropropuskov.
-func (s *companyService) checkAdmin(ctx context.Context, username string) error {
-	var result struct {
-		UserType string
-	}
-	err := s.db.WithContext(ctx).
-		Table("users u").
-		Select("ut.code as user_type").
-		Joins("JOIN user_types ut ON u.type_id = ut.id").
-		Where("u.username = ?", username).
-		Scan(&result).Error
-	if err != nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "User not found")
-	}
-	if result.UserType != "buropropuskov" {
-		return echo.NewHTTPError(http.StatusForbidden, "Insufficient permissions")
-	}
-	return nil
-}


### PR DESCRIPTION
## Что и зачем

Срез Ф5: снятие легаси type-code привязки на сервисе компаний.

Изменяющие операции и история `/companies` (create/update/delete/restore/history/update-tables/update-unload-places) авторизовались внутри сервиса `checkAdmin(username)` по коду типа (`buropropuskov`). Перевёл на роут-middleware `RequirePermissionV2(page.admin)` поэндпоинтно — как фронт гейтит «Компании».

Списки (`GetAll`/with-users/...), привязка пользователей (`UpdateUsers`), чтения tables/unload-places остаются как были (без отдельного гейта — у них и не было `checkAdmin`).

Изменения:
- `router.go`: `requireAdmin` на 7 изменяющих/history эндпоинтах `/companies`.
- `company_service.go`: удалён `checkAdmin`, из интерфейса и 7 методов убран параметр `username`; `callerUserID` для аудита сохранён.
- `companies.go` (handler): перестал извлекать/прокидывать `username`.

## Проверка

- `go build`+`go vet` зелёные; `go test ./internal/handlers/` зелёный целиком (83s, свежая БД) — существующие `TestCompanies_*_Forbidden` теперь проверяют middleware-гейт.

## Дальше по Ф5

organization, затем user_service (последний).