### PR TITLE
feat(guide): бэкенд разделов руководства - модель, read-API, скачивание PDF

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -205,6 +205,7 @@ func main() {
 	documentFileService := services.NewDocumentFileService(cfg.UploadPath)
 	documentGroupService := services.NewDocumentGroupService(db)
 	documentService := services.NewDocumentService(db, documentFileService, settingsService)
+	guideService := services.NewGuideService(db, permissionResolver)
 	statisticsService := services.NewStatisticsService(db, time.Duration(cfg.AnalyticsCacheRefreshSec)*time.Second)
 
 	// Handlers
@@ -248,6 +249,7 @@ func main() {
 	trashHandler := handlers.NewTrashHandler(trashService, trashDBRef)
 	documentGroupHandler := handlers.NewDocumentGroupHandler(documentGroupService)
 	documentHandler := handlers.NewDocumentHandler(documentService, documentFileService)
+	guideHandler := handlers.NewGuideHandler(guideService, cfg.UploadPath)
 	statisticsHandler := handlers.NewStatisticsHandler(statisticsService)
 
 	// Swagger UI: http://localhost:8090/swagger/index.html
@@ -307,6 +309,7 @@ func main() {
 		Trash:               trashHandler,
 		DocumentGroups:      documentGroupHandler,
 		Documents:           documentHandler,
+		Guide:               guideHandler,
 		Statistics:          statisticsHandler,
 		Onboarding:          onboardingHandler,
 		PermResolver:        permissionResolver,

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -165,6 +165,9 @@ func AllModels() []interface{} {
 		&models.DocumentGroup{},
 		&models.Document{},
 
+		// Разделы руководства (B1): текст по ролям + метаданные PDF
+		&models.GuideSection{},
+
 		// Report templates (#632): сохранённые наборы конструктора отчётов
 		&models.ReportTemplate{},
 		// Дневные пики онлайна пользователей (#632): снимок фонового тикера
@@ -651,6 +654,60 @@ func Seed(db *gorm.DB) error {
 		slog.Error("failed to backfill user_types.is_system", "error", result.Error)
 	} else if result.RowsAffected > 0 {
 		slog.Info("backfilled user_types.is_system", "count", result.RowsAffected)
+	}
+
+	// Разделы руководства (B1): дефолтный контент-черновик по ролям. PDF грузится
+	// админом отдельно, поэтому file-поля пустые (в ответе file:null). Идемпотентно:
+	// сидим только когда таблица пуста, тексты в DB после этого правятся не сидом.
+	var guideCount int64
+	db.Model(&models.GuideSection{}).Count(&guideCount)
+	if guideCount == 0 {
+		slog.Info("seeding guide_sections")
+		jsonItems := func(items []string) json.RawMessage {
+			b, _ := json.Marshal(items)
+			return b
+		}
+		sections := []models.GuideSection{
+			{
+				Role:      "user",
+				SortOrder: 1,
+				Title:     "Руководство пользователя",
+				Lead:      "Для сотрудников организаций, которые подают заявки на въезд людей и автомобилей.",
+				Items: jsonItems([]string{
+					"Подача заявки: типы вложений (автозаявка, проведение работ, разовый пропуск), период и время прохода",
+					"Добавление сотрудников и автомобилей, выбор места разгрузки и таблицы прохода",
+					"Контроль статуса заявок в Центре заявок, согласующие, копирование номера",
+					"Личный кабинет: данные организации, уведомления, список заявок",
+				}),
+			},
+			{
+				Role:      "guard",
+				SortOrder: 2,
+				Title:     "Руководство охранника",
+				Lead:      "Для сотрудников охраны на постах: проверка пропусков и отметки въезда/выезда.",
+				Items: jsonItems([]string{
+					"Раздел «Доступные мне»: поиск, фильтры и сортировка по постам",
+					"Отметка въезда и выезда транспорта и людей",
+					"Таблицы постов и мест прохода, расписание работы",
+					"Действия при несоответствии данных заявки",
+				}),
+			},
+			{
+				Role:      "admin",
+				SortOrder: 3,
+				Title:     "Руководство администратора",
+				Lead:      "Для администраторов системы: управление справочниками, пользователями и правами.",
+				Items: jsonItems([]string{
+					"Учётные записи: создание пользователей, пароли, привязка к организациям",
+					"Организации, компании, отделы; места разгрузки и расписания",
+					"Конструктор таблиц (посты и места прохода), форматы номеров, отметки",
+					"Документы и руководства, объявления и новости",
+				}),
+			},
+		}
+		if err := db.Create(&sections).Error; err != nil {
+			return fmt.Errorf("failed to seed guide sections: %w", err)
+		}
 	}
 
 	// Organizations: глобальный uniqueIndex по name заменяем на partial unique

--- a/internal/handlers/guide.go
+++ b/internal/handlers/guide.go
@@ -1,0 +1,82 @@
+package handlers
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"systemburo/internal/services"
+
+	"github.com/labstack/echo/v4"
+)
+
+// GuideHandler -- разделы руководства (read-only API + скачивание PDF).
+type GuideHandler struct {
+	service   services.GuideService
+	uploadDir string
+}
+
+// NewGuideHandler. uploadPath -- корень uploads; PDF разделов лежат в uploads/guide.
+func NewGuideHandler(service services.GuideService, uploadPath string) *GuideHandler {
+	return &GuideHandler{
+		service:   service,
+		uploadDir: filepath.Join(uploadPath, "guide"),
+	}
+}
+
+// ListSections godoc
+// @Summary Разделы руководства, доступные пользователю
+// @Description Возвращает разделы (user/guard/admin), на которые есть право guide.<role>.
+// @Tags guide
+// @Produce json
+// @Success 200 {object} map[string]interface{}
+// @Security BearerAuth
+// @Router /guide/sections [get]
+func (h *GuideHandler) ListSections(c echo.Context) error {
+	userID := GetUserID(c)
+	sections, err := h.service.ListForUser(c.Request().Context(), userID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to load guide sections")
+	}
+	return RespondSuccess(c, sections)
+}
+
+// Download godoc
+// @Summary Скачать PDF раздела руководства
+// @Tags guide
+// @Param role path string true "Роль раздела (user|guard|admin)"
+// @Success 200 {file} binary
+// @Failure 403 {object} map[string]interface{}
+// @Failure 404 {object} map[string]interface{}
+// @Security BearerAuth
+// @Router /guide/sections/{role}/download [get]
+func (h *GuideHandler) Download(c echo.Context) error {
+	userID := GetUserID(c)
+	role := c.Param("role")
+	if !services.IsGuideRole(role) {
+		return echo.NewHTTPError(http.StatusNotFound, "guide section not found")
+	}
+
+	sec, allowed, err := h.service.GetSectionForUser(c.Request().Context(), userID, role)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to load guide section")
+	}
+	if !allowed {
+		return echo.NewHTTPError(http.StatusForbidden, "no access to this guide section")
+	}
+	if sec == nil || sec.StoredName == "" {
+		return echo.NewHTTPError(http.StatusNotFound, "guide file not available")
+	}
+
+	path := filepath.Join(h.uploadDir, sec.StoredName)
+	if _, statErr := os.Stat(path); statErr != nil {
+		return echo.NewHTTPError(http.StatusNotFound, "guide file not available")
+	}
+
+	name := sec.FileName
+	if name == "" {
+		name = "guide.pdf"
+	}
+	c.Response().Header().Set("Content-Disposition", `attachment; filename="`+sanitizeHeader(name)+`"`)
+	return c.File(path)
+}

--- a/internal/handlers/guide_test.go
+++ b/internal/handlers/guide_test.go
@@ -1,0 +1,85 @@
+package handlers_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Супер-админ видит все засеянные разделы руководства, items развёрнуты в массив,
+// file == nil пока PDF не загружен.
+func TestGuideSections_SuperAdminSeesAll(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	// Ключи раздела совпадают с каталогом прав (защита от молчаливого рассинхрона
+	// permission_catalog.go). guide.guard в каталоге пока нет (заводит perm-gating).
+	require.Equal(t, services.KeyGuideUser, services.GuideKeyForRole("user"))
+	require.Equal(t, services.KeyGuideAdmin, services.GuideKeyForRole("admin"))
+
+	token := testutil.RegisterAdmin(t, e, 0, 0)
+	rec := testutil.GET(t, e, "/guide/sections", testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	sections := testutil.ParseResponse[[]models.GuideSectionResponse](t, rec)
+	require.Len(t, sections, 3)
+
+	// Порядок по sort_order: user -> guard -> admin.
+	assert.Equal(t, "user", sections[0].Role)
+	assert.Equal(t, "guard", sections[1].Role)
+	assert.Equal(t, "admin", sections[2].Role)
+
+	assert.Equal(t, "Руководство пользователя", sections[0].Title)
+	assert.NotEmpty(t, sections[0].Lead)
+	require.NotEmpty(t, sections[0].Items, "items должны разворачиваться из jsonb в массив строк")
+	assert.Nil(t, sections[0].File, "file == nil пока PDF не загружен")
+}
+
+// Обычный пользователь с правом только на guide.user видит лишь свой раздел;
+// download гейтит та же проверка.
+func TestGuideSections_GatedByPermission(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	const username, password = "guideuser", "Password123!"
+	testutil.RegisterUser(t, e, username, password, 1, 0, 0)
+
+	var u models.User
+	require.NoError(t, db.Where("username = ?", username).First(&u).Error)
+	require.NoError(t, db.Create(&models.UserPermissionOverride{
+		UserID:        u.ID,
+		PermissionKey: services.KeyGuideUser,
+		Value:         "allow",
+		GrantedAt:     time.Now().UTC(),
+	}).Error)
+
+	token, _ := testutil.LoginUser(t, e, username, password)
+	h := testutil.AuthHeader(token)
+
+	rec := testutil.GET(t, e, "/guide/sections", h)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+	sections := testutil.ParseResponse[[]models.GuideSectionResponse](t, rec)
+	require.Len(t, sections, 1, "виден только раздел с выданным правом")
+	assert.Equal(t, "user", sections[0].Role)
+
+	// Разрешённый раздел без загруженного файла -> 404.
+	rec = testutil.GET(t, e, "/guide/sections/user/download", h)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+
+	// Запрещённый раздел -> 403 (нет права guide.admin).
+	rec = testutil.GET(t, e, "/guide/sections/admin/download", h)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+
+	// Неизвестная роль -> 404.
+	rec = testutil.GET(t, e, "/guide/sections/bogus/download", h)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}

--- a/internal/models/guide_section.go
+++ b/internal/models/guide_section.go
@@ -1,0 +1,46 @@
+package models
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// GuideSection -- раздел руководства по роли (user|guard|admin), раскладка «Вкладки».
+// Текст (lead + items) сидится дефолтным черновиком; PDF-файл загружается админом
+// в отдельном будущем срезе, поэтому file-поля до загрузки пустые и в ответе
+// отдаётся file:null. Доступ к разделу гейтится правом guide.<role>.
+type GuideSection struct {
+	ID            int             `json:"id"`
+	Role          string          `gorm:"size:20;uniqueIndex:uidx_guide_sections_role" json:"role"`
+	Title         string          `gorm:"size:255" json:"title"`
+	Lead          string          `gorm:"type:text" json:"lead"`
+	Items         json.RawMessage `gorm:"type:jsonb" json:"items"`
+	FileName      string          `gorm:"size:255" json:"file_name"`
+	StoredName    string          `gorm:"size:255" json:"stored_name"`
+	FileExt       string          `gorm:"size:10" json:"file_ext"`
+	MimeType      string          `gorm:"size:120" json:"mime_type"`
+	FileSize      int64           `json:"file_size"`
+	FileUpdatedAt *time.Time      `json:"file_updated_at"`
+	SortOrder     int             `gorm:"default:0" json:"sort_order"`
+	CreatedAt     time.Time       `json:"created_at"`
+	UpdatedAt     time.Time       `json:"updated_at"`
+}
+
+// GuideSectionResponse -- раздел руководства для фронта (модалка «Руководство»).
+type GuideSectionResponse struct {
+	Role  string         `json:"role"`
+	Title string         `json:"title"`
+	Lead  string         `json:"lead"`
+	Items []string       `json:"items"`
+	File  *GuideFileInfo `json:"file"`
+}
+
+// GuideFileInfo -- метаданные PDF раздела. nil пока файл не загружен.
+type GuideFileInfo struct {
+	Name        string    `json:"name"`
+	Ext         string    `json:"ext"`
+	MimeType    string    `json:"mime_type"`
+	Size        int64     `json:"size"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	DownloadURL string    `json:"download_url"`
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -54,6 +54,7 @@ type Dependencies struct {
 	Trash               *handlers.TrashHandler
 	DocumentGroups      *handlers.DocumentGroupHandler
 	Documents           *handlers.DocumentHandler
+	Guide               *handlers.GuideHandler
 	Statistics          *handlers.StatisticsHandler
 
 	// Services (для middleware и audit)
@@ -111,6 +112,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	trash := d.Trash
 	docGroups := d.DocumentGroups
 	docs := d.Documents
+	guide := d.Guide
 	statistics := d.Statistics
 	permResolver := d.PermResolver
 	denialLog := d.DenialLog
@@ -630,6 +632,15 @@ func Setup(e *echo.Echo, d Dependencies) {
 		docsGroup.GET("/:id/download", docs.Download)
 
 		protected.GET("/public/documents", docs.GetPublic)
+	}
+
+	// Руководство (B1). Любому авторизованному; список отдаёт только разделы, на
+	// которые есть право guide.<role>, скачивание гейтит ту же проверку в хендлере
+	// (динамический ключ по :role не выражается статическим middleware).
+	if guide != nil {
+		guideGroup := protected.Group("/guide")
+		guideGroup.GET("/sections", guide.ListSections)
+		guideGroup.GET("/sections/:role/download", guide.Download)
 	}
 
 	// Документ согласия на обработку данных. Просмотр/скачивание -- любому авторизованному

--- a/internal/services/guide_service.go
+++ b/internal/services/guide_service.go
@@ -1,0 +1,133 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"systemburo/internal/models"
+
+	"gorm.io/gorm"
+)
+
+// GuideRoles -- порядок ролей в раскладке «Вкладки».
+var GuideRoles = []string{"user", "guard", "admin"}
+
+// GuideKeyForRole возвращает permission-ключ раздела для роли. guide.user и
+// guide.admin уже описаны в каталоге прав (permission_catalog.go: KeyGuideUser,
+// KeyGuideAdmin) -- гейтинг идёт через PermissionResolver как по любому ключу,
+// ядро прав не затрагивается. guide.guard пока не заведён в каталоге (добавляет
+// perm-gating отдельным срезом), поэтому раздел «Охранник» до этого виден только
+// супер-админу; код роль-агностичен и подхватит ключ автоматически.
+func GuideKeyForRole(role string) string {
+	return "guide." + role
+}
+
+// IsGuideRole сообщает, известна ли роль руководства.
+func IsGuideRole(role string) bool {
+	for _, r := range GuideRoles {
+		if r == role {
+			return true
+		}
+	}
+	return false
+}
+
+// GuideService отдаёт разделы руководства с учётом прав пользователя.
+type GuideService interface {
+	// ListForUser возвращает разделы, на которые у пользователя есть право guide.<role>.
+	ListForUser(ctx context.Context, userID int) ([]models.GuideSectionResponse, error)
+	// GetSectionForUser возвращает раздел роли. allowed=false -- нет права на раздел;
+	// section=nil при allowed=true -- раздел ещё не заведён.
+	GetSectionForUser(ctx context.Context, userID int, role string) (section *models.GuideSection, allowed bool, err error)
+}
+
+type guideService struct {
+	db       *gorm.DB
+	resolver *PermissionResolver
+}
+
+// NewGuideService конструирует GuideService поверх PermissionResolver.
+func NewGuideService(db *gorm.DB, resolver *PermissionResolver) GuideService {
+	return &guideService{db: db, resolver: resolver}
+}
+
+func (s *guideService) ListForUser(ctx context.Context, userID int) ([]models.GuideSectionResponse, error) {
+	set, err := s.resolver.Resolve(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve permissions: %w", err)
+	}
+
+	var sections []models.GuideSection
+	if err := s.db.WithContext(ctx).Order("sort_order, id").Find(&sections).Error; err != nil {
+		return nil, fmt.Errorf("failed to load guide sections: %w", err)
+	}
+
+	result := make([]models.GuideSectionResponse, 0, len(sections))
+	for i := range sections {
+		sec := sections[i]
+		if !set.Has(GuideKeyForRole(sec.Role)) {
+			continue
+		}
+		resp, err := toGuideResponse(sec)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, resp)
+	}
+	return result, nil
+}
+
+func (s *guideService) GetSectionForUser(ctx context.Context, userID int, role string) (*models.GuideSection, bool, error) {
+	allowed, err := s.resolver.HasPermission(ctx, userID, GuideKeyForRole(role))
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to check guide permission: %w", err)
+	}
+	if !allowed {
+		return nil, false, nil
+	}
+
+	var sec models.GuideSection
+	if err := s.db.WithContext(ctx).Where("role = ?", role).First(&sec).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, true, nil
+		}
+		return nil, true, fmt.Errorf("failed to load guide section: %w", err)
+	}
+	return &sec, true, nil
+}
+
+// toGuideResponse разворачивает jsonb items в []string и собирает file-блок
+// (nil пока PDF не загружен).
+func toGuideResponse(sec models.GuideSection) (models.GuideSectionResponse, error) {
+	items := []string{}
+	if len(sec.Items) > 0 {
+		if err := json.Unmarshal(sec.Items, &items); err != nil {
+			return models.GuideSectionResponse{}, fmt.Errorf("failed to parse items for guide section %q: %w", sec.Role, err)
+		}
+	}
+
+	resp := models.GuideSectionResponse{
+		Role:  sec.Role,
+		Title: sec.Title,
+		Lead:  sec.Lead,
+		Items: items,
+	}
+
+	if sec.StoredName != "" {
+		updated := sec.UpdatedAt
+		if sec.FileUpdatedAt != nil {
+			updated = *sec.FileUpdatedAt
+		}
+		resp.File = &models.GuideFileInfo{
+			Name:        sec.FileName,
+			Ext:         sec.FileExt,
+			MimeType:    sec.MimeType,
+			Size:        sec.FileSize,
+			UpdatedAt:   updated,
+			DownloadURL: "/api/guide/sections/" + sec.Role + "/download",
+		}
+	}
+	return resp, nil
+}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -44,6 +44,7 @@ var tables = []string{
 	"role_default_groups", "permission_groups",
 	"user_permissions", "permissions",
 	"bug_reports",
+	"guide_sections",
 	"documents", "document_groups",
 	"request_log", "request_logs", "notifications", "news", "announcements",
 	"feedback", "application_items", "items",
@@ -152,6 +153,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	documentFileService := services.NewDocumentFileService("./uploads")
 	documentGroupService := services.NewDocumentGroupService(db)
 	documentService := services.NewDocumentService(db, documentFileService, settingsService)
+	guideService := services.NewGuideService(db, permissionResolver)
 
 	// Create all handlers
 	authHandler := handlers.NewAuthHandler(authService, maintenanceService, false, 168*time.Hour)
@@ -196,6 +198,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	trashHandler := handlers.NewTrashHandler(trashService, trashDBRef)
 	documentGroupHandler := handlers.NewDocumentGroupHandler(documentGroupService)
 	documentHandler := handlers.NewDocumentHandler(documentService, documentFileService)
+	guideHandler := handlers.NewGuideHandler(guideService, "./uploads")
 
 	// Setup Echo with routes (no rate limiter, no logger — clean for tests)
 	e := echo.New()
@@ -244,6 +247,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 		Trash:               trashHandler,
 		DocumentGroups:      documentGroupHandler,
 		Documents:           documentHandler,
+		Guide:               guideHandler,
 		PermResolver:        permissionResolver,
 		DenialLog:           accessDenialService,
 		JWTSecret:           []byte(TestJWTSecret),


### PR DESCRIPTION
Срез B1 эпика multitab-fixes (фаза «Руководство»). Бэкенд под модалку «Руководство» (3 раздела: Пользователь/Охранник/Администратор, раскладка «Вкладки» — мокап B0 согласован).

## Что внутри
- Модель `GuideSection` (роль с uniqueIndex, заголовок, lead, items в jsonb, метаданные PDF) + DTO `GuideSectionResponse`/`GuideFileInfo`.
- `GET /guide/sections` — отдаёт только разделы, на которые у пользователя есть право `guide.<role>` (фильтрация через `PermissionResolver`; super-admin видит все).
- `GET /guide/sections/:role/download` — скачивание PDF с проверкой того же права (403 без права, 404 при неизвестной роли/отсутствии файла).
- Аддитивная миграция: новая таблица `guide_sections` в `AllModels()`, идемпотентный сид трёх разделов (контент — согласованный черновик из мокапа).
- Интеграционные тесты в пакете `handlers` (super-admin видит 3; гейт-юзер с override `guide.user` видит 1; download 404/403/404).

## Права (важно, согласовано с владельцем)
Гейтинг роль-агностичен: ключ = `guide.<role>`. `guide.user` и `guide.admin` уже есть в каталоге прав (`permission_catalog.go`, добавлены perm-gating, на dev через #847). `guide.guard` в каталоге пока **нет** — его и нормальный доступ ко всем трём разделам настроит параллельная perm-gating сессия отдельно. До этого раздел «Охранник» виден только super-admin; код подхватит ключ автоматически без правок. **Ядро прав (permission_catalog/permission_service/middleware) не тронуто.**

PDF в B1 не загружается (сид без файла) → в ответе `file: null`. Загрузку/правку добавит будущий админ-срез (вне B1 по согласованию). FE-модалку перестраивает срез B2.

## Ревью
Прогнал `code-reviewer`: 1 must-fix (Content-Disposition без санитизации имени файла) — исправлен переиспользованием проектного `sanitizeHeader()`. Гейтинг/миграция/jsonb/тесты — чисто.

Полный `go test ./...` зелёный кроме известного pre-existing флака `TestLogPartitionMaintenance` (internal/database, копит строки на расшаренной локальной тест-БД; на чистой БД CI зелёный). Пакет `handlers` со всем новым кодом — зелёный.
