### PR TITLE
feat(permissions): гейтинг действий Центра заявок по каталогу прав

### DIFF
--- a/frontend/src/components/ApplicationDetail/ApplicationDetail.vue
+++ b/frontend/src/components/ApplicationDetail/ApplicationDetail.vue
@@ -31,7 +31,7 @@
             </div>
             <!-- Кнопка пересылки (рядом с датой) -->
             <button
-              v-if="mode === 'center' && canForwardApplication"
+              v-if="mode === 'center' && canForwardApplication && can('action.forward.application')"
               class="forward-btn"
               data-testid="app-detail-button-forward"
               :disabled="updatingConfirmation || processingApplication"
@@ -47,6 +47,7 @@
         </div>
         <div class="detail-header-right">
           <ApplicationActionBar
+            v-if="mode !== 'center' || can('action.approve.application')"
             :application="applicationData"
             :current-user-id="currentUserId"
             :responsible-users="responsibleUsers"
@@ -281,7 +282,7 @@
 
           <!-- Поле для комментария (только для пользователей, которые еще не выполнили действие) -->
           <div
-            v-if="canLeaveComment && !hasUserVoted && !isApproverActionDone"
+            v-if="canLeaveComment && !hasUserVoted && !isApproverActionDone && (mode !== 'center' || can('action.approve.application'))"
             class="comment-action-section"
           >
             <h4>Комментарий</h4>
@@ -303,7 +304,10 @@
             :updating-confirmation="updatingConfirmation"
           />
 
-          <div class="history-button-section">
+          <div
+            v-if="can('center.application_history')"
+            class="history-button-section"
+          >
             <ApplicationHistory
               ref="historyComponent"
               :application-id="applicationData.id"
@@ -364,6 +368,7 @@ import { apiRequest } from '@/api/client'
 import { markAsRead } from '@/api/applications'
 import { useDeletionsStore } from '@/stores/deletions'
 import { useUiStore } from '@/stores/ui'
+import { usePermissionsStore } from '@/stores/permissions'
 import ApplicationAttachments from './ApplicationAttachments.vue'
 import ApplicationConfirmation from './ApplicationConfirmation.vue'
 import ApplicationHistory from './ApplicationHistory.vue'
@@ -411,6 +416,10 @@ export default {
         }
     },
     emits: ['close', 'confirmation-updated', 'duplicate', 'application-updated', 'update-application', 'application-changed'],
