### PR TITLE
refactor(access): гейт организаций через middleware прав (Ф5)

### DIFF
--- a/internal/handlers/organizations.go
+++ b/internal/handlers/organizations.go
@@ -54,11 +54,6 @@ func (h *OrganizationHandler) GetAll(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /organizations [post]
 func (h *OrganizationHandler) Create(c echo.Context) error {
-	username := c.Get("username").(string)
-	if err := services.CheckAdminPermissions(h.db, c.Request().Context(), username); err != nil {
-		return err
-	}
-
 	var req services.CreateOrganizationRequest
 	if err := BindAndValidate(c, &req); err != nil {
 		return err
@@ -87,11 +82,6 @@ func (h *OrganizationHandler) Create(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /organizations/{id} [put]
 func (h *OrganizationHandler) Update(c echo.Context) error {
-	username := c.Get("username").(string)
-	if err := services.CheckAdminPermissions(h.db, c.Request().Context(), username); err != nil {
-		return err
-	}
-
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid organization ID")
@@ -125,11 +115,6 @@ func (h *OrganizationHandler) Update(c echo.Context) error {
 // @Failure      409 {object} models.HTTPError
 // @Router       /organizations/{id} [delete]
 func (h *OrganizationHandler) Delete(c echo.Context) error {
-	username := c.Get("username").(string)
-	if err := services.CheckAdminPermissions(h.db, c.Request().Context(), username); err != nil {
-		return err
-	}
-
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid organization ID")
@@ -154,10 +139,6 @@ func (h *OrganizationHandler) Delete(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /organizations/{id}/restore [post]
 func (h *OrganizationHandler) Restore(c echo.Context) error {
-	username := c.Get("username").(string)
-	if err := services.CheckAdminPermissions(h.db, c.Request().Context(), username); err != nil {
-		return err
-	}
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid organization ID")
@@ -180,10 +161,6 @@ func (h *OrganizationHandler) Restore(c echo.Context) error {
 // @Failure      500 {object} models.HTTPError
 // @Router       /organizations/{id}/history [get]
 func (h *OrganizationHandler) GetHistory(c echo.Context) error {
-	username := c.Get("username").(string)
-	if err := services.CheckAdminPermissions(h.db, c.Request().Context(), username); err != nil {
-		return err
-	}
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid organization ID")
@@ -350,11 +327,6 @@ func (h *OrganizationHandler) GetOrganizationTables(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /organizations/{id}/tables [put]
 func (h *OrganizationHandler) UpdateOrganizationTables(c echo.Context) error {
-	username := c.Get("username").(string)
-	if err := services.CheckAdminPermissions(h.db, c.Request().Context(), username); err != nil {
-		return err
-	}
-
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid organization ID")
@@ -411,11 +383,6 @@ func (h *OrganizationHandler) GetOrganizationUnloadPlaces(c echo.Context) error 
 // @Failure      403 {object} models.HTTPError
 // @Router       /organizations/{id}/unload-places [put]
 func (h *OrganizationHandler) UpdateOrganizationUnloadPlaces(c echo.Context) error {
-	username := c.Get("username").(string)
-	if err := services.CheckAdminPermissions(h.db, c.Request().Context(), username); err != nil {
-		return err
-	}
-
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Invalid organization ID")

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -272,22 +272,23 @@ func Setup(e *echo.Echo, d Dependencies) {
 	attRoot.GET("/:id/field-config", attachmentTemplates.GetFieldConfig)
 	attRoot.PUT("/:id/field-config", attachmentTemplates.SaveFieldConfig)
 
-	// Организации
+	// Организации. Изменяющие операции и история - page.admin (Ф5, ранее handler-level
+	// CheckAdminPermissions); списки и привязка пользователей - как было, без гейта.
 	orgg := protected.Group("/organizations")
 	orgg.GET("", org.GetAll)
-	orgg.POST("", org.Create)
-	orgg.PUT("/:id", org.Update)
-	orgg.DELETE("/:id", org.Delete)
-	orgg.POST("/:id/restore", org.Restore)
-	orgg.GET("/:id/history", org.GetHistory)
+	orgg.POST("", org.Create, requireAdmin)
+	orgg.PUT("/:id", org.Update, requireAdmin)
+	orgg.DELETE("/:id", org.Delete, requireAdmin)
+	orgg.POST("/:id/restore", org.Restore, requireAdmin)
+	orgg.GET("/:id/history", org.GetHistory, requireAdmin)
 	orgg.GET("/with-users", org.GetWithUsers)
 	orgg.GET("/with-users-extended", org.GetWithUsersExtended)
 	orgg.GET("/:id/users", org.GetOrganizationUsers)
 	orgg.PUT("/:id/users", org.UpdateOrganizationUsers)
 	orgg.GET("/:id/tables", org.GetOrganizationTables)
-	orgg.PUT("/:id/tables", org.UpdateOrganizationTables)
+	orgg.PUT("/:id/tables", org.UpdateOrganizationTables, requireAdmin)
 	orgg.GET("/:id/unload-places", org.GetOrganizationUnloadPlaces)
-	orgg.PUT("/:id/unload-places", org.UpdateOrganizationUnloadPlaces)
+	orgg.PUT("/:id/unload-places", org.UpdateOrganizationUnloadPlaces, requireAdmin)
 	protected.GET("/get-organization", org.GetMyOrganization)
 
 	// Компании

--- a/internal/services/organization_service.go
+++ b/internal/services/organization_service.go
@@ -150,27 +150,6 @@ func NewOrganizationService(db *gorm.DB) OrganizationService {
 	return &organizationService{db: db, history: NewOrganizationHistoryService(db)}
 }
 
-// CheckAdminPermissions проверяет, что пользователь имеет тип buropropuskov.
-// Вызывается из хендлера перед admin-операциями.
-func CheckAdminPermissions(db *gorm.DB, ctx context.Context, username string) error {
-	var result struct {
-		Code string
-	}
-	err := db.WithContext(ctx).
-		Table("users").
-		Select("user_types.code").
-		Joins("JOIN user_types ON users.type_id = user_types.id").
-		Where("users.username = ?", username).
-		Scan(&result).Error
-	if err != nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "User not found")
-	}
-	if result.Code != "buropropuskov" {
-		return echo.NewHTTPError(http.StatusForbidden, "Insufficient permissions")
-	}
-	return nil
-}
-
 // GetAll возвращает список всех организаций.
 func (s *organizationService) GetAll(ctx context.Context) ([]OrganizationInfoResponse, error) {
 	orgs := make([]OrganizationInfoResponse, 0)


### PR DESCRIPTION
## Что

Изменяющие операции организаций (Create/Update/Delete/Restore, история, обновление таблиц и мест разгрузки) гейтились handler-level проверкой типа пользователя - `services.CheckAdminPermissions` сверяла код типа с `buropropuskov`. Это последний legacy type-check в домене организаций (Ф5 эпика прав).

## Как

- Убрал экспортируемую `CheckAdminPermissions` из `organization_service.go` и 7 вызовов из хендлеров.
- Навесил route-middleware `requireAdmin` (= `RequirePermissionV2(page.admin)`) на изменяющие маршруты в `router.go`.
- Списки (`GET`), `with-users`, привязка пользователей и чтение таблиц/мест разгрузки остались без гейта - поведение как было.

## Проверка

- `go build` + `go vet ./internal/...` чисто.
- `go test ./internal/handlers/` целиком зелёный (94s), включая `TestOrganizations_*_Forbidden` (403 для обычного типа) и success-кейсы под админом.
- `go test ./internal/services/` зелёный.