### PR TITLE
fix(ui): починил иконку руководства и причесал модалки обзора

### DIFF
--- a/frontend/src/components/AnnouncementModal.vue
+++ b/frontend/src/components/AnnouncementModal.vue
@@ -154,7 +154,7 @@ export default {
   font-weight: 600;
   color: #1a1a1a;
   flex: 1;
-  padding-bottom: 15px;
+  padding-bottom: 26px;
 }
 
 .announcement-title {

--- a/frontend/src/components/ConfirmDialog.vue
+++ b/frontend/src/components/ConfirmDialog.vue
@@ -100,7 +100,7 @@ export default {
   width: 100%;
   max-width: 400px;
   background: #FFFFFF;
-  border-radius: 16px;
+  border-radius: 30px;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
   overflow: hidden;
   font-family: 'Montserrat', sans-serif;
@@ -155,8 +155,8 @@ export default {
 }
 
 .confirm-dialog__btn {
-  padding: 8px 16px;
-  border-radius: 6px;
+  padding: 9px 20px;
+  border-radius: var(--radius-pill, 50px);
   cursor: pointer;
   font-size: 0.85em;
   font-weight: 500;

--- a/frontend/src/components/CreateApplication/TableInfoModal.vue
+++ b/frontend/src/components/CreateApplication/TableInfoModal.vue
@@ -116,10 +116,6 @@
                       </span>
                       <div class="slot-badges">
                         <span
-                          v-if="slot.is_next_day"
-                          class="next-day-badge"
-                        >+1</span>
-                        <span
                           v-if="!slot.is_active"
                           class="inactive-badge"
                         >неакт</span>

--- a/frontend/src/components/CreateApplication/UnloadPlaceModal.vue
+++ b/frontend/src/components/CreateApplication/UnloadPlaceModal.vue
@@ -107,10 +107,6 @@
                       </span>
                       <div class="slot-badges">
                         <span
-                          v-if="slot.is_next_day"
-                          class="next-day-badge"
-                        >+1</span>
-                        <span
                           v-if="!slot.is_active"
                           class="inactive-badge"
                         >неакт</span>

--- a/frontend/src/views/NewsAndReview.vue
+++ b/frontend/src/views/NewsAndReview.vue
@@ -79,35 +79,17 @@
                   <svg
                     width="35"
                     height="35"
-                    viewBox="0 0 35 35"
+                    viewBox="0 0 24 24"
                     fill="none"
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <rect
-                      width="35"
-                      height="35"
-                      fill="url(#pattern0)"
+                    <path
+                      d="M12 6.5C10.4 5 7.8 4.5 4 4.5V18.5C7.8 18.5 10.4 19 12 20.5C13.6 19 16.2 18.5 20 18.5V4.5C16.2 4.5 13.6 5 12 6.5ZM12 6.5V20.5"
+                      stroke="#4F5BDF"
+                      stroke-width="1.6"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
                     />
-                    <defs>
-                      <pattern
-                        id="pattern0"
-                        patternContentUnits="objectBoundingBox"
-                        width="1"
-                        height="1"
-                      >
-                        <use
-                          xlink:href="#image0"
-                          transform="scale(0.015625)"
-                        />
-                      </pattern>
-                      <image
-                        id="image0"
-                        width="64"
-                        height="64"
-                        preserveAspectRatio="none"
-                        xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAACXBIWXMAAAHYAAAB2AH6XKZyAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAwxJREFUeJzt209oHkUcxvGPMQlqBAk9WCoBJZdoDuLJQyMtlBZSKv4Be6m3QpRcKmoN9RQPpVCCUA+e9FRPCqWlHixeVGwPUpFCrNhi0ItQJH+MQpU2TQ+7L+8SeHl3N7OZTbJfWN7Z3fnNPPMw876zs/PSsL15oGRcP17AM3gknJyg/IwvQxfajynMY3UTHM+HbPwgvqtBo4ocr3drVG/OxvfiC0m3bzGHS1jOWcZaxrA7TV/G94FiDmG0pKaOvKHt6grexYPrLHM6U+Z0wJizKugBxzPpDzCTM6729OTI8zSG0/QiTlcnZ+PJY8BwJn0F/1WkJQp5DHgsk16qSkgs8hiQnSytViUkFnkM2NI0BsQWEJvGgNgCOjCDf2zAhKuOBkzhHTyafr5XZWV1M+AgTq65dgovV1VhnQx4Dp9rP2TdTT978Fl6Pzh1MWAnLmAgPf8dz+K39HxAsrrzROiK62LABIbS9DJexHVJ12+tN+zC0dAV18WA1nR7RfIMP5uez+Kw9nAou4bZkboY0OJtXFxz7ZJkAaYS6mTAp/iow70z+LiKSmMakH20/hpvdsl/LM3XYjGEiLxLYlXwCZ5EH97XHueduIvXJPOC/9P4dRPTgH/xVsGYvzEZUkSdvgOi0BgQW0BsGgNiC4hNY0BsAbFpDIgtIDaNAbEFxKYxILaA2DQGxBYQm8aA2AJis+0NKLskNoZXJRsSd4STE4SniWQuasAQvsGegnGxWOmWoagBm6XhJMvuV7plKjsE/pK8qLiMhZJlVM2cHO8OyhjwE8Zxq0Rs7Sj6K3Abr9gijad4DziHP9L0wziBkaCKwnAPV/Fhml4XR7S3n2f360yq5k8OIY8D3RqXZwhkX2I+lEn/mSM2JityDNU8Gw5G8Eua/hZ7M/d2S3Zu1JEbuBaqsJva3Wo8VKGbiQltA5bwUlw54ci756YXX2Ff5tqPkn+RLeBOYF0h+BXnQxY4KHkOiP3NXuQY69aoIhOhReyX/BTOF4irNWW3nfVJ3B3F4+l5nbiHHwQeAg1bkfsR5B+/y7yHCAAAAABJRU5ErkJggg=="
-                      />
-                    </defs>
                   </svg>
                 </div>
                 <div class="guide-title-text">


### PR DESCRIPTION
Эпик multitab-fixes, фаза A. A1/A3/A9: иконка руководства (чистый svg), скругление ConfirmDialog 30px+pill, отступ заголовка новости, убран бейдж +1 в окнах мест

Ревью пройдено: дифф чисто-FE, непересекающиеся файлы, FE vitest зелёный. Go-фейл partitions_test при фан-ауте — pre-existing неизолированный тест на расшаренной БД, к срезу отношения нет.