### PR TITLE
fix(permissions): точечные права через user_permission_overrides (#867)

### DIFF
--- a/internal/handlers/permissions.go
+++ b/internal/handlers/permissions.go
@@ -105,6 +105,8 @@ func (h *PermissionHandler) UpdateUserPermissions(c echo.Context) error {
 	if err := h.service.UpdateUserPermissions(c.Request().Context(), IsSuperAdmin(c), GetUserID(c), userID, req); err != nil {
 		return err
 	}
+	// Сбрасываем кэш резолвера (TTL 30s), чтобы выданные права применились сразу.
+	h.resolver.Invalidate(userID)
 	return RespondMessage(c, "ok")
 }
 

--- a/internal/handlers/permissions_override_fix_test.go
+++ b/internal/handlers/permissions_override_fix_test.go
@@ -1,0 +1,62 @@
+package handlers_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"systemburo/internal/models"
+	"systemburo/internal/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPermissions_CatalogOverride_PersistsAndApplies покрывает #867: точечное
+// право на КАТАЛОЖНЫЙ ключ (page.center - Go-константа, строкой в permissions её
+// нет) должно (1) сохраняться в read-back, чтобы тумблер не слетал после F5, и
+// (2) реально действовать - резолвер обязан увидеть его в /permissions/my.
+// Раньше запись шла в legacy user_permissions (резолвер её не читает), а read-back
+// делал INNER JOIN с permissions и выбрасывал каталожные ключи.
+func TestPermissions_CatalogOverride_PersistsAndApplies(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	adminToken := testutil.RegisterAdmin(t, e, td.OrgID, td.CompanyID)
+	userToken := testutil.RegisterAndLogin(t, e, "permtarget", "password123", 1, td.OrgID, td.CompanyID)
+	var userID int
+	require.NoError(t, db.Table("users").Select("id").Where("username = ?", "permtarget").Row().Scan(&userID))
+	admin := testutil.AuthHeader(adminToken)
+
+	// Админ выдаёт каталожное право page.center.
+	body := `{"permissions":[{"key":"page.center","value":"allow"}]}`
+	rec := testutil.PUT(t, e, fmt.Sprintf("/permissions/user/%d", userID), body, admin)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	// Read-back сохраняет каталожный ключ (раньше INNER JOIN его терял -> тумблер слетал).
+	rec = testutil.GET(t, e, fmt.Sprintf("/permissions/user/%d", userID), admin)
+	require.Equal(t, http.StatusOK, rec.Code)
+	perms := testutil.ParseResponse[[]models.UserPermissionResponse](t, rec)
+	var got *models.UserPermissionResponse
+	for i := range perms {
+		if perms[i].Key == "page.center" {
+			got = &perms[i]
+		}
+	}
+	require.NotNil(t, got, "page.center должен сохраниться в read-back")
+	assert.Equal(t, "allow", got.Value)
+
+	// Право реально действует: резолвер видит page.center allow в /permissions/my юзера.
+	rec = testutil.GET(t, e, "/permissions/my", testutil.AuthHeader(userToken))
+	require.Equal(t, http.StatusOK, rec.Code)
+	my := testutil.ParseResponse[models.MyPermissionsResponse](t, rec)
+	has := false
+	for _, it := range my.Permissions {
+		if it.Key == "page.center" && it.Value == "allow" {
+			has = true
+		}
+	}
+	assert.True(t, has, "выданное право page.center должно действовать (резолвер видит его)")
+}

--- a/internal/services/permission_service.go
+++ b/internal/services/permission_service.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"time"
 
 	"systemburo/internal/models"
 
@@ -70,13 +71,17 @@ func (s *permissionService) GetUserPermissions(ctx context.Context, userID int) 
 func (s *permissionService) getUserPermissionsList(ctx context.Context, userID int) ([]models.UserPermissionResponse, error) {
 	var results []models.UserPermissionResponse
 
+	// Читаем из user_permission_overrides (источник точечных прав). LEFT JOIN, а
+	// не INNER: каталожные ключи (page.*, tab.*) - Go-константы, их нет строкой в
+	// permissions, и INNER JOIN их выбрасывал -> тумблер слетал после F5 (#867).
+	// Ключ берём из up.permission_key, чтобы он был и для каталожных.
 	err := s.db.WithContext(ctx).
-		Table("user_permissions up").
-		Select("p.key, p.category, p.display_name, up.value, u.username as granted_by_name").
-		Joins("JOIN permissions p ON p.key = up.permission_key").
+		Table("user_permission_overrides up").
+		Select("up.permission_key as key, p.category, p.display_name, up.value, u.username as granted_by_name").
+		Joins("LEFT JOIN permissions p ON p.key = up.permission_key").
 		Joins("LEFT JOIN users u ON u.id = up.granted_by").
 		Where("up.user_id = ?", userID).
-		Order("p.category, p.key").
+		Order("up.permission_key").
 		Scan(&results).Error
 	if err != nil {
 		slog.Error("не удалось получить разрешения пользователя", "user_id", userID, "error", err)
@@ -131,23 +136,28 @@ func (s *permissionService) UpdateUserPermissions(ctx context.Context, isSuperAd
 
 	adminID := actorID
 
+	now := time.Now()
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		for _, p := range req.Permissions {
-			up := models.UserPermission{
+			// Точечные права пишем в user_permission_overrides - именно их читает
+			// резолвер (computeSet). Раньше писали в legacy user_permissions, которую
+			// резолвер не смотрит, поэтому выдача прав не имела эффекта (#867).
+			ov := models.UserPermissionOverride{
 				UserID:        userID,
 				PermissionKey: p.Key,
 				Value:         p.Value,
+				GrantedAt:     now,
 			}
 			if adminID > 0 {
-				up.GrantedBy = &adminID
+				ov.GrantedBy = &adminID
 			}
 
 			// Upsert: update value if exists, create if not
 			result := tx.Where("user_id = ? AND permission_key = ?", userID, p.Key).
-				Assign(models.UserPermission{Value: p.Value, GrantedBy: up.GrantedBy}).
-				FirstOrCreate(&up)
+				Assign(models.UserPermissionOverride{Value: p.Value, GrantedBy: ov.GrantedBy, GrantedAt: now}).
+				FirstOrCreate(&ov)
 			if result.Error != nil {
-				slog.Error("не удалось обновить разрешение", "user_id", userID, "key", p.Key, "error", result.Error)
+				slog.Error("не удалось обновить override прав", "user_id", userID, "key", p.Key, "error", result.Error)
 				return echo.NewHTTPError(http.StatusInternalServerError, "Ошибка обновления разрешений")
 			}
 		}


### PR DESCRIPTION
Закрывает #867. OFF-LIMITS (auth) - НЕ мержить без явного OK.

## Корень
- UpdateUserPermissions писал в legacy `user_permissions`, а резолвер (computeSet) читает `user_permission_overrides` -> выдача прав не действовала (shumilin, chop_kpp4/post72).
- Read-back `getUserPermissionsList` делал INNER JOIN с `permissions`; каталожные ключи (page.*, tab.* как Go-константы) строкой в `permissions` отсутствуют -> отбрасывались -> тумблер слетал после F5.

## Фикс
- UpdateUserPermissions: upsert в `UserPermissionOverride` (GrantedAt time.Now()).
- getUserPermissionsList: читаем `user_permission_overrides`, LEFT JOIN permissions, ключ из `up.permission_key` (каталожные не теряются).
- Хендлер: `resolver.Invalidate(userID)` после апдейта - права применяются сразу (без 30s TTL).

## Тесты
Новый handler-тест: выдать `page.center` -> read-back содержит его (тумблер не слетает) + `/permissions/my` юзера показывает allow (резолвер видит). Все существующие perm-тесты зелёные.
