### PR TITLE
fix(create-application): инструкция вложения в модалке по центру + копирование номера через notify (A6)

### DIFF
--- a/frontend/src/components/CreateApplication/ApplicationSuccessModal.vue
+++ b/frontend/src/components/CreateApplication/ApplicationSuccessModal.vue
@@ -184,7 +184,7 @@
 </template>
 
 <script>
-import { useToast } from '@/composables/useToast';
+import { useDeletionsStore } from '@/stores/deletions';
 
 export default {
     name: 'ApplicationSuccessModal',
@@ -225,9 +225,9 @@ export default {
                     document.execCommand('copy');
                     document.body.removeChild(ta);
                 }
-                useToast().success(`Номер ${number} скопирован`);
+                useDeletionsStore().notify({ prefix: 'Номер заявки ', bold: String(number), suffix: ' скопирован', type: 'success' });
             } catch {
-                useToast().error('Не удалось скопировать номер');
+                useDeletionsStore().notify({ prefix: 'Не удалось скопировать номер', type: 'error' });
             }
         }
     }

--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -2669,4 +2669,87 @@ export default {
             padding: 0 8px;
         }
     }
+
+    /* Модалка инструкции к вложению. Раньше у .modal-overlay не было правил,
+       и телепортированный в body блок без позиционирования уезжал в конец
+       страницы. Приводим к эталону модалок (fixed overlay по центру, radius 30px). */
+    .modal-overlay {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.5);
+        backdrop-filter: blur(0.1px);
+        -webkit-backdrop-filter: blur(0.1px);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 10000;
+        padding: 24px;
+        animation: instruction-fade 0.2s ease;
+    }
+
+    @keyframes instruction-fade {
+        from { opacity: 0; }
+        to { opacity: 1; }
+    }
+
+    .instruction-modal-large {
+        width: min(720px, 100%);
+        max-height: 88vh;
+        background: #fff;
+        border-radius: 30px;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+        box-shadow: 0 24px 70px rgba(20, 24, 60, 0.28);
+        animation: instruction-pop 0.22s ease;
+    }
+
+    @keyframes instruction-pop {
+        from { opacity: 0; transform: translateY(12px) scale(0.985); }
+        to { opacity: 1; transform: none; }
+    }
+
+    .instruction-modal-large .modal-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 16px;
+        padding: 22px 26px 18px;
+    }
+
+    .instruction-modal-large .modal-header h3 {
+        margin: 0;
+        font-size: 20px;
+        font-weight: 700;
+        letter-spacing: -0.01em;
+        color: #1a1a1a;
+    }
+
+    .instruction-modal-large .modal-header h3 .blue {
+        color: var(--color-primary);
+    }
+
+    .instruction-modal-large .modal-close {
+        width: 36px;
+        height: 36px;
+        border: none;
+        background: #f3f4fa;
+        border-radius: 50%;
+        font-size: 22px;
+        line-height: 1;
+        color: #6a6a7d;
+        cursor: pointer;
+        transition: background 0.15s ease, color 0.15s ease;
+        flex-shrink: 0;
+    }
+
+    .instruction-modal-large .modal-close:hover {
+        background: #e9eaf4;
+        color: #1a1a1a;
+    }
+
+    .instruction-content {
+        padding: 0 26px 24px;
+        overflow-y: auto;
+    }
 </style>

--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -24,7 +24,7 @@
     <Teleport to="body">
       <div
         v-if="showAttachmentInstruction"
-        class="modal-overlay"
+        class="instruction-overlay"
         @click.self="showAttachmentInstruction = false"
       >
         <div class="instruction-modal-large">
@@ -2670,10 +2670,13 @@ export default {
         }
     }
 
