### PR TITLE
fix(access): понятная ошибка вместо 500 при удалении роли

### DIFF
--- a/frontend/src/api/permissions.js
+++ b/frontend/src/api/permissions.js
@@ -140,7 +140,11 @@ export async function deleteRole(id) {
   const res = await apiRequest(`/roles/${id}`, {
     method: 'DELETE',
   });
-  return res.json();
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error(body?.error || body?.message || 'Не удалось удалить роль');
+  }
+  return body;
 }
 
 export async function setRoleDefaultGroups(id, groupIds) {

--- a/frontend/src/views/admin/AdminRoles.vue
+++ b/frontend/src/views/admin/AdminRoles.vue
@@ -373,8 +373,8 @@ export default {
         await deleteRole(role.id);
         await this.fetchAll();
         useDeletionsStore().notify({ prefix: 'Роль ', bold: role.name, suffix: ' удалена' });
-      } catch {
-        useDeletionsStore().notify({ prefix: 'Не удалось удалить ', bold: role.name, suffix: ': возможно, есть привязанные пользователи', type: 'error' });
+      } catch (e) {
+        useDeletionsStore().notify({ prefix: 'Не удалось удалить ', bold: role.name, suffix: `: ${e?.message || 'неизвестная ошибка'}`, type: 'error' });
       }
     },
   },

--- a/internal/handlers/roles_test.go
+++ b/internal/handlers/roles_test.go
@@ -1,0 +1,80 @@
+package handlers_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"systemburo/internal/models"
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRoles_Delete_SystemRole_Conflict: системную роль («Пользователь») удалить
+// нельзя - 409 с понятной причиной, а не 500.
+func TestRoles_Delete_SystemRole_Conflict(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	var sysRole models.Role
+	require.NoError(t, db.Where("is_system = ?", true).First(&sysRole).Error)
+
+	rec := testutil.DELETE(t, e, fmt.Sprintf("/roles/%d", sysRole.ID), testutil.AuthHeader(token))
+
+	assert.Equal(t, http.StatusConflict, rec.Code)
+	assert.Contains(t, rec.Body.String(), "системную")
+}
+
+// TestRoles_Delete_WithAssignedUsers_Conflict: роль с привязанными юзерами
+// удалить нельзя - 409 с количеством, а не 500.
+func TestRoles_Delete_WithAssignedUsers_Conflict(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	role := models.Role{Code: "role_with_users", Name: "С юзерами"}
+	require.NoError(t, db.Create(&role).Error)
+	user := models.User{Username: "role_holder", TypeID: 1, RoleID: &role.ID}
+	require.NoError(t, db.Create(&user).Error)
+
+	rec := testutil.DELETE(t, e, fmt.Sprintf("/roles/%d", role.ID), testutil.AuthHeader(token))
+
+	assert.Equal(t, http.StatusConflict, rec.Code)
+	assert.Contains(t, rec.Body.String(), "назначена")
+}
+
+// TestRoles_Delete_NotFound: несуществующая роль - 404, а не 500.
+func TestRoles_Delete_NotFound(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	rec := testutil.DELETE(t, e, "/roles/999999", testutil.AuthHeader(token))
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// TestRoles_Delete_EmptyCustomRole_OK: пустую кастомную роль без юзеров можно удалить.
+func TestRoles_Delete_EmptyCustomRole_OK(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	role := models.Role{Code: "role_empty", Name: "Пустая"}
+	require.NoError(t, db.Create(&role).Error)
+
+	rec := testutil.DELETE(t, e, fmt.Sprintf("/roles/%d", role.ID), testutil.AuthHeader(token))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}

--- a/internal/services/role_service.go
+++ b/internal/services/role_service.go
@@ -2,10 +2,13 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 
 	"systemburo/internal/models"
 
+	"github.com/labstack/echo/v4"
 	"gorm.io/gorm"
 )
 
@@ -127,18 +130,24 @@ func (s *RoleService) Update(ctx context.Context, roleID int, req models.UpdateR
 func (s *RoleService) Delete(ctx context.Context, roleID int) error {
 	var role models.Role
 	if err := s.db.WithContext(ctx).First(&role, roleID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "Роль не найдена")
+		}
 		return fmt.Errorf("failed to load role: %w", err)
 	}
 	if role.IsSystem {
-		return fmt.Errorf("cannot delete system role")
+		return echo.NewHTTPError(http.StatusConflict, "Нельзя удалить системную роль")
 	}
 
+	// Считаем всех пользователей с ролью, включая архивных: у архивных role_id
+	// сохраняется, и удаление роли осиротит ссылку. Сначала переназначить.
 	var count int64
 	if err := s.db.WithContext(ctx).Model(&models.User{}).Where("role_id = ?", roleID).Count(&count).Error; err != nil {
 		return fmt.Errorf("failed to count users: %w", err)
 	}
 	if count > 0 {
-		return fmt.Errorf("cannot delete role: %d users still assigned", count)
+		return echo.NewHTTPError(http.StatusConflict,
+			fmt.Sprintf("Роль назначена пользователям (%d, включая архивных). Сначала переназначьте их на другую роль.", count))
 	}
 	if err := s.db.WithContext(ctx).Delete(&models.Role{}, roleID).Error; err != nil {
 		return fmt.Errorf("failed to delete role: %w", err)


### PR DESCRIPTION
## Проблема

`DELETE /api/roles/:id` отдавал 500 на бизнес-ошибки (системная роль, есть привязанные юзеры) - сервис возвращал обычные `fmt.Errorf`, Echo делал из них Internal Server Error, фронт по 5xx редиректил на /500. Юзер видел страницу ошибки без причины.

## Фикс

- `role_service.go Delete`: 409 «Нельзя удалить системную роль», 409 «Роль назначена пользователям (N, включая архивных)...», 404 «Роль не найдена» (echo.NewHTTPError).
- FE `deleteRole`: бросает с сообщением бэка на non-ok; `AdminRoles.confirmDelete` показывает реальную причину в уведомлении вместо общей фразы.
- Архивные юзеры считаются в guard'е (у них сохраняется role_id, удаление осиротит ссылку) - текст это поясняет.

## Тесты

`go test ./internal/handlers/` - новые TestRoles_Delete_* (409 системной, 409 с юзерами, 404, 200 для пустой кастомной) зелёные.