### PR TITLE
fix(access): плашка блокировки - BanCheck пускает забаненного на /permissions/my

### DIFF
--- a/internal/handlers/ban_overlay_test.go
+++ b/internal/handlers/ban_overlay_test.go
@@ -1,0 +1,45 @@
+package handlers_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"systemburo/internal/middleware"
+	"systemburo/internal/services"
+	"systemburo/internal/testutil"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+// BanCheck пропускает забаненного на /api/permissions/my (allowlist) - оттуда
+// фронт узнаёт статус и показывает плашку блокировки. Прочие protected-роуты
+// остаются 403 (окно access-токена закрыто).
+func TestBanCheck_AllowlistPermissionsMy(t *testing.T) {
+	_, db, _ := testutil.SetupTestApp(t)
+	userID, _, cleanup := setupMWUser(t, db, false, true) // забанен
+	defer cleanup()
+
+	banCheck := middleware.BanCheck(services.NewBanCheckService(db, time.Minute))
+	inject := func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			c.Set("user_id", userID)
+			return next(c)
+		}
+	}
+	ok := func(c echo.Context) error { return c.String(http.StatusOK, "ok") }
+
+	e := echo.New()
+	e.GET("/api/permissions/my", ok, inject, banCheck)
+	e.GET("/api/users/me", ok, inject, banCheck)
+
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/permissions/my", nil))
+	assert.Equal(t, http.StatusOK, rec.Code, "/permissions/my доступен забаненному (для плашки)")
+
+	rec = httptest.NewRecorder()
+	e.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/users/me", nil))
+	assert.Equal(t, http.StatusForbidden, rec.Code, "/users/me остаётся заблокированным")
+}

--- a/internal/middleware/ban_check.go
+++ b/internal/middleware/ban_check.go
@@ -19,6 +19,16 @@ import (
 // окно живого access-токена.
 //
 // Должен стоять после JWTAuth (нужен user_id в context).
+// banAwarePaths -- роуты, доступные заблокированному пользователю, чтобы фронт
+// узнал статус блокировки и показал плашку (BanOverlay) + увёл в ЛК. Иначе все
+// запросы (вкл. /permissions/my) возвращают 403, и юзер не понимает, что забанен.
+// Только /permissions/my: отдаёт собственный статус (mode=banned, ban_reason),
+// чужих данных не разглашает и реального доступа не даёт (permissions пусты).
+// /users/me намеренно остаётся 403 (закрывает окно access-токена для API-клиентов).
+var banAwarePaths = map[string]struct{}{
+	"/api/permissions/my": {},
+}
+
 func BanCheck(svc *services.BanCheckService) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
@@ -33,10 +43,16 @@ func BanCheck(svc *services.BanCheckService) echo.MiddlewareFunc {
 				slog.Warn("ban_check: db lookup failed, fail-open", "user_id", userID, "error", err)
 				return next(c)
 			}
-			if banned {
-				return echo.NewHTTPError(http.StatusForbidden, "Учётная запись заблокирована")
-			}
-			if !active {
+			if banned || !active {
+				// Ban-aware роуты пропускаем даже заблокированному: по ним фронт
+				// узнаёт статус блокировки и показывает плашку. Иначе юзер получает
+				// 403 на ВСЁ (включая /users/me) и не понимает, что заблокирован.
+				if _, ok := banAwarePaths[c.Path()]; ok {
+					return next(c)
+				}
+				if banned {
+					return echo.NewHTTPError(http.StatusForbidden, "Учётная запись заблокирована")
+				}
 				return echo.NewHTTPError(http.StatusForbidden, "Учётная запись отключена")
 			}
 			return next(c)


### PR DESCRIPTION
## Проблема

Заблокированный пользователь не видел плашку блокировки и не уводился в ЛК. `BanCheck` middleware отдавал 403 на ВСЕ protected-роуты, включая `/permissions/my` - а именно оттуда фронт (permissions-стор -> BanOverlay) узнаёт `banned=true`. Замкнутый круг: плашка не показывалась, юзер просто получал 403 на всё.

## Фикс (BE)

`BanCheck` пропускает забаненного только на `/api/permissions/my` (allowlist): эндпоинт отдаёт собственный статус (`mode=banned`, `ban_reason`), чужих данных не разглашает и реального доступа не даёт (permissions пусты). `/users/me` и прочие protected-роуты остаются 403 (окно access-токена закрыто, E2E ban-check-middleware сохраняется).

## FE

Уже в dev (другая сессия смержила Ф4): `BanOverlay.vue` читает `permissions.banned/banReason`, App.vue показывает плашку + редиректит в ЛК. Этот PR — недостающее BE-звено, чтобы стор получил `banned=true`.

## Тест

`TestBanCheck_AllowlistPermissionsMy` (middleware-уровень): забаненный 200 на /permissions/my, 403 на /users/me. Полный `go test ./internal/handlers/` зелёный.