-    /* Модалка инструкции к вложению. Раньше у .modal-overlay не было правил,
-       и телепортированный в body блок без позиционирования уезжал в конец
-       страницы. Приводим к эталону модалок (fixed overlay по центру, radius 30px). */
-    .modal-overlay {
+    /* Модалка инструкции к вложению. Раньше overlay не имел правил позиционирования,
+       и телепортированный в body блок уезжал в конец страницы. Приводим к эталону
+       (fixed overlay по центру, radius 30px). Свой класс .instruction-overlay, а не
+       общий .modal-overlay - глобальное !important-правило мобильного bottom-sheet в
+       App.vue (.modal-overlay > .modal-content) не подходит карточке .instruction-modal-large
+       и дало бы полусломанный лист; мобильный bottom-sheet делаем сами ниже. */
+    .instruction-overlay {
         position: fixed;
         inset: 0;
         background: rgba(0, 0, 0, 0.5);
@@ -2751,5 +2754,19 @@ export default {
     .instruction-content {
         padding: 0 26px 24px;
         overflow-y: auto;
+    }
+
+    /* Мобильный bottom-sheet (как общий паттерн App.vue, но для своего класса). */
+    @media (max-width: 768px) {
+        .instruction-overlay {
+            padding: 0;
+            align-items: flex-end;
+        }
+
+        .instruction-modal-large {
+            width: 100%;
+            max-height: 90dvh;
+            border-radius: 20px 20px 0 0;
+        }
     }
 </style>

--- a/frontend/src/components/CreateApplication/__tests__/ApplicationSuccessModal.spec.js
+++ b/frontend/src/components/CreateApplication/__tests__/ApplicationSuccessModal.spec.js
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { useDeletionsStore } from '@/stores/deletions';
+
+import ApplicationSuccessModal from '../ApplicationSuccessModal.vue';
+
+function mountModal(props = {}) {
+  return mount(ApplicationSuccessModal, {
+    props: { show: true, applicationNumber: 'A-1024', ...props },
+    global: { stubs: { teleport: true } },
+    attachTo: document.body,
+  });
+}
+
+describe('ApplicationSuccessModal — копирование номера (эталон notify)', () => {
+  let notify;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    notify = vi.spyOn(useDeletionsStore(), 'notify').mockImplementation(() => {});
+  });
+
+  it('успешное копирование -> notify(success) с номером, без useToast', async () => {
+    const writeText = vi.fn().mockResolvedValue();
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    const wrapper = mountModal();
+    await wrapper.find('.number--copyable').trigger('click');
+    await Promise.resolve();
+
+    expect(writeText).toHaveBeenCalledWith('A-1024');
+    expect(notify).toHaveBeenCalledTimes(1);
+    const arg = notify.mock.calls[0][0];
+    expect(arg.type).toBe('success');
+    expect(arg.bold).toBe('A-1024');
+    expect(`${arg.prefix}${arg.bold}${arg.suffix}`).toContain('A-1024');
+    expect(`${arg.prefix}${arg.suffix}`).toContain('скопирован');
+  });
+
+  it('сбой копирования -> notify(error)', async () => {
+    Object.assign(navigator, { clipboard: { writeText: vi.fn().mockRejectedValue(new Error('denied')) } });
+    // execCommand-фолбэк тоже роняем, чтобы попасть в catch
+    document.execCommand = vi.fn(() => { throw new Error('no exec'); });
+
+    const wrapper = mountModal();
+    await wrapper.find('.number--copyable').trigger('click');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(notify.mock.calls[0][0].type).toBe('error');
+    expect(notify.mock.calls[0][0].prefix).toContain('Не удалось');
+  });
+
+  it('пустой номер -> ничего не копирует и не нотифаит', async () => {
+    const writeText = vi.fn().mockResolvedValue();
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    const wrapper = mountModal({ applicationNumber: '' });
+    await wrapper.find('.number--copyable').trigger('click');
+    await Promise.resolve();
+
+    expect(writeText).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/CreateApplication/__tests__/ApplicationSuccessModal.spec.js
+++ b/frontend/src/components/CreateApplication/__tests__/ApplicationSuccessModal.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { mount } from '@vue/test-utils';
+import { mount, flushPromises } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { useDeletionsStore } from '@/stores/deletions';
 
@@ -27,7 +27,7 @@ describe('ApplicationSuccessModal — копирование номера (эт�
 
     const wrapper = mountModal();
     await wrapper.find('.number--copyable').trigger('click');
-    await Promise.resolve();
+    await flushPromises();
 
     expect(writeText).toHaveBeenCalledWith('A-1024');
     expect(notify).toHaveBeenCalledTimes(1);
@@ -45,8 +45,7 @@ describe('ApplicationSuccessModal — копирование номера (эт�
 
     const wrapper = mountModal();
     await wrapper.find('.number--copyable').trigger('click');
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushPromises();
 
     expect(notify).toHaveBeenCalledTimes(1);
     expect(notify.mock.calls[0][0].type).toBe('error');
@@ -59,7 +58,7 @@ describe('ApplicationSuccessModal — копирование номера (эт�
 
     const wrapper = mountModal({ applicationNumber: '' });
     await wrapper.find('.number--copyable').trigger('click');
-    await Promise.resolve();
+    await flushPromises();
 
     expect(writeText).not.toHaveBeenCalled();
     expect(notify).not.toHaveBeenCalled();


### PR DESCRIPTION
Срез A6 эпика multitab-fixes. Чисто фронт, два фикса в Оформлении заявки.

## Что
1. Модалка инструкции к вложению («Инструкция» в шапке формы) телепортировалась в body, но у оверлея не было CSS-правил позиционирования - неформатированный блок уезжал в конец страницы (баг OQ-1). Привёл к эталону: fixed overlay по центру, карточка radius 30px, анимация, header/close/content. Структуру шаблона не менял, Escape и закрытие по оверлею уже были.
2. «Номер заявки скопирован» в окне успеха (ApplicationSuccessModal) переведён с `useToast()` на `useDeletionsStore().notify()` (эталон: только notify). Формулировка «Номер заявки X скопирован» / ошибка «Не удалось скопировать номер».

## Решения по ревью
- Оверлей вынесен в свой класс `.instruction-overlay`, НЕ общий `.modal-overlay`: глобальное !important-правило мобильного bottom-sheet в App.vue рассчитано на `.modal-overlay > .modal-content`, а моя карточка `.instruction-modal-large` -> дало бы полусломанный лист. Мобильный bottom-sheet сделал сам (full-width, верхние углы скруглены).
- В спеке error-ветки `Promise.resolve()` заменён на `flushPromises()` (надёжнее).

## Проверка
- vitest: ApplicationSuccessModal.spec.js 3/3 (success/error/пустой номер), весь CreateApplication/ 95/95, eslint чисто.
- Локально (vite, dev-инстанс компонента): desktop - модалка центрирована (position:fixed, align center, radius 30px, centeredX/Y=true); mobile 390px - bottom-sheet (align flex-end, width 100%, radius 20px сверху). Скрины приложены пользователю до мержа.

## Риск
Конфликт с незамерженными `feat/657-onboarding-*` (createapp-flow2/polish2 тоже трогают CreateApplication.vue). Подтверждено по факту: их маркеры НЕ на staging. Пользователь принял риск (при будущем мерже онбординга нужен будет ребейз).