### PR TITLE
feat(create-application): редактирование имени вложения и поиск по нему (#883)

### DIFF
--- a/frontend/src/components/BlankSelector.vue
+++ b/frontend/src/components/BlankSelector.vue
@@ -22,27 +22,54 @@
             v-for="attachment in getCategoryAttachments(category)"
             :key="getAttachmentKey(attachment)"
             class="attachment"
-            :class="{ selected: isSelected(attachment) }"
+            :class="{ selected: isSelected(attachment), editing: isEditing(attachment) }"
             @click="selectAttachment(attachment)"
             @mouseenter="handleMouseEnter(attachment, $event)"
             @mouseleave="handleMouseLeave"
           >
-            <input
-              v-model="selectedAttachments"
-              type="checkbox"
-              :value="getAttachmentKey(attachment)"
-              class="attachment-checkbox"
-              @click.stop
-            >
-            <span class="attachment-name">{{ attachment.display_name }}</span>
+            <template v-if="isEditing(attachment)">
+              <input
+                ref="renameInput"
+                v-model="editingName"
+                type="text"
+                class="attachment-name-input"
+                maxlength="255"
+                @click.stop
+                @keydown.enter.prevent="commitRename(attachment)"
+                @keydown.esc.prevent="cancelRename"
+                @blur="commitRename(attachment)"
+              >
+            </template>
+            <template v-else>
+              <input
+                v-model="selectedAttachments"
+                type="checkbox"
+                :value="getAttachmentKey(attachment)"
+                class="attachment-checkbox"
+                @click.stop
+              >
+              <span
+                class="attachment-name"
+                @dblclick.stop="startRename(attachment)"
+              >{{ attachment.display_name }}</span>
 
-            <button
-              v-if="hoveredAttachment === getAttachmentKey(attachment)"
-              class="delete-btn"
-              @click.stop="confirmDelete(attachment)"
-            >
-              ×
-            </button>
+              <button
+                v-if="hoveredAttachment === getAttachmentKey(attachment)"
+                class="edit-btn"
+                title="Переименовать"
+                @click.stop="startRename(attachment)"
+              >
+                ✎
+              </button>
+              <button
+                v-if="hoveredAttachment === getAttachmentKey(attachment)"
+                class="delete-btn"
+                title="Удалить"
+                @click.stop="confirmDelete(attachment)"
+              >
+                ×
+              </button>
+            </template>
           </div>
         </transition-group>
 
@@ -114,7 +141,7 @@ export default {
             default: () => ({})
         }
     },
