### PR TITLE
feat(guide): админ-управление руководством - загрузка PDF и правка текста разделов (B1b)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -203,6 +203,7 @@ func main() {
 	trashService := services.NewTrashService(db)
 	trashDBRef := services.NewTrashDBRef(db)
 	documentFileService := services.NewDocumentFileService(cfg.UploadPath)
+	guideFileService := services.NewDocumentFileServiceIn(cfg.UploadPath, "guide")
 	documentGroupService := services.NewDocumentGroupService(db)
 	documentService := services.NewDocumentService(db, documentFileService, settingsService)
 	guideService := services.NewGuideService(db, permissionResolver)
@@ -249,7 +250,7 @@ func main() {
 	trashHandler := handlers.NewTrashHandler(trashService, trashDBRef)
 	documentGroupHandler := handlers.NewDocumentGroupHandler(documentGroupService)
 	documentHandler := handlers.NewDocumentHandler(documentService, documentFileService)
-	guideHandler := handlers.NewGuideHandler(guideService, cfg.UploadPath)
+	guideHandler := handlers.NewGuideHandler(guideService, guideFileService, cfg.UploadMaxFileSize)
 	statisticsHandler := handlers.NewStatisticsHandler(statisticsService)
 
 	// Swagger UI: http://localhost:8090/swagger/index.html

--- a/internal/handlers/guide.go
+++ b/internal/handlers/guide.go
@@ -1,27 +1,39 @@
 package handlers
 
 import (
+	"errors"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"systemburo/internal/services"
 
 	"github.com/labstack/echo/v4"
 )
 
-// GuideHandler -- разделы руководства (read-only API + скачивание PDF).
+// GuideHandler -- разделы руководства: read-only API + скачивание PDF (B1) и
+// админ-управление (правка текста + PDF-файл по разделу, B1b; авторизация page.admin
+// на роут-middleware).
 type GuideHandler struct {
-	service   services.GuideService
-	uploadDir string
+	service     services.GuideService
+	fileSvc     services.DocumentFileService
+	maxFileSize int64
 }
 
-// NewGuideHandler. uploadPath -- корень uploads; PDF разделов лежат в uploads/guide.
-func NewGuideHandler(service services.GuideService, uploadPath string) *GuideHandler {
+// NewGuideHandler. fileSvc указывает на uploads/guide (см. main.go), maxFileSize -- лимит PDF.
+func NewGuideHandler(service services.GuideService, fileSvc services.DocumentFileService, maxFileSize int64) *GuideHandler {
 	return &GuideHandler{
-		service:   service,
-		uploadDir: filepath.Join(uploadPath, "guide"),
+		service:     service,
+		fileSvc:     fileSvc,
+		maxFileSize: maxFileSize,
 	}
+}
+
+// updateGuideContentRequest -- правка текста раздела руководства.
+type updateGuideContentRequest struct {
+	Lead  string   `json:"lead"`
+	Items []string `json:"items"`
 }
 
 // ListSections godoc
@@ -68,7 +80,7 @@ func (h *GuideHandler) Download(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusNotFound, "guide file not available")
 	}
 
-	path := filepath.Join(h.uploadDir, sec.StoredName)
+	path := filepath.Join(h.fileSvc.UploadDir(), sec.StoredName)
 	if _, statErr := os.Stat(path); statErr != nil {
 		return echo.NewHTTPError(http.StatusNotFound, "guide file not available")
 	}
@@ -79,4 +91,139 @@ func (h *GuideHandler) Download(c echo.Context) error {
 	}
 	c.Response().Header().Set("Content-Disposition", `attachment; filename="`+sanitizeHeader(name)+`"`)
 	return c.File(path)
+}
+
+// AdminListSections godoc
+// @Summary Все разделы руководства (админ-управление)
+// @Description Возвращает все разделы без фильтра по правам. Гейт page.admin.
+// @Tags guide
+// @Produce json
+// @Success 200 {object} map[string]interface{}
+// @Security BearerAuth
+// @Router /guide/admin/sections [get]
+func (h *GuideHandler) AdminListSections(c echo.Context) error {
+	sections, err := h.service.ListAll(c.Request().Context())
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to load guide sections")
+	}
+	return RespondSuccess(c, sections)
+}
+
+// UpdateSection godoc
+// @Summary Правка текста раздела руководства (lead + items)
+// @Tags guide
+// @Accept json
+// @Produce json
+// @Param role path string true "Роль раздела (user|guard|admin)"
+// @Param request body updateGuideContentRequest true "lead + items"
+// @Success 200 {object} map[string]interface{}
+// @Failure 404 {object} map[string]interface{}
+// @Security BearerAuth
+// @Router /guide/admin/sections/{role} [put]
+func (h *GuideHandler) UpdateSection(c echo.Context) error {
+	role := c.Param("role")
+	if !services.IsGuideRole(role) {
+		return echo.NewHTTPError(http.StatusNotFound, "guide section not found")
+	}
+
+	var req updateGuideContentRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+
+	items := make([]string, 0, len(req.Items))
+	for _, it := range req.Items {
+		if trimmed := strings.TrimSpace(it); trimmed != "" {
+			items = append(items, trimmed)
+		}
+	}
+
+	resp, err := h.service.UpdateContent(c.Request().Context(), role, strings.TrimSpace(req.Lead), items)
+	if err != nil {
+		return mapGuideError(err)
+	}
+	return RespondSuccess(c, resp)
+}
+
+// UploadFile godoc
+// @Summary Загрузить/заменить PDF раздела руководства
+// @Tags guide
+// @Accept multipart/form-data
+// @Produce json
+// @Param role path string true "Роль раздела (user|guard|admin)"
+// @Param file formData file true "PDF-файл"
+// @Success 200 {object} map[string]interface{}
+// @Failure 400 {object} map[string]interface{}
+// @Failure 404 {object} map[string]interface{}
+// @Security BearerAuth
+// @Router /guide/admin/sections/{role}/file [put]
+func (h *GuideHandler) UploadFile(c echo.Context) error {
+	role := c.Param("role")
+	if !services.IsGuideRole(role) {
+		return echo.NewHTTPError(http.StatusNotFound, "guide section not found")
+	}
+
+	file, err := c.FormFile("file")
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Файл не передан")
+	}
+	if strings.ToLower(filepath.Ext(file.Filename)) != ".pdf" {
+		return echo.NewHTTPError(http.StatusBadRequest, "Недопустимый тип файла. Разрешён только PDF")
+	}
+
+	ctx := c.Request().Context()
+	// Save валидирует размер и magic-байты %PDF (familyPDF), сохраняет в uploads/guide.
+	storedName, savedExt, err := h.fileSvc.Save(ctx, file, h.maxFileSize)
+	if err != nil {
+		return err
+	}
+
+	resp, oldStored, err := h.service.SetFile(ctx, role, services.GuideFileMeta{
+		StoredName: storedName,
+		FileName:   file.Filename,
+		Ext:        savedExt,
+		MimeType:   services.DetectMimeType(savedExt),
+		Size:       file.Size,
+	})
+	if err != nil {
+		h.fileSvc.Delete(storedName)
+		return mapGuideError(err)
+	}
+	if oldStored != "" && oldStored != storedName {
+		h.fileSvc.Delete(oldStored)
+	}
+	return RespondSuccess(c, resp)
+}
+
+// DeleteFile godoc
+// @Summary Удалить PDF раздела руководства
+// @Tags guide
+// @Produce json
+// @Param role path string true "Роль раздела (user|guard|admin)"
+// @Success 200 {object} map[string]interface{}
+// @Failure 404 {object} map[string]interface{}
+// @Security BearerAuth
+// @Router /guide/admin/sections/{role}/file [delete]
+func (h *GuideHandler) DeleteFile(c echo.Context) error {
+	role := c.Param("role")
+	if !services.IsGuideRole(role) {
+		return echo.NewHTTPError(http.StatusNotFound, "guide section not found")
+	}
+
+	resp, oldStored, err := h.service.ClearFile(c.Request().Context(), role)
+	if err != nil {
+		return mapGuideError(err)
+	}
+	if oldStored != "" {
+		h.fileSvc.Delete(oldStored)
+	}
+	return RespondSuccess(c, resp)
+}
+
+// mapGuideError переводит доменные ошибки сервиса в HTTP-статусы.
+func mapGuideError(err error) error {
+	if errors.Is(err, services.ErrGuideSectionNotFound) {
+		return echo.NewHTTPError(http.StatusNotFound, "guide section not found")
+	}
+	return echo.NewHTTPError(http.StatusInternalServerError, "failed to update guide section")
 }

