### PR TITLE
feat(bureau): бэкенд расписания работы Бюро - модель, миграция, CRUD (C1a)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -163,6 +163,7 @@ func main() {
 	userService := services.NewUserService(db, notificationServiceEarly)
 	onboardingService := services.NewOnboardingService(db)
 	unloadPlaceService := services.NewUnloadPlaceService(db)
+	bureauService := services.NewBureauService(db)
 	carService := services.NewCarService(db)
 	employeeService := services.NewEmployeeService(db)
 	permissionService := services.NewPermissionService(db)
@@ -220,6 +221,7 @@ func main() {
 	usersHandler := handlers.NewUsersHandler(userService)
 	onboardingHandler := handlers.NewOnboardingHandler(onboardingService)
 	unloadPlaceHandler := handlers.NewUnloadPlaceHandler(unloadPlaceService, cfg.UploadMaxFileSize, cfg.UploadPath)
+	bureauHandler := handlers.NewBureauHandler(bureauService)
 	carHandler := handlers.NewCarHandler(carService)
 	employeeHandler := handlers.NewEmployeeHandler(employeeService)
 	systemTableHistoryService := services.NewSystemTableHistoryService(db)
@@ -311,6 +313,7 @@ func main() {
 		DocumentGroups:      documentGroupHandler,
 		Documents:           documentHandler,
 		Guide:               guideHandler,
+		Bureau:              bureauHandler,
 		Statistics:          statisticsHandler,
 		Onboarding:          onboardingHandler,
 		PermResolver:        permissionResolver,

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -65,6 +65,9 @@ func AllModels() []interface{} {
 		&models.OrganizationUnloadPlace{},
 		&models.CompaniesUnloadPlace{},
 
+		// Bureau (single-owner schedule, no FK)
+		&models.BureauTimeSlot{},
+
 		// Applications (depends on User, Organization, Company)
 		&models.Application{},
 		&models.ApplicationRead{},

--- a/internal/handlers/bureau.go
+++ b/internal/handlers/bureau.go
@@ -1,0 +1,122 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"systemburo/internal/services"
+
+	"github.com/labstack/echo/v4"
+)
+
+// BureauHandler -- HTTP-обработчики расписания работы Бюро (single-owner).
+type BureauHandler struct {
+	service services.BureauService
+}
+
+// NewBureauHandler создаёт новый экземпляр обработчика расписания Бюро.
+func NewBureauHandler(service services.BureauService) *BureauHandler {
+	return &BureauHandler{service: service}
+}
+
+// GetTimeSlots возвращает временные слоты расписания Бюро.
+// @Summary      Получение расписания Бюро
+// @Description  Возвращает все временные слоты расписания работы Бюро
+// @Tags         bureau
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200 {array} models.BureauTimeSlot
+// @Failure      401 {object} models.HTTPError
+// @Failure      500 {object} models.HTTPError
+// @Router       /bureau/time-slots [get]
+func (h *BureauHandler) GetTimeSlots(c echo.Context) error {
+	slots, err := h.service.GetTimeSlots(c.Request().Context())
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, slots)
+}
+
+// AddTimeSlot добавляет временной слот в расписание Бюро.
+// @Summary      Добавление слота расписания Бюро
+// @Description  Создаёт новый временной слот расписания работы Бюро
+// @Tags         bureau
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        request body services.CreateTimeSlotRequest true "Данные временного слота"
+// @Success      200 {object} map[string]interface{} "id и message"
+// @Failure      400 {object} models.HTTPError
+// @Failure      401 {object} models.HTTPError
+// @Failure      403 {object} models.HTTPError
+// @Failure      500 {object} models.HTTPError
+// @Router       /bureau/time-slots [post]
+func (h *BureauHandler) AddTimeSlot(c echo.Context) error {
+	var req services.CreateTimeSlotRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	id, err := h.service.AddTimeSlot(c.Request().Context(), req)
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, map[string]interface{}{
+		"id":      id,
+		"message": "Временной слот успешно добавлен",
+	})
+}
+
+// UpdateTimeSlot обновляет временной слот расписания Бюро.
+// @Summary      Обновление слота расписания Бюро
+// @Description  Обновляет поля временного слота расписания Бюро (только переданные)
+// @Tags         bureau
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        slot_id path int true "ID временного слота"
+// @Param        request body services.UpdateTimeSlotRequest true "Обновляемые поля"
+// @Success      200 {string} string "Временной слот успешно обновлен"
+// @Failure      400 {object} models.HTTPError
+// @Failure      401 {object} models.HTTPError
+// @Failure      403 {object} models.HTTPError
+// @Failure      404 {object} models.HTTPError
+// @Failure      500 {object} models.HTTPError
+// @Router       /bureau/time-slots/{slot_id} [put]
+func (h *BureauHandler) UpdateTimeSlot(c echo.Context) error {
+	slotID, err := strconv.Atoi(c.Param("slot_id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid slot_id")
+	}
+	var req services.UpdateTimeSlotRequest
+	if err := BindAndValidate(c, &req); err != nil {
+		return err
+	}
+	if err := h.service.UpdateTimeSlot(c.Request().Context(), slotID, req); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Временной слот успешно обновлен")
+}
+
+// DeleteTimeSlot удаляет временной слот расписания Бюро.
+// @Summary      Удаление слота расписания Бюро
+// @Description  Удаляет временной слот расписания работы Бюро
+// @Tags         bureau
+// @Produce      json
+// @Security     BearerAuth
+// @Param        slot_id path int true "ID временного слота"
+// @Success      200 {string} string "Временной слот успешно удален"
+// @Failure      401 {object} models.HTTPError
+// @Failure      403 {object} models.HTTPError
+// @Failure      404 {object} models.HTTPError
+// @Failure      500 {object} models.HTTPError
+// @Router       /bureau/time-slots/{slot_id} [delete]
+func (h *BureauHandler) DeleteTimeSlot(c echo.Context) error {
+	slotID, err := strconv.Atoi(c.Param("slot_id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid slot_id")
+	}
+	if err := h.service.DeleteTimeSlot(c.Request().Context(), slotID); err != nil {
+		return err
+	}
+	return RespondMessage(c, "Временной слот успешно удален")
+}

--- a/internal/handlers/bureau_test.go
+++ b/internal/handlers/bureau_test.go
@@ -1,0 +1,115 @@
+package handlers_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBureau_TimeSlots_Unauthorized(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	rec := testutil.GET(t, e, "/bureau/time-slots", nil)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestBureau_TimeSlots_CRUD(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	// Изначально расписание пустое.
+	rec := testutil.GET(t, e, "/bureau/time-slots", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Len(t, testutil.ParseSlice(t, rec), 0)
+
+	// Add
+	rec = testutil.POST(t, e, "/bureau/time-slots", `{"day_of_week":0,"open_time":"08:00","close_time":"17:00"}`, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	slotID := int(testutil.ParseMap(t, rec)["id"].(float64))
+	assert.Greater(t, slotID, 0)
+
+	// Get
+	rec = testutil.GET(t, e, "/bureau/time-slots", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	slots := testutil.ParseSlice(t, rec)
+	require.Len(t, slots, 1)
+	assert.Equal(t, float64(0), slots[0]["day_of_week"])
+	assert.Equal(t, "08:00", slots[0]["open_time"])
+	assert.Equal(t, "17:00", slots[0]["close_time"])
+
+	// Update
+	rec = testutil.PUT(t, e, fmt.Sprintf("/bureau/time-slots/%d", slotID), `{"open_time":"09:00","close_time":"18:00"}`, h)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = testutil.GET(t, e, "/bureau/time-slots", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	slots = testutil.ParseSlice(t, rec)
+	require.Len(t, slots, 1)
+	assert.Equal(t, "09:00", slots[0]["open_time"])
+	assert.Equal(t, "18:00", slots[0]["close_time"])
+
+	// Delete
+	rec = testutil.DELETE(t, e, fmt.Sprintf("/bureau/time-slots/%d", slotID), h)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = testutil.GET(t, e, "/bureau/time-slots", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Len(t, testutil.ParseSlice(t, rec), 0)
+}
+
+func TestBureau_TimeSlots_InvalidTime(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	// Неверный формат времени.
+	rec := testutil.POST(t, e, "/bureau/time-slots", `{"day_of_week":0,"open_time":"invalid","close_time":"17:00"}`, h)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	// День недели вне диапазона.
+	rec = testutil.POST(t, e, "/bureau/time-slots", `{"day_of_week":7,"open_time":"08:00","close_time":"17:00"}`, h)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// Запись расписания Бюро гейтится requireAdmin: обычный пользователь получает 403.
+func TestBureau_TimeSlots_NonAdminForbidden(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAndLogin(t, e, "bureau_regular", "pass123", 1, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	rec := testutil.POST(t, e, "/bureau/time-slots", `{"day_of_week":0,"open_time":"08:00","close_time":"17:00"}`, h)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+// 404 при обновлении/удалении несуществующего слота.
+func TestBureau_TimeSlots_NotFound(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	rec := testutil.PUT(t, e, "/bureau/time-slots/99999", `{"open_time":"09:00"}`, h)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+
+	rec = testutil.DELETE(t, e, "/bureau/time-slots/99999", h)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}

--- a/internal/models/bureau.go
+++ b/internal/models/bureau.go
@@ -1,0 +1,21 @@
+package models
+
+import "time"
+
+// BureauTimeSlot -- временной слот расписания работы Бюро. Single-owner: FK к
+// родителю нет (Бюро в системе одно), но структура полей совпадает с
+// UnloadPlaceTimeSlot/SystemTableTimeSlot, чтобы агрегатор режимов работы (C2)
+// приводил все три типа к единой форме слота без преобразований.
+type BureauTimeSlot struct {
+	ID        int       `json:"id"`
+	DayOfWeek int       `json:"day_of_week"` // 0=Пн..6=Вс
+	OpenTime  string    `gorm:"size:10" json:"open_time"`
+	CloseTime string    `gorm:"size:10" json:"close_time"`
+	IsNextDay bool      `gorm:"default:false" json:"is_next_day"`
+	IsActive  bool      `gorm:"default:true" json:"is_active"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// GetID реализует контракт timeSlotModel для общего стора слотов.
+func (s BureauTimeSlot) GetID() int { return s.ID }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -56,6 +56,7 @@ type Dependencies struct {
 	Documents           *handlers.DocumentHandler
 	Guide               *handlers.GuideHandler
 	Statistics          *handlers.StatisticsHandler
+	Bureau              *handlers.BureauHandler
 
 	// Services (для middleware и audit)
 	PermResolver *services.PermissionResolver
@@ -114,6 +115,7 @@ func Setup(e *echo.Echo, d Dependencies) {
 	docs := d.Documents
 	guide := d.Guide
 	statistics := d.Statistics
+	bureau := d.Bureau
 	permResolver := d.PermResolver
 	denialLog := d.DenialLog
 	// requireAdmin — гейт admin-страниц по page.admin (super/admin проходят,
@@ -329,6 +331,14 @@ func Setup(e *echo.Echo, d Dependencies) {
 	upg.POST("/:id/photos", up.UploadPhoto)
 	upg.DELETE("/:place_id/photos/:photo_id", up.DeletePhoto)
 	upg.POST("/:place_id/photos/:photo_id/main", up.SetMainPhoto)
+
+	// Расписание работы Бюро (single-owner). Чтение -- любой авторизованный
+	// (нужно модалке режимов работы), изменения -- админ (раздел «Информация Бюро»).
+	bureauGroup := protected.Group("/bureau")
+	bureauGroup.GET("/time-slots", bureau.GetTimeSlots)
+	bureauGroup.POST("/time-slots", bureau.AddTimeSlot, requireAdmin)
+	bureauGroup.PUT("/time-slots/:slot_id", bureau.UpdateTimeSlot, requireAdmin)
+	bureauGroup.DELETE("/time-slots/:slot_id", bureau.DeleteTimeSlot, requireAdmin)
 
 	// Управление пользователями - page.admin.users (Ф5, ранее service checkAdmin
 	// по type-коду manager/buropropuskov). Тот же ключ, что и у FE-роута раздела.

--- a/internal/services/bureau_service.go
+++ b/internal/services/bureau_service.go
@@ -1,0 +1,67 @@
+package services
+
+import (
+	"context"
+
+	"systemburo/internal/models"
+
+	"gorm.io/gorm"
+)
+
+// BureauService -- бизнес-логика расписания работы Бюро. Бюро в системе одно,
+// поэтому это single-owner: слоты не привязаны к родителю.
+type BureauService interface {
+	GetTimeSlots(ctx context.Context) ([]models.BureauTimeSlot, error)
+	AddTimeSlot(ctx context.Context, req CreateTimeSlotRequest) (int, error)
+	UpdateTimeSlot(ctx context.Context, slotID int, req UpdateTimeSlotRequest) error
+	DeleteTimeSlot(ctx context.Context, slotID int) error
+}
+
+type bureauService struct {
+	db *gorm.DB
+}
+
+// NewBureauService создаёт реализацию BureauService.
+func NewBureauService(db *gorm.DB) BureauService {
+	return &bureauService{db: db}
+}
+
+// timeSlots -- общий стор слотов в single-owner режиме: fkColumn пуст (нет
+// партиционирования по родителю), проверка родителя всегда успешна.
+func (s *bureauService) timeSlots() timeSlotStore[models.BureauTimeSlot] {
+	return timeSlotStore[models.BureauTimeSlot]{
+		db:          s.db,
+		entity:      "bureau",
+		fkColumn:    "",
+		checkParent: func(_ context.Context, _ int) error { return nil },
+		newSlot: func(_ int, req models.CreateTimeSlotRequest) models.BureauTimeSlot {
+			return models.BureauTimeSlot{
+				DayOfWeek: req.DayOfWeek,
+				OpenTime:  req.OpenTime,
+				CloseTime: req.CloseTime,
+				IsNextDay: req.IsNextDay != nil && *req.IsNextDay,
+				IsActive:  req.IsActive == nil || *req.IsActive,
+			}
+		},
+	}
+}
+
+// GetTimeSlots возвращает все слоты расписания Бюро.
+func (s *bureauService) GetTimeSlots(ctx context.Context) ([]models.BureauTimeSlot, error) {
+	return s.timeSlots().list(ctx, 0)
+}
+
+// AddTimeSlot добавляет слот в расписание Бюро.
+func (s *bureauService) AddTimeSlot(ctx context.Context, req CreateTimeSlotRequest) (int, error) {
+	return s.timeSlots().add(ctx, 0, models.CreateTimeSlotRequest(req))
+}
+
+// UpdateTimeSlot обновляет слот расписания Бюро.
+func (s *bureauService) UpdateTimeSlot(ctx context.Context, slotID int, req UpdateTimeSlotRequest) error {
+	return s.timeSlots().update(ctx, 0, slotID, models.UpdateTimeSlotRequest(req))
+}
+
+// DeleteTimeSlot удаляет слот расписания Бюро.
+func (s *bureauService) DeleteTimeSlot(ctx context.Context, slotID int) error {
+	return s.timeSlots().remove(ctx, 0, slotID)
+}

--- a/internal/services/timeslot_store.go
+++ b/internal/services/timeslot_store.go
@@ -22,20 +22,30 @@ type timeSlotModel interface {
 // timeSlotStore -- generic-CRUD временных слотов поверх произвольной модели слота.
 // Раньше эта логика была продублирована в system_table и unload_place сервисах;
 // специфика таблицы (имя FK-колонки, проверка родителя, конструктор слота) задаётся
-// полями, остальное общее.
+// полями, остальное общее. Для single-owner таблиц (расписание Бюро) fkColumn пуст:
+// фильтрации по родителю нет, parentID игнорируется.
 type timeSlotStore[T timeSlotModel] struct {
 	db          *gorm.DB
-	entity      string                                                 // для логов: "system_table" | "unload_place"
-	fkColumn    string                                                 // "table_id" | "unload_place_id"
+	entity      string                                                 // для логов: "system_table" | "unload_place" | "bureau"
+	fkColumn    string                                                 // "table_id" | "unload_place_id"; "" для single-owner
 	checkParent func(ctx context.Context, parentID int) error          // существование родителя + текст 404
 	newSlot     func(parentID int, req models.CreateTimeSlotRequest) T // конструктор слота с FK и полями
+}
+
+// scopeParent ограничивает запрос родителем для parent-keyed стора. Для
+// single-owner стора (fkColumn == "") фильтр не добавляется -- таблица
+// обслуживает единственного владельца, parentID не используется.
+func (st timeSlotStore[T]) scopeParent(q *gorm.DB, parentID int) *gorm.DB {
+	if st.fkColumn == "" {
+		return q
+	}
+	return q.Where(st.fkColumn+" = ?", parentID)
 }
 
 // list возвращает слоты родителя, отсортированные по дню и времени открытия.
 func (st timeSlotStore[T]) list(ctx context.Context, parentID int) ([]T, error) {
 	slots := make([]T, 0)
-	if err := st.db.WithContext(ctx).
-		Where(st.fkColumn+" = ?", parentID).
+	if err := st.scopeParent(st.db.WithContext(ctx), parentID).
 		Order("day_of_week, open_time").
 		Find(&slots).Error; err != nil {
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Error fetching time slots")
@@ -70,8 +80,7 @@ func (st timeSlotStore[T]) add(ctx context.Context, parentID int, req models.Cre
 // update применяет переданные поля к существующему слоту (404, если слота нет).
 func (st timeSlotStore[T]) update(ctx context.Context, parentID, slotID int, req models.UpdateTimeSlotRequest) error {
 	var existing T
-	if err := st.db.WithContext(ctx).
-		Where("id = ? AND "+st.fkColumn+" = ?", slotID, parentID).
+	if err := st.scopeParent(st.db.WithContext(ctx).Where("id = ?", slotID), parentID).
 		First(&existing).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return errTimeSlotNotFound()
@@ -107,9 +116,7 @@ func (st timeSlotStore[T]) update(ctx context.Context, parentID, slotID int, req
 		updates["is_active"] = *req.IsActive
 	}
 
-	result := st.db.WithContext(ctx).
-		Model(new(T)).
-		Where("id = ? AND "+st.fkColumn+" = ?", slotID, parentID).
+	result := st.scopeParent(st.db.WithContext(ctx).Model(new(T)).Where("id = ?", slotID), parentID).
 		Updates(updates)
 	if result.Error != nil {
 		slog.Error("не удалось обновить временной слот", "entity", st.entity, "slot_id", slotID, "parent_id", parentID, "error", result.Error)
@@ -124,8 +131,7 @@ func (st timeSlotStore[T]) update(ctx context.Context, parentID, slotID int, req
 
 // remove удаляет слот родителя (404, если слота нет).
 func (st timeSlotStore[T]) remove(ctx context.Context, parentID, slotID int) error {
-	result := st.db.WithContext(ctx).
-		Where("id = ? AND "+st.fkColumn+" = ?", slotID, parentID).
+	result := st.scopeParent(st.db.WithContext(ctx).Where("id = ?", slotID), parentID).
 		Delete(new(T))
 	if result.Error != nil {
 		slog.Error("не удалось удалить временной слот", "entity", st.entity, "slot_id", slotID, "parent_id", parentID, "error", result.Error)

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -111,6 +111,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	userService := services.NewUserService(db, notificationServiceEarly)
 	onboardingService := services.NewOnboardingService(db)
 	unloadPlaceService := services.NewUnloadPlaceService(db)
+	bureauService := services.NewBureauService(db)
 	carService := services.NewCarService(db)
 	employeeService := services.NewEmployeeService(db)
 	permissionService := services.NewPermissionService(db)
@@ -167,6 +168,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	usersHandler := handlers.NewUsersHandler(userService)
 	onboardingHandler := handlers.NewOnboardingHandler(onboardingService)
 	unloadPlaceHandler := handlers.NewUnloadPlaceHandler(unloadPlaceService, 10*1024*1024, "./uploads")
+	bureauHandler := handlers.NewBureauHandler(bureauService)
 	carHandler := handlers.NewCarHandler(carService)
 	employeeHandler := handlers.NewEmployeeHandler(employeeService)
 	systemTableHistoryService := services.NewSystemTableHistoryService(db)
@@ -219,6 +221,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 		Users:               usersHandler,
 		Onboarding:          onboardingHandler,
 		UnloadPlace:         unloadPlaceHandler,
+		Bureau:              bureauHandler,
 		Cars:                carHandler,
 		Employees:           employeeHandler,
 		SystemTable:         systemTableHandler,


### PR DESCRIPTION
## Что это
Срез **C1a** эпика multitab-fixes (фаза C «Режимы работы»). Бэкенд расписания работы Бюро под будущий агрегатор режимов (C2) и редактор в настройках (C1b).

C1 разбит на C1a (этот, чистый BE, CI-верифицируемо) и C1b (FE: «Информация Бюро» + редактор расписания) — full-stack одним PR ломает верификацию, а FE-часть требует скриншот-до-мержа.

## Изменения
- `internal/models/bureau.go` — модель `BureauTimeSlot` (single-owner: FK к родителю нет, Бюро одно; структура полей 1:1 с `UnloadPlaceTimeSlot`/`SystemTableTimeSlot` под единую форму слота в C2).
- `internal/services/timeslot_store.go` — обобщил generic-стор на single-owner: при пустом `fkColumn` фильтр по родителю не добавляется. Для parent-keyed сторов (места разгрузки, посты) поведение SQL не изменилось: `scopeParent(db.Where("id=?"), parentID)` = прежний `WHERE id=? AND fk=?` (chained Where = AND).
- `internal/services/bureau_service.go` — `BureauService` поверх стора в single-owner режиме.
- `internal/handlers/bureau.go` — CRUD-эндпоинты `/bureau/time-slots[/:slot_id]`.
- `internal/router/router.go` — регистрация группы: GET под `protected`, POST/PUT/DELETE под `requireAdmin` (редактор в админ-настройках; чтение оставлено открытым для будущей пользовательской модалки режимов).
- `cmd/server/main.go`, `internal/testutil/testutil.go` — провязка сервиса/хендлера.
- `internal/handlers/bureau_test.go` — тесты CRUD, валидация времени/дня (400), гейт `requireAdmin` для не-админа (403), 404 на несуществующий слот.

## ⚠️ Off-limits: `internal/database/migrate.go`
Одна **аддитивная** строка — регистрация `&models.BureauTimeSlot{}` в `AllModels()` (новая таблица через AutoMigrate, ничего деструктивного). Это явно в скоупе задачи C1 («аддитивная миграция») и повторяет паттерн смерженного в этом же эпике B1 (#849, добавление `GuideSection`). Прошу явный OK на мерж из-за статуса off-limits-файла.

## Проверка
- `go build ./...` чисто, `go vet` чисто, `gofmt` чисто.
- `go test ./internal/handlers/` — зелёный целиком (все bureau-тесты + регресс time-slots мест разгрузки/постов).
- Полный `go test ./...` локально краснит только на известных флейках расшаренной грязной тест-БД (`TestLogPartitionMaintenance` — копится `request_logs_daily`; concurrent AutoMigrate при `-p>1`) — не относится к диффу; в CI тест-БД чистая.
- Ревью `code-reviewer`: регрессии в shared-сторе нет, авторизация адекватна, тесты осмысленны; единственный стоп — процедурный гейт по migrate.go (см. выше).