### PR TITLE
feat(permissions): гибрид-доступ page.available к разделу Доступные мне

### DIFF
--- a/frontend/src/components/__tests__/NavMenuAccessibleAttachments.spec.js
+++ b/frontend/src/components/__tests__/NavMenuAccessibleAttachments.spec.js
@@ -56,6 +56,17 @@ describe('NavMenu: гейтинг пункта "Доступные мне" (FE-S
     expect(wrapper.find(TESTID).isVisible()).toBe(true);
   });
 
+  // Гибрид page.available (срез 6b): обычный юзер (не охранник, не супер) с грантом
+  // page.available получает canViewAccessibleAttachments=true и видит пункт. NavMenu
+  // следует getter'у независимо от источника доступа (тип vs грант роли/группы).
+  it('обычный пользователь с грантом page.available видит пункт', () => {
+    useAuthStore.mockReturnValue({ isSuperAdmin: false, canViewAccessibleAttachments: true });
+    wrapper = mountNav();
+    const item = wrapper.find(TESTID);
+    expect(item.exists()).toBe(true);
+    expect(item.isVisible()).toBe(true);
+  });
+
   it('обычный пользователь не видит пункт', () => {
     useAuthStore.mockReturnValue({ isSuperAdmin: false, canViewAccessibleAttachments: false });
     wrapper = mountNav();

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -311,6 +311,14 @@ router.beforeEach(async (to, from, next) => {
     if (!isSuperAdmin && authStore.userTypeCode === null) {
       await authStore.loadUserTypeCode();
     }
+    // Грант page.available приходит ролью/группой через permissions store, но на
+    // F5/прямой ссылке permissions ещё не загружены (fetch ниже), поэтому
+    // подгружаем до getter - иначе обычный юзер с грантом ошибочно уедет в ЛК.
+    if (!isSuperAdmin && !authStore.isSecurity) {
+      const { usePermissionsStore } = await import('@/stores/permissions');
+      const permStore = usePermissionsStore();
+      if (permStore.isStale) await permStore.fetchPermissions();
+    }
     if (!authStore.canViewAccessibleAttachments) {
       next('/personal-cabinet');
       return;

--- a/frontend/src/stores/__tests__/auth.spec.js
+++ b/frontend/src/stores/__tests__/auth.spec.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
 import { useAuthStore } from '../auth';
+import { usePermissionsStore } from '../permissions';
 
 vi.mock('@/api/auth', () => ({
   getMe: vi.fn(),
@@ -152,6 +153,26 @@ describe('auth store', () => {
       const store = useAuthStore();
       store.setTokens(createMockJWT({ type_id: 2 }));
       store.userTypeCode = 'user';
+      expect(store.canViewAccessibleAttachments).toBe(false);
+    });
+
+    it('возвращает true для обычного пользователя с грантом page.available', () => {
+      const store = useAuthStore();
+      store.setTokens(createMockJWT({ type_id: 2 }));
+      store.userTypeCode = 'user';
+      const perms = usePermissionsStore();
+      perms.mode = 'normal';
+      perms.effective = { 'page.available': { value: 'allow', source: 'role' } };
+      expect(store.canViewAccessibleAttachments).toBe(true);
+    });
+
+    it('остаётся false если у обычного пользователя грант другого ключа', () => {
+      const store = useAuthStore();
+      store.setTokens(createMockJWT({ type_id: 2 }));
+      store.userTypeCode = 'user';
+      const perms = usePermissionsStore();
+      perms.mode = 'normal';
+      perms.effective = { 'page.statistics': { value: 'allow', source: 'role' } };
       expect(store.canViewAccessibleAttachments).toBe(false);
     });
   });

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -1,5 +1,9 @@
 import { defineStore } from 'pinia';
 import { getMe } from '@/api/auth';
+// Циклический импорт с permissions.js (он импортит useAuthStore) безопасен:
+// обе стороны зовут стор только в рантайме (getter / parsePermissionsResponse),
+// не на этапе инициализации модуля - ESM live bindings уже заполнены к вызову.
+import { usePermissionsStore } from './permissions';
 
 function decodeToken(token) {
   try {
@@ -49,8 +53,15 @@ export const useAuthStore = defineStore('auth', {
     isSecurity() {
       return this.userTypeCode === 'security';
     },
+    // Гибрид: охранник и супер-админ видят раздел по типу/роли, плюс любая роль
+    // с грантом page.available. Тумблер только добавляет доступ - отозвать его
+    // у охранника нельзя (доступ по типу пользователя).
     canViewAccessibleAttachments() {
-      return this.isSecurity || this.isSuperAdmin;
+      return (
+        this.isSuperAdmin
+        || this.isSecurity
+        || usePermissionsStore().hasPermission('page.available')
+      );
     },
   },
 


### PR DESCRIPTION
## Что

Срез 6b эпика permission-gating. Тумблер каталога прав `page.available` был «мёртвым» — раздел «Доступные мне» (`/accessible-attachments`) видели только охранник (тип `security`) и супер-админ по типу пользователя. Теперь это гибрид:

```js
canViewAccessibleAttachments = isSuperAdmin || isSecurity || hasPermission('page.available')
```

Любая роль с грантом `page.available` получает доступ, не отбирая его у охранников (тумблер только **добавляет**, отозвать у security по типу нельзя — принятый минус).

## Изменения
- `stores/auth.js` — getter `canViewAccessibleAttachments` дополнен проверкой гранта.
- `router.js` — в guard-блоке `requiresSecurityOrAdmin` подгружаю permissions до проверки getter'а для не-super/не-security. Без этого на F5/прямой ссылке permissions ещё не загружены (их fetch ниже по guard) и юзер с грантом ошибочно редиректился в ЛК. `isStale`-гейт исключает двойной fetch с polling-блоком ниже.
- Тесты: `auth.spec.js` (реальный getter — позитив с грантом + негатив с грантом другого ключа), `NavMenuAccessibleAttachments.spec.js` (кейс normal+грант видит пункт).

## Zero-regression
Существующие пути (охранник/супер-админ) короткозамыкаются в getter'е до обращения к permissions — поведение и лишние вызовы не меняются. `seed`/`migrate.go` не трогал.

## Проверки
- Полный vitest: 115 файлов, 1169 тестов зелёные.
- ESLint на изменённых файлах чист.
- Ревью `code-reviewer`: GO, блокеров нет.

## Известные не-блокеры (из ревью)
- F5 на `/accessible-attachments` при **сетевом сбое** `fetchPermissions` отбросит грантированного юзера в ЛК — это согласованная деградация всей permission-системы при отказе сети (тот же путь у polling-блока), не новый класс бага.
- Кейс в `NavMenuAccessibleAttachments.spec.js` документирует, что NavMenu следует getter'у независимо от источника доступа; реальное покрытие новой ветки getter'а — в `auth.spec.js`.