### PR TITLE
feat(permissions): подключил гранулярные права истории в карточках авто и сотрудника

### DIFF
--- a/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
@@ -551,7 +551,7 @@ export default {
             return 'Детальная информация о сотруднике';
         },
         showHistoryButton() {
-            return this.source !== 'employeeslist';
+            return this.source !== 'employeeslist' && this.canSeeFullHistory;
         },
         entryExitHistory() {
             return this.history.filter(item => item.action_type === 'entry' || item.action_type === 'exit');
@@ -572,10 +572,22 @@ export default {
             return this.source !== 'employeeslist' && this.source !== 'trash';
         },
         showHistorySection() {
-            return this.source !== 'employeeslist';
+            return this.source !== 'employeeslist' && this.canSeeEntryExit;
         },
         canManageBlacklist() {
             return usePermissionsStore().hasPermission('page.admin.blacklist');
+        },
+        // Право на кнопку «Полная история» / секцию «История проходов»: гейтим ТОЛЬКО
+        // когда карта задаёт ключ права (string); контекстные false/true оставляем на
+        // условия видимости выше (showHistoryButton/showHistorySection) — нулевая
+        // регрессия дефолтной видимости, добавляется лишь возможность отозвать ролью.
+        canSeeFullHistory() {
+            const v = getModalActionPermission('employee', this.source, 'history');
+            return typeof v === 'string' ? usePermissionsStore().hasPermission(v) : true;
+        },
+        canSeeEntryExit() {
+            const v = getModalActionPermission('employee', this.source, 'entryExit');
+            return typeof v === 'string' ? usePermissionsStore().hasPermission(v) : true;
         },
         // Доступные действия/разделы модалки по контексту (source) и правам (#187
         // Фаза 2). Значение из карты: boolean - по контексту; строка - ключ права,
@@ -594,7 +606,6 @@ export default {
                 blacklist: resolve('blacklist'),
                 entryExit: resolve('entryExit'),
                 documents: resolve('documents'),
-                passHistory: resolve('passHistory'),
             };
         },
         personLast() {

--- a/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/EmployeeDetailsModal.vue
@@ -601,10 +601,8 @@ export default {
                 return typeof v === 'boolean' ? v : perms.hasPermission(v);
             };
             return {
-                history: resolve('history'),
                 openApplication: resolve('openApplication'),
                 blacklist: resolve('blacklist'),
-                entryExit: resolve('entryExit'),
                 documents: resolve('documents'),
             };
         },

--- a/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
+++ b/frontend/src/components/CreateApplication/VehicleDetailsModal.vue
@@ -24,7 +24,7 @@
                 class="header-actions"
               >
                 <button
-                  v-if="showCarFeatures"
+                  v-if="showCarFeatures && canSeeFullHistory"
                   class="history-btn"
                   @click="openCarHistory"
                 >
@@ -277,7 +277,7 @@
 
                 <!-- Секция История въездов и выездов (только entry/exit) -->
                 <div
-                  v-if="showCarFeatures"
+                  v-if="showCarFeatures && canSeeEntryExit"
                   class="details-section"
                 >
                   <div class="section-header">
@@ -526,10 +526,22 @@ export default {
                 : usePermissionsStore().hasPermission(perm);
             return allowed && !!(this.vehicle?.applicationId || this.vehicle?.application_id);
         },
-        // Кнопки в шапке: "Полная история" видна при showCarFeatures,
+        // Право на кнопку «Полная история» / секцию «История въездов и выездов»:
+        // гейтим ТОЛЬКО когда карта задаёт ключ права (string); контекстные false/true
+        // оставляем на showCarFeatures — нулевая регрессия дефолтной видимости,
+        // добавляется лишь возможность отозвать ролью.
+        canSeeFullHistory() {
+            const v = getModalActionPermission('vehicle', this.source, 'history');
+            return typeof v === 'string' ? usePermissionsStore().hasPermission(v) : true;
+        },
+        canSeeEntryExit() {
+            const v = getModalActionPermission('vehicle', this.source, 'entryExit');
+            return typeof v === 'string' ? usePermissionsStore().hasPermission(v) : true;
+        },
+        // Кнопки в шапке: "Полная история" видна при showCarFeatures + право,
         // "Открыть заявку" - при canOpenApplication.
         visibleActionsCount() {
-            const history = this.showCarFeatures ? 1 : 0;
+            const history = (this.showCarFeatures && this.canSeeFullHistory) ? 1 : 0;
             const application = this.canOpenApplication ? 1 : 0;
             return history + application;
         },