--- a/internal/handlers/guide_test.go
+++ b/internal/handlers/guide_test.go
@@ -1,7 +1,11 @@
 package handlers_test
 
 import (
+	"bytes"
 	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -9,9 +13,33 @@ import (
 	"systemburo/internal/services"
 	"systemburo/internal/testutil"
 
+	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
+
+// guideStoredName читает stored_name раздела из БД (для проверки файла на диске).
+func guideStoredName(t *testing.T, db *gorm.DB, role string) string {
+	t.Helper()
+	var sec models.GuideSection
+	require.NoError(t, db.Where("role = ?", role).First(&sec).Error)
+	return sec.StoredName
+}
+
+// uploadGuideFile грузит PDF раздела руководства multipart-запросом (PUT) от имени token.
+func uploadGuideFile(t *testing.T, e *echo.Echo, token, role, filename string, content []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	body, ct := buildMultipartDoc(t, filename, content, nil)
+	req := httptest.NewRequest(http.MethodPut, "/api/guide/admin/sections/"+role+"/file", body)
+	req.Header.Set("Content-Type", ct)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	return rec
+}
 
 // Супер-админ видит все засеянные разделы руководства, items развёрнуты в массив,
 // file == nil пока PDF не загружен.
@@ -82,4 +110,194 @@ func TestGuideSections_GatedByPermission(t *testing.T) {
 	// Неизвестная роль -> 404.
 	rec = testutil.GET(t, e, "/guide/sections/bogus/download", h)
 	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// minimalGuidePDF -- корректная PDF magic-сигнатура (%PDF) для тестов загрузки.
+var minimalGuidePDF = []byte("%PDF-1.4\n1 0 obj<<>>endobj\ntrailer<<>>\n%%EOF\n")
+
+// Админ (page.admin) видит все 3 раздела через admin-листинг без фильтра по правам.
+func TestGuide_AdminList_AllSections(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	token := testutil.RegisterAdmin(t, e, 0, 0)
+	rec := testutil.GET(t, e, "/guide/admin/sections", testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	sections := testutil.ParseResponse[[]models.GuideSectionResponse](t, rec)
+	require.Len(t, sections, 3)
+	assert.Equal(t, "user", sections[0].Role)
+	assert.Equal(t, "guard", sections[1].Role)
+	assert.Equal(t, "admin", sections[2].Role)
+	assert.Nil(t, sections[0].File, "file == nil пока PDF не загружен")
+}
+
+// Правка lead+items раздела сохраняется и видна в последующем ответе; пустые элементы
+// отбрасываются.
+func TestGuide_AdminUpdateContent(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	token := testutil.RegisterAdmin(t, e, 0, 0)
+	h := testutil.AuthHeader(token)
+
+	body := `{"lead":"Новый лид охранника","items":["Первый пункт","   ","Второй пункт"]}`
+	rec := testutil.PUT(t, e, "/guide/admin/sections/guard", body, h)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	updated := testutil.ParseResponse[models.GuideSectionResponse](t, rec)
+	assert.Equal(t, "guard", updated.Role)
+	assert.Equal(t, "Новый лид охранника", updated.Lead)
+	require.Equal(t, []string{"Первый пункт", "Второй пункт"}, updated.Items, "пустые элементы отброшены")
+
+	// Повторное чтение из admin-листинга отражает правку.
+	list := testutil.ParseResponse[[]models.GuideSectionResponse](t,
+		testutil.GET(t, e, "/guide/admin/sections", h))
+	require.Len(t, list, 3)
+	assert.Equal(t, "Новый лид охранника", list[1].Lead)
+}
+
+// Невалидная роль раздела -> 404.
+func TestGuide_AdminUpdateContent_InvalidRole(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	token := testutil.RegisterAdmin(t, e, 0, 0)
+	rec := testutil.PUT(t, e, "/guide/admin/sections/bogus", `{"lead":"x","items":[]}`, testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// Загрузка PDF: метаданные появляются в ответе и в admin-листинге, файл скачивается.
+func TestGuide_AdminUploadFile_Success(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	token := testutil.RegisterAdmin(t, e, 0, 0)
+	h := testutil.AuthHeader(token)
+
+	rec := uploadGuideFile(t, e, token, "user", "Инструкция.pdf", minimalGuidePDF)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	resp := testutil.ParseResponse[models.GuideSectionResponse](t, rec)
+	require.NotNil(t, resp.File)
+	assert.Equal(t, "Инструкция.pdf", resp.File.Name)
+	assert.Equal(t, ".pdf", resp.File.Ext)
+	assert.Equal(t, "application/pdf", resp.File.MimeType)
+	assert.Greater(t, resp.File.Size, int64(0))
+	assert.Equal(t, "/api/guide/sections/user/download", resp.File.DownloadURL)
+
+	// Admin-листинг показывает загруженный файл.
+	list := testutil.ParseResponse[[]models.GuideSectionResponse](t,
+		testutil.GET(t, e, "/guide/admin/sections", h))
+	require.NotNil(t, list[0].File)
+
+	// Реальное скачивание отдаёт PDF.
+	dl := testutil.GET(t, e, "/guide/sections/user/download", h)
+	require.Equal(t, http.StatusOK, dl.Code)
+	assert.True(t, bytes.HasPrefix(dl.Body.Bytes(), []byte("%PDF")), "тело -- PDF")
+	assert.Contains(t, dl.Header().Get("Content-Disposition"), "attachment")
+}
+
+// Замена файла: повторная загрузка успешна, старый файл удаляется с диска,
+// скачивание отдаёт новый.
+func TestGuide_AdminUploadFile_Replace(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	token := testutil.RegisterAdmin(t, e, 0, 0)
+	require.Equal(t, http.StatusOK, uploadGuideFile(t, e, token, "user", "v1.pdf", minimalGuidePDF).Code)
+	oldStored := guideStoredName(t, db, "user")
+	guideDir := filepath.Join("uploads", "guide")
+	_, statErr := os.Stat(filepath.Join(guideDir, oldStored))
+	require.NoError(t, statErr, "первый файл должен лежать на диске")
+
+	rec := uploadGuideFile(t, e, token, "user", "v2.pdf", minimalGuidePDF)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+	resp := testutil.ParseResponse[models.GuideSectionResponse](t, rec)
+	require.NotNil(t, resp.File)
+	assert.Equal(t, "v2.pdf", resp.File.Name)
+
+	newStored := guideStoredName(t, db, "user")
+	require.NotEqual(t, oldStored, newStored, "storedName должен смениться")
+	_, statErr = os.Stat(filepath.Join(guideDir, oldStored))
+	assert.True(t, os.IsNotExist(statErr), "старый файл удалён с диска (без orphan)")
+	_, statErr = os.Stat(filepath.Join(guideDir, newStored))
+	assert.NoError(t, statErr, "новый файл лежит на диске")
+
+	dl := testutil.GET(t, e, "/guide/sections/user/download", testutil.AuthHeader(token))
+	assert.Equal(t, http.StatusOK, dl.Code)
+}
+
+// Не-PDF расширение -> 400 (guide принимает только PDF).
+func TestGuide_AdminUploadFile_NonPDFExt(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	token := testutil.RegisterAdmin(t, e, 0, 0)
+	rec := uploadGuideFile(t, e, token, "user", "doc.docx", []byte("PK\x03\x04zzz"))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// .pdf по имени, но содержимое не PDF -> 400 (magic-проверка DocumentFileService).
+func TestGuide_AdminUploadFile_WrongMagic(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	token := testutil.RegisterAdmin(t, e, 0, 0)
+	content := append([]byte{0x4D, 0x5A}, bytes.Repeat([]byte("x"), 100)...)
+	rec := uploadGuideFile(t, e, token, "user", "fake.pdf", content)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// Удаление файла очищает метаданные; скачивание после удаления -> 404.
+func TestGuide_AdminDeleteFile(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	token := testutil.RegisterAdmin(t, e, 0, 0)
+	h := testutil.AuthHeader(token)
+	require.Equal(t, http.StatusOK, uploadGuideFile(t, e, token, "user", "g.pdf", minimalGuidePDF).Code)
+
+	del := testutil.DELETE(t, e, "/guide/admin/sections/user/file", h)
+	require.Equal(t, http.StatusOK, del.Code, "body: %s", del.Body.String())
+	resp := testutil.ParseResponse[models.GuideSectionResponse](t, del)
+	assert.Nil(t, resp.File, "file == nil после удаления")
+
+	dl := testutil.GET(t, e, "/guide/sections/user/download", h)
+	assert.Equal(t, http.StatusNotFound, dl.Code)
+}
+
+// Не-админ получает 403 на всех admin-эндпоинтах руководства (гейт page.admin).
+func TestGuide_Admin_NonAdmin_Forbidden(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	user := testutil.RegisterAndLogin(t, e, "guide_nonadmin", "password123456789012345678901234", 1, 0, 0)
+	h := testutil.AuthHeader(user)
+
+	assert.Equal(t, http.StatusForbidden, testutil.GET(t, e, "/guide/admin/sections", h).Code)
+	assert.Equal(t, http.StatusForbidden, testutil.PUT(t, e, "/guide/admin/sections/user", `{"lead":"x","items":[]}`, h).Code)
+	assert.Equal(t, http.StatusForbidden, uploadGuideFile(t, e, user, "user", "g.pdf", minimalGuidePDF).Code)
+	assert.Equal(t, http.StatusForbidden, testutil.DELETE(t, e, "/guide/admin/sections/user/file", h).Code)
+}
+
+// Без токена admin-эндпоинты руководства отвечают 401.
+func TestGuide_Admin_Unauthenticated(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	assert.Equal(t, http.StatusUnauthorized, testutil.GET(t, e, "/guide/admin/sections", nil).Code)
+	assert.Equal(t, http.StatusUnauthorized, testutil.PUT(t, e, "/guide/admin/sections/user", `{"lead":"x","items":[]}`, nil).Code)
+	assert.Equal(t, http.StatusUnauthorized, uploadGuideFile(t, e, "", "user", "g.pdf", minimalGuidePDF).Code)
+	assert.Equal(t, http.StatusUnauthorized, testutil.DELETE(t, e, "/guide/admin/sections/user/file", nil).Code)
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -641,6 +641,12 @@ func Setup(e *echo.Echo, d Dependencies) {
 		guideGroup := protected.Group("/guide")
 		guideGroup.GET("/sections", guide.ListSections)
 		guideGroup.GET("/sections/:role/download", guide.Download)
+
+		// Админ-управление (B1b): правка текста раздела + загрузка/удаление PDF. Гейт page.admin.
+		guideGroup.GET("/admin/sections", guide.AdminListSections, requireAdmin)
+		guideGroup.PUT("/admin/sections/:role", guide.UpdateSection, requireAdmin)
+		guideGroup.PUT("/admin/sections/:role/file", guide.UploadFile, requireAdmin)
+		guideGroup.DELETE("/admin/sections/:role/file", guide.DeleteFile, requireAdmin)
 	}
 
 	// Документ согласия на обработку данных. Просмотр/скачивание -- любому авторизованному

--- a/internal/services/document_file_service.go
+++ b/internal/services/document_file_service.go
@@ -63,10 +63,18 @@ type documentFileService struct {
 	uploadDir string
 }
 
-// NewDocumentFileService создаёт DocumentFileService. uploadPath -- корневая папка uploads.
+// NewDocumentFileService создаёт DocumentFileService для документов (uploads/documents).
+// uploadPath -- корневая папка uploads.
 func NewDocumentFileService(uploadPath string) DocumentFileService {
+	return NewDocumentFileServiceIn(uploadPath, "documents")
+}
+
+// NewDocumentFileServiceIn создаёт DocumentFileService с произвольным подкаталогом
+// внутри uploads (напр. "guide" для PDF разделов руководства). Валидация и magic-bytes
+// те же, что у документов; ограничение по типу (только PDF и т.п.) накладывает вызывающий хендлер.
+func NewDocumentFileServiceIn(uploadPath, subdir string) DocumentFileService {
 	return &documentFileService{
-		uploadDir: filepath.Join(uploadPath, "documents"),
+		uploadDir: filepath.Join(uploadPath, subdir),
 	}
 }
 

--- a/internal/services/guide_service.go
+++ b/internal/services/guide_service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"systemburo/internal/models"
 
@@ -34,13 +35,36 @@ func IsGuideRole(role string) bool {
 	return false
 }
 
-// GuideService отдаёт разделы руководства с учётом прав пользователя.
+// ErrGuideSectionNotFound -- раздел с такой ролью не заведён (хотя роль валидна).
+var ErrGuideSectionNotFound = errors.New("guide section not found")
+
+// GuideFileMeta -- метаданные PDF, сохранённого на диск (заполняет хендлер после Save).
+type GuideFileMeta struct {
+	StoredName string
+	FileName   string
+	Ext        string
+	MimeType   string
+	Size       int64
+}
+
+// GuideService отдаёт разделы руководства с учётом прав пользователя и админ-управление
+// (правка текста + PDF-файл по разделу; авторизация page.admin -- на роут-middleware).
 type GuideService interface {
 	// ListForUser возвращает разделы, на которые у пользователя есть право guide.<role>.
 	ListForUser(ctx context.Context, userID int) ([]models.GuideSectionResponse, error)
 	// GetSectionForUser возвращает раздел роли. allowed=false -- нет права на раздел;
 	// section=nil при allowed=true -- раздел ещё не заведён.
 	GetSectionForUser(ctx context.Context, userID int, role string) (section *models.GuideSection, allowed bool, err error)
+
+	// ListAll возвращает все разделы (для админ-управления), без фильтра по правам.
+	ListAll(ctx context.Context) ([]models.GuideSectionResponse, error)
+	// UpdateContent правит lead и items раздела. items сохраняются как jsonb.
+	UpdateContent(ctx context.Context, role, lead string, items []string) (*models.GuideSectionResponse, error)
+	// SetFile записывает метаданные нового PDF раздела. oldStored -- прежний storedName
+	// (для удаления файла с диска вызывающим хендлером после успешной записи).
+	SetFile(ctx context.Context, role string, meta GuideFileMeta) (resp *models.GuideSectionResponse, oldStored string, err error)
+	// ClearFile очищает метаданные PDF раздела. oldStored -- удалённый storedName.
+	ClearFile(ctx context.Context, role string) (resp *models.GuideSectionResponse, oldStored string, err error)
 }
 
 type guideService struct {
@@ -96,6 +120,116 @@ func (s *guideService) GetSectionForUser(ctx context.Context, userID int, role s
 		return nil, true, fmt.Errorf("failed to load guide section: %w", err)
 	}
 	return &sec, true, nil
+}
+
+func (s *guideService) ListAll(ctx context.Context) ([]models.GuideSectionResponse, error) {
+	var sections []models.GuideSection
+	if err := s.db.WithContext(ctx).Order("sort_order, id").Find(&sections).Error; err != nil {
+		return nil, fmt.Errorf("failed to load guide sections: %w", err)
+	}
+	result := make([]models.GuideSectionResponse, 0, len(sections))
+	for i := range sections {
+		resp, err := toGuideResponse(sections[i])
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, resp)
+	}
+	return result, nil
+}
+
+func (s *guideService) UpdateContent(ctx context.Context, role, lead string, items []string) (*models.GuideSectionResponse, error) {
+	sec, err := s.findSection(ctx, role)
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := json.Marshal(items)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal guide items: %w", err)
+	}
+	if err := s.db.WithContext(ctx).Model(sec).Updates(map[string]any{"lead": lead, "items": raw}).Error; err != nil {
+		return nil, fmt.Errorf("failed to update guide section: %w", err)
+	}
+	sec.Lead = lead
+	sec.Items = raw
+	return responsePtr(*sec)
+}
+
+func (s *guideService) SetFile(ctx context.Context, role string, meta GuideFileMeta) (*models.GuideSectionResponse, string, error) {
+	sec, err := s.findSection(ctx, role)
+	if err != nil {
+		return nil, "", err
+	}
+	oldStored := sec.StoredName
+
+	now := time.Now().UTC()
+	if err := s.db.WithContext(ctx).Model(sec).Updates(map[string]any{
+		"file_name":       meta.FileName,
+		"stored_name":     meta.StoredName,
+		"file_ext":        meta.Ext,
+		"mime_type":       meta.MimeType,
+		"file_size":       meta.Size,
+		"file_updated_at": now,
+	}).Error; err != nil {
+		return nil, "", fmt.Errorf("failed to save guide file meta: %w", err)
+	}
+	sec.FileName, sec.StoredName, sec.FileExt = meta.FileName, meta.StoredName, meta.Ext
+	sec.MimeType, sec.FileSize, sec.FileUpdatedAt = meta.MimeType, meta.Size, &now
+	resp, err := responsePtr(*sec)
+	if err != nil {
+		return nil, "", err
+	}
+	return resp, oldStored, nil
+}
+
+func (s *guideService) ClearFile(ctx context.Context, role string) (*models.GuideSectionResponse, string, error) {
+	sec, err := s.findSection(ctx, role)
+	if err != nil {
+		return nil, "", err
+	}
+	oldStored := sec.StoredName
+	if err := s.db.WithContext(ctx).Model(sec).Updates(map[string]any{
+		"file_name":       "",
+		"stored_name":     "",
+		"file_ext":        "",
+		"mime_type":       "",
+		"file_size":       0,
+		"file_updated_at": nil,
+	}).Error; err != nil {
+		return nil, "", fmt.Errorf("failed to clear guide file meta: %w", err)
+	}
+	sec.FileName, sec.StoredName, sec.FileExt = "", "", ""
+	sec.MimeType, sec.FileSize, sec.FileUpdatedAt = "", 0, nil
+	resp, err := responsePtr(*sec)
+	if err != nil {
+		return nil, "", err
+	}
+	return resp, oldStored, nil
+}
+
+// findSection грузит раздел по роли; ErrGuideSectionNotFound если роль валидна, но раздела нет.
+func (s *guideService) findSection(ctx context.Context, role string) (*models.GuideSection, error) {
+	if !IsGuideRole(role) {
+		return nil, ErrGuideSectionNotFound
+	}
+	var sec models.GuideSection
+	if err := s.db.WithContext(ctx).Where("role = ?", role).First(&sec).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrGuideSectionNotFound
+		}
+		return nil, fmt.Errorf("failed to load guide section: %w", err)
+	}
+	return &sec, nil
+}
+
+// responsePtr собирает ответ из раздела (уже с применёнными правками в памяти).
+func responsePtr(sec models.GuideSection) (*models.GuideSectionResponse, error) {
+	resp, err := toGuideResponse(sec)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
 }
 
 // toGuideResponse разворачивает jsonb items в []string и собирает file-блок

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -151,6 +151,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	trashService := services.NewTrashService(db)
 	trashDBRef := services.NewTrashDBRef(db)
 	documentFileService := services.NewDocumentFileService("./uploads")
+	guideFileService := services.NewDocumentFileServiceIn("./uploads", "guide")
 	documentGroupService := services.NewDocumentGroupService(db)
 	documentService := services.NewDocumentService(db, documentFileService, settingsService)
 	guideService := services.NewGuideService(db, permissionResolver)
@@ -198,7 +199,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	trashHandler := handlers.NewTrashHandler(trashService, trashDBRef)
 	documentGroupHandler := handlers.NewDocumentGroupHandler(documentGroupService)
 	documentHandler := handlers.NewDocumentHandler(documentService, documentFileService)
-	guideHandler := handlers.NewGuideHandler(guideService, "./uploads")
+	guideHandler := handlers.NewGuideHandler(guideService, guideFileService, 10*1024*1024)
 
 	// Setup Echo with routes (no rate limiter, no logger — clean for tests)
 	e := echo.New()


### PR DESCRIPTION
Срез B1b эпика multitab-fixes (бэкенд). После B1 (#849, модель+read-API+download) и B2 (#851, фронт-модалка).

## Что
Admin-эндпоинты под гейтом `page.admin` (requireAdmin) для управления разделами руководства:
- `GET /guide/admin/sections` - все разделы без фильтра по правам;
- `PUT /guide/admin/sections/:role` - правка lead + items (пустые элементы отбрасываются);
- `PUT /guide/admin/sections/:role/file` - загрузка/замена PDF;
- `DELETE /guide/admin/sections/:role/file` - удаление PDF.

PDF валидируется и сохраняется переиспользованным `DocumentFileService` (magic-байты %PDF + лимит размера) в `uploads/guide` через новый конструктор `NewDocumentFileServiceIn(uploadPath, subdir)`. Хендлер ограничивает тип только PDF. Порядок: сохранить на диск -> записать метаданные в БД -> удалить старый файл (откат нового при сбое БД, защита от orphan).

Ядро прав не тронуто: гейт - существующий `requireAdmin`/`page.admin`.

## Ревью (code-reviewer, GO без блокеров)
- Убрал окно «БД записана, повторное чтение упало -> новый файл удалён»: ответ строится из раздела в памяти, без второго запроса.
- Добавил тест 401 (без токена) на все 4 admin-роута.
- Replace-тест теперь проверяет, что старый файл реально удалён с диска.
- Двойную проверку `IsGuideRole` в сервисе оставил осознанно (defensive, сервис безопасен независимо от хендлера).

## Тесты
`go test ./internal/handlers ./internal/services` - зелёные (handlers 107s). Новые: admin-листинг, правка текста, загрузка PDF (success/replace+disk-cleanup/wrong-magic/non-pdf), удаление, 403 non-admin, 401 unauth, invalid-role 404.

## Не входит
FE админ-UI руководства - отдельный срез B1c (непроектированная поверхность: admin-роут, эталонная структура, пункт навигации).