+    setup() {
+        const permissionsStore = usePermissionsStore();
+        return { permissionsStore };
+    },
     data() {
         return {
             applicationData: { ...this.application },
@@ -555,6 +564,9 @@ export default {
         this.$nextTick(() => this.updateMessageClamp());
     },
     methods: {
+        can(key) {
+            return this.permissionsStore.hasPermission(key);
+        },
         updateMessageClamp() {
             const el = this.$refs.messagePreview;
             this.messageClamped = !!el && el.scrollHeight > el.clientHeight + 2;

--- a/frontend/src/components/ApplicationDetail/__tests__/ApplicationDetailForwardGate.spec.js
+++ b/frontend/src/components/ApplicationDetail/__tests__/ApplicationDetailForwardGate.spec.js
@@ -5,6 +5,10 @@ import { createPinia, setActivePinia } from 'pinia';
 // #680 срез role-gate: кнопку "Переслать" видит только ответственный по заявке
 // (Принимающий). Согласующий (глобальная роль, видит все заявки) и обычный читатель
 // её не видят - BE-проверка forward пускает только sender||responsible.
+// Срез 5 (permission-gating) добавил поверх право action.forward.application: ниже
+// его выдаём во всех тестах, чтобы изолировать именно role/mode-gate (#680).
+
+import { usePermissionsStore } from '@/stores/permissions';
 
 vi.mock('@/api/client', () => ({
   apiRequest: vi.fn().mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue([]) }),
@@ -17,7 +21,14 @@ import ApplicationDetail from '../ApplicationDetail.vue';
 
 const FORWARD = '[data-testid="app-detail-button-forward"]';
 
+/** Выдаёт право пересылки в свежем сторе - тесты проверяют именно role/mode-gate. */
+function grantForward() {
+  const perms = usePermissionsStore();
+  perms.effective = { 'action.forward.application': { value: 'allow', source: 'role' } };
+}
+
 async function mountDetail(props = {}, data = {}) {
+  grantForward();
   const wrapper = shallowMount(ApplicationDetail, {
     props: {
       application: { id: 7, application_number: 'A-7', status: 'Непрочитано' },

--- a/frontend/src/components/ApplicationDetail/__tests__/ApplicationDetailPermissionGating.spec.js
+++ b/frontend/src/components/ApplicationDetail/__tests__/ApplicationDetailPermissionGating.spec.js
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { setActivePinia, createPinia } from 'pinia';
+
+import ApplicationDetail from '../ApplicationDetail.vue';
+import { usePermissionsStore } from '@/stores/permissions';
+
+// Деталь заявки на mounted дёргает loadApplicationDetails/markAsRead - глушим, нас
+// интересует только гейтинг центр-действий (срез 5): forward / approve / history.
+vi.mock('@/api/client', () => ({ apiRequest: vi.fn().mockResolvedValue({ ok: false }) }));
+vi.mock('@/api/applications', () => ({ markAsRead: vi.fn().mockResolvedValue({}) }));
+
+const stubs = {
+  teleport: true,
+  ForwardModal: true,
+  ApplicationActionBar: { name: 'ApplicationActionBar', template: '<div class="action-bar-stub"><slot name="user-actions" /></div>' },
+  ApplicationAttachments: true,
+  ApplicationMessageModal: true,
+  ApplicationAttachmentDetail: true,
+  ApplicationConfirmation: true,
+  ApplicationHistory: true,
+  VehicleDetailsModal: true,
+  EmployeeDetailsModal: true,
+  BlacklistOverrideModal: true,
+  Badge: true,
+};
+
+const APP = {
+  id: 1,
+  application_number: 'A-1',
+  sending_datetime: '2026-01-01T10:00:00Z',
+  status: 'Согласование',
+  confirmation: 'Согласование',
+  organization_name: 'Орг',
+};
+
+/** Задаёт режим/права в свежем сторе до монтирования детали. */
+function seedPerms({ mode = 'normal', allow = [] } = {}) {
+  const perms = usePermissionsStore();
+  perms.mode = mode;
+  perms.effective = Object.fromEntries(allow.map(k => [k, { value: 'allow', source: 'role' }]));
+}
+
+function mountDetail(props = {}) {
+  return mount(ApplicationDetail, {
+    props: { application: APP, currentUserId: 5, mode: 'center', ...props },
+    global: { stubs },
+  });
+}
+
+/** Делает текущего пользователя ответственным -> canForwardApplication/canLeaveComment. */
+async function makeResponsible(w) {
+  w.vm.responsibleUsers = [{ id: 5, approval_status: 'pending' }];
+  await w.vm.$nextTick();
+}
+
+const forward = w => w.find('[data-testid="app-detail-button-forward"]');
+const actionBar = w => w.find('.action-bar-stub');
+const duplicate = w => w.find('.duplicate-btn');
+const history = w => w.find('.history-button-section');
+const comment = w => w.find('.comment-action-section');
+
+describe('ApplicationDetail — гейтинг центр-действий (срез 5)', () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  describe('Переслать заявку (action.forward.application)', () => {
+    it('normal с правом и ответственный: кнопка пересылки видна', async () => {
+      seedPerms({ allow: ['action.forward.application'] });
+      const w = mountDetail();
+      await makeResponsible(w);
+      expect(forward(w).exists()).toBe(true);
+    });
+
+    it('normal без права, но ответственный: кнопка скрыта (тумблер гейтит)', async () => {
+      seedPerms({ allow: [] });
+      const w = mountDetail();
+      await makeResponsible(w);
+      expect(forward(w).exists()).toBe(false);
+    });
+
+    it('super: кнопка видна без явного гранта', async () => {
+      seedPerms({ mode: 'super' });
+      const w = mountDetail();
+      await makeResponsible(w);
+      expect(forward(w).exists()).toBe(true);
+    });
+  });
+
+  describe('Согласовать заявку (action.approve.application)', () => {
+    it('normal с правом: панель действий и поле комментария видны', async () => {
+      seedPerms({ allow: ['action.approve.application'] });
+      const w = mountDetail();
+      await makeResponsible(w);
+      expect(actionBar(w).exists()).toBe(true);
+      expect(comment(w).exists()).toBe(true);
+    });
+
+    it('normal без права: панель действий и поле комментария скрыты', async () => {
+      seedPerms({ allow: [] });
+      const w = mountDetail();
+      await makeResponsible(w);
+      expect(actionBar(w).exists()).toBe(false);
+      expect(comment(w).exists()).toBe(false);
+    });
+
+    it('admin (mode admin): панель действий видна без явного гранта', async () => {
+      seedPerms({ mode: 'admin' });
+      const w = mountDetail();
+      await makeResponsible(w);
+      expect(actionBar(w).exists()).toBe(true);
+    });
+
+    it('режим заявителя (mode=user) без права: панель и «Продублировать» остаются (гейт согласования не трогает user-режим)', async () => {
+      seedPerms({ allow: [] });
+      const w = mountDetail({ mode: 'user' });
+      await makeResponsible(w);
+      expect(actionBar(w).exists()).toBe(true);
+      expect(duplicate(w).exists()).toBe(true);
+    });
+  });
+
+  describe('История заявки (center.application_history) — Q2: только по ключу', () => {
+    it('normal с правом: секция истории видна', () => {
+      seedPerms({ allow: ['center.application_history'] });
+      expect(history(mountDetail()).exists()).toBe(true);
+    });
+
+    it('normal без права: секция истории скрыта', () => {
+      seedPerms({ allow: [] });
+      expect(history(mountDetail()).exists()).toBe(false);
+    });
+
+    it('режим заявителя (mode=user) без права: история своей заявки тоже скрыта (без context-исключения)', () => {
+      seedPerms({ allow: [] });
+      expect(history(mountDetail({ mode: 'user' })).exists()).toBe(false);
+    });
+
+    it('super: секция истории видна без явного гранта', () => {
+      seedPerms({ mode: 'super' });
+      expect(history(mountDetail()).exists()).toBe(true);
+    });
+  });
+});

--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -5,7 +5,10 @@
         <h2 class="center__title">
           Центр заявок
         </h2>
-        <div class="center__tabs">
+        <div
+          v-if="canViewArchive"
+          class="center__tabs"
+        >
           <FilterTabs
             v-model="archiveMode"
             :tabs="archiveTabs"
@@ -502,7 +505,7 @@
                 </div>
                 <div class="application-col actions-col">
                   <button
-                    v-if="application.has_blank_template"
+                    v-if="application.has_blank_template && can('action.export.applications')"
                     class="download-btn"
                     title="Скачать"
                     @click.stop="downloadApplication(application)"
@@ -557,6 +560,7 @@
 import { apiRequest } from '@/api/client'
 import { useAuthStore } from '@/stores/auth'
 import { useSoundStore } from '@/stores/sound'
+import { usePermissionsStore } from '@/stores/permissions'
 import { playPreset, SOUND_PRESETS } from '@/utils/notificationSound'
 import OrganizationFilter from '@/components/OrganizationFilter.vue';
 import RefreshButton from '../components/RefreshButton.vue';
@@ -590,7 +594,8 @@ export default {
     emits: ['refresh-data'],
     setup() {
         const soundStore = useSoundStore()
-        return { soundStore }
+        const permissionsStore = usePermissionsStore()
+        return { soundStore, permissionsStore }
     },
     data() {
         return {
@@ -657,6 +662,9 @@ export default {
         };
     },
     computed: {
+        canViewArchive() {
+            return this.permissionsStore.hasPermission('center.archive');
+        },
         filteredApplications() {
             let filtered = this.applications;
 
@@ -786,13 +794,13 @@ export default {
             this.fetchApplications();
         },
         '$route.query.archive'(val) {
-            this.archiveMode = val === 'true' ? 'archive' : 'active';
+            this.archiveMode = val === 'true' && this.canViewArchive ? 'archive' : 'active';
         },
     },
     mounted() {
         this.startShakeAnimation();
 
-        if (this.$route.query.archive === 'true') {
+        if (this.$route.query.archive === 'true' && this.canViewArchive) {
             this.archiveMode = 'archive';
         }
 
@@ -849,6 +857,9 @@ export default {
         document.removeEventListener('mousedown', this._soundClickOutsideHandler);
     },
     methods: {
+        can(key) {
+            return this.permissionsStore.hasPermission(key);
+        },
         toggleSoundPopover() {
             this.showSoundPopover = !this.showSoundPopover;
         },

--- a/frontend/src/views/__tests__/ApplicationsCenterPermissionGating.spec.js
+++ b/frontend/src/views/__tests__/ApplicationsCenterPermissionGating.spec.js
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { setActivePinia, createPinia } from 'pinia';
+
+import ApplicationsCenter from '../ApplicationsCenter.vue';
+import { usePermissionsStore } from '@/stores/permissions';
+
+// Центр на mounted дёргает fetch/polling - глушим API; нас интересует гейтинг
+// раздела «Архив» (center.archive) и кнопки «Скачать» (action.export.applications).
+vi.mock('@/api/client', () => ({ apiRequest: vi.fn().mockResolvedValue({ ok: false, json: vi.fn().mockResolvedValue([]) }) }));
+vi.mock('@/utils/notificationSound', () => ({ playPreset: vi.fn(), SOUND_PRESETS: [] }));
+
+const stubs = {
+  teleport: true,
+  OrganizationFilter: true,
+  RefreshButton: true,
+  ApplicationDetail: true,
+  DateFilter: true,
+  FilterTabs: true,
+  SkeletonTransition: { template: '<div><slot /></div>' },
+  SkeletonTable: true,
+  LoaderSpinner: true,
+  DownloadBlanksModal: true,
+  Badge: true,
+  BaseDropdown: true,
+};
+
+function seedPerms({ mode = 'normal', allow = [] } = {}) {
+  const perms = usePermissionsStore();
+  perms.mode = mode;
+  perms.effective = Object.fromEntries(allow.map(k => [k, { value: 'allow', source: 'role' }]));
+}
+
+function mountCenter() {
+  return mount(ApplicationsCenter, {
+    global: {
+      stubs,
+      mocks: { $route: { query: {} }, $router: { push: vi.fn() } },
+    },
+  });
+}
+
+/** Кладёт одну заявку c бланком в список (минуя API) и снимает скелетон. */
+async function withApplication(w) {
+  w.vm.loading = false;
+  w.vm.applications = [{
+    id: 1,
+    application_number: 'A-1',
+    sending_datetime: '2026-01-01T10:00:00Z',
+    status: 'Согласование',
+    confirmation: 'Согласование',
+    organization_name: 'Орг',
+    sender_name: 'Иванов',
+    is_read: true,
+    has_blank_template: true,
+  }];
+  await w.vm.$nextTick();
+}
+
+const tabs = w => w.find('.center__tabs');
+const download = w => w.find('.download-btn');
+
+let wrapper;
+
+describe('ApplicationsCenter — гейтинг центр-действий (срез 5)', () => {
+  beforeEach(() => setActivePinia(createPinia()));
+  afterEach(() => wrapper?.unmount());
+
+  describe('Раздел «Архив» (center.archive)', () => {
+    it('normal с правом: переключатель Активные/Архив виден', () => {
+      seedPerms({ allow: ['center.archive'] });
+      wrapper = mountCenter();
+      expect(tabs(wrapper).exists()).toBe(true);
+    });
+
+    it('normal без права: переключатель скрыт', () => {
+      seedPerms({ allow: [] });
+      wrapper = mountCenter();
+      expect(tabs(wrapper).exists()).toBe(false);
+    });
+
+    it('без права прямой URL ?archive=true не переключает в архив', () => {
+      seedPerms({ allow: [] });
+      wrapper = mount(ApplicationsCenter, {
+        global: { stubs, mocks: { $route: { query: { archive: 'true' } }, $router: { push: vi.fn() } } },
+      });
+      expect(wrapper.vm.archiveMode).toBe('active');
+    });
+
+    it('super: переключатель виден без явного гранта', () => {
+      seedPerms({ mode: 'super' });
+      wrapper = mountCenter();
+      expect(tabs(wrapper).exists()).toBe(true);
+    });
+  });
+
+  describe('Экспорт заявок / «Скачать» (action.export.applications)', () => {
+    it('normal с правом: кнопка «Скачать» у заявки с бланком видна', async () => {
+      seedPerms({ allow: ['action.export.applications'] });
+      wrapper = mountCenter();
+      await withApplication(wrapper);
+      expect(download(wrapper).exists()).toBe(true);
+    });
+
+    it('normal без права: кнопка «Скачать» скрыта даже при наличии бланка', async () => {
+      seedPerms({ allow: [] });
+      wrapper = mountCenter();
+      await withApplication(wrapper);
+      expect(download(wrapper).exists()).toBe(false);
+    });
+
+    it('super: кнопка «Скачать» видна без явного гранта', async () => {
+      seedPerms({ mode: 'super' });
+      wrapper = mountCenter();
+      await withApplication(wrapper);
+      expect(download(wrapper).exists()).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Что

Срез 5 эпика permission-gating (center-actions). Подключил к реальному гейтингу 5 каталожных ключей категории «Центр заявок», которые были мёртвыми тумблерами (фронт их не проверял):

| Ключ | Где гейтит |
|------|-----------|
| `center.archive` | Переключатель «Активные / Архив» в Центре (+ защита от прямого URL `?archive=true`) |
| `action.export.applications` | Кнопка «Скачать» бланк у заявки |
| `action.forward.application` | Кнопка «Переслать» в карточке детали |
| `action.approve.application` | Панель согласования (ApplicationActionBar) + поле комментария |
| `center.application_history` | Блок «История заявки» в карточке детали |

## Как

`setup()` подключает `usePermissionsStore`, метод `can(key)` зеркалит существующий паттерн `TablesComponent.vue`. Ключи AND-ятся в существующие гейты. Ключи admin-scope (не засеяны в базовую роль намеренно - это операторские действия), поэтому **super/admin видят всё как раньше (zero default regression)**, обычная роль получает действие только по гранту.

## Решения

- **Q2**: `center.application_history` гейтит историю целиком по ключу, БЕЗ context-исключения для заявителя своей заявки (история скрывается и в `mode='user'`, если ключа нет) - намеренно.
- **Согласование и user-режим**: ActionBar и поле комментария гейтятся по ключу ТОЛЬКО в `mode='center'` (`mode !== 'center' || can(...)`). В `mode='user'` ActionBar остаётся, чтобы не скрыть слот `#user-actions` (кнопка «Продублировать») у заявителя - регресс, пойманный ревью и закрытый.
- **Экспорт**: «Экспорт заявок» в Центре = единственный экспорт там - кнопка «Скачать» бланк (массового экспорта нет).

## Проверка

- vitest: 2 новых спека гейтинга, 18 тестов (грант->видно, без->скрыто, super/admin->видно, user-режим истории скрыт, «Продублировать» в user-режиме сохранён). Зелёные локально.
- eslint изменённых файлов чист.
- verify-app под super на локальном стеке: Центр и карточка детали рендерятся без runtime-ошибок, все элементы видны (контроль регрессии). Ошибки консоли - только pre-existing 404 на нереализованные локально роуты.
- Ревью `code-reviewer`: поймало регресс «Продублировать», закрыт; финальный вердикт GO.

Чисто FE, off-limits файлы не затронуты (seed не нужен).