### PR TITLE
fix(admin): live-тумблеры прав + полировка модалки пользователя

### DIFF
--- a/frontend/src/components/UserControl.vue
+++ b/frontend/src/components/UserControl.vue
@@ -314,7 +314,7 @@
               <label class="detail-label">Организация:</label>
               <BaseDropdown
                 :model-value="selectedUser.organization_id"
-                :options="organizations"
+                :options="orgOptionsWithNone"
                 label-key="name"
                 value-key="id"
                 placeholder="Не выбрано"
@@ -373,7 +373,7 @@
               <label class="detail-label">Компания:</label>
               <BaseDropdown
                 :model-value="selectedUser.company_id"
-                :options="companies"
+                :options="companyOptionsWithNone"
                 label-key="name"
                 value-key="id"
                 placeholder="Не выбрано"
@@ -490,7 +490,7 @@
     <BaseModal
       :show="showCreateModal"
       title="Создание пользователя"
-      width="740px"
+      width="600px"
       content-class="user-create-modal"
       @close="closeCreateModal"
     >
@@ -1857,12 +1857,17 @@ export default {
 
 .modal-input {
   width: 100%;
-  padding: 10px 12px;
+  padding: 8px 12px;
   border: 1px solid #e0e0e0;
   border-radius: 15px;
   font-size: 14px;
   transition: border-color 0.2s ease;
   background: #fff;
+}
+
+/* Модалка создания пользователя: чуть уже (width prop 600) и скруглённее. */
+:deep(.user-create-modal) {
+  border-radius: 30px;
 }
 
 .modal-input:focus {

--- a/frontend/src/components/admin/UserAccessModal.vue
+++ b/frontend/src/components/admin/UserAccessModal.vue
@@ -338,6 +338,20 @@ export default {
       return result;
     },
   },
+  watch: {
+    // Дерево тумблеров отражает наследованные права (роль + её default-группы +
+    // назначенные группы). Пересчитываем сразу при смене роли/групп, чтобы не
+    // требовалось переоткрывать модалку (#867 UX).
+    'form.role_id'() {
+      this.recomputeInherited();
+    },
+    selectedGroupIds() {
+      this.recomputeInherited();
+    },
+    roles() {
+      this.recomputeInherited();
+    },
+  },
   created() {
     this.overlay.close = () => this.close();
   },
@@ -356,6 +370,36 @@ export default {
       if (this.leaving) return;
       this.leaving = true;
       setTimeout(() => this.$emit('close'), 250);
+    },
+    // Наследованные allow/source = гранты выбранной роли (direct + её default-группы)
+    // + ключи назначенных групп. Зовётся из load() и watch'ей роли/групп.
+    recomputeInherited() {
+      const allow = new Set();
+      const source = {};
+      const role = this.roles.find((r) => r.id === this.form.role_id) || null;
+      if (role) {
+        for (const g of role.default_groups || []) {
+          for (const k of g.keys || []) {
+            allow.add(k);
+            source[k] = 'group';
+          }
+        }
+        for (const k of role.direct_grants || []) {
+          allow.add(k);
+          source[k] = 'role';
+        }
+      }
+      for (const gid of this.selectedGroupIds) {
+        const g = this.groups.find((x) => x.id === gid);
+        if (g) {
+          for (const k of g.keys || []) {
+            allow.add(k);
+            source[k] = 'group';
+          }
+        }
+      }
+      this.inheritedAllow = allow;
+      this.inheritedSource = source;
     },
     async load() {
       if (!this.user) return;
@@ -382,16 +426,8 @@ export default {
         this.initialIsAdmin = this.effective.mode === 'admin' || !!this.user.is_admin;
         this.localIsAdmin = this.initialIsAdmin;
 
-        const inh = new Set();
-        const src = {};
-        for (const p of this.effective.permissions || []) {
-          if (p.source === 'role' || p.source === 'group') {
-            inh.add(p.key);
-            src[p.key] = p.source;
-          }
-        }
-        this.inheritedAllow = inh;
-        this.inheritedSource = src;
+        // inheritedAllow/inheritedSource теперь computed (от выбранной роли/групп) -
+        // снимок из effective тут больше не нужен, иначе он бы "замораживал" дерево.
 
         const ov = {};
         if (Array.isArray(overrides)) {
@@ -399,6 +435,8 @@ export default {
         }
         this.overrideInit = { ...ov };
         this.overrideMap = { ...ov };
+
+        this.recomputeInherited();
 
         this.banReasonInput = this.banReasonCurrent;
       } catch (e) {

--- a/frontend/src/components/admin/__tests__/UserAccessModal.spec.js
+++ b/frontend/src/components/admin/__tests__/UserAccessModal.spec.js
@@ -18,7 +18,10 @@ const CATALOG = [
   { key: 'action.grant.admin', display_name: 'Выдача прав администратора', category: 'Администрирование', super_only: true },
 ];
 
-const ROLES = [{ id: 1, name: 'Пользователь', code: 'user' }, { id: 2, name: 'Охранник', code: 'guard' }];
+const ROLES = [
+  { id: 1, name: 'Пользователь', code: 'user', direct_grants: ['page.center'], default_groups: [] },
+  { id: 2, name: 'Охранник', code: 'guard', direct_grants: [], default_groups: [] },
+];
 const GROUPS = [
   { id: 5, name: 'Аналитика', keys: ['page.statistics'] },
   { id: 6, name: 'Все таблицы', keys: [] },
@@ -111,6 +114,17 @@ describe('UserAccessModal (#187 Фаза 3, две колонки)', () => {
     expect(wrapper.vm.stateByKey['page.cars']).toMatchObject({ on: false, source: null });
     // super-only заблокировано для не-супера.
     expect(wrapper.vm.stateByKey['action.grant.admin'].locked).toBe(true);
+  });
+
+  it('смена роли сразу пересчитывает наследованные тумблеры (#867 UX)', async () => {
+    const wrapper = await mountModal();
+    // Роль 1 (Пользователь) грантит page.center -> тумблер включён.
+    expect(wrapper.vm.stateByKey['page.center']).toMatchObject({ on: true, source: 'role' });
+    // Меняем роль на 2 (Охранник, без грантов) через дропдаун - тумблер обновляется
+    // сразу, без переоткрытия (как в браузере: v-model -> watch -> recomputeInherited).
+    wrapper.findComponent('[data-testid="role-select"]').vm.$emit('update:model-value', 2);
+    await flushPromises();
+    expect(wrapper.vm.stateByKey['page.center']).toMatchObject({ on: false, source: null });
   });
 
   it('включение флага Администратор делает все не-super права on и сохраняется через setUserAdmin', async () => {


### PR DESCRIPTION
По фидбеку:
- Права доступа (UserAccessModal): наследованные тумблеры (роль + её default-группы + назначенные группы) пересчитываются СРАЗУ при смене роли/групп - через watch('form.role_id'/selectedGroupIds) + recomputeInherited (раньше снимок брался один раз в load, нужно было переоткрывать модалку). Admin-тумблер уже был реактивен. + тест на реактивность.
- Модалка создания пользователя (UserControl): уже (width 740->600), скруглённее (border-radius 30 через content-class), инпуты чуть компактнее (padding 8px).
- Дропдауны Организация/Компания в карточке пользователя: пункт "Не выбрано" (перевёл на orgOptionsWithNone/companyOptionsWithNone, как в форме создания).
