### PR TITLE
fix(permissions): гигиена каталога прав - Аналитика на page.statistics, убрал news.manage

### DIFF
--- a/frontend/src/components/admin/__tests__/UserAccessModal.spec.js
+++ b/frontend/src/components/admin/__tests__/UserAccessModal.spec.js
@@ -14,13 +14,13 @@ import {
 const CATALOG = [
   { key: 'page.center', display_name: 'Центр заявок', category: 'Навигация' },
   { key: 'page.cars', display_name: 'Автомобили', category: 'Навигация' },
-  { key: 'page.analytics', display_name: 'Аналитика', category: 'Навигация' },
+  { key: 'page.statistics', display_name: 'Аналитика', category: 'Навигация' },
   { key: 'action.grant.admin', display_name: 'Выдача прав администратора', category: 'Администрирование', super_only: true },
 ];
 
 const ROLES = [{ id: 1, name: 'Пользователь', code: 'user' }, { id: 2, name: 'Охранник', code: 'guard' }];
 const GROUPS = [
-  { id: 5, name: 'Аналитика', keys: ['page.analytics'] },
+  { id: 5, name: 'Аналитика', keys: ['page.statistics'] },
   { id: 6, name: 'Все таблицы', keys: [] },
 ];
 

--- a/internal/services/permission_catalog.go
+++ b/internal/services/permission_catalog.go
@@ -13,15 +13,13 @@ import "strings"
 //   center.*  -- разделы/кнопки центра заявок,
 //   detail.*  -- кнопки/разделы карточек авто/сотрудника (общие для контекстов),
 //   section.* -- разделы внутри страниц (владельческие вкладки реестров),
-//   guide.*   -- вкладки руководства,
-//   news.*    -- управление новостями.
+//   guide.*   -- вкладки руководства.
 
 // Новые ключи каталога (существующие переиспользуются из permission_keys.go).
 const (
 	KeyPageNewApplication = "page.new_application"
 	KeyPageAvailable      = "page.available"
 	KeyPageTables         = "page.tables"
-	KeyPageAnalytics      = "page.analytics"
 
 	KeyPageAdminMonitoring  = "page.admin.monitoring"
 	KeyPageAdminDirectories = "page.admin.directories"
@@ -46,7 +44,6 @@ const (
 
 	KeyActionGrantAdmin = "action.grant.admin"
 
-	KeyNewsManage = "news.manage"
 	KeyGuideUser  = "guide.user"
 	KeyGuideAdmin = "guide.admin"
 )
@@ -89,7 +86,7 @@ func staticCatalog() []CatalogNode {
 		{Key: KeyPageTables, DisplayName: "Таблицы", Category: CatNavigation},
 		{Key: KeyPageEmployees, DisplayName: "Сотрудники", Category: CatNavigation},
 		{Key: KeyPageCars, DisplayName: "Автомобили", Category: CatNavigation},
-		{Key: KeyPageAnalytics, DisplayName: "Аналитика", Category: CatNavigation},
+		{Key: KeyPageStatistics, DisplayName: "Аналитика", Category: CatNavigation},
 		{Key: KeyPageAdmin, DisplayName: "Администрирование", Category: CatNavigation},
 		{Key: KeyPageNews, DisplayName: "Обзор и новости", Category: CatNavigation},
 		{Key: KeyPagePersonal, DisplayName: "Личный кабинет", Category: CatNavigation},
@@ -137,8 +134,9 @@ func staticCatalog() []CatalogNode {
 		{Key: KeyActionGrantAdmin, DisplayName: "Выдача прав администратора", Category: CatAdmin, SuperOnly: true},
 		{Key: KeyPageSystemControl, DisplayName: "Режим техработ", Category: CatAdmin, SuperOnly: true},
 
-		// Обзор и новости
-		{Key: KeyNewsManage, DisplayName: "Управление новостями и объявлениями", Category: CatOverview},
+		// Обзор и новости (управление новостями -- в Администрировании, /admin/news).
+		// guide.* остаются тумблерами, но их FE-гейтинг подключается отдельно после
+		// редизайна трёх вкладок руководства (пользователь/админ/охранник).
 		{Key: KeyGuideUser, DisplayName: "Руководство пользователя", Category: CatOverview},
 		{Key: KeyGuideAdmin, DisplayName: "Руководство администратора", Category: CatOverview},
 	}

--- a/internal/services/permission_catalog_test.go
+++ b/internal/services/permission_catalog_test.go
@@ -77,6 +77,23 @@ func TestIsValidKey(t *testing.T) {
 	}
 }
 
+// Гигиена каталога (#permission-gating срез 1): «Аналитика» гейтится реально
+// enforced ключом page.statistics, а не orphan page.analytics; управление новостями
+// живёт в Администрировании (/admin/news), отдельного тумблера news.manage на
+// «Обзор и новости» нет.
+func TestCatalogHygiene(t *testing.T) {
+	t.Parallel()
+	if !IsCatalogKey(KeyPageStatistics) {
+		t.Error("Аналитика должна гейтиться page.statistics (ключ обязан быть в каталоге)")
+	}
+	if IsCatalogKey("page.analytics") {
+		t.Error("orphan page.analytics не должен остаться в каталоге")
+	}
+	if IsCatalogKey("news.manage") {
+		t.Error("news.manage убран с «Обзор и новости» (управление новостями -- в Администрировании)")
+	}
+}
+
 func TestAllCatalogKeysMatchesSet(t *testing.T) {
 	t.Parallel()
 	keys := AllCatalogKeys()


### PR DESCRIPTION
## Что
Срез 1 эпика permission-gating (привести каталог точечных прав к реальному гейтингу).

- Убрал тумблер `news.manage` («Управление новостями и объявлениями») из категории «Обзор и новости». На этой странице управления новостями нет — оно в Администрировании (/admin/news), покрывается `page.admin` (далее гранулярно `page.admin.directories`).
- «Аналитика» гейтилась orphan-ключом `page.analytics`, которого фронт не проверяет (NavMenu/router используют `page.statistics`). Свёл каталог на реально enforced `page.statistics`, удалил мёртвую константу.
- Регресс-тест `TestCatalogHygiene` + синхронизировал мок-каталог в `UserAccessModal.spec.js`.

## Проверка
- `go test ./internal/services/ -run Catalog...` зелёный; сборка чистая; grep — висячих ссылок на удалённые константы нет.
- vitest `UserAccessModal.spec.js` — 7/7.
- Ревью code-reviewer пройдено (нашёл стейл-фикстуру `page.analytics` в UserAccessModal.spec — исправлено).

## Заметка
Файл `permission_catalog.go` в off-limits-зоне (permission_*); правка санкционирована (прямое указание по очистке каталога). guide.* НЕ трогаются — их гейтинг отложен до редизайна 3 вкладок руководства.