### PR TITLE
feat(settings): расписание работы Бюро и переименование в "Информация Бюро" (C1b)

### DIFF
--- a/frontend/src/views/AdminSettings.vue
+++ b/frontend/src/views/AdminSettings.vue
@@ -70,7 +70,7 @@
           @click="activeSection = 'contacts'"
           @keydown.enter="activeSection = 'contacts'"
         >
-          Контакты Бюро
+          Информация Бюро
         </div>
       </nav>
 
@@ -231,14 +231,18 @@
             </button>
           </div>
 
-          <!-- Контакты Бюро -->
+          <!-- Информация Бюро -->
           <div
             v-else-if="activeSection === 'contacts'"
             class="settings-section"
           >
             <h3 class="section-title">
-              Контакты Бюро пропусков
+              Информация Бюро
             </h3>
+
+            <h4 class="subsection-title">
+              Контакты
+            </h4>
             <p class="form-hint section-intro">
               Телефон и почта Бюро. Показываются на странице входа и в плашке блокировки.
             </p>
@@ -283,6 +287,21 @@
             >
               {{ saving ? 'Сохранение...' : 'Сохранить' }}
             </button>
+
+            <div class="bureau-schedule">
+              <p
+                v-if="bureauSlotsLoading && !bureauSlotsLoaded"
+                class="form-hint"
+              >
+                Загрузка расписания...
+              </p>
+              <WorkScheduleTab
+                v-else
+                resource-url="/bureau"
+                :time-slots="bureauTimeSlots"
+                @update="fetchBureauSchedule"
+              />
+            </div>
           </div>
 
           <!-- Уведомления -->
@@ -539,6 +558,8 @@ import { SkeletonTransition, SkeletonLine, SkeletonBlock } from '@/components/ui
 import { useDeletionsStore } from '@/stores/deletions';
 import { useUiStore } from '@/stores/ui';
 import { useContactsStore } from '@/stores/contacts';
+import { apiRequest } from '@/api/client';
+import WorkScheduleTab from '@/components/WorkScheduleTab.vue';
 
 export default {
   name: 'AdminSettings',
@@ -546,6 +567,7 @@ export default {
     SkeletonTransition,
     SkeletonLine,
     SkeletonBlock,
+    WorkScheduleTab,
   },
   data() {
     return {
@@ -585,6 +607,10 @@ export default {
       dpLoading: false,
       dpUploading: false,
       dpDeleting: false,
+      bureauTimeSlots: [],
+      bureauSlotsLoaded: false,
+      bureauSlotsLoading: false,
+      bureauSeq: 0,
     };
   },
   computed: {
@@ -627,6 +653,9 @@ export default {
     activeSection(section) {
       if (section === 'data-processing' && !this.dpLoaded) {
         this.fetchDataProcessingDoc();
+      }
+      if (section === 'contacts' && !this.bureauSlotsLoaded) {
+        this.fetchBureauSchedule();
       }
     },
   },
@@ -767,6 +796,29 @@ export default {
         useDeletionsStore().notify({ prefix: 'Ошибка сохранения настроек', type: 'error' });
       } finally {
         this.saving = false;
+      }
+    },
+
+    async fetchBureauSchedule() {
+      // seq-токен: быстрые @update от тумблеров 24/7 шлют параллельные fetch'и,
+      // в стор пишет только последний - иначе устаревший ответ затрёт актуальный.
+      const seq = ++this.bureauSeq;
+      this.bureauSlotsLoading = true;
+      try {
+        const response = await apiRequest('/bureau/time-slots');
+        if (!response.ok) {
+          throw new Error('Не удалось загрузить расписание');
+        }
+        const data = await response.json();
+        if (seq !== this.bureauSeq) return;
+        this.bureauTimeSlots = Array.isArray(data) ? data : [];
+        this.bureauSlotsLoaded = true;
+      } catch (error) {
+        if (seq !== this.bureauSeq) return;
+        console.error('Ошибка загрузки расписания Бюро:', error);
+        useDeletionsStore().notify({ prefix: 'Не удалось загрузить расписание Бюро', type: 'error' });
+      } finally {
+        if (seq === this.bureauSeq) this.bureauSlotsLoading = false;
       }
     },
 
@@ -1034,6 +1086,19 @@ export default {
 .section-intro {
   margin: 0 0 16px;
   font-size: 13px;
+}
+
+.subsection-title {
+  margin: 0 0 8px;
+  font-size: 16px;
+  font-weight: 600;
+  color: #000;
+}
+
+.bureau-schedule {
+  margin-top: 24px;
+  padding-top: 20px;
+  border-top: 1px solid #e6e6e6;
 }
 
 .form-range {


### PR DESCRIPTION
Срез C1b эпика multitab-fixes (фаза C, Режимы работы). Зависит от C1a #856 (бэкенд `/bureau/time-slots`, уже в dev).

## Что
- Вкладка и заголовок секции настроек «Контакты Бюро» -> **«Информация Бюро»** (#831/#833 уже в dev).
- Секция теперь = подсекция «Контакты» (телефон/почта, без изменений логики) + новый блок «Режим работы» через реюз `WorkScheduleTab` (`resource-url="/bureau"`), грузит/пишет `/bureau/time-slots` из C1a.
- Fetch расписания защищён seq-токеном от гонки устаревшего ответа (быстрые `@update` от тумблеров 24/7).

## Файлы
- `frontend/src/views/AdminSettings.vue` (+68/-3)

## Проверено
- eslint чисто; vitest AdminSettings (contacts/dataProcessing/security/notifications) 12/12 зелёные.
- Локальный рендер (vite worktree, `/bureau/time-slots` застаблен — локальный бэкенд-контейнер недельной давности без роута C1a): заголовок «Информация Бюро», подсекция «Контакты», `WorkScheduleTab` отрисован («Режим работы» + «+ Добавить окно»), сетка 7 дней Пн-Вс, расписание ниже контактов, консоль без новых ошибок. Скриншот согласован с пользователем до мержа.
- Реальные слоты подхватятся на staging (C1a в dev).