### PR TITLE
feat(permissions): подключил засеянные ключи прав - кнопка шапки «Подать заявку» и «Открыть заявку»

### DIFF
--- a/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
@@ -418,6 +418,7 @@ import LoaderSpinner from '@/components/ui/LoaderSpinner.vue';
 import AddToBlacklistModal from '@/components/admin/blacklist/AddToBlacklistModal.vue';
 import { useOverlayClose } from '@/composables/useOverlayClose';
 import { usePermissionsStore } from '@/stores/permissions';
+import { getModalActionPermission } from '@/constants/detailModalActions';
 import { useDeletionsStore } from '@/stores/deletions';
 import { listVehicleBlacklist, createVehicleBlacklist } from '@/api/blacklist';
 import { listMarks } from '@/api/marks';
@@ -516,10 +517,14 @@ export default {
             return this.source === 'application' ? 10003 : 10001;
         },
         // Намеренно НЕ зависит от showCarFeatures: на вкладке Автомобили features выкл,
-        // но переход в заявку нужен. Гейт - наличие заявки (как у EmployeeDetailsModal).
+        // но переход в заявку нужен. Гейт: право detail.open_application по контексту
+        // (карта detailModalActions, как у EmployeeDetailsModal) И наличие заявки.
         canOpenApplication() {
-            return this.source !== 'application' && this.source !== 'blacklist'
-                && !!(this.vehicle?.applicationId || this.vehicle?.application_id);
+            const perm = getModalActionPermission('vehicle', this.source, 'openApplication');
+            const allowed = typeof perm === 'boolean'
+                ? perm
+                : usePermissionsStore().hasPermission(perm);
+            return allowed && !!(this.vehicle?.applicationId || this.vehicle?.application_id);
         },
         // Кнопки в шапке: "Полная история" видна при showCarFeatures,
         // "Открыть заявку" - при canOpenApplication.

--- a/frontend/src/components/TheHeader/TheHeader.vue
+++ b/frontend/src/components/TheHeader/TheHeader.vue
@@ -81,7 +81,7 @@
         />
       </div>
       <div
-        v-if="can('page.new_application')"
+        v-if="can('header.create_application')"
         class="appl-btn__container"
       >
         <button
@@ -128,8 +128,9 @@ export default {
   emits: ['refresh-feedback'],
   setup() {
     // uiStore нужен для сдвига приветствия, когда рельс скрыт (плавающая кнопка
-    // возврата перекрывала бы заголовок). permissionsStore - гейт кнопки
-    // «Подать заявку» по праву page.new_application (#187 Фаза 2).
+    // возврата перекрывала бы заголовок). permissionsStore - гейт кнопок шапки:
+    // «Сообщить о проблеме» (header.report_problem) и «Подать заявку»
+    // (header.create_application, отдельно от nav «Новая заявка» = page.new_application).
     const uiStore = useUiStore();
     const permissionsStore = usePermissionsStore();
     return { uiStore, permissionsStore };

--- a/frontend/src/components/TheHeader/__tests__/TheHeader.reportProblem.spec.js
+++ b/frontend/src/components/TheHeader/__tests__/TheHeader.reportProblem.spec.js
@@ -55,3 +55,40 @@ describe('TheHeader — кнопка «Сообщить о проблеме» п
     expect(feedbackBtn(wrapper).exists()).toBe(true)
   })
 })
+
+describe('TheHeader — кнопка «Подать заявку» по праву header.create_application', () => {
+  let wrapper
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    hasPermission.mockReset()
+    global.IntersectionObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  })
+  afterEach(() => wrapper?.unmount())
+
+  const submitBtn = (w) => w.find('[data-testid="header-button-submit-app"]')
+
+  it('скрыта без права header.create_application', async () => {
+    hasPermission.mockReturnValue(false)
+    wrapper = mountHeader()
+    await flushPromises()
+    expect(submitBtn(wrapper).exists()).toBe(false)
+  })
+
+  it('видна при наличии header.create_application', async () => {
+    hasPermission.mockImplementation((key) => key === 'header.create_application')
+    wrapper = mountHeader()
+    await flushPromises()
+    expect(submitBtn(wrapper).exists()).toBe(true)
+  })
+
+  it('отвязана от page.new_application: только nav-право кнопку не показывает', async () => {
+    hasPermission.mockImplementation((key) => key === 'page.new_application')
+    wrapper = mountHeader()
+    await flushPromises()
+    expect(submitBtn(wrapper).exists()).toBe(false)
+  })
+})