-    emits: ['attachment-added', 'attachment-removed', 'attachment-selected'],
+    emits: ['attachment-added', 'attachment-removed', 'attachment-selected', 'attachment-renamed'],
     setup() {
         // Онбординг-тур просит показать реальную форму, добавляя демо-вложение
         // нужного типа (см. watch onboardingStore.demoAttachmentType ниже).
@@ -133,7 +160,10 @@ export default {
             tooltipTimeout: null,
             selectedAttachments: [],
             // Демо-вложение, добавленное онбордингом (чтобы убрать его потом).
-            demoAttachment: null
+            demoAttachment: null,
+            // Inline-переименование вложения (#883): ключ редактируемого + черновик имени.
+            editingKey: null,
+            editingName: ''
         }
     },
     computed: {
@@ -161,6 +191,11 @@ export default {
             handler(newAttachments) {
                 const existingIds = new Set(newAttachments.map(a => this.getAttachmentKey(a)));
                 this.selectedAttachments = this.selectedAttachments.filter(id => existingIds.has(id));
+
+                // Редактируемое вложение удалили - выходим из режима переименования.
+                if (this.editingKey !== null && !existingIds.has(this.editingKey)) {
+                    this.cancelRename();
+                }
 
                 if (this.selectedAttachment && !existingIds.has(this.getAttachmentKey(this.selectedAttachment))) {
                     this.selectedAttachment = null;
@@ -333,6 +368,38 @@ export default {
             const enriched = this.withCurrentInstruction(attachment);
             this.selectedAttachment = enriched;
             this.$emit('attachment-selected', enriched);
+        },
+
+        isEditing(attachment) {
+            return this.editingKey !== null && this.editingKey === this.getAttachmentKey(attachment);
+        },
+
+        startRename(attachment) {
+            this.editingKey = this.getAttachmentKey(attachment);
+            this.editingName = attachment.display_name || '';
+            this.$nextTick(() => {
+                const input = this.$el.querySelector('.attachment-name-input');
+                if (input) {
+                    input.focus();
+                    input.select();
+                }
+            });
+        },
+
+        commitRename(attachment) {
+            // Enter и blur оба зовут commit; после первого editingKey уже null - выходим.
+            if (this.editingKey === null) return;
+            const name = this.editingName.trim();
+            this.editingKey = null;
+            this.editingName = '';
+            // Пустое имя или без изменений - откатываем без эмита.
+            if (!name || name === attachment.display_name) return;
+            this.$emit('attachment-renamed', { attachment, display_name: name });
+        },
+
+        cancelRename() {
+            this.editingKey = null;
+            this.editingName = '';
         },
 
         withCurrentInstruction(attachment) {
@@ -642,6 +709,45 @@ export default {
 
 .delete-btn:hover {
     background-color: rgba(255, 68, 68, 0.1);
+}
+
+.edit-btn {
+    background: none;
+    border: none;
+    font-size: 11px;
+    color: #4F5BDF;
+    cursor: pointer;
+    padding: 0;
+    width: 16px;
+    height: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    transition: background-color 0.3s ease;
+    flex-shrink: 0;
+}
+
+.edit-btn:hover {
+    background-color: rgba(79, 91, 223, 0.1);
+}
+
+/* В режиме переименования чип занимает всю ширину панели - чтобы инпут был удобным. */
+.attachment.editing {
+    max-width: none;
+}
+
+.attachment-name-input {
+    flex: 1;
+    min-width: 0;
+    border: 1px solid #4F5BDF;
+    border-radius: 8px;
+    padding: 2px 6px;
+    font-size: 12px;
+    font-weight: 500;
+    color: #000;
+    outline: none;
+    background: #fff;
 }
 
 .tooltip {

--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -16,6 +16,7 @@
         @attachment-selected="handleAttachmentSelected"
         @attachment-added="handleAttachmentAdded"
         @attachment-removed="handleAttachmentRemoved"
+        @attachment-renamed="handleAttachmentRenamed"
       />
 
       <div
@@ -1162,6 +1163,19 @@ export default {
 
         selectAttachment(attachment) {
             this.selectedAttachment = attachment;
+        },
+
+        handleAttachmentRenamed({ attachment, display_name }) {
+            const key = this.attachmentKey(attachment);
+            // attachments - источник истины для payload (сериализуется отсюда) и для чипов.
+            const target = this.attachments.find(a => this.attachmentKey(a) === key);
+            if (target) target.display_name = display_name;
+            // selectedAttachment может быть копией (withCurrentInstruction) - обновляем и его,
+            // чтобы заголовок формы (currentFormTitle) подхватил новое имя.
+            if (this.selectedAttachment && this.attachmentKey(this.selectedAttachment) === key) {
+                this.selectedAttachment.display_name = display_name;
+            }
+            this.saveToLocalStorage();
         },
 
         handleAttachmentRemoved(attachment) {

--- a/frontend/src/components/__tests__/BlankSelector.spec.js
+++ b/frontend/src/components/__tests__/BlankSelector.spec.js
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { shallowMount, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import BlankSelector from '../BlankSelector.vue';
+
+// #883: inline-переименование вложения. Имя редактируется в чипе, эмитится наверх
+// (attachment-renamed) и оттуда уходит в форму/payload/поиск.
+
+vi.mock('@/api/client', () => ({
+  apiRequest: vi.fn().mockResolvedValue({
+    ok: true,
+    json: vi.fn().mockResolvedValue([
+      { id: 1, title: 'Автомобили', name: 'cars', display_name: 'Автомобили', attachment_type: 'cars' },
+    ]),
+  }),
+}));
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+});
+
+const ATTACHMENTS = [
+  { local_id: 'a1', title: 'Автомобили', name: 'cars_1', display_name: 'Автомобили №1', attachment_type: 'cars' },
+];
+
+async function mountSelector(attachments = ATTACHMENTS) {
+  const w = shallowMount(BlankSelector, { props: { attachments } });
+  await flushPromises();
+  return w;
+}
+
+describe('BlankSelector - inline-переименование вложения (#883)', () => {
+  it('commitRename эмитит attachment-renamed с новым именем и выходит из режима', async () => {
+    const w = await mountSelector();
+    w.vm.startRename(ATTACHMENTS[0]);
+    expect(w.vm.editingKey).toBe('a1');
+    w.vm.editingName = 'Грузовики';
+    w.vm.commitRename(ATTACHMENTS[0]);
+
+    const ev = w.emitted('attachment-renamed');
+    expect(ev).toBeTruthy();
+    expect(ev[0][0]).toMatchObject({ display_name: 'Грузовики' });
+    expect(ev[0][0].attachment.local_id).toBe('a1');
+    expect(w.vm.editingKey).toBe(null);
+  });
+
+  it('пустое имя не эмитит и откатывает редактирование', async () => {
+    const w = await mountSelector();
+    w.vm.startRename(ATTACHMENTS[0]);
+    w.vm.editingName = '   ';
+    w.vm.commitRename(ATTACHMENTS[0]);
+    expect(w.emitted('attachment-renamed')).toBeFalsy();
+    expect(w.vm.editingKey).toBe(null);
+  });
+
+  it('имя без изменений не эмитит', async () => {
+    const w = await mountSelector();
+    w.vm.startRename(ATTACHMENTS[0]);
+    w.vm.editingName = 'Автомобили №1';
+    w.vm.commitRename(ATTACHMENTS[0]);
+    expect(w.emitted('attachment-renamed')).toBeFalsy();
+  });
+
+  it('cancelRename выходит без эмита', async () => {
+    const w = await mountSelector();
+    w.vm.startRename(ATTACHMENTS[0]);
+    w.vm.editingName = 'Другое имя';
+    w.vm.cancelRename();
+    expect(w.emitted('attachment-renamed')).toBeFalsy();
+    expect(w.vm.editingKey).toBe(null);
+  });
+
+  it('blur после Enter не дублирует эмит', async () => {
+    const w = await mountSelector();
+    w.vm.startRename(ATTACHMENTS[0]);
+    w.vm.editingName = 'Грузовики';
+    w.vm.commitRename(ATTACHMENTS[0]); // Enter
+    w.vm.commitRename(ATTACHMENTS[0]); // blur по удалению инпута
+    expect(w.emitted('attachment-renamed').length).toBe(1);
+  });
+
+  it('удаление редактируемого вложения сбрасывает режим (watch)', async () => {
+    const w = await mountSelector();
+    w.vm.startRename(ATTACHMENTS[0]);
+    expect(w.vm.editingKey).toBe('a1');
+    await w.setProps({ attachments: [] });
+    expect(w.vm.editingKey).toBe(null);
+  });
+});

--- a/internal/handlers/applications_test.go
+++ b/internal/handlers/applications_test.go
@@ -240,6 +240,38 @@ func TestGetApplications_SearchFindsItemWork(t *testing.T) {
 	assert.True(t, found, "заявка должна находиться по наименованию работ из items-вложения")
 }
 
+// TestGetApplications_SearchFindsAttachmentName: поиск находит заявку по
+// пользовательскому наименованию вложения (#883). Имя вложения редактируется
+// при подаче и хранится в attachments.attachment_display_name; раньше в мега-поиске
+// не участвовало - заявку по переименованному вложению было не найти.
+func TestGetApplications_SearchFindsAttachmentName(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	token := testutil.RegisterAndLogin(t, e, "attnamesearch", "pass123", 1, td.OrgID, td.CompanyID)
+	appID := createSimpleApplication(t, e, token, td.OrgID)
+
+	require.NoError(t, db.Exec(
+		`INSERT INTO attachments (application_id, attachment_type, attachment_display_name, created_at, updated_at)
+		 VALUES (?, 'cars', ?, now(), now())`, appID, "Грузовикиzzqx уникальное").Error)
+
+	rec := testutil.GET(t, e,
+		"/applications?search_query="+url.QueryEscape("Грузовикиzzqx уникальное"),
+		testutil.AuthHeader(token))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	apps := testutil.ParseResponse[[]map[string]interface{}](t, rec)
+	found := false
+	for _, a := range apps {
+		if id, ok := a["id"].(float64); ok && int(id) == appID {
+			found = true
+		}
+	}
+	assert.True(t, found, "заявка должна находиться по наименованию вложения")
+}
+
 // --- GET /applications/user ---
 
 func TestGetUserApplications_ReturnsOwnApplications(t *testing.T) {

--- a/internal/services/application_helpers.go
+++ b/internal/services/application_helpers.go
@@ -335,8 +335,18 @@ func applyApplicationFilters(query *gorm.DB, filter ApplicationFilter, includeUs
 			WHERE att5.application_id = a.id AND (` + itemCond + `)
 		)`
 
+		// --- вложения: наименование вложения ---
+		// Имя вложения редактируется пользователем при подаче (#883) и хранится в
+		// attachments.attachment_display_name; ищем по нему и по служебному attachment_name.
+		attNameCond, attNameArgs := ilikePatternsArgs([]string{"att6.attachment_display_name", "att6.attachment_name"}, variants)
+		attNameSubquery := `EXISTS(
+			SELECT 1 FROM attachments att6
+			WHERE att6.application_id = a.id AND (` + attNameCond + `)
+		)`
+
 		fullCond := baseCond + " OR " + carSubquery + " OR " + empSubquery +
-			" OR " + upSubquery + " OR " + apprSubquery + " OR " + itemSubquery
+			" OR " + upSubquery + " OR " + apprSubquery + " OR " + itemSubquery +
+			" OR " + attNameSubquery
 
 		allArgs := baseArgs
 		allArgs = append(allArgs, carNumArgs...)
@@ -349,6 +359,7 @@ func applyApplicationFilters(query *gorm.DB, filter ApplicationFilter, includeUs
 		allArgs = append(allArgs, apprIlikeArgs...)
 		allArgs = append(allArgs, raw) // для word_similarity согласующих
 		allArgs = append(allArgs, itemArgs...)
+		allArgs = append(allArgs, attNameArgs...)
 
 		query = query.Where(fullCond, allArgs...)
 	}


### PR DESCRIPTION
Закрывает #883.

## Что
- **Inline-переименование вложения** при подаче: карандаш на ховере чипа в `BlankSelector` (или двойной клик по имени) раскрывает инпут прямо в чипе. Enter/blur сохраняет, Esc отменяет, пустое имя откатывается.
- Новое имя сразу видно везде: заголовок формы, тултипы валидации, payload (`attachment_display_name`), модалка успеха. Переживает перезагрузку через localStorage-черновик.
- **Поиск заявок по имени вложения**: дописал EXISTS-подзапрос по `attachments.attachment_display_name`/`attachment_name` в мега-поиск (`applyApplicationFilters`). Хранение имени уже работало (payload -> INSERT), новой колонки/миграции не нужно.

## Тесты
- BE: `TestGetApplications_SearchFindsAttachmentName` (handler-тест реального `GET /applications?search_query=<имя>` -> заявка находится). Полный `go test ./...` зелёный (кроме известного неизолированного `TestLogPartitionMaintenance` на грязной локальной тест-БД; на чистой БД CI проходит).
- FE: `BlankSelector.spec.js` (7 кейсов: эмит rename, пустое/без изменений не эмитит, cancel, no-double-emit на blur-после-Enter, сброс при удалении). Полный scoped vitest зелёный, eslint чистый.

## Проверено живьём
Локально на worktree-фронте: переименование уходит в заголовок формы и чип, первый чип не тронут, localStorage сохраняет имя (скриншоты отправлены).