### PR TITLE
feat(settings): контакты Бюро в настройках + показ на логине и в плашке блокировки

### DIFF
--- a/frontend/src/api/settings.js
+++ b/frontend/src/api/settings.js
@@ -45,6 +45,22 @@ export async function getUploadSettings() {
 }
 
 /**
+ * Публичные контакты Бюро пропусков (телефон, почта). Без авторизации -- нужны
+ * на странице логина и в плашке блокировки.
+ * @returns {Promise<{phone: string, email: string}>}
+ */
+export async function getPublicContacts() {
+  const response = await apiRequest('/settings/contacts')
+
+  if (!response.ok) {
+    throw new Error(`Ошибка загрузки контактов: ${response.status}`)
+  }
+
+  const json = await response.json()
+  return json.data ?? json
+}
+
+/**
  * @returns {Promise<import('@/utils/passwordPolicy').PasswordPolicy>}
  */
 export async function getPasswordPolicy() {

--- a/frontend/src/components/BanOverlay.vue
+++ b/frontend/src/components/BanOverlay.vue
@@ -63,6 +63,25 @@
               Если вы считаете, что блокировка ошибочна, обратитесь к администратору системы.
             </p>
 
+            <div
+              v-if="hasContacts"
+              class="ban-contacts"
+            >
+              <div class="ban-contacts__label">
+                Контакты Бюро пропусков
+              </div>
+              <a
+                v-if="bureauPhone"
+                class="ban-contacts__item"
+                :href="`tel:${bureauPhone}`"
+              >{{ bureauPhone }}</a>
+              <a
+                v-if="bureauEmail"
+                class="ban-contacts__item"
+                :href="`mailto:${bureauEmail}`"
+              >{{ bureauEmail }}</a>
+            </div>
+
             <div class="ban-modal__actions">
               <button
                 type="button"
@@ -81,6 +100,7 @@
 
 <script>
 import { usePermissionsStore } from '@/stores/permissions'
+import { useContactsStore } from '@/stores/contacts'
 
 /**
  * Полноэкранный неснимаемый оверлей для забаненного пользователя (Фаза 4
@@ -100,6 +120,18 @@ export default {
     banReason() {
       return usePermissionsStore().banReason
     },
+    bureauPhone() {
+      return useContactsStore().phone
+    },
+    bureauEmail() {
+      return useContactsStore().email
+    },
+    hasContacts() {
+      return useContactsStore().hasAny
+    },
+  },
+  mounted() {
+    useContactsStore().fetch()
   },
   methods: {
     handleLogout() {
@@ -203,6 +235,38 @@ export default {
   font-size: 13px;
   line-height: 1.6;
   color: var(--color-text-muted, #999);
+}
+
+.ban-contacts {
+  margin-top: 16px;
+  padding: 14px 16px;
+  border: 1px solid var(--color-border, #e6e6e6);
+  border-radius: var(--radius-md, 15px);
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.ban-contacts__label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-text-muted, #999);
+  margin-bottom: 2px;
+}
+
+.ban-contacts__item {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-primary, #4f5bdf);
+  text-decoration: none;
+  overflow-wrap: anywhere;
+}
+
+.ban-contacts__item:hover {
+  text-decoration: underline;
 }
 
 .ban-modal__actions {

--- a/frontend/src/components/LoginComponent.vue
+++ b/frontend/src/components/LoginComponent.vue
@@ -187,7 +187,7 @@
               class="contact__text contact__text--clickable"
               @click="copyEmail"
             >
-              buropropuskov@dreamisland.ru
+              {{ bureauEmail }}
             </p>
           </div>
           <div class="contact">
@@ -200,7 +200,7 @@
               class="contact__text contact__text--clickable"
               @click="copyPhone"
             >
-              +7 (910) 083 00-55
+              {{ bureauPhone }}
             </p>
           </div>
           <p class="time">
@@ -220,7 +220,12 @@
 <script>
 import { apiRequest } from '@/api/client'
 import { useAuthStore } from '@/stores/auth'
+import { useContactsStore } from '@/stores/contacts'
 import PasswordRecoveryModal from '@/components/PasswordRecoveryModal.vue'
+
+// Фолбэк-контакты Бюро, если в настройках системы они ещё не заданы.
+const FALLBACK_BUREAU_EMAIL = 'buropropuskov@dreamisland.ru'
+const FALLBACK_BUREAU_PHONE = '+7 (910) 083 00-55'
 export default {
     components: { PasswordRecoveryModal },
     emits: ['login-success'],
@@ -254,6 +259,12 @@ export default {
             if (this.isLoading) return 'Вход...';
             if (this.isSuccess) return 'Успешно!';
             return 'Войти';
+        },
+        bureauEmail() {
+            return useContactsStore().email || FALLBACK_BUREAU_EMAIL;
+        },
+        bureauPhone() {
+            return useContactsStore().phone || FALLBACK_BUREAU_PHONE;
         },
         parallaxStyle() {
             const moveX = (this.mouseX - window.innerWidth / 8) / 25;
@@ -323,6 +334,7 @@ export default {
         setTimeout(() => {
             this.elementsVisible = true;
         }, 100);
+        useContactsStore().fetch();
     },
     beforeUnmount() {
         if (this.animationTimeout) {
@@ -396,12 +408,12 @@ export default {
         },
 
         async copyEmail() {
-            await this.copyToClipboard('buropropuskov@dreamisland.ru');
+            await this.copyToClipboard(this.bureauEmail);
             this.showNotificationMessage('E-mail скопирован');
         },
 
         async copyPhone() {
-            await this.copyToClipboard('+7 (910) 083 00-55');
+            await this.copyToClipboard(this.bureauPhone);
             this.showNotificationMessage('Номер телефона скопирован');
         },
         

--- a/frontend/src/stores/contacts.js
+++ b/frontend/src/stores/contacts.js
@@ -1,0 +1,32 @@
+import { defineStore } from 'pinia'
+import { getPublicContacts } from '@/api/settings'
+
+/**
+ * Контакты Бюро пропусков (телефон, почта) из системных настроек. Единый источник
+ * для всех мест, где показываются контакты Бюро: страница логина, плашка блокировки
+ * и т.д. Грузится один раз и кэшируется; пустые значения = "не настроено".
+ */
+export const useContactsStore = defineStore('contacts', {
+  state: () => ({
+    phone: '',
+    email: '',
+    loaded: false,
+  }),
+  getters: {
+    hasAny: (state) => Boolean(state.phone || state.email),
+  },
+  actions: {
+    async fetch(force = false) {
+      if (this.loaded && !force) return
+      try {
+        const data = await getPublicContacts()
+        this.phone = data?.phone || ''
+        this.email = data?.email || ''
+        this.loaded = true
+      } catch {
+        // Контакты опциональны (best-effort справочная информация): при сбое
+        // публичного эндпоинта оставляем пустыми, не ломая логин/плашку.
+      }
+    },
+  },
+})

--- a/frontend/src/views/AdminSettings.vue
+++ b/frontend/src/views/AdminSettings.vue
@@ -62,6 +62,16 @@
         >
           Обработка данных
         </div>
+        <div
+          class="sidebar-item"
+          :class="{ 'sidebar-item--active': activeSection === 'contacts' }"
+          role="button"
+          tabindex="0"
+          @click="activeSection = 'contacts'"
+          @keydown.enter="activeSection = 'contacts'"
+        >
+          Контакты Бюро
+        </div>
       </nav>
 
       <div class="admin-settings__content">
@@ -216,6 +226,60 @@
               class="btn btn--primary"
               :disabled="saving"
               @click="savePaginationSettings"
+            >
+              {{ saving ? 'Сохранение...' : 'Сохранить' }}
+            </button>
+          </div>
+
+          <!-- Контакты Бюро -->
+          <div
+            v-else-if="activeSection === 'contacts'"
+            class="settings-section"
+          >
+            <h3 class="section-title">
+              Контакты Бюро пропусков
+            </h3>
+            <p class="form-hint section-intro">
+              Телефон и почта Бюро. Показываются на странице входа и в плашке блокировки.
+            </p>
+
+            <div class="form-group">
+              <label
+                class="form-label"
+                for="bureau-phone"
+              >
+                Телефон
+              </label>
+              <input
+                id="bureau-phone"
+                v-model="settings.bureau_phone"
+                type="text"
+                class="form-input"
+                placeholder="+7 (495) 123-45-67"
+                maxlength="30"
+              >
+            </div>
+
+            <div class="form-group">
+              <label
+                class="form-label"
+                for="bureau-email"
+              >
+                Электронная почта
+              </label>
+              <input
+                id="bureau-email"
+                v-model="settings.bureau_email"
+                type="email"
+                class="form-input"
+                placeholder="bureau@example.com"
+              >
+            </div>
+
+            <button
+              class="btn btn--primary"
+              :disabled="saving"
+              @click="saveContactsSettings"
             >
               {{ saving ? 'Сохранение...' : 'Сохранить' }}
             </button>
@@ -474,6 +538,7 @@ import {
 import { SkeletonTransition, SkeletonLine, SkeletonBlock } from '@/components/ui';
 import { useDeletionsStore } from '@/stores/deletions';
 import { useUiStore } from '@/stores/ui';
+import { useContactsStore } from '@/stores/contacts';
 
 export default {
   name: 'AdminSettings',
@@ -503,6 +568,8 @@ export default {
         password_require_lowercase: false,
         password_require_digit: true,
         password_require_special: false,
+        bureau_phone: '',
+        bureau_email: '',
       },
       availableImageTypes: ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/svg+xml'],
       availableDocTypes: ['application/pdf', 'application/msword', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', 'text/plain'],
@@ -627,6 +694,12 @@ export default {
           case 'password.require_special':
             this.settings.password_require_special = item.value === 'true';
             break;
+          case 'contacts.bureau_phone':
+            this.settings.bureau_phone = item.value || '';
+            break;
+          case 'contacts.bureau_email':
+            this.settings.bureau_email = item.value || '';
+            break;
         }
       }
     },
@@ -660,6 +733,35 @@ export default {
         await updateSetting('upload.allowed_image_types', JSON.stringify(this.selectedImageTypes));
         await updateSetting('upload.allowed_doc_types', JSON.stringify(this.selectedDocTypes));
         useDeletionsStore().notify({ prefix: 'Настройки загрузки сохранены' });
+      } catch (error) {
+        console.error('Ошибка сохранения:', error);
+        useDeletionsStore().notify({ prefix: 'Ошибка сохранения настроек', type: 'error' });
+      } finally {
+        this.saving = false;
+      }
+    },
+
+    async saveContactsSettings() {
+      const phone = (this.settings.bureau_phone || '').trim();
+      const email = (this.settings.bureau_email || '').trim();
+      if (!phone && !email) {
+        useDeletionsStore().notify({ prefix: 'Укажите телефон или почту Бюро', type: 'error' });
+        return;
+      }
+      if (email && !/^\S+@\S+\.\S+$/.test(email)) {
+        useDeletionsStore().notify({ prefix: 'Некорректный адрес электронной почты', type: 'error' });
+        return;
+      }
+      if (phone && (phone.length < 5 || phone.length > 30)) {
+        useDeletionsStore().notify({ prefix: 'Телефон: от 5 до 30 символов', type: 'error' });
+        return;
+      }
+      this.saving = true;
+      try {
+        if (phone) await updateSetting('contacts.bureau_phone', phone);
+        if (email) await updateSetting('contacts.bureau_email', email);
+        useContactsStore().fetch(true);
+        useDeletionsStore().notify({ prefix: 'Контакты Бюро сохранены' });
       } catch (error) {
         console.error('Ошибка сохранения:', error);
         useDeletionsStore().notify({ prefix: 'Ошибка сохранения настроек', type: 'error' });
@@ -927,6 +1029,11 @@ export default {
   font-size: 11px;
   color: #888;
   margin-top: 4px;
+}
+
+.section-intro {
+  margin: 0 0 16px;
+  font-size: 13px;
 }
 
 .form-range {

--- a/frontend/src/views/__tests__/AdminSettings.contacts.spec.js
+++ b/frontend/src/views/__tests__/AdminSettings.contacts.spec.js
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { shallowMount, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+
+const getSettings = vi.fn();
+const updateSetting = vi.fn();
+const getPublicContacts = vi.fn();
+vi.mock('@/api/settings', () => ({
+  getSettings: (...a) => getSettings(...a),
+  updateSetting: (...a) => updateSetting(...a),
+  getPublicContacts: (...a) => getPublicContacts(...a),
+}));
+
+import AdminSettings from '../AdminSettings.vue';
+
+async function mountView() {
+  getSettings.mockResolvedValue([
+    { key: 'contacts.bureau_phone', value: '+7 (495) 111-22-33', type: 'string' },
+    { key: 'contacts.bureau_email', value: 'bureau@example.com', type: 'string' },
+  ]);
+  updateSetting.mockResolvedValue({});
+  getPublicContacts.mockResolvedValue({ phone: '', email: '' });
+  const wrapper = shallowMount(AdminSettings);
+  await flushPromises();
+  return wrapper;
+}
+
+describe('AdminSettings - контакты Бюро', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    getSettings.mockReset();
+    updateSetting.mockReset();
+    getPublicContacts.mockReset();
+  });
+
+  it('маппит ключи contacts.* из ответа', async () => {
+    const wrapper = await mountView();
+    expect(wrapper.vm.settings.bureau_phone).toBe('+7 (495) 111-22-33');
+    expect(wrapper.vm.settings.bureau_email).toBe('bureau@example.com');
+  });
+
+  it('saveContactsSettings шлёт телефон и почту', async () => {
+    const wrapper = await mountView();
+    await wrapper.vm.saveContactsSettings();
+    const keys = updateSetting.mock.calls.map((c) => c[0]);
+    expect(keys).toEqual(expect.arrayContaining(['contacts.bureau_phone', 'contacts.bureau_email']));
+  });
+
+  it('saveContactsSettings отклоняет некорректный email без запроса', async () => {
+    const wrapper = await mountView();
+    wrapper.vm.settings.bureau_email = 'not-an-email';
+    wrapper.vm.settings.bureau_phone = '';
+    updateSetting.mockClear();
+    await wrapper.vm.saveContactsSettings();
+    expect(updateSetting).not.toHaveBeenCalled();
+  });
+});

--- a/internal/handlers/settings.go
+++ b/internal/handlers/settings.go
@@ -64,3 +64,9 @@ func (h *SettingsHandler) GetNotificationSettings(c echo.Context) error {
 func (h *SettingsHandler) GetPasswordPolicy(c echo.Context) error {
 	return RespondSuccess(c, h.service.GetPasswordPolicy())
 }
+
+// GetPublicContacts возвращает контакты Бюро пропусков (телефон, почта). Публичный
+// (без JWT): нужен на странице логина и в плашке блокировки до/без авторизации.
+func (h *SettingsHandler) GetPublicContacts(c echo.Context) error {
+	return RespondSuccess(c, h.service.GetPublicContacts(c.Request().Context()))
+}

--- a/internal/handlers/settings_test.go
+++ b/internal/handlers/settings_test.go
@@ -70,6 +70,46 @@ func TestSettings_Update_InvalidValue(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+// TestSettings_PublicContacts_NoAuth: контакты Бюро доступны публично (без JWT),
+// дефолт пустой, после установки супер-админом отдаются актуальные значения.
+func TestSettings_PublicContacts_NoAuth(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	rec := testutil.GET(t, e, "/settings/contacts", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	resp := testutil.ParseMap(t, rec)
+	assert.Equal(t, "", resp["phone"], "дефолт телефона пустой")
+	assert.Equal(t, "", resp["email"], "дефолт почты пустой")
+
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	require.Equal(t, http.StatusOK, testutil.PUT(t, e, "/settings/contacts.bureau_phone", `{"value":"+7 (495) 123-45-67"}`, testutil.AuthHeader(token)).Code)
+	require.Equal(t, http.StatusOK, testutil.PUT(t, e, "/settings/contacts.bureau_email", `{"value":"bureau@example.com"}`, testutil.AuthHeader(token)).Code)
+
+	rec = testutil.GET(t, e, "/settings/contacts", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	resp = testutil.ParseMap(t, rec)
+	assert.Equal(t, "+7 (495) 123-45-67", resp["phone"])
+	assert.Equal(t, "bureau@example.com", resp["email"])
+}
+
+// TestSettings_UpdateContacts_Validation: некорректный email/слишком короткий
+// телефон -> 400; корректные значения -> 200.
+func TestSettings_UpdateContacts_Validation(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+
+	assert.Equal(t, http.StatusBadRequest, testutil.PUT(t, e, "/settings/contacts.bureau_email", `{"value":"not-an-email"}`, testutil.AuthHeader(token)).Code)
+	assert.Equal(t, http.StatusBadRequest, testutil.PUT(t, e, "/settings/contacts.bureau_phone", `{"value":"123"}`, testutil.AuthHeader(token)).Code)
+	assert.Equal(t, http.StatusOK, testutil.PUT(t, e, "/settings/contacts.bureau_email", `{"value":"ok@example.com"}`, testutil.AuthHeader(token)).Code)
+	assert.Equal(t, http.StatusOK, testutil.PUT(t, e, "/settings/contacts.bureau_phone", `{"value":"+7 495 123 45 67"}`, testutil.AuthHeader(token)).Code)
+}
+
 func TestSettings_GetNotifications_ReturnsDurations(t *testing.T) {
 	e, db, cleanup := testutil.SetupTestApp(t)
 	defer cleanup()

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -142,6 +142,8 @@ func Setup(e *echo.Echo, d Dependencies) {
 	// Публичный статус техработ - без JWT, чтобы страница /maintenance и форма /login
 	// могли его опросить.
 	api.GET("/settings/maintenance", maintenance.GetPublicStatus)
+	// Публичные контакты Бюро пропусков - нужны на логине и в плашке блокировки.
+	api.GET("/settings/contacts", settings.GetPublicContacts)
 
 	// Protected routes
 	protected := api.Group("")

--- a/internal/services/settings_service.go
+++ b/internal/services/settings_service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/mail"
 	"strconv"
 	"sync"
 
@@ -25,6 +26,7 @@ type SettingsService interface {
 	GetUploadSettings(ctx context.Context) (map[string]interface{}, error)
 	GetNotificationSettings(ctx context.Context) (map[string]interface{}, error)
 	GetPasswordPolicy() models.PasswordPolicy
+	GetPublicContacts(ctx context.Context) map[string]string
 	GetDataProcessingDoc(ctx context.Context) (*models.DataProcessingDocument, error)
 	SetDataProcessingDoc(ctx context.Context, meta *models.DataProcessingDocument) error
 	ClearDataProcessingDoc(ctx context.Context) error
@@ -45,6 +47,8 @@ var knownKeys = map[string]string{
 	"password.require_lowercase":     "bool",
 	"password.require_digit":         "bool",
 	"password.require_special":       "bool",
+	"contacts.bureau_phone":          "string",
+	"contacts.bureau_email":          "string",
 }
 
 type settingsService struct {
@@ -71,6 +75,8 @@ func NewSettingsService(db *gorm.DB, cfg *config.Config) SettingsService {
 		"password.require_lowercase":     {Key: "password.require_lowercase", Value: "false", Type: "bool"},
 		"password.require_digit":         {Key: "password.require_digit", Value: "true", Type: "bool"},
 		"password.require_special":       {Key: "password.require_special", Value: "false", Type: "bool"},
+		"contacts.bureau_phone":          {Key: "contacts.bureau_phone", Value: "", Type: "string"},
+		"contacts.bureau_email":          {Key: "contacts.bureau_email", Value: "", Type: "string"},
 	}
 
 	s := &settingsService{db: db, defaults: defaults, cache: make(map[string]models.SystemSetting)}
@@ -190,6 +196,18 @@ func (s *settingsService) GetNotificationSettings(ctx context.Context) (map[stri
 		"delete_duration":  del,
 		"restore_duration": res,
 	}, nil
+}
+
+// GetPublicContacts возвращает контактные данные Бюро пропусков (телефон, почта)
+// для публичного отображения (логин, плашка блокировки). Без проверки прав --
+// это публичная справочная информация. Пустые значения означают "не настроено".
+func (s *settingsService) GetPublicContacts(ctx context.Context) map[string]string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return map[string]string{
+		"phone": s.cache["contacts.bureau_phone"].Value,
+		"email": s.cache["contacts.bureau_email"].Value,
+	}
 }
 
 // GetPasswordPolicy собирает текущую политику паролей из кэша настроек.
@@ -313,6 +331,14 @@ func validateSettingValue(key, value string) error {
 	case "password.require_letter", "password.require_uppercase", "password.require_lowercase", "password.require_digit", "password.require_special":
 		if value != "true" && value != "false" {
 			return fmt.Errorf("%s: true/false (получено %s)", key, value)
+		}
+	case "contacts.bureau_email":
+		if _, err := mail.ParseAddress(value); err != nil {
+			return fmt.Errorf("contacts.bureau_email: некорректный email (получено %s)", value)
+		}
+	case "contacts.bureau_phone":
+		if l := len([]rune(value)); l < 5 || l > 30 {
+			return fmt.Errorf("contacts.bureau_phone: 5-30 символов (получено %s)", value)
 		}
 	case "upload.allowed_image_types", "upload.allowed_doc_types":
 		var arr []string


### PR DESCRIPTION
## Зачем
Контакты Бюро (телефон, почта) были захардкожены на странице логина - сменить без правки кода нельзя. Юзер попросил редактируемые из настроек контакты, используемые везде (логин, плашка блокировки).

## BE
- Ключи настроек `contacts.bureau_phone`/`contacts.bureau_email` (тип string) с валидацией: email через mail.ParseAddress, телефон 5-30 символов.
- Публичный `GET /api/settings/contacts` (без JWT) - нужен на логине до авторизации; отдаёт только {phone, email}.
- Правка значений - super-only (как все настройки).

## FE
- Раздел "Контакты Бюро" в AdminSettings (телефон + почта, сохранение через PUT /settings/:key).
- Общий `contacts`-стор (один фетч, кэш) - единый источник.
- Плашка блокировки (BanOverlay): блок контактов с tel:/mailto: ссылками.
- Логин: контакты теперь из настроек (раньше хардкод), с фолбэком на прежние значения если не настроено.

## Тесты
- Go: публичный GET без auth (дефолт пустой -> после установки актуальные), валидация email/телефона. Полный go test (handlers+services) зелёный.
- FE: AdminSettings.contacts.spec (маппинг ключей, сохранение, отклонение кривого email) - 3 зелёных; существующие AdminSettings-спеки не сломаны.