### PR TITLE
feat(access): точечные права роли поверх default-групп

### DIFF
--- a/frontend/src/api/permissions.js
+++ b/frontend/src/api/permissions.js
@@ -155,6 +155,15 @@ export async function setRoleDefaultGroups(id, groupIds) {
   return res.json();
 }
 
+// Точечные права роли (полная замена прямых allow-грантов по ключам каталога).
+export async function setRolePermissions(id, keys) {
+  const res = await apiRequest(`/roles/${id}/permissions`, {
+    method: 'PUT',
+    body: JSON.stringify({ keys }),
+  });
+  return res.json();
+}
+
 // --- Access Denials (#230) ---
 
 export async function listAccessDenials(params = {}) {

--- a/frontend/src/views/admin/AdminRoles.vue
+++ b/frontend/src/views/admin/AdminRoles.vue
@@ -73,12 +73,34 @@
           </div>
         </div>
 
+        <div class="card__section">
+          <span class="card__section-label">Точечные права:</span>
+          <div class="card__chips">
+            <span
+              v-if="(role.direct_grants || []).length > 0"
+              class="chip chip--role"
+            >
+              {{ (role.direct_grants || []).length }} {{ pluralPrava((role.direct_grants || []).length) }}
+            </span>
+            <span
+              v-else
+              class="card__empty-text"
+            >не настроены</span>
+          </div>
+        </div>
+
         <footer class="card__footer">
           <button
             class="lk-button lk-button--ghost"
             @click="openEditGroups(role)"
           >
             Настроить группы
+          </button>
+          <button
+            class="lk-button lk-button--ghost"
+            @click="openEditPermissions(role)"
+          >
+            Точечные права
           </button>
           <button
             class="lk-button lk-button--ghost"
@@ -166,7 +188,7 @@
             <header class="rgm-head">
               <h3>Дефолтные группы для «{{ groupsRole?.name }}»</h3>
               <p class="form-modal__hint">
-                Юзеры с этой ролью получают права из всех выбранных групп. Справа — итоговый набор прав роли.
+                Юзеры с этой ролью получают права из всех выбранных групп плюс точечные права роли. Справа — итоговый набор прав роли.
               </p>
             </header>
             <div class="rgm-body">
@@ -230,6 +252,16 @@
         </div>
       </transition>
     </Teleport>
+
+    <GroupPermissionsModal
+      :show="permsOpen"
+      :title="`Точечные права роли «${permsRole?.name || ''}»`"
+      :catalog="catalog"
+      :initial-keys="permsInitialKeys"
+      :saving="saving"
+      @close="permsOpen = false"
+      @save="savePermissions"
+    />
   </section>
 </template>
 
@@ -240,17 +272,19 @@ import {
   updateRole,
   deleteRole,
   setRoleDefaultGroups,
+  setRolePermissions,
   listPermissionGroups,
   getPermissionCatalog,
 } from '@/api/permissions';
 import RefreshButton from '@/components/RefreshButton.vue';
 import EffectivePermissionsTree from '@/components/admin/EffectivePermissionsTree.vue';
+import GroupPermissionsModal from '@/components/admin/GroupPermissionsModal.vue';
 import { useDeletionsStore } from '@/stores/deletions';
 import { useUiStore } from '@/stores/ui';
 
 export default {
   name: 'AdminRoles',
-  components: { RefreshButton, EffectivePermissionsTree },
+  components: { RefreshButton, EffectivePermissionsTree, GroupPermissionsModal },
   data() {
     return {
       roles: [],
@@ -265,24 +299,35 @@ export default {
       groupsOpen: false,
       groupsRole: null,
       selectedGroupIds: new Set(),
+      permsOpen: false,
+      permsRole: null,
+      permsInitialKeys: [],
     };
   },
   computed: {
-    // Итоговый набор прав роли = объединение ключей всех выбранных дефолтных групп.
-    // Read-only превью (все locked, источник «группа») в стиле карточки прав.
+    // Итоговый набор прав роли = прямые точечные гранты роли ∪ ключи выбранных
+    // дефолтных групп. Read-only превью (всё locked): прямые гранты бейджатся как
+    // «роль», группо-только -- как «группа».
     previewStateByKey() {
-      const union = new Set();
+      const groupUnion = new Set();
       for (const g of this.allGroups) {
         if (this.selectedGroupIds.has(g.id)) {
-          for (const k of g.keys || []) union.add(k);
+          for (const k of g.keys || []) groupUnion.add(k);
         }
       }
+      const directSet = new Set((this.groupsRole?.direct_grants) || []);
       const result = {};
+      const apply = (key) => {
+        const inDirect = directSet.has(key);
+        result[key] = {
+          on: inDirect || groupUnion.has(key),
+          source: inDirect ? 'role' : 'group',
+          locked: true,
+        };
+      };
       for (const node of this.catalog) {
-        result[node.key] = { on: union.has(node.key), source: 'group', locked: true };
-        for (const child of node.children || []) {
-          result[child.key] = { on: union.has(child.key), source: 'group', locked: true };
-        }
+        apply(node.key);
+        for (const child of node.children || []) apply(child.key);
       }
       return result;
     },
@@ -356,6 +401,29 @@ export default {
         await setRoleDefaultGroups(this.groupsRole.id, Array.from(this.selectedGroupIds));
         await this.fetchAll();
         this.groupsOpen = false;
+      } finally {
+        this.saving = false;
+      }
+    },
+    pluralPrava(n) {
+      const mod10 = n % 10;
+      const mod100 = n % 100;
+      if (mod10 === 1 && mod100 !== 11) return 'право';
+      if (mod10 >= 2 && mod10 <= 4 && (mod100 < 10 || mod100 >= 20)) return 'права';
+      return 'прав';
+    },
+    openEditPermissions(role) {
+      this.permsRole = role;
+      this.permsInitialKeys = [...(role.direct_grants || [])];
+      this.permsOpen = true;
+    },
+    async savePermissions(keys) {
+      if (!this.permsRole) return;
+      this.saving = true;
+      try {
+        await setRolePermissions(this.permsRole.id, keys);
+        await this.fetchAll();
+        this.permsOpen = false;
       } finally {
         this.saving = false;
       }
@@ -486,6 +554,11 @@ export default {
   background: #eef0ff;
   color: #3a45c0;
   border-radius: var(--radius-pill);
+}
+
+.chip--role {
+  background: #eef0f6;
+  color: #6b7280;
 }
 
 .card__empty-text {

--- a/internal/handlers/roles.go
+++ b/internal/handlers/roles.go
@@ -84,3 +84,19 @@ func (h *RoleHandler) SetDefaultGroups(c echo.Context) error {
 	}
 	return RespondSuccess(c, map[string]any{"updated": true})
 }
+
+// SetPermissions -- PUT /roles/:id/permissions. Полная замена прямых грантов роли.
+func (h *RoleHandler) SetPermissions(c echo.Context) error {
+	id, err := ParseID(c, "id")
+	if err != nil {
+		return err
+	}
+	var req models.SetRolePermissionsRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	if err := h.service.SetPermissions(c.Request().Context(), id, req.Keys); err != nil {
+		return err
+	}
+	return RespondSuccess(c, map[string]any{"updated": true})
+}

--- a/internal/handlers/roles_test.go
+++ b/internal/handlers/roles_test.go
@@ -78,3 +78,121 @@ func TestRoles_Delete_EmptyCustomRole_OK(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
+
+// TestRoles_SetPermissions_OK: PUT /roles/:id/permissions пишет прямые гранты,
+// и List отдаёт их в direct_grants.
+func TestRoles_SetPermissions_OK(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	role := models.Role{Code: "role_grants", Name: "С грантами"}
+	require.NoError(t, db.Create(&role).Error)
+
+	body := `{"keys":["page.tables","header.report_problem"]}`
+	rec := testutil.PUT(t, e, fmt.Sprintf("/roles/%d/permissions", role.ID), body, testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var grants []models.RolePermissionGrant
+	require.NoError(t, db.Where("role_id = ?", role.ID).Find(&grants).Error)
+	assert.Len(t, grants, 2)
+	for _, g := range grants {
+		assert.Equal(t, "allow", g.Value)
+	}
+
+	listRec := testutil.GET(t, e, "/roles", testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, listRec.Code)
+	roles := testutil.ParseResponse[[]models.RoleResponse](t, listRec)
+	var found *models.RoleResponse
+	for i := range roles {
+		if roles[i].ID == role.ID {
+			found = &roles[i]
+		}
+	}
+	require.NotNil(t, found)
+	assert.ElementsMatch(t, []string{"page.tables", "header.report_problem"}, found.DirectGrants)
+}
+
+// TestRoles_SetPermissions_InvalidKey: неизвестный ключ -> 400, гранты не пишутся.
+func TestRoles_SetPermissions_InvalidKey(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	role := models.Role{Code: "role_badkey", Name: "Плохой ключ"}
+	require.NoError(t, db.Create(&role).Error)
+
+	rec := testutil.PUT(t, e, fmt.Sprintf("/roles/%d/permissions", role.ID), `{"keys":["bogus.key"]}`, testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	var count int64
+	require.NoError(t, db.Model(&models.RolePermissionGrant{}).Where("role_id = ?", role.ID).Count(&count).Error)
+	assert.Zero(t, count)
+}
+
+// TestRoles_SetPermissions_SuperOnlyRejected: super-only ключ нельзя выдать через роль -> 403.
+func TestRoles_SetPermissions_SuperOnlyRejected(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	role := models.Role{Code: "role_super", Name: "Супер ключ"}
+	require.NoError(t, db.Create(&role).Error)
+
+	rec := testutil.PUT(t, e, fmt.Sprintf("/roles/%d/permissions", role.ID), `{"keys":["action.grant.admin"]}`, testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+// TestRoles_SetPermissions_NotFound: несуществующая роль -> 404.
+func TestRoles_SetPermissions_NotFound(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	rec := testutil.PUT(t, e, "/roles/999999/permissions", `{"keys":["page.tables"]}`, testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// TestRoles_SetPermissions_EmptyClears: пустой список очищает все прямые гранты роли.
+func TestRoles_SetPermissions_EmptyClears(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	role := models.Role{Code: "role_clear", Name: "Очистка"}
+	require.NoError(t, db.Create(&role).Error)
+	require.NoError(t, db.Create(&models.RolePermissionGrant{RoleID: role.ID, PermissionKey: "page.tables", Value: "allow"}).Error)
+
+	rec := testutil.PUT(t, e, fmt.Sprintf("/roles/%d/permissions", role.ID), `{"keys":[]}`, testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var count int64
+	require.NoError(t, db.Model(&models.RolePermissionGrant{}).Where("role_id = ?", role.ID).Count(&count).Error)
+	assert.Zero(t, count)
+}
+
+// TestRoles_SetPermissions_AdminAllowed: обычный администратор (не супер) тоже
+// управляет точечными правами роли -- гейт auditManage пускает is_admin.
+func TestRoles_SetPermissions_AdminAllowed(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterManager(t, e, "rolemgr", td.OrgID, td.CompanyID)
+
+	role := models.Role{Code: "role_byadmin", Name: "Админ ставит"}
+	require.NoError(t, db.Create(&role).Error)
+
+	rec := testutil.PUT(t, e, fmt.Sprintf("/roles/%d/permissions", role.ID), `{"keys":["page.cars"]}`, testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+}

--- a/internal/models/role.go
+++ b/internal/models/role.go
@@ -45,11 +45,19 @@ type SetRoleGroupsRequest struct {
 	GroupIDs []int `json:"group_ids" validate:"required"`
 }
 
+// SetRolePermissionsRequest -- запрос на установку точечных прав роли (полная замена).
+// Пустой/отсутствующий список очищает все прямые гранты роли, поэтому без required.
+type SetRolePermissionsRequest struct {
+	Keys []string `json:"keys"`
+}
+
 // RoleResponse -- ответ с информацией о роли + привязанных группах.
+// DirectGrants -- ключи прав, выданных роли напрямую (allow), помимо default-групп.
 type RoleResponse struct {
 	ID            int                       `json:"id"`
 	Code          string                    `json:"code"`
 	Name          string                    `json:"name"`
 	Description   *string                   `json:"description"`
 	DefaultGroups []PermissionGroupResponse `json:"default_groups"`
+	DirectGrants  []string                  `json:"direct_grants"`
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -529,6 +529,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	rolesGroup.PUT("/:id", roles.Update, auditManage)
 	rolesGroup.DELETE("/:id", roles.Delete, auditManage)
 	rolesGroup.PUT("/:id/default-groups", roles.SetDefaultGroups, auditManage)
+	rolesGroup.PUT("/:id/permissions", roles.SetPermissions, auditManage)
 
 	// Журнал отказов в доступе (#230).
 	denialsGroup := protected.Group("/access-denials")

--- a/internal/services/role_service.go
+++ b/internal/services/role_service.go
@@ -55,6 +55,16 @@ func (s *RoleService) List(ctx context.Context) ([]models.RoleResponse, error) {
 		return nil, err
 	}
 
+	var grants []models.RolePermissionGrant
+	if err := s.db.WithContext(ctx).Where("role_id IN ? AND value = ?", roleIDs, "allow").
+		Find(&grants).Error; err != nil {
+		return nil, fmt.Errorf("failed to load role grants: %w", err)
+	}
+	grantsByRole := make(map[int][]string)
+	for _, g := range grants {
+		grantsByRole[g.RoleID] = append(grantsByRole[g.RoleID], g.PermissionKey)
+	}
+
 	result := make([]models.RoleResponse, len(roles))
 	for i, r := range roles {
 		groups := make([]models.PermissionGroupResponse, 0)
@@ -63,12 +73,17 @@ func (s *RoleService) List(ctx context.Context) ([]models.RoleResponse, error) {
 				groups = append(groups, resp)
 			}
 		}
+		direct := grantsByRole[r.ID]
+		if direct == nil {
+			direct = []string{}
+		}
 		result[i] = models.RoleResponse{
 			ID:            r.ID,
 			Code:          r.Code,
 			Name:          r.Name,
 			Description:   r.Description,
 			DefaultGroups: groups,
+			DirectGrants:  direct,
 		}
 	}
 	return result, nil
@@ -175,6 +190,56 @@ func (s *RoleService) SetDefaultGroups(ctx context.Context, roleID int, groupIDs
 		}
 		if err := tx.Create(&records).Error; err != nil {
 			return fmt.Errorf("failed to insert role defaults: %w", err)
+		}
+		return nil
+	})
+	if err == nil {
+		s.resolver.InvalidateAll()
+	}
+	return err
+}
+
+// SetPermissions полностью заменяет набор прямых (allow) грантов роли по ключам.
+// Ключи валидируются по каталогу; super-only выдавать через роль нельзя (резолвер
+// их всё равно игнорирует у не-супера -- отклоняем явно, чтобы не плодить мёртвые гранты).
+func (s *RoleService) SetPermissions(ctx context.Context, roleID int, keys []string) error {
+	var exists int64
+	if err := s.db.WithContext(ctx).Model(&models.Role{}).Where("id = ?", roleID).Count(&exists).Error; err != nil {
+		return fmt.Errorf("failed to check role: %w", err)
+	}
+	if exists == 0 {
+		return echo.NewHTTPError(http.StatusNotFound, "Роль не найдена")
+	}
+
+	seen := make(map[string]struct{}, len(keys))
+	unique := make([]string, 0, len(keys))
+	for _, k := range keys {
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		seen[k] = struct{}{}
+		if !IsValidKey(k) {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Неизвестный ключ права: %s", k))
+		}
+		if IsSuperOnly(k) {
+			return echo.NewHTTPError(http.StatusForbidden, "Эти права нельзя выдать через роль")
+		}
+		unique = append(unique, k)
+	}
+
+	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("role_id = ?", roleID).Delete(&models.RolePermissionGrant{}).Error; err != nil {
+			return fmt.Errorf("failed to clear role grants: %w", err)
+		}
+		if len(unique) == 0 {
+			return nil
+		}
+		records := make([]models.RolePermissionGrant, 0, len(unique))
+		for _, k := range unique {
+			records = append(records, models.RolePermissionGrant{RoleID: roleID, PermissionKey: k, Value: "allow"})
+		}
+		if err := tx.Create(&records).Error; err != nil {
+			return fmt.Errorf("failed to insert role grants: %w", err)
 		}
 		return nil
 	})


### PR DESCRIPTION
## Что

Срез 4 мини-эпика perm-bugfixes. Роль умела наследовать права только через default-группы - добавил прямые точечные (allow) гранты роли.

## Бэкенд
- `PUT /roles/:id/permissions` - полная замена прямых грантов роли (гейт `auditManage`, т.е. super + admin).
- `RoleService.SetPermissions` - валидация ключей по каталогу (400 на неизвестный), super-only через роль выдать нельзя (403; резолвер их у не-супера всё равно игнорирует - отклоняем явно, чтобы не плодить мёртвые гранты), пустой список очищает.
- `RoleResponse.direct_grants` - List отдаёт текущие прямые гранты.
- Модель `RolePermissionGrant` и чтение в `collectRoleGrants` уже были - добавлен только writer.

## Фронт
- AdminRoles: кнопка "Точечные права" -> редактор тумблерами (переиспользован `GroupPermissionsModal`), секция-счётчик на карточке.
- Превью "итоговых прав роли" в модалке групп теперь = прямые гранты ∪ default-группы (прямые бейджатся как "роль").

## Тесты
6 handler-тестов через реальный endpoint: ок, неизвестный ключ -> 400, super-only -> 403, 404, пустой очищает, обычный admin допущен. Полный `go test ./...` зелёный (падение internal/database в общем прогоне - известная гонка параллельных AutoMigrate по общей тест-БД, изолированно зелёный).