### PR TITLE
fix(text-constructor): дефолтный размер вводимого текста 14px (#873)

### DIFF
--- a/frontend/src/components/TextConstructor.vue
+++ b/frontend/src/components/TextConstructor.vue
@@ -869,6 +869,8 @@ defineExpose({ editor });
   min-height: inherit;
   line-height: 150%;
   word-break: break-word;
+  /* Дефолтный размер вводимого текста (без выбранного font-size-класса). */
+  font-size: 14px;
 }
 
 /* Чтобы плавающие (float) картинки не вылезали за пределы редактора. */


### PR DESCRIPTION
Закрывает #873. Базовый .ProseMirror в TextConstructor не задавал font-size (наследовал размер окружения). Задал font-size:14px по умолчанию для вводимого текста.