### PR TITLE
fix(access): администратор управляет правами пользователей (не только супер)

### DIFF
--- a/internal/handlers/permissions.go
+++ b/internal/handlers/permissions.go
@@ -1,8 +1,6 @@
 package handlers
 
 import (
-	"net/http"
-
 	"systemburo/internal/models"
 	"systemburo/internal/services"
 
@@ -40,13 +38,11 @@ func (h *PermissionHandler) GetMyPermissions(c echo.Context) error {
 
 // GetUserEffectivePermissions возвращает эффективные права указанного пользователя
 // с источником (роль/группа/override) -- для админ-экрана настройки доступа (#187 Фаза 3).
-// Только super-admin. Формат идентичен GetMyPermissions, но считается для целевого юзера,
-// чтобы в правом столбце модалки прав показать бейдж источника каждого права и
-// унаследованные от роли/групп права (а не только личные override из /user/:id).
+// Доступ - permission.audit.manage (super + admin), гейтится route-middleware.
+// Формат идентичен GetMyPermissions, но считается для целевого юзера, чтобы в правом
+// столбце модалки прав показать бейдж источника каждого права и унаследованные от
+// роли/групп права (а не только личные override из /user/:id).
 func (h *PermissionHandler) GetUserEffectivePermissions(c echo.Context) error {
-	if !IsSuperAdmin(c) {
-		return echo.NewHTTPError(http.StatusForbidden, "Доступ только для супер-администратора")
-	}
 	userID, err := ParseID(c, "id")
 	if err != nil {
 		return err
@@ -80,20 +76,23 @@ func buildPermissionsResponse(set services.PermissionSet) models.MyPermissionsRe
 	}
 }
 
-// GetUserPermissions возвращает разрешения указанного пользователя (только super-admin).
+// GetUserPermissions возвращает индивидуальные override указанного пользователя.
+// Доступ - permission.audit.manage (super + admin), гейтится route-middleware.
 func (h *PermissionHandler) GetUserPermissions(c echo.Context) error {
 	userID, err := ParseID(c, "id")
 	if err != nil {
 		return err
 	}
-	perms, err := h.service.GetUserPermissions(c.Request().Context(), IsSuperAdmin(c), userID)
+	perms, err := h.service.GetUserPermissions(c.Request().Context(), userID)
 	if err != nil {
 		return err
 	}
 	return RespondSuccess(c, perms)
 }
 
-// UpdateUserPermissions обновляет разрешения указанного пользователя (только super-admin).
+// UpdateUserPermissions обновляет индивидуальные override указанного пользователя.
+// Доступ - permission.audit.manage (super + admin). Флаг isSuperAdmin прокидывается
+// в сервис: не-супер не может выдать override на super-only ключи.
 func (h *PermissionHandler) UpdateUserPermissions(c echo.Context) error {
 	userID, err := ParseID(c, "id")
 	if err != nil {

--- a/internal/handlers/permissions_admin_manage_test.go
+++ b/internal/handlers/permissions_admin_manage_test.go
@@ -1,0 +1,80 @@
+package handlers_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"systemburo/internal/models"
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Администратор (is_admin, не супер) может читать и менять права пользователей -
+// раздел управления правами больше не super-only (page.admin.users/audit.manage).
+func TestPermissions_Admin_CanReadAndUpdate(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	testutil.RegisterAndLogin(t, e, "managed_user", "password123", 1, td.OrgID, td.CompanyID)
+	var userID int
+	require.NoError(t, db.Table("users").Select("id").Where("username = ?", "managed_user").Row().Scan(&userID))
+
+	// is_admin, НЕ супер (RegisterManager -> type 5 -> is_admin).
+	adminToken := testutil.RegisterManager(t, e, "plain_admin", td.OrgID, td.CompanyID)
+
+	rec := testutil.GET(t, e, fmt.Sprintf("/permissions/user/%d/effective", userID), testutil.AuthHeader(adminToken))
+	require.Equal(t, http.StatusOK, rec.Code, "admin должен читать effective-права")
+
+	body := `{"permissions":[{"key":"tab.cars.view","value":"allow"}]}`
+	rec = testutil.PUT(t, e, fmt.Sprintf("/permissions/user/%d", userID), body, testutil.AuthHeader(adminToken))
+	require.Equal(t, http.StatusOK, rec.Code, "admin должен ставить override")
+
+	rec = testutil.GET(t, e, fmt.Sprintf("/permissions/user/%d", userID), testutil.AuthHeader(adminToken))
+	require.Equal(t, http.StatusOK, rec.Code)
+	perms := testutil.ParseResponse[[]models.UserPermissionResponse](t, rec)
+	require.Equal(t, 1, len(perms))
+	assert.Equal(t, "tab.cars.view", perms[0].Key)
+	assert.Equal(t, "allow", perms[0].Value)
+}
+
+// Администратор НЕ может через override выдать super-only ключ (защита от эскалации),
+// а супер-админ - может.
+func TestPermissions_Admin_CannotGrantSuperOnly(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	testutil.RegisterAndLogin(t, e, "managed_user2", "password123", 1, td.OrgID, td.CompanyID)
+	var userID int
+	require.NoError(t, db.Table("users").Select("id").Where("username = ?", "managed_user2").Row().Scan(&userID))
+
+	adminToken := testutil.RegisterManager(t, e, "plain_admin2", td.OrgID, td.CompanyID)
+	body := `{"permissions":[{"key":"action.grant.admin","value":"allow"}]}`
+	rec := testutil.PUT(t, e, fmt.Sprintf("/permissions/user/%d", userID), body, testutil.AuthHeader(adminToken))
+	assert.Equal(t, http.StatusForbidden, rec.Code, "admin не может выдать super-only ключ")
+
+	superToken := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	rec = testutil.PUT(t, e, fmt.Sprintf("/permissions/user/%d", userID), body, testutil.AuthHeader(superToken))
+	assert.Equal(t, http.StatusOK, rec.Code, "супер-админ может управлять super-only ключами")
+}
+
+// Обычный пользователь без permission.audit.manage не имеет доступа к управлению правами.
+func TestPermissions_Regular_ForbiddenToManage(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	userToken := testutil.RegisterAndLogin(t, e, "plain_user", "password123", 1, td.OrgID, td.CompanyID)
+	var userID int
+	require.NoError(t, db.Table("users").Select("id").Where("username = ?", "plain_user").Row().Scan(&userID))
+
+	rec := testutil.GET(t, e, fmt.Sprintf("/permissions/user/%d/effective", userID), testutil.AuthHeader(userToken))
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -487,25 +487,26 @@ func Setup(e *echo.Echo, d Dependencies) {
 	aag.POST("", approvers.Create, requireAdmin)
 	aag.DELETE("/:id", approvers.Delete, requireAdmin)
 
-	// Разрешения
-	permGroup := protected.Group("/permissions")
-	permGroup.GET("/my", permissions.GetMyPermissions)
-	permGroup.GET("/user/:id", permissions.GetUserPermissions)
-	permGroup.GET("/user/:id/effective", permissions.GetUserEffectivePermissions)
-	permGroup.PUT("/user/:id", permissions.UpdateUserPermissions)
-	permGroup.GET("/tree", permissions.GetPermissionTree)
-	permGroup.GET("/catalog", permissions.GetCatalog)
-	permGroup.POST("/auto-generate", permissions.AutoGenerate)
-
-	// permission.audit.manage = управление системой прав
-	// (роли, группы, назначения, журнал отказов).
-	// GET-эндпоинты остаются открытыми для любых авторизованных, т.к. они
-	// нужны UI UserPermissionsModal для отображения списков (не разглашают
-	// ничего секретного - только публичные метаданные ролей/групп).
+	// permission.audit.manage = управление системой прав (роли, группы, назначения,
+	// индивидуальные права пользователей). super + admin проходят (audit.manage не
+	// super-only), обычный - по гранту. auditRead - чтение журнала отказов.
+	// Публичные GET-списки групп/ролей остаются открытыми любому авторизованному.
 	auditRead := mw.RequirePermissionV2(permResolver, denialLog, services.KeyAuditRead)
 	auditManage := mw.RequirePermissionV2(permResolver, denialLog, services.KeyAuditManage)
 	// Выдача/снятие тумблера "Администратор" -- super-only (ключ action.grant.admin).
 	grantAdmin := mw.RequirePermissionV2(permResolver, denialLog, services.KeyActionGrantAdmin)
+
+	// Разрешения. Чтение/запись чужих прав (effective, override) - auditManage
+	// (super + admin). Выдача super-only ключей через override не-суперу запрещена
+	// в сервисе. Свои права (/my) - любому авторизованному.
+	permGroup := protected.Group("/permissions")
+	permGroup.GET("/my", permissions.GetMyPermissions)
+	permGroup.GET("/user/:id", permissions.GetUserPermissions, auditManage)
+	permGroup.GET("/user/:id/effective", permissions.GetUserEffectivePermissions, auditManage)
+	permGroup.PUT("/user/:id", permissions.UpdateUserPermissions, auditManage)
+	permGroup.GET("/tree", permissions.GetPermissionTree)
+	permGroup.GET("/catalog", permissions.GetCatalog)
+	permGroup.POST("/auto-generate", permissions.AutoGenerate)
 
 	// Группы прав (#187a). CRUD защищён permission.audit.manage.
 	pgGroup := protected.Group("/permission-groups")

--- a/internal/services/permission_service.go
+++ b/internal/services/permission_service.go
@@ -15,7 +15,7 @@ import (
 // PermissionService определяет интерфейс управления разрешениями.
 type PermissionService interface {
 	GetMyPermissions(ctx context.Context, username string) ([]models.UserPermissionResponse, error)
-	GetUserPermissions(ctx context.Context, isSuperAdmin bool, userID int) ([]models.UserPermissionResponse, error)
+	GetUserPermissions(ctx context.Context, userID int) ([]models.UserPermissionResponse, error)
 	UpdateUserPermissions(ctx context.Context, isSuperAdmin bool, actorID int, userID int, req models.UpdatePermissionsRequest) error
 	GetPermissionTree(ctx context.Context) ([]models.PermissionTreeNode, error)
 	GetCatalog(ctx context.Context) ([]CatalogNode, error)
@@ -50,10 +50,8 @@ func (s *permissionService) GetMyPermissions(ctx context.Context, username strin
 }
 
 // GetUserPermissions возвращает разрешения указанного пользователя (admin-only).
-func (s *permissionService) GetUserPermissions(ctx context.Context, isSuperAdmin bool, userID int) ([]models.UserPermissionResponse, error) {
-	if !isSuperAdmin {
-		return nil, echo.NewHTTPError(http.StatusForbidden, "Доступ только для супер-администратора")
-	}
+func (s *permissionService) GetUserPermissions(ctx context.Context, userID int) ([]models.UserPermissionResponse, error) {
+	// Доступ гейтится route-middleware permission.audit.manage (super + admin).
 
 	// Verify user exists
 	var count int64
@@ -91,8 +89,15 @@ func (s *permissionService) getUserPermissionsList(ctx context.Context, userID i
 
 // UpdateUserPermissions обновляет набор разрешений пользователя (admin-only).
 func (s *permissionService) UpdateUserPermissions(ctx context.Context, isSuperAdmin bool, actorID int, userID int, req models.UpdatePermissionsRequest) error {
+	// Доступ гейтится route-middleware permission.audit.manage (super + admin).
+	// Но super-only ключи (выдача админки, техработы) через override может
+	// раздавать только супер-админ - иначе admin поднял бы себе/другим super-права.
 	if !isSuperAdmin {
-		return echo.NewHTTPError(http.StatusForbidden, "Доступ только для супер-администратора")
+		for _, p := range req.Permissions {
+			if IsSuperOnly(p.Key) {
+				return echo.NewHTTPError(http.StatusForbidden, "Эти права может выдавать только супер-администратор")
+			}
+		}
 	}
 
 	// Verify user exists


### PR DESCRIPTION
## Проблема

Управление правами пользователей было жёстко super-only: `GET /permissions/user/:id/effective`, `GET/PUT /permissions/user/:id` проверяли `IsSuperAdmin` в хендлерах и сервисе. Администратор (is_admin) ловил 403 «недостаточно прав». По решению — админ должен мочь управлять правами.

## Как (решение юзера: всё кроме выдачи админки/техработ)

- Гейт 3 эндпоинтов прав пользователя переведён на route-middleware `permission.audit.manage` (super + admin проходят; ключ не super-only; обычный — по гранту).
- Снят super-чек из `permissions.go` (handler) и `permission_service.go` (GetUserPermissions/UpdateUserPermissions).
- **Защита от эскалации:** не-супер не может через override выдать super-only ключи (`action.grant.admin`, `page.admin.system_control`) — проверка в `UpdateUserPermissions`. Выдача флага «Администратор» (`PUT /users/:id/admin`, grantAdmin) остаётся super-only, как было.

## Тесты

- Новые: admin читает effective + ставит override (200); admin НЕ может выдать super-only (403), супер — может (200); обычный юзер — 403.
- Существующие super-only тесты (regular 403 / super 200) остаются зелёными.
- `go test ./internal/handlers/ ./internal/services/` целиком зелёный.

## OFF-LIMITS

Трогает `internal/services/permission_service.go` (off-limits) — мерж по твоему OK.