--- a/frontend/src/constants/__tests__/detailModalActions.spec.js
+++ b/frontend/src/constants/__tests__/detailModalActions.spec.js
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { getModalActionPermission } from '@/constants/detailModalActions'
+
+describe('detailModalActions — openApplication гейтится detail.open_application', () => {
+  it('vehicle: контексты с переходом в заявку требуют detail.open_application', () => {
+    for (const src of ['carstable', 'facttable', 'general']) {
+      expect(getModalActionPermission('vehicle', src, 'openApplication')).toBe('detail.open_application')
+    }
+  })
+
+  it('employee: контексты с переходом в заявку требуют detail.open_application', () => {
+    for (const src of ['employeesview', 'peopletable', 'general']) {
+      expect(getModalActionPermission('employee', src, 'openApplication')).toBe('detail.open_application')
+    }
+  })
+
+  it('контекстно-скрытые остаются false (уже в заявке / корзина / ЧС / страница авто)', () => {
+    expect(getModalActionPermission('vehicle', 'application', 'openApplication')).toBe(false)
+    expect(getModalActionPermission('vehicle', 'carsview', 'openApplication')).toBe(false)
+    expect(getModalActionPermission('employee', 'application', 'openApplication')).toBe(false)
+    expect(getModalActionPermission('employee', 'trash', 'openApplication')).toBe(false)
+  })
+
+  it('не задел смежные действия: documents/blacklist прежние', () => {
+    expect(getModalActionPermission('vehicle', 'carsview', 'documents')).toBe('detail.documents')
+    expect(getModalActionPermission('employee', 'peopletable', 'blacklist')).toBe('page.admin.blacklist')
+  })
+})

--- a/frontend/src/constants/detailModalActions.js
+++ b/frontend/src/constants/detailModalActions.js
@@ -44,7 +44,7 @@ export const VEHICLE_MODAL_ACTIONS = {
   },
   carstable: {
     history:         'entity.cars.read',
-    openApplication: true,   // есть application_id, доступ без доп. права
+    openApplication: 'detail.open_application', // есть application_id; гейт по detail.open_application (базовая роль)
     blacklist:       'page.admin.blacklist',
     entryExit:       'entity.cars.read',
     documents:       false,
@@ -52,7 +52,7 @@ export const VEHICLE_MODAL_ACTIONS = {
   },
   facttable: {
     history:         'entity.cars.read',
-    openApplication: true,
+    openApplication: 'detail.open_application',
     blacklist:       'page.admin.blacklist',
     entryExit:       'entity.cars.read',
     documents:       false,
@@ -89,7 +89,7 @@ export const VEHICLE_MODAL_ACTIONS = {
   },
   general: {
     history:         'entity.cars.read',
-    openApplication: true,
+    openApplication: 'detail.open_application',
     blacklist:       'page.admin.blacklist',
     entryExit:       'entity.cars.read',
     documents:       'detail.documents',
@@ -116,7 +116,7 @@ export const EMPLOYEE_MODAL_ACTIONS = {
   employeesview: {
     // Страница «Сотрудники»: полный набор действий для имеющих право
     history:         'entity.employees.read',
-    openApplication: true,
+    openApplication: 'detail.open_application',
     blacklist:       'page.admin.blacklist',
     entryExit:       'entity.employees.read',
     documents:       'detail.documents',
@@ -137,7 +137,7 @@ export const EMPLOYEE_MODAL_ACTIONS = {
   peopletable: {
     // Таблица людей в центре заявок
     history:         'entity.employees.read',
-    openApplication: true,
+    openApplication: 'detail.open_application',
     blacklist:       'page.admin.blacklist',
     entryExit:       'entity.employees.read',
     documents:       'detail.documents',
@@ -161,7 +161,7 @@ export const EMPLOYEE_MODAL_ACTIONS = {
   },
   general: {
     history:         'entity.employees.read',
-    openApplication: true,
+    openApplication: 'detail.open_application',
     blacklist:       'page.admin.blacklist',
     entryExit:       'entity.employees.read',
     documents:       'detail.documents',


### PR DESCRIPTION
## Что
Срез 2 эпика permission-gating. Базовая роль «Пользователь» уже выдаёт гранулярные ключи, но фронт их не проверял («мёртвые тумблеры»). Подключил два:

- **`header.create_application`** — кнопка шапки «Подать заявку» (была на `page.new_application`). Теперь отдельный тумблер от nav «Новая заявка»; альтернативный путь подачи через nav сохранён.
- **`detail.open_application`** — действие «Открыть заявку» в карточках. В `detailModalActions` 6 контекстов (`true` -> ключ), false-контексты не тронуты. `EmployeeDetailsModal` уже резолвил карту; `VehicleDetailsModal` имел собственный `canOpenApplication` без проверки права — привёл к карте (симметрия + гейт реально применяется).

Без регрессий: оба ключа в базовой роли, админ/супер проходят всё.

## Передекомпозиция
Изначально срез включал вкладки реестров (`section.registry.organization/company` в EmployeeView/CarsView). E2E поймал регрессию: `e2e_user` создаётся без базовой роли (default-deny, 0 прав — см. TODO в navigation.spec/admin-access.spec про «расширение seed»), а вкладки до этого были data-driven, и гейт их корректно скрыл -> `cars/employees filter-tabs` упали. Вынес section.registry.* в срез 6, где сначала фикшу seed e2e_user (выдать базовую роль), потом гейчу вкладки. Здесь — только два чистых ключа.

## Проверка
- vitest: TheHeader (submit-button gating, отвязка от page.new_application) + detailModalActions (openApplication по контекстам) — 9/9; eslint чист.
- Греп тест-дерева: спеков на старое поведение нет; `securityOnboardingSteps.spec` утверждает, что тур охранника НЕ таргетит кнопку подачи — консистентно.
- Ревью code-reviewer: поймало неработавший гейт для машин (VehicleDetailsModal не читал карту) — исправлено; устаревший комментарий — исправлен.