--- a/frontend/src/components/CreateApplication/__tests__/DetailModalsPermissionGating.spec.js
+++ b/frontend/src/components/CreateApplication/__tests__/DetailModalsPermissionGating.spec.js
@@ -73,6 +73,18 @@ describe('VehicleDetailsModal — гейтинг истории по detail.* (�
     expect(w.find('.history-btn').exists()).toBe(true);
     expect(hasSection(w, 'История въездов и выездов')).toBe(true);
   });
+
+  it('контекст «Корзина»: normal без detail.full_history — кнопка истории скрыта', () => {
+    seedPerms({ allow: [] });
+    const w = mountVehicle({ source: 'trash' });
+    expect(w.find('.history-btn').exists()).toBe(false);
+  });
+
+  it('контекст «Корзина»: с detail.full_history кнопка истории видна (контекст не ломает гейт)', () => {
+    seedPerms({ allow: ['detail.full_history'] });
+    const w = mountVehicle({ source: 'trash' });
+    expect(w.find('.history-btn').exists()).toBe(true);
+  });
 });
 
 describe('EmployeeDetailsModal — гейтинг истории по detail.* (срез 4)', () => {
@@ -97,5 +109,12 @@ describe('EmployeeDetailsModal — гейтинг истории по detail.* (
     const w = mountEmployee();
     expect(w.find('.history-btn').exists()).toBe(true);
     expect(hasSection(w, 'История проходов')).toBe(true);
+  });
+
+  it('контекст «Список в заявке» (employeeslist): история скрыта даже у super — контекст-гард жив', () => {
+    seedPerms({ mode: 'super' });
+    const w = mountEmployee({ source: 'employeeslist' });
+    expect(w.find('.history-btn').exists()).toBe(false);
+    expect(hasSection(w, 'История проходов')).toBe(false);
   });
 });

