### PR TITLE
fix(fe): доработки по фидбеку со staging

### DIFF
--- a/frontend/src/components/CreateApplication/VehicleForm.vue
+++ b/frontend/src/components/CreateApplication/VehicleForm.vue
@@ -21,31 +21,30 @@
     >
       <div class="existing-cars-header">
         <span class="existing-cars-count">Машин добавлено: {{ selectedExistingCars.length }}</span>
-        <div
-          class="existing-cars-actions"
-          style="position: relative"
-        >
+        <div class="existing-cars-actions">
           <button
             class="view-cars-btn"
             @click="openExistingCarsModal"
           >
             Просмотреть
           </button>
-          <button
-            class="add-existing-btn"
-            :disabled="!canAddExistingCars"
-            @click="addExistingCars"
-            @mouseenter="showExistingTooltip = true"
-            @mouseleave="showExistingTooltip = false"
-          >
-            Добавить
-          </button>
-          <div
-            v-if="showExistingTooltip && !canAddExistingCars"
-            class="tooltip"
-          >
-            <div class="tooltip-content">
-              хотя бы одно место разгрузки
+          <div class="add-existing-wrap">
+            <button
+              class="add-existing-btn"
+              :disabled="!canAddExistingCars"
+              @click="addExistingCars"
+              @mouseenter="showExistingTooltip = true"
+              @mouseleave="showExistingTooltip = false"
+            >
+              Добавить
+            </button>
+            <div
+              v-if="showExistingTooltip && !canAddExistingCars"
+              class="tooltip"
+            >
+              <div class="tooltip-content">
+                {{ existingCarsTooltip }}
+              </div>
             </div>
           </div>
         </div>
@@ -57,7 +56,15 @@
           :key="car.id || car.number"
           class="existing-car-item"
         >
-          {{ car.number }} - {{ car.mark || 'не указана' }}
+          <span>{{ car.number }} - {{ car.mark || 'не указана' }}</span>
+          <button
+            class="existing-car-remove"
+            type="button"
+            title="Убрать машину"
+            @click="removeExistingCar(car)"
+          >
+            ×
+          </button>
         </div>
         <button
           v-if="selectedExistingCars.length > 5 && !showAllExistingCars"
@@ -536,6 +543,23 @@ export default {
             const placesOk = !this.fieldVisible('unloading_places') || (this.selectedUnloadingPlaces.length > 0 && !hasInactiveSelected);
             return this.selectedExistingCars.length > 0 && placesOk;
         },
