### PR TITLE
refactor(access): убрал legacy type_id из гейта уведомлений + мёртвый плумбинг (Ф5)

### DIFF
--- a/internal/handlers/helpers.go
+++ b/internal/handlers/helpers.go
@@ -47,12 +47,6 @@ func GetUserID(c echo.Context) int {
 	return id
 }
 
-// GetTypeID безопасно извлекает type_id из контекста.
-func GetTypeID(c echo.Context) int {
-	id, _ := c.Get("type_id").(int)
-	return id
-}
-
 // IsSuperAdmin безопасно извлекает is_super_admin из контекста (#231).
 // Используется вместо хардкода type_id == 6.
 func IsSuperAdmin(c echo.Context) bool {

--- a/internal/handlers/notifications.go
+++ b/internal/handlers/notifications.go
@@ -117,10 +117,6 @@ func (h *NotificationHandler) DeleteAll(c echo.Context) error {
 // @Failure      403 {object} models.HTTPError
 // @Router       /notifications [post]
 func (h *NotificationHandler) Create(c echo.Context) error {
-	typeID := c.Get("type_id").(int)
-	if typeID != 5 && typeID != 6 {
-		return echo.NewHTTPError(403, "Insufficient permissions")
-	}
 	var req models.CreateNotificationRequest
 	if err := BindAndValidate(c, &req); err != nil {
 		return err

--- a/internal/handlers/notifications_test.go
+++ b/internal/handlers/notifications_test.go
@@ -1,0 +1,67 @@
+package handlers_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"systemburo/internal/models"
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNotifications_Create_Admin: админ создаёт рассылку - 200 и уведомление
+// появляется у целевого пользователя.
+func TestNotifications_Create_Admin(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	target := models.User{
+		Username:       "notif_target",
+		Password:       "x",
+		TypeID:         1,
+		OrganizationID: &td.OrgID,
+		CompanyID:      &td.CompanyID,
+	}
+	require.NoError(t, db.Create(&target).Error)
+
+	body := fmt.Sprintf(`{"user_id":%d,"title":"Внимание"}`, target.ID)
+	rec := testutil.POST(t, e, "/notifications", body, testutil.AuthHeader(token))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	n := testutil.ParseMap(t, rec)
+	assert.Equal(t, "Внимание", n["title"])
+	assert.Equal(t, float64(target.ID), n["user_id"])
+}
+
+// TestNotifications_Create_Forbidden_NonAdmin: обычный пользователь не может
+// создавать рассылку - гейт page.admin (Ф5, ранее type_id 5/6).
+func TestNotifications_Create_Forbidden_NonAdmin(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAndLogin(t, e, "regularuser", "password123", 1, td.OrgID, td.CompanyID)
+
+	body := `{"user_id":1,"title":"X"}`
+	rec := testutil.POST(t, e, "/notifications", body, testutil.AuthHeader(token))
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+// TestNotifications_Create_Unauthorized: без токена - 401.
+func TestNotifications_Create_Unauthorized(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	body := `{"user_id":1,"title":"X"}`
+	rec := testutil.POST(t, e, "/notifications", body, nil)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}

--- a/internal/middleware/jwt.go
+++ b/internal/middleware/jwt.go
@@ -27,7 +27,6 @@ func JWTAuth(jwtSecret []byte) echo.MiddlewareFunc {
 			username, _ := claims.GetSubject()
 			c.Set("username", username)
 			c.Set("user_id", claims.UserID)
-			c.Set("type_id", claims.TypeID)
 			c.Set("is_super_admin", claims.IsSuperAdmin)
 
 			return next(c)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -574,10 +574,11 @@ func Setup(e *echo.Echo, d Dependencies) {
 	ag.PUT("/:id", news.UpdateAnnouncement, requireAdmin)
 	ag.DELETE("/:id", news.DeleteAnnouncement, requireAdmin)
 
-	// Уведомления
+	// Уведомления. Свои - любому авторизованному; рассылка (Create) - админ
+	// (page.admin, Ф5: ранее handler-проверка type_id 5/6 manager/buropropuskov).
 	notif := protected.Group("/notifications")
 	notif.GET("", notifications.GetNotifications)
-	notif.POST("", notifications.Create)
+	notif.POST("", notifications.Create, requireAdmin)
 	notif.PUT("/:id/read", notifications.MarkRead)
 	notif.DELETE("/:id", notifications.Delete)
 	notif.DELETE("", notifications.DeleteAll)


### PR DESCRIPTION
## Что

При чистке `type_id` нашёлся последний legacy type-check, проскочивший Ф5: `POST /notifications` (рассылка) гейтился в хендлере проверкой `type_id != 5 && type_id != 6` (manager/buropropuskov числовыми id - поэтому греп по строкам кодов его не поймал).

## Как

- `notifications.go`: убрал type-check, хендлер стал тонким.
- `router.go`: `POST /notifications` гейтится `requireAdmin` (page.admin). GET/read/delete своих уведомлений - как было, любому авторизованному.
- Добавил `notifications_test.go`: 403 не-админу, 200 админу (+ проверка что уведомление создано у целевого юзера), 401 без токена.
- Почистил мёртвый плумбинг: удалил неиспользуемый helper `GetTypeID` и `c.Set("type_id")` в `jwt.go` (после фикса никто не читает `type_id` из echo-контекста).

## Важно: claim в JWT оставлен

`type_id` в JWT-claim НЕ трогал - его декодирует фронт (`authStore.userType` -> `UserProfileHeader`) для отображения типа пользователя. Это классификация, не авторизация.

## Проверка

- `go build` + `go vet` чисто.
- `go test ./internal/handlers/` целиком зелёный (94s).