### PR TITLE
fix(nginx): object-src blob: для предпросмотра PDF согласия

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -67,5 +67,5 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'self';" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; object-src 'self' blob:; frame-ancestors 'self';" always;
 }

--- a/nginx/staging.conf
+++ b/nginx/staging.conf
@@ -87,7 +87,7 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'self';" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; object-src 'self' blob:; frame-ancestors 'self';" always;
 
     # Staging auth cookie (см. map выше). "always" - на всех статусах, map сам
     # фильтрует 401 в пустую строку (nginx игнорирует пустой Set-Cookie).


### PR DESCRIPTION
## Баг
На /data-processing документ согласия загружается (meta + кнопка Скачать работают), но встроенный предпросмотр PDF пустой.

## Причина
`DataProcessingView` встраивает PDF через `<embed type=application/pdf src=blob:...>`. `<embed>` подчиняется CSP-директиве `object-src`, которой в конфиге не было -> откат к `default-src 'self'`, куда `blob:` не входит. Браузер режет blob: (в консоли `Refused to load ... object-src`). Скачивание живёт, т.к. это навигация, не object-src.

## Фикс
Добавил `object-src 'self' blob:` в CSP боевого (`nginx.conf`) и staging (`staging.conf`). blob: генерится из same-origin ответа, расширение минимальное и стандартное для inline-PDF. `<embed>` не меняем.

## Деплой
nginx off-limits и деплой за тобой - PR на ревью, мержить/раскатывать сам. После раскатки CSP превью PDF появится без перезагрузки кода фронта.