### PR TITLE
fix(access): забаненный видит read-only кабинет под плашкой, без спама 403

### DIFF
--- a/frontend/e2e/tests/permissions-ban-flow.spec.cjs
+++ b/frontend/e2e/tests/permissions-ban-flow.spec.cjs
@@ -41,8 +41,10 @@ test.describe('Admin / Ban flow', () => {
       await loginPage.goto();
       await loginPage.login(BAN_TARGET_USERNAME, targetPassword);
 
+      // Забаненный видит плашку блокировки поверх своего read-only личного
+      // кабинета (роутер уводит в /personal-cabinet, BanOverlay блокирует действия).
       await expect(page.locator('body')).toContainText(/заблокирован|ban/i, { timeout: 5000 });
-      await expect(page).not.toHaveURL(/personal-cabinet|news/);
+      await expect(page).toHaveURL(/personal-cabinet/);
     } finally {
       await unbanUser(request, token, targetId).catch(() => {});
     }

--- a/frontend/src/api/__tests__/client.spec.js
+++ b/frontend/src/api/__tests__/client.spec.js
@@ -240,14 +240,12 @@ describe('403 handling', () => {
     );
   });
 
-  it('показывает специальный текст для заблокированной учётки (banned:true)', async () => {
+  it('НЕ показывает тост 403 для заблокированной учётки (banned:true) -- плашка блокировки уже всё объясняет', async () => {
     fetchMock.mockResolvedValueOnce(errJson({ banned: true }, 403));
 
     await apiRequest('/applications', { method: 'POST' });
 
-    expect(notifyMock).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'error', prefix: 'Учётная запись заблокирована. Обратитесь к администратору.' })
-    );
+    expect(notifyMock).not.toHaveBeenCalled();
   });
 
   it('не вызывает notify при silent403:true', async () => {

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,6 +1,7 @@
 import { useAuthStore } from '@/stores/auth'
 import { useMaintenanceStore } from '@/stores/maintenance'
 import { useDeletionsStore } from '@/stores/deletions'
+import { usePermissionsStore } from '@/stores/permissions'
 import router from '@/router'
 import { buildBugContext, saveBugContext } from '@/composables/useBugReport'
 
@@ -37,6 +38,23 @@ function show403Notify(msg) {
   _403dedup.set(msg, true)
   setTimeout(() => _403dedup.delete(msg), DEDUP_TTL_MS)
   useDeletionsStore().notify({ prefix: msg, type: 'error' })
+}
+
+// Забаненному не показываем тосты 403: плашка блокировки (BanOverlay) уже всё
+// объясняет, а read-only кабинет может ловить 403 на мутациях/фоновых запросах.
+// Сигнал бана -- флаг стора (из /permissions/my) или поле banned в теле ответа.
+async function isBanContext(response) {
+  try {
+    if (usePermissionsStore().banned) return true
+  } catch {
+    // pinia ещё не активна на раннем запросе -- молча игнорируем
+  }
+  try {
+    const body = await response.clone().json()
+    return Boolean(body?.banned)
+  } catch {
+    return false
+  }
 }
 
 let refreshPromise = null
@@ -175,17 +193,8 @@ async function baseRequest(path, options = {}) {
   // но НЕ редиректим: вызывающий код сам решит как обработать.
   // Тихий режим: опция silent403 или путь из списка фоновых/ожидаемых запросов.
   if (response.status === 403 && !isAuthEndpoint(path)) {
-    if (!options.silent403 && !shouldSilence403(path)) {
-      try {
-        const body = await response.clone().json()
-        const msg = body?.banned
-          ? 'Учётная запись заблокирована. Обратитесь к администратору.'
-          : 'Недостаточно прав для этого действия.'
-        show403Notify(msg)
-      } catch {
-        // body может быть пустым/не json -- показываем дефолтное сообщение
-        show403Notify('Недостаточно прав для этого действия.')
-      }
+    if (!options.silent403 && !shouldSilence403(path) && !(await isBanContext(response))) {
+      show403Notify('Недостаточно прав для этого действия.')
     }
     return response
   }

--- a/internal/handlers/ban_overlay_test.go
+++ b/internal/handlers/ban_overlay_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// BanCheck пропускает забаненного на /api/permissions/my (allowlist) - оттуда
-// фронт узнаёт статус и показывает плашку блокировки. Прочие protected-роуты
-// остаются 403 (окно access-токена закрыто).
-func TestBanCheck_AllowlistPermissionsMy(t *testing.T) {
+// BanCheck оставляет забаненному доступ ТОЛЬКО на чтение: GET-ручки (включая
+// /permissions/my для плашки и /users/me для ФИО в кабинете) проходят, а любая
+// мутация (POST/PUT/DELETE) -- 403. Так кабинет грузится read-only под плашкой.
+func TestBanCheck_ReadOnlyForBanned(t *testing.T) {
 	_, db, _ := testutil.SetupTestApp(t)
 	userID, _, cleanup := setupMWUser(t, db, false, true) // забанен
 	defer cleanup()
@@ -34,12 +34,26 @@ func TestBanCheck_AllowlistPermissionsMy(t *testing.T) {
 	e := echo.New()
 	e.GET("/api/permissions/my", ok, inject, banCheck)
 	e.GET("/api/users/me", ok, inject, banCheck)
+	e.POST("/api/applications", ok, inject, banCheck)
+	e.PUT("/api/users/me", ok, inject, banCheck)
+	e.DELETE("/api/notifications", ok, inject, banCheck)
 
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/permissions/my", nil))
-	assert.Equal(t, http.StatusOK, rec.Code, "/permissions/my доступен забаненному (для плашки)")
+	for _, p := range []string{"/api/permissions/my", "/api/users/me"} {
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, p, nil))
+		assert.Equal(t, http.StatusOK, rec.Code, "GET %s доступен забаненному (read-only кабинет)", p)
+	}
 
-	rec = httptest.NewRecorder()
-	e.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/users/me", nil))
-	assert.Equal(t, http.StatusForbidden, rec.Code, "/users/me остаётся заблокированным")
+	mutations := []struct {
+		method, path string
+	}{
+		{http.MethodPost, "/api/applications"},
+		{http.MethodPut, "/api/users/me"},
+		{http.MethodDelete, "/api/notifications"},
+	}
+	for _, m := range mutations {
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, httptest.NewRequest(m.method, m.path, nil))
+		assert.Equal(t, http.StatusForbidden, rec.Code, "%s %s заблокирован для забаненного", m.method, m.path)
+	}
 }

--- a/internal/handlers/permission_middleware_integration_test.go
+++ b/internal/handlers/permission_middleware_integration_test.go
@@ -268,34 +268,46 @@ func TestBanCheck_AllowsActiveUser(t *testing.T) {
 	}
 }
 
+// banCheckHarness строит echo с GET и POST /test под BanCheck для заданного юзера.
+func banCheckHarness(userID int, svc *services.BanCheckService) *echo.Echo {
+	e := echo.New()
+	inject := func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			c.Set("user_id", userID)
+			return next(c)
+		}
+	}
+	ok := func(c echo.Context) error { return c.String(http.StatusOK, "ok") }
+	e.GET("/test", ok, inject, middleware.BanCheck(svc))
+	e.POST("/test", ok, inject, middleware.BanCheck(svc))
+	return e
+}
+
 func TestBanCheck_DeniesBannedUser(t *testing.T) {
+	// Забаненный: чтение (GET) проходит read-only, мутация (POST) -- 403.
 	_, db, _ := testutil.SetupTestApp(t)
 	svc := services.NewBanCheckService(db, time.Minute)
 
 	userID, _, cleanup := setupMWUser(t, db, false, true)
 	defer cleanup()
 
-	e := echo.New()
-	e.GET("/test", func(c echo.Context) error { return c.String(http.StatusOK, "ok") },
-		func(next echo.HandlerFunc) echo.HandlerFunc {
-			return func(c echo.Context) error {
-				c.Set("user_id", userID)
-				return next(c)
-			}
-		},
-		middleware.BanCheck(svc),
-	)
-	req := httptest.NewRequest(http.MethodGet, "/test", nil)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
-	if rec.Code != http.StatusForbidden {
-		t.Errorf("expected 403 for banned user, got %d (body: %s)", rec.Code, rec.Body.String())
+	e := banCheckHarness(userID, svc)
+
+	recGet := httptest.NewRecorder()
+	e.ServeHTTP(recGet, httptest.NewRequest(http.MethodGet, "/test", nil))
+	if recGet.Code != http.StatusOK {
+		t.Errorf("expected 200 GET for banned user (read-only), got %d (body: %s)", recGet.Code, recGet.Body.String())
+	}
+
+	recPost := httptest.NewRecorder()
+	e.ServeHTTP(recPost, httptest.NewRequest(http.MethodPost, "/test", nil))
+	if recPost.Code != http.StatusForbidden {
+		t.Errorf("expected 403 POST for banned user, got %d (body: %s)", recPost.Code, recPost.Body.String())
 	}
 }
 
 func TestBanCheck_DeniesArchivedUser(t *testing.T) {
-	// Архивный (is_active=false) юзер с живым access-токеном должен получать 403
-	// на каждом запросе - офбординг не ждёт истечения токена.
+	// Архивный (is_active=false) с живым access-токеном: read-only, мутации -- 403.
 	_, db, _ := testutil.SetupTestApp(t)
 	svc := services.NewBanCheckService(db, time.Minute)
 
@@ -305,21 +317,18 @@ func TestBanCheck_DeniesArchivedUser(t *testing.T) {
 		t.Fatalf("archive user: %v", err)
 	}
 
-	e := echo.New()
-	e.GET("/test", func(c echo.Context) error { return c.String(http.StatusOK, "ok") },
-		func(next echo.HandlerFunc) echo.HandlerFunc {
-			return func(c echo.Context) error {
-				c.Set("user_id", userID)
-				return next(c)
-			}
-		},
-		middleware.BanCheck(svc),
-	)
-	req := httptest.NewRequest(http.MethodGet, "/test", nil)
-	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
-	if rec.Code != http.StatusForbidden {
-		t.Errorf("expected 403 for archived user, got %d (body: %s)", rec.Code, rec.Body.String())
+	e := banCheckHarness(userID, svc)
+
+	recGet := httptest.NewRecorder()
+	e.ServeHTTP(recGet, httptest.NewRequest(http.MethodGet, "/test", nil))
+	if recGet.Code != http.StatusOK {
+		t.Errorf("expected 200 GET for archived user (read-only), got %d (body: %s)", recGet.Code, recGet.Body.String())
+	}
+
+	recPost := httptest.NewRecorder()
+	e.ServeHTTP(recPost, httptest.NewRequest(http.MethodPost, "/test", nil))
+	if recPost.Code != http.StatusForbidden {
+		t.Errorf("expected 403 POST for archived user, got %d (body: %s)", recPost.Code, recPost.Body.String())
 	}
 }
 

--- a/internal/middleware/ban_check.go
+++ b/internal/middleware/ban_check.go
@@ -19,14 +19,20 @@ import (
 // окно живого access-токена.
 //
 // Должен стоять после JWTAuth (нужен user_id в context).
-// banAwarePaths -- роуты, доступные заблокированному пользователю, чтобы фронт
-// узнал статус блокировки и показал плашку (BanOverlay) + увёл в ЛК. Иначе все
-// запросы (вкл. /permissions/my) возвращают 403, и юзер не понимает, что забанен.
-// Только /permissions/my: отдаёт собственный статус (mode=banned, ban_reason),
-// чужих данных не разглашает и реального доступа не даёт (permissions пусты).
-// /users/me намеренно остаётся 403 (закрывает окно access-токена для API-клиентов).
-var banAwarePaths = map[string]struct{}{
-	"/api/permissions/my": {},
+//
+// Заблокированному/архивному оставляем доступ ТОЛЬКО на чтение (безопасные методы
+// GET/HEAD/OPTIONS): личный кабинет грузит свои данные (ФИО, заявки, уведомления,
+// статус блокировки из /permissions/my) под неснимаемой плашкой, но любая мутация
+// (POST/PUT/PATCH/DELETE) -- 403. Чужие/админские данные закрыты и на чтении:
+// permission-гейтнутые ручки всё равно 403 (резолвер: banned > admin, права пусты).
+// Раньше резалось всё подряд - юзер видел пустой кабинет + спам "недостаточно прав".
+func isSafeMethod(method string) bool {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		return true
+	default:
+		return false
+	}
 }
 
 func BanCheck(svc *services.BanCheckService) echo.MiddlewareFunc {
@@ -44,10 +50,8 @@ func BanCheck(svc *services.BanCheckService) echo.MiddlewareFunc {
 				return next(c)
 			}
 			if banned || !active {
-				// Ban-aware роуты пропускаем даже заблокированному: по ним фронт
-				// узнаёт статус блокировки и показывает плашку. Иначе юзер получает
-				// 403 на ВСЁ (включая /users/me) и не понимает, что заблокирован.
-				if _, ok := banAwarePaths[c.Path()]; ok {
+				// Чтение (GET/HEAD/OPTIONS) пропускаем: кабинет показывается read-only.
+				if isSafeMethod(c.Request().Method) {
 					return next(c)
 				}
 				if banned {


### PR DESCRIPTION
## Проблема (приёмка staging)
Забаненный юзер: плашка блокировки есть, но за ней пустой ЛК, шапка без имени и спам тостов "недостаточно прав". BanCheck резал 403'ом вообще всё, кроме /permissions/my.

## Что сделано
- **BE `ban_check.go`**: забаненному/архивному пропускаем безопасные методы (GET/HEAD/OPTIONS) - кабинет грузит self-данные (ФИО /users/me, заявки, уведомления) под неснимаемой плашкой. Любая мутация (POST/PUT/PATCH/DELETE) - 403. Чужие/админские данные закрыты и на чтении: permission-гейтнутые ручки у забаненного всё равно 403 (резолвер: banned > admin).
- **FE `client.js`**: когда юзер забанен (флаг стора из /permissions/my или поле banned в ответе) - не показываем тосты 403. Плашка и так всё объясняет.
- Шапка "Добрый день, {имя}" оживает сама (/users/me теперь доступен на чтение).
- Роутер уже уводит забаненного в /personal-cabinet (был) - теперь кабинет наполнен.

## Тесты
- Go: BanCheck read-only (GET 200 / мутации 403) для забаненного и архивного; обновлены 3 существующих теста под новое поведение. handlers+middleware зелёные.
- FE: client.spec обновлён (banned -> нет тоста), 24 теста зелёные.
- E2E ban-flow обновлён (забаненный на /personal-cabinet под плашкой).

## Внимание (security)
Меняет политику бана: забаненный сохраняет **read-only** доступ к своим данным до логаута/истечения токена (раньше резалось всё). Действия заблокированы полностью. Это явное требование владельца продукта (наполненный кабинет под плашкой).