--- a/frontend/src/components/CreateApplication/__tests__/DetailModalsPermissionGating.spec.js
+++ b/frontend/src/components/CreateApplication/__tests__/DetailModalsPermissionGating.spec.js
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { setActivePinia, createPinia } from 'pinia';
+
+import VehicleDetailsModal from '../VehicleDetailsModal.vue';
+import EmployeeDetailsModal from '../EmployeeDetailsModal.vue';
+import { usePermissionsStore } from '@/stores/permissions';
+
+// Карточки на show=true дёргают вспомогательные API (статус/история) - глушим, нас
+// интересует только гейтинг кнопки «Полная история» и секции истории проходов по праву.
+vi.mock('@/api/client', () => ({ apiRequest: vi.fn().mockResolvedValue({ ok: false }) }));
+vi.mock('@/api/blacklist', () => ({
+  listVehicleBlacklist: vi.fn().mockResolvedValue([]),
+  checkPersonBlacklist: vi.fn().mockResolvedValue({ is_blacklisted: false }),
+  listPersonBlacklist: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('@/api/marks', () => ({ listMarks: vi.fn().mockResolvedValue([]) }));
+vi.mock('exceljs', () => ({ default: {} }));
+
+const stubs = {
+  teleport: true,
+  UnloadPlaceModal: true,
+  CarHistoryModal: true,
+  EmployeeHistoryModal: true,
+  TableInfoModal: true,
+  AddToBlacklistModal: true,
+  LoaderSpinner: true,
+};
+
+/** Задаёт режим/права в свежем сторе до монтирования модалки. */
+function seedPerms({ mode = 'normal', allow = [] } = {}) {
+  const perms = usePermissionsStore();
+  perms.mode = mode;
+  perms.effective = Object.fromEntries(allow.map(k => [k, { value: 'allow', source: 'role' }]));
+}
+
+function mountVehicle(props = {}) {
+  return mount(VehicleDetailsModal, {
+    props: { show: true, vehicle: { id: 1, plateNumber: 'А123ВС', mark: 'Toyota', unloadPlaces: [] }, source: 'application', showCarFeatures: true, ...props },
+    global: { stubs },
+  });
+}
+
+function mountEmployee(props = {}) {
+  return mount(EmployeeDetailsModal, {
+    props: { show: true, employee: { id: 1, last_name: 'Иваноф', first_name: 'Иван', middle_name: 'Иванович', target_tables: [] }, source: 'application', ...props },
+    global: { stubs },
+  });
+}
+
+const hasSection = (w, title) => w.findAll('.section-title').some(h => h.text().includes(title));
+
+describe('VehicleDetailsModal — гейтинг истории по detail.* (срез 4)', () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  it('normal с detail.full_history/entry_exit_history: кнопка истории и секция проходов видны', () => {
+    seedPerms({ allow: ['detail.full_history', 'detail.entry_exit_history'] });
+    const w = mountVehicle();
+    expect(w.find('.history-btn').exists()).toBe(true);
+    expect(hasSection(w, 'История въездов и выездов')).toBe(true);
+  });
+
+  it('normal без прав: кнопка истории и секция проходов скрыты (тумблер реально гейтит)', () => {
+    seedPerms({ allow: [] });
+    const w = mountVehicle();
+    expect(w.find('.history-btn').exists()).toBe(false);
+    expect(hasSection(w, 'История въездов и выездов')).toBe(false);
+  });
+
+  it('super видит историю без явных грантов', () => {
+    seedPerms({ mode: 'super' });
+    const w = mountVehicle();
+    expect(w.find('.history-btn').exists()).toBe(true);
+    expect(hasSection(w, 'История въездов и выездов')).toBe(true);
+  });
+});
+
+describe('EmployeeDetailsModal — гейтинг истории по detail.* (срез 4)', () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  it('normal с detail.full_history/entry_exit_history: кнопка истории и секция проходов видны', () => {
+    seedPerms({ allow: ['detail.full_history', 'detail.entry_exit_history'] });
+    const w = mountEmployee();
+    expect(w.find('.history-btn').exists()).toBe(true);
+    expect(hasSection(w, 'История проходов')).toBe(true);
+  });
+
+  it('normal без прав: кнопка истории и секция проходов скрыты', () => {
+    seedPerms({ allow: [] });
+    const w = mountEmployee();
+    expect(w.find('.history-btn').exists()).toBe(false);
+    expect(hasSection(w, 'История проходов')).toBe(false);
+  });
+
+  it('super видит историю без явных грантов', () => {
+    seedPerms({ mode: 'super' });
+    const w = mountEmployee();
+    expect(w.find('.history-btn').exists()).toBe(true);
+    expect(hasSection(w, 'История проходов')).toBe(true);
+  });
+});

--- a/frontend/src/constants/__tests__/detailModalActions.spec.js
+++ b/frontend/src/constants/__tests__/detailModalActions.spec.js
@@ -26,3 +26,44 @@ describe('detailModalActions — openApplication гейтится detail.open_ap
     expect(getModalActionPermission('employee', 'peopletable', 'blacklist')).toBe('page.admin.blacklist')
   })
 })
