### PR TITLE
perf: пул соединений БД, семафор Argon2 и HTTP-таймауты

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -108,6 +108,19 @@ func main() {
 	}
 	slog.Info("connected to database")
 
+	if err := database.ConfigureConnectionPool(db, database.PoolConfig{
+		MaxOpenConns:    cfg.DBMaxOpenConns,
+		MaxIdleConns:    cfg.DBMaxIdleConns,
+		ConnMaxLifetime: cfg.DBConnMaxLifetime,
+		ConnMaxIdleTime: cfg.DBConnMaxIdleTime,
+	}); err != nil {
+		slog.Error("failed to configure DB connection pool", "error", err)
+		os.Exit(1)
+	}
+
+	// Ограничиваем число одновременных Argon2-вычислений до приёма трафика.
+	services.SetArgon2Concurrency(cfg.Argon2HashConcurrency)
+
 	// AutoMigrate all tables (like Laravel Schema::create)
 	if err := database.AutoMigrate(db); err != nil {
 		slog.Error("AutoMigrate failed", "error", err)
@@ -125,6 +138,18 @@ func main() {
 	e.HideBanner = true
 	e.HTTPErrorHandler = handlers.CustomHTTPErrorHandler
 	e.Validator = appvalidator.New()
+
+	// HTTP-таймауты: slowloris-защита и реап keep-alive безопасны всегда.
+	// Body-таймауты (Read/Write) включаются, только если заданы явно, - иначе
+	// рвут большие загрузки/выгрузки файлов.
+	e.Server.ReadHeaderTimeout = cfg.HTTPReadHeaderTimeout
+	e.Server.IdleTimeout = cfg.HTTPIdleTimeout
+	if cfg.HTTPReadTimeout > 0 {
+		e.Server.ReadTimeout = cfg.HTTPReadTimeout
+	}
+	if cfg.HTTPWriteTimeout > 0 {
+		e.Server.WriteTimeout = cfg.HTTPWriteTimeout
+	}
 
 	// Global middleware
 	e.Use(mw.RequestID())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -154,5 +154,22 @@ func (c *Config) Validate() error {
 	if c.JWTRefreshTTL <= c.JWTAccessTTL {
 		return fmt.Errorf("JWT_REFRESH_TTL (%s) must be greater than JWT_ACCESS_TTL (%s)", c.JWTRefreshTTL, c.JWTAccessTTL)
 	}
+	// Ловим отрицательные значения там, где они молча откатывают добавленную
+	// защиту: при отрицательном DB_MAX_OPEN_CONNS guard в пуле не сработает и
+	// останется драйверный безлимит соединений, а отрицательный
+	// ReadHeader/Idle таймаут net/http трактует как "выключено" и тихо снимает
+	// slowloris-защиту с реапом keep-alive. 0 валиден (= дефолт), отрицательное - опечатка.
+	if c.DBMaxOpenConns < 0 {
+		return fmt.Errorf("DB_MAX_OPEN_CONNS must not be negative (got %d)", c.DBMaxOpenConns)
+	}
+	if c.DBMaxIdleConns < 0 {
+		return fmt.Errorf("DB_MAX_IDLE_CONNS must not be negative (got %d)", c.DBMaxIdleConns)
+	}
+	if c.HTTPReadHeaderTimeout < 0 {
+		return fmt.Errorf("HTTP_READ_HEADER_TIMEOUT must not be negative (got %s)", c.HTTPReadHeaderTimeout)
+	}
+	if c.HTTPIdleTimeout < 0 {
+		return fmt.Errorf("HTTP_IDLE_TIMEOUT must not be negative (got %s)", c.HTTPIdleTimeout)
+	}
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -77,6 +77,31 @@ type Config struct {
 	// PdAuditRetentionMonths - срок хранения аудита ПД (152-ФЗ): партиции старше
 	// дропаются. По умолчанию 36 месяцев (3 года).
 	PdAuditRetentionMonths int `env:"PD_AUDIT_RETENTION_MONTHS" envDefault:"36"`
+
+	// Пул соединений с БД (database/sql). По умолчанию драйвер не ограничивает
+	// число открытых соединений и держит лишь 2 idle: под нагрузкой это либо
+	// упирается в postgres max_connections, либо рвёт и заново открывает
+	// соединения на каждом пике. DBMaxOpenConns держим ниже max_connections
+	// (запас под pgAdmin и служебные подключения).
+	DBMaxOpenConns    int           `env:"DB_MAX_OPEN_CONNS" envDefault:"50"`
+	DBMaxIdleConns    int           `env:"DB_MAX_IDLE_CONNS" envDefault:"10"`
+	DBConnMaxLifetime time.Duration `env:"DB_CONN_MAX_LIFETIME" envDefault:"1h"`
+	DBConnMaxIdleTime time.Duration `env:"DB_CONN_MAX_IDLE_TIME" envDefault:"10m"`
+
+	// HTTP-таймауты сервера. ReadHeaderTimeout защищает от slowloris (медленная
+	// отправка заголовков), IdleTimeout реапит висящие keep-alive соединения -
+	// оба безопасны для любого трафика. ReadTimeout/WriteTimeout=0 (выключены)
+	// по умолчанию: ненулевые рвут большие загрузки/выгрузки файлов, их значения
+	// подбираем на сервере по замерам.
+	HTTPReadHeaderTimeout time.Duration `env:"HTTP_READ_HEADER_TIMEOUT" envDefault:"10s"`
+	HTTPReadTimeout       time.Duration `env:"HTTP_READ_TIMEOUT" envDefault:"0s"`
+	HTTPWriteTimeout      time.Duration `env:"HTTP_WRITE_TIMEOUT" envDefault:"0s"`
+	HTTPIdleTimeout       time.Duration `env:"HTTP_IDLE_TIMEOUT" envDefault:"120s"`
+
+	// Argon2HashConcurrency ограничивает число одновременных вычислений Argon2id.
+	// Каждое держит ~19 МБ; без лимита login-storm при 1-2k онлайн умножает это
+	// на число параллельных логинов и валит процесс в OOM. 0 = по числу ядер.
+	Argon2HashConcurrency int `env:"ARGON2_HASH_CONCURRENCY" envDefault:"0"`
 }
 
 func Load() (*Config, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -104,6 +104,31 @@ func TestValidate_InvalidLogLevel(t *testing.T) {
 	assert.Contains(t, err.Error(), "LOG_LEVEL")
 }
 
+func TestValidate_NegativeDBMaxOpenConns(t *testing.T) {
+	cfg := validConfig()
+	cfg.DBMaxOpenConns = -1
+	err := cfg.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "DB_MAX_OPEN_CONNS")
+}
+
+func TestValidate_NegativeHTTPReadHeaderTimeout(t *testing.T) {
+	cfg := validConfig()
+	cfg.HTTPReadHeaderTimeout = -1 * time.Second
+	err := cfg.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP_READ_HEADER_TIMEOUT")
+}
+
+func TestValidate_PoolAndTimeoutsPositivePass(t *testing.T) {
+	cfg := validConfig()
+	cfg.DBMaxOpenConns = 50
+	cfg.DBMaxIdleConns = 10
+	cfg.HTTPReadHeaderTimeout = 10 * time.Second
+	cfg.HTTPIdleTimeout = 120 * time.Second
+	require.NoError(t, cfg.Validate())
+}
+
 func TestValidate_InvalidDatabaseURL(t *testing.T) {
 	cfg := &Config{
 		DatabaseURL:       "mysql://user:pass@localhost/db",

--- a/internal/database/pool.go
+++ b/internal/database/pool.go
@@ -1,0 +1,41 @@
+package database
+
+import (
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// PoolConfig задаёт параметры пула соединений database/sql под открытым GORM.
+type PoolConfig struct {
+	MaxOpenConns    int
+	MaxIdleConns    int
+	ConnMaxLifetime time.Duration
+	ConnMaxIdleTime time.Duration
+}
+
+// ConfigureConnectionPool применяет параметры пула к открытому *gorm.DB.
+// По умолчанию database/sql не ограничивает число открытых соединений и держит
+// лишь 2 idle: под пиковой нагрузкой это либо упирается в postgres
+// max_connections, либо рвёт и заново открывает соединения на каждом всплеске.
+// Нулевые поля не трогаются - остаётся дефолт драйвера.
+func ConfigureConnectionPool(db *gorm.DB, cfg PoolConfig) error {
+	sqlDB, err := db.DB()
+	if err != nil {
+		return fmt.Errorf("failed to get sql.DB for pool config: %w", err)
+	}
+	if cfg.MaxOpenConns > 0 {
+		sqlDB.SetMaxOpenConns(cfg.MaxOpenConns)
+	}
+	if cfg.MaxIdleConns > 0 {
+		sqlDB.SetMaxIdleConns(cfg.MaxIdleConns)
+	}
+	if cfg.ConnMaxLifetime > 0 {
+		sqlDB.SetConnMaxLifetime(cfg.ConnMaxLifetime)
+	}
+	if cfg.ConnMaxIdleTime > 0 {
+		sqlDB.SetConnMaxIdleTime(cfg.ConnMaxIdleTime)
+	}
+	return nil
+}

--- a/internal/database/pool_test.go
+++ b/internal/database/pool_test.go
@@ -1,0 +1,57 @@
+package database_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"systemburo/internal/database"
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// TestConfigureConnectionPool проверяет, что лимит открытых соединений реально
+// удерживается: при MaxOpenConns=2 и пачке параллельных медленных запросов
+// одновременно открыто не больше двух, а лишние ждут очереди (WaitCount>0).
+// Открываем отдельное соединение, чтобы не трогать общий пул тестовой БД.
+func TestConfigureConnectionPool(t *testing.T) {
+	t.Parallel()
+
+	db, err := gorm.Open(
+		postgres.Open(database.EnsureUTCTimezone(testutil.TestDSN())),
+		&gorm.Config{Logger: logger.Default.LogMode(logger.Silent)},
+	)
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	defer sqlDB.Close()
+
+	require.NoError(t, database.ConfigureConnectionPool(db, database.PoolConfig{
+		MaxOpenConns:    2,
+		MaxIdleConns:    2,
+		ConnMaxLifetime: time.Hour,
+		ConnMaxIdleTime: 10 * time.Minute,
+	}))
+
+	require.Equal(t, 2, sqlDB.Stats().MaxOpenConnections)
+
+	const workers = 6
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// pg_sleep держит соединение занятым, чтобы пул дошёл до предела.
+			require.NoError(t, db.Exec("SELECT pg_sleep(0.1)").Error)
+		}()
+	}
+	wg.Wait()
+
+	stats := sqlDB.Stats()
+	require.LessOrEqual(t, stats.OpenConnections, 2, "пул не должен превышать MaxOpenConns")
+	require.Positive(t, stats.WaitCount, "часть запросов должна была ждать освобождения соединения")
+}

--- a/internal/database/pool_test.go
+++ b/internal/database/pool_test.go
@@ -40,16 +40,23 @@ func TestConfigureConnectionPool(t *testing.T) {
 	require.Equal(t, 2, sqlDB.Stats().MaxOpenConnections)
 
 	const workers = 6
+	// Ошибки собираем в канал и проверяем после wg.Wait(): require/FailNow из
+	// дочерней горутины завершил бы только её (runtime.Goexit), а не тест.
+	errs := make(chan error, workers)
 	var wg sync.WaitGroup
 	for i := 0; i < workers; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			// pg_sleep держит соединение занятым, чтобы пул дошёл до предела.
-			require.NoError(t, db.Exec("SELECT pg_sleep(0.1)").Error)
+			errs <- db.Exec("SELECT pg_sleep(0.1)").Error
 		}()
 	}
 	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
 
 	stats := sqlDB.Stats()
 	require.LessOrEqual(t, stats.OpenConnections, 2, "пул не должен превышать MaxOpenConns")

--- a/internal/services/argon2_limit.go
+++ b/internal/services/argon2_limit.go
@@ -1,0 +1,37 @@
+package services
+
+import "runtime"
+
+// argon2Sem ограничивает число одновременных вычислений Argon2id. Каждое такое
+// вычисление держит ~19 МБ рабочей памяти и грузит ядро; без лимита login-storm
+// при 1-2k онлайн умножает 19 МБ на число параллельных логинов и валит процесс в
+// OOM. Слот занимается только на время самого IDKey, поэтому лишние логины ждут
+// очереди вместо одновременного выделения памяти.
+var argon2Sem = make(chan struct{}, defaultArgon2Concurrency())
+
+func defaultArgon2Concurrency() int {
+	if n := runtime.GOMAXPROCS(0); n > 0 {
+		return n
+	}
+	return 1
+}
+
+// SetArgon2Concurrency перенастраивает лимит одновременных Argon2-вычислений.
+// n<=0 - по числу ядер (GOMAXPROCS). Вызывать на старте до приёма трафика:
+// переустановка канала не синхронизирована с работающими withArgon2Slot.
+func SetArgon2Concurrency(n int) {
+	if n <= 0 {
+		n = defaultArgon2Concurrency()
+	}
+	argon2Sem = make(chan struct{}, n)
+}
+
+// withArgon2Slot выполняет fn, заняв слот семафора, и освобождает его после.
+// Канал захватывается в локальную переменную, чтобы захват и освобождение шли
+// через один и тот же экземпляр семафора даже при гонке с SetArgon2Concurrency.
+func withArgon2Slot(fn func()) {
+	sem := argon2Sem
+	sem <- struct{}{}
+	defer func() { <-sem }()
+	fn()
+}

--- a/internal/services/argon2_limit_test.go
+++ b/internal/services/argon2_limit_test.go
@@ -1,0 +1,50 @@
+package services
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestArgon2SlotLimitsConcurrency проверяет, что withArgon2Slot не пускает
+// больше заданного числа вычислений одновременно - это и есть защита от
+// OOM при login-storm, которую используют hashPassword/verifyPassword.
+func TestArgon2SlotLimitsConcurrency(t *testing.T) {
+	SetArgon2Concurrency(2)
+	defer SetArgon2Concurrency(0) // вернуть дефолт по числу ядер
+
+	var inFlight, maxSeen int32
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			withArgon2Slot(func() {
+				cur := atomic.AddInt32(&inFlight, 1)
+				for {
+					m := atomic.LoadInt32(&maxSeen)
+					if cur <= m || atomic.CompareAndSwapInt32(&maxSeen, m, cur) {
+						break
+					}
+				}
+				time.Sleep(5 * time.Millisecond)
+				atomic.AddInt32(&inFlight, -1)
+			})
+		}()
+	}
+	wg.Wait()
+
+	require.LessOrEqual(t, maxSeen, int32(2), "одновременных Argon2-вычислений не должно быть больше лимита")
+}
+
+// TestSetArgon2ConcurrencyDefaults проверяет, что неположительное n возвращает
+// семафор по числу ядер, а не нулевой (нулевой канал заблокировал бы логины).
+func TestSetArgon2ConcurrencyDefaults(t *testing.T) {
+	SetArgon2Concurrency(-1)
+	defer SetArgon2Concurrency(0)
+	require.Equal(t, defaultArgon2Concurrency(), cap(argon2Sem))
+	require.Positive(t, cap(argon2Sem))
+}

--- a/internal/services/auth_service.go
+++ b/internal/services/auth_service.go
@@ -90,7 +90,10 @@ func hashPassword(password string) string {
 	salt := generateSalt()
 	// Argon2id with default params matching Rust argon2 0.5.3 defaults:
 	// m=19456 (19 MiB), t=2, p=1
-	hash := argon2.IDKey([]byte(password), salt, 2, 19456, 1, 32)
+	var hash []byte
+	withArgon2Slot(func() {
+		hash = argon2.IDKey([]byte(password), salt, 2, 19456, 1, 32)
+	})
 	// PHC format: $argon2id$v=19$m=19456,t=2,p=1$<salt>$<hash>
 	saltB64 := base64RawEncode(salt)
 	hashB64 := base64RawEncode(hash)
@@ -103,7 +106,10 @@ func verifyPassword(phcHash, password string) bool {
 	if err != nil {
 		return false
 	}
-	computed := argon2.IDKey([]byte(password), salt, params.time, params.memory, params.threads, uint32(len(expectedHash)))
+	var computed []byte
+	withArgon2Slot(func() {
+		computed = argon2.IDKey([]byte(password), salt, params.time, params.memory, params.threads, uint32(len(expectedHash)))
+	})
 	return subtleCompare(computed, expectedHash)
 }
 

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -291,6 +291,11 @@ func initTestDB() *gorm.DB {
 	return db
 }
 
+// TestDSN возвращает DSN изолированной тестовой БД. Экспортирован для тестов,
+// которым нужно собственное соединение (например, тюнинг пула), чтобы не менять
+// настройки общего cachedDB.
+func TestDSN() string { return getTestDSN() }
+
 func getTestDSN() string {
 	if dsn := os.Getenv("DATABASE_URL_TEST"); dsn != "" {
 		return dsn


### PR DESCRIPTION
Часть #755 (вертикальное масштабирование под 1-2k онлайн на 6c/32g). Три код-уровневые оптимизации, которые можно реализовать в репозитории до доступа к серверу. На мерж пока не выкатываю: значения тюнятся и валидируются на проде под k6.

## Что меняется

**Пул соединений БД.** `database/sql` по умолчанию держит безлимит открытых соединений и лишь 2 idle - под пиком это либо упор в `max_connections`, либо рвём и заново открываем соединения на каждом всплеске. Добавил `ConfigureConnectionPool`, вызывается сразу после открытия БД. Дефолты через env: `DB_MAX_OPEN_CONNS=50` (ниже prod `max_connections=150`), `DB_MAX_IDLE_CONNS=10`, lifetime `1h`, idle-time `10m`.

**Семафор Argon2.** Каждый `verifyPassword`/`hashPassword` занимает слот семафора. Без лимита login-storm при 1-2k онлайн = тысячи параллельных Argon2id по ~19 МБ -> OOM. Лимит по числу ядер (на проде `GOMAXPROCS=6` -> макс ~114 МБ на хеши под штормом), тюнится `ARGON2_HASH_CONCURRENCY`.

**HTTP-таймауты.** На `e.Server`: `ReadHeaderTimeout=10s` (slowloris) и `IdleTimeout=120s` (реап keep-alive) активны всегда - безопасны для любого трафика. `ReadTimeout`/`WriteTimeout` по умолчанию выключены (env-тюнятся): ненулевые рвут большие загрузки/выгрузки файлов.

## Сознательно отложено на сервер-сессию

- **PrepareStmt** - конфликтует с динамическим DDL партиционного воркера (#753 создаёт таблицы с уникальными именами по дням), нужен session-opt-out + замер выигрыша на parse/plan под нагрузкой.
- **Батчинг записи логов** - риск durability/ordering, тюнить по реальной частоте записи; партиционирование уже срезало стоимость.

## Проверка

`go build` + `go vet` чистые. `-race` тесты зелёные: пул реально держит предел (`MaxOpenConns=2`, лишние ждут - `WaitCount>0`); семафор Argon2 не пускает больше лимита одновременно. Логин/пароль через handlers зелёные - обёртка Argon2 верификацию не сломала.