### PR TITLE
feat(permissions): guide.guard в каталоге прав - финал permission-gating

### DIFF
--- a/internal/services/guide_service.go
+++ b/internal/services/guide_service.go
@@ -15,12 +15,10 @@ import (
 // GuideRoles -- порядок ролей в раскладке «Вкладки».
 var GuideRoles = []string{"user", "guard", "admin"}
 
-// GuideKeyForRole возвращает permission-ключ раздела для роли. guide.user и
-// guide.admin уже описаны в каталоге прав (permission_catalog.go: KeyGuideUser,
-// KeyGuideAdmin) -- гейтинг идёт через PermissionResolver как по любому ключу,
-// ядро прав не затрагивается. guide.guard пока не заведён в каталоге (добавляет
-// perm-gating отдельным срезом), поэтому раздел «Охранник» до этого виден только
-// супер-админу; код роль-агностичен и подхватит ключ автоматически.
+// GuideKeyForRole возвращает permission-ключ раздела для роли. Все три ключа
+// (guide.user, guide.guard, guide.admin) описаны в каталоге прав
+// (permission_catalog.go) -- гейтинг идёт через PermissionResolver как по любому
+// ключу, ядро прав не затрагивается; код роль-агностичен.
 func GuideKeyForRole(role string) string {
 	return "guide." + role
 }

--- a/internal/services/permission_catalog.go
+++ b/internal/services/permission_catalog.go
@@ -44,6 +44,7 @@ const (
 
 	KeyGuideUser  = "guide.user"
 	KeyGuideAdmin = "guide.admin"
+	KeyGuideGuard = "guide.guard"
 )
 
 // Категории-заголовки для группировки в UI.
@@ -131,9 +132,10 @@ func staticCatalog() []CatalogNode {
 		{Key: KeyPageSystemControl, DisplayName: "Режим техработ", Category: CatAdmin, SuperOnly: true},
 
 		// Обзор и новости (управление новостями -- в Администрировании, /admin/news).
-		// guide.* остаются тумблерами, но их FE-гейтинг подключается отдельно после
-		// редизайна трёх вкладок руководства (пользователь/админ/охранник).
+		// Три раздела руководства (пользователь/охранник/админ) гейтятся по guide.<role>:
+		// GET /guide/sections отдаёт только разделы, на которые есть право (guide_service.ListForUser).
 		{Key: KeyGuideUser, DisplayName: "Руководство пользователя", Category: CatOverview},
+		{Key: KeyGuideGuard, DisplayName: "Руководство охранника", Category: CatOverview},
 		{Key: KeyGuideAdmin, DisplayName: "Руководство администратора", Category: CatOverview},
 	}
 }

--- a/internal/services/permission_catalog_test.go
+++ b/internal/services/permission_catalog_test.go
@@ -97,6 +97,20 @@ func TestCatalogHygiene(t *testing.T) {
 	}
 }
 
+// Гейтинг руководства (#permission-gating срез 7): все три раздела
+// (user/guard/admin) гейтятся по guide.<role>, поэтому каждый ключ обязан быть
+// тумблером каталога -- иначе раздел enforced на бэке, но неуправляем (guide.guard
+// был именно таким до этого среза).
+func TestGuideKeysInCatalog(t *testing.T) {
+	t.Parallel()
+	for _, role := range GuideRoles {
+		key := GuideKeyForRole(role)
+		if !IsCatalogKey(key) {
+			t.Errorf("ключ руководства %q должен быть в каталоге (раздел %q)", key, role)
+		}
+	}
+}
+
 func TestAllCatalogKeysMatchesSet(t *testing.T) {
 	t.Parallel()
 	keys := AllCatalogKeys()


### PR DESCRIPTION
## Что

Финальный срез эпика permission-gating. Раздел руководства охранника гейтился на бэке по ключу `guide.guard` (`guide_service.ListForUser` фильтрует `GET /guide/sections` по `guide.<role>`), но самого ключа не было в каталоге прав - тумблер не показывался, выдать/отозвать раздел роли через UI каталога было нельзя (enforced, но неуправляем).

Завёл `guide.guard` третьим разделом руководства в каталоге (`permission_catalog.go`), рядом с уже существующими `guide.user`/`guide.admin`. Порядок записей соответствует `GuideRoles = [user, guard, admin]`.

## Коррекция scope относительно плана

- План эпика называл ключ `guide.security` - в реальности третья роль руководства называется `guard` (Охранник), ключ `guide.guard`. Исправлено.
- «Гейт 3 вкладок» уже сделан на бэкенде при редизайне модалки (PR #851): фронт рисует ровно то, что вернул `GET /guide/sections`, FE-гейта по `can()` нет и не требуется. Поэтому срез свёлся к добавлению недостающего тумблера каталога.

## Zero-regression

- `migrate.go::baseRoleGrants` НЕ тронут - `guide.guard` намеренно не в базовой роли (раздел охранника не виден обычному юзеру по умолчанию; админ видит через admin-mode `!denied`, супер - всё).
- Добавление ключа в каталог не меняет effective-права существующих юзеров (каталог = список грантуемых ключей, не сами гранты). Меняется только то, что тумблер теперь появляется в UI каталога.

## Тесты

- `TestGuideKeysInCatalog`: все три `guide.<role>` присутствуют в каталоге (упал бы до этого среза на `guide.guard`).
- `go build ./...` + `go vet ./internal/services/` + `go test ./internal/services/` зелёные.
- Обновлены устаревшие комментарии в `guide_service.go` и `permission_catalog.go` («guide.guard пока не заведён» / «FE-гейтинг подключается отдельно»).

## Off-limits

`permission_catalog.go` - off-limits (`permission_*`). Правки прав в этом эпике санкционированы; мерж согласовать с человеком.