+
+describe('detailModalActions — гранулярные detail-ключи карточки', () => {
+  it('history гейтится detail.full_history (vehicle и employee)', () => {
+    for (const src of ['application', 'carstable', 'facttable', 'carsview', 'trash', 'general']) {
+      expect(getModalActionPermission('vehicle', src, 'history')).toBe('detail.full_history')
+    }
+    for (const src of ['application', 'employeesview', 'peopletable', 'trash', 'general']) {
+      expect(getModalActionPermission('employee', src, 'history')).toBe('detail.full_history')
+    }
+  })
+
+  it('entryExit гейтится detail.entry_exit_history там, где раздел доступен', () => {
+    for (const src of ['application', 'carstable', 'facttable', 'carsview', 'general']) {
+      expect(getModalActionPermission('vehicle', src, 'entryExit')).toBe('detail.entry_exit_history')
+    }
+    for (const src of ['application', 'employeesview', 'peopletable', 'general']) {
+      expect(getModalActionPermission('employee', src, 'entryExit')).toBe('detail.entry_exit_history')
+    }
+  })
+
+  it('passHistory выкинут (нет UI «История пропусков») — всегда false', () => {
+    for (const src of ['carsview', 'general', 'application', 'trash']) {
+      expect(getModalActionPermission('vehicle', src, 'passHistory')).toBe(false)
+    }
+    for (const src of ['employeesview', 'general', 'peopletable', 'trash']) {
+      expect(getModalActionPermission('employee', src, 'passHistory')).toBe(false)
+    }
+  })
+
+  it('контекст ЧС не задет: history там остаётся page.admin.blacklist', () => {
+    expect(getModalActionPermission('vehicle', 'blacklist', 'history')).toBe('page.admin.blacklist')
+    expect(getModalActionPermission('employee', 'blacklist', 'history')).toBe('page.admin.blacklist')
+  })
+
+  it('контекстно-скрытые detail-действия остаются false', () => {
+    expect(getModalActionPermission('vehicle', 'trash', 'entryExit')).toBe(false)
+    expect(getModalActionPermission('vehicle', 'application', 'passHistory')).toBe(false)
+    expect(getModalActionPermission('employee', 'employeeslist', 'history')).toBe(false)
+    expect(getModalActionPermission('employee', 'peopletable', 'passHistory')).toBe(false)
+  })
+})

--- a/frontend/src/constants/detailModalActions.js
+++ b/frontend/src/constants/detailModalActions.js
@@ -25,7 +25,6 @@
  *   blacklist       — кнопка «В ЧС» / управление чёрным списком
  *   entryExit       — вкладка/секция «Въезд/Выезд» (история проходов на территорию)
  *   documents       — раздел «Документы» (прикреплённые документы сущности)