+        existingCarsTooltip() {
+            if (this.canAddExistingCars) return '';
+            const hasInactiveSelected = this.selectedUnloadingPlaces.some(placeId => {
+                const place = this.allUnloadingPlaces.find(p => p.id === placeId);
+                return place && place.status !== 'active';
+            });
+            const missing = [];
+            if (this.fieldVisible('unloading_places') && this.selectedUnloadingPlaces.length === 0) {
+                missing.push('хотя бы одно место разгрузки');
+            }
+            if (hasInactiveSelected) {
+                missing.push('убрать неактивное место разгрузки');
+            }
+            if (missing.length === 0) return 'Заполните обязательные поля';
+            if (missing.length === 1) return `Заполните поле: ${missing[0]}`;
+            return `Заполните поля:\n${missing.map(f => `• ${f}`).join('\n')}`;
+        },
         displayedExistingCars() {
             if (this.showAllExistingCars) return this.selectedExistingCars;
             return this.selectedExistingCars.slice(0, 5);
@@ -1004,6 +1028,13 @@ export default {
             this.showAllExistingCars = false;
             this.showExistingCarsModal = false;
             this.clearVehicleFormPartial();
+        },
+
+        // Отмена добавления конкретной существующей машины из блока "Машин добавлено".
+        removeExistingCar(car) {
+            const key = car.id || car.number;
+            this.selectedExistingCars = this.selectedExistingCars.filter(c => (c.id || c.number) !== key);
+            if (this.selectedExistingCars.length <= 5) this.showAllExistingCars = false;
         },
 
         addExistingCars() {
@@ -1895,12 +1926,39 @@ export default {
 }
 
 .existing-car-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
     font-size: 12px;
     color: #555;
     padding: 3px 6px;
     background: #fff;
     border-radius: 8px;
     border: 1px solid #e6e6e6;
+}
+
+.existing-car-remove {
+    flex-shrink: 0;
+    width: 18px;
+    height: 18px;
+    line-height: 1;
+    border: none;
+    border-radius: 50%;
+    background: #f1f1f4;
+    color: #888;
+    font-size: 14px;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+}
+
+.existing-car-remove:hover {
+    background: #ffe0e0;
+    color: #d33;
+}
+
+.add-existing-wrap {
+    position: relative;
 }
 
 .show-all-btn {

--- a/frontend/src/components/UnloadPlaces/UnloadPlacesContainer.vue
+++ b/frontend/src/components/UnloadPlaces/UnloadPlacesContainer.vue
@@ -1801,8 +1801,8 @@ async uploadPhotoFiles(files) {
 
 .photos-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
-  gap: 12px;
+  grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+  gap: 10px;
   max-height: 250px;
   overflow-y: auto;
   padding: 4px;

--- a/frontend/src/components/news/UserGuideModal.vue
+++ b/frontend/src/components/news/UserGuideModal.vue
@@ -296,8 +296,9 @@ export default {
 
 .guide {
   width: min(720px, 100%);
-  min-height: min(520px, 88vh);
-  max-height: 88vh;
+  /* Фиксированная высота: контент вкладок едет скроллом в .guide__body, модалка
+     не меняет высоту при смене роли Пользователь/Охранник/Администратор. */
+  height: min(560px, 88vh);
   background: #fff;
   border-radius: 30px;
   display: flex;
@@ -409,7 +410,8 @@ export default {
 .guide__body {
   padding: 18px 26px 8px;
   overflow-y: auto;
-  min-height: 200px;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .file-card {

--- a/frontend/src/views/ApplicationsCenter.vue
+++ b/frontend/src/views/ApplicationsCenter.vue
@@ -244,16 +244,32 @@
             <div class="filter-section__header">
               <span class="filter-label">Теги</span>
             </div>
-            <div class="status-buttons">
+            <div class="tags-dropdown">
               <button
-                v-for="tag in tags"
-                :key="tag.value"
-                class="status-btn"
-                :class="{ 'status-btn--active': selectedTags.includes(tag.value) }"
-                @click="toggleTag(tag.value)"
+                class="tags-dropdown__btn"
+                :class="{ 'tags-dropdown__btn--active': selectedTags.length > 0 }"
+                @click="tagsDropdownOpen = !tagsDropdownOpen"
               >
-                {{ tag.label }}
+                {{ selectedTags.length ? `Выбрано: ${selectedTags.length}` : 'Все теги' }}
+                <span class="tags-dropdown__chev" :class="{ open: tagsDropdownOpen }">▾</span>
               </button>
+              <template v-if="tagsDropdownOpen">
+                <div
+                  class="tags-dropdown__backdrop"
+                  @click="tagsDropdownOpen = false"
+                />
+                <div class="tags-dropdown__panel">
+                  <button
+                    v-for="tag in tags"
+                    :key="tag.value"
+                    class="status-btn tags-dropdown__item"
+                    :class="{ 'status-btn--active': selectedTags.includes(tag.value) }"
+                    @click="toggleTag(tag.value)"
+                  >
+                    {{ tag.label }}
+                  </button>
+                </div>
+              </template>
             </div>
           </div>
         </div>
@@ -631,6 +647,7 @@ export default {
             selectedConfirmations: [],
             selectedApplicationStatuses: [],
             selectedTags: [],
+            tagsDropdownOpen: false,
             organizations: [],
             sortField: null,
             sortDirection: 'desc',
@@ -2271,20 +2288,62 @@ export default {
     scrollbar-color: #D9E2FF transparent;
 }
 
-/* При одной строке таблица схлопывается до fit-content, а overflow:hidden/.table-body scroll
-   обрезает подсказки, раскрывающиеся вниз. Поднимаем их вверх от элемента. */
-.table-body--single-row .sender-tooltip-anchor::after,
-.table-body--single-row .tag-hint::after {
-    top: auto;
-    bottom: calc(100% + 6px);
+/* При одной строке таблица низкая, а overflow:hidden + scroll обрезали подсказки
+   (раскрываются вниз, top:100%). Скролл при одной строке не нужен - включаем
+   overflow:visible, и подсказка показывается целиком вниз от элемента. */
+.applications-table:has(.table-body--single-row) {
+    overflow: visible;
+}
+.table-body--single-row {
+    overflow: visible;
 }
 
-.table-body--single-row .sender-tooltip-anchor::before,
-.table-body--single-row .tag-hint::before {
-    top: auto;
-    bottom: 100%;
-    border-bottom-color: transparent;
-    border-top-color: #333;
+/* Фильтр по тегам - компактный дропдаун, чтобы фильтры держались в строке. */
+.tags-dropdown {
+    position: relative;
+}
+.tags-dropdown__btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border: 1px solid #e0e0e0;
+    border-radius: 12px;
+    background: #fff;
+    cursor: pointer;
+    font-size: 13px;
+    white-space: nowrap;
+}
+.tags-dropdown__btn--active {
+    border-color: var(--color-primary, #4F5BDF);
+    color: var(--color-primary, #4F5BDF);
+}
+.tags-dropdown__chev {
+    font-size: 10px;
+    transition: transform 0.15s;
+}
+.tags-dropdown__chev.open {
+    transform: rotate(180deg);
+}
+.tags-dropdown__backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 40;
+}
+.tags-dropdown__panel {
+    position: absolute;
+    top: calc(100% + 6px);
+    left: 0;
+    z-index: 50;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    min-width: 170px;
+    padding: 10px;
+    background: #fff;
+    border: 1px solid #e0e0e0;
+    border-radius: 12px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
 }
 
 .applications-list::-webkit-scrollbar {


### PR DESCRIPTION
Правки по результатам ручной проверки на staging (после батча #865/#873-880):

- Места разгрузки: превью уже добавленных фото уменьшены (минтайл 210->110px, gap 12->10).
- Руководство (#875): высота модалки больше не прыгает при смене роли - фикс. height + .guide__body flex:1/overflow (вместо min-height, которого не хватало).
- Центр (#879): фильтр по тегам свёрнут в компактный дропдаун (кнопка "Все теги/Выбрано: N" + панель), фильтры держатся в строке. Подсказка при одной заявке - через overflow:visible на single-row (раньше флип резал сверху).
- VehicleForm (#880): подсказка "Добавить" привязана к кнопке (.add-existing-wrap relative, не уезжает), текст "Заполните поле: ..."; добавлена кнопка отмены (×) каждой добавленной машины (removeExistingCar).

eslint чист. Проверю замерами на staging после деплоя.