### PR TITLE
fix(nav): звук новой заявки только при доступе к Центру заявок

### DIFF
--- a/frontend/src/components/NavMenu.vue
+++ b/frontend/src/components/NavMenu.vue
@@ -785,9 +785,10 @@ export default {
   async mounted() {
     document.body.classList.add('auth-active');
     this.syncContentMargin();
-    // Права нужны для гейтинга пунктов/таблиц/админки. Идемпотентно (вернёт кэш,
-    // если router-guard уже загрузил), но защищает от пустого первого рендера.
-    this.permissionsStore.fetchPermissions();
+    // Права нужны для гейтинга пунктов/таблиц/админки и опроса новых заявок.
+    // Ждём загрузку (идемпотентно - вернёт кэш, если router-guard уже загрузил),
+    // чтобы первый опрос не стартовал у пользователя без page.center.
+    await this.permissionsStore.fetchPermissions();
     await this.fetchBanStatus();
     await this.fetchSystemTables();
     this.startApplicationsPolling();
@@ -1033,6 +1034,13 @@ export default {
     },
 
     async fetchNewApplicationsCount() {
+      // Счётчик и звук новых заявок - операторская фича «Центра заявок». Без права
+      // page.center не опрашиваем и не играем звук: иначе заявитель, ставший
+      // responsible своей же заявки, получает сигнал о «новой заявке в Центре».
+      if (!this.can('page.center')) {
+        this.newApplicationsCount = 0
+        return
+      }
       const SOUND_COOLDOWN_MS = 5000
       try {
         const data = await getUnreadCount()

--- a/frontend/src/components/__tests__/NavMenu.sound.spec.js
+++ b/frontend/src/components/__tests__/NavMenu.sound.spec.js
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { shallowMount, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+
+const getUnreadCount = vi.fn();
+vi.mock('@/api/applications', () => ({
+  getUnreadCount: (...a) => getUnreadCount(...a),
+}));
+
+const getFeedbackStats = vi.fn();
+vi.mock('@/api/feedback', () => ({
+  getFeedbackStats: (...a) => getFeedbackStats(...a),
+}));
+
+const playPreset = vi.fn();
+vi.mock('@/utils/notificationSound', () => ({
+  playPreset: (...a) => playPreset(...a),
+}));
+
+const apiRequest = vi.fn();
+vi.mock('@/api/client', () => ({
+  apiRequest: (...a) => apiRequest(...a),
+}));
+
+const hasPermission = vi.fn();
+const fetchPermissions = vi.fn();
+vi.mock('@/stores/permissions', () => ({
+  usePermissionsStore: () => ({ hasPermission, fetchPermissions }),
+}));
+
+import NavMenu from '../NavMenu.vue';
+
+function jsonResponse(body) {
+  return { ok: true, json: async () => body };
+}
+
+async function mountNav() {
+  apiRequest.mockImplementation((url) => {
+    if (url === '/users/me') return Promise.resolve(jsonResponse({ data: { is_banned: false } }));
+    if (url === '/system-tables') return Promise.resolve(jsonResponse([]));
+    return Promise.resolve(jsonResponse({}));
+  });
+  fetchPermissions.mockResolvedValue(undefined);
+  const wrapper = shallowMount(NavMenu, {
+    global: {
+      mocks: {
+        $bus: { on: vi.fn(), off: vi.fn(), emit: vi.fn() },
+        $route: { path: '/personal-cabinet', params: {} },
+        $router: { push: vi.fn() },
+      },
+    },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+describe('NavMenu - звук новой заявки гейтится page.center', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    getUnreadCount.mockReset();
+    getFeedbackStats.mockReset();
+    playPreset.mockReset();
+    apiRequest.mockReset();
+    hasPermission.mockReset();
+    fetchPermissions.mockReset();
+    getUnreadCount.mockResolvedValue({ count: 0 });
+  });
+
+  it('без page.center не опрашивает счётчик и не играет звук', async () => {
+    hasPermission.mockReturnValue(false);
+    const wrapper = await mountNav();
+    expect(getUnreadCount).not.toHaveBeenCalled();
+    expect(playPreset).not.toHaveBeenCalled();
+    expect(wrapper.vm.newApplicationsCount).toBe(0);
+    wrapper.unmount();
+  });
+
+  it('с page.center опрашивает счётчик новых заявок', async () => {
+    hasPermission.mockImplementation((key) => key === 'page.center');
+    const wrapper = await mountNav();
+    expect(getUnreadCount).toHaveBeenCalled();
+    wrapper.unmount();
+  });
+
+  it('играет звук при росте счётчика только при наличии page.center', async () => {
+    hasPermission.mockImplementation((key) => key === 'page.center');
+    const wrapper = await mountNav();
+    // Первый опрос спраймил soundPrimed; эмулируем рост 0 -> 2.
+    getUnreadCount.mockResolvedValue({ count: 2 });
+    wrapper.vm.soundStore.setEnabled(true);
+    await wrapper.vm.fetchNewApplicationsCount();
+    expect(playPreset).toHaveBeenCalledTimes(1);
+    expect(wrapper.vm.newApplicationsCount).toBe(2);
+    wrapper.unmount();
+  });
+});


### PR DESCRIPTION
## Баг
Пользователь без доступа к вкладке «Центр заявок» получал звуковой сигнал о новой заявке. Подавая заявку, он становился её `responsible_user`, заявка попадала в его `unread-count`, рост счётчика триггерил звук в NavMenu.

## Причина
Пункт меню «Центр заявок» гейтится `can('page.center')`, а опрос `getUnreadCount` + звук (`startApplicationsPolling` -> `fetchNewApplicationsCount`) запускались в `mounted` безусловно.

## Фикс
`fetchNewApplicationsCount` рано выходит без права `page.center` (опрос и звук операторские, привязаны к Центру). Гейт реактивный — переживает выдачу права без перезагрузки. Опрос обратной связи (`fetchNewFeedbackCount`, своя проверка на супер-админа) не затронут. В `mounted` ждём загрузку прав, чтобы первый опрос видел реальные права.

## Тесты
`NavMenu.sound.spec.js`: без `page.center` нет вызова `getUnreadCount` и звука; с правом — опрос идёт; звук играет при росте счётчика. 3/3 зелёные.