### PR TITLE
feat(modes): агрегатор режимов работы - единая форма слота для 3 типов (C2)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -178,6 +178,7 @@ func main() {
 	if err := systemTableService.SeedMissingFields(context.Background()); err != nil {
 		slog.Error("не удалось досидить отсутствующие поля таблиц (#345)", "error", err)
 	}
+	workModesService := services.NewWorkModesService(unloadPlaceService, systemTableService, bureauService)
 	uniqueCarService := services.NewUniqueCarService(db)
 	uniqueEmployeeService := services.NewUniqueEmployeeService(db)
 	feedbackService := services.NewFeedbackService(db)
@@ -222,6 +223,7 @@ func main() {
 	onboardingHandler := handlers.NewOnboardingHandler(onboardingService)
 	unloadPlaceHandler := handlers.NewUnloadPlaceHandler(unloadPlaceService, cfg.UploadMaxFileSize, cfg.UploadPath)
 	bureauHandler := handlers.NewBureauHandler(bureauService)
+	workModesHandler := handlers.NewWorkModesHandler(workModesService)
 	carHandler := handlers.NewCarHandler(carService)
 	employeeHandler := handlers.NewEmployeeHandler(employeeService)
 	systemTableHistoryService := services.NewSystemTableHistoryService(db)
@@ -314,6 +316,7 @@ func main() {
 		Documents:           documentHandler,
 		Guide:               guideHandler,
 		Bureau:              bureauHandler,
+		WorkModes:           workModesHandler,
 		Statistics:          statisticsHandler,
 		Onboarding:          onboardingHandler,
 		PermResolver:        permissionResolver,

--- a/internal/handlers/work_modes.go
+++ b/internal/handlers/work_modes.go
@@ -1,0 +1,36 @@
+package handlers
+
+import (
+	"systemburo/internal/services"
+
+	"github.com/labstack/echo/v4"
+)
+
+// WorkModesHandler -- HTTP-обработчик агрегатора режимов работы (read-only).
+type WorkModesHandler struct {
+	service services.WorkModesService
+}
+
+// NewWorkModesHandler создаёт новый обработчик режимов работы.
+func NewWorkModesHandler(service services.WorkModesService) *WorkModesHandler {
+	return &WorkModesHandler{service: service}
+}
+
+// GetWorkModes возвращает расписания Бюро, мест разгрузки и мест прохода в единой
+// форме слота с текущим статусом каждого объекта.
+// @Summary      Режимы работы
+// @Description  Агрегирует расписания Бюро, мест разгрузки и мест прохода (постов) в единую форму слота с current_status. Неархивные объекты, включая операционно неактивные.
+// @Tags         work-modes
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200 {object} services.WorkModesResponse
+// @Failure      401 {object} models.HTTPError
+// @Failure      500 {object} models.HTTPError
+// @Router       /work-modes [get]
+func (h *WorkModesHandler) GetWorkModes(c echo.Context) error {
+	modes, err := h.service.GetWorkModes(c.Request().Context())
+	if err != nil {
+		return err
+	}
+	return RespondSuccess(c, modes)
+}

--- a/internal/handlers/work_modes_test.go
+++ b/internal/handlers/work_modes_test.go
@@ -1,0 +1,136 @@
+package handlers_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"systemburo/internal/models"
+	"systemburo/internal/services"
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// todayDOW -- текущий день недели в формате слотов (0=Пн..6=Вс).
+func todayDOW() int { return int(time.Now().Weekday()+6) % 7 }
+
+func TestWorkModes_Unauthorized(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+
+	rec := testutil.GET(t, e, "/work-modes", nil)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+// Агрегатор приводит три типа к единой форме слота: Бюро, места разгрузки и
+// места прохода. Архивные исключаются, операционно неактивные включаются с status.
+func TestWorkModes_Aggregates(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAndLogin(t, e, "modes_user", "pass123", 1, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	today := todayDOW()
+
+	// Бюро: круглосуточный слот на сегодня -> current_status open.
+	require.NoError(t, db.Create(&models.BureauTimeSlot{
+		DayOfWeek: today, OpenTime: "00:00", CloseTime: "23:59", IsNextDay: false, IsActive: true,
+	}).Error)
+
+	// Место разгрузки активное, открыто сейчас.
+	active := models.UnloadPlace{Name: "Склад активный", Status: "active", IsActive: true}
+	require.NoError(t, db.Create(&active).Error)
+	require.NoError(t, db.Create(&models.UnloadPlaceTimeSlot{
+		UnloadPlaceID: active.ID, DayOfWeek: today, OpenTime: "00:00", CloseTime: "23:59", IsActive: true,
+	}).Error)
+
+	// Место разгрузки операционно неактивное -- включается с флагом status.
+	inactive := models.UnloadPlace{Name: "Склад неактивный", Status: "inactive", IsActive: true}
+	require.NoError(t, db.Create(&inactive).Error)
+
+	// Архивное (soft-delete, is_active=false) -- НЕ должно попасть в выдачу.
+	// is_active имеет gorm default:true, поэтому zero-value при Create опускается и
+	// БД ставит true -- форсируем false явным Update.
+	archived := models.UnloadPlace{Name: "Склад архивный", Status: "active"}
+	require.NoError(t, db.Create(&archived).Error)
+	require.NoError(t, db.Model(&archived).Update("is_active", false).Error)
+
+	// Место прохода (пост) -- системная таблица с display_name и слотом.
+	display := "КПП-1 - главный въезд"
+	table := models.SystemTable{Name: "kpp1", DisplayName: &display, Status: "active", IsActive: true}
+	require.NoError(t, db.Create(&table).Error)
+	require.NoError(t, db.Create(&models.SystemTableTimeSlot{
+		TableID: table.ID, DayOfWeek: today, OpenTime: "08:00", CloseTime: "20:00", IsActive: true,
+	}).Error)
+
+	rec := testutil.GET(t, e, "/work-modes", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	resp := testutil.ParseResponse[services.WorkModesResponse](t, rec)
+
+	// Бюро всегда присутствует, открыто по круглосуточному слоту.
+	assert.Equal(t, "bureau", resp.Bureau.Kind)
+	assert.Equal(t, "active", resp.Bureau.Status)
+	assert.Equal(t, "open", resp.Bureau.CurrentStatus)
+	require.Len(t, resp.Bureau.TimeSlots, 1)
+	assert.Equal(t, today, resp.Bureau.TimeSlots[0].DayOfWeek)
+	assert.Equal(t, "00:00", resp.Bureau.TimeSlots[0].OpenTime)
+	assert.Equal(t, "23:59", resp.Bureau.TimeSlots[0].CloseTime)
+
+	// Места разгрузки: активное + неактивное, БЕЗ архивного.
+	require.Len(t, resp.UnloadPlaces, 2)
+	byName := map[string]services.WorkModeEntity{}
+	for _, p := range resp.UnloadPlaces {
+		byName[p.Name] = p
+		assert.Equal(t, "unload_place", p.Kind)
+	}
+	require.Contains(t, byName, "Склад активный")
+	require.Contains(t, byName, "Склад неактивный")
+	assert.NotContains(t, byName, "Склад архивный")
+	assert.Equal(t, "active", byName["Склад активный"].Status)
+	assert.Equal(t, "open", byName["Склад активный"].CurrentStatus)
+	assert.Equal(t, "inactive", byName["Склад неактивный"].Status)
+
+	// Слот активного места в единой форме {day_of_week,open_time,close_time,is_next_day,is_active}.
+	require.Len(t, byName["Склад активный"].TimeSlots, 1)
+	slot := byName["Склад активный"].TimeSlots[0]
+	assert.Equal(t, today, slot.DayOfWeek)
+	assert.Equal(t, "00:00", slot.OpenTime)
+	assert.Equal(t, "23:59", slot.CloseTime)
+	assert.False(t, slot.IsNextDay)
+	assert.True(t, slot.IsActive)
+
+	// Места прохода: пост с display_name, единые слоты.
+	require.Len(t, resp.Checkpoints, 1)
+	cp := resp.Checkpoints[0]
+	assert.Equal(t, "checkpoint", cp.Kind)
+	assert.Equal(t, display, cp.Name)
+	assert.Equal(t, "active", cp.Status)
+	require.Len(t, cp.TimeSlots, 1)
+	assert.Equal(t, "08:00", cp.TimeSlots[0].OpenTime)
+	assert.Equal(t, "20:00", cp.TimeSlots[0].CloseTime)
+}
+
+// Пустая система: Бюро присутствует со статусом closed и пустыми слотами, списки пусты.
+func TestWorkModes_Empty(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+	token := testutil.RegisterAndLogin(t, e, "modes_empty", "pass123", 1, td.OrgID, td.CompanyID)
+	h := testutil.AuthHeader(token)
+
+	rec := testutil.GET(t, e, "/work-modes", h)
+	require.Equal(t, http.StatusOK, rec.Code)
+	resp := testutil.ParseResponse[services.WorkModesResponse](t, rec)
+
+	assert.Equal(t, "bureau", resp.Bureau.Kind)
+	assert.Equal(t, "closed", resp.Bureau.CurrentStatus)
+	assert.Empty(t, resp.Bureau.TimeSlots)
+	assert.Empty(t, resp.UnloadPlaces)
+	assert.Empty(t, resp.Checkpoints)
+}

--- a/internal/handlers/work_modes_test.go
+++ b/internal/handlers/work_modes_test.go
@@ -94,6 +94,9 @@ func TestWorkModes_Aggregates(t *testing.T) {
 	assert.Equal(t, "active", byName["Склад активный"].Status)
 	assert.Equal(t, "open", byName["Склад активный"].CurrentStatus)
 	assert.Equal(t, "inactive", byName["Склад неактивный"].Status)
+	// Операционно неактивное место всегда closed (canonical computeUnloadPlaceStatus
+	// при status != active) -- проверяем, что семантика пробросилась через агрегатор.
+	assert.Equal(t, "closed", byName["Склад неактивный"].CurrentStatus)
 
 	// Слот активного места в единой форме {day_of_week,open_time,close_time,is_next_day,is_active}.
 	require.Len(t, byName["Склад активный"].TimeSlots, 1)
@@ -104,7 +107,9 @@ func TestWorkModes_Aggregates(t *testing.T) {
 	assert.False(t, slot.IsNextDay)
 	assert.True(t, slot.IsActive)
 
-	// Места прохода: пост с display_name, единые слоты.
+	// Места прохода: пост с display_name, единые слоты. current_status поста
+	// (слот 08:00-20:00) зависит от времени прогона -- детерминированно его логику
+	// покрывает unit-тест computeWorkModeStatus; здесь проверяем проброс формы слота.
 	require.Len(t, resp.Checkpoints, 1)
 	cp := resp.Checkpoints[0]
 	assert.Equal(t, "checkpoint", cp.Kind)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -57,6 +57,7 @@ type Dependencies struct {
 	Guide               *handlers.GuideHandler
 	Statistics          *handlers.StatisticsHandler
 	Bureau              *handlers.BureauHandler
+	WorkModes           *handlers.WorkModesHandler
 
 	// Services (для middleware и audit)
 	PermResolver *services.PermissionResolver
@@ -339,6 +340,11 @@ func Setup(e *echo.Echo, d Dependencies) {
 	bureauGroup.POST("/time-slots", bureau.AddTimeSlot, requireAdmin)
 	bureauGroup.PUT("/time-slots/:slot_id", bureau.UpdateTimeSlot, requireAdmin)
 	bureauGroup.DELETE("/time-slots/:slot_id", bureau.DeleteTimeSlot, requireAdmin)
+
+	// Режимы работы -- read-only агрегатор расписаний Бюро, мест разгрузки и мест
+	// прохода в единой форме слота (для модалки «Режимы работы» в ЛК). Чтение
+	// любому авторизованному.
+	protected.GET("/work-modes", d.WorkModes.GetWorkModes)
 
 	// Управление пользователями - page.admin.users (Ф5, ранее service checkAdmin
 	// по type-коду manager/buropropuskov). Тот же ключ, что и у FE-роута раздела.

--- a/internal/services/work_modes_service.go
+++ b/internal/services/work_modes_service.go
@@ -65,6 +65,9 @@ func NewWorkModesService(unloadPlaces UnloadPlaceService, systemTables SystemTab
 // и постов берётся как есть из их сервисов (canonical-логика), Бюро считается
 // здесь (всегда операционно активно).
 func (s *workModesService) GetWorkModes(ctx context.Context) (*WorkModesResponse, error) {
+	// Осознанно переиспользуем GetAll сервисов (отдают и фото, агрегатору ненужные)
+	// ради canonical current_status без дублирования SQL. Эндпоинт редкий (открытие
+	// модалки), число мест/постов невелико -- лишние запросы фото приемлемы.
 	places, err := s.unloadPlaces.GetAll(ctx, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load unload places for work modes: %w", err)

--- a/internal/services/work_modes_service.go
+++ b/internal/services/work_modes_service.go
@@ -1,0 +1,213 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"systemburo/internal/models"
+)
+
+// WorkModeSlot -- единая форма временного слота расписания для всех трёх типов
+// (места разгрузки, места прохода, Бюро). Агрегатор режимов работы (C2) приводит
+// к ней разные исходные модели слотов, чтобы фронт рисовал расписание одинаково.
+type WorkModeSlot struct {
+	DayOfWeek int    `json:"day_of_week"` // 0=Пн..6=Вс
+	OpenTime  string `json:"open_time"`
+	CloseTime string `json:"close_time"`
+	IsNextDay bool   `json:"is_next_day"`
+	IsActive  bool   `json:"is_active"`
+}
+
+// WorkModeEntity -- объект расписания: место разгрузки, место прохода (пост) или
+// Бюро. Status -- операционный статус (active|inactive|maintenance), как в
+// карточках UnloadPlaceModal/TableInfoModal: при status != "active" фронт рисует
+// бейдж «Неактивно»/«На обслуживании», иначе open/closed по CurrentStatus. Бюро
+// всегда active (single-owner, отдельного поля статуса у него нет).
+type WorkModeEntity struct {
+	ID            int            `json:"id"`
+	Kind          string         `json:"kind"` // bureau | unload_place | checkpoint
+	Name          string         `json:"name"`
+	Status        string         `json:"status"`         // active | inactive | maintenance
+	CurrentStatus string         `json:"current_status"` // open | closed
+	TimeSlots     []WorkModeSlot `json:"time_slots"`
+}
+
+// WorkModesResponse -- сгруппированный по типам ответ агрегатора режимов работы.
+// Бюро присутствует всегда (single-owner). Списки мест возвращают только
+// неархивные записи (is_active=true), включая операционно неактивные
+// (status != "active") -- их фронт показывает с бейджем «Неактивно».
+type WorkModesResponse struct {
+	Bureau       WorkModeEntity   `json:"bureau"`
+	UnloadPlaces []WorkModeEntity `json:"unload_places"`
+	Checkpoints  []WorkModeEntity `json:"checkpoints"`
+}
+
+// WorkModesService -- read-only агрегатор расписаний всех мест и Бюро (C2).
+type WorkModesService interface {
+	GetWorkModes(ctx context.Context) (*WorkModesResponse, error)
+}
+
+type workModesService struct {
+	unloadPlaces UnloadPlaceService
+	systemTables SystemTableService
+	bureau       BureauService
+}
+
+// NewWorkModesService создаёт агрегатор поверх сервисов мест разгрузки,
+// системных таблиц (места прохода) и Бюро. Своих запросов к БД не делает -- берёт
+// готовые детали с уже вычисленным current_status, чтобы не дублировать логику.
+func NewWorkModesService(unloadPlaces UnloadPlaceService, systemTables SystemTableService, bureau BureauService) WorkModesService {
+	return &workModesService{unloadPlaces: unloadPlaces, systemTables: systemTables, bureau: bureau}
+}
+
+// GetWorkModes собирает расписания трёх типов в единую форму. current_status мест
+// и постов берётся как есть из их сервисов (canonical-логика), Бюро считается
+// здесь (всегда операционно активно).
+func (s *workModesService) GetWorkModes(ctx context.Context) (*WorkModesResponse, error) {
+	places, err := s.unloadPlaces.GetAll(ctx, false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load unload places for work modes: %w", err)
+	}
+	tables, err := s.systemTables.GetAll(ctx, false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load system tables for work modes: %w", err)
+	}
+	bureauSlots, err := s.bureau.GetTimeSlots(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load bureau schedule for work modes: %w", err)
+	}
+
+	resp := &WorkModesResponse{
+		Bureau:       buildBureauWorkMode(bureauSlots),
+		UnloadPlaces: make([]WorkModeEntity, 0, len(places)),
+		Checkpoints:  make([]WorkModeEntity, 0, len(tables)),
+	}
+
+	for _, p := range places {
+		resp.UnloadPlaces = append(resp.UnloadPlaces, WorkModeEntity{
+			ID:            p.ID,
+			Kind:          "unload_place",
+			Name:          p.Name,
+			Status:        normalizeStatus(p.Status),
+			CurrentStatus: p.CurrentStatus,
+			TimeSlots:     unloadSlotsToWorkMode(p.TimeSlots),
+		})
+	}
+
+	for _, t := range tables {
+		resp.Checkpoints = append(resp.Checkpoints, WorkModeEntity{
+			ID:            t.Table.ID,
+			Kind:          "checkpoint",
+			Name:          systemTableName(t.Table),
+			Status:        normalizeStatus(t.Table.Status),
+			CurrentStatus: t.CurrentStatus,
+			TimeSlots:     systemTableSlotsToWorkMode(t.TimeSlots),
+		})
+	}
+
+	return resp, nil
+}
+
+// buildBureauWorkMode превращает слоты Бюро в единый объект расписания. Бюро
+// single-owner: фиксированное имя, статус всегда active, текущий статус -- по слотам.
+func buildBureauWorkMode(slots []models.BureauTimeSlot) WorkModeEntity {
+	wmSlots := make([]WorkModeSlot, 0, len(slots))
+	for _, s := range slots {
+		wmSlots = append(wmSlots, WorkModeSlot{
+			DayOfWeek: s.DayOfWeek,
+			OpenTime:  s.OpenTime,
+			CloseTime: s.CloseTime,
+			IsNextDay: s.IsNextDay,
+			IsActive:  s.IsActive,
+		})
+	}
+	return WorkModeEntity{
+		ID:            0,
+		Kind:          "bureau",
+		Name:          "Бюро",
+		Status:        "active",
+		CurrentStatus: computeWorkModeStatus(wmSlots),
+		TimeSlots:     wmSlots,
+	}
+}
+
+// computeWorkModeStatus вычисляет текущий статус (open/closed) по слотам единой
+// формы. Зеркалит canonical computeUnloadPlaceStatus/computeCurrentStatus
+// (круглосуточный слот 00:00-23:59, переход через полночь is_next_day), но без
+// проверки операционного статуса -- применяется к Бюро, которое всегда active.
+func computeWorkModeStatus(slots []WorkModeSlot) string {
+	now := time.Now()
+	// 0=Пн..6=Вс (Go Weekday: 0=Вс).
+	currentDay := int(now.Weekday()+6) % 7
+	currentTime := now.Format("15:04")
+
+	for _, s := range slots {
+		if s.DayOfWeek == currentDay && s.IsActive &&
+			s.OpenTime == "00:00" && s.CloseTime == "23:59" && !s.IsNextDay {
+			return "open"
+		}
+	}
+
+	for _, s := range slots {
+		if s.DayOfWeek != currentDay || !s.IsActive {
+			continue
+		}
+		if s.IsNextDay {
+			if currentTime >= s.OpenTime {
+				return "open"
+			}
+		} else {
+			if currentTime >= s.OpenTime && currentTime <= s.CloseTime {
+				return "open"
+			}
+		}
+	}
+
+	return "closed"
+}
+
+// normalizeStatus подставляет "active" вместо пустого статуса (старые строки без
+// явного значения), чтобы фронт не путал "" с неактивностью.
+func normalizeStatus(status string) string {
+	if status == "" {
+		return "active"
+	}
+	return status
+}
+
+// systemTableName -- отображаемое имя поста: display_name, иначе техническое name.
+func systemTableName(t models.SystemTable) string {
+	if t.DisplayName != nil && *t.DisplayName != "" {
+		return *t.DisplayName
+	}
+	return t.Name
+}
+
+func unloadSlotsToWorkMode(slots []models.UnloadPlaceTimeSlot) []WorkModeSlot {
+	out := make([]WorkModeSlot, 0, len(slots))
+	for _, s := range slots {
+		out = append(out, WorkModeSlot{
+			DayOfWeek: s.DayOfWeek,
+			OpenTime:  s.OpenTime,
+			CloseTime: s.CloseTime,
+			IsNextDay: s.IsNextDay,
+			IsActive:  s.IsActive,
+		})
+	}
+	return out
+}
+
+func systemTableSlotsToWorkMode(slots []models.SystemTableTimeSlot) []WorkModeSlot {
+	out := make([]WorkModeSlot, 0, len(slots))
+	for _, s := range slots {
+		out = append(out, WorkModeSlot{
+			DayOfWeek: s.DayOfWeek,
+			OpenTime:  s.OpenTime,
+			CloseTime: s.CloseTime,
+			IsNextDay: s.IsNextDay,
+			IsActive:  s.IsActive,
+		})
+	}
+	return out
+}

--- a/internal/services/work_modes_status_test.go
+++ b/internal/services/work_modes_status_test.go
@@ -1,0 +1,51 @@
+package services
+
+import (
+	"testing"
+	"time"
+)
+
+// computeWorkModeStatus зависит от текущего времени; кейсы подобраны так, чтобы
+// результат был детерминирован в любой момент суток (привязка к "сегодня" и к
+// слотам, открытым/закрытым независимо от времени).
+func TestComputeWorkModeStatus(t *testing.T) {
+	today := int(time.Now().Weekday()+6) % 7
+	otherDay := (today + 1) % 7
+
+	cases := []struct {
+		name  string
+		slots []WorkModeSlot
+		want  string
+	}{
+		{"пусто", nil, "closed"},
+		{
+			"круглосуточно сегодня",
+			[]WorkModeSlot{{DayOfWeek: today, OpenTime: "00:00", CloseTime: "23:59", IsActive: true}},
+			"open",
+		},
+		{
+			// is_next_day: открытие в полночь -> currentTime >= "00:00" всегда true.
+			"переход через полночь сегодня",
+			[]WorkModeSlot{{DayOfWeek: today, OpenTime: "00:00", CloseTime: "06:00", IsNextDay: true, IsActive: true}},
+			"open",
+		},
+		{
+			"круглосуточно на другой день",
+			[]WorkModeSlot{{DayOfWeek: otherDay, OpenTime: "00:00", CloseTime: "23:59", IsActive: true}},
+			"closed",
+		},
+		{
+			"неактивный круглосуточный слот сегодня",
+			[]WorkModeSlot{{DayOfWeek: today, OpenTime: "00:00", CloseTime: "23:59", IsActive: false}},
+			"closed",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := computeWorkModeStatus(tc.slots); got != tc.want {
+				t.Errorf("computeWorkModeStatus() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -59,6 +59,7 @@ var tables = []string{
 	"unique_employees", "unique_cars", "unique_attachment_histories", "unique_attachments",
 	"application_reads", "application_viewers", "application_approver_histories", "application_approvers", "application_responsible_users",
 	"application_status_history", "application_history", "applications",
+	"bureau_time_slots",
 	"companies_unload_places", "organization_unload_places",
 	"unload_place_histories",
 	"unload_place_time_slots", "unload_place_photos", "unload_places",
@@ -121,6 +122,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	accessDenialService := services.NewAccessDenialService(db)
 	userBanService := services.NewUserBanService(db, permissionResolver, nil)
 	systemTableService := services.NewSystemTableService(db, "./uploads", 10*1024*1024, permissionService)
+	workModesService := services.NewWorkModesService(unloadPlaceService, systemTableService, bureauService)
 	uniqueCarService := services.NewUniqueCarService(db)
 	uniqueEmployeeService := services.NewUniqueEmployeeService(db)
 	feedbackService := services.NewFeedbackService(db)
@@ -169,6 +171,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 	onboardingHandler := handlers.NewOnboardingHandler(onboardingService)
 	unloadPlaceHandler := handlers.NewUnloadPlaceHandler(unloadPlaceService, 10*1024*1024, "./uploads")
 	bureauHandler := handlers.NewBureauHandler(bureauService)
+	workModesHandler := handlers.NewWorkModesHandler(workModesService)
 	carHandler := handlers.NewCarHandler(carService)
 	employeeHandler := handlers.NewEmployeeHandler(employeeService)
 	systemTableHistoryService := services.NewSystemTableHistoryService(db)
@@ -222,6 +225,7 @@ func SetupTestApp(t *testing.T) (*echo.Echo, *gorm.DB, func()) {
 		Onboarding:          onboardingHandler,
 		UnloadPlace:         unloadPlaceHandler,
 		Bureau:              bureauHandler,
+		WorkModes:           workModesHandler,
 		Cars:                carHandler,
 		Employees:           employeeHandler,
 		SystemTable:         systemTableHandler,


### PR DESCRIPTION
## Что это
Срез C2 эпика multitab-fixes. Read-only агрегирующий эндпоинт **GET /api/work-modes** для будущей модалки «Режимы работы» (C3). Приводит три источника расписаний к ЕДИНОЙ форме слота, чтобы фронт рисовал их одинаково.

## Форма ответа (envelope `data`)
```
{
  "bureau":        { id, kind:"bureau", name, status, current_status, time_slots[] },
  "unload_places": [ { id, kind:"unload_place", name, status, current_status, time_slots[] } ],
  "checkpoints":   [ { id, kind:"checkpoint",   name, status, current_status, time_slots[] } ]
}
```
Единый слот: `{day_of_week, open_time, close_time, is_next_day, is_active}`.

## Решения
- **Три источника → одна форма:** места разгрузки (`UnloadPlace`, плоский), места прохода/посты (`SystemTable`, double-wrap `.table`), Бюро (`BureauTimeSlot`, single-owner из C1a #856).
- **Переиспользование, не свой SQL:** агрегатор берёт `GetAll` сервисов мест/таблиц — их `current_status` уже посчитан canonical-логикой, не дублирую. Для Бюро (нет поля status, всегда активно) считаю статус сам — `computeWorkModeStatus` зеркалит canonical (круглосуточный слот, `is_next_day` через полночь, `0=Пн`).
- **Семантика статуса 1:1 с модалками** `UnloadPlaceModal`/`TableInfoModal`: `status != "active"` → фронт рисует «Неактивно»/«На обслуживании».
- **Архивные** (`is_active=false`) исключены (`GetAll(false)`); **операционно неактивные** (`status != active`) включены с флагом — как требует мокап C0.
- Read-only, гейт `protected` (любой авторизованный, как `bureau` GET).

## Тесты
- `internal/handlers/work_modes_test.go`: реальный endpoint — агрегация трёх типов, архивное исключено, неактивное включено со `status=inactive`/`current_status=closed`, единая форма слота, пустая система.
- `internal/services/work_modes_status_test.go`: детерминированный unit `computeWorkModeStatus` (круглосуточный, `is_next_day`, другой день, неактивный слот, пусто).
- Заодно: `bureau_time_slots` не чистилась в `CleanDB` (пробел из C1a) — слоты текли между тестами, добавил в список очистки.

Локально зелёные: build, `internal/handlers`, `internal/services`. `internal/database` падал только на известном флейке грязной локальной БД (`request_logs_daily`), на чистой БД зелёный.

Ревью `code-reviewer` пройдено: must-fix (ассерт `current_status` неактивного) и suggestions (unit на `is_next_day`, known-cost reuse) закрыты.