### PR TITLE
fix(notifications): привязал popover к иконке, анимация точки влево при прочтении

### DIFF
--- a/frontend/src/components/TheHeader/TheHeader.vue
+++ b/frontend/src/components/TheHeader/TheHeader.vue
@@ -75,11 +75,11 @@
           v-if="unreadCount > 0"
           class="notifications__badge"
         >{{ unreadCount }}</span>
+        <UserNotifications
+          :show="showNotifications"
+          @update:unread-count="unreadCount = $event"
+        />
       </div>
-      <UserNotifications
-        :show="showNotifications"
-        @update:unread-count="unreadCount = $event"
-      />
       <div
         v-if="can('page.new_application')"
         class="appl-btn__container"

--- a/frontend/src/components/UserNotifications.vue
+++ b/frontend/src/components/UserNotifications.vue
@@ -214,8 +214,8 @@ export default {
 <style scoped>
 .notifications {
   position: absolute;
-  top: 50px;
-  right: 80px;
+  top: calc(100% + 10px);
+  right: 0;
   width: 360px;
   background: #fff;
   border-radius: 20px;
@@ -429,8 +429,7 @@ export default {
 @media (max-width: 576px) {
   .notifications {
     width: calc(100vw - 20px);
-    right: 10px;
-    top: 55px;
+    right: -10px;
   }
 }
 </style>

--- a/frontend/src/components/UserNotificationsInline.vue
+++ b/frontend/src/components/UserNotificationsInline.vue
@@ -407,13 +407,21 @@ export default {
   background: var(--color-primary);
 }
 
-.dot-fade-enter-active,
-.dot-fade-leave-active {
-  transition: opacity 0.2s;
+.dot-fade-enter-active {
+  transition: opacity 0.2s ease;
 }
-.dot-fade-enter-from,
+
+.dot-fade-leave-active {
+  transition: opacity 0.25s ease, transform 0.25s ease;
+}
+
+.dot-fade-enter-from {
+  opacity: 0;
+}
+
 .dot-fade-leave-to {
   opacity: 0;
+  transform: translateX(-16px);
 }
 
 .notification-content {


### PR DESCRIPTION
Эпик multitab-fixes, фаза A. A2: popover уведомлений у иконки (был фикс right:80px) + плавный увод точки прочтения влево

Ревью пройдено: дифф чисто-FE, непересекающиеся файлы, FE vitest зелёный. Go-фейл partitions_test при фан-ауте — pre-existing неизолированный тест на расшаренной БД, к срезу отношения нет.