### PR TITLE
style(access): дропдауны в правах на BaseDropdown вместо нативных select

### DIFF
--- a/frontend/src/components/admin/UserAccessModal.vue
+++ b/frontend/src/components/admin/UserAccessModal.vue
@@ -53,23 +53,13 @@
               <div class="field-label">
                 Роль
               </div>
-              <select
+              <BaseDropdown
                 v-model="form.role_id"
-                class="lk-select"
                 data-testid="role-select"
+                :options="roleOptions"
+                placeholder="Без роли"
                 :disabled="saving"
-              >
-                <option :value="null">
-                  Без роли
-                </option>
-                <option
-                  v-for="r in roles"
-                  :key="r.id"
-                  :value="r.id"
-                >
-                  {{ r.name }}
-                </option>
-              </select>
+              />
             </div>
 
             <div class="field-block">
@@ -256,6 +246,7 @@ import {
 import { apiRequest } from '@/api/client';
 import EffectivePermissionsTree from './EffectivePermissionsTree.vue';
 import LoaderSpinner from '../ui/LoaderSpinner.vue';
+import BaseDropdown from '../ui/BaseDropdown.vue';
 
 /**
  * Модалка «Права доступа» в две колонки: слева источники прав (флаг Администратор,
@@ -265,7 +256,7 @@ import LoaderSpinner from '../ui/LoaderSpinner.vue';
  */
 export default {
   name: 'UserAccessModal',
-  components: { EffectivePermissionsTree, LoaderSpinner },
+  components: { EffectivePermissionsTree, LoaderSpinner, BaseDropdown },
   props: {
     user: { type: Object, default: null },
   },
@@ -299,6 +290,9 @@ export default {
     };
   },
   computed: {
+    roleOptions() {
+      return [{ id: null, name: 'Без роли' }, ...this.roles];
+    },
     isSuper() {
       return this.effective.mode === 'super' || !!this.user?.is_super_admin;
     },

--- a/frontend/src/views/admin/AccessDenialsLog.vue
+++ b/frontend/src/views/admin/AccessDenialsLog.vue
@@ -43,20 +43,14 @@
         type="text"
         placeholder="Ресурс (substring)"
       >
-      <select
+      <BaseDropdown
         v-model="filters.reason"
-        class="lk-select filter-input"
-      >
-        <option value="">
-          Причина — все
-        </option>
-        <option value="permission_denied">
-          Нет прав
-        </option>
-        <option value="account_banned">
-          Заблокирован
-        </option>
-      </select>
+        class="filter-input"
+        :options="reasonOptions"
+        value-key="value"
+        label-key="label"
+        placeholder="Причина — все"
+      />
       <input
         v-model="filters.from"
         class="lk-input filter-input"
@@ -191,12 +185,13 @@ import {
   archiveAccessDenials,
 } from '@/api/permissions';
 import RefreshButton from '@/components/RefreshButton.vue';
+import BaseDropdown from '@/components/ui/BaseDropdown.vue';
 import { useDeletionsStore } from '@/stores/deletions';
 import { useUiStore } from '@/stores/ui';
 
 export default {
   name: 'AccessDenialsLog',
-  components: { RefreshButton },
+  components: { RefreshButton, BaseDropdown },
   data() {
     return {
       mode: 'active',
@@ -206,6 +201,11 @@ export default {
       limit: 50,
       loading: false,
       filters: { user_id: '', resource: '', reason: '', from: '', to: '' },
+      reasonOptions: [
+        { value: '', label: 'Причина — все' },
+        { value: 'permission_denied', label: 'Нет прав' },
+        { value: 'account_banned', label: 'Заблокирован' },
+      ],
     };
   },
   computed: {


### PR DESCRIPTION
## Что
Срез 5 perm-bugfixes. Нативные `<select>` в управлении правами выбивались из стиля проекта.

- **UserAccessModal** (модалка "Права доступа"): выбор роли -> BaseDropdown (computed roleOptions с "Без роли").
- **AccessDenialsLog** (журнал отказов): фильтр причины -> BaseDropdown (reasonOptions).

Биндинги через v-model сохранены, data-testid=role-select прокидывается на корень. UserAccessModal-спек (7) зелёный; нативных select в правах больше нет.