### PR TITLE
fix(work-modes): статус по МСК + Бюро пропусков, высота, поиск (#868)

### DIFF
--- a/frontend/src/components/news/WorkModesModal.vue
+++ b/frontend/src/components/news/WorkModesModal.vue
@@ -77,13 +77,24 @@
 
             <div class="modes__body">
               <div
-                v-if="!currentItems.length"
-                class="modes__empty"
+                v-if="activeCat !== 'bureau'"
+                class="modes__search"
               >
-                Нет объектов в этой категории
+                <input
+                  v-model="searchQuery"
+                  type="text"
+                  class="lk-input"
+                  placeholder="Поиск по названию..."
+                >
               </div>
               <div
-                v-for="item in currentItems"
+                v-if="!visibleItems.length"
+                class="modes__empty"
+              >
+                {{ searchQuery ? 'Ничего не найдено' : 'Нет объектов в этой категории' }}
+              </div>
+              <div
+                v-for="item in visibleItems"
                 v-else
                 :key="`${item.kind}:${item.id}`"
                 class="obj"
@@ -221,6 +232,7 @@ export default {
       error: false,
       loadSeq: 0,
       activeCat: 'bureau',
+      searchQuery: '',
       openKeys: [],
       titleId: `work-modes-title-${uid}`,
     };
@@ -233,13 +245,19 @@ export default {
     categories() {
       const d = this.data;
       return [
-        { key: 'bureau', label: 'Бюро', items: d?.bureau ? [d.bureau] : [], showCount: false },
+        { key: 'bureau', label: 'Бюро пропусков', items: d?.bureau ? [d.bureau] : [], showCount: false },
         { key: 'unload', label: 'Места разгрузки', items: d?.unload_places || [], showCount: true },
         { key: 'pass', label: 'Места прохода', items: d?.checkpoints || [], showCount: true },
       ];
     },
     currentItems() {
       return this.categories.find((c) => c.key === this.activeCat)?.items || [];
+    },
+    // Список с учётом поиска (поиск показывается для мест разгрузки/прохода).
+    visibleItems() {
+      const q = this.searchQuery.trim().toLowerCase();
+      if (!q) return this.currentItems;
+      return this.currentItems.filter((it) => (it.name || '').toLowerCase().includes(q));
     },
   },
   watch: {
@@ -248,6 +266,10 @@ export default {
     show(visible) {
       document.body.style.overflow = visible ? 'hidden' : '';
       if (visible) this.load();
+    },
+    // Сброс поиска при переключении категории.
+    activeCat() {
+      this.searchQuery = '';
     },
   },
   mounted() {
@@ -361,7 +383,9 @@ export default {
 
 .modes {
   width: min(720px, 100%);
-  max-height: 88vh;
+  /* Фиксированная высота: список едет скроллом в .modes__body, модалка не прыгает
+     при смене вкладок Бюро пропусков/Места разгрузки/Места прохода. */
+  height: min(620px, 88vh);
   background: #fff;
   border-radius: 30px;
   display: flex;
@@ -489,6 +513,16 @@ export default {
 .modes__body {
   padding: 16px 26px 8px;
   overflow-y: auto;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.modes__search {
+  margin-bottom: 12px;
+}
+
+.modes__search .lk-input {
+  width: 100%;
 }
 
 .modes__body::-webkit-scrollbar {

--- a/internal/handlers/work_modes_test.go
+++ b/internal/handlers/work_modes_test.go
@@ -13,8 +13,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// todayDOW -- текущий день недели в формате слотов (0=Пн..6=Вс).
-func todayDOW() int { return int(time.Now().Weekday()+6) % 7 }
+// todayDOW -- текущий день недели в формате слотов (0=Пн..6=Вс) в МСК,
+// как и сервис (computeWorkModeStatus считает в Europe/Moscow).
+func todayDOW() int {
+	return int(time.Now().In(time.FixedZone("MSK", 3*60*60)).Weekday()+6) % 7
+}
 
 func TestWorkModes_Unauthorized(t *testing.T) {
 	e, db, cleanup := testutil.SetupTestApp(t)

--- a/internal/services/work_modes_service.go
+++ b/internal/services/work_modes_service.go
@@ -135,12 +135,18 @@ func buildBureauWorkMode(slots []models.BureauTimeSlot) WorkModeEntity {
 	}
 }
 
+// moscowWorkModeLoc -- бизнес-зона расписаний (МСК, UTC+3 без DST с 2014).
+// FixedZone, а не LoadLocation: в alpine-образе нет tzdata, LoadLocation упал бы
+// на UTC и статус "Открыто/Закрыто" съехал бы на 3 часа (баг #868: пятница в
+// рабочее время по Москве показывало "Закрыто", т.к. в контейнере UTC).
+var moscowWorkModeLoc = time.FixedZone("MSK", 3*60*60)
+
 // computeWorkModeStatus вычисляет текущий статус (open/closed) по слотам единой
 // формы. Зеркалит canonical computeUnloadPlaceStatus/computeCurrentStatus
 // (круглосуточный слот 00:00-23:59, переход через полночь is_next_day), но без
 // проверки операционного статуса -- применяется к Бюро, которое всегда active.
 func computeWorkModeStatus(slots []WorkModeSlot) string {
-	now := time.Now()
+	now := time.Now().In(moscowWorkModeLoc)
 	// 0=Пн..6=Вс (Go Weekday: 0=Вс).
 	currentDay := int(now.Weekday()+6) % 7
 	currentTime := now.Format("15:04")

--- a/internal/services/work_modes_status_test.go
+++ b/internal/services/work_modes_status_test.go
@@ -9,7 +9,7 @@ import (
 // результат был детерминирован в любой момент суток (привязка к "сегодня" и к
 // слотам, открытым/закрытым независимо от времени).
 func TestComputeWorkModeStatus(t *testing.T) {
-	today := int(time.Now().Weekday()+6) % 7
+	today := int(time.Now().In(moscowWorkModeLoc).Weekday()+6) % 7
 	otherDay := (today + 1) % 7
 
 	cases := []struct {


### PR DESCRIPTION
Закрывает #868.

BE: computeWorkModeStatus считал now в UTC (контейнер), слоты по Москве -> ложное Закрыто в рабочее время. Считаю в FixedZone(MSK, +3) - Москва UTC+3 без DST, FixedZone вместо LoadLocation (в alpine нет tzdata, иначе fallback на UTC). Тесты выровнены на МСК.

FE WorkModesModal: лейбл Бюро -> Бюро пропусков; высота модалки фиксированная (height + flex-body), не прыгает при смене вкладок; добавлен поиск по названию для Мест разгрузки/прохода (сброс при смене вкладки).
