### PR TITLE
feat(create-application): блок получателей-читателей заявки (#884)

### DIFF
--- a/frontend/src/components/CreateApplication/ApplicationRecipientsRow.vue
+++ b/frontend/src/components/CreateApplication/ApplicationRecipientsRow.vue
@@ -1,0 +1,469 @@
+<template>
+  <div
+    ref="root"
+    class="recipients-row"
+  >
+    <span class="recipients-label">Получатели:</span>
+
+    <div class="recipients-chips">
+      <span
+        v-for="chip in visibleChips"
+        :key="chip.key"
+        class="recipient-chip"
+        :class="{ 'is-reader': chip.removable }"
+        :title="chip.name + ' — ' + chip.roleLabel"
+      >
+        <span class="recipient-chip__name">{{ chip.name }}</span>
+        <span class="recipient-chip__role">{{ chip.roleLabel }}</span>
+        <button
+          v-if="chip.removable"
+          class="recipient-chip__remove"
+          title="Убрать читателя"
+          @click="removeReader(chip.userId)"
+        >
+          ×
+        </button>
+      </span>
+
+      <span
+        v-if="!allChips.length"
+        class="recipients-empty"
+      >Нет получателей</span>
+
+      <!-- Переполнение: остальные получатели в выпадающем списке -->
+      <div
+        v-if="overflowChips.length"
+        class="recipients-extra"
+      >
+        <button
+          class="recipients-extra__btn"
+          type="button"
+          @click="toggleOverflow"
+        >
+          +{{ overflowChips.length }}
+          <span
+            class="recipients-chevron"
+            :class="{ open: showOverflow }"
+          >▾</span>
+        </button>
+        <transition name="rdrop">
+          <div
+            v-if="showOverflow"
+            class="recipients-popover recipients-popover--overflow"
+          >
+            <span
+              v-for="chip in overflowChips"
+              :key="chip.key"
+              class="recipient-chip"
+              :class="{ 'is-reader': chip.removable }"
+            >
+              <span class="recipient-chip__name">{{ chip.name }}</span>
+              <span class="recipient-chip__role">{{ chip.roleLabel }}</span>
+              <button
+                v-if="chip.removable"
+                class="recipient-chip__remove"
+                title="Убрать читателя"
+                @click="removeReader(chip.userId)"
+              >
+                ×
+              </button>
+            </span>
+          </div>
+        </transition>
+      </div>
+
+      <!-- Добавить читателя (только Руководители) -->
+      <div class="recipients-add">
+        <button
+          class="recipients-add__btn"
+          type="button"
+          title="Добавить получателя-читателя (только руководители)"
+          @click="toggleAdd"
+        >
+          + получатель
+        </button>
+        <transition name="rdrop">
+          <div
+            v-if="showAdd"
+            class="recipients-popover recipients-popover--add"
+          >
+            <input
+              v-model="search"
+              class="recipients-search"
+              type="text"
+              placeholder="Поиск руководителя"
+            >
+            <div class="recipients-add-list">
+              <button
+                v-for="u in availableManagers"
+                :key="u.userId"
+                class="recipients-add-item"
+                type="button"
+                @click="addReader(u)"
+              >
+                <span class="recipients-add-item__name">{{ u.name }}</span>
+                <span
+                  v-if="u.position"
+                  class="recipients-add-item__pos"
+                >{{ u.position }}</span>
+              </button>
+              <div
+                v-if="!availableManagers.length"
+                class="recipients-add-empty"
+              >
+                {{ managerUsers.length ? 'Все руководители уже добавлены' : 'Нет руководителей' }}
+              </div>
+            </div>
+          </div>
+        </transition>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { apiRequest } from '@/api/client'
+
+const MAX_VISIBLE = 4
+
+export default {
+  name: 'ApplicationRecipientsRow',
+  props: {
+    /** Дефолтные согласующие организации/компании - показываются, удалить нельзя. */
+    approvers: {
+      type: Array,
+      default: () => []
+    },
+    /** Добавленные читатели (read-only доступ). v-model. */
+    readers: {
+      type: Array,
+      default: () => []
+    }
+  },
+  emits: ['update:readers'],
+  data() {
+    return {
+      managerUsers: [],
+      search: '',
+      showAdd: false,
+      showOverflow: false
+    }
+  },
+  computed: {
+    allChips() {
+      const approverChips = this.approvers.map(a => ({
+        key: `a-${a.user_id}`,
+        userId: a.user_id,
+        name: a.name,
+        roleLabel: 'согласующий',
+        removable: false
+      }))
+      const readerChips = this.readers.map(r => ({
+        key: `r-${r.user_id}`,
+        userId: r.user_id,
+        name: r.name,
+        roleLabel: 'читатель',
+        removable: true
+      }))
+      return [...approverChips, ...readerChips]
+    },
+    visibleChips() {
+      return this.allChips.slice(0, MAX_VISIBLE)
+    },
+    overflowChips() {
+      return this.allChips.slice(MAX_VISIBLE)
+    },
+    availableManagers() {
+      const taken = new Set([
+        ...this.approvers.map(a => a.user_id),
+        ...this.readers.map(r => r.user_id)
+      ])
+      const q = this.search.trim().toLowerCase()
+      return this.managerUsers
+        .filter(u => !taken.has(u.userId))
+        .filter(u => !q || u.name.toLowerCase().includes(q) || (u.position || '').toLowerCase().includes(q))
+    }
+  },
+  mounted() {
+    this.fetchManagers()
+    document.addEventListener('mousedown', this.handleOutside)
+  },
+  beforeUnmount() {
+    document.removeEventListener('mousedown', this.handleOutside)
+  },
+  methods: {
+    async fetchManagers() {
+      try {
+        const response = await apiRequest('/users/all', {})
+        if (!response.ok) return
+        const users = await response.json()
+        this.managerUsers = (users || [])
+          .filter(u => u.user_type === 'Руководитель')
+          .map(u => ({
+            userId: u.id,
+            name: this.displayName(u),
+            username: u.username,
+            position: u.position || ''
+          }))
+      } catch (error) {
+        console.error('Ошибка загрузки руководителей:', error)
+      }
+    },
+
+    displayName(u) {
+      const names = [u.last_name, u.first_name, u.middle_name].filter(Boolean)
+      return names.length ? names.join(' ') : u.username
+    },
+
+    addReader(user) {
+      if (this.readers.some(r => r.user_id === user.userId)) return
+      this.$emit('update:readers', [
+        ...this.readers,
+        { user_id: user.userId, name: user.name, username: user.username }
+      ])
+      this.search = ''
+      this.showAdd = false
+    },
+
+    removeReader(userId) {
+      this.$emit('update:readers', this.readers.filter(r => r.user_id !== userId))
+    },
+
+    toggleAdd() {
+      this.showAdd = !this.showAdd
+      if (this.showAdd) this.showOverflow = false
+    },
+
+    toggleOverflow() {
+      this.showOverflow = !this.showOverflow
+      if (this.showOverflow) this.showAdd = false
+    },
+
+    handleOutside(event) {
+      if (this.$refs.root && !this.$refs.root.contains(event.target)) {
+        this.showAdd = false
+        this.showOverflow = false
+      }
+    }
+  }
+}
+</script>
+
+<style scoped>
+.recipients-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 10px;
+}
+
+.recipients-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #64748b;
+  flex-shrink: 0;
+}
+
+.recipients-chips {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.recipient-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid #e2e8f0;
+  background: #f8fafc;
+  font-size: 0.78rem;
+  color: #1e293b;
+  white-space: nowrap;
+}
+
+.recipient-chip.is-reader {
+  border-color: rgba(79, 91, 223, 0.35);
+  background: rgba(79, 91, 223, 0.08);
+}
+
+.recipient-chip__name {
+  font-weight: 500;
+}
+
+.recipient-chip__role {
+  font-size: 0.62rem;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: #94a3b8;
+}
+
+.recipient-chip.is-reader .recipient-chip__role {
+  color: #4F5BDF;
+}
+
+.recipient-chip__remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border: none;
+  border-radius: 50%;
+  background: none;
+  color: #94a3b8;
+  font-size: 0.95rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.recipient-chip__remove:hover {
+  background: rgba(239, 68, 68, 0.12);
+  color: #ef4444;
+}
+
+.recipients-empty {
+  font-size: 0.75rem;
+  color: #94a3b8;
+  font-style: italic;
+}
+
+.recipients-extra,
+.recipients-add {
+  position: relative;
+  display: inline-flex;
+}
+
+.recipients-extra__btn,
+.recipients-add__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 12px;
+  border-radius: 999px;
+  border: 1px dashed #cbd5e1;
+  background: #fff;
+  font-size: 0.76rem;
+  font-weight: 500;
+  color: #4F5BDF;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.recipients-extra__btn:hover,
+.recipients-add__btn:hover {
+  border-color: #4F5BDF;
+  background: rgba(79, 91, 223, 0.06);
+}
+
+.recipients-chevron {
+  font-size: 0.7rem;
+  transition: transform 0.2s ease;
+}
+
+.recipients-chevron.open {
+  transform: rotate(180deg);
+}
+
+.recipients-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  z-index: 50;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.12);
+  padding: 10px;
+}
+
+.recipients-popover--overflow {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 200px;
+  max-height: 260px;
+  overflow-y: auto;
+}
+
+.recipients-popover--add {
+  width: 240px;
+}
+
+.recipients-search {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 6px 10px;
+  border: 1px solid #e2e8f0;
+  border-radius: var(--radius-md, 15px);
+  font-size: 0.78rem;
+  margin-bottom: 8px;
+  outline: none;
+}
+
+.recipients-search:focus {
+  border-color: #4F5BDF;
+}
+
+.recipients-add-list {
+  max-height: 220px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.recipients-add-item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1px;
+  width: 100%;
+  text-align: left;
+  padding: 6px 8px;
+  border: none;
+  border-radius: 8px;
+  background: none;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.recipients-add-item:hover {
+  background: #f1f5f9;
+}
+
+.recipients-add-item__name {
+  font-size: 0.78rem;
+  color: #1e293b;
+  font-weight: 500;
+}
+
+.recipients-add-item__pos {
+  font-size: 0.65rem;
+  color: #94a3b8;
+}
+
+.recipients-add-empty {
+  padding: 10px 8px;
+  text-align: center;
+  color: #94a3b8;
+  font-size: 0.72rem;
+  font-style: italic;
+}
+
+/* Плавное раскрытие выпадающих списков (transform + opacity). */
+.rdrop-enter-active,
+.rdrop-leave-active {
+  transition: opacity 0.18s ease, transform 0.18s ease;
+}
+
+.rdrop-enter-from,
+.rdrop-leave-to {
+  opacity: 0;
+  transform: translateY(-6px);
+}
+</style>

--- a/frontend/src/components/CreateApplication/CreateApplication.vue
+++ b/frontend/src/components/CreateApplication/CreateApplication.vue
@@ -1,10 +1,17 @@
 <template>
   <div class="create">
     <div class="create__header">
-      <div class="create__title">
-        <h3>Оформление и подача заявки</h3>
+      <div class="create__header-top">
+        <div class="create__title">
+          <h3>Оформление и подача заявки</h3>
+        </div>
+        <h4>{{ currentFormTitle }}</h4>
       </div>
-      <h4>{{ currentFormTitle }}</h4>
+      <ApplicationRecipientsRow
+        :approvers="defaultApprovers"
+        :readers="readers"
+        @update:readers="readers = $event"
+      />
     </div>
 
     <div class="create__container">
@@ -326,6 +333,7 @@ import UniversalBindingModal from './UniversalBindingModal.vue';
 import ApplicationSuccessModal from './ApplicationSuccessModal.vue';
 import CustomFieldsSection from './CustomFieldsSection.vue';
 import TextConstructor from '@/components/TextConstructor.vue';
+import ApplicationRecipientsRow from './ApplicationRecipientsRow.vue';
 
 export default {
     name: 'CreateApplication',
@@ -342,7 +350,8 @@ export default {
         UniversalBindingModal,
         ApplicationSuccessModal,
         CustomFieldsSection,
-        TextConstructor
+        TextConstructor,
+        ApplicationRecipientsRow
     },
     data() {
         return {
@@ -364,7 +373,12 @@ export default {
 
             organizationId: null,
             companyId: null,
-            
+
+            // Получатели заявки (#884): дефолтные согласующие орг/компании (показ,
+            // удалить нельзя) и добавленные читатели (read-only доступ, уходят в payload.readers).
+            defaultApprovers: [],
+            readers: [],
+
             selectedAttachment: null,
             attachments: [],
 
@@ -1022,7 +1036,9 @@ export default {
                     
                     this.hasOrganization = !!this.organizationId;
                     this.hasCompany = !!this.companyId;
-                    
+
+                    this.loadDefaultApprovers();
+
                     const lastName = userData.last_name || '';
                     const firstName = userData.first_name || '';
                     const middleName = userData.middle_name || '';
@@ -1041,6 +1057,37 @@ export default {
             } catch (error) {
                 console.error("Ошибка:", error);
             }
+        },
+
+        /**
+         * Дефолтные согласующие заявки (#884) - ответственные орг/компании с
+         * required_approval. Показываются как неудаляемые чипы-получатели; бэк и так
+         * добавляет их в ответственные при подаче, тут только отображение.
+         */
+        async loadDefaultApprovers() {
+            const byId = new Map();
+            const collect = async (url) => {
+                try {
+                    const r = await apiRequest(url, {});
+                    if (!r.ok) return;
+                    const users = await r.json();
+                    (users || []).forEach(u => {
+                        if (u.required_approval && !byId.has(u.id)) {
+                            byId.set(u.id, { user_id: u.id, name: this.userDisplayName(u) });
+                        }
+                    });
+                } catch (error) {
+                    console.error('Ошибка загрузки согласующих:', error);
+                }
+            };
+            if (this.organizationId) await collect(`/organizations/${this.organizationId}/users`);
+            if (this.companyId) await collect(`/companies/${this.companyId}/users`);
+            this.defaultApprovers = Array.from(byId.values());
+        },
+
+        userDisplayName(u) {
+            const names = [u.last_name, u.first_name, u.middle_name].filter(Boolean);
+            return names.length ? names.join(' ') : (u.username || '');
         },
 
         handleFormatPhoneNumber() {
@@ -1815,6 +1862,7 @@ export default {
             }
             this.selectedAttachment = null;
             this.attachments = [];
+            this.readers = [];
 
             this.clearLocalStorageAfterSubmit();
         },
@@ -1832,6 +1880,8 @@ export default {
                 responsible_person: this.responsiblePerson,
                 contact_phone: this.phoneNumber.replace(/\D/g, ''),
                 data_approval: this.consentGiven,
+                // Читатели-получатели (#884): только просмотр заявки после подачи.
+                readers: this.readers.map(r => r.user_id),
                 attachments: []
             };
 
@@ -2114,6 +2164,7 @@ export default {
             }
             this.selectedAttachment = null;
             this.attachments = [];
+            this.readers = [];
 
             this.clearLocalStorageAfterSubmit();
         },
@@ -2130,6 +2181,7 @@ export default {
                     phoneNumber: this.phoneNumber,
                     rawPhoneNumber: this.rawPhoneNumber,
                     consentGiven: this.consentGiven,
+                    readers: this.readers,
 
                     // attachments - источник истины для UI. Без них vehiclesByAttachment
                     // остаётся сиротским (ключи без самих attachment-записей) - BlankSelector
@@ -2172,6 +2224,7 @@ export default {
                     this.phoneNumber = parsedData.phoneNumber || '';
                     this.rawPhoneNumber = parsedData.rawPhoneNumber || '';
                     this.consentGiven = parsedData.consentGiven || false;
+                    this.readers = parsedData.readers || [];
 
                     this.attachments = parsedData.attachments || [];
 
@@ -2295,9 +2348,16 @@ export default {
 
     .create__header {
         display: flex;
+        flex-direction: column;
+        align-items: stretch;
+        gap: 6px;
+        padding-bottom: 15px;
+    }
+
+    .create__header-top {
+        display: flex;
         align-items: center;
         justify-content: space-between;
-        padding-bottom: 15px;
     }
 
     .create__container {

--- a/frontend/src/components/CreateApplication/__tests__/ApplicationRecipientsRow.spec.js
+++ b/frontend/src/components/CreateApplication/__tests__/ApplicationRecipientsRow.spec.js
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { shallowMount, flushPromises } from '@vue/test-utils';
+import ApplicationRecipientsRow from '../ApplicationRecipientsRow.vue';
+
+// #884: блок получателей-читателей. Дефолтные согласующие неудаляемы, читателей
+// (только Руководители) можно добавить/удалить, переполнение -> дропдаун.
+
+vi.mock('@/api/client', () => ({
+  apiRequest: vi.fn().mockResolvedValue({
+    ok: true,
+    json: vi.fn().mockResolvedValue([
+      { id: 1, username: 'man1', user_type: 'Руководитель', last_name: 'Иванов', first_name: 'Иван', position: 'Директор' },
+      { id: 2, username: 'man2', user_type: 'Руководитель', last_name: 'Петров', first_name: 'Пётр', position: '' },
+      { id: 3, username: 'usr3', user_type: 'Пользователь', last_name: 'Сидоров', first_name: 'Сидор' },
+      { id: 4, username: 'man4', user_type: 'Руководитель', last_name: 'Кузнецов', first_name: 'Кузьма' },
+    ]),
+  }),
+}));
+
+async function mountRow(props = {}) {
+  const w = shallowMount(ApplicationRecipientsRow, {
+    props: { approvers: [], readers: [], ...props },
+  });
+  await flushPromises();
+  return w;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ApplicationRecipientsRow (#884)', () => {
+  it('fetchManagers берёт только пользователей с типом Руководитель', async () => {
+    const w = await mountRow();
+    expect(w.vm.managerUsers.map(u => u.userId).sort()).toEqual([1, 2, 4]);
+    expect(w.vm.managerUsers.find(u => u.userId === 1).name).toBe('Иванов Иван');
+  });
+
+  it('addReader эмитит update:readers с добавленным читателем', async () => {
+    const w = await mountRow();
+    w.vm.addReader({ userId: 2, name: 'Петров Пётр', username: 'man2' });
+    const ev = w.emitted('update:readers');
+    expect(ev).toBeTruthy();
+    expect(ev[0][0]).toEqual([{ user_id: 2, name: 'Петров Пётр', username: 'man2' }]);
+  });
+
+  it('removeReader эмитит список без удалённого', async () => {
+    const w = await mountRow({
+      readers: [
+        { user_id: 2, name: 'Петров Пётр' },
+        { user_id: 4, name: 'Кузнецов Кузьма' },
+      ],
+    });
+    w.vm.removeReader(2);
+    const ev = w.emitted('update:readers');
+    expect(ev[0][0]).toEqual([{ user_id: 4, name: 'Кузнецов Кузьма' }]);
+  });
+
+  it('availableManagers исключает уже-согласующих и уже-читателей', async () => {
+    const w = await mountRow({
+      approvers: [{ user_id: 1, name: 'Иванов Иван' }],
+      readers: [{ user_id: 2, name: 'Петров Пётр' }],
+    });
+    expect(w.vm.availableManagers.map(u => u.userId)).toEqual([4]);
+  });
+
+  it('согласующие неудаляемы (removable=false), читатели removable=true', async () => {
+    const w = await mountRow({
+      approvers: [{ user_id: 1, name: 'Иванов Иван' }],
+      readers: [{ user_id: 2, name: 'Петров Пётр' }],
+    });
+    const chips = w.vm.allChips;
+    expect(chips.find(c => c.userId === 1).removable).toBe(false);
+    expect(chips.find(c => c.userId === 2).removable).toBe(true);
+  });
+
+  it('переполнение: чипы сверх лимита уходят в overflowChips', async () => {
+    const approvers = Array.from({ length: 6 }, (_, i) => ({ user_id: 100 + i, name: `Согл ${i}` }));
+    const w = await mountRow({ approvers });
+    expect(w.vm.visibleChips.length).toBe(4);
+    expect(w.vm.overflowChips.length).toBe(2);
+  });
+
+  it('addReader не дублирует уже добавленного', async () => {
+    const w = await mountRow({ readers: [{ user_id: 2, name: 'Петров Пётр' }] });
+    w.vm.addReader({ userId: 2, name: 'Петров Пётр', username: 'man2' });
+    expect(w.emitted('update:readers')).toBeFalsy();
+  });
+});

--- a/internal/handlers/applications_test.go
+++ b/internal/handlers/applications_test.go
@@ -118,6 +118,65 @@ func submitCompleteApplication(t *testing.T, e *echo.Echo, token string, orgName
 	return resp.ApplicationID
 }
 
+// TestSubmitCompleteApplication_AddsReaders: получатели-читатели (#884) кладутся в
+// application_viewers и получают view-доступ к заявке, не становясь согласующими.
+func TestSubmitCompleteApplication_AddsReaders(t *testing.T) {
+	e, db, cleanup := testutil.SetupTestApp(t)
+	defer cleanup()
+	testutil.CleanDB(t, db)
+	td := testutil.SeedTestData(t, db)
+
+	senderToken := testutil.RegisterAndLogin(t, e, "rsender", "pass123", 1, td.OrgID, td.CompanyID)
+	readerToken := testutil.RegisterAndLogin(t, e, "rreader", "pass123", 1, td.OrgID, td.CompanyID)
+	readerID := getUserID(t, db, "rreader")
+	uaID := seedUniqueAttachment(t, db, "cars", "cars_rd", "Cars RD")
+
+	body := fmt.Sprintf(`{
+		"message": "app with readers",
+		"organization": "Test Organization",
+		"responsible_person": "Test Person",
+		"contact_phone": "+79001234567",
+		"data_approval": true,
+		"readers": [%d],
+		"attachments": [{
+			"attachment_type": "cars",
+			"attachment_name": "cars_template",
+			"attachment_display_name": "Cars Template",
+			"unique_attachment_id": %d,
+			"entry_date_from": "2026-04-01",
+			"entry_date_to": "2099-12-31",
+			"entry_time_from": "08:00",
+			"entry_time_to": "18:00",
+			"data": { "vehicles": [{ "car_number": "A001AA777", "car_brand": "Toyota" }] }
+		}]
+	}`, readerID, uaID)
+
+	rec := testutil.POST(t, e, "/applications/submit-complete-application", body, testutil.AuthHeader(senderToken))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	appID := testutil.ParseResponse[services.CompleteApplicationResponse](t, rec).ApplicationID
+
+	// Читатель попал в список viewers заявки.
+	vrec := testutil.GET(t, e, fmt.Sprintf("/applications/%d/viewers", appID), testutil.AuthHeader(senderToken))
+	require.Equal(t, http.StatusOK, vrec.Code, vrec.Body.String())
+	viewers := testutil.ParseResponse[[]services.ViewerWithUser](t, vrec)
+	foundViewer := false
+	for _, v := range viewers {
+		if v.UserID == readerID {
+			foundViewer = true
+		}
+	}
+	assert.True(t, foundViewer, "читатель должен попасть в application_viewers")
+
+	// Читатель получил view-доступ к заявке (раньше 403 - не свой/не ответственный).
+	arec := testutil.GET(t, e, fmt.Sprintf("/applications/%d", appID), testutil.AuthHeader(readerToken))
+	assert.Equal(t, http.StatusOK, arec.Code, "читатель должен видеть заявку")
+
+	// Но в согласующих его нет (только просмотр).
+	var respCount int64
+	db.Raw("SELECT COUNT(*) FROM application_responsible_users WHERE application_id = ? AND user_id = ?", appID, readerID).Scan(&respCount)
+	assert.Zero(t, respCount, "читатель не должен попадать в ответственных/согласующих")
+}
+
 // --- 401 Unauthorized tests ---
 
 func TestApplications_Unauthorized(t *testing.T) {

--- a/internal/services/application_service.go
+++ b/internal/services/application_service.go
@@ -231,6 +231,9 @@ type CompleteApplicationRequest struct {
 	DataApproval      bool                 `json:"data_approval"`
 	Attachments       []AttachmentData     `json:"attachments"`
 	RequiredUsers     *[]RequiredUserInput `json:"required_users"`
+	// Readers - получатели-читатели заявки (#884): доступ только на просмотр.
+	// Кладутся в application_viewers (как форвард-флоу), без права согласования.
+	Readers *[]int `json:"readers"`
 }
 
 // AttachmentData данные вложения при создании заявки.
@@ -1478,6 +1481,26 @@ func (s *applicationService) SubmitCompleteApplication(ctx context.Context, user
 			INSERT INTO application_history (application_id, user_id, action_type, metadata, created_at)
 			VALUES (?, ?, 'assigned_responsible', ?, ?)
 		`, appID, ru.UserID, string(meta), historyTime)
+	}
+
+	// Читатели-получатели заявки (#884): доступ только на просмотр через application_viewers
+	// (как форвард-флоу) - CanAccessApplication пускает их на чтение, но не в согласующие.
+	// Пропускаем тех, кто уже ответственный (у них доступ и так есть).
+	if req.Readers != nil {
+		seenViewer := make(map[int]bool, len(responsibleUsers))
+		for _, ru := range responsibleUsers {
+			seenViewer[ru.UserID] = true
+		}
+		for _, readerID := range *req.Readers {
+			if readerID <= 0 || seenViewer[readerID] {
+				continue
+			}
+			seenViewer[readerID] = true
+			tx.Exec(`
+				INSERT INTO application_viewers (application_id, user_id, created_at, created_by)
+				VALUES (?, ?, ?, ?)
+			`, appID, readerID, baseTime, user.ID)
+		}
 	}
 
 	// Вставленные машины/сотрудники для пост-коммит проверки близости к ЧС (#481).


### PR DESCRIPTION
Закрывает #884.

## Что
- Строка **Получатели** под заголовком «Оформление и подача заявки» (новый `ApplicationRecipientsRow.vue`).
- **Дефолтные согласующие** организации/компании (required_approval) показываются неудаляемыми чипами. Бэк и так добавляет их в ответственные при подаче - тут только отображение.
- **Читатели**: любой может добавить получателей через дропдаун с поиском, но только пользователей с типом **Руководитель** (`user_type='Руководитель'`). Они становятся read-only: видят заявку, не согласовывают/не редактируют. Добавленных можно удалить, дефолтных - нельзя.
- **Переполнение**: чипы сверх лимита (4) сворачиваются в `+N` с плавно раскрывающимся выпадающим списком.
- Читатели переживают перезагрузку (localStorage-черновик), сбрасываются после подачи.

## BE
- Переиспользовал существующую `application_viewers` (без новой модели/миграции, ни одного off-limits файла). Расширил `CompleteApplicationRequest.Readers []int`; в submit-сервисе вставка в `application_viewers` (как форвард-флоу), пропуская уже-ответственных. View-доступ даёт существующий `CanAccessApplication` (уже учитывает viewers).

## Тесты
- BE: `TestSubmitCompleteApplication_AddsReaders` - читатель попадает в viewers, получает 200 на `GET /applications/:id`, в согласующих его нет. Полный `go test ./...` зелёный (кроме известного неизолированного `TestLogPartitionMaintenance` на грязной локальной тест-БД; на чистой БД CI проходит).
- FE: `ApplicationRecipientsRow.spec.js` (7 кейсов: фильтр Руководителей, add/remove эмиты, исключение уже-выбранных, неудаляемость согласующих, переполнение, no-dup). Полный scoped vitest зелёный, eslint чистый.

## Проверено живьём
Локально: дефолтные согласующие неудаляемы, дропдаун только с Руководителями, читатель добавляется/удаляется (скриншоты отправлены).