### PR TITLE
fix(access): право на кнопку «Сообщить о проблеме» и свежесть карточки прав

### DIFF
--- a/frontend/src/components/TheHeader/TheHeader.vue
+++ b/frontend/src/components/TheHeader/TheHeader.vue
@@ -38,6 +38,7 @@
 
     <div class="header__info">
       <button
+        v-if="can('header.report_problem')"
         class="feedback-btn"
         data-testid="header-button-feedback"
         @click="openFeedbackModal"

--- a/frontend/src/components/TheHeader/__tests__/TheHeader.reportProblem.spec.js
+++ b/frontend/src/components/TheHeader/__tests__/TheHeader.reportProblem.spec.js
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.mock('@/api/client', () => ({
+  apiRequest: vi.fn().mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue({}) }),
+}))
+
+const hasPermission = vi.fn()
+vi.mock('@/stores/permissions', () => ({
+  usePermissionsStore: () => ({ hasPermission, loaded: true, fetchPermissions: vi.fn() }),
+}))
+
+import TheHeader from '@/components/TheHeader/TheHeader.vue'
+
+function mountHeader() {
+  return mount(TheHeader, {
+    global: {
+      mocks: {
+        $bus: { on: vi.fn(), off: vi.fn(), emit: vi.fn() },
+        $router: { push: vi.fn() },
+        $route: { path: '/' },
+      },
+      stubs: { FeedbackModal: true, AnnouncementModal: true, UserNotifications: true, SkeletonLine: true },
+    },
+  })
+}
+
+describe('TheHeader — кнопка «Сообщить о проблеме» по праву', () => {
+  let wrapper
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    hasPermission.mockReset()
+    global.IntersectionObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  })
+  afterEach(() => wrapper?.unmount())
+
+  const feedbackBtn = (w) => w.find('[data-testid="header-button-feedback"]')
+
+  it('скрыта без права header.report_problem', async () => {
+    hasPermission.mockReturnValue(false)
+    wrapper = mountHeader()
+    await flushPromises()
+    expect(feedbackBtn(wrapper).exists()).toBe(false)
+  })
+
+  it('видна при наличии права', async () => {
+    hasPermission.mockImplementation((key) => key === 'header.report_problem')
+    wrapper = mountHeader()
+    await flushPromises()
+    expect(feedbackBtn(wrapper).exists()).toBe(true)
+  })
+})

--- a/frontend/src/components/UserControl.vue
+++ b/frontend/src/components/UserControl.vue
@@ -893,6 +893,17 @@ export default {
     this.fetchAllUsers();
     this.loadDraft();
   },