- *   passHistory     — История пропусков (выданные пропуска)
  */
 
 /**
@@ -40,7 +39,6 @@ export const VEHICLE_MODAL_ACTIONS = {
     blacklist:       'page.admin.blacklist',
     entryExit:       'detail.entry_exit_history',
     documents:       false,
-    passHistory:     false,
   },
   carstable: {
     history:         'detail.full_history',
@@ -48,7 +46,6 @@ export const VEHICLE_MODAL_ACTIONS = {
     blacklist:       'page.admin.blacklist',
     entryExit:       'detail.entry_exit_history',
     documents:       false,
-    passHistory:     false,
   },
   facttable: {
     history:         'detail.full_history',
@@ -56,10 +53,9 @@ export const VEHICLE_MODAL_ACTIONS = {
     blacklist:       'page.admin.blacklist',
     entryExit:       'detail.entry_exit_history',
     documents:       false,
-    passHistory:     false,
   },
   carsview: {
-    // Страница «Автомобили»: нет связи с заявкой, документы и история пропусков доступны
+    // Страница «Автомобили»: нет связи с заявкой, документы доступны по detail.documents
     history:         'detail.full_history',
     openApplication: false,
     blacklist:       'page.admin.blacklist',
@@ -67,7 +63,6 @@ export const VEHICLE_MODAL_ACTIONS = {
     // Документы доступны по detail.documents (есть в базовой роли) - владелец видит
     // документы своих машин; админ/супер - всегда.
     documents:       'detail.documents',
-    passHistory:     false,
   },
   trash: {
     // Корзина: только чтение, без ЧС и действий
@@ -76,7 +71,6 @@ export const VEHICLE_MODAL_ACTIONS = {
     blacklist:       false,
     entryExit:       false,
     documents:       false,
-    passHistory:     false,
   },
   blacklist: {
     // Открыта из раздела ЧС: переход в заявку не нужен, добавление в ЧС не нужно
@@ -85,7 +79,6 @@ export const VEHICLE_MODAL_ACTIONS = {
     blacklist:       false,
     entryExit:       false,
     documents:       false,
-    passHistory:     false,
   },
   general: {
     history:         'detail.full_history',
@@ -93,7 +86,6 @@ export const VEHICLE_MODAL_ACTIONS = {
     blacklist:       'page.admin.blacklist',
     entryExit:       'detail.entry_exit_history',
     documents:       'detail.documents',
-    passHistory:     false,
   },
 }
 
@@ -111,7 +103,6 @@ export const EMPLOYEE_MODAL_ACTIONS = {
     // Документы доступны по detail.documents (есть в базовой роли): обычный юзер
     // видит документы своих сотрудников в заявке; админ/супер - всегда.
     documents:       'detail.documents',
-    passHistory:     false,
   },
   employeesview: {
     // Страница «Сотрудники»: полный набор действий для имеющих право
@@ -120,7 +111,6 @@ export const EMPLOYEE_MODAL_ACTIONS = {
     blacklist:       'page.admin.blacklist',
     entryExit:       'detail.entry_exit_history',
     documents:       'detail.documents',
-    passHistory:     false,
   },
   employeeslist: {
     // Список сотрудников внутри создания/редактирования заявки: режим просмотра
@@ -132,7 +122,6 @@ export const EMPLOYEE_MODAL_ACTIONS = {
     blacklist:       false,
     entryExit:       false,
     documents:       true,
-    passHistory:     false,
   },
   peopletable: {
     // Таблица людей в центре заявок
@@ -141,7 +130,6 @@ export const EMPLOYEE_MODAL_ACTIONS = {
     blacklist:       'page.admin.blacklist',
     entryExit:       'detail.entry_exit_history',
     documents:       'detail.documents',
-    passHistory:     false,
   },
   trash: {
     history:         'detail.full_history',
@@ -149,7 +137,6 @@ export const EMPLOYEE_MODAL_ACTIONS = {
     blacklist:       false,
     entryExit:       false,
     documents:       false,
-    passHistory:     false,
   },
   blacklist: {
     history:         'page.admin.blacklist',
@@ -157,7 +144,6 @@ export const EMPLOYEE_MODAL_ACTIONS = {
     blacklist:       false,
     entryExit:       false,
     documents:       false,
-    passHistory:     false,
   },
   general: {
     history:         'detail.full_history',
@@ -165,7 +151,6 @@ export const EMPLOYEE_MODAL_ACTIONS = {
     blacklist:       'page.admin.blacklist',
     entryExit:       'detail.entry_exit_history',
     documents:       'detail.documents',
-    passHistory:     false,
   },
 }
 

--- a/frontend/src/constants/detailModalActions.js
+++ b/frontend/src/constants/detailModalActions.js
@@ -35,43 +35,43 @@
 export const VEHICLE_MODAL_ACTIONS = {
   application: {
     // Открыта из деталей заявки: история есть, переход в заявку не нужен (уже в ней)
-    history:         'entity.cars.read',
+    history:         'detail.full_history',
     openApplication: false,
     blacklist:       'page.admin.blacklist',
-    entryExit:       'entity.cars.read',
+    entryExit:       'detail.entry_exit_history',
     documents:       false,
     passHistory:     false,
   },
   carstable: {
-    history:         'entity.cars.read',
+    history:         'detail.full_history',
     openApplication: 'detail.open_application', // есть application_id; гейт по detail.open_application (базовая роль)
     blacklist:       'page.admin.blacklist',
-    entryExit:       'entity.cars.read',
+    entryExit:       'detail.entry_exit_history',
     documents:       false,
     passHistory:     false,
   },
   facttable: {
-    history:         'entity.cars.read',
+    history:         'detail.full_history',
     openApplication: 'detail.open_application',
     blacklist:       'page.admin.blacklist',
-    entryExit:       'entity.cars.read',
+    entryExit:       'detail.entry_exit_history',
     documents:       false,
     passHistory:     false,
   },
   carsview: {
     // Страница «Автомобили»: нет связи с заявкой, документы и история пропусков доступны
-    history:         'entity.cars.read',
+    history:         'detail.full_history',
     openApplication: false,
     blacklist:       'page.admin.blacklist',
-    entryExit:       'entity.cars.read',
+    entryExit:       'detail.entry_exit_history',
     // Документы доступны по detail.documents (есть в базовой роли) - владелец видит
     // документы своих машин; админ/супер - всегда.
     documents:       'detail.documents',
-    passHistory:     'entity.cars.read',
+    passHistory:     false,
   },
   trash: {
     // Корзина: только чтение, без ЧС и действий
-    history:         'entity.cars.read',
+    history:         'detail.full_history',
     openApplication: false,
     blacklist:       false,
     entryExit:       false,
@@ -88,12 +88,12 @@ export const VEHICLE_MODAL_ACTIONS = {
     passHistory:     false,
   },
   general: {
-    history:         'entity.cars.read',
+    history:         'detail.full_history',
     openApplication: 'detail.open_application',
     blacklist:       'page.admin.blacklist',
-    entryExit:       'entity.cars.read',
+    entryExit:       'detail.entry_exit_history',
     documents:       'detail.documents',
-    passHistory:     'entity.cars.read',
+    passHistory:     false,
   },
 }
 
@@ -104,10 +104,10 @@ export const VEHICLE_MODAL_ACTIONS = {
 export const EMPLOYEE_MODAL_ACTIONS = {
   application: {
     // Открыта из деталей заявки: "Открыть заявку" не нужно (уже в ней)
-    history:         'entity.employees.read',
+    history:         'detail.full_history',
     openApplication: false,
     blacklist:       'page.admin.blacklist',
-    entryExit:       'entity.employees.read',
+    entryExit:       'detail.entry_exit_history',
     // Документы доступны по detail.documents (есть в базовой роли): обычный юзер
     // видит документы своих сотрудников в заявке; админ/супер - всегда.
     documents:       'detail.documents',
@@ -115,12 +115,12 @@ export const EMPLOYEE_MODAL_ACTIONS = {
   },
   employeesview: {
     // Страница «Сотрудники»: полный набор действий для имеющих право
-    history:         'entity.employees.read',
+    history:         'detail.full_history',
     openApplication: 'detail.open_application',
     blacklist:       'page.admin.blacklist',
-    entryExit:       'entity.employees.read',
+    entryExit:       'detail.entry_exit_history',
     documents:       'detail.documents',
-    passHistory:     'entity.employees.read',
+    passHistory:     false,
   },
   employeeslist: {
     // Список сотрудников внутри создания/редактирования заявки: режим просмотра
@@ -136,15 +136,15 @@ export const EMPLOYEE_MODAL_ACTIONS = {
   },
   peopletable: {
     // Таблица людей в центре заявок
-    history:         'entity.employees.read',
+    history:         'detail.full_history',
     openApplication: 'detail.open_application',
     blacklist:       'page.admin.blacklist',
-    entryExit:       'entity.employees.read',
+    entryExit:       'detail.entry_exit_history',
     documents:       'detail.documents',
     passHistory:     false,
   },
   trash: {
-    history:         'entity.employees.read',
+    history:         'detail.full_history',
     openApplication: false,
     blacklist:       false,
     entryExit:       false,
@@ -160,12 +160,12 @@ export const EMPLOYEE_MODAL_ACTIONS = {
     passHistory:     false,
   },
   general: {
-    history:         'entity.employees.read',
+    history:         'detail.full_history',
     openApplication: 'detail.open_application',
     blacklist:       'page.admin.blacklist',
-    entryExit:       'entity.employees.read',
+    entryExit:       'detail.entry_exit_history',
     documents:       'detail.documents',
-    passHistory:     'entity.employees.read',
+    passHistory:     false,
   },
 }
 

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -530,6 +530,8 @@ var baseRoleGrants = []string{
 	"guide.user",
 	"detail.open_application",
 	"detail.documents",
+	"detail.full_history",
+	"detail.entry_exit_history",
 }
 
 // seedBaseRole создаёт неудаляемую базовую роль "Пользователь" и её дефолтные

--- a/internal/services/permission_catalog.go
+++ b/internal/services/permission_catalog.go
@@ -33,10 +33,8 @@ const (
 
 	KeyDetailFullHistory      = "detail.full_history"
 	KeyDetailOpenApplication  = "detail.open_application"
-	KeyDetailBlacklist        = "detail.blacklist"
 	KeyDetailEntryExitHistory = "detail.entry_exit_history"
 	KeyDetailDocuments        = "detail.documents"
-	KeyDetailPassHistory      = "detail.pass_history"
 
 	KeySectionRegistryOrganization = "section.registry.organization"
 	KeySectionRegistryCompany      = "section.registry.company"
@@ -105,10 +103,8 @@ func staticCatalog() []CatalogNode {
 		// Карточка авто/сотрудника (общие действия; где кнопка уместна -- определяет контекст на фронте)
 		{Key: KeyDetailFullHistory, DisplayName: "Кнопка «Полная история»", Category: CatDetail},
 		{Key: KeyDetailOpenApplication, DisplayName: "Кнопка «Открыть заявку»", Category: CatDetail},
-		{Key: KeyDetailBlacklist, DisplayName: "Кнопка «В ЧС»", Category: CatDetail},
 		{Key: KeyDetailEntryExitHistory, DisplayName: "Раздел «История въездов и выездов»", Category: CatDetail},
 		{Key: KeyDetailDocuments, DisplayName: "Раздел «Документы»", Category: CatDetail},
-		{Key: KeyDetailPassHistory, DisplayName: "Раздел «История проходов»", Category: CatDetail},
 
 		// Сотрудники и автомобили
 		{Key: KeyEntityCarsRead, DisplayName: "Автомобили: просмотр", Category: CatRegistry},

--- a/internal/services/permission_catalog_test.go
+++ b/internal/services/permission_catalog_test.go
@@ -49,8 +49,11 @@ func TestIsCatalogKey(t *testing.T) {
 	if !IsCatalogKey(KeyPageCenter) {
 		t.Error("KeyPageCenter должен быть в каталоге")
 	}
-	if !IsCatalogKey(KeyDetailBlacklist) {
-		t.Error("KeyDetailBlacklist должен быть в каталоге")
+	if !IsCatalogKey(KeyDetailFullHistory) {
+		t.Error("KeyDetailFullHistory должен быть в каталоге")
+	}
+	if IsCatalogKey("detail.blacklist") {
+		t.Error("detail.blacklist убран из каталога (ЧС гейтится page.admin.blacklist)")
 	}
 	if IsCatalogKey("nonexistent.key") {
 		t.Error("несуществующий ключ не должен быть в каталоге")


### PR DESCRIPTION
## Что
Срез 4 эпика permission-gating. Каталог прав обещал ключи `detail.full_history` и `detail.entry_exit_history`, но фронт их не проверял - мёртвые тумблеры. Подключил к реальному гейтингу кнопки «Полная история» и секции истории проходов в карточках авто (`VehicleDetailsModal`) и сотрудника (`EmployeeDetailsModal`).

## Как
- Computed `canSeeFullHistory`/`canSeeEntryExit` = `typeof v === 'string' ? hasPermission(v) : true`, где `v = getModalActionPermission(entity, source, action)`. Право проверяется ТОЛЬКО когда карта отдаёт строку-ключ; контекстные boolean (false для trash/employeeslist) остаются на откуп существующим v-if. Нулевая регрессия дефолтной видимости для super/admin/базовой роли - добавляется лишь возможность отозвать историю ролью.
- AND'ятся в существующие условия: `showCarFeatures && canSeeFullHistory`, `source !== 'employeeslist' && canSeeFullHistory`.

## Чистка orphan-ключей
- Выкинул `detail.blacklist` и `detail.pass_history` из каталога (`permission_catalog.go`) и теста - UI для них нет.
- В `baseRoleGrants` (`migrate.go`) добавил `detail.full_history` + `detail.entry_exit_history` (idempotent FirstOrCreate).
- Поле `passHistory` убрал из карты `detailModalActions.js` целиком (инертный `false` во всех контекстах, потребителя нет).

## Тесты
- `DetailModalsPermissionGating.spec.js` (новый): mount обеих модалок, проверка наличия/отсутствия кнопки истории и секции при наличии/отсутствии грантов; super-режим; регресс на контексты Корзина и employeeslist.
- `detailModalActions.spec.js`: покрытие новых ключей.
- vitest 18/18, eslint чисто, go test ./... зелёный.

## Off-limits
Затрагивает `internal/services/permission_catalog.go` и `internal/database/migrate.go` (seed) - правка согласована, мерж по решению мейнтейнера.