+  watch: {
+    // После рефетча списка (роль/группы/блокировка менялись в модалке прав)
+    // пере-резолвим открытую карточку на свежий объект из allUsers. Иначе
+    // selectedUser держит копию старого user и роль/права в карточке остаются
+    // устаревшими до перезагрузки страницы.
+    allUsers(list) {
+      if (!this.selectedUser) return;
+      const fresh = list.find((u) => u.username === this.selectedUser.username);
+      if (fresh) this.selectedUser = { ...fresh, newPassword: this.selectedUser.newPassword || '' };
+    },
+  },
  
   methods: {
     ...mapActions(useOrganizationsStore, {

--- a/frontend/src/components/__tests__/UserControl.accessSync.spec.js
+++ b/frontend/src/components/__tests__/UserControl.accessSync.spec.js
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import { createPinia, setActivePinia } from 'pinia'
+import UserControl from '@/components/UserControl.vue'
+
+vi.mock('@/api/settings', () => ({
+  getPasswordPolicy: vi.fn().mockResolvedValue({
+    min_length: 8, require_letter: true, require_digit: true,
+  }),
+}))
+vi.mock('@/api/client', () => ({
+  apiRequest: vi.fn().mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue([]) }),
+}))
+vi.mock('@/api/onboarding', () => ({ resetOnboardingForUser: vi.fn().mockResolvedValue({}) }))
+vi.mock('@/utils/notificationSound', () => ({ playPreset: vi.fn() }))
+
+function mountUserControl(allUsers = []) {
+  return mount(UserControl, {
+    props: { allUsers },
+    global: {
+      mocks: {
+        $bus: { on: vi.fn(), off: vi.fn(), emit: vi.fn() },
+        $router: { push: vi.fn() },
+        $route: { path: '/admin/users', params: {} },
+      },
+    },
+  })
+}
+
+describe('UserControl — синхронизация открытой карточки после рефетча', () => {
+  let wrapper
+  beforeEach(() => setActivePinia(createPinia()))
+  afterEach(() => wrapper?.unmount())
+
+  it('обновляет роль открытой карточки при свежем allUsers', async () => {
+    const initial = [{ id: 1, username: 'chop_kpp4', role_id: null, role_name: 'Пользователь' }]
+    wrapper = mountUserControl(initial)
+    await flushPromises()
+
+    wrapper.vm.selectUser(initial[0])
+    await nextTick()
+    expect(wrapper.vm.selectedUser.role_id).toBe(null)
+
+    // Рефетч списка (после выдачи роли в модалке) отдаёт того же юзера с новой ролью.
+    await wrapper.setProps({
+      allUsers: [{ id: 1, username: 'chop_kpp4', role_id: 7, role_name: 'Охранник' }],
+    })
+    await nextTick()
+    expect(wrapper.vm.selectedUser.role_id).toBe(7)
+    expect(wrapper.vm.selectedUser.role_name).toBe('Охранник')
+  })
+
+  it('не трогает selectedUser, если карточка не открыта', async () => {
+    wrapper = mountUserControl([{ id: 1, username: 'a', role_id: 1 }])
+    await flushPromises()
+    expect(wrapper.vm.selectedUser).toBe(null)
+
+    await wrapper.setProps({ allUsers: [{ id: 1, username: 'a', role_id: 2 }] })
+    await nextTick()
+    expect(wrapper.vm.selectedUser).toBe(null)
+  })
+
+  it('сохраняет введённый newPassword при пере-резолве', async () => {
+    const initial = [{ id: 1, username: 'u', role_id: 1 }]
+    wrapper = mountUserControl(initial)
+    await flushPromises()
+    wrapper.vm.selectUser(initial[0])
+    wrapper.vm.selectedUser.newPassword = 'TypedPass1'
+    await nextTick()
+
+    await wrapper.setProps({ allUsers: [{ id: 1, username: 'u', role_id: 5 }] })
+    await nextTick()
+    expect(wrapper.vm.selectedUser.role_id).toBe(5)
+    expect(wrapper.vm.selectedUser.newPassword).toBe('TypedPass1')
+  })
+})


### PR DESCRIPTION
## Что чинит (два FE-бага из разбора прав)

### Кнопка «Сообщить о проблеме» игнорировала право
`TheHeader` рендерил кнопку без проверки — снятый `header.report_problem` не действовал. Закрыл под `v-if="can(header.report_problem)"`, тем же паттерном, что уже у «Подать заявку».

⚠️ Импликация: ключ раньше был декоративным, его никто не гранил. После енфорса кнопку видят только super/admin и те, кому право выдано ролью/группой/лично. Если нужно сохранить её для всех — добавить `header.report_problem` в дефолтные роли/группы.

### Карточка прав показывала старую роль до F5
`UserControl` держал `selectedUser = { ...user }` (копия). После выдачи роли в модалке список перезапрашивался (`fetch-users`), но открытая карточка не пере-резолвилась → роль/права устаревшие до перезагрузки. Добавил `watch` на `allUsers`, обновляющий `selectedUser` из свежего списка (по username), сохраняя введённый `newPassword`.

## Тесты
- `TheHeader.reportProblem.spec.js`: кнопка скрыта без права, видна с правом.
- `UserControl.accessSync.spec.js`: роль карточки обновляется при свежем `allUsers`; не трогает закрытую карточку; сохраняет набранный пароль.
- Регресс `UserControl.passwordPolicy.spec.js` — зелёный.

Остальные пункты разбора прав (slug-лейблы таблиц, рассинхрон `page.analytics`, неподключённые `news.manage`/`guide.*`/`detail.*`/`center.*`, гранулярность Администрирования) — бэкенд `permission_*` (off-limits), жду твоего